### PR TITLE
Fire Mode: Launch NTP in different modes

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -40,7 +40,6 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.activity.viewModels
 import androidx.annotation.VisibleForTesting
-import androidx.core.os.BundleCompat
 import androidx.core.view.isVisible
 import androidx.core.view.postDelayed
 import androidx.lifecycle.Lifecycle
@@ -278,11 +277,12 @@ open class BrowserActivity : DuckDuckGoActivity() {
     private var lastIntent: Intent? = null
 
     /**
-     * Holds an [Intent] that arrived while in [BrowserMode.FIRE] and must be processed in
-     * [BrowserMode.REGULAR]. Read once by [BrowserStateRenderer.showWebContent] and cleared;
-     * takes precedence over [lastIntent].
+     * Holds an action deferred across a browser-mode switch. Switching mode recreates the activity
+     * (see [observeBrowserModeChanges]), which cancels [lifecycleScope], so the action is stashed
+     * here, carried across the recreate via [onSaveInstanceState], and replayed on the recreated,
+     * target-mode instance by [BrowserStateRenderer.showWebContent]. See [switchModeThen].
      */
-    private var pendingFireToRegularIntent: Intent? = null
+    private var pendingModeSwitch: PendingModeSwitch? = null
 
     // we don't store isExternal in the tab model, as it's only meant for the first time the tab is loaded.
     private val externalLaunchTabIds = mutableSetOf<String>()
@@ -384,9 +384,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
         renderer = BrowserStateRenderer()
         val newInstanceState = if (dataClearer.isFreshAppLaunch) null else savedInstanceState
         instanceStateBundles = CombinedInstanceState(originalInstanceState = savedInstanceState, newInstanceState = newInstanceState)
-        pendingFireToRegularIntent = newInstanceState?.let {
-            BundleCompat.getParcelable(it, KEY_PENDING_FIRE_TO_REGULAR_INTENT, Intent::class.java)
-        }
+        pendingModeSwitch = newInstanceState?.getBundle(KEY_PENDING_MODE_SWITCH)?.toPendingModeSwitch()
 
         super.onCreate(savedInstanceState = newInstanceState, daggerInject = false)
 
@@ -442,7 +440,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
         if (swipingTabsFeature.isEnabled) {
             outState.putParcelable(KEY_TAB_PAGER_STATE, tabPagerAdapter.saveState())
         }
-        pendingFireToRegularIntent?.let { outState.putParcelable(KEY_PENDING_FIRE_TO_REGULAR_INTENT, it) }
+        pendingModeSwitch?.let { outState.putBundle(KEY_PENDING_MODE_SWITCH, it.toBundle()) }
     }
 
     private suspend fun configureFlowCollectors() {
@@ -742,14 +740,11 @@ open class BrowserActivity : DuckDuckGoActivity() {
         }
 
         // Intents stamped with LAUNCH_REQUIRES_REGULAR_MODE must reach BrowserActivity in REGULAR
-        // mode. Stash the intent and carry it to the recreated REGULAR-bound instance.
+        // mode. Switch first (recreating the activity) and process the intent on the REGULAR instance.
         val requiresRegularBrowserMode = intent.getBooleanExtra(LAUNCH_REQUIRES_REGULAR_MODE, false)
         if (requiresRegularBrowserMode && currentBrowserMode != BrowserMode.REGULAR) {
             logcat(INFO) { "Intent requires REGULAR mode while in a non-regular mode — switching before processing" }
-            pendingFireToRegularIntent = intent
-            lifecycleScope.launch {
-                viewModel.switchToMode(BrowserMode.REGULAR)
-            }
+            switchModeThen(BrowserMode.REGULAR, PendingAction.ProcessIntent(intent))
             return
         }
 
@@ -1415,8 +1410,9 @@ open class BrowserActivity : DuckDuckGoActivity() {
 
         private const val MAX_ACTIVE_TABS = 40
         private const val KEY_TAB_PAGER_STATE = "tabPagerState"
-        private const val KEY_PENDING_FIRE_TO_REGULAR_INTENT = "pendingFireToRegularIntent"
         private const val KEY_SAVED_BROWSER_MODE = "savedBrowserMode"
+
+        private const val KEY_PENDING_MODE_SWITCH = "pendingModeSwitch"
 
         private const val DISABLE_SWIPING_DELAY = 1000L
 
@@ -1457,11 +1453,11 @@ open class BrowserActivity : DuckDuckGoActivity() {
             configureObservers()
             binding.clearingInProgressView.gone()
 
-            pendingFireToRegularIntent?.let { pending ->
-                logcat(INFO) { "Intent deferred across FIRE→REGULAR recreate; handling now" }
-                pendingFireToRegularIntent = null
+            pendingModeSwitch?.let { pending ->
+                logcat(INFO) { "Action deferred across mode-switch recreate; handling now" }
+                pendingModeSwitch = null
                 processedOriginalIntent = true
-                launchNewSearchOrQuery(pending)
+                switchModeThen(pending.targetMode, pending.action)
                 return
             }
 
@@ -1702,6 +1698,57 @@ open class BrowserActivity : DuckDuckGoActivity() {
         sourceTabId: String? = null,
         skipHome: Boolean = false,
         isExternal: Boolean = false,
+        browserMode: BrowserMode = currentBrowserMode,
+    ) {
+        switchModeThen(browserMode, PendingAction.OpenNewTab(query, sourceTabId, skipHome, isExternal))
+    }
+
+    /**
+     * Switches to [targetMode] (in either direction) and then runs [action]. If [targetMode] is
+     * already current, the action runs immediately. Otherwise switchToMode — a synchronous mutation
+     * of the app-scoped mode holder — recreates the activity in the target mode (see
+     * [observeBrowserModeChanges]), cancelling [lifecycleScope], so the action is stashed in
+     * [pendingModeSwitch], carried across the recreate via [onSaveInstanceState], and replayed by
+     * [BrowserStateRenderer.showWebContent].
+     *
+     * The replay calls this same method, so it is self-correcting: on the recreated instance the
+     * mode matches and the action runs; were it ever to run before the recreate, it simply re-stashes.
+     */
+    private fun switchModeThen(targetMode: BrowserMode, action: PendingAction) {
+        if (targetMode == currentBrowserMode) {
+            runAction(action)
+            return
+        }
+        if (viewModel.switchToMode(targetMode)) {
+            pendingModeSwitch = PendingModeSwitch(targetMode, action)
+        } else {
+            // Switch rejected (e.g. Fire mode unavailable); run the action in the current mode.
+            runAction(action)
+        }
+    }
+
+    private fun runAction(action: PendingAction) {
+        when (action) {
+            // Security invariant: a carried Intent is only ever *consumed* here (its extras read by
+            // processIntent), never re-launched via startActivity/startService. Launching an Intent
+            // sourced from our (externally reachable) launch Intent would be an intent-redirection
+            // sink — see https://developer.android.com/privacy-and-security/risks/intent-redirection.
+            // Any future PendingAction that needs to launch a target must allowlist it first.
+            is PendingAction.ProcessIntent -> processIntent(action.intent)
+            is PendingAction.OpenNewTab -> openNewTabInCurrentMode(
+                action.query,
+                action.sourceTabId,
+                action.skipHome,
+                action.isExternal,
+            )
+        }
+    }
+
+    private fun openNewTabInCurrentMode(
+        query: String?,
+        sourceTabId: String?,
+        skipHome: Boolean,
+        isExternal: Boolean,
     ) {
         lifecycleScope.launch {
             if (swipingTabsFeature.isEnabled) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -805,10 +805,10 @@ class BrowserTabFragment :
                 duckChat.openVoiceDuckChat()
             }
             onMenuItemClicked(contentView.findViewById(com.duckduckgo.duckchat.impl.R.id.chatMenuPopupNewTab)) {
-                browserActivity?.launchNewTab()
+                browserActivity?.launchNewTab(browserMode = BrowserMode.REGULAR)
             }
             onMenuItemClicked(contentView.findViewById(com.duckduckgo.duckchat.impl.R.id.chatMenuPopupNewFireTab)) {
-                browserActivity?.launchNewTab()
+                browserActivity?.launchNewTab(browserMode = BrowserMode.FIRE)
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/PendingModeSwitch.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/PendingModeSwitch.kt
@@ -66,7 +66,7 @@ internal fun PendingModeSwitch.toBundle(): Bundle {
 }
 
 internal fun Bundle.toPendingModeSwitch(): PendingModeSwitch? {
-    val targetMode = getString(KEY_TARGET_MODE)?.let { BrowserMode.valueOf(it) } ?: return null
+    val targetMode = getString(KEY_TARGET_MODE)?.let { runCatching { BrowserMode.valueOf(it) }.getOrNull() } ?: return null
     val action = when (getString(KEY_ACTION)) {
         ACTION_PROCESS_INTENT -> {
             val intent = BundleCompat.getParcelable(this, KEY_INTENT, Intent::class.java) ?: return null

--- a/app/src/main/java/com/duckduckgo/app/browser/PendingModeSwitch.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/PendingModeSwitch.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.core.os.BundleCompat
+import androidx.core.os.bundleOf
+import com.duckduckgo.browsermode.api.BrowserMode
+
+/**
+ * An action to run once the browser is in a given [BrowserMode]. Must be bundle-encodable (see
+ * [toBundle] / [Bundle.toPendingModeSwitch]) so it can survive the activity recreation that a mode
+ * switch triggers. Dispatched by `BrowserActivity.switchModeThen`.
+ */
+internal sealed class PendingAction {
+    /**
+     * Re-process [intent] (BrowserActivity's own launch Intent) by reading its extras. The intent
+     * must be *consumed*, never re-launched — see the security invariant in `BrowserActivity.runAction`.
+     */
+    data class ProcessIntent(val intent: Intent) : PendingAction()
+    data class OpenNewTab(
+        val query: String?,
+        val sourceTabId: String?,
+        val skipHome: Boolean,
+        val isExternal: Boolean,
+    ) : PendingAction()
+}
+
+/** A [PendingAction] paired with the [BrowserMode] it must run in. */
+internal data class PendingModeSwitch(
+    val targetMode: BrowserMode,
+    val action: PendingAction,
+)
+
+internal fun PendingModeSwitch.toBundle(): Bundle {
+    val bundle = bundleOf(KEY_TARGET_MODE to targetMode.name)
+    when (val pendingAction = action) {
+        is PendingAction.ProcessIntent -> {
+            bundle.putString(KEY_ACTION, ACTION_PROCESS_INTENT)
+            bundle.putParcelable(KEY_INTENT, pendingAction.intent)
+        }
+        is PendingAction.OpenNewTab -> {
+            bundle.putString(KEY_ACTION, ACTION_OPEN_NEW_TAB)
+            bundle.putString(KEY_QUERY, pendingAction.query)
+            bundle.putString(KEY_SOURCE_TAB_ID, pendingAction.sourceTabId)
+            bundle.putBoolean(KEY_SKIP_HOME, pendingAction.skipHome)
+            bundle.putBoolean(KEY_IS_EXTERNAL, pendingAction.isExternal)
+        }
+    }
+    return bundle
+}
+
+internal fun Bundle.toPendingModeSwitch(): PendingModeSwitch? {
+    val targetMode = getString(KEY_TARGET_MODE)?.let { BrowserMode.valueOf(it) } ?: return null
+    val action = when (getString(KEY_ACTION)) {
+        ACTION_PROCESS_INTENT -> {
+            val intent = BundleCompat.getParcelable(this, KEY_INTENT, Intent::class.java) ?: return null
+            PendingAction.ProcessIntent(intent)
+        }
+        ACTION_OPEN_NEW_TAB -> PendingAction.OpenNewTab(
+            query = getString(KEY_QUERY),
+            sourceTabId = getString(KEY_SOURCE_TAB_ID),
+            skipHome = getBoolean(KEY_SKIP_HOME),
+            isExternal = getBoolean(KEY_IS_EXTERNAL),
+        )
+        else -> return null
+    }
+    return PendingModeSwitch(targetMode, action)
+}
+
+private const val KEY_TARGET_MODE = "pendingModeSwitchTargetMode"
+private const val KEY_ACTION = "pendingModeSwitchAction"
+private const val KEY_INTENT = "pendingModeSwitchIntent"
+private const val KEY_QUERY = "pendingModeSwitchQuery"
+private const val KEY_SOURCE_TAB_ID = "pendingModeSwitchSourceTabId"
+private const val KEY_SKIP_HOME = "pendingModeSwitchSkipHome"
+private const val KEY_IS_EXTERNAL = "pendingModeSwitchIsExternal"
+private const val ACTION_PROCESS_INTENT = "processIntent"
+private const val ACTION_OPEN_NEW_TAB = "openNewTab"

--- a/app/src/test/java/com/duckduckgo/app/browser/PendingModeSwitchTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/PendingModeSwitchTest.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser
+
+import android.content.Intent
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.browsermode.api.BrowserMode
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PendingModeSwitchTest {
+
+    @Test
+    fun whenProcessIntentEncodedThenItRoundTripsPreservingModeAndIntent() {
+        val intent = Intent(Intent.ACTION_VIEW).putExtra(EXTRA_KEY, EXTRA_VALUE)
+        val original = PendingModeSwitch(BrowserMode.REGULAR, PendingAction.ProcessIntent(intent))
+
+        val restored = original.toBundle().toPendingModeSwitch()
+
+        assertEquals(BrowserMode.REGULAR, restored?.targetMode)
+        val action = restored?.action
+        assertTrue(action is PendingAction.ProcessIntent)
+        val restoredIntent = (action as PendingAction.ProcessIntent).intent
+        assertEquals(Intent.ACTION_VIEW, restoredIntent.action)
+        assertEquals(EXTRA_VALUE, restoredIntent.getStringExtra(EXTRA_KEY))
+    }
+
+    @Test
+    fun whenOpenNewTabWithAllFieldsEncodedThenItRoundTripsExactly() {
+        val original = PendingModeSwitch(
+            targetMode = BrowserMode.FIRE,
+            action = PendingAction.OpenNewTab(
+                query = "duckduckgo privacy",
+                sourceTabId = "tab-123",
+                skipHome = true,
+                isExternal = true,
+            ),
+        )
+
+        val restored = original.toBundle().toPendingModeSwitch()
+
+        assertEquals(original, restored)
+    }
+
+    @Test
+    fun whenOpenNewTabWithNullQueryAndSourceTabIdEncodedThenItRoundTripsExactly() {
+        val original = PendingModeSwitch(
+            targetMode = BrowserMode.REGULAR,
+            action = PendingAction.OpenNewTab(
+                query = null,
+                sourceTabId = null,
+                skipHome = false,
+                isExternal = false,
+            ),
+        )
+
+        val restored = original.toBundle().toPendingModeSwitch()
+
+        assertEquals(original, restored)
+    }
+
+    @Test
+    fun whenBundleIsEmptyThenDecodesToNull() {
+        assertNull(android.os.Bundle().toPendingModeSwitch())
+    }
+
+    @Test
+    fun whenTargetModeNameIsUnknownThenDecodesToNull() {
+        // Start from a valid bundle and corrupt only the mode so a wrong key would surface as a failure here.
+        val bundle = openNewTabBundle()
+        bundle.putString(KEY_TARGET_MODE, "NOT_A_REAL_MODE")
+
+        assertNull(bundle.toPendingModeSwitch())
+    }
+
+    @Test
+    fun whenActionIsMissingThenDecodesToNull() {
+        val bundle = openNewTabBundle()
+        bundle.remove(KEY_ACTION)
+
+        assertNull(bundle.toPendingModeSwitch())
+    }
+
+    @Test
+    fun whenActionIsUnknownThenDecodesToNull() {
+        val bundle = openNewTabBundle()
+        bundle.putString(KEY_ACTION, "someUnsupportedAction")
+
+        assertNull(bundle.toPendingModeSwitch())
+    }
+
+    @Test
+    fun whenProcessIntentActionHasNoIntentThenDecodesToNull() {
+        val bundle = PendingModeSwitch(BrowserMode.REGULAR, PendingAction.ProcessIntent(Intent(Intent.ACTION_VIEW)))
+            .toBundle()
+        bundle.remove(KEY_INTENT)
+
+        assertNull(bundle.toPendingModeSwitch())
+    }
+
+    private fun openNewTabBundle() = PendingModeSwitch(
+        targetMode = BrowserMode.REGULAR,
+        action = PendingAction.OpenNewTab(query = "q", sourceTabId = "t", skipHome = false, isExternal = false),
+    ).toBundle()
+
+    private companion object {
+        const val EXTRA_KEY = "extra_key"
+        const val EXTRA_VALUE = "extra_value"
+
+        // Wire-format keys — mirror the private constants in PendingModeSwitch.kt. The malformed-bundle
+        // tests above start from a valid bundle and mutate a single field, so a stale key here fails the
+        // assertNull rather than silently passing.
+        const val KEY_TARGET_MODE = "pendingModeSwitchTargetMode"
+        const val KEY_ACTION = "pendingModeSwitchAction"
+        const val KEY_INTENT = "pendingModeSwitchIntent"
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1215275434974447?focus=true

### Description

This PR implements the functionality that allows launching NTPs specifically in Regular or Browser mode.

### Steps to test this PR

- [ ] Enable Fire tabs FF in dev settings
- [ ] Make Search & Duck.ai option is enabled in AI settings
- [ ] Open a new Duck.ai chat tab in Regular mode
- [ ] Tap on the + button and tap on "New Fire tab"
- [ ] Verify a new tab is launched and the browser is now in Fire Mode (Fire mode theme is used)
- [ ] While in Fire Mode, open Duck.ai chat tab
- [ ] Tap on the + button and tap on "New tab"
- [ ] Verify a new tab is launched and the browser is now in Regular Mode (regular theme is used)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core BrowserActivity lifecycle, mode switching, and intent handling; incorrect deferral or replay could drop tabs or mishandle launch intents, though ProcessIntent consumption is explicitly guarded.
> 
> **Overview**
> Adds **mode-aware new tab launches** from Duck.ai’s “+” menu: **New tab** switches to Regular mode first; **New Fire tab** switches to Fire mode first.
> 
> Replaces the old FIRE→REGULAR-only deferred `Intent` stash with a general **`switchModeThen`** flow: pending work is stored as **`PendingModeSwitch`** (`ProcessIntent` or `OpenNewTab`), saved in instance state across activity recreate, then replayed in `showWebContent`. **`launchNewTab`** gains an optional **`browserMode`** parameter (default: current mode) and always goes through that deferral path when a switch is needed.
> 
> New **`PendingModeSwitch.kt`** defines bundle round-tripping; **`PendingModeSwitchTest`** covers encode/decode edge cases. **`runAction`** documents that carried intents are consumed via `processIntent`, not re-launched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 407bc24427f1adfed325193d32ae894d324faa97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->