### PR TITLE
Move streaming stop button into a plugin

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputPlugin.kt
@@ -31,6 +31,9 @@ interface NativeInputHost {
     /** Submit the current input as a chat message; opens a new chat session if the input is empty. */
     fun submit()
 
+    /** Stop the active chat stream. Delegates to the host's [NativeInputWidget.onStopTapped] callback. */
+    fun stop()
+
     fun showAttachmentChooser(showing: Boolean)
     fun showModelPicker(showing: Boolean)
     fun showReasoningPicker(showing: Boolean)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/StopStreamingNativeInputPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/plugins/StopStreamingNativeInputPlugin.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.nativeinput.plugins
+
+import android.content.Context
+import android.view.View
+import com.duckduckgo.anvil.annotations.ContributesActivePlugin
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
+import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.StopStreamingView
+import javax.inject.Inject
+
+@ContributesActivePlugin(
+    scope = AppScope::class,
+    boundType = NativeInputPlugin::class,
+    featureName = "pluginStopStreamingNativeInput",
+    parentFeatureName = "pluginPointNativeInput",
+)
+class StopStreamingNativeInputPlugin @Inject constructor() : NativeInputPlugin {
+
+    override val containerId: Int = R.id.streamingButtonsContainer
+
+    override fun createView(context: Context, host: NativeInputHost): View = StopStreamingView(context).apply {
+        onStopClicked = { host.stop() }
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -199,7 +199,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private var tabCountLiveData: LiveData<Int>? = null
     private var tabCountObserver: Observer<Int>? = null
     private var submitButtons: InputScreenButtons? = null
-    private var streamingButtons: InputScreenButtons? = null
     private var floatingButtons: InputScreenButtons? = null
     private var floatingSubmitContainer: ViewGroup? = null
     private var chatStateJob: Job? = null
@@ -357,7 +356,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
         chatIdJob = null
         modelPickerView = null
         optionsView = null
-        streamingButtons = null
         widgetRoot = null
         tearDownChatSuggestions()
     }
@@ -1092,12 +1090,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private fun setChatStreaming(streaming: Boolean) {
         isStreaming = streaming
         configureSubmitButtons()
-        val streamingContainer = findViewById<FrameLayout?>(R.id.streamingButtonsContainer)
-        if (streaming) {
-            streamingContainer?.visibility = VISIBLE
-            streamingButtons?.setSendButtonVisible(true)
-        } else {
-            streamingContainer?.visibility = GONE
+        if (!streaming) {
             submitButtons?.showSendButton()
             applyTabUi()
             floatingSubmitContainer?.visibility = if (attachmentLimitExceeded) GONE else VISIBLE
@@ -1129,6 +1122,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
         // in Duck.ai mode we treat this as submitting prompts.
         // In non-Duck.ai mode we treat this as starting a chat with or without a prompt.
         if (!submitAsChat()) viewModel.openNewChat()
+    }
+
+    override fun stop() {
+        onStopTapped?.invoke()
     }
 
     override fun showAttachmentChooser(showing: Boolean) {
@@ -1178,24 +1175,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
             }
             bottomContainer.addView(buttons)
             submitButtons = buttons
-        }
-
-        if (streamingButtons == null) {
-            val streamingContainer = findViewById<FrameLayout?>(R.id.streamingButtonsContainer)
-            if (streamingContainer != null) {
-                val buttons = InputScreenButtons(
-                    context = context,
-                    useTopBar = false,
-                    layoutResId = R.layout.view_native_input_screen_buttons,
-                ).apply {
-                    onStopClick = { this@NativeInputModeWidget.onStopTapped?.invoke() }
-                    showStopButton()
-                    setSendButtonVisible(false)
-                    setNewLineButtonVisible(false)
-                }
-                streamingContainer.addView(buttons)
-                streamingButtons = buttons
-            }
         }
 
         val floating = floatingSubmitContainer

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StopStreamingView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StopStreamingView.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.nativeinput.views
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import android.widget.FrameLayout
+import android.widget.ImageView
+import androidx.core.view.isVisible
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.findViewTreeViewModelStoreOwner
+import androidx.lifecycle.lifecycleScope
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.common.utils.ViewViewModelFactory
+import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.duckchat.impl.R
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+
+@InjectWith(ViewScope::class)
+class StopStreamingView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyle: Int = 0,
+) : FrameLayout(context, attrs, defStyle) {
+
+    @Inject lateinit var viewModelFactory: ViewViewModelFactory
+
+    private val viewModel by lazy {
+        ViewModelProvider(findViewTreeViewModelStoreOwner()!!, viewModelFactory)[StopStreamingViewModel::class.java]
+    }
+
+    private val button: ImageView by lazy { findViewById(R.id.stopStreamingButton) }
+    private var visibilityJob: Job? = null
+
+    var onStopClicked: (() -> Unit)? = null
+
+    init {
+        inflate(context, R.layout.view_stop_streaming, this)
+    }
+
+    override fun onAttachedToWindow() {
+        AndroidSupportInjection.inject(this)
+        super.onAttachedToWindow()
+        button.setOnClickListener { onStopClicked?.invoke() }
+        observeVisibility()
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        visibilityJob?.cancel()
+        visibilityJob = null
+    }
+
+    private fun observeVisibility() {
+        val scope = findViewTreeLifecycleOwner()?.lifecycleScope ?: return
+        visibilityJob?.cancel()
+        visibilityJob = viewModel.isVisible
+            .onEach { visible ->
+                isVisible = visible
+                (parent as? View)?.isVisible = visible
+            }
+            .launchIn(scope)
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StopStreamingViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StopStreamingViewModel.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.nativeinput.views
+
+import androidx.lifecycle.ViewModel
+import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+@ContributesViewModel(ViewScope::class)
+class StopStreamingViewModel @Inject constructor(
+    nativeInputStateProvider: NativeInputStateProvider,
+) : ViewModel() {
+
+    /** Show the stop button only while the chat is actively streaming a response. */
+    val isVisible: Flow<Boolean> = nativeInputStateProvider.state.map { it.isChatStreaming }
+}

--- a/duckchat/duckchat-impl/src/main/res/layout/view_stop_streaming.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_stop_streaming.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <ImageView
+        android:id="@+id/stopStreamingButton"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:layout_gravity="end|center_vertical"
+        android:background="@drawable/background_input_screen_button"
+        android:backgroundTint="?attr/daxColorControlFillPrimary"
+        android:contentDescription="@string/duckChatStopStreamingContentDescription"
+        android:foreground="@drawable/selectable_circular_ripple"
+        android:importantForAccessibility="no"
+        android:scaleType="centerInside"
+        app:srcCompat="@drawable/ic_stop_16"
+        app:tint="?attr/daxColorPrimaryIcon" />
+
+</merge>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -41,6 +41,7 @@
 
     <!-- Start chat icon content description -->
     <string name="duckChatStartChatContentDescription">Start chat</string>
+    <string name="duckChatStopStreamingContentDescription">Stop generating</string>
 
     <!-- Image attachment -->
     <string name="duckChatImageAttachmentRemoveContentDescription">Remove image</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1215277941433621

> Based on #8733 — review that first.

### Description
Moves the streaming stop button out of `NativeInputModeWidget` and into the plugin architecture, following the `StartChatNativeInputPlugin` pattern.

- `StopStreamingViewModel` — maps `NativeInputState.isChatStreaming` to `isVisible: Flow<Boolean>`
- `StopStreamingView` — observes the VM, shows/hides itself and its parent container; single grey-tinted stop button matching the voice chat button style
- `StopStreamingNativeInputPlugin` — `containerId = R.id.streamingButtonsContainer`, wires `onStopClicked = { host.stop() }`
- `NativeInputHost` gains `fun stop()`, implemented in the widget as `onStopTapped?.invoke()`
- Widget no longer manages `streamingButtons` or the streaming container — `setChatStreaming` only handles the send-button restore path

### Steps to test this PR

- [ ] Start a Duck.ai chat and confirm the grey stop button appears inline with the text field while streaming
- [ ] Tap the stop button — confirm streaming stops
- [ ] When streaming ends, confirm the stop button disappears and the controls row reappears on focus

### UI changes
| Before  | After |
| ------ | ----- |
|Upload before screenshot|Upload after screenshot|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI refactor in chat input with stop still delegated to the existing onStopTapped callback; no auth or data-path changes.
> 
> **Overview**
> Refactors the **stop generating** control out of `NativeInputModeWidget` into the native input **plugin** stack (same pattern as start chat).
> 
> **`StopStreamingNativeInputPlugin`** mounts a **`StopStreamingView`** in `streamingButtonsContainer` and routes taps through **`NativeInputHost.stop()`**, which the widget implements by invoking **`onStopTapped`**. **`StopStreamingViewModel`** drives visibility from **`NativeInputState.isChatStreaming`**; the view also shows/hides its parent container.
> 
> The widget **drops** inline `streamingButtons` / `InputScreenButtons` stop wiring and no longer toggles the streaming container in **`setChatStreaming`**—it only restores send/floating UI when streaming ends. Adds **`view_stop_streaming`** layout and **“Stop generating”** content description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc0526c89bc2d9b70cbe907bdd1301b8b475bb49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->