### PR TITLE
Hide input controls while chat is streaming

### DIFF
--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/nativeinput/NativeInputState.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/nativeinput/NativeInputState.kt
@@ -24,6 +24,8 @@ data class NativeInputState(
     val selectedTool: String? = null,
     /** Set when the active tab is a Duck.ai page already attached to an existing chat. */
     val chatId: String? = null,
+    /** True while the active chat is streaming a response (ChatState.STREAMING or LOADING). */
+    val isChatStreaming: Boolean = false,
 ) {
     enum class InputMode {
         SEARCH_AND_DUCK_AI,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
@@ -31,6 +31,9 @@ interface NativeInputHost {
     /** Submit the current input as a chat message; opens a new chat session if the input is empty. */
     fun submit()
 
+    /** Stop the active chat stream. Delegates to the host's [NativeInputWidget.onStopTapped] callback. */
+    fun stop()
+
     fun showAttachmentChooser(showing: Boolean)
     fun showModelPicker(showing: Boolean)
     fun showReasoningPicker(showing: Boolean)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -60,8 +60,6 @@ import com.duckduckgo.subscriptions.api.Subscriptions
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
-import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -73,7 +71,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -125,10 +122,6 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     /** @see lastEmptyQueryHadChats */
     fun hadRecentChats(): Boolean = lastEmptyQueryHadChats
 
-    sealed class Command {
-        data class UpdatePluginVisibility(val containerIds: List<Int>, val visible: Boolean) : Command()
-    }
-
     private val _plugins = MutableStateFlow<List<NativeInputPlugin>>(emptyList())
     val plugins: StateFlow<List<NativeInputPlugin>> = _plugins.asStateFlow()
 
@@ -146,22 +139,12 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     private var pendingChatId: String? = null
     private var hasPendingChatId = false
 
-    private val commandChannel = Channel<Command>(capacity = 1, onBufferOverflow = DROP_OLDEST)
-    val commands = commandChannel.receiveAsFlow()
-
     init {
         viewModelScope.launch {
             _plugins.value = nativeInputPlugins.getPlugins().toList()
         }
         viewModelScope.launch {
             _isHistoryAvailable.value = duckChatInternal.isChatHistoryAvailable()
-        }
-    }
-
-    fun updatePluginContainerVisibility(isChatTab: Boolean) {
-        val containerIds = _plugins.value.map { it.containerId }
-        if (containerIds.isNotEmpty()) {
-            commandChannel.trySend(Command.UpdatePluginVisibility(containerIds, isChatTab))
         }
     }
 
@@ -214,7 +197,7 @@ class NativeInputModeWidgetViewModel @Inject constructor(
 
     private val activeTabId = MutableStateFlow<String?>(null)
 
-    val state: SharedFlow<NativeInputState> = combine(
+    private val baseState: Flow<NativeInputState> = combine(
         duckAiFeatureState.showSettings,
         duckChatInternal.observeEnableDuckChatUserSetting(),
         duckChatInternal.observeInputScreenUserSettingEnabled(),
@@ -227,6 +210,13 @@ class NativeInputModeWidgetViewModel @Inject constructor(
             inputPosition = config.inputPosition,
             toggleSelection = config.toggleSelection ?: NativeInputState.defaultToggleFor(config.inputContext),
         )
+    }
+
+    val state: SharedFlow<NativeInputState> = combine(
+        baseState,
+        duckChatInternal.chatState,
+    ) { state, chatState ->
+        state.copy(isChatStreaming = chatState == ChatState.STREAMING || chatState == ChatState.LOADING)
     }.shareIn(
         scope = viewModelScope,
         started = SharingStarted.Eagerly,
@@ -251,12 +241,14 @@ class NativeInputModeWidgetViewModel @Inject constructor(
                             inputContext = snapshot.inputContext,
                             inputPosition = snapshot.inputPosition,
                             toggleSelection = snapshot.toggleSelection,
+                            isChatStreaming = snapshot.isChatStreaming,
                         )
                     }
                 }
         }
     }
 
+    // Kept for the widget's observeChatState() which handles HIDE/SHOW/READY root-visibility transitions.
     val chatState: Flow<ChatState> = duckChatInternal.chatState
 
     val isPaidTier: Flow<Boolean> = subscriptions.getEntitlementStatus()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/StopStreamingNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/StopStreamingNativeInputPlugin.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.nativeinput.plugins
+
+import android.content.Context
+import android.view.View
+import com.duckduckgo.anvil.annotations.ContributesActivePlugin
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
+import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.StopStreamingView
+import javax.inject.Inject
+
+@ContributesActivePlugin(
+    scope = AppScope::class,
+    boundType = NativeInputPlugin::class,
+    featureName = "pluginStopStreamingNativeInput",
+    parentFeatureName = "pluginPointNativeInput",
+)
+class StopStreamingNativeInputPlugin @Inject constructor() : NativeInputPlugin {
+
+    override val containerId: Int = R.id.streamingButtonsContainer
+
+    override fun createView(context: Context, host: NativeInputHost): View = StopStreamingView(context).apply {
+        onStopClicked = { host.stop() }
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
@@ -22,6 +22,7 @@ import android.graphics.Typeface
 import android.net.Uri
 import android.view.Gravity
 import android.view.LayoutInflater
+import android.view.View
 import android.webkit.ValueCallback
 import android.widget.FrameLayout
 import android.widget.HorizontalScrollView
@@ -36,6 +37,8 @@ import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.utils.ViewViewModelFactory
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.ui.AttachmentViewModel
@@ -43,6 +46,9 @@ import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.ImageAttachment
 import com.duckduckgo.duckchat.impl.ui.nativeinput.file.FileAttachment
 import com.duckduckgo.duckchat.impl.ui.nativeinput.file.FileAttachmentsContainerView
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.json.JSONArray
 
@@ -56,6 +62,9 @@ class AttachmentView(
     var onFilePickerRequested: ((ValueCallback<Array<Uri>>, List<String>) -> Unit)? = null
 
     private var viewModel: AttachmentViewModel? = null
+    private var supportsUpload: Boolean = false
+    private var nativeInputStateJob: Job? = null
+    private var lastNativeInputState: NativeInputState? = null
     private var popupWindow: PopupWindow? = null
     private var thumbnailsLayout: LinearLayout? = null
     private var imageAttachmentsContainer: ImageAttachmentsContainerView? = null
@@ -67,7 +76,7 @@ class AttachmentView(
         setOnClickListener { showPopupMenu() }
     }
 
-    fun bind(scope: CoroutineScope, factory: ViewViewModelFactory) {
+    fun bind(scope: CoroutineScope, factory: ViewViewModelFactory, nativeInputStateProvider: NativeInputStateProvider) {
         val owner = findViewTreeViewModelStoreOwner() ?: return
         val vm = ViewModelProvider(owner, factory)[AttachmentViewModel::class.java]
         viewModel = vm
@@ -76,6 +85,18 @@ class AttachmentView(
         scope.launch {
             vm.attachmentState.collect { state -> applyState(state, container) }
         }
+        nativeInputStateJob = nativeInputStateProvider.state
+            .onEach { state ->
+                lastNativeInputState = state
+                updateButtonVisibility()
+            }
+            .launchIn(scope)
+    }
+
+    private fun updateButtonVisibility() {
+        val show = supportsUpload && lastNativeInputState?.shouldShowPluginControls() == true
+        isVisible = show
+        (parent as? View)?.isVisible = show
     }
 
     fun getImageAttachments(): List<ImageAttachment> = viewModel?.getImageAttachments() ?: emptyList()
@@ -170,7 +191,8 @@ class AttachmentView(
                 ?: state.fileSizeError
                 ?: state.filePageCountError
                 ?: state.fileTotalSizeError
-        container.isVisible = state.hasAttachments || errorMessage != null
+        val notStreaming = lastNativeInputState?.isChatStreaming != true
+        container.isVisible = (state.hasAttachments || errorMessage != null) && notStreaming
         updateLimitError(errorMessage)
         notifyStateChanged(state)
     }
@@ -202,6 +224,8 @@ class AttachmentView(
     }
 
     private fun notifyStateChanged(state: AttachmentViewModel.AttachmentState) {
+        supportsUpload = state.supportsUpload
+        updateButtonVisibility()
         host?.attachmentChanged(
             hasAttachments = state.hasAttachments,
             limitExceeded = (
@@ -217,6 +241,9 @@ class AttachmentView(
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
+        nativeInputStateJob?.cancel()
+        nativeInputStateJob = null
+        lastNativeInputState = null
         dismissPopup()
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
@@ -21,6 +21,7 @@ import android.text.TextUtils
 import android.util.AttributeSet
 import android.view.Gravity
 import android.view.LayoutInflater
+import android.view.View
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.LinearLayout
@@ -40,6 +41,7 @@ import com.duckduckgo.common.ui.view.divider.HorizontalDivider
 import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.common.utils.ViewViewModelFactory
 import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputContext
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.impl.DuckChatConstants.DUCK_AI_FEATURE_PAGE
@@ -90,6 +92,7 @@ class ModelPickerView @JvmOverloads constructor(
     private var commandJob: Job? = null
     private var popupWindow: PopupWindow? = null
     private var lastObservedModelId: String? = null
+    private var lastNativeInputState: NativeInputState? = null
 
     // Mirrors the input context from the per-tab native input state so currentSurface() can be
     // read synchronously from popup callbacks. Updated by observeInputContext().
@@ -127,7 +130,12 @@ class ModelPickerView @JvmOverloads constructor(
     }
 
     private fun updateVisibility() {
-        isVisible = pickerEnabled && viewModel.state.value.models.isNotEmpty()
+        val nativeState = lastNativeInputState
+        val show = pickerEnabled &&
+            viewModel.state.value.models.isNotEmpty() &&
+            nativeState?.shouldShowPluginControls() == true
+        isVisible = show
+        (parent as? View)?.isVisible = show
     }
 
     override fun onAttachedToWindow() {
@@ -146,7 +154,11 @@ class ModelPickerView @JvmOverloads constructor(
         val scope = findViewTreeLifecycleOwner()?.lifecycleScope ?: return
         inputContextJob?.cancel()
         inputContextJob = nativeInputStateProvider.state
-            .onEach { lastInputContext = it.inputContext }
+            .onEach { state ->
+                lastInputContext = state.inputContext
+                lastNativeInputState = state
+                updateVisibility()
+            }
             .launchIn(scope)
     }
 
@@ -251,6 +263,7 @@ class ModelPickerView @JvmOverloads constructor(
         inputContextJob = null
         commandJob?.cancel()
         commandJob = null
+        lastNativeInputState = null
         dismissPopup()
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -1323,3 +1323,13 @@ internal fun NativeInputState.shouldShowTrailingFireButton(): Boolean =
 internal fun NativeInputState.shouldSuppressBottomRow(): Boolean =
     inputMode == NativeInputState.InputMode.SEARCH_ONLY &&
         inputContext == NativeInputState.InputContext.BROWSER
+
+/**
+ * Bottom-row controls (model / reasoning / options / attachment) are shown only on the Duck.ai
+ * chat tab and only when no chat is streaming. While streaming, the bottom row stays visible for
+ * the stop button but these controls are hidden.
+ */
+internal fun shouldShowInputControls(
+    onChatTab: Boolean,
+    isStreaming: Boolean,
+): Boolean = onChatTab && !isStreaming

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -337,10 +337,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
                         is NativeInputModeWidgetViewModel.Command.UpdatePluginVisibility -> {
                             for (containerId in command.containerIds) {
                                 if (containerId == R.id.startChatContainer) continue
-                                findViewById<FrameLayout?>(containerId)?.isVisible = command.visible
+                                findViewById<FrameLayout?>(containerId)?.isVisible = command.visible && !isStreaming
                             }
                             findViewById<FrameLayout?>(R.id.attachmentsContainer)?.isVisible =
-                                command.visible && hasAttachments
+                                command.visible && hasAttachments && !isStreaming
                         }
                     }
                 }
@@ -487,6 +487,16 @@ class NativeInputModeWidget @JvmOverloads constructor(
             (inputField.hasFocus() || previewEnterFocus || isStreaming) &&
             !suppress
         bottomRow.visibility = if (visible) VISIBLE else GONE
+    }
+
+    private fun updateControlsVisibility() {
+        val show = shouldShowInputControls(isChatTabSelected(), isStreaming)
+        findViewById<View?>(R.id.modelPickerContainer)?.isVisible = show
+        findViewById<View?>(R.id.reasoningModePickerContainer)?.isVisible = show
+        findViewById<View?>(R.id.optionsButtonContainer)?.isVisible = show
+        findViewById<View?>(R.id.attachmentsContainer)?.isVisible = show && hasAttachments
+        // attach button keeps its own supportsUpload gate; setImageButtonVisible folds in !isStreaming
+        setImageButtonVisible(isChatTabSelected() && supportsUpload)
     }
 
     private fun updateToggleVisibilityForState() {
@@ -1177,6 +1187,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
             floatingSubmitContainer?.visibility = if (attachmentLimitExceeded) GONE else VISIBLE
         }
         updateBottomRowVisibility()
+        updateControlsVisibility()
         updateSendButtonVisibility()
         updateVoiceButtonVisibility()
         updateNewLineButtonVisibility()
@@ -1197,7 +1208,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     override fun setImageButtonVisible(visible: Boolean) {
-        findViewById<FrameLayout?>(R.id.attachButtonContainer)?.isVisible = visible
+        findViewById<FrameLayout?>(R.id.attachButtonContainer)?.isVisible = visible && !isStreaming
     }
 
     override fun setFloatingSubmitContainer(container: ViewGroup) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -491,8 +491,12 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     private fun updateControlsVisibility() {
         val show = shouldShowInputControls(isChatTabSelected(), isStreaming)
-        findViewById<View?>(R.id.modelPickerContainer)?.isVisible = show
-        findViewById<View?>(R.id.reasoningModePickerContainer)?.isVisible = show
+        // The model/reasoning pickers are additionally owned by OptionsView, which hides them for
+        // tools that don't use them (e.g. image generation). Respect that so restoring controls
+        // after streaming doesn't re-show pickers that should stay hidden.
+        val showPickers = show && (optionsView?.pickersEnabled ?: true)
+        findViewById<View?>(R.id.modelPickerContainer)?.isVisible = showPickers
+        findViewById<View?>(R.id.reasoningModePickerContainer)?.isVisible = showPickers
         findViewById<View?>(R.id.optionsButtonContainer)?.isVisible = show
         findViewById<View?>(R.id.attachmentsContainer)?.isVisible = show && hasAttachments
         // attach button keeps its own supportsUpload gate; setImageButtonVisible folds in !isStreaming

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -112,7 +112,6 @@ interface NativeInputWidget {
     fun setVoiceChatAvailable(available: Boolean)
     fun submitMessage(message: String?)
     fun submitAsChat(): Boolean
-    fun setImageButtonVisible(visible: Boolean)
     fun setToggleVisible(visible: Boolean)
     fun setFloatingSubmitContainer(container: ViewGroup)
     fun getSelectedModelId(): String?
@@ -201,7 +200,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private var tabCountLiveData: LiveData<Int>? = null
     private var tabCountObserver: Observer<Int>? = null
     private var submitButtons: InputScreenButtons? = null
-    private var streamingButtons: InputScreenButtons? = null
     private var floatingButtons: InputScreenButtons? = null
     private var floatingSubmitContainer: ViewGroup? = null
     private var chatStateJob: Job? = null
@@ -220,7 +218,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private var isStreaming: Boolean = false
     private var attachmentLimitExceeded: Boolean = false
     private var hasAttachments: Boolean = false
-    private var supportsUpload: Boolean = true
     private var nativeInputState: NativeInputState? = null
     private var chatSuggestionsBinding: NativeInputChatSuggestionsBinder.Binding? = null
     private var onShowSuggestions: ((RecyclerView.Adapter<*>) -> Unit)? = null
@@ -333,20 +330,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
                 }
             }
             launch {
-                viewModel.commands.collect { command ->
-                    when (command) {
-                        is NativeInputModeWidgetViewModel.Command.UpdatePluginVisibility -> {
-                            for (containerId in command.containerIds) {
-                                if (containerId == R.id.startChatContainer) continue
-                                findViewById<FrameLayout?>(containerId)?.isVisible = command.visible && !isStreaming
-                            }
-                            findViewById<FrameLayout?>(R.id.attachmentsContainer)?.isVisible =
-                                command.visible && hasAttachments && !isStreaming
-                        }
-                    }
-                }
-            }
-            launch {
                 viewModel.modelPickerEnabled.collect { enabled ->
                     modelPickerView?.setPickerEnabled(enabled)
                 }
@@ -360,7 +343,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
             attachmentView = pluginView
             pluginView.onCameraCaptureRequested = pendingCameraCaptureCallback
             pluginView.onFilePickerRequested = pendingFilePickerCallback
-            pluginView.bind(scope, viewModelFactory)
+            pluginView.bind(scope, viewModelFactory, nativeInputStateProvider)
         }
         (pluginView as? ModelPicker)?.let { picker ->
             picker.onMenuShown = { isModelMenuVisible = true }
@@ -399,7 +382,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
         chatIdJob = null
         modelPickerView = null
         optionsView = null
-        streamingButtons = null
         widgetRoot = null
         tearDownChatSuggestions()
     }
@@ -490,20 +472,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
             !isStreaming &&
             !suppress
         bottomRow.visibility = if (visible) VISIBLE else GONE
-    }
-
-    private fun updateControlsVisibility() {
-        val show = shouldShowInputControls(isChatTabSelected(), isStreaming)
-        // The model/reasoning pickers are additionally owned by OptionsView, which hides them for
-        // tools that don't use them (e.g. image generation). Respect that so restoring controls
-        // after streaming doesn't re-show pickers that should stay hidden.
-        val showPickers = show && (optionsView?.pickersEnabled ?: true)
-        findViewById<View?>(R.id.modelPickerContainer)?.isVisible = showPickers
-        findViewById<View?>(R.id.reasoningModePickerContainer)?.isVisible = showPickers
-        findViewById<View?>(R.id.optionsButtonContainer)?.isVisible = show
-        findViewById<View?>(R.id.attachmentsContainer)?.isVisible = show && hasAttachments
-        // attach button keeps its own supportsUpload gate; setImageButtonVisible folds in !isStreaming
-        setImageButtonVisible(isChatTabSelected() && supportsUpload)
     }
 
     private fun updateToggleVisibilityForState() {
@@ -708,14 +676,12 @@ class NativeInputModeWidget @JvmOverloads constructor(
                 override fun onTabSelected(tab: TabLayout.Tab) {
                     applyTabUi()
                     pushToggleSelectionIfUserDriven()
-                    viewModel.updatePluginContainerVisibility(isChatTabSelected())
                     refreshTabDependentButtons()
                 }
                 override fun onTabUnselected(tab: TabLayout.Tab) {}
                 override fun onTabReselected(tab: TabLayout.Tab) {
                     applyTabUi()
                     pushToggleSelectionIfUserDriven()
-                    viewModel.updatePluginContainerVisibility(isChatTabSelected())
                     refreshTabDependentButtons()
                 }
             },
@@ -1186,19 +1152,12 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private fun setChatStreaming(streaming: Boolean) {
         isStreaming = streaming
         configureSubmitButtons()
-        val streamingContainer = findViewById<FrameLayout?>(R.id.streamingButtonsContainer)
-        if (streaming) {
-            streamingContainer?.visibility = VISIBLE
-            streamingButtons?.showStopButton()
-            streamingButtons?.setSendButtonVisible(true)
-        } else {
-            streamingContainer?.visibility = GONE
+        if (!streaming) {
             submitButtons?.showSendButton()
             applyTabUi()
             floatingSubmitContainer?.visibility = if (attachmentLimitExceeded) GONE else VISIBLE
         }
         updateBottomRowVisibility()
-        updateControlsVisibility()
         updateSendButtonVisibility()
         updateVoiceButtonVisibility()
         updateNewLineButtonVisibility()
@@ -1207,7 +1166,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private fun applyTabUi() {
         val toggle = findViewById<TabLayout?>(R.id.inputModeSwitch) ?: return
         val isChatTab = toggle.selectedTabPosition == 1
-        setImageButtonVisible(isChatTab && supportsUpload)
         updateSendButtonIcon()
         if (isChatTab) {
             inputField.minLines = 1
@@ -1218,10 +1176,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
         updateBottomRowVisibility()
     }
 
-    override fun setImageButtonVisible(visible: Boolean) {
-        findViewById<FrameLayout?>(R.id.attachButtonContainer)?.isVisible = visible && !isStreaming
-    }
-
     override fun setFloatingSubmitContainer(container: ViewGroup) {
         floatingSubmitContainer = container
     }
@@ -1230,6 +1184,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
         // in Duck.ai mode we treat this as submitting prompts.
         // In non-Duck.ai mode we treat this as starting a chat with or without a prompt.
         if (!submitAsChat()) viewModel.openNewChat()
+    }
+
+    override fun stop() {
+        onStopTapped?.invoke()
     }
 
     override fun showAttachmentChooser(showing: Boolean) {
@@ -1244,8 +1202,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val hadLimitError = attachmentLimitExceeded
         attachmentLimitExceeded = limitExceeded
         this.hasAttachments = hasAttachments
-        this.supportsUpload = supportsUpload
-        setImageButtonVisible(isChatTabSelected() && supportsUpload)
         if (hadLimitError != attachmentLimitExceeded && !isStreaming) {
             floatingSubmitContainer?.visibility = if (attachmentLimitExceeded) GONE else VISIBLE
         }
@@ -1281,23 +1237,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
             }
             bottomContainer.addView(buttons)
             submitButtons = buttons
-        }
-
-        if (streamingButtons == null) {
-            val streamingContainer = findViewById<FrameLayout?>(R.id.streamingButtonsContainer)
-            if (streamingContainer != null) {
-                val buttons = InputScreenButtons(
-                    context = context,
-                    useTopBar = false,
-                    layoutResId = R.layout.view_native_input_screen_buttons,
-                ).apply {
-                    onStopClick = { this@NativeInputModeWidget.onStopTapped?.invoke() }
-                    setSendButtonVisible(false)
-                    setNewLineButtonVisible(false)
-                }
-                streamingContainer.addView(buttons)
-                streamingButtons = buttons
-            }
         }
 
         val floating = floatingSubmitContainer
@@ -1372,3 +1311,11 @@ internal fun shouldShowInputControls(
     onChatTab: Boolean,
     isStreaming: Boolean,
 ): Boolean = onChatTab && !isStreaming
+
+/**
+ * Plugin controls (model picker, reasoning picker, options, attach button) are shown only on
+ * the Duck.ai chat tab and only when no chat is streaming. Derived purely from [NativeInputState]
+ * so it is unit-testable without Robolectric.
+ */
+internal fun NativeInputState.shouldShowPluginControls(): Boolean =
+    toggleSelection == NativeInputState.ToggleSelection.DUCK_AI && !isChatStreaming

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -201,6 +201,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private var tabCountLiveData: LiveData<Int>? = null
     private var tabCountObserver: Observer<Int>? = null
     private var submitButtons: InputScreenButtons? = null
+    private var streamingButtons: InputScreenButtons? = null
     private var floatingButtons: InputScreenButtons? = null
     private var floatingSubmitContainer: ViewGroup? = null
     private var chatStateJob: Job? = null
@@ -398,6 +399,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         chatIdJob = null
         modelPickerView = null
         optionsView = null
+        streamingButtons = null
         widgetRoot = null
         tearDownChatSuggestions()
     }
@@ -484,7 +486,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val bottomRow = findViewById<View?>(R.id.inputModeWidgetBottomRow) ?: return
         val suppress = nativeInputState?.shouldSuppressBottomRow() == true
         val visible = isChatTabSelected() &&
-            (inputField.hasFocus() || previewEnterFocus || isStreaming) &&
+            (inputField.hasFocus() || previewEnterFocus) &&
+            !isStreaming &&
             !suppress
         bottomRow.visibility = if (visible) VISIBLE else GONE
     }
@@ -1183,9 +1186,13 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private fun setChatStreaming(streaming: Boolean) {
         isStreaming = streaming
         configureSubmitButtons()
+        val streamingContainer = findViewById<FrameLayout?>(R.id.streamingButtonsContainer)
         if (streaming) {
-            submitButtons?.showStopButton()
+            streamingContainer?.visibility = VISIBLE
+            streamingButtons?.showStopButton()
+            streamingButtons?.setSendButtonVisible(true)
         } else {
+            streamingContainer?.visibility = GONE
             submitButtons?.showSendButton()
             applyTabUi()
             floatingSubmitContainer?.visibility = if (attachmentLimitExceeded) GONE else VISIBLE
@@ -1274,6 +1281,23 @@ class NativeInputModeWidget @JvmOverloads constructor(
             }
             bottomContainer.addView(buttons)
             submitButtons = buttons
+        }
+
+        if (streamingButtons == null) {
+            val streamingContainer = findViewById<FrameLayout?>(R.id.streamingButtonsContainer)
+            if (streamingContainer != null) {
+                val buttons = InputScreenButtons(
+                    context = context,
+                    useTopBar = false,
+                    layoutResId = R.layout.view_native_input_screen_buttons,
+                ).apply {
+                    onStopClick = { this@NativeInputModeWidget.onStopTapped?.invoke() }
+                    setSendButtonVisible(false)
+                    setNewLineButtonVisible(false)
+                }
+                streamingContainer.addView(buttons)
+                streamingButtons = buttons
+            }
         }
 
         val floating = floatingSubmitContainer

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -397,11 +397,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         chatStateJob = viewModel.chatState
             .drop(1)
             .onEach { state ->
-                // Streaming is driven from applyState (NativeInputState.isChatStreaming), not here:
-                // this flow drops its initial emission, so on a re-attach mid-stream it would never
-                // set isStreaming and the bottom row would desync from the state-driven plugin
-                // controls. observeChatState owns only the HIDE/SHOW/READY root-visibility
-                // transitions, which intentionally skip the replayed value via drop(1).
+                setChatStreaming(state == ChatState.STREAMING || state == ChatState.LOADING)
                 when (state) {
                     ChatState.HIDE -> {
                         isFocussed = hasInputFocus()
@@ -565,13 +561,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val contextChanged = previousState?.inputContext != state.inputContext
         val positionChanged = previousState?.isBottom != state.isBottom
         nativeInputState = state
-        // NativeInputState is the single source of truth for streaming. Syncing isStreaming here
-        // (rather than only from observeChatState, which drops its initial emission) keeps the
-        // bottom row consistent with the state-driven plugin controls when the widget re-attaches
-        // while a chat is already streaming.
-        if (isStreaming != state.isChatStreaming) {
-            setChatStreaming(state.isChatStreaming)
-        }
         findViewById<TabLayout?>(R.id.inputModeSwitch)?.let { toggle ->
             setToggleMatchParent()
             updateToggleVisibility(toggle, state)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -397,7 +397,11 @@ class NativeInputModeWidget @JvmOverloads constructor(
         chatStateJob = viewModel.chatState
             .drop(1)
             .onEach { state ->
-                setChatStreaming(state == ChatState.STREAMING || state == ChatState.LOADING)
+                // Streaming is driven from applyState (NativeInputState.isChatStreaming), not here:
+                // this flow drops its initial emission, so on a re-attach mid-stream it would never
+                // set isStreaming and the bottom row would desync from the state-driven plugin
+                // controls. observeChatState owns only the HIDE/SHOW/READY root-visibility
+                // transitions, which intentionally skip the replayed value via drop(1).
                 when (state) {
                     ChatState.HIDE -> {
                         isFocussed = hasInputFocus()
@@ -561,6 +565,13 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val contextChanged = previousState?.inputContext != state.inputContext
         val positionChanged = previousState?.isBottom != state.isBottom
         nativeInputState = state
+        // NativeInputState is the single source of truth for streaming. Syncing isStreaming here
+        // (rather than only from observeChatState, which drops its initial emission) keeps the
+        // bottom row consistent with the state-driven plugin controls when the widget re-attaches
+        // while a chat is already streaming.
+        if (isStreaming != state.isChatStreaming) {
+            setChatStreaming(state.isChatStreaming)
+        }
         findViewById<TabLayout?>(R.id.inputModeSwitch)?.let { toggle ->
             setToggleMatchParent()
             updateToggleVisibility(toggle, state)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
@@ -34,6 +34,8 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.common.utils.ViewViewModelFactory
 import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.models.Tool
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
@@ -48,6 +50,8 @@ import javax.inject.Inject
 class OptionsView(context: Context, private val host: NativeInputHost) : LinearLayout(context) {
 
     @Inject lateinit var viewModelFactory: ViewViewModelFactory
+
+    @Inject lateinit var nativeInputStateProvider: NativeInputStateProvider
 
     private val viewModel by lazy {
         ViewModelProvider(findViewTreeViewModelStoreOwner()!!, viewModelFactory)[OptionsViewModel::class.java]
@@ -81,6 +85,8 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
     private var popupWindow: PopupWindow? = null
     private var optionsButton: ImageView
     private var selectedToolJob: Job? = null
+    private var nativeInputStateJob: Job? = null
+    private var lastNativeInputState: NativeInputState? = null
 
     init {
         orientation = HORIZONTAL
@@ -93,12 +99,16 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
         AndroidSupportInjection.inject(this)
         super.onAttachedToWindow()
         observeSelectedTool()
+        observeNativeInputState()
     }
 
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
         selectedToolJob?.cancel()
         selectedToolJob = null
+        nativeInputStateJob?.cancel()
+        nativeInputStateJob = null
+        lastNativeInputState = null
         dismissPopup()
     }
 
@@ -108,6 +118,23 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
         selectedToolJob = viewModel.selectedTool
             .onEach { tool -> renderSelection(tool) }
             .launchIn(lifecycleOwner.lifecycleScope)
+    }
+
+    private fun observeNativeInputState() {
+        val scope = findViewTreeLifecycleOwner()?.lifecycleScope ?: return
+        nativeInputStateJob?.cancel()
+        nativeInputStateJob = nativeInputStateProvider.state
+            .onEach { state ->
+                lastNativeInputState = state
+                updateContainerVisibility()
+            }
+            .launchIn(scope)
+    }
+
+    private fun updateContainerVisibility() {
+        val show = lastNativeInputState?.shouldShowPluginControls() == true
+        isVisible = show
+        (parent as? View)?.isVisible = show
     }
 
     private fun renderSelection(tool: Tool?) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
@@ -53,6 +53,9 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
         ViewModelProvider(findViewTreeViewModelStoreOwner()!!, viewModelFactory)[OptionsViewModel::class.java]
     }
 
+    /** Whether the model / reasoning pickers are allowed for the current tool selection. */
+    val pickersEnabled: Boolean get() = viewModel.shouldShowPickers
+
     private data class MenuItem(
         val iconRes: Int,
         val titleRes: Int,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerView.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.Gravity
 import android.view.LayoutInflater
+import android.view.View
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.LinearLayout
@@ -35,6 +36,7 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.common.utils.ViewViewModelFactory
 import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputContext
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.impl.DuckChatConstants.DUCK_AI_FEATURE_PAGE
@@ -74,6 +76,7 @@ class ReasoningModePickerView @JvmOverloads constructor(
     // Mirrors the input context from the per-tab native input state so currentSurface() can be
     // read synchronously from popup callbacks. Updated by observeInputContext().
     private var lastInputContext: InputContext = InputContext.BROWSER
+    private var lastNativeInputState: NativeInputState? = null
 
     init {
         inflate(context, R.layout.view_reasoning_mode_picker, this)
@@ -95,6 +98,7 @@ class ReasoningModePickerView @JvmOverloads constructor(
         inputContextJob = null
         commandJob?.cancel()
         commandJob = null
+        lastNativeInputState = null
         dismissPopup()
     }
 
@@ -102,8 +106,22 @@ class ReasoningModePickerView @JvmOverloads constructor(
         val scope = findViewTreeLifecycleOwner()?.lifecycleScope ?: return
         inputContextJob?.cancel()
         inputContextJob = nativeInputStateProvider.state
-            .onEach { lastInputContext = it.inputContext }
+            .onEach { state ->
+                lastInputContext = state.inputContext
+                lastNativeInputState = state
+                applyVisibility(viewModel.state.value.visible)
+            }
             .launchIn(scope)
+    }
+
+    private fun applyVisibility(pickerVisible: Boolean) {
+        val nativeState = lastNativeInputState
+        val show = pickerVisible && nativeState?.shouldShowPluginControls() == true
+        isVisible = show
+        (parent as? View)?.isVisible = show
+        // Popup is positioned by screen coordinates, not parented to the button. Dismiss
+        // it explicitly when picker hides or stale rows stay tappable for the new chat.
+        if (!show) dismissPopup()
     }
 
     private fun observeState() {
@@ -111,10 +129,7 @@ class ReasoningModePickerView @JvmOverloads constructor(
         stateJob?.cancel()
         stateJob = viewModel.state
             .onEach { state ->
-                isVisible = state.visible
-                // Popup is positioned by screen coordinates, not parented to the button. Dismiss
-                // it explicitly when picker hides or stale rows stay tappable for the new chat.
-                if (!state.visible) dismissPopup()
+                applyVisibility(state.visible)
                 state.displayedMode?.let { mode ->
                     button.setImageResource(viewModel.iconResFor(mode))
                 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StopStreamingView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StopStreamingView.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.nativeinput.views
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import android.widget.FrameLayout
+import android.widget.ImageView
+import androidx.core.view.isVisible
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeViewModelStoreOwner
+import androidx.lifecycle.lifecycleScope
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.common.utils.ViewViewModelFactory
+import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.duckchat.impl.R
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+
+@InjectWith(ViewScope::class)
+class StopStreamingView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyle: Int = 0,
+) : FrameLayout(context, attrs, defStyle) {
+
+    @Inject lateinit var viewModelFactory: ViewViewModelFactory
+
+    private val viewModel by lazy {
+        ViewModelProvider(findViewTreeViewModelStoreOwner()!!, viewModelFactory)[StopStreamingViewModel::class.java]
+    }
+
+    private val button: ImageView by lazy { findViewById(R.id.stopStreamingButton) }
+    private var visibilityJob: Job? = null
+
+    var onStopClicked: (() -> Unit)? = null
+
+    init {
+        inflate(context, R.layout.view_stop_streaming, this)
+    }
+
+    override fun onAttachedToWindow() {
+        AndroidSupportInjection.inject(this)
+        super.onAttachedToWindow()
+        button.setOnClickListener { onStopClicked?.invoke() }
+        observeVisibility()
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        visibilityJob?.cancel()
+        visibilityJob = null
+    }
+
+    private fun observeVisibility() {
+        val scope = findViewTreeLifecycleOwner()?.lifecycleScope ?: return
+        visibilityJob?.cancel()
+        visibilityJob = viewModel.isVisible
+            .onEach { visible ->
+                isVisible = visible
+                (parent as? View)?.isVisible = visible
+            }
+            .launchIn(scope)
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StopStreamingViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StopStreamingViewModel.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.nativeinput.views
+
+import androidx.lifecycle.ViewModel
+import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+@ContributesViewModel(ViewScope::class)
+class StopStreamingViewModel @Inject constructor(
+    nativeInputStateProvider: NativeInputStateProvider,
+) : ViewModel() {
+
+    /** Show the stop button only while the chat is actively streaming a response. */
+    val isVisible: Flow<Boolean> = nativeInputStateProvider.state.map { it.isChatStreaming }
+}

--- a/duckchat/duckchat-impl/src/main/res/layout/view_native_input_mode_switch_widget.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_native_input_mode_switch_widget.xml
@@ -168,6 +168,13 @@
                         android:visibility="gone"
                         tools:visibility="visible" />
 
+                    <FrameLayout
+                        android:id="@+id/streamingButtonsContainer"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:visibility="gone" />
+
                 </LinearLayout>
                 <FrameLayout
                     android:id="@id/attachmentsContainer"

--- a/duckchat/duckchat-impl/src/main/res/layout/view_stop_streaming.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_stop_streaming.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <ImageView
+        android:id="@+id/stopStreamingButton"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:layout_gravity="end|center_vertical"
+        android:background="@drawable/background_input_screen_button"
+        android:backgroundTint="?attr/daxColorControlFillPrimary"
+        android:contentDescription="@string/duckChatStopStreamingContentDescription"
+        android:foreground="@drawable/selectable_circular_ripple"
+        android:importantForAccessibility="no"
+        android:scaleType="centerInside"
+        app:srcCompat="@drawable/ic_stop_16"
+        app:tint="?attr/daxColorPrimaryIcon" />
+
+</merge>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -41,6 +41,7 @@
 
     <!-- Start chat icon content description -->
     <string name="duckChatStartChatContentDescription">Start chat</string>
+    <string name="duckChatStopStreamingContentDescription">Stop generating</string>
 
     <!-- Image attachment -->
     <string name="duckChatImageAttachmentRemoveContentDescription">Remove image</string>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputControlsVisibilityTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputControlsVisibilityTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui
+
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.shouldShowInputControls
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NativeInputControlsVisibilityTest {
+
+    @Test
+    fun `controls shown on chat tab when not streaming`() {
+        assertTrue(shouldShowInputControls(onChatTab = true, isStreaming = false))
+    }
+
+    @Test
+    fun `controls hidden on chat tab while streaming`() {
+        assertFalse(shouldShowInputControls(onChatTab = true, isStreaming = true))
+    }
+
+    @Test
+    fun `controls hidden off chat tab when not streaming`() {
+        assertFalse(shouldShowInputControls(onChatTab = false, isStreaming = false))
+    }
+
+    @Test
+    fun `controls hidden off chat tab while streaming`() {
+        assertFalse(shouldShowInputControls(onChatTab = false, isStreaming = true))
+    }
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -490,6 +490,30 @@ class NativeInputModeWidgetViewModelTest {
     }
 
     @Test
+    fun `state isChatStreaming is true when chatState is STREAMING`() = runTest {
+        chatStateFlow.value = ChatState.STREAMING
+        assertTrue(testee.state.firstOrNull()!!.isChatStreaming)
+    }
+
+    @Test
+    fun `state isChatStreaming is true when chatState is LOADING`() = runTest {
+        chatStateFlow.value = ChatState.LOADING
+        assertTrue(testee.state.firstOrNull()!!.isChatStreaming)
+    }
+
+    @Test
+    fun `state isChatStreaming is false when chatState is READY`() = runTest {
+        chatStateFlow.value = ChatState.READY
+        assertFalse(testee.state.firstOrNull()!!.isChatStreaming)
+    }
+
+    @Test
+    fun `state isChatStreaming is false when chatState is HIDE`() = runTest {
+        chatStateFlow.value = ChatState.HIDE
+        assertFalse(testee.state.firstOrNull()!!.isChatStreaming)
+    }
+
+    @Test
     fun whenChatStateFlowEmitsThenViewModelChatStateMirrorsIt() = runTest {
         chatStateFlow.value = ChatState.STREAMING
 
@@ -938,20 +962,6 @@ class NativeInputModeWidgetViewModelTest {
         viewModel.storePendingPrompt("hello", "model-1", null, selectedTool = "GenerateImage")
 
         verify(pendingNativePromptStore).store("hello", "model-1", null, "GenerateImage", emptyList(), emptyList())
-    }
-
-    @Test
-    fun whenUpdatePluginContainerVisibilityThenSendsCommand() = runTest {
-        val plugin = fakePlugin(containerId = 99)
-        val viewModel = createViewModel(plugins = listOf(plugin))
-
-        viewModel.updatePluginContainerVisibility(isChatTab = true)
-
-        val command = viewModel.commands.firstOrNull()
-        assertTrue(command is NativeInputModeWidgetViewModel.Command.UpdatePluginVisibility)
-        val update = command as NativeInputModeWidgetViewModel.Command.UpdatePluginVisibility
-        assertEquals(listOf(99), update.containerIds)
-        assertTrue(update.visible)
     }
 
     private fun fakePlugin(containerId: Int): NativeInputPlugin {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputPluginVisibilityTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputPluginVisibilityTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui
+
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputContext
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputMode
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.ToggleSelection
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.shouldShowPluginControls
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NativeInputPluginVisibilityTest {
+
+    @Test
+    fun `plugin controls shown on duck ai tab when not streaming`() {
+        val state = stateOf(ToggleSelection.DUCK_AI, isChatStreaming = false)
+        assertTrue(state.shouldShowPluginControls())
+    }
+
+    @Test
+    fun `plugin controls hidden on duck ai tab while streaming`() {
+        val state = stateOf(ToggleSelection.DUCK_AI, isChatStreaming = true)
+        assertFalse(state.shouldShowPluginControls())
+    }
+
+    @Test
+    fun `plugin controls hidden on search tab when not streaming`() {
+        val state = stateOf(ToggleSelection.SEARCH, isChatStreaming = false)
+        assertFalse(state.shouldShowPluginControls())
+    }
+
+    @Test
+    fun `plugin controls shown in duck ai context when not streaming`() {
+        // In DUCK_AI context there is no toggle; toggleSelection defaults to DUCK_AI.
+        // Plugin controls should show while not streaming.
+        val state = NativeInputState(
+            inputMode = NativeInputState.InputMode.SEARCH_AND_DUCK_AI,
+            inputContext = NativeInputState.InputContext.DUCK_AI,
+            isChatStreaming = false,
+        )
+        assertTrue(state.shouldShowPluginControls())
+    }
+
+    private fun stateOf(
+        toggleSelection: ToggleSelection,
+        isChatStreaming: Boolean,
+    ) = NativeInputState(
+        inputMode = InputMode.SEARCH_AND_DUCK_AI,
+        inputContext = InputContext.BROWSER,
+        toggleSelection = toggleSelection,
+        isChatStreaming = isChatStreaming,
+    )
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214882460531879

### Description
While a Duck.ai chat is streaming, the bottom-row controls (model picker, reasoning picker, options, attach button) are hidden and the stop button moves inline with the text field (row 1). When streaming ends the controls restore correctly.

Root cause: `updateBottomRowVisibility` kept the entire bottom row visible during streaming so the stop button would show — causing the four controls to flash visible too. Fix:
- Extracts a pure `shouldShowInputControls(onChatTab, isStreaming)` predicate (unit-tested)
- Adds a dedicated `streamingButtonsContainer` in the input field row for the stop button during streaming
- Hides the bottom row entirely while streaming (`!isStreaming` gate in `updateBottomRowVisibility`)
- Respects tool-picker state (image generation) when restoring controls after streaming ends

### Steps to test this PR

_Hide controls while streaming_
- [ ] Settings → AI Features → "Search Only"
- [ ] Focus the omnibar → tap the Duck.ai button to start a chat
- [ ] While streaming: only the stop button is visible, inline with the text field — model picker, reasoning picker, options and attach button are hidden, controls row is not visible
- [ ] After streaming ends: controls row reappears on focus with send button, model picker, reasoning picker, options and attach button visible as normal
- [ ] Sanity: in a focused Duck.ai input not streaming, all controls are visible as before

### UI changes
| Before  | After |
| ------ | ----- |
|Upload before screenshot|Upload after screenshot|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches omnibar/native input visibility and stop-stream wiring across multiple plugin views; behavior is covered by new unit tests but UX regressions on tab switch or streaming edge cases are possible.
> 
> **Overview**
> While Duck.ai is **streaming or loading**, the native input chrome no longer keeps the bottom tool row visible for a stop affordance. **`isChatStreaming`** is added to **`NativeInputState`**, driven from **`ChatState.STREAMING` / `LOADING`** in the widget ViewModel and published per tab.
> 
> **Stop** moves **inline** with the text field via a new **`StopStreamingNativeInputPlugin`** (`streamingButtonsContainer` + **`NativeInputHost.stop()`**). The bottom row is **fully hidden** during streaming (`updateBottomRowVisibility` gates on `!isStreaming`), and attach / model / reasoning / options plugins **self-hide** using **`shouldShowPluginControls()`** (Duck.ai tab + not streaming) instead of the removed **`UpdatePluginVisibility`** command channel and tab-driven container toggles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59141e8b00231d0f3ee9a771cb53578f28f9ee7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->