### PR TITLE
Fix contextual showing when unified input is focussed

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1372,6 +1372,7 @@ class BrowserTabFragment :
             if (!nativeInputManager.isNativeInputEnabled()) {
                 launchInputScreen(query)
             } else {
+                removeDuckChatContextualSheet()
                 showNativeInput(query)
             }
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1215286152129817?focus=true

### Description

- Hides the Duck.ai contextual sheet when the unified input is shown

### Steps to test this PR

_With the native input enabled_
- [ ] Search for something
- [ ] Tap the Duck.ai omnibar icon to show the contextual sheet
- [ ] Pull the omnibar down and focus it
- [ ] Verify that the contextual sheet is hidden

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single UI dismissal call on an existing code path; no auth, data, or navigation logic changes.
> 
> **Overview**
> Fixes the Duck Chat **contextual sheet** staying on screen when the user opens **unified/native input** from the omnibar.
> 
> When native input is enabled, the input-screen launch path now calls `removeDuckChatContextualSheet()` before `showNativeInput`, matching the behavior already used when the legacy omnibar field gains focus.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2aee1218cb75d0bdc0374b8785fbb95005d73b7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->