### PR TITLE
Add optional sourceTabId to BrowserNav.openInNewTab

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -859,7 +859,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
                     viewModel.launchFromThirdParty()
                 }
                 val selectedText = intent.getBooleanExtra(SELECTED_TEXT_EXTRA, false)
-                val sourceTabId = if (selectedText) currentTab?.tabId else null
+                val sourceTabId = intent.getStringExtra(SOURCE_TAB_ID_EXTRA) ?: if (selectedText) currentTab?.tabId else null
                 val skipHome = !selectedText
                 if (swipingTabsFeature.isEnabled) {
                     val query =
@@ -1299,6 +1299,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
             notifyDataCleared: Boolean = false,
             openInCurrentTab: Boolean = false,
             selectedText: Boolean = false,
+            sourceTabId: String? = null,
             isExternal: Boolean = false,
             interstitialScreen: Boolean = false,
             openExistingTabId: String? = null,
@@ -1316,6 +1317,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
             intent.putExtra(NOTIFY_DATA_CLEARED_EXTRA, notifyDataCleared)
             intent.putExtra(OPEN_IN_CURRENT_TAB_EXTRA, openInCurrentTab)
             intent.putExtra(SELECTED_TEXT_EXTRA, selectedText)
+            intent.putExtra(SOURCE_TAB_ID_EXTRA, sourceTabId)
             intent.putExtra(LAUNCH_FROM_EXTERNAL_EXTRA, isExternal)
             intent.putExtra(LAUNCH_FROM_INTERSTITIAL_EXTRA, interstitialScreen)
             intent.putExtra(OPEN_EXISTING_TAB_ID_EXTRA, openExistingTabId)
@@ -1339,6 +1341,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
         const val LAUNCH_FROM_NOTIFICATION_PIXEL_NAME = "LAUNCH_FROM_NOTIFICATION_PIXEL_NAME"
         const val OPEN_IN_CURRENT_TAB_EXTRA = "OPEN_IN_CURRENT_TAB_EXTRA"
         const val SELECTED_TEXT_EXTRA = "SELECTED_TEXT_EXTRA"
+        const val SOURCE_TAB_ID_EXTRA = "SOURCE_TAB_ID_EXTRA"
         private const val LAUNCH_FROM_INTERSTITIAL_EXTRA = "INTERSTITIAL_SCREEN_EXTRA"
         const val OPEN_EXISTING_TAB_ID_EXTRA = "OPEN_EXISTING_TAB_ID_EXTRA"
 

--- a/app/src/main/java/com/duckduckgo/app/browser/navigation/AppBrowserNav.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/navigation/AppBrowserNav.kt
@@ -32,8 +32,15 @@ class AppBrowserNav @Inject constructor() : BrowserNav {
     override fun openInNewTab(
         context: Context,
         url: String,
+        sourceTabId: String?,
     ): Intent {
-        return BrowserActivity.intent(context = context, launchSource = InAppNavigation, queryExtra = url, interstitialScreen = true)
+        return BrowserActivity.intent(
+            context = context,
+            launchSource = InAppNavigation,
+            queryExtra = url,
+            interstitialScreen = true,
+            sourceTabId = sourceTabId,
+        )
     }
 
     override fun openInCurrentTab(

--- a/app/src/test/java/com/duckduckgo/app/browser/navigation/AppBrowserNavTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/navigation/AppBrowserNavTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.navigation
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.app.browser.BrowserActivity
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AppBrowserNavTest {
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+    private val testee = AppBrowserNav()
+
+    @Test
+    fun whenOpenInNewTabWithSourceTabIdThenIntentCarriesSourceTab() {
+        val intent = testee.openInNewTab(context, "https://example.com", sourceTabId = "tab-123")
+
+        assertEquals("tab-123", intent.getStringExtra(BrowserActivity.SOURCE_TAB_ID_EXTRA))
+    }
+
+    @Test
+    fun whenOpenInNewTabWithoutSourceTabIdThenIntentHasNoSourceTab() {
+        val intent = testee.openInNewTab(context, "https://example.com")
+
+        assertNull(intent.getStringExtra(BrowserActivity.SOURCE_TAB_ID_EXTRA))
+    }
+}

--- a/browser-api/src/main/java/com/duckduckgo/app/tabs/BrowserNav.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/tabs/BrowserNav.kt
@@ -23,8 +23,14 @@ import android.content.Intent
  * Public interface to provide navigation Intents related to browser screen
  */
 interface BrowserNav {
-    // opens url on a new tab
-    fun openInNewTab(context: Context, url: String): Intent
+    /**
+     * Returns an Intent that opens [url] in a new browser tab.
+     *
+     * @param context used to build the Intent.
+     * @param url the URL to open in the new tab.
+     * @param sourceTabId When provided, the new tab is anchored to `sourceTabId`, so closing the new tab returns to that tab instead of leaving an orphan tab.
+     */
+    fun openInNewTab(context: Context, url: String, sourceTabId: String? = null): Intent
     fun openInCurrentTab(context: Context, url: String): Intent
     fun openDuckChat(context: Context, hasSessionActive: Boolean = false, duckChatUrl: String): Intent
     fun closeDuckChat(context: Context): Intent


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1215287611914592?focus=true

### Description

Adds an optional `sourceTabId` parameter to `BrowserNav.openInNewTab`, so a caller can anchor a newly opened tab to a "source" tab. When set, closing the new tab returns to that source tab.

This is the API groundwork (**part 1 of 2**). It unblocks a fix for a bug where opening a chat from the Chats history screen creates a tab with no parent, so closing it (back button, or the X in Duck.ai) drops the user out of the browser and exits the app. The consumer change that uses this (the Chats screen passing a source tab) will be in a follow-up PR.

Pure addition: `AppBrowserNav` is the only implementer, and all existing two-argument `openInNewTab(context, url)` calls compile and behave unchanged.

### Steps to test this PR

No new user-facing behaviour, this is an additive API change, so testing is a regression check that existing "open in a new tab" flows are unaffected (Open in new tab links, opening duck.ai chats, opening bookmarks/favourites. 

### UI changes

No UI changes.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and intent extra with default null; existing two-argument callers unchanged until follow-up wiring.
> 
> **Overview**
> Adds an optional **`sourceTabId`** to **`BrowserNav.openInNewTab`** so callers can anchor a new tab to an existing one; closing the child tab should return to that parent instead of leaving a detached tab.
> 
> The value is threaded through **`AppBrowserNav`** into **`BrowserActivity.intent`** via a new **`SOURCE_TAB_ID_EXTRA`**. When handling “open in new tab” intents, **`BrowserActivity`** now prefers that extra (with the previous **selected-text → current tab** behavior as fallback). **`AppBrowserNavTest`** asserts the intent carries or omits the extra. No feature modules use the parameter yet—this is API groundwork for a follow-up (e.g. Chats history opening Duck.ai).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4e316fc4c9a4597a8778944d72f3a5d5581742b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->