### PR TITLE
Remove serpLogoInMenu kill switch from AndroidBrowserConfigFeature

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1692,11 +1692,7 @@ class BrowserTabFragment :
     ) {
         val currentSite = viewModel.siteLiveData.value
         val omnibarState = viewModel.omnibarViewState.value
-        val serpLogoUrl = if (viewModel.isSerpLogoInMenuEnabled) {
-            (omnibarState?.serpLogo as? SerpLogo.EasterEgg)?.logoUrl
-        } else {
-            null
-        }
+        val serpLogoUrl = (omnibarState?.serpLogo as? SerpLogo.EasterEgg)?.logoUrl
         val browseMenuState = browserMenuViewStateFactory.create(
             omnibarViewMode = omnibarViewMode,
             viewState = viewState,

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -733,10 +733,6 @@ class BrowserTabViewModel @Inject constructor(
     private var alreadyShownKeyboard: Boolean = false
     private var pendingDuckChatAuthUpdate: Boolean = false
 
-    @Volatile
-    var isSerpLogoInMenuEnabled: Boolean = true
-        private set
-
     private val pdfDownloadCommandFlow = MutableSharedFlow<DownloadCommand>(extraBufferCapacity = 1)
 
     private val isFullUrlEnabled = urlDisplayRepository.isFullUrlEnabled
@@ -827,10 +823,6 @@ class BrowserTabViewModel @Inject constructor(
 
         viewModelScope.launch {
             addressBarTrackersAnimationManager.fetchFeatureState()
-        }
-
-        viewModelScope.launch(dispatchers.io()) {
-            isSerpLogoInMenuEnabled = androidBrowserConfig.serpLogoInMenu().isEnabled()
         }
 
         observeSyncStatusChangesForDuckChat()

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -358,15 +358,6 @@ interface AndroidBrowserConfigFeature {
     fun storePageContext(): Toggle
 
     /**
-     * Kill switch for SERP logo display in the browser menu header.
-     * @return `true` when the remote config has the global "serpLogoInMenu" androidBrowserConfig
-     * sub-feature flag enabled
-     * If the remote feature is not present defaults to `true`
-     */
-    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
-    fun serpLogoInMenu(): Toggle
-
-    /**
      * Controls whether the tab state restoration fix is enabled for swiping tabs.
      * When enabled, the adapter populates tabs before restoring state to prevent
      * garbage collection.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211850753229323/task/1213908136120535?focus=true 

### Description

Clean serpLogoInMenu FF

### Steps to test this PR

n/a

### UI changes

n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small flag cleanup with no auth or data changes; behavior change is always showing SERP logo in menu when easter-egg state exists, which matches the former default-on flag.
> 
> **Overview**
> Removes the **`serpLogoInMenu`** remote-config toggle from `AndroidBrowserConfigFeature` and deletes the related plumbing in **`BrowserTabViewModel`** (`isSerpLogoInMenuEnabled` and its IO load on init).
> 
> **`BrowserTabFragment.renderBrowserMenu`** now always derives `serpLogoUrl` from omnibar `SerpLogo.EasterEgg` when present, instead of gating that URL behind the kill switch (which previously forced `null` when disabled).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da44aaa81fee141888eb216284e9773249857bc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->