### PR TITLE
Ignore CLAUDE.local.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,4 +111,5 @@ PixelDefinitions/node_modules/
 # LLM
 .claude/settings.local.json
 /.claude/worktrees/*
+CLAUDE.local.md
 docs/*


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207908166761516/task/1215281196352040?focus=true

### Description

Adds `CLAUDE.local.md` to the `# LLM` section of `.gitignore` so per-developer, machine-local Claude Code project instructions are never committed.

### Steps to test this PR

_Ignore rule_
- [x] Create a `CLAUDE.local.md` file at the repo root
- [x] Run `git check-ignore CLAUDE.local.md` — it prints `CLAUDE.local.md`
- [x] Run `git status` — `CLAUDE.local.md` is not listed as untracked

### UI changes
No UI changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single `.gitignore` entry with no runtime, security, or application behavior impact.
> 
> **Overview**
> Adds **`CLAUDE.local.md`** to the **`# LLM`** block in **`.gitignore`**, alongside existing Claude-related ignores like **`.claude/settings.local.json`**.
> 
> This keeps per-developer, machine-local Claude Code project instructions out of version control so they are not committed or shown as untracked files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6007de47a086916b244060c80cc785123aec181. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->