### PR TITLE
"Duck.ai: + menu in omnibar and fire button in the chat input""

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -273,9 +273,11 @@ import com.duckduckgo.browser.ui.browsermenu.BrowserMenuBottomSheet
 import com.duckduckgo.browser.ui.browsermenu.VpnMenuState
 import com.duckduckgo.browser.ui.newtab.hatch.NewTabReturnHatchView
 import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.FireModeAvailability
 import com.duckduckgo.browsermode.api.WebViewModeInitializer
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.DuckDuckGoFragment
+import com.duckduckgo.common.ui.menu.PopupMenu
 import com.duckduckgo.common.ui.store.BrowserAppTheme
 import com.duckduckgo.common.ui.tabs.SwipingTabsFeatureProvider
 import com.duckduckgo.common.ui.view.DaxDialog
@@ -635,6 +637,9 @@ class BrowserTabFragment :
     lateinit var duckChat: DuckChat
 
     @Inject
+    lateinit var fireModeAvailability: FireModeAvailability
+
+    @Inject
     lateinit var duckAiFeatureState: DuckAiFeatureState
 
     @Inject
@@ -788,6 +793,24 @@ class BrowserTabFragment :
 
     private val browserActivity
         get() = activity as? BrowserActivity
+
+    // Duck.ai "+" popup menu, anchored to the omnibar + button (see popup_chat_menu.xml).
+    private val chatMenuPopup by lazy {
+        PopupMenu(layoutInflater, com.duckduckgo.duckchat.impl.R.layout.popup_chat_menu).apply {
+            onMenuItemClicked(contentView.findViewById(com.duckduckgo.duckchat.impl.R.id.chatMenuPopupNewChat)) {
+                viewModel.openNewDuckChat(omnibar.viewMode)
+            }
+            onMenuItemClicked(contentView.findViewById(com.duckduckgo.duckchat.impl.R.id.chatMenuPopupNewVoiceChat)) {
+                duckChat.openVoiceDuckChat()
+            }
+            onMenuItemClicked(contentView.findViewById(com.duckduckgo.duckchat.impl.R.id.chatMenuPopupNewTab)) {
+                browserActivity?.launchNewTab()
+            }
+            onMenuItemClicked(contentView.findViewById(com.duckduckgo.duckchat.impl.R.id.chatMenuPopupNewFireTab)) {
+                browserActivity?.launchNewTab()
+            }
+        }
+    }
 
     private var webView: DuckDuckGoWebView? = null
     private var isWebViewGestureInProgress = false
@@ -1423,6 +1446,7 @@ class BrowserTabFragment :
                         ),
                     )
                 },
+                onFireButtonPressed = { onFireButtonPressed() },
                 onVoiceSearchPressed = { isChatTab ->
                     val mode = if (isChatTab) VoiceSearchMode.DUCK_AI else VoiceSearchMode.SEARCH
                     webView?.onPause()
@@ -3766,6 +3790,17 @@ class BrowserTabFragment :
 
                 override fun onFireButtonPressed() {
                     this@BrowserTabFragment.onFireButtonPressed()
+                }
+
+                override fun onPlusButtonPressed(anchor: View) {
+                    val activity = activity ?: return
+                    // Only offer "New Fire Tab" to users whose feature flag + WebView profile
+                    // support actually allow Fire Mode. Re-checked on each open so a WebView/flag
+                    // change is reflected without rebuilding the menu.
+                    chatMenuPopup.contentView
+                        .findViewById<View>(com.duckduckgo.duckchat.impl.R.id.chatMenuPopupNewFireTab)
+                        .isVisible = fireModeAvailability.isAvailable()
+                    chatMenuPopup.showAnchoredView(activity, binding.rootView, anchor)
                 }
 
                 override fun onBrowserMenuPressed() {

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -73,6 +73,7 @@ class NativeInputCallbacks(
     val onChatHistoryShortcutClicked: () -> Unit = {},
     val onClearAutocomplete: () -> Unit,
     val onStopTapped: () -> Unit,
+    val onFireButtonPressed: () -> Unit = {},
     val onVoiceSearchPressed: (isChatTab: Boolean) -> Unit = {},
     val onCameraCaptureRequested: (ValueCallback<Array<Uri>>) -> Unit = {},
     val onFilePickerRequested: (ValueCallback<Array<Uri>>, List<String>) -> Unit = { _, _ -> },
@@ -541,6 +542,7 @@ class RealNativeInputManager @Inject constructor(
     ) {
         widgetFrom(widgetView)?.apply {
             onStopTapped = callbacks.onStopTapped
+            onFireButtonTapped = callbacks.onFireButtonPressed
             bindTabCount(lifecycleOwner, tabs.map { it.size })
             hideMainButtons()
             onAttachmentChooserStateChanged = { showing -> isPickingImage = showing }

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
@@ -69,6 +69,8 @@ class Omnibar(
 
         fun onFireButtonPressed()
 
+        fun onPlusButtonPressed(anchor: View)
+
         fun onBrowserMenuPressed()
 
         fun onPrivacyShieldPressed()

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -166,6 +166,7 @@ class OmnibarLayout @JvmOverloads constructor(
         val showSpacer: Boolean,
         val showDuckSidebar: Boolean,
         val showDuckBack: Boolean,
+        val isDuckAiMode: Boolean,
     )
 
     @Inject
@@ -283,6 +284,7 @@ class OmnibarLayout @JvmOverloads constructor(
     override val omnibarTextInput: KeyboardAwareEditText by lazy { findViewById(R.id.omnibarTextInput) }
     internal val tabsMenu: TabSwitcherButton by lazy { findViewById(R.id.tabsMenu) }
     internal val fireIconMenu: FrameLayout by lazy { findViewById(R.id.fireIconMenu) }
+    internal val plusIconMenu: FrameLayout by lazy { findViewById(R.id.plusIconMenu) }
     internal val aiChatMenu: View? by lazy { findViewById(R.id.aiChatIconMenu) }
     private val aiChatDivider: View by lazy { findViewById(R.id.verticalDivider) }
     internal val browserMenu: FrameLayout by lazy { findViewById(R.id.browserMenu) }
@@ -334,6 +336,7 @@ class OmnibarLayout @JvmOverloads constructor(
                     addTarget(clearTextButton)
                     addTarget(voiceSearchButton)
                     addTarget(fireIconMenu)
+                    addTarget(plusIconMenu)
                     addTarget(tabsMenu)
                     addTarget(aiChatMenu)
                     addTarget(browserMenu)
@@ -565,6 +568,9 @@ class OmnibarLayout @JvmOverloads constructor(
                 viewModel.onFireIconPressed(isPulseAnimationPlaying())
             }
             omnibarItemPressedListener?.onFireButtonPressed()
+        }
+        plusIconMenu.setOnClickListener {
+            omnibarItemPressedListener?.onPlusButtonPressed(it)
         }
         browserMenu.setOnClickListener {
             omnibarItemPressedListener?.onBrowserMenuPressed()
@@ -843,11 +849,13 @@ class OmnibarLayout @JvmOverloads constructor(
                 showSpacer = viewState.showClearButton || viewState.showVoiceSearch,
                 showDuckSidebar = viewState.showDuckAISidebar,
                 showDuckBack = viewState.showDuckAISidebar,
+                isDuckAiMode = viewState.viewMode is ViewMode.DuckAI,
             )
 
         if (omnibarAnimationManager.isFeatureEnabled() && previousTransitionState != null &&
             (
                 newTransitionState.showFireIcon != previousTransitionState?.showFireIcon ||
+                    newTransitionState.isDuckAiMode != previousTransitionState?.isDuckAiMode ||
                     newTransitionState.showTabsMenu != previousTransitionState?.showTabsMenu ||
                     newTransitionState.showBrowserMenu != previousTransitionState?.showBrowserMenu ||
                     newTransitionState.showDuckSidebar != previousTransitionState?.showDuckSidebar
@@ -859,7 +867,11 @@ class OmnibarLayout @JvmOverloads constructor(
         clearTextButton.isVisible = viewState.showClearButton
         voiceSearchButton.isVisible = viewState.showVoiceSearch
         tabsMenu.isVisible = newTransitionState.showTabsMenu
-        fireIconMenu.isVisible = newTransitionState.showFireIcon
+        // The fire/+ slot is shared: when the user is in a Duck.ai chat the + icon takes
+        // over from fire as the leading action. Driven by viewMode rather than a separate
+        // state flag so it can't drift out of sync with other state-update paths.
+        fireIconMenu.isVisible = newTransitionState.showFireIcon && !newTransitionState.isDuckAiMode
+        plusIconMenu.isVisible = newTransitionState.showFireIcon && newTransitionState.isDuckAiMode
         browserMenu.isVisible = newTransitionState.showBrowserMenu
         browserMenuHighlight.isVisible = newTransitionState.showBrowserMenuHighlight
         aiChatMenu?.isVisible = newTransitionState.showChatMenu

--- a/app/src/main/res/layout/input_mode_widget_card_view_bottom.xml
+++ b/app/src/main/res/layout/input_mode_widget_card_view_bottom.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (c) 2026 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,30 +18,57 @@
     android:id="@+id/inputModeBottomRoot"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="?daxColorSurface"
-    android:layout_gravity="bottom">
+    android:layout_gravity="bottom"
+    android:background="?daxColorSurface">
 
-    <!-- Negative bottom margin pulls the card down to account for the shadow -->
-    <com.google.android.material.card.MaterialCardView
-        android:id="@+id/inputModeWidgetCard"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/keyline_2"
-        android:layout_marginEnd="@dimen/keyline_2"
-        android:layout_marginBottom="@dimen/keyline_2"
-        android:layout_marginTop="@dimen/keyline_2"
-        app:cardBackgroundColor="?attr/daxColorWindow"
-        app:cardCornerRadius="26dp"
-        app:cardElevation="3dp"
-        app:cardUseCompatPadding="false">
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:paddingStart="@dimen/keyline_2"
+        android:paddingEnd="@dimen/keyline_2">
 
-        <com.duckduckgo.duckchat.impl.ui.nativeinput.views.NativeInputModeWidget
-            android:id="@+id/inputModeWidget"
-            android:paddingStart="@dimen/keyline_1"
-            android:paddingTop="@dimen/keyline_2"
-            android:paddingEnd="@dimen/keyline_1"
-            android:paddingBottom="@dimen/keyline_2"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
-    </com.google.android.material.card.MaterialCardView>
+        <FrameLayout
+            android:id="@+id/inputFieldFireIconMenu"
+            android:layout_width="@dimen/toolbarIcon"
+            android:layout_height="@dimen/toolbarIcon"
+            android:layout_marginEnd="@dimen/keyline_2"
+            android:background="@drawable/selectable_item_rounded_corner_background"
+            android:visibility="gone">
+
+            <ImageView
+                android:id="@+id/inputFieldFireIconImageview"
+                android:layout_width="@dimen/bottomNavIcon"
+                android:layout_height="@dimen/bottomNavIcon"
+                android:layout_gravity="center"
+                android:contentDescription="@string/fireMenu"
+                android:scaleType="center"
+                android:src="@drawable/ic_fire_24" />
+        </FrameLayout>
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/inputModeWidgetCard"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/keyline_2"
+            android:layout_marginBottom="@dimen/keyline_2"
+            android:layout_weight="1"
+            app:cardBackgroundColor="?attr/daxColorWindow"
+            app:cardCornerRadius="26dp"
+            app:cardElevation="3dp"
+            app:cardUseCompatPadding="false">
+
+            <com.duckduckgo.duckchat.impl.ui.nativeinput.views.NativeInputModeWidget
+                android:id="@+id/inputModeWidget"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingStart="@dimen/keyline_1"
+                android:paddingTop="@dimen/keyline_2"
+                android:paddingEnd="@dimen/keyline_1"
+                android:paddingBottom="@dimen/keyline_2" />
+
+        </com.google.android.material.card.MaterialCardView>
+
+    </LinearLayout>
 </com.duckduckgo.duckchat.impl.ui.nativeinput.views.NonCollapsingFrameLayout>

--- a/app/src/main/res/layout/view_omnibar.xml
+++ b/app/src/main/res/layout/view_omnibar.xml
@@ -496,8 +496,16 @@
                     android:layout_height="@dimen/toolbarIcon"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toStartOf="@id/browserMenu"
-                    app:layout_constraintStart_toEndOf="@id/fireIconMenu"
+                    app:layout_constraintStart_toEndOf="@id/leadingIconBarrier"
                     app:layout_constraintTop_toTopOf="parent" />
+
+                <androidx.constraintlayout.widget.Barrier
+                    android:id="@+id/leadingIconBarrier"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:barrierAllowsGoneWidgets="false"
+                    app:barrierDirection="end"
+                    app:constraint_referenced_ids="fireIconMenu,plusIconMenu" />
 
                 <FrameLayout
                     android:id="@+id/browserMenu"
@@ -535,7 +543,6 @@
                     android:layout_height="@dimen/toolbarIcon"
                     android:background="@drawable/selectable_item_rounded_corner_background"
                     app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintEnd_toStartOf="@id/tabsMenu"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent">
 
@@ -547,6 +554,26 @@
                         android:contentDescription="@string/fireMenu"
                         android:scaleType="center"
                         android:src="@drawable/ic_fire_24" />
+                </FrameLayout>
+
+                <FrameLayout
+                    android:id="@+id/plusIconMenu"
+                    android:layout_width="@dimen/toolbarIcon"
+                    android:layout_height="@dimen/toolbarIcon"
+                    android:background="@drawable/selectable_item_rounded_corner_background"
+                    android:visibility="gone"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent">
+
+                    <ImageView
+                        android:id="@+id/plusIconImageView"
+                        android:layout_width="@dimen/bottomNavIcon"
+                        android:layout_height="@dimen/bottomNavIcon"
+                        android:layout_gravity="center"
+                        android:contentDescription="@string/duckChatPlusButtonContentDescription"
+                        android:scaleType="center"
+                        android:src="@drawable/ic_add_24" />
                 </FrameLayout>
 
                 <Space

--- a/browser/browser-ui/src/main/res/values/donottranslate.xml
+++ b/browser/browser-ui/src/main/res/values/donottranslate.xml
@@ -30,4 +30,9 @@
     <string name="newTabReturnHatchTabClosed">Tab closed</string>
     <string name="newTabReturnHatchUndo">Undo</string>
     <string name="browserMenuChats">Chats</string>
+
+    <string name="chatMenuPopupNewChat">New Chat</string>
+    <string name="chatMenuPopupNewVoiceChat">New Voice Chat</string>
+    <string name="chatMenuPopupNewTab">New Tab</string>
+    <string name="chatMenuPopupNewFireTab">New Fire Tab</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -84,6 +84,7 @@ interface NativeInputWidget {
     var onSearchSelected: ((animate: Boolean) -> Unit)?
     var onChatSelected: ((animate: Boolean) -> Unit)?
     var onClearTextTapped: (() -> Unit)?
+    var onFireButtonTapped: (() -> Unit)?
     var onStopTapped: (() -> Unit)?
     var onVoiceSearchClick: (() -> Unit)?
     var onVoiceChatClick: (() -> Unit)?
@@ -274,7 +275,32 @@ class NativeInputModeWidget @JvmOverloads constructor(
         observeChatState()
         observeChatSuggestionsEnabled()
         observeNativeInputState()
+        bindLeadingFireButtonClick()
         if (onPaidTierChanged != null) observeTier()
+    }
+
+    /**
+     * The leading fire menu in the bottom-bar layout lives as a sibling of this widget
+     * (see input_mode_widget_card_view_bottom.xml). Wire its click here so it shares the
+     * same [onFireButtonTapped] callback as the trailing fire that lives inside the widget.
+     */
+    private fun bindLeadingFireButtonClick() {
+        leadingFireButtonView()?.setOnClickListener { onFireButtonTapped?.invoke() }
+    }
+
+    /**
+     * Walk up the view hierarchy looking for the leading fire menu. The button is a
+     * sibling-of-an-ancestor rather than a direct sibling of this widget — in the bottom-bar
+     * layout it lives outside the MaterialCardView that wraps this widget — so a single
+     * `parent.findViewById` isn't enough.
+     */
+    private fun leadingFireButtonView(): View? {
+        var current: android.view.ViewParent? = parent
+        while (current is ViewGroup) {
+            current.findViewById<View?>(R.id.inputFieldFireIconMenu)?.let { return it }
+            current = current.parent
+        }
+        return null
     }
 
     private fun setupPlugins() {
@@ -439,6 +465,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
             if (hasFocus) beginFocusTransition()
             updateBottomRowVisibility()
             applyVerticalPaddingForFocus()
+            nativeInputState?.let { updateFireButtonVisibility(it) }
             if (!hasFocus && isDuckAiPageContext()) {
                 hideKeyboard()
             }
@@ -544,6 +571,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
             updateToggleVisibility(toggle, state)
         }
         updateBackButtons(state)
+        updateFireButtonVisibility(state)
         updateBottomRowVisibility()
         applyVerticalPaddingForFocus()
         updateNewLineButtonVisibility()
@@ -582,6 +610,22 @@ class NativeInputModeWidget @JvmOverloads constructor(
         findViewById<View?>(R.id.inputModeWidgetBack)?.setBackgroundResource(
             com.duckduckgo.mobile.android.R.drawable.selectable_circular_container_ripple,
         )
+    }
+
+    /**
+     * In a fullscreen Duck.ai chat the fire button moves into the bottom-bar layout
+     * (sibling to this widget, see input_mode_widget_card_view_bottom.xml). The trailing
+     * fire that lives inside the widget hides in DUCK_AI so the user only ever sees one
+     * fire affordance; other contexts keep today's trailing placement.
+     *
+     * The leading fire is additionally hidden while the input field has focus — the user is
+     * typing and the chrome around the input should yield space to the keyboard / input area.
+     */
+    private fun updateFireButtonVisibility(state: NativeInputState) {
+        val showLeading = state.shouldShowLeadingFireButton() && !inputField.hasFocus()
+        leadingFireButtonView()?.visibility = if (showLeading) VISIBLE else GONE
+        findViewById<View?>(R.id.inputFieldFireButton)?.visibility =
+            if (state.shouldShowTrailingFireButton()) VISIBLE else GONE
     }
 
     private fun removeMargins() {
@@ -1229,6 +1273,14 @@ internal fun NativeInputState.shouldShowToggleRowBack(): Boolean =
 
 internal fun NativeInputState.shouldShowCardRowBack(): Boolean =
     !toggleVisible && inputContext == NativeInputState.InputContext.BROWSER
+
+/** Fire button placed inside the input field card at the leading edge — only in a fullscreen Duck.ai chat. */
+internal fun NativeInputState.shouldShowLeadingFireButton(): Boolean =
+    inputContext == NativeInputState.InputContext.DUCK_AI
+
+/** Trailing fire button (in the buttons row next to tabs/menu) — hidden in fullscreen Duck.ai chat, otherwise shown. */
+internal fun NativeInputState.shouldShowTrailingFireButton(): Boolean =
+    inputContext != NativeInputState.InputContext.DUCK_AI
 
 /**
  * The bottom row hosts chat-mode tools (attachments, options, reasoning, model picker).

--- a/duckchat/duckchat-impl/src/main/res/drawable/ic_compose_24.xml
+++ b/duckchat/duckchat-impl/src/main/res/drawable/ic_compose_24.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12.091,3.031C12.505,3.031 12.841,3.367 12.841,3.781C12.841,4.195 12.505,4.531 12.091,4.531H6.99C5.057,4.531 3.49,6.098 3.49,8.031V15.969C3.49,17.902 5.057,19.469 6.99,19.469H16.962C18.884,19.469 20.446,17.919 20.462,15.997L20.494,11.994C20.497,11.58 20.836,11.247 21.25,11.25C21.664,11.253 21.997,11.592 21.994,12.006L21.962,16.009C21.94,18.755 19.707,20.969 16.962,20.969H6.99C4.229,20.969 1.99,18.73 1.99,15.969V8.031C1.99,5.27 4.229,3.031 6.99,3.031H12.091ZM17.227,2.905C18.313,1.819 20.073,1.819 21.158,2.905C22.244,3.991 22.244,5.751 21.158,6.836L12.969,15.025C12.658,15.336 12.286,15.581 11.877,15.743L9.222,16.799C7.989,17.288 6.76,16.087 7.22,14.843L8.113,12.436C8.275,11.999 8.529,11.602 8.859,11.273L17.227,2.905ZM20.098,3.966C19.598,3.466 18.787,3.466 18.288,3.966L9.919,12.334C9.743,12.51 9.606,12.723 9.52,12.957L8.627,15.365C8.623,15.374 8.623,15.378 8.623,15.379C8.623,15.38 8.623,15.381 8.623,15.381C8.624,15.383 8.626,15.39 8.634,15.398C8.642,15.406 8.649,15.408 8.651,15.409C8.652,15.409 8.652,15.409 8.653,15.409C8.654,15.409 8.659,15.408 8.668,15.405L11.323,14.35C11.542,14.262 11.742,14.131 11.909,13.964L20.098,5.775C20.597,5.276 20.597,4.465 20.098,3.966Z"
+      android:fillColor="?daxColorPrimaryIcon" />
+</vector>

--- a/duckchat/duckchat-impl/src/main/res/drawable/ic_fire_tabs_24.xml
+++ b/duckchat/duckchat-impl/src/main/res/drawable/ic_fire_tabs_24.xml
@@ -1,0 +1,24 @@
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M14.906,12C16.615,12 18,13.385 18,15.094V18.906C18,20.615 16.615,22 14.906,22H9.094C7.385,22 6,20.615 6,18.906V15.094C6,13.385 7.385,12 9.094,12H14.906ZM9.094,13.5C8.214,13.5 7.5,14.213 7.5,15.094V18.906C7.5,19.786 8.214,20.5 9.094,20.5H14.906C15.786,20.5 16.5,19.786 16.5,18.906V15.094C16.5,14.213 15.786,13.5 14.906,13.5H9.094ZM9.896,2.036C10.097,1.971 10.318,1.994 10.502,2.099C11.632,2.751 12.225,3.674 12.6,4.625C12.942,5.495 13.107,6.419 13.383,7.309C13.427,7.453 13.775,8.271 14.934,8.271C15.498,8.271 15.833,8.108 16.037,7.949C16.252,7.782 16.369,7.581 16.429,7.452C16.51,7.25 16.546,7.028 16.591,6.816C16.638,6.593 16.675,6.352 16.794,6.153C16.819,6.111 16.913,5.957 17.105,5.855C17.219,5.796 17.37,5.752 17.543,5.77C17.687,5.786 17.817,5.843 17.933,5.928V5.929C18.055,6.024 22.031,9.12 22.031,14.509C22.031,15.943 21.506,17.243 20.625,18.341C20.227,18.837 19.5,18.513 19.5,17.877V17.763C19.5,17.486 19.596,17.221 19.747,16.989C20.231,16.249 20.518,15.403 20.531,14.509C20.531,11.318 18.898,9.042 17.856,7.915C17.685,8.394 17.358,8.822 16.958,9.133C16.482,9.503 15.82,9.771 14.934,9.771C12.829,9.771 12.088,8.197 11.95,7.754C11.546,6.45 11.415,4.902 10.403,3.894C9.135,6.301 7.424,7.893 6.082,9.319C4.578,10.918 3.531,12.303 3.531,14.509C3.544,15.371 3.811,16.19 4.266,16.912C4.409,17.139 4.5,17.399 4.5,17.668V17.805C4.5,18.444 3.768,18.765 3.375,18.261C2.532,17.18 2.031,15.909 2.031,14.509C2.031,11.698 3.434,9.946 4.99,8.292C6.559,6.624 8.282,5.044 9.442,2.444C9.534,2.253 9.691,2.102 9.896,2.036Z"
+      android:fillColor="?daxColorPrimaryIcon" />
+</vector>

--- a/duckchat/duckchat-impl/src/main/res/drawable/ic_tabs_add_24.xml
+++ b/duckchat/duckchat-impl/src/main/res/drawable/ic_tabs_add_24.xml
@@ -1,0 +1,31 @@
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M10,9.75C10,10.165 10.336,10.5 10.75,10.5L13.25,10.5L13.25,13C13.25,13.414 13.586,13.75 14,13.75C14.414,13.75 14.75,13.414 14.75,13L14.75,10.5L17.25,10.5C17.664,10.5 18,10.164 18,9.75C18,9.336 17.664,9 17.25,9L14.75,9L14.75,6.75C14.75,6.336 14.414,6 14,6C13.586,6 13.25,6.336 13.25,6.75L13.25,9L10.75,9C10.336,9 10,9.336 10,9.75Z"
+      android:fillColor="?daxColorPrimaryIcon" />
+  <path
+      android:pathData="M11,2C8.239,2 6,4.239 6,7V13C6,15.762 8.239,18 11,18H17C19.761,18 22,15.762 22,13V7C22,4.239 19.761,2 17,2H11ZM17,3.5H11C9.067,3.5 7.5,5.067 7.5,7V13C7.5,14.933 9.067,16.5 11,16.5H17C18.933,16.5 20.5,14.933 20.5,13V7C20.5,5.067 18.933,3.5 17,3.5Z"
+      android:fillColor="?daxColorPrimaryIcon"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M4.5,7.569C4.5,6.958 3.877,6.555 3.411,6.951C2.548,7.684 2,8.778 2,10V15C2,18.866 5.134,22 9,22H14C15.222,22 16.315,21.452 17.049,20.589C17.445,20.123 17.042,19.5 16.43,19.5C16.159,19.5 15.91,19.635 15.713,19.821C15.266,20.242 14.663,20.5 14,20.5H9C5.962,20.5 3.5,18.037 3.5,15V10C3.5,9.337 3.758,8.734 4.18,8.286C4.365,8.089 4.5,7.84 4.5,7.569Z"
+      android:fillColor="?daxColorPrimaryIcon" />
+</vector>

--- a/duckchat/duckchat-impl/src/main/res/layout/popup_chat_menu.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/popup_chat_menu.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2025 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/popup_menu_bg"
+    android:orientation="vertical">
+
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
+        android:id="@+id/chatMenuPopupNewChat"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:leadingIcon="@drawable/ic_compose_24"
+        app:primaryText="@string/chatMenuPopupNewChat" />
+
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
+        android:id="@+id/chatMenuPopupNewVoiceChat"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:primaryText="@string/chatMenuPopupNewVoiceChat"
+        app:leadingIcon="@drawable/ic_voice_24" />
+
+    <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+        app:defaultPadding="false"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
+        android:id="@+id/chatMenuPopupNewTab"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:primaryText="@string/chatMenuPopupNewTab"
+        app:leadingIcon="@drawable/ic_tabs_add_24" />
+
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
+        android:id="@+id/chatMenuPopupNewFireTab"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:leadingIcon="@drawable/ic_fire_tabs_24"
+        app:primaryText="@string/chatMenuPopupNewFireTab" />
+
+</LinearLayout>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -112,4 +112,7 @@
     <string name="duck_ai_chat_history_download_complete" instruction="%1$s is the saved chat filename (e.g. \'My Chat.txt\').">Download complete for %1$s</string>
     <string name="duck_ai_chat_history_download_view">Show</string>
     <string name="duck_ai_chat_history_download_error">Couldn\'t export chat</string>
+
+    <!-- Duck.ai header -->
+    <string name="duckChatPlusButtonContentDescription">Open Duck.ai menu</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/ids.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/ids.xml
@@ -16,4 +16,9 @@
 
 <resources>
     <item name="inputModeWidget" type="id"/>
+    <!-- Declared here (not in a layout) because the leading fire menu lives in the host
+         module's bottom-bar layout (app/.../input_mode_widget_card_view_bottom.xml) as a
+         sibling of the NativeInputModeWidget. Declaring the id in duckchat-impl lets the
+         widget bind its visibility and click via R.id. -->
+    <item name="inputFieldFireIconMenu" type="id"/>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -111,6 +111,7 @@
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Clear data</string>
     <string name="duckChatBrowserMenuContentDescription">More options</string>
+    <string name="duckChatPlusButtonContentDescription" tools:ignore="MissingTranslation">Open Duck.ai menu</string>
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Voice Chat</string>

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -111,7 +111,6 @@
     <!-- Content Descriptions -->
     <string name="duckChatFireButtonContentDescription">Clear data</string>
     <string name="duckChatBrowserMenuContentDescription">More options</string>
-    <string name="duckChatPlusButtonContentDescription" tools:ignore="MissingTranslation">Open Duck.ai menu</string>
 
     <!-- Duck AI Voice Chat Shortcut Setting -->
     <string name="duckAiVoiceChatVisibilitySetting" instruction="Voice Chat is a feature that lets users talk to Duck.ai using their voice instead of typing.">Voice Chat</string>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetFireButtonsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetFireButtonsTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui
+
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputContext
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputMode
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.shouldShowLeadingFireButton
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.shouldShowTrailingFireButton
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NativeInputModeWidgetFireButtonsTest {
+
+    @Test
+    fun `leading fire is shown in duck ai context`() {
+        assertTrue(stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.DUCK_AI).shouldShowLeadingFireButton())
+        assertTrue(stateOf(InputMode.SEARCH_ONLY, InputContext.DUCK_AI).shouldShowLeadingFireButton())
+    }
+
+    @Test
+    fun `leading fire is hidden in browser context`() {
+        assertFalse(stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.BROWSER).shouldShowLeadingFireButton())
+        assertFalse(stateOf(InputMode.SEARCH_ONLY, InputContext.BROWSER).shouldShowLeadingFireButton())
+    }
+
+    @Test
+    fun `leading fire is hidden in duck ai contextual context`() {
+        assertFalse(stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.DUCK_AI_CONTEXTUAL).shouldShowLeadingFireButton())
+        assertFalse(stateOf(InputMode.SEARCH_ONLY, InputContext.DUCK_AI_CONTEXTUAL).shouldShowLeadingFireButton())
+    }
+
+    @Test
+    fun `trailing fire is hidden in duck ai context`() {
+        assertFalse(stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.DUCK_AI).shouldShowTrailingFireButton())
+        assertFalse(stateOf(InputMode.SEARCH_ONLY, InputContext.DUCK_AI).shouldShowTrailingFireButton())
+    }
+
+    @Test
+    fun `trailing fire is shown in browser context`() {
+        assertTrue(stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.BROWSER).shouldShowTrailingFireButton())
+        assertTrue(stateOf(InputMode.SEARCH_ONLY, InputContext.BROWSER).shouldShowTrailingFireButton())
+    }
+
+    @Test
+    fun `trailing fire is shown in duck ai contextual context`() {
+        assertTrue(stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.DUCK_AI_CONTEXTUAL).shouldShowTrailingFireButton())
+        assertTrue(stateOf(InputMode.SEARCH_ONLY, InputContext.DUCK_AI_CONTEXTUAL).shouldShowTrailingFireButton())
+    }
+
+    private fun stateOf(inputMode: InputMode, inputContext: InputContext): NativeInputState =
+        NativeInputState(inputMode = inputMode, inputContext = inputContext)
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1215159003631560?focus=true

### Description

Last piece of the iOS Ship Review nav model for Duck.ai. Two coordinated changes, both scoped to Duck.ai fullscreen context (no change anywhere else):

1. **Omnibar fire → "+" menu.** In `ViewMode.DuckAI` the omnibar's fire icon is replaced by a "+" that opens a popup menu. The swap is derived from the view mode at render time (no separate state flag that can drift), and `tabsMenu` follows whichever of fire/+ is visible via a barrier.

2. **Fire button moves into the chat input.** In a Duck.ai chat (bottom bar) the fire button sits at the leading edge of the input row, outside the card so the card's rounded corners don't clip it. The trailing in-widget fire is hidden there so the user only ever sees one fire affordance, and the leading fire hides while the input is focused.

**The "+" popup menu** (`popup_chat_menu.xml`, shown anchored via the shared `PopupMenu.showAnchoredView` so it positions above/below depending on whether the omnibar is at the top or bottom):

| Item | Action |
|---|---|
| New Chat | `openNewDuckChat` → `NativeAction.NEW_CHAT` |
| New Voice Chat | `duckChat.openVoiceDuckChat()` |
| New Tab | `launchNewTab` (fresh NTP) |
| New Fire Tab | `launchNewTab` (same as New Tab for now) |

**New Fire Tab** is only shown when `FireModeAvailability.isAvailable()` is true (feature flag + WebView MultiProfile support), re-checked each time the menu opens, so we don't surface it to users who can't use Fire Mode.

Outside fullscreen mode (legacy Intent path), nothing changes — the omnibar never enters `ViewMode.DuckAI`.

Stacks conceptually on #8699 (toggle removal + back arrow) and #8700 (new-tab navigation), but is independent and lands on its own.

### Steps to test this PR

_Omnibar fire → +_
- [x] On a normal browser tab the omnibar shows the fire icon (unchanged).
- [x] Open a Duck.ai chat. The omnibar shows **+** where fire was; the fire icon is gone; the tabs button stays correctly positioned next to it.
- [x] Switch back to a browser tab — fire returns, + is gone. Confirm + never appears on NTP or in custom tabs.

_+ popup menu_
- [x] Tap **+** in a Duck.ai chat. A popup opens anchored to the + (above it when the omnibar is at the bottom, below when at the top).
- [x] **New Chat** starts a fresh chat.
- [x] **New Voice Chat** opens voice mode.
- [x] **New Tab** opens a fresh New Tab Page.
- [ ] **New Fire Tab** opens a fresh New Tab Page (same as New Tab for now).

_New Fire Tab gating_
- [ ] With Fire Mode available (flag on + supported WebView), **New Fire Tab** is present.
- [x] With Fire Mode unavailable (flag off or unsupported WebView), **New Fire Tab** is hidden and the rest of the menu is intact.

_Fire button in the chat input_
- [x] In a Duck.ai chat (bottom bar), a fire icon sits at the leading edge of the input row, fully visible (not clipped by the card corners).
- [x] The trailing in-widget fire (next to tabs/menu) is not shown in chat.
- [x] Tap the leading fire — the fire / clear-data dialog opens, same as the omnibar fire.
- [x] Focus the input — the leading fire hides; defocus — it reappears.
- [x] On a browser tab, the trailing fire is shown and the leading fire is hidden (unchanged).

_Legacy mode (fullscreen mode off)_
- [ ] Disable the Duck.ai fullscreen-mode flag. No UI changes anywhere — Duck.ai opens via the legacy Intent path and the omnibar never enters DuckAI view mode.

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and navigation changes in Duck.ai fullscreen only; Fire Mode menu item is gated; no auth or data-layer changes.
> 
> **Overview**
> For **fullscreen Duck.ai** (`ViewMode.DuckAI`), the omnibar **swaps the fire icon for a "+"** that opens a anchored popup (`popup_chat_menu.xml`) with New Chat, New Voice Chat, New Tab, and optionally **New Fire Tab** (gated by `FireModeAvailability` on each open). **New Fire Tab** currently calls the same `launchNewTab()` as New Tab.
> 
> In the **Duck.ai bottom input bar**, a **leading fire** sits beside the input card; the in-widget trailing fire is hidden in `DUCK_AI` context, and the leading fire hides while the field is focused. Fire/clear-data is wired through `NativeInputCallbacks` / `onFireButtonTapped` from both placements.
> 
> Omnibar layout uses a **barrier** so tabs align with whichever leading control is visible; transitions key off `isDuckAiMode` so fire/+ cannot drift from view mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 799555e6a1cb5c9bd1f18d2be3369b37e4982f16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->