### PR TITLE
Fix RequestBlocklistTest on native input builds

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/espresso/RequestBlocklistTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/RequestBlocklistTest.kt
@@ -24,8 +24,10 @@ import androidx.test.espresso.IdlingResource
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.espresso.action.ViewActions.clearText
+import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.pressImeActionButton
 import androidx.test.espresso.action.ViewActions.typeText
+import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.web.model.Atoms
 import androidx.test.espresso.web.sugar.Web
@@ -73,7 +75,18 @@ class RequestBlocklistTest {
 
         WebViewIdlingResource(webView).track()
 
-        onView(withId(R.id.omnibarTextInput)).perform(
+        // On internal builds native input is enabled, which disables the legacy omnibar field
+        // and routes a tap to the unified input screen. Drive that flow — open the input screen
+        // and type the URL into the native input field — instead of typing into the disabled
+        // omnibar. Loading the warm-up page first also gives the privacy config time to load
+        // before the test page fires its requests.
+        // inputField lives in :duckchat-impl; resolve its id by name so we don't import an impl
+        // R class (forbidden by the NoImplImportsInAppModule lint rule).
+        val inputFieldId = inputFieldId()
+        onView(withId(R.id.omnibarTextInputClickCatcher)).perform(click())
+        onView(isRoot()).perform(waitFor(1000))
+        onView(isRoot()).perform(waitForView(withId(inputFieldId)))
+        onView(withId(inputFieldId)).perform(
             clearText(),
             typeText("https://privacy-test-pages.site/privacy-protections/request-blocklist/"),
             pressImeActionButton(),
@@ -81,7 +94,7 @@ class RequestBlocklistTest {
 
         WebViewIdlingResource(webView).track()
 
-        // Now register — window.results won't exist until the new page's finished() fires
+        // window.results won't exist until the request-blocklist page's finished() fires
         JsObjectIdlingResource(webView, "window.results").track()
 
         val results = Web.onWebView()
@@ -107,6 +120,12 @@ class RequestBlocklistTest {
         val moshi = Moshi.Builder().add(JSONObjectAdapter()).build()
         val jsonAdapter: JsonAdapter<TestJson> = moshi.adapter(TestJson::class.java)
         return jsonAdapter.fromJson(jsonString)
+    }
+
+    private fun inputFieldId(): Int {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        return context.resources.getIdentifier("inputField", "id", context.packageName)
+            .also { require(it != 0) { "inputField id not found in ${context.packageName}" } }
     }
 
     private fun IdlingResource.track() = apply {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/1184843898389381/1215259352559550

### Description

The nightly **Internal Privacy Tests** job started failing on `RequestBlocklistTest#whenRequestBlocklistIsEnabledRequestsAreHandledCorrectly`. The failure is **not a privacy regression** — it's an Espresso `PerformException`.

`Enable native input for internal builds (#8588)` set `DuckChatFeature.nativeInputField()` to default `INTERNAL`. On internal builds the omnibar now disables the legacy `omnibarTextInput` EditText and overlays a click-catcher that routes taps to the unified input screen (`OmnibarLayout.kt:1504-1533`, driven by `showTextInputClickCatcher`). The test typed its URL straight into that EditText, and Espresso refuses `typeText()` on a disabled view (`is-enabled=false`, no input connection). The sibling `@PrivacyTest` suite runs on the **play** build (native input off) and still passes — the differential that confirms the cause.

Rather than bypassing the UI, this drives the **real internal-build flow**: after the warm-up page loads, tap the omnibar click-catcher to open the unified input screen and type the URL into the native `inputField` (the same path the unified-input e2e tests exercise). Loading the warm-up page first also lets the privacy config finish loading before the request-blocklist page fires its requests, which avoids a content-level race that a direct page load could hit.

### Steps to test this PR

_Internal Privacy Tests (API 34)_
- [x] Ran on a Pixel 8 Pro emulator (API 34, same level as CI's `MediumPhone.arm-34`): `RequestBlocklistTest#whenRequestBlocklistIsEnabledRequestsAreHandledCorrectly` **passes 4/4 runs** (~75s each — opens the unified input, navigates, and all assertions pass)
- [ ] The `Internal Privacy Tests` CI job passes — it runs this `@InternalPrivacyTest` on `MediumPhone.arm-34`

> Note: cannot be verified on API 36 (Android 16) devices/emulators — Espresso's input injection is incompatible there (`InputManager.getInstance` `NoSuchMethodException`), unrelated to this change. Run on API ≤34.

### UI changes

No UI changes — test-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Espresso change with no production code, auth, or data-handling impact.
> 
> **Overview**
> Updates **`RequestBlocklistTest`** so internal-build **Internal Privacy Tests** match the native-input omnibar flow instead of typing into the disabled legacy **`omnibarTextInput`**.
> 
> After the warm-up page loads, the test taps **`omnibarTextInputClickCatcher`**, waits for the unified input screen, then enters the request-blocklist URL in **`inputField`** (resolved at runtime via **`getIdentifier`** to avoid importing **`:duckchat-impl`** R IDs). WebView assertions are unchanged; only navigation setup differs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60439bd7739b7ef429692042e710b97ad7144cee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215278829316732