### PR TITLE
Fix omnibar showing Duck.ai URLs

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1525,10 +1525,18 @@ class BrowserTabViewModel @Inject constructor(
 
         globalLayoutState.value = Browser(isNewTabState = false)
         findInPageViewState.value = FindInPageViewState(visible = false)
+        // A submitted Duck.ai URL opens in full-screen Duck.ai mode (empty address bar), so never
+        // paint its URL into the omnibar — otherwise it flashes for the brief window between submit
+        // and full-screen mode engaging, and lingers if the user navigates back during that window.
+        val isDuckChatUrl = duckChat.isDuckChatUrl(trimmedInput.toUri())
         omnibarViewState.value =
             currentOmnibarViewState().copy(
-                omnibarText = if (isFullUrlEnabled.value) trimmedInput else addressDisplayFormatter.getShortUrl(trimmedInput),
-                queryOrFullUrl = trimmedInput,
+                omnibarText = when {
+                    isDuckChatUrl -> ""
+                    isFullUrlEnabled.value -> trimmedInput
+                    else -> addressDisplayFormatter.getShortUrl(trimmedInput)
+                },
+                queryOrFullUrl = if (isDuckChatUrl) "" else trimmedInput,
                 forceExpand = true,
             )
         browserViewState.value =
@@ -2292,6 +2300,7 @@ class BrowserTabViewModel @Inject constructor(
         showFullUrl: Boolean,
     ): String {
         if (url == null) return ""
+        if (duckChat.isDuckChatUrl(url.toUri())) return ""
 
         return if (duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(url)) {
             duckDuckGoUrlDetector.extractQuery(url) ?: url

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -1258,6 +1258,18 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenDuckChatUrlSubmittedThenOmnibarTextAndQueryRemainBlank() {
+        val duckChatUrl = "https://duck.ai/chat?q=test&prompt=1&duckai=5"
+        whenever(mockDuckChat.isDuckChatUrl(duckChatUrl.toUri())).thenReturn(true)
+        whenever(mockOmnibarConverter.convertQueryToUrl(duckChatUrl, null)).thenReturn(duckChatUrl)
+
+        testee.onUserSubmittedQuery(duckChatUrl)
+
+        assertEquals("", omnibarViewState().omnibarText)
+        assertEquals("", omnibarViewState().queryOrFullUrl)
+    }
+
+    @Test
     fun whenQuerySubmittedWhileOnNtpAndFeatureEnabledThenNtpSearchSubmittedNotified() {
         fakeAndroidConfigBrowserFeature.showNTPAfterIdleReturn().setRawStoredState(State(enable = true))
         whenever(mockOmnibarConverter.convertQueryToUrl("cats", null)).thenReturn("https://duckduckgo.com/?q=cats")
@@ -1680,6 +1692,15 @@ class BrowserTabViewModelTest {
     fun whenNotBrowsingAndUrlLoadedWithQueryUrlThenOmnibarTextextRemainsBlank() {
         loadUrl("http://duckduckgo.com?q=test", isBrowserShowing = false)
         assertEquals("", omnibarViewState().omnibarText)
+    }
+
+    @Test
+    fun whenBrowsingAndDuckChatUrlLoadedThenOmnibarTextRemainsBlank() {
+        val duckChatUrl = "https://duck.ai/chat?q=DuckDuckGo+AI+Chat&duckai=5"
+        whenever(mockDuckChat.isDuckChatUrl(duckChatUrl.toUri())).thenReturn(true)
+        loadUrl(duckChatUrl, isBrowserShowing = true)
+        assertEquals("", omnibarViewState().omnibarText)
+        assertEquals("", omnibarViewState().queryOrFullUrl)
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1213689666003866?focus=true

### Description

- Fixes the Duck.ai URL sometimes showing in the omnibar

### Steps to test this PR

_With Search and Duck.ai disabled_
- [x] Type something in the omnibar
- [x] Tap the Duck.ai omnibar icon
- [x] Go back quickly
- [x] Verify that the Browser tab does not show the Duck.ai URL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized omnibar display logic with unit tests; no auth, networking, or data-layer changes.
> 
> **Overview**
> **Keeps Duck.ai URLs out of the omnibar** so full-screen Duck.ai mode stays consistent: the address bar should stay empty, but omnibar state was still being set from submitted or loaded `duck.ai` URLs.
> 
> In **`BrowserTabViewModel`**, when the user submits a query, **`duckChat.isDuckChatUrl`** now forces **`omnibarText`** and **`queryOrFullUrl`** to blank instead of showing the full or shortened URL. The same rule is applied in **`omnibarTextForUrl`**, which drives omnibar updates on navigation (e.g. after **`loadUrl`** / page changes), so browsing Duck.ai no longer repopulates the bar.
> 
> **Tests** cover submit and load paths for Duck.ai URLs asserting empty omnibar fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9675e5134a061a14cc284e73bff407c17aad6313. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->