### PR TITLE
Create shared classes for the edge-to-edge support

### DIFF
--- a/android-design-system/design-system/src/main/res/layout/include_tab_switcher_toolbar_bottom.xml
+++ b/android-design-system/design-system/src/main/res/layout/include_tab_switcher_toolbar_bottom.xml
@@ -26,6 +26,7 @@
     android:outlineProvider="none">
 
     <View
+        android:id="@+id/bottomBarDivider"
         android:layout_width="match_parent"
         android:layout_height="0.5dp"
         android:background="?attr/daxColorShadeSolid" />

--- a/android-design-system/design-system/src/main/res/layout/include_tab_switcher_toolbar_bottom.xml
+++ b/android-design-system/design-system/src/main/res/layout/include_tab_switcher_toolbar_bottom.xml
@@ -26,7 +26,6 @@
     android:outlineProvider="none">
 
     <View
-        android:id="@+id/bottomBarDivider"
         android:layout_width="match_parent"
         android:layout_height="0.5dp"
         android:background="?attr/daxColorShadeSolid" />

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -275,12 +275,23 @@ class TabSwitcherActivity :
     }
 
     private fun configureEdgeToEdgeInsets() {
-        edgeToEdgeHandler.applyNavigationBarInsets(binding.root)
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+
         when (settingsDataStore.omnibarType) {
-            OmnibarType.SINGLE_TOP, OmnibarType.SPLIT ->
+            OmnibarType.SINGLE_TOP -> {
                 edgeToEdgeHandler.applyStatusBarInsets(binding.tabSwitcherToolbarTop.root)
-            OmnibarType.SINGLE_BOTTOM ->
+                edgeToEdgeHandler.applyNavigationBarInsets(tabsRecycler)
+            }
+            OmnibarType.SINGLE_BOTTOM -> {
                 edgeToEdgeHandler.applyStatusBarInsets(tabsContainer)
+                edgeToEdgeHandler.applyNavigationBarInsets(binding.tabSwitcherToolbarBottom.root)
+                window.isNavigationBarContrastEnforced = false
+            }
+            OmnibarType.SPLIT -> {
+                edgeToEdgeHandler.applyStatusBarInsets(binding.tabSwitcherToolbarTop.root)
+                edgeToEdgeHandler.applyNavigationBarInsets(binding.navigationBar)
+                window.isNavigationBarContrastEnforced = false
+            }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -19,7 +19,7 @@ package com.duckduckgo.app.tabs.ui
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
-import android.os.Build
+import android.graphics.Color
 import android.os.Bundle
 import android.view.Gravity
 import android.view.Menu
@@ -29,6 +29,7 @@ import android.view.View
 import android.widget.FrameLayout
 import android.widget.ImageView
 import androidx.activity.OnBackPressedCallback
+import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatDelegate.FEATURE_SUPPORT_ACTION_BAR
 import androidx.appcompat.widget.Toolbar
@@ -83,12 +84,14 @@ import com.duckduckgo.browser.api.ui.BrowserScreens.TabSwitcherScreenNoParams
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.menu.PopupMenu
+import com.duckduckgo.common.ui.store.AppTheme
 import com.duckduckgo.common.ui.view.button.ButtonType
 import com.duckduckgo.common.ui.view.button.ButtonType.DESTRUCTIVE
 import com.duckduckgo.common.ui.view.button.ButtonType.GHOST
 import com.duckduckgo.common.ui.view.button.ButtonType.GHOST_ALT
 import com.duckduckgo.common.ui.view.dialog.DaxAlertDialog
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
+import com.duckduckgo.common.ui.view.getColorFromAttr
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.hide
 import com.duckduckgo.common.ui.view.show
@@ -160,6 +163,9 @@ class TabSwitcherActivity :
 
     @Inject
     lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
+    @Inject
+    lateinit var appTheme: AppTheme
 
     private val viewModel: TabSwitcherViewModel by bindViewModel()
 
@@ -250,7 +256,12 @@ class TabSwitcherActivity :
 
         val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BROWSER)
         if (edgeToEdgeEnabled) {
-            enableEdgeToEdge()
+            val barStyle = if (appTheme.isLightModeEnabled()) {
+                SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT)
+            } else {
+                SystemBarStyle.dark(Color.TRANSPARENT)
+            }
+            enableEdgeToEdge(statusBarStyle = barStyle, navigationBarStyle = barStyle)
         }
 
         setContentView(binding.root)
@@ -285,21 +296,15 @@ class TabSwitcherActivity :
             }
             OmnibarType.SINGLE_BOTTOM -> {
                 edgeToEdgeHandler.applyStatusBarInsets(tabsContainer)
-                edgeToEdgeHandler.applyNavigationBarInsets(binding.tabSwitcherToolbarBottom.root)
-                disableNavigationBarContrast()
+                edgeToEdgeHandler.applyNavigationBarInsets(binding.tabSwitcherToolbarBottom.appBarLayout)
+                binding.tabSwitcherToolbarBottom.appBarLayout.setBackgroundColor(
+                    getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorToolbar),
+                )
             }
             OmnibarType.SPLIT -> {
                 edgeToEdgeHandler.applyStatusBarInsets(binding.tabSwitcherToolbarTop.root)
                 edgeToEdgeHandler.applyNavigationBarInsets(binding.navigationBar)
-                disableNavigationBarContrast()
             }
-        }
-    }
-
-    private fun disableNavigationBarContrast() {
-        // isNavigationBarContrastEnforced was added in API 29
-        if (Build.VERSION.SDK_INT >= 29) {
-            window.isNavigationBarContrastEnforced = false
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.tabs.ui
 import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.view.Gravity
 import android.view.Menu
@@ -285,13 +286,20 @@ class TabSwitcherActivity :
             OmnibarType.SINGLE_BOTTOM -> {
                 edgeToEdgeHandler.applyStatusBarInsets(tabsContainer)
                 edgeToEdgeHandler.applyNavigationBarInsets(binding.tabSwitcherToolbarBottom.root)
-                window.isNavigationBarContrastEnforced = false
+                disableNavigationBarContrast()
             }
             OmnibarType.SPLIT -> {
                 edgeToEdgeHandler.applyStatusBarInsets(binding.tabSwitcherToolbarTop.root)
                 edgeToEdgeHandler.applyNavigationBarInsets(binding.navigationBar)
-                window.isNavigationBarContrastEnforced = false
+                disableNavigationBarContrast()
             }
+        }
+    }
+
+    private fun disableNavigationBarContrast() {
+        // isNavigationBarContrastEnforced was added in API 29
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isNavigationBarContrastEnforced = false
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -292,7 +292,7 @@ class TabSwitcherActivity :
         when (settingsDataStore.omnibarType) {
             OmnibarType.SINGLE_TOP -> {
                 edgeToEdgeHandler.applyStatusBarInsets(binding.tabSwitcherToolbarTop.root)
-                edgeToEdgeHandler.applyNavigationBarInsets(tabsRecycler)
+                edgeToEdgeHandler.applyNavigationBarInsets(tabsContainer)
             }
             OmnibarType.SINGLE_BOTTOM -> {
                 edgeToEdgeHandler.applyStatusBarInsets(tabsContainer)

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -84,7 +84,6 @@ import com.duckduckgo.browser.api.ui.BrowserScreens.TabSwitcherScreenNoParams
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.menu.PopupMenu
-import com.duckduckgo.common.ui.store.AppTheme
 import com.duckduckgo.common.ui.view.button.ButtonType
 import com.duckduckgo.common.ui.view.button.ButtonType.DESTRUCTIVE
 import com.duckduckgo.common.ui.view.button.ButtonType.GHOST
@@ -163,9 +162,6 @@ class TabSwitcherActivity :
 
     @Inject
     lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
-
-    @Inject
-    lateinit var appTheme: AppTheme
 
     private val viewModel: TabSwitcherViewModel by bindViewModel()
 
@@ -256,10 +252,10 @@ class TabSwitcherActivity :
 
         val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BROWSER)
         if (edgeToEdgeEnabled) {
-            val barStyle = if (appTheme.isLightModeEnabled()) {
-                SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT)
-            } else {
+            val barStyle = if (isDarkThemeEnabled()) {
                 SystemBarStyle.dark(Color.TRANSPARENT)
+            } else {
+                SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT)
             }
             enableEdgeToEdge(statusBarStyle = barStyle, navigationBarStyle = barStyle)
         }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -298,7 +298,7 @@ class TabSwitcherActivity :
 
     private fun disableNavigationBarContrast() {
         // isNavigationBarContrastEnforced was added in API 29
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        if (Build.VERSION.SDK_INT >= 29) {
             window.isNavigationBarContrastEnforced = false
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -28,6 +28,7 @@ import android.view.View
 import android.widget.FrameLayout
 import android.widget.ImageView
 import androidx.activity.OnBackPressedCallback
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatDelegate.FEATURE_SUPPORT_ACTION_BAR
 import androidx.appcompat.widget.Toolbar
 import androidx.core.view.children
@@ -93,6 +94,9 @@ import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.dataclearing.api.fire.FireDialogProvider
 import com.duckduckgo.dataclearing.api.fire.FireDialogProvider.FireDialogOrigin.TabSwitcher
 import com.duckduckgo.di.scopes.ActivityScope
@@ -149,6 +153,12 @@ class TabSwitcherActivity :
 
     @Inject
     lateinit var omnibarRepository: OmnibarRepository
+
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
 
     private val viewModel: TabSwitcherViewModel by bindViewModel()
 
@@ -236,6 +246,12 @@ class TabSwitcherActivity :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BROWSER)
+        if (edgeToEdgeEnabled) {
+            enableEdgeToEdge()
+        }
+
         setContentView(binding.root)
 
         tabsAdapter.setAnimationTileCloseClickListener {
@@ -248,10 +264,24 @@ class TabSwitcherActivity :
         configureRecycler()
         configureNavigationBar()
 
+        if (edgeToEdgeEnabled) {
+            configureEdgeToEdgeInsets()
+        }
+
         configureObservers()
         configureOnBackPressedListener()
 
         initMenuClickListeners()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.root)
+        when (settingsDataStore.omnibarType) {
+            OmnibarType.SINGLE_TOP, OmnibarType.SPLIT ->
+                edgeToEdgeHandler.applyStatusBarInsets(binding.tabSwitcherToolbarTop.root)
+            OmnibarType.SINGLE_BOTTOM ->
+                edgeToEdgeHandler.applyStatusBarInsets(tabsContainer)
+        }
     }
 
     private fun configureNavigationBar() {

--- a/common/common-utils/build.gradle
+++ b/common/common-utils/build.gradle
@@ -78,6 +78,7 @@ dependencies {
     testImplementation "androidx.test:runner:_"
     testImplementation Testing.robolectric
     testImplementation project(path: ':common-test')
+    testImplementation project(path: ':feature-toggles-test')
 
     coreLibraryDesugaring Android.tools.desugarJdkLibs
 }

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeBucket.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeBucket.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.utils.edgetoedge
+
+/**
+ * Edge-to-edge rollout buckets. Each bucket maps to a sub-toggle of the `edgeToEdge` remote feature
+ */
+enum class EdgeToEdgeBucket {
+    BROWSER,
+    SETTINGS,
+}

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeFeature.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeFeature.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.utils.edgetoedge
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "edgeToEdge",
+)
+interface EdgeToEdgeFeature {
+
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun self(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun browser(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun settings(): Toggle
+}

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeHandler.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeHandler.kt
@@ -44,6 +44,7 @@ class EdgeToEdgeHandler @Inject constructor() {
             v.updatePadding(top = initialTop + top)
             insets
         }
+        ViewCompat.requestApplyInsets(view)
     }
 
     /**
@@ -59,6 +60,7 @@ class EdgeToEdgeHandler @Inject constructor() {
             v.updatePadding(bottom = initialBottom + bottom)
             insets
         }
+        ViewCompat.requestApplyInsets(view)
     }
 
     /**
@@ -81,5 +83,6 @@ class EdgeToEdgeHandler @Inject constructor() {
             )
             insets
         }
+        ViewCompat.requestApplyInsets(view)
     }
 }

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeHandler.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeHandler.kt
@@ -46,22 +46,38 @@ class EdgeToEdgeHandler @Inject constructor() {
         }
     }
 
+    /**
+     * Bottom inset: navigation bar + display cutout, bottom edge only
+     */
     fun applyNavigationBarInsets(view: View) {
-        val initialLeft = view.paddingLeft
-        val initialRight = view.paddingRight
         val initialBottom = view.paddingBottom
         ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
-            // The nav bar sits at the bottom in portrait but moves to a side edge in landscape
-            // (where bottom is then 0); the display cutout (camera notch) likewise moves to a side
-            // edge in landscape. Union both so content clears the nav bar AND the cutout on whichever
-            // side/bottom edge they land. The top edge is handled by applyStatusBarInsets.
+            val bottom = insets.getInsets(
+                WindowInsetsCompat.Type.navigationBars() or WindowInsetsCompat.Type.displayCutout(),
+            ).bottom
+
+            v.updatePadding(bottom = initialBottom + bottom)
+            insets
+        }
+    }
+
+    /**
+     * Horizontal inset: navigation bar + display cutout on the left and right edges. In landscape the
+     * 3-button nav bar and the camera cutout move to a side edge and run the full height, so applying
+     * this to a screen's root insets the whole column (toolbar, content, bottom bar) at once. No-op in
+     * portrait. The listener is non-consuming, so child views still receive insets for their own
+     * top/bottom handling.
+     */
+    fun applyHorizontalSystemBarInsets(view: View) {
+        val initialLeft = view.paddingLeft
+        val initialRight = view.paddingRight
+        ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
             val barsAndCutout = insets.getInsets(
                 WindowInsetsCompat.Type.navigationBars() or WindowInsetsCompat.Type.displayCutout(),
             )
             v.updatePadding(
                 left = initialLeft + barsAndCutout.left,
                 right = initialRight + barsAndCutout.right,
-                bottom = initialBottom + barsAndCutout.bottom,
             )
             insets
         }

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeHandler.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeHandler.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.utils.edgetoedge
+
+import android.view.View
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
+import javax.inject.Inject
+
+/**
+ * Standardised window-insets handling for edge-to-edge screens.
+ *
+ * Each method installs an [androidx.core.view.OnApplyWindowInsetsListener] that adds the relevant
+ * system-bar inset on top of the view's *original* padding (captured once), so repeated inset
+ * dispatches never accumulate padding. Insets are requested as soon as the view is attached.
+ *
+ * Callers should only invoke these when edge-to-edge is enabled for the screen's bucket
+ * (see [EdgeToEdgeProvider]); when disabled the window reserves the bars itself and no padding
+ * should be added.
+ */
+class EdgeToEdgeHandler @Inject constructor() {
+
+    fun applyStatusBarInsets(view: View) {
+        val initialTop = view.paddingTop
+        ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
+            val top = insets.getInsets(
+                WindowInsetsCompat.Type.statusBars() or WindowInsetsCompat.Type.displayCutout(),
+            ).top
+            v.updatePadding(top = initialTop + top)
+            insets
+        }
+    }
+
+    fun applyNavigationBarInsets(view: View) {
+        val initialLeft = view.paddingLeft
+        val initialRight = view.paddingRight
+        val initialBottom = view.paddingBottom
+        ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
+            // The nav bar sits at the bottom in portrait but moves to a side edge in landscape
+            // (where bottom is then 0); the display cutout (camera notch) likewise moves to a side
+            // edge in landscape. Union both so content clears the nav bar AND the cutout on whichever
+            // side/bottom edge they land. The top edge is handled by applyStatusBarInsets.
+            val barsAndCutout = insets.getInsets(
+                WindowInsetsCompat.Type.navigationBars() or WindowInsetsCompat.Type.displayCutout(),
+            )
+            v.updatePadding(
+                left = initialLeft + barsAndCutout.left,
+                right = initialRight + barsAndCutout.right,
+                bottom = initialBottom + barsAndCutout.bottom,
+            )
+            insets
+        }
+    }
+}

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeProvider.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeProvider.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.utils.edgetoedge
+
+/**
+ * Single source of truth for whether edge-to-edge should be applied to a given [EdgeToEdgeBucket].
+ *
+ * Activities check this in [android.app.Activity.onCreate] before calling `enableEdgeToEdge()` and
+ * before applying insets
+ */
+interface EdgeToEdgeProvider {
+
+    /** @return true only if the master toggle AND the [bucket]'s sub-toggle are both enabled. */
+    fun isEnabled(bucket: EdgeToEdgeBucket): Boolean
+}

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/RealEdgeToEdgeProvider.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/RealEdgeToEdgeProvider.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.utils.edgetoedge
+
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealEdgeToEdgeProvider @Inject constructor(
+    private val edgeToEdgeFeature: EdgeToEdgeFeature,
+) : EdgeToEdgeProvider {
+
+    override fun isEnabled(bucket: EdgeToEdgeBucket): Boolean = if (edgeToEdgeFeature.self().isEnabled()) {
+        val bucketToggle = when (bucket) {
+            EdgeToEdgeBucket.BROWSER -> edgeToEdgeFeature.browser()
+            EdgeToEdgeBucket.SETTINGS -> edgeToEdgeFeature.settings()
+        }
+        bucketToggle.isEnabled()
+    } else {
+        false
+    }
+}

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/RealEdgeToEdgeProvider.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/RealEdgeToEdgeProvider.kt
@@ -16,16 +16,39 @@
 
 package com.duckduckgo.common.utils.edgetoedge
 
+import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @SingleInstanceIn(AppScope::class)
-@ContributesBinding(AppScope::class)
+@ContributesBinding(AppScope::class, boundType = EdgeToEdgeProvider::class)
+@ContributesMultibinding(AppScope::class, boundType = MainProcessLifecycleObserver::class)
 class RealEdgeToEdgeProvider @Inject constructor(
     private val edgeToEdgeFeature: EdgeToEdgeFeature,
-) : EdgeToEdgeProvider {
+    private val dispatchers: DispatcherProvider,
+    @param:AppCoroutineScope private val appScope: CoroutineScope,
+) : EdgeToEdgeProvider, MainProcessLifecycleObserver {
+
+    override fun onCreate(owner: LifecycleOwner) {
+        super.onCreate(owner)
+
+        appScope.launch {
+            withContext(dispatchers.io()) {
+                edgeToEdgeFeature.self().isEnabled()
+                edgeToEdgeFeature.browser().isEnabled()
+                edgeToEdgeFeature.settings().isEnabled()
+            }
+        }
+    }
 
     override fun isEnabled(bucket: EdgeToEdgeBucket): Boolean = if (edgeToEdgeFeature.self().isEnabled()) {
         val bucketToggle = when (bucket) {

--- a/common/common-utils/src/test/java/com/duckduckgo/common/utils/edgetoedge/RealEdgeToEdgeProviderTest.kt
+++ b/common/common-utils/src/test/java/com/duckduckgo/common/utils/edgetoedge/RealEdgeToEdgeProviderTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.utils.edgetoedge
+
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RealEdgeToEdgeProviderTest {
+
+    private val feature = FakeFeatureToggleFactory.create(EdgeToEdgeFeature::class.java)
+    private val testee = RealEdgeToEdgeProvider(feature)
+
+    @Test
+    fun whenMasterDisabledThenBucketDisabledEvenIfBucketToggleEnabled() {
+        feature.self().setRawStoredState(State(enable = false))
+        feature.settings().setRawStoredState(State(enable = true))
+
+        assertFalse(testee.isEnabled(EdgeToEdgeBucket.SETTINGS))
+    }
+
+    @Test
+    fun whenMasterEnabledButBucketDisabledThenBucketDisabled() {
+        feature.self().setRawStoredState(State(enable = true))
+        feature.settings().setRawStoredState(State(enable = false))
+
+        assertFalse(testee.isEnabled(EdgeToEdgeBucket.SETTINGS))
+    }
+
+    @Test
+    fun whenMasterAndBucketEnabledThenBucketEnabled() {
+        feature.self().setRawStoredState(State(enable = true))
+        feature.browser().setRawStoredState(State(enable = true))
+
+        assertTrue(testee.isEnabled(EdgeToEdgeBucket.BROWSER))
+    }
+
+    @Test
+    fun whenMasterAndOneBucketEnabledThenOtherBucketsRemainDisabled() {
+        feature.self().setRawStoredState(State(enable = true))
+        feature.browser().setRawStoredState(State(enable = true))
+        feature.settings().setRawStoredState(State(enable = false))
+
+        assertTrue(testee.isEnabled(EdgeToEdgeBucket.BROWSER))
+        assertFalse(testee.isEnabled(EdgeToEdgeBucket.SETTINGS))
+    }
+}

--- a/common/common-utils/src/test/java/com/duckduckgo/common/utils/edgetoedge/RealEdgeToEdgeProviderTest.kt
+++ b/common/common-utils/src/test/java/com/duckduckgo/common/utils/edgetoedge/RealEdgeToEdgeProviderTest.kt
@@ -16,16 +16,25 @@
 
 package com.duckduckgo.common.utils.edgetoedge
 
+import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Rule
 import org.junit.Test
 
 class RealEdgeToEdgeProviderTest {
 
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
     private val feature = FakeFeatureToggleFactory.create(EdgeToEdgeFeature::class.java)
-    private val testee = RealEdgeToEdgeProvider(feature)
+    private val testee = RealEdgeToEdgeProvider(
+        edgeToEdgeFeature = feature,
+        dispatchers = coroutineRule.testDispatcherProvider,
+        appScope = coroutineRule.testScope,
+    )
 
     @Test
     fun whenMasterDisabledThenBucketDisabledEvenIfBucketToggleEnabled() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211724162604201/task/1214047527401573

### Description

First step of the Android 16 edge-to-edge migration. Adds the shared edge-to-edge infrastructure in `common-utils` and applies it to the tab switcher (bucket 1, `browser()` toggle).

- **`EdgeToEdgeFeature` / `RealEdgeToEdgeProvider`** — remote feature with a master kill-switch plus per-bucket sub-toggles; the provider requires both the master and the bucket toggle to be on.
- **`EdgeToEdgeHandler`** — standardised inset helpers for the status bar (top), navigation bar (bottom) and horizontal system bars (left/right, for landscape side bars/cutouts), each preserving the view's original padding.
- **`TabSwitcherActivity`** — enables edge-to-edge behind `browser()`, applying the appropriate status-bar, navigation-bar and horizontal insets per omnibar layout (top / bottom / split).

### Steps to test this PR

_Edge-to-edge on the tab switcher_

The `browser()` toggle defaults to `INTERNAL`, so it is on for internal builds. To exercise edge-to-edge enforcement app-wide (simulating `targetSdk 36`) while testing, apply this patch to remove the theme opt-out:

```diff
diff --git a/android-design-system/design-system/src/main/res/values-v35/design-system-theming.xml b/android-design-system/design-system/src/main/res/values-v35/design-system-theming.xml
index 356887ea16..a16dab91ae 100644
--- a/android-design-system/design-system/src/main/res/values-v35/design-system-theming.xml
+++ b/android-design-system/design-system/src/main/res/values-v35/design-system-theming.xml
@@ -25,7 +25,7 @@
         <item name="android:navigationBarColor">?attr/preferredNavigationBarColor</item>
         <item name="preferDarkNavigationBarIcons">false</item>
         <item name="preferredNavigationBarColor">?attr/daxColorBlack</item>
-        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
+        <item name="android:windowOptOutEdgeToEdgeEnforcement">false</item>
     </style>

 </resources>
```

- [x] Build & install an internal variant on a device/emulator running Android 15+ (ideally Android 16 / API 36)
- [x] Open the browser, then open the tab switcher
- [x] **Portrait:** confirm the top toolbar sits below the status bar and the grid's last row scrolls clear of the navigation bar
- [x] **Landscape (both orientations):** confirm the toolbar, the trackers banner, and the tab cards all stay clear of the side navigation bar and the camera cutout
- [x] Repeat in both **3-button** and **gesture** navigation
- [x] Repeat for each omnibar position (top / bottom / split) via Settings → Appearance → Address Bar
- [x] Repeat for light mode/ dark mode
- [x] Test on an Android emulator with API 33

### UI changes
| Before  | After |
| ------ | ----- |
| <img width="1080" height="2340" alt="Screenshot_20260602_115613" src="https://github.com/user-attachments/assets/0593f9e4-15cd-4846-863f-27fcc7fb90be" /> | <img width="1080" height="2340" alt="Screenshot_20260602_115546" src="https://github.com/user-attachments/assets/8c2b2a7e-93cc-4fbc-bd70-d25988362c74" /> |
 | ------ | ----- |
 | <img width="1080" height="2340" alt="Screenshot_20260602_191825" src="https://github.com/user-attachments/assets/bdf2b9ca-25cd-46f0-bb30-cefecccc85c8" /> | <img width="1080" height="2340" alt="Screenshot_20260602_191904" src="https://github.com/user-attachments/assets/1fb8c9b0-8437-45c3-bfb8-197b937eb22c" /> | 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> UI/layout behavior changes on the tab switcher across orientations, nav modes, and omnibar variants; rollout is mitigated by feature toggles but incorrect insets could affect usability on Android 15+.
> 
> **Overview**
> Introduces reusable **edge-to-edge** plumbing in `common-utils` and wires the **tab switcher** as the first **BROWSER** bucket consumer, gated by remote feature toggles.
> 
> **`EdgeToEdgeFeature`** adds a master `edgeToEdge` remote toggle plus **`browser()`** and **`settings()`** sub-toggles (default **INTERNAL**). **`RealEdgeToEdgeProvider`** exposes **`isEnabled(EdgeToEdgeBucket)`** only when both master and bucket toggles are on, and prefetches toggle state on app start. **`EdgeToEdgeHandler`** centralizes status-bar, navigation-bar, and horizontal system-bar inset padding without accumulating padding on repeated dispatches.
> 
> **`TabSwitcherActivity`** checks **`EdgeToEdgeBucket.BROWSER`**, calls **`enableEdgeToEdge()`** with transparent system bars when enabled, and applies insets per **omnibar layout** (top / bottom / split)—including toolbar background for bottom omnibar. Unit tests cover master vs bucket toggle combinations; **`common-utils`** adds **`feature-toggles-test`** for those tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e97f6e533aacb32f07ebdd6cb8c9f218c69906bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->