### PR TITLE
Update content scope scripts to version 15.0.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -51,7 +51,6 @@
   var Uint16Array = globalThis.Uint16Array;
   var Uint32Array2 = globalThis.Uint32Array;
   var JSONparse = JSON.parse;
-  var Arrayfrom = Array.from;
   var ReflectDeleteProperty = Reflect2.deleteProperty.bind(Reflect2);
   var ReflectApply = Reflect2.apply.bind(Reflect2);
   var getRandomValues = globalThis.crypto?.getRandomValues?.bind(globalThis.crypto);
@@ -1266,21 +1265,27 @@
      * @param {import('../index.js').MessagingContext} messagingContext
      */
     constructor(config, messagingContext) {
-      /** @type {Record<string, any>} */
-      __publicField(this, "capturedWebkitHandlers", {});
       /**
-       * @type {{name: string, length: number}}
-       * @internal
+       * Null-prototype cache so a hostile page that pollutes `Object.prototype`
+       * cannot supply a callable from there if `capture` ever misses a handler.
+       *
+       * Uses the `{ __proto__: null }` literal rather than `Object.create(null)`
+       * because the latter is a method dispatch through `globalThis.Object`, which
+       * page JS could replace before this class field runs if transport
+       * construction is deferred (`Messaging` is lazy on `ContentFeature.messaging`).
+       * The `__proto__: null` literal is a syntactic construct, not method
+       * dispatch, so it always yields a true null-prototype object.
+       * @type {Record<string, { handler: any, postMessage: Function }>}
        */
-      __publicField(this, "algoObj", {
-        name: "AES-GCM",
-        length: 256
-      });
+      __publicField(
+        this,
+        "capturedWebkitHandlers",
+        /** @type {any} */
+        { __proto__: null }
+      );
       this.messagingContext = messagingContext;
       this.config = config;
-      if (!this.config.hasModernWebkitAPI) {
-        this.captureWebkitHandlers(this.config.webkitMessageHandlerNames);
-      }
+      this.captureWebkitHandlers(this.config.webkitMessageHandlerNames);
     }
     /**
      * Sends message to the webkit layer (fire and forget)
@@ -1291,24 +1296,11 @@
      * @internal
      */
     wkSend(handler, data = {}) {
-      if (!(handler in window.webkit.messageHandlers)) {
+      const captured = this.capturedWebkitHandlers[handler];
+      if (!captured || typeof captured.postMessage !== "function") {
         throw new MissingHandler(`Missing webkit handler: '${handler}'`, handler);
       }
-      if (!this.config.hasModernWebkitAPI) {
-        const outgoing = {
-          ...data,
-          messageHandling: {
-            ...data.messageHandling,
-            secret: this.config.secret
-          }
-        };
-        if (!(handler in this.capturedWebkitHandlers)) {
-          throw new MissingHandler(`cannot continue, method ${handler} not captured on macos < 11`, handler);
-        } else {
-          return this.capturedWebkitHandlers[handler](outgoing);
-        }
-      }
-      return window.webkit.messageHandlers[handler].postMessage?.(data);
+      return ReflectApply(captured.postMessage, captured.handler, [data]);
     }
     /**
      * Sends message to the webkit layer and waits for the specified response
@@ -1318,44 +1310,8 @@
      * @internal
      */
     async wkSendAndWait(handler, data) {
-      if (this.config.hasModernWebkitAPI) {
-        const response = await this.wkSend(handler, data);
-        return JSONparse(response || "{}");
-      }
-      try {
-        const randMethodName = this.createRandMethodName();
-        const key = await this.createRandKey();
-        const iv = this.createRandIv();
-        const { ciphertext, tag } = await new Promise2((resolve) => {
-          this.generateRandomMethod(randMethodName, resolve);
-          data.messageHandling = new SecureMessagingParams({
-            methodName: randMethodName,
-            secret: this.config.secret,
-            key: Arrayfrom(key),
-            iv: Arrayfrom(iv)
-          });
-          this.wkSend(handler, data);
-        });
-        const cipher = new Uint8Array2([...ciphertext, ...tag]);
-        const decrypted = await this.decryptResponse(
-          /** @type {BufferSource} */
-          /** @type {unknown} */
-          cipher,
-          /** @type {BufferSource} */
-          /** @type {unknown} */
-          key,
-          iv
-        );
-        return JSONparse(decrypted || "{}");
-      } catch (e) {
-        if (e instanceof MissingHandler) {
-          throw e;
-        } else {
-          console.error("decryption failed", e);
-          console.error(e);
-          return { error: e };
-        }
-      }
+      const response = await this.wkSend(handler, data);
+      return JSONparse(response || "{}");
     }
     /**
      * @param {import('../index.js').NotificationMessage} msg
@@ -1380,77 +1336,19 @@
       throw new Error2("an unknown error occurred");
     }
     /**
-     * Generate a random method name and adds it to navigator.duckduckgo.messageHandlers
-     * The native layer will use this method to send the response
-     * @param {string | number} randomMethodName
-     * @param {Function} callback
-     * @internal
-     */
-    generateRandomMethod(randomMethodName, callback) {
-      const target = ensureNavigatorDuckDuckGo().messageHandlers;
-      objectDefineProperty(target, randomMethodName, {
-        enumerable: false,
-        configurable: true,
-        writable: false,
-        /**
-         * @param {any[]} args
-         */
-        value: (...args) => {
-          callback(...args);
-          ReflectDeleteProperty(target, randomMethodName);
-        }
-      });
-    }
-    /**
-     * @internal
-     * @return {string}
-     */
-    randomString() {
-      return "" + getRandomValues(new Uint32Array2(1))[0];
-    }
-    /**
-     * @internal
-     * @return {string}
-     */
-    createRandMethodName() {
-      return "_" + this.randomString();
-    }
-    /**
-     * @returns {Promise<Uint8Array>}
-     * @internal
-     */
-    async createRandKey() {
-      const key = await generateKey(this.algoObj, true, ["encrypt", "decrypt"]);
-      const exportedKey = await exportKey("raw", key);
-      return new Uint8Array2(exportedKey);
-    }
-    /**
-     * @returns {Uint8Array}
-     * @internal
-     */
-    createRandIv() {
-      return getRandomValues(new Uint8Array2(12));
-    }
-    /**
-     * @param {BufferSource} ciphertext
-     * @param {BufferSource} key
-     * @param {Uint8Array} iv
-     * @returns {Promise<string>}
-     * @internal
-     */
-    async decryptResponse(ciphertext, key, iv) {
-      const cryptoKey = await importKey("raw", key, "AES-GCM", false, ["decrypt"]);
-      const algo = {
-        name: "AES-GCM",
-        iv
-      };
-      const decrypted = await decrypt(algo, cryptoKey, ciphertext);
-      const dec = new TextDecoder();
-      return dec.decode(decrypted);
-    }
-    /**
-     * When required (such as on macos 10.x), capture the `postMessage` method on
-     * each webkit messageHandler
+     * Capture the `postMessage` method on each webkit messageHandler so the
+     * transport can call them later without re-reading `window.webkit.messageHandlers`.
+     * Makes the transport resilient to later removal or replacement of
+     * `window.webkit.messageHandlers` (e.g. by privacy hardening that nullifies
+     * the namespace for site JS to reduce fingerprinting surface).
+     *
+     * Stores the handler object and its `postMessage` function as a pair so
+     * `wkSend` can dispatch via the captured `ReflectApply` rather than calling
+     * `.bind()` here. `.bind` is a method on the page-mutable
+     * `Function.prototype` — if transport construction is deferred (`Messaging`
+     * is lazy on `ContentFeature.messaging`) page JS could replace
+     * `Function.prototype.bind` first and have the cache store an attacker-
+     * controlled function. Storing the unbound pair sidesteps that.
      *
      * @param {string[]} handlerNames
      */
@@ -1458,11 +1356,12 @@
       const handlers = window.webkit.messageHandlers;
       if (!handlers) throw new MissingHandler("window.webkit.messageHandlers was absent", "all");
       for (const webkitMessageHandlerName of handlerNames) {
-        if (typeof handlers[webkitMessageHandlerName]?.postMessage === "function") {
-          const original = handlers[webkitMessageHandlerName];
-          const bound = handlers[webkitMessageHandlerName].postMessage?.bind(original);
-          this.capturedWebkitHandlers[webkitMessageHandlerName] = bound;
-          delete handlers[webkitMessageHandlerName].postMessage;
+        const handler = handlers[webkitMessageHandlerName];
+        if (typeof handler?.postMessage === "function") {
+          this.capturedWebkitHandlers[webkitMessageHandlerName] = {
+            handler,
+            postMessage: handler.postMessage
+          };
         }
       }
     }
@@ -1495,30 +1394,11 @@
   var WebkitMessagingConfig = class {
     /**
      * @param {object} params
-     * @param {boolean} params.hasModernWebkitAPI
      * @param {string[]} params.webkitMessageHandlerNames
-     * @param {string} params.secret
      * @internal
      */
     constructor(params) {
-      this.hasModernWebkitAPI = params.hasModernWebkitAPI;
       this.webkitMessageHandlerNames = params.webkitMessageHandlerNames;
-      this.secret = params.secret;
-    }
-  };
-  var SecureMessagingParams = class {
-    /**
-     * @param {object} params
-     * @param {string} params.methodName
-     * @param {string} params.secret
-     * @param {number[]} params.key
-     * @param {number[]} params.iv
-     */
-    constructor(params) {
-      this.methodName = params.methodName;
-      this.secret = params.secret;
-      this.key = params.key;
-      this.iv = params.iv;
     }
   };
 

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -1574,7 +1574,6 @@
   var Uint16Array = globalThis.Uint16Array;
   var Uint32Array = globalThis.Uint32Array;
   var JSONparse = JSON.parse;
-  var Arrayfrom = Array.from;
   var ReflectDeleteProperty = Reflect2.deleteProperty.bind(Reflect2);
   var ReflectApply = Reflect2.apply.bind(Reflect2);
   var getRandomValues = globalThis.crypto?.getRandomValues?.bind(globalThis.crypto);
@@ -2806,21 +2805,27 @@
      * @param {import('../index.js').MessagingContext} messagingContext
      */
     constructor(config, messagingContext) {
-      /** @type {Record<string, any>} */
-      __publicField(this, "capturedWebkitHandlers", {});
       /**
-       * @type {{name: string, length: number}}
-       * @internal
+       * Null-prototype cache so a hostile page that pollutes `Object.prototype`
+       * cannot supply a callable from there if `capture` ever misses a handler.
+       *
+       * Uses the `{ __proto__: null }` literal rather than `Object.create(null)`
+       * because the latter is a method dispatch through `globalThis.Object`, which
+       * page JS could replace before this class field runs if transport
+       * construction is deferred (`Messaging` is lazy on `ContentFeature.messaging`).
+       * The `__proto__: null` literal is a syntactic construct, not method
+       * dispatch, so it always yields a true null-prototype object.
+       * @type {Record<string, { handler: any, postMessage: Function }>}
        */
-      __publicField(this, "algoObj", {
-        name: "AES-GCM",
-        length: 256
-      });
+      __publicField(
+        this,
+        "capturedWebkitHandlers",
+        /** @type {any} */
+        { __proto__: null }
+      );
       this.messagingContext = messagingContext;
       this.config = config;
-      if (!this.config.hasModernWebkitAPI) {
-        this.captureWebkitHandlers(this.config.webkitMessageHandlerNames);
-      }
+      this.captureWebkitHandlers(this.config.webkitMessageHandlerNames);
     }
     /**
      * Sends message to the webkit layer (fire and forget)
@@ -2831,24 +2836,11 @@
      * @internal
      */
     wkSend(handler, data2 = {}) {
-      if (!(handler in window.webkit.messageHandlers)) {
+      const captured = this.capturedWebkitHandlers[handler];
+      if (!captured || typeof captured.postMessage !== "function") {
         throw new MissingHandler(`Missing webkit handler: '${handler}'`, handler);
       }
-      if (!this.config.hasModernWebkitAPI) {
-        const outgoing = {
-          ...data2,
-          messageHandling: {
-            ...data2.messageHandling,
-            secret: this.config.secret
-          }
-        };
-        if (!(handler in this.capturedWebkitHandlers)) {
-          throw new MissingHandler(`cannot continue, method ${handler} not captured on macos < 11`, handler);
-        } else {
-          return this.capturedWebkitHandlers[handler](outgoing);
-        }
-      }
-      return window.webkit.messageHandlers[handler].postMessage?.(data2);
+      return ReflectApply(captured.postMessage, captured.handler, [data2]);
     }
     /**
      * Sends message to the webkit layer and waits for the specified response
@@ -2858,44 +2850,8 @@
      * @internal
      */
     async wkSendAndWait(handler, data2) {
-      if (this.config.hasModernWebkitAPI) {
-        const response = await this.wkSend(handler, data2);
-        return JSONparse(response || "{}");
-      }
-      try {
-        const randMethodName = this.createRandMethodName();
-        const key = await this.createRandKey();
-        const iv = this.createRandIv();
-        const { ciphertext, tag } = await new Promise2((resolve) => {
-          this.generateRandomMethod(randMethodName, resolve);
-          data2.messageHandling = new SecureMessagingParams({
-            methodName: randMethodName,
-            secret: this.config.secret,
-            key: Arrayfrom(key),
-            iv: Arrayfrom(iv)
-          });
-          this.wkSend(handler, data2);
-        });
-        const cipher = new Uint8Array2([...ciphertext, ...tag]);
-        const decrypted = await this.decryptResponse(
-          /** @type {BufferSource} */
-          /** @type {unknown} */
-          cipher,
-          /** @type {BufferSource} */
-          /** @type {unknown} */
-          key,
-          iv
-        );
-        return JSONparse(decrypted || "{}");
-      } catch (e) {
-        if (e instanceof MissingHandler) {
-          throw e;
-        } else {
-          console.error("decryption failed", e);
-          console.error(e);
-          return { error: e };
-        }
-      }
+      const response = await this.wkSend(handler, data2);
+      return JSONparse(response || "{}");
     }
     /**
      * @param {import('../index.js').NotificationMessage} msg
@@ -2920,77 +2876,19 @@
       throw new Error2("an unknown error occurred");
     }
     /**
-     * Generate a random method name and adds it to navigator.duckduckgo.messageHandlers
-     * The native layer will use this method to send the response
-     * @param {string | number} randomMethodName
-     * @param {Function} callback
-     * @internal
-     */
-    generateRandomMethod(randomMethodName, callback) {
-      const target = ensureNavigatorDuckDuckGo().messageHandlers;
-      objectDefineProperty(target, randomMethodName, {
-        enumerable: false,
-        configurable: true,
-        writable: false,
-        /**
-         * @param {any[]} args
-         */
-        value: (...args) => {
-          callback(...args);
-          ReflectDeleteProperty(target, randomMethodName);
-        }
-      });
-    }
-    /**
-     * @internal
-     * @return {string}
-     */
-    randomString() {
-      return "" + getRandomValues(new Uint32Array(1))[0];
-    }
-    /**
-     * @internal
-     * @return {string}
-     */
-    createRandMethodName() {
-      return "_" + this.randomString();
-    }
-    /**
-     * @returns {Promise<Uint8Array>}
-     * @internal
-     */
-    async createRandKey() {
-      const key = await generateKey(this.algoObj, true, ["encrypt", "decrypt"]);
-      const exportedKey = await exportKey("raw", key);
-      return new Uint8Array2(exportedKey);
-    }
-    /**
-     * @returns {Uint8Array}
-     * @internal
-     */
-    createRandIv() {
-      return getRandomValues(new Uint8Array2(12));
-    }
-    /**
-     * @param {BufferSource} ciphertext
-     * @param {BufferSource} key
-     * @param {Uint8Array} iv
-     * @returns {Promise<string>}
-     * @internal
-     */
-    async decryptResponse(ciphertext, key, iv) {
-      const cryptoKey = await importKey("raw", key, "AES-GCM", false, ["decrypt"]);
-      const algo = {
-        name: "AES-GCM",
-        iv
-      };
-      const decrypted = await decrypt(algo, cryptoKey, ciphertext);
-      const dec = new TextDecoder();
-      return dec.decode(decrypted);
-    }
-    /**
-     * When required (such as on macos 10.x), capture the `postMessage` method on
-     * each webkit messageHandler
+     * Capture the `postMessage` method on each webkit messageHandler so the
+     * transport can call them later without re-reading `window.webkit.messageHandlers`.
+     * Makes the transport resilient to later removal or replacement of
+     * `window.webkit.messageHandlers` (e.g. by privacy hardening that nullifies
+     * the namespace for site JS to reduce fingerprinting surface).
+     *
+     * Stores the handler object and its `postMessage` function as a pair so
+     * `wkSend` can dispatch via the captured `ReflectApply` rather than calling
+     * `.bind()` here. `.bind` is a method on the page-mutable
+     * `Function.prototype` — if transport construction is deferred (`Messaging`
+     * is lazy on `ContentFeature.messaging`) page JS could replace
+     * `Function.prototype.bind` first and have the cache store an attacker-
+     * controlled function. Storing the unbound pair sidesteps that.
      *
      * @param {string[]} handlerNames
      */
@@ -2998,11 +2896,12 @@
       const handlers = window.webkit.messageHandlers;
       if (!handlers) throw new MissingHandler("window.webkit.messageHandlers was absent", "all");
       for (const webkitMessageHandlerName of handlerNames) {
-        if (typeof handlers[webkitMessageHandlerName]?.postMessage === "function") {
-          const original = handlers[webkitMessageHandlerName];
-          const bound = handlers[webkitMessageHandlerName].postMessage?.bind(original);
-          this.capturedWebkitHandlers[webkitMessageHandlerName] = bound;
-          delete handlers[webkitMessageHandlerName].postMessage;
+        const handler = handlers[webkitMessageHandlerName];
+        if (typeof handler?.postMessage === "function") {
+          this.capturedWebkitHandlers[webkitMessageHandlerName] = {
+            handler,
+            postMessage: handler.postMessage
+          };
         }
       }
     }
@@ -3035,30 +2934,11 @@
   var WebkitMessagingConfig = class {
     /**
      * @param {object} params
-     * @param {boolean} params.hasModernWebkitAPI
      * @param {string[]} params.webkitMessageHandlerNames
-     * @param {string} params.secret
      * @internal
      */
     constructor(params) {
-      this.hasModernWebkitAPI = params.hasModernWebkitAPI;
       this.webkitMessageHandlerNames = params.webkitMessageHandlerNames;
-      this.secret = params.secret;
-    }
-  };
-  var SecureMessagingParams = class {
-    /**
-     * @param {object} params
-     * @param {string} params.methodName
-     * @param {string} params.secret
-     * @param {number[]} params.key
-     * @param {number[]} params.iv
-     */
-    constructor(params) {
-      this.methodName = params.methodName;
-      this.secret = params.secret;
-      this.key = params.key;
-      this.iv = params.iv;
     }
   };
 

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -1574,7 +1574,6 @@
   var Uint16Array = globalThis.Uint16Array;
   var Uint32Array = globalThis.Uint32Array;
   var JSONparse = JSON.parse;
-  var Arrayfrom = Array.from;
   var ReflectDeleteProperty = Reflect2.deleteProperty.bind(Reflect2);
   var ReflectApply = Reflect2.apply.bind(Reflect2);
   var getRandomValues = globalThis.crypto?.getRandomValues?.bind(globalThis.crypto);
@@ -2775,21 +2774,27 @@
      * @param {import('../index.js').MessagingContext} messagingContext
      */
     constructor(config, messagingContext) {
-      /** @type {Record<string, any>} */
-      __publicField(this, "capturedWebkitHandlers", {});
       /**
-       * @type {{name: string, length: number}}
-       * @internal
+       * Null-prototype cache so a hostile page that pollutes `Object.prototype`
+       * cannot supply a callable from there if `capture` ever misses a handler.
+       *
+       * Uses the `{ __proto__: null }` literal rather than `Object.create(null)`
+       * because the latter is a method dispatch through `globalThis.Object`, which
+       * page JS could replace before this class field runs if transport
+       * construction is deferred (`Messaging` is lazy on `ContentFeature.messaging`).
+       * The `__proto__: null` literal is a syntactic construct, not method
+       * dispatch, so it always yields a true null-prototype object.
+       * @type {Record<string, { handler: any, postMessage: Function }>}
        */
-      __publicField(this, "algoObj", {
-        name: "AES-GCM",
-        length: 256
-      });
+      __publicField(
+        this,
+        "capturedWebkitHandlers",
+        /** @type {any} */
+        { __proto__: null }
+      );
       this.messagingContext = messagingContext;
       this.config = config;
-      if (!this.config.hasModernWebkitAPI) {
-        this.captureWebkitHandlers(this.config.webkitMessageHandlerNames);
-      }
+      this.captureWebkitHandlers(this.config.webkitMessageHandlerNames);
     }
     /**
      * Sends message to the webkit layer (fire and forget)
@@ -2800,24 +2805,11 @@
      * @internal
      */
     wkSend(handler, data2 = {}) {
-      if (!(handler in window.webkit.messageHandlers)) {
+      const captured = this.capturedWebkitHandlers[handler];
+      if (!captured || typeof captured.postMessage !== "function") {
         throw new MissingHandler(`Missing webkit handler: '${handler}'`, handler);
       }
-      if (!this.config.hasModernWebkitAPI) {
-        const outgoing = {
-          ...data2,
-          messageHandling: {
-            ...data2.messageHandling,
-            secret: this.config.secret
-          }
-        };
-        if (!(handler in this.capturedWebkitHandlers)) {
-          throw new MissingHandler(`cannot continue, method ${handler} not captured on macos < 11`, handler);
-        } else {
-          return this.capturedWebkitHandlers[handler](outgoing);
-        }
-      }
-      return window.webkit.messageHandlers[handler].postMessage?.(data2);
+      return ReflectApply(captured.postMessage, captured.handler, [data2]);
     }
     /**
      * Sends message to the webkit layer and waits for the specified response
@@ -2827,44 +2819,8 @@
      * @internal
      */
     async wkSendAndWait(handler, data2) {
-      if (this.config.hasModernWebkitAPI) {
-        const response = await this.wkSend(handler, data2);
-        return JSONparse(response || "{}");
-      }
-      try {
-        const randMethodName = this.createRandMethodName();
-        const key = await this.createRandKey();
-        const iv = this.createRandIv();
-        const { ciphertext, tag } = await new Promise2((resolve) => {
-          this.generateRandomMethod(randMethodName, resolve);
-          data2.messageHandling = new SecureMessagingParams({
-            methodName: randMethodName,
-            secret: this.config.secret,
-            key: Arrayfrom(key),
-            iv: Arrayfrom(iv)
-          });
-          this.wkSend(handler, data2);
-        });
-        const cipher = new Uint8Array2([...ciphertext, ...tag]);
-        const decrypted = await this.decryptResponse(
-          /** @type {BufferSource} */
-          /** @type {unknown} */
-          cipher,
-          /** @type {BufferSource} */
-          /** @type {unknown} */
-          key,
-          iv
-        );
-        return JSONparse(decrypted || "{}");
-      } catch (e) {
-        if (e instanceof MissingHandler) {
-          throw e;
-        } else {
-          console.error("decryption failed", e);
-          console.error(e);
-          return { error: e };
-        }
-      }
+      const response = await this.wkSend(handler, data2);
+      return JSONparse(response || "{}");
     }
     /**
      * @param {import('../index.js').NotificationMessage} msg
@@ -2889,77 +2845,19 @@
       throw new Error2("an unknown error occurred");
     }
     /**
-     * Generate a random method name and adds it to navigator.duckduckgo.messageHandlers
-     * The native layer will use this method to send the response
-     * @param {string | number} randomMethodName
-     * @param {Function} callback
-     * @internal
-     */
-    generateRandomMethod(randomMethodName, callback) {
-      const target = ensureNavigatorDuckDuckGo().messageHandlers;
-      objectDefineProperty(target, randomMethodName, {
-        enumerable: false,
-        configurable: true,
-        writable: false,
-        /**
-         * @param {any[]} args
-         */
-        value: (...args) => {
-          callback(...args);
-          ReflectDeleteProperty(target, randomMethodName);
-        }
-      });
-    }
-    /**
-     * @internal
-     * @return {string}
-     */
-    randomString() {
-      return "" + getRandomValues(new Uint32Array(1))[0];
-    }
-    /**
-     * @internal
-     * @return {string}
-     */
-    createRandMethodName() {
-      return "_" + this.randomString();
-    }
-    /**
-     * @returns {Promise<Uint8Array>}
-     * @internal
-     */
-    async createRandKey() {
-      const key = await generateKey(this.algoObj, true, ["encrypt", "decrypt"]);
-      const exportedKey = await exportKey("raw", key);
-      return new Uint8Array2(exportedKey);
-    }
-    /**
-     * @returns {Uint8Array}
-     * @internal
-     */
-    createRandIv() {
-      return getRandomValues(new Uint8Array2(12));
-    }
-    /**
-     * @param {BufferSource} ciphertext
-     * @param {BufferSource} key
-     * @param {Uint8Array} iv
-     * @returns {Promise<string>}
-     * @internal
-     */
-    async decryptResponse(ciphertext, key, iv) {
-      const cryptoKey = await importKey("raw", key, "AES-GCM", false, ["decrypt"]);
-      const algo = {
-        name: "AES-GCM",
-        iv
-      };
-      const decrypted = await decrypt(algo, cryptoKey, ciphertext);
-      const dec = new TextDecoder();
-      return dec.decode(decrypted);
-    }
-    /**
-     * When required (such as on macos 10.x), capture the `postMessage` method on
-     * each webkit messageHandler
+     * Capture the `postMessage` method on each webkit messageHandler so the
+     * transport can call them later without re-reading `window.webkit.messageHandlers`.
+     * Makes the transport resilient to later removal or replacement of
+     * `window.webkit.messageHandlers` (e.g. by privacy hardening that nullifies
+     * the namespace for site JS to reduce fingerprinting surface).
+     *
+     * Stores the handler object and its `postMessage` function as a pair so
+     * `wkSend` can dispatch via the captured `ReflectApply` rather than calling
+     * `.bind()` here. `.bind` is a method on the page-mutable
+     * `Function.prototype` — if transport construction is deferred (`Messaging`
+     * is lazy on `ContentFeature.messaging`) page JS could replace
+     * `Function.prototype.bind` first and have the cache store an attacker-
+     * controlled function. Storing the unbound pair sidesteps that.
      *
      * @param {string[]} handlerNames
      */
@@ -2967,11 +2865,12 @@
       const handlers = window.webkit.messageHandlers;
       if (!handlers) throw new MissingHandler("window.webkit.messageHandlers was absent", "all");
       for (const webkitMessageHandlerName of handlerNames) {
-        if (typeof handlers[webkitMessageHandlerName]?.postMessage === "function") {
-          const original = handlers[webkitMessageHandlerName];
-          const bound = handlers[webkitMessageHandlerName].postMessage?.bind(original);
-          this.capturedWebkitHandlers[webkitMessageHandlerName] = bound;
-          delete handlers[webkitMessageHandlerName].postMessage;
+        const handler = handlers[webkitMessageHandlerName];
+        if (typeof handler?.postMessage === "function") {
+          this.capturedWebkitHandlers[webkitMessageHandlerName] = {
+            handler,
+            postMessage: handler.postMessage
+          };
         }
       }
     }
@@ -3004,30 +2903,11 @@
   var WebkitMessagingConfig = class {
     /**
      * @param {object} params
-     * @param {boolean} params.hasModernWebkitAPI
      * @param {string[]} params.webkitMessageHandlerNames
-     * @param {string} params.secret
      * @internal
      */
     constructor(params) {
-      this.hasModernWebkitAPI = params.hasModernWebkitAPI;
       this.webkitMessageHandlerNames = params.webkitMessageHandlerNames;
-      this.secret = params.secret;
-    }
-  };
-  var SecureMessagingParams = class {
-    /**
-     * @param {object} params
-     * @param {string} params.methodName
-     * @param {string} params.secret
-     * @param {number[]} params.key
-     * @param {number[]} params.iv
-     */
-    constructor(params) {
-      this.methodName = params.methodName;
-      this.secret = params.secret;
-      this.key = params.key;
-      this.iv = params.iv;
     }
   };
 

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -2675,21 +2675,27 @@
      * @param {import('../index.js').MessagingContext} messagingContext
      */
     constructor(config, messagingContext) {
-      /** @type {Record<string, any>} */
-      __publicField(this, "capturedWebkitHandlers", {});
       /**
-       * @type {{name: string, length: number}}
-       * @internal
+       * Null-prototype cache so a hostile page that pollutes `Object.prototype`
+       * cannot supply a callable from there if `capture` ever misses a handler.
+       *
+       * Uses the `{ __proto__: null }` literal rather than `Object.create(null)`
+       * because the latter is a method dispatch through `globalThis.Object`, which
+       * page JS could replace before this class field runs if transport
+       * construction is deferred (`Messaging` is lazy on `ContentFeature.messaging`).
+       * The `__proto__: null` literal is a syntactic construct, not method
+       * dispatch, so it always yields a true null-prototype object.
+       * @type {Record<string, { handler: any, postMessage: Function }>}
        */
-      __publicField(this, "algoObj", {
-        name: "AES-GCM",
-        length: 256
-      });
+      __publicField(
+        this,
+        "capturedWebkitHandlers",
+        /** @type {any} */
+        { __proto__: null }
+      );
       this.messagingContext = messagingContext;
       this.config = config;
-      if (!this.config.hasModernWebkitAPI) {
-        this.captureWebkitHandlers(this.config.webkitMessageHandlerNames);
-      }
+      this.captureWebkitHandlers(this.config.webkitMessageHandlerNames);
     }
     /**
      * Sends message to the webkit layer (fire and forget)
@@ -2700,24 +2706,11 @@
      * @internal
      */
     wkSend(handler, data = {}) {
-      if (!(handler in window.webkit.messageHandlers)) {
+      const captured2 = this.capturedWebkitHandlers[handler];
+      if (!captured2 || typeof captured2.postMessage !== "function") {
         throw new MissingHandler(`Missing webkit handler: '${handler}'`, handler);
       }
-      if (!this.config.hasModernWebkitAPI) {
-        const outgoing = {
-          ...data,
-          messageHandling: {
-            ...data.messageHandling,
-            secret: this.config.secret
-          }
-        };
-        if (!(handler in this.capturedWebkitHandlers)) {
-          throw new MissingHandler(`cannot continue, method ${handler} not captured on macos < 11`, handler);
-        } else {
-          return this.capturedWebkitHandlers[handler](outgoing);
-        }
-      }
-      return window.webkit.messageHandlers[handler].postMessage?.(data);
+      return ReflectApply(captured2.postMessage, captured2.handler, [data]);
     }
     /**
      * Sends message to the webkit layer and waits for the specified response
@@ -2727,44 +2720,8 @@
      * @internal
      */
     async wkSendAndWait(handler, data) {
-      if (this.config.hasModernWebkitAPI) {
-        const response = await this.wkSend(handler, data);
-        return JSONparse(response || "{}");
-      }
-      try {
-        const randMethodName = this.createRandMethodName();
-        const key = await this.createRandKey();
-        const iv = this.createRandIv();
-        const { ciphertext, tag } = await new Promise2((resolve) => {
-          this.generateRandomMethod(randMethodName, resolve);
-          data.messageHandling = new SecureMessagingParams({
-            methodName: randMethodName,
-            secret: this.config.secret,
-            key: Arrayfrom(key),
-            iv: Arrayfrom(iv)
-          });
-          this.wkSend(handler, data);
-        });
-        const cipher = new Uint8Array2([...ciphertext, ...tag]);
-        const decrypted = await this.decryptResponse(
-          /** @type {BufferSource} */
-          /** @type {unknown} */
-          cipher,
-          /** @type {BufferSource} */
-          /** @type {unknown} */
-          key,
-          iv
-        );
-        return JSONparse(decrypted || "{}");
-      } catch (e) {
-        if (e instanceof MissingHandler) {
-          throw e;
-        } else {
-          console.error("decryption failed", e);
-          console.error(e);
-          return { error: e };
-        }
-      }
+      const response = await this.wkSend(handler, data);
+      return JSONparse(response || "{}");
     }
     /**
      * @param {import('../index.js').NotificationMessage} msg
@@ -2789,77 +2746,19 @@
       throw new Error2("an unknown error occurred");
     }
     /**
-     * Generate a random method name and adds it to navigator.duckduckgo.messageHandlers
-     * The native layer will use this method to send the response
-     * @param {string | number} randomMethodName
-     * @param {Function} callback
-     * @internal
-     */
-    generateRandomMethod(randomMethodName, callback) {
-      const target = ensureNavigatorDuckDuckGo().messageHandlers;
-      objectDefineProperty(target, randomMethodName, {
-        enumerable: false,
-        configurable: true,
-        writable: false,
-        /**
-         * @param {any[]} args
-         */
-        value: (...args) => {
-          callback(...args);
-          ReflectDeleteProperty(target, randomMethodName);
-        }
-      });
-    }
-    /**
-     * @internal
-     * @return {string}
-     */
-    randomString() {
-      return "" + getRandomValues(new Uint32Array2(1))[0];
-    }
-    /**
-     * @internal
-     * @return {string}
-     */
-    createRandMethodName() {
-      return "_" + this.randomString();
-    }
-    /**
-     * @returns {Promise<Uint8Array>}
-     * @internal
-     */
-    async createRandKey() {
-      const key = await generateKey(this.algoObj, true, ["encrypt", "decrypt"]);
-      const exportedKey = await exportKey("raw", key);
-      return new Uint8Array2(exportedKey);
-    }
-    /**
-     * @returns {Uint8Array}
-     * @internal
-     */
-    createRandIv() {
-      return getRandomValues(new Uint8Array2(12));
-    }
-    /**
-     * @param {BufferSource} ciphertext
-     * @param {BufferSource} key
-     * @param {Uint8Array} iv
-     * @returns {Promise<string>}
-     * @internal
-     */
-    async decryptResponse(ciphertext, key, iv) {
-      const cryptoKey = await importKey("raw", key, "AES-GCM", false, ["decrypt"]);
-      const algo = {
-        name: "AES-GCM",
-        iv
-      };
-      const decrypted = await decrypt(algo, cryptoKey, ciphertext);
-      const dec = new TextDecoder();
-      return dec.decode(decrypted);
-    }
-    /**
-     * When required (such as on macos 10.x), capture the `postMessage` method on
-     * each webkit messageHandler
+     * Capture the `postMessage` method on each webkit messageHandler so the
+     * transport can call them later without re-reading `window.webkit.messageHandlers`.
+     * Makes the transport resilient to later removal or replacement of
+     * `window.webkit.messageHandlers` (e.g. by privacy hardening that nullifies
+     * the namespace for site JS to reduce fingerprinting surface).
+     *
+     * Stores the handler object and its `postMessage` function as a pair so
+     * `wkSend` can dispatch via the captured `ReflectApply` rather than calling
+     * `.bind()` here. `.bind` is a method on the page-mutable
+     * `Function.prototype` — if transport construction is deferred (`Messaging`
+     * is lazy on `ContentFeature.messaging`) page JS could replace
+     * `Function.prototype.bind` first and have the cache store an attacker-
+     * controlled function. Storing the unbound pair sidesteps that.
      *
      * @param {string[]} handlerNames
      */
@@ -2867,11 +2766,12 @@
       const handlers = window.webkit.messageHandlers;
       if (!handlers) throw new MissingHandler("window.webkit.messageHandlers was absent", "all");
       for (const webkitMessageHandlerName of handlerNames) {
-        if (typeof handlers[webkitMessageHandlerName]?.postMessage === "function") {
-          const original = handlers[webkitMessageHandlerName];
-          const bound = handlers[webkitMessageHandlerName].postMessage?.bind(original);
-          this.capturedWebkitHandlers[webkitMessageHandlerName] = bound;
-          delete handlers[webkitMessageHandlerName].postMessage;
+        const handler = handlers[webkitMessageHandlerName];
+        if (typeof handler?.postMessage === "function") {
+          this.capturedWebkitHandlers[webkitMessageHandlerName] = {
+            handler,
+            postMessage: handler.postMessage
+          };
         }
       }
     }
@@ -2904,30 +2804,11 @@
   var WebkitMessagingConfig = class {
     /**
      * @param {object} params
-     * @param {boolean} params.hasModernWebkitAPI
      * @param {string[]} params.webkitMessageHandlerNames
-     * @param {string} params.secret
      * @internal
      */
     constructor(params) {
-      this.hasModernWebkitAPI = params.hasModernWebkitAPI;
       this.webkitMessageHandlerNames = params.webkitMessageHandlerNames;
-      this.secret = params.secret;
-    }
-  };
-  var SecureMessagingParams = class {
-    /**
-     * @param {object} params
-     * @param {string} params.methodName
-     * @param {string} params.secret
-     * @param {number[]} params.key
-     * @param {number[]} params.iv
-     */
-    constructor(params) {
-      this.methodName = params.methodName;
-      this.secret = params.secret;
-      this.key = params.key;
-      this.iv = params.iv;
     }
   };
 

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
@@ -50,7 +50,6 @@
   var Uint16Array = globalThis.Uint16Array;
   var Uint32Array = globalThis.Uint32Array;
   var JSONparse = JSON.parse;
-  var Arrayfrom = Array.from;
   var ReflectDeleteProperty = Reflect2.deleteProperty.bind(Reflect2);
   var ReflectApply = Reflect2.apply.bind(Reflect2);
   var getRandomValues = globalThis.crypto?.getRandomValues?.bind(globalThis.crypto);
@@ -1230,21 +1229,27 @@
      * @param {import('../index.js').MessagingContext} messagingContext
      */
     constructor(config, messagingContext) {
-      /** @type {Record<string, any>} */
-      __publicField(this, "capturedWebkitHandlers", {});
       /**
-       * @type {{name: string, length: number}}
-       * @internal
+       * Null-prototype cache so a hostile page that pollutes `Object.prototype`
+       * cannot supply a callable from there if `capture` ever misses a handler.
+       *
+       * Uses the `{ __proto__: null }` literal rather than `Object.create(null)`
+       * because the latter is a method dispatch through `globalThis.Object`, which
+       * page JS could replace before this class field runs if transport
+       * construction is deferred (`Messaging` is lazy on `ContentFeature.messaging`).
+       * The `__proto__: null` literal is a syntactic construct, not method
+       * dispatch, so it always yields a true null-prototype object.
+       * @type {Record<string, { handler: any, postMessage: Function }>}
        */
-      __publicField(this, "algoObj", {
-        name: "AES-GCM",
-        length: 256
-      });
+      __publicField(
+        this,
+        "capturedWebkitHandlers",
+        /** @type {any} */
+        { __proto__: null }
+      );
       this.messagingContext = messagingContext;
       this.config = config;
-      if (!this.config.hasModernWebkitAPI) {
-        this.captureWebkitHandlers(this.config.webkitMessageHandlerNames);
-      }
+      this.captureWebkitHandlers(this.config.webkitMessageHandlerNames);
     }
     /**
      * Sends message to the webkit layer (fire and forget)
@@ -1255,24 +1260,11 @@
      * @internal
      */
     wkSend(handler, data = {}) {
-      if (!(handler in window.webkit.messageHandlers)) {
+      const captured = this.capturedWebkitHandlers[handler];
+      if (!captured || typeof captured.postMessage !== "function") {
         throw new MissingHandler(`Missing webkit handler: '${handler}'`, handler);
       }
-      if (!this.config.hasModernWebkitAPI) {
-        const outgoing = {
-          ...data,
-          messageHandling: {
-            ...data.messageHandling,
-            secret: this.config.secret
-          }
-        };
-        if (!(handler in this.capturedWebkitHandlers)) {
-          throw new MissingHandler(`cannot continue, method ${handler} not captured on macos < 11`, handler);
-        } else {
-          return this.capturedWebkitHandlers[handler](outgoing);
-        }
-      }
-      return window.webkit.messageHandlers[handler].postMessage?.(data);
+      return ReflectApply(captured.postMessage, captured.handler, [data]);
     }
     /**
      * Sends message to the webkit layer and waits for the specified response
@@ -1282,44 +1274,8 @@
      * @internal
      */
     async wkSendAndWait(handler, data) {
-      if (this.config.hasModernWebkitAPI) {
-        const response = await this.wkSend(handler, data);
-        return JSONparse(response || "{}");
-      }
-      try {
-        const randMethodName = this.createRandMethodName();
-        const key = await this.createRandKey();
-        const iv = this.createRandIv();
-        const { ciphertext, tag } = await new Promise2((resolve) => {
-          this.generateRandomMethod(randMethodName, resolve);
-          data.messageHandling = new SecureMessagingParams({
-            methodName: randMethodName,
-            secret: this.config.secret,
-            key: Arrayfrom(key),
-            iv: Arrayfrom(iv)
-          });
-          this.wkSend(handler, data);
-        });
-        const cipher = new Uint8Array2([...ciphertext, ...tag]);
-        const decrypted = await this.decryptResponse(
-          /** @type {BufferSource} */
-          /** @type {unknown} */
-          cipher,
-          /** @type {BufferSource} */
-          /** @type {unknown} */
-          key,
-          iv
-        );
-        return JSONparse(decrypted || "{}");
-      } catch (e) {
-        if (e instanceof MissingHandler) {
-          throw e;
-        } else {
-          console.error("decryption failed", e);
-          console.error(e);
-          return { error: e };
-        }
-      }
+      const response = await this.wkSend(handler, data);
+      return JSONparse(response || "{}");
     }
     /**
      * @param {import('../index.js').NotificationMessage} msg
@@ -1344,77 +1300,19 @@
       throw new Error2("an unknown error occurred");
     }
     /**
-     * Generate a random method name and adds it to navigator.duckduckgo.messageHandlers
-     * The native layer will use this method to send the response
-     * @param {string | number} randomMethodName
-     * @param {Function} callback
-     * @internal
-     */
-    generateRandomMethod(randomMethodName, callback) {
-      const target = ensureNavigatorDuckDuckGo().messageHandlers;
-      objectDefineProperty(target, randomMethodName, {
-        enumerable: false,
-        configurable: true,
-        writable: false,
-        /**
-         * @param {any[]} args
-         */
-        value: (...args) => {
-          callback(...args);
-          ReflectDeleteProperty(target, randomMethodName);
-        }
-      });
-    }
-    /**
-     * @internal
-     * @return {string}
-     */
-    randomString() {
-      return "" + getRandomValues(new Uint32Array(1))[0];
-    }
-    /**
-     * @internal
-     * @return {string}
-     */
-    createRandMethodName() {
-      return "_" + this.randomString();
-    }
-    /**
-     * @returns {Promise<Uint8Array>}
-     * @internal
-     */
-    async createRandKey() {
-      const key = await generateKey(this.algoObj, true, ["encrypt", "decrypt"]);
-      const exportedKey = await exportKey("raw", key);
-      return new Uint8Array2(exportedKey);
-    }
-    /**
-     * @returns {Uint8Array}
-     * @internal
-     */
-    createRandIv() {
-      return getRandomValues(new Uint8Array2(12));
-    }
-    /**
-     * @param {BufferSource} ciphertext
-     * @param {BufferSource} key
-     * @param {Uint8Array} iv
-     * @returns {Promise<string>}
-     * @internal
-     */
-    async decryptResponse(ciphertext, key, iv) {
-      const cryptoKey = await importKey("raw", key, "AES-GCM", false, ["decrypt"]);
-      const algo = {
-        name: "AES-GCM",
-        iv
-      };
-      const decrypted = await decrypt(algo, cryptoKey, ciphertext);
-      const dec = new TextDecoder();
-      return dec.decode(decrypted);
-    }
-    /**
-     * When required (such as on macos 10.x), capture the `postMessage` method on
-     * each webkit messageHandler
+     * Capture the `postMessage` method on each webkit messageHandler so the
+     * transport can call them later without re-reading `window.webkit.messageHandlers`.
+     * Makes the transport resilient to later removal or replacement of
+     * `window.webkit.messageHandlers` (e.g. by privacy hardening that nullifies
+     * the namespace for site JS to reduce fingerprinting surface).
+     *
+     * Stores the handler object and its `postMessage` function as a pair so
+     * `wkSend` can dispatch via the captured `ReflectApply` rather than calling
+     * `.bind()` here. `.bind` is a method on the page-mutable
+     * `Function.prototype` — if transport construction is deferred (`Messaging`
+     * is lazy on `ContentFeature.messaging`) page JS could replace
+     * `Function.prototype.bind` first and have the cache store an attacker-
+     * controlled function. Storing the unbound pair sidesteps that.
      *
      * @param {string[]} handlerNames
      */
@@ -1422,11 +1320,12 @@
       const handlers = window.webkit.messageHandlers;
       if (!handlers) throw new MissingHandler("window.webkit.messageHandlers was absent", "all");
       for (const webkitMessageHandlerName of handlerNames) {
-        if (typeof handlers[webkitMessageHandlerName]?.postMessage === "function") {
-          const original = handlers[webkitMessageHandlerName];
-          const bound = handlers[webkitMessageHandlerName].postMessage?.bind(original);
-          this.capturedWebkitHandlers[webkitMessageHandlerName] = bound;
-          delete handlers[webkitMessageHandlerName].postMessage;
+        const handler = handlers[webkitMessageHandlerName];
+        if (typeof handler?.postMessage === "function") {
+          this.capturedWebkitHandlers[webkitMessageHandlerName] = {
+            handler,
+            postMessage: handler.postMessage
+          };
         }
       }
     }
@@ -1459,30 +1358,11 @@
   var WebkitMessagingConfig = class {
     /**
      * @param {object} params
-     * @param {boolean} params.hasModernWebkitAPI
      * @param {string[]} params.webkitMessageHandlerNames
-     * @param {string} params.secret
      * @internal
      */
     constructor(params) {
-      this.hasModernWebkitAPI = params.hasModernWebkitAPI;
       this.webkitMessageHandlerNames = params.webkitMessageHandlerNames;
-      this.secret = params.secret;
-    }
-  };
-  var SecureMessagingParams = class {
-    /**
-     * @param {object} params
-     * @param {string} params.methodName
-     * @param {string} params.secret
-     * @param {number[]} params.key
-     * @param {number[]} params.iv
-     */
-    constructor(params) {
-      this.methodName = params.methodName;
-      this.secret = params.secret;
-      this.key = params.key;
-      this.iv = params.iv;
     }
   };
 

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiDataClearing.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiDataClearing.js
@@ -50,7 +50,6 @@
   var Uint16Array = globalThis.Uint16Array;
   var Uint32Array = globalThis.Uint32Array;
   var JSONparse = JSON.parse;
-  var Arrayfrom = Array.from;
   var ReflectDeleteProperty = Reflect2.deleteProperty.bind(Reflect2);
   var ReflectApply = Reflect2.apply.bind(Reflect2);
   var getRandomValues = globalThis.crypto?.getRandomValues?.bind(globalThis.crypto);
@@ -1230,21 +1229,27 @@
      * @param {import('../index.js').MessagingContext} messagingContext
      */
     constructor(config, messagingContext) {
-      /** @type {Record<string, any>} */
-      __publicField(this, "capturedWebkitHandlers", {});
       /**
-       * @type {{name: string, length: number}}
-       * @internal
+       * Null-prototype cache so a hostile page that pollutes `Object.prototype`
+       * cannot supply a callable from there if `capture` ever misses a handler.
+       *
+       * Uses the `{ __proto__: null }` literal rather than `Object.create(null)`
+       * because the latter is a method dispatch through `globalThis.Object`, which
+       * page JS could replace before this class field runs if transport
+       * construction is deferred (`Messaging` is lazy on `ContentFeature.messaging`).
+       * The `__proto__: null` literal is a syntactic construct, not method
+       * dispatch, so it always yields a true null-prototype object.
+       * @type {Record<string, { handler: any, postMessage: Function }>}
        */
-      __publicField(this, "algoObj", {
-        name: "AES-GCM",
-        length: 256
-      });
+      __publicField(
+        this,
+        "capturedWebkitHandlers",
+        /** @type {any} */
+        { __proto__: null }
+      );
       this.messagingContext = messagingContext;
       this.config = config;
-      if (!this.config.hasModernWebkitAPI) {
-        this.captureWebkitHandlers(this.config.webkitMessageHandlerNames);
-      }
+      this.captureWebkitHandlers(this.config.webkitMessageHandlerNames);
     }
     /**
      * Sends message to the webkit layer (fire and forget)
@@ -1255,24 +1260,11 @@
      * @internal
      */
     wkSend(handler, data = {}) {
-      if (!(handler in window.webkit.messageHandlers)) {
+      const captured = this.capturedWebkitHandlers[handler];
+      if (!captured || typeof captured.postMessage !== "function") {
         throw new MissingHandler(`Missing webkit handler: '${handler}'`, handler);
       }
-      if (!this.config.hasModernWebkitAPI) {
-        const outgoing = {
-          ...data,
-          messageHandling: {
-            ...data.messageHandling,
-            secret: this.config.secret
-          }
-        };
-        if (!(handler in this.capturedWebkitHandlers)) {
-          throw new MissingHandler(`cannot continue, method ${handler} not captured on macos < 11`, handler);
-        } else {
-          return this.capturedWebkitHandlers[handler](outgoing);
-        }
-      }
-      return window.webkit.messageHandlers[handler].postMessage?.(data);
+      return ReflectApply(captured.postMessage, captured.handler, [data]);
     }
     /**
      * Sends message to the webkit layer and waits for the specified response
@@ -1282,44 +1274,8 @@
      * @internal
      */
     async wkSendAndWait(handler, data) {
-      if (this.config.hasModernWebkitAPI) {
-        const response = await this.wkSend(handler, data);
-        return JSONparse(response || "{}");
-      }
-      try {
-        const randMethodName = this.createRandMethodName();
-        const key = await this.createRandKey();
-        const iv = this.createRandIv();
-        const { ciphertext, tag } = await new Promise2((resolve) => {
-          this.generateRandomMethod(randMethodName, resolve);
-          data.messageHandling = new SecureMessagingParams({
-            methodName: randMethodName,
-            secret: this.config.secret,
-            key: Arrayfrom(key),
-            iv: Arrayfrom(iv)
-          });
-          this.wkSend(handler, data);
-        });
-        const cipher = new Uint8Array2([...ciphertext, ...tag]);
-        const decrypted = await this.decryptResponse(
-          /** @type {BufferSource} */
-          /** @type {unknown} */
-          cipher,
-          /** @type {BufferSource} */
-          /** @type {unknown} */
-          key,
-          iv
-        );
-        return JSONparse(decrypted || "{}");
-      } catch (e) {
-        if (e instanceof MissingHandler) {
-          throw e;
-        } else {
-          console.error("decryption failed", e);
-          console.error(e);
-          return { error: e };
-        }
-      }
+      const response = await this.wkSend(handler, data);
+      return JSONparse(response || "{}");
     }
     /**
      * @param {import('../index.js').NotificationMessage} msg
@@ -1344,77 +1300,19 @@
       throw new Error2("an unknown error occurred");
     }
     /**
-     * Generate a random method name and adds it to navigator.duckduckgo.messageHandlers
-     * The native layer will use this method to send the response
-     * @param {string | number} randomMethodName
-     * @param {Function} callback
-     * @internal
-     */
-    generateRandomMethod(randomMethodName, callback) {
-      const target = ensureNavigatorDuckDuckGo().messageHandlers;
-      objectDefineProperty(target, randomMethodName, {
-        enumerable: false,
-        configurable: true,
-        writable: false,
-        /**
-         * @param {any[]} args
-         */
-        value: (...args) => {
-          callback(...args);
-          ReflectDeleteProperty(target, randomMethodName);
-        }
-      });
-    }
-    /**
-     * @internal
-     * @return {string}
-     */
-    randomString() {
-      return "" + getRandomValues(new Uint32Array(1))[0];
-    }
-    /**
-     * @internal
-     * @return {string}
-     */
-    createRandMethodName() {
-      return "_" + this.randomString();
-    }
-    /**
-     * @returns {Promise<Uint8Array>}
-     * @internal
-     */
-    async createRandKey() {
-      const key = await generateKey(this.algoObj, true, ["encrypt", "decrypt"]);
-      const exportedKey = await exportKey("raw", key);
-      return new Uint8Array2(exportedKey);
-    }
-    /**
-     * @returns {Uint8Array}
-     * @internal
-     */
-    createRandIv() {
-      return getRandomValues(new Uint8Array2(12));
-    }
-    /**
-     * @param {BufferSource} ciphertext
-     * @param {BufferSource} key
-     * @param {Uint8Array} iv
-     * @returns {Promise<string>}
-     * @internal
-     */
-    async decryptResponse(ciphertext, key, iv) {
-      const cryptoKey = await importKey("raw", key, "AES-GCM", false, ["decrypt"]);
-      const algo = {
-        name: "AES-GCM",
-        iv
-      };
-      const decrypted = await decrypt(algo, cryptoKey, ciphertext);
-      const dec = new TextDecoder();
-      return dec.decode(decrypted);
-    }
-    /**
-     * When required (such as on macos 10.x), capture the `postMessage` method on
-     * each webkit messageHandler
+     * Capture the `postMessage` method on each webkit messageHandler so the
+     * transport can call them later without re-reading `window.webkit.messageHandlers`.
+     * Makes the transport resilient to later removal or replacement of
+     * `window.webkit.messageHandlers` (e.g. by privacy hardening that nullifies
+     * the namespace for site JS to reduce fingerprinting surface).
+     *
+     * Stores the handler object and its `postMessage` function as a pair so
+     * `wkSend` can dispatch via the captured `ReflectApply` rather than calling
+     * `.bind()` here. `.bind` is a method on the page-mutable
+     * `Function.prototype` — if transport construction is deferred (`Messaging`
+     * is lazy on `ContentFeature.messaging`) page JS could replace
+     * `Function.prototype.bind` first and have the cache store an attacker-
+     * controlled function. Storing the unbound pair sidesteps that.
      *
      * @param {string[]} handlerNames
      */
@@ -1422,11 +1320,12 @@
       const handlers = window.webkit.messageHandlers;
       if (!handlers) throw new MissingHandler("window.webkit.messageHandlers was absent", "all");
       for (const webkitMessageHandlerName of handlerNames) {
-        if (typeof handlers[webkitMessageHandlerName]?.postMessage === "function") {
-          const original = handlers[webkitMessageHandlerName];
-          const bound = handlers[webkitMessageHandlerName].postMessage?.bind(original);
-          this.capturedWebkitHandlers[webkitMessageHandlerName] = bound;
-          delete handlers[webkitMessageHandlerName].postMessage;
+        const handler = handlers[webkitMessageHandlerName];
+        if (typeof handler?.postMessage === "function") {
+          this.capturedWebkitHandlers[webkitMessageHandlerName] = {
+            handler,
+            postMessage: handler.postMessage
+          };
         }
       }
     }
@@ -1459,30 +1358,11 @@
   var WebkitMessagingConfig = class {
     /**
      * @param {object} params
-     * @param {boolean} params.hasModernWebkitAPI
      * @param {string[]} params.webkitMessageHandlerNames
-     * @param {string} params.secret
      * @internal
      */
     constructor(params) {
-      this.hasModernWebkitAPI = params.hasModernWebkitAPI;
       this.webkitMessageHandlerNames = params.webkitMessageHandlerNames;
-      this.secret = params.secret;
-    }
-  };
-  var SecureMessagingParams = class {
-    /**
-     * @param {object} params
-     * @param {string} params.methodName
-     * @param {string} params.secret
-     * @param {number[]} params.key
-     * @param {number[]} params.iv
-     */
-    constructor(params) {
-      this.methodName = params.methodName;
-      this.secret = params.secret;
-      this.key = params.key;
-      this.iv = params.iv;
     }
   };
 

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
@@ -387,7 +387,6 @@
   var Uint16Array = globalThis.Uint16Array;
   var Uint32Array = globalThis.Uint32Array;
   var JSONparse = JSON.parse;
-  var Arrayfrom = Array.from;
   var ReflectDeleteProperty = Reflect2.deleteProperty.bind(Reflect2);
   var ReflectApply = Reflect2.apply.bind(Reflect2);
   var getRandomValues = globalThis.crypto?.getRandomValues?.bind(globalThis.crypto);
@@ -414,8 +413,22 @@
 
   // ../messaging/lib/webkit.js
   var WebkitMessagingTransport = class {
-    /** @type {Record<string, any>} */
-    capturedWebkitHandlers = {};
+    /**
+     * Null-prototype cache so a hostile page that pollutes `Object.prototype`
+     * cannot supply a callable from there if `capture` ever misses a handler.
+     *
+     * Uses the `{ __proto__: null }` literal rather than `Object.create(null)`
+     * because the latter is a method dispatch through `globalThis.Object`, which
+     * page JS could replace before this class field runs if transport
+     * construction is deferred (`Messaging` is lazy on `ContentFeature.messaging`).
+     * The `__proto__: null` literal is a syntactic construct, not method
+     * dispatch, so it always yields a true null-prototype object.
+     * @type {Record<string, { handler: any, postMessage: Function }>}
+     */
+    capturedWebkitHandlers = (
+      /** @type {any} */
+      { __proto__: null }
+    );
     /**
      * @param {WebkitMessagingConfig} config
      * @param {import('../index.js').MessagingContext} messagingContext
@@ -423,9 +436,7 @@
     constructor(config, messagingContext) {
       this.messagingContext = messagingContext;
       this.config = config;
-      if (!this.config.hasModernWebkitAPI) {
-        this.captureWebkitHandlers(this.config.webkitMessageHandlerNames);
-      }
+      this.captureWebkitHandlers(this.config.webkitMessageHandlerNames);
     }
     /**
      * Sends message to the webkit layer (fire and forget)
@@ -436,24 +447,11 @@
      * @internal
      */
     wkSend(handler, data = {}) {
-      if (!(handler in window.webkit.messageHandlers)) {
+      const captured = this.capturedWebkitHandlers[handler];
+      if (!captured || typeof captured.postMessage !== "function") {
         throw new MissingHandler(`Missing webkit handler: '${handler}'`, handler);
       }
-      if (!this.config.hasModernWebkitAPI) {
-        const outgoing = {
-          ...data,
-          messageHandling: {
-            ...data.messageHandling,
-            secret: this.config.secret
-          }
-        };
-        if (!(handler in this.capturedWebkitHandlers)) {
-          throw new MissingHandler(`cannot continue, method ${handler} not captured on macos < 11`, handler);
-        } else {
-          return this.capturedWebkitHandlers[handler](outgoing);
-        }
-      }
-      return window.webkit.messageHandlers[handler].postMessage?.(data);
+      return ReflectApply(captured.postMessage, captured.handler, [data]);
     }
     /**
      * Sends message to the webkit layer and waits for the specified response
@@ -463,44 +461,8 @@
      * @internal
      */
     async wkSendAndWait(handler, data) {
-      if (this.config.hasModernWebkitAPI) {
-        const response = await this.wkSend(handler, data);
-        return JSONparse(response || "{}");
-      }
-      try {
-        const randMethodName = this.createRandMethodName();
-        const key = await this.createRandKey();
-        const iv = this.createRandIv();
-        const { ciphertext, tag } = await new Promise2((resolve) => {
-          this.generateRandomMethod(randMethodName, resolve);
-          data.messageHandling = new SecureMessagingParams({
-            methodName: randMethodName,
-            secret: this.config.secret,
-            key: Arrayfrom(key),
-            iv: Arrayfrom(iv)
-          });
-          this.wkSend(handler, data);
-        });
-        const cipher = new Uint8Array2([...ciphertext, ...tag]);
-        const decrypted = await this.decryptResponse(
-          /** @type {BufferSource} */
-          /** @type {unknown} */
-          cipher,
-          /** @type {BufferSource} */
-          /** @type {unknown} */
-          key,
-          iv
-        );
-        return JSONparse(decrypted || "{}");
-      } catch (e3) {
-        if (e3 instanceof MissingHandler) {
-          throw e3;
-        } else {
-          console.error("decryption failed", e3);
-          console.error(e3);
-          return { error: e3 };
-        }
-      }
+      const response = await this.wkSend(handler, data);
+      return JSONparse(response || "{}");
     }
     /**
      * @param {import('../index.js').NotificationMessage} msg
@@ -525,85 +487,19 @@
       throw new Error2("an unknown error occurred");
     }
     /**
-     * Generate a random method name and adds it to navigator.duckduckgo.messageHandlers
-     * The native layer will use this method to send the response
-     * @param {string | number} randomMethodName
-     * @param {Function} callback
-     * @internal
-     */
-    generateRandomMethod(randomMethodName, callback) {
-      const target = ensureNavigatorDuckDuckGo().messageHandlers;
-      objectDefineProperty(target, randomMethodName, {
-        enumerable: false,
-        configurable: true,
-        writable: false,
-        /**
-         * @param {any[]} args
-         */
-        value: (...args) => {
-          callback(...args);
-          ReflectDeleteProperty(target, randomMethodName);
-        }
-      });
-    }
-    /**
-     * @internal
-     * @return {string}
-     */
-    randomString() {
-      return "" + getRandomValues(new Uint32Array(1))[0];
-    }
-    /**
-     * @internal
-     * @return {string}
-     */
-    createRandMethodName() {
-      return "_" + this.randomString();
-    }
-    /**
-     * @type {{name: string, length: number}}
-     * @internal
-     */
-    algoObj = {
-      name: "AES-GCM",
-      length: 256
-    };
-    /**
-     * @returns {Promise<Uint8Array>}
-     * @internal
-     */
-    async createRandKey() {
-      const key = await generateKey(this.algoObj, true, ["encrypt", "decrypt"]);
-      const exportedKey = await exportKey("raw", key);
-      return new Uint8Array2(exportedKey);
-    }
-    /**
-     * @returns {Uint8Array}
-     * @internal
-     */
-    createRandIv() {
-      return getRandomValues(new Uint8Array2(12));
-    }
-    /**
-     * @param {BufferSource} ciphertext
-     * @param {BufferSource} key
-     * @param {Uint8Array} iv
-     * @returns {Promise<string>}
-     * @internal
-     */
-    async decryptResponse(ciphertext, key, iv) {
-      const cryptoKey = await importKey("raw", key, "AES-GCM", false, ["decrypt"]);
-      const algo = {
-        name: "AES-GCM",
-        iv
-      };
-      const decrypted = await decrypt(algo, cryptoKey, ciphertext);
-      const dec = new TextDecoder();
-      return dec.decode(decrypted);
-    }
-    /**
-     * When required (such as on macos 10.x), capture the `postMessage` method on
-     * each webkit messageHandler
+     * Capture the `postMessage` method on each webkit messageHandler so the
+     * transport can call them later without re-reading `window.webkit.messageHandlers`.
+     * Makes the transport resilient to later removal or replacement of
+     * `window.webkit.messageHandlers` (e.g. by privacy hardening that nullifies
+     * the namespace for site JS to reduce fingerprinting surface).
+     *
+     * Stores the handler object and its `postMessage` function as a pair so
+     * `wkSend` can dispatch via the captured `ReflectApply` rather than calling
+     * `.bind()` here. `.bind` is a method on the page-mutable
+     * `Function.prototype` — if transport construction is deferred (`Messaging`
+     * is lazy on `ContentFeature.messaging`) page JS could replace
+     * `Function.prototype.bind` first and have the cache store an attacker-
+     * controlled function. Storing the unbound pair sidesteps that.
      *
      * @param {string[]} handlerNames
      */
@@ -611,11 +507,12 @@
       const handlers = window.webkit.messageHandlers;
       if (!handlers) throw new MissingHandler("window.webkit.messageHandlers was absent", "all");
       for (const webkitMessageHandlerName of handlerNames) {
-        if (typeof handlers[webkitMessageHandlerName]?.postMessage === "function") {
-          const original = handlers[webkitMessageHandlerName];
-          const bound = handlers[webkitMessageHandlerName].postMessage?.bind(original);
-          this.capturedWebkitHandlers[webkitMessageHandlerName] = bound;
-          delete handlers[webkitMessageHandlerName].postMessage;
+        const handler = handlers[webkitMessageHandlerName];
+        if (typeof handler?.postMessage === "function") {
+          this.capturedWebkitHandlers[webkitMessageHandlerName] = {
+            handler,
+            postMessage: handler.postMessage
+          };
         }
       }
     }
@@ -648,30 +545,11 @@
   var WebkitMessagingConfig = class {
     /**
      * @param {object} params
-     * @param {boolean} params.hasModernWebkitAPI
      * @param {string[]} params.webkitMessageHandlerNames
-     * @param {string} params.secret
      * @internal
      */
     constructor(params) {
-      this.hasModernWebkitAPI = params.hasModernWebkitAPI;
       this.webkitMessageHandlerNames = params.webkitMessageHandlerNames;
-      this.secret = params.secret;
-    }
-  };
-  var SecureMessagingParams = class {
-    /**
-     * @param {object} params
-     * @param {string} params.methodName
-     * @param {string} params.secret
-     * @param {number[]} params.key
-     * @param {number[]} params.iv
-     */
-    constructor(params) {
-      this.methodName = params.methodName;
-      this.secret = params.secret;
-      this.key = params.key;
-      this.iv = params.iv;
     }
   };
 
@@ -1430,8 +1308,6 @@
         return new Messaging(messageContext, opts2);
       } else if (opts.injectName === "apple") {
         const opts2 = new WebkitMessagingConfig({
-          hasModernWebkitAPI: true,
-          secret: "",
           webkitMessageHandlerNames: ["specialPages"]
         });
         return new Messaging(messageContext, opts2);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.85.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.14.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.0.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.85.1",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.85.1.tgz",
-      "integrity": "sha512-il25QI4eplTIWXkzAtvHUAa7nuZoMHB6UFIqXqwhKgJ4UCXKN9lbaND705Fu1MYvxDXXf27qKe3AVA1VcdxElw==",
+      "version": "14.85.5",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.85.5.tgz",
+      "integrity": "sha512-LmzQGM9K9MWjKMwapqx81RVNgBIt7q2AFIM/4KceHRhXltmbeQZRiFFTBLKHbrNrajYpVcNfsM5XhdkV/s4TLQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#0d678e5ea42dd082c22237469599186b5d3a753a",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#512a2657dd2f3b73682babf77561068cccd28c41",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -402,9 +402,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -678,18 +678,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.0.tgz",
-      "integrity": "sha512-/mb9kRld+x1sIMXxWNOAp5m6C+D4GrAORWlJkOJ5dElvxdN1eutz/o7qHLp9gFvDF4Y3/L2xeScoxz6AbEo8rQ==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
+      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.4.0.tgz",
-      "integrity": "sha512-F/xMOEOBEadHoaap73sz2utvE0vAvKv3h/a5vZYt3zLrJY51sGYIifbV2x8KNhENaU6xrTevydtVZjEr1iAfKQ==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.4.2.tgz",
+      "integrity": "sha512-z2Lk9PdA6eiK4NrBqq3nTFpg0t22yhYvG4ggwB/sjdvEftRMerlAANoQnFBgOWqR1LVpjTmPF5egtKhCc1HDBg==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.4.0"
+        "tldts-core": "^7.4.2"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.85.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#14.14.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.0.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1215297258324348/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches injected script messaging to native code; behavior shifts (always capture handlers, no legacy crypto path) warrant content-scope and privacy test runs when build artifacts change.
> 
> **Overview**
> Bumps **`@duckduckgo/content-scope-scripts`** from **14.14.0** to **15.0.0** and refreshes the copied **`node_modules/@duckduckgo/content-scope-scripts/build/android/**`** bundles (plus **`package-lock.json`**).
> 
> The vendored update changes **`WebkitMessagingTransport`**: it always captures WebKit handlers up front, routes sends through a null-prototype handler cache and **`ReflectApply`** (instead of **`.bind()`** or live **`window.webkit.messageHandlers`** reads), and drops the legacy encrypted **`wkSendAndWait`** path and **`hasModernWebkitAPI` / `secret`** config. **`WebkitMessagingConfig`** for the duckplayer apple inject is updated to match (handler names only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5ca57e696147e9688ab942bdf420309c4689488. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->