### PR TITLE
Anchor Duck.ai chats opened from the Chats list to the current tab

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
@@ -27,6 +27,7 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.common.ui.DuckDuckGoFragment
 import com.duckduckgo.common.ui.menu.PopupMenu
 import com.duckduckgo.common.ui.view.PopupMenuItemView
@@ -73,6 +74,9 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
 
     @Inject
     lateinit var globalActivityStarter: GlobalActivityStarter
+
+    @Inject
+    lateinit var browserNav: BrowserNav
 
     private val binding: FragmentChatHistoryBinding by viewBinding()
     private val viewModel: ChatHistoryViewModel by lazy {
@@ -161,6 +165,8 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
 
     private fun onNavigationEvent(event: ChatHistoryViewModel.NavigationEvent) {
         when (event) {
+            is ChatHistoryViewModel.NavigationEvent.OpenChat ->
+                startActivity(browserNav.openInNewTab(requireContext(), event.url, event.sourceTabId))
             is ChatHistoryViewModel.NavigationEvent.OpenRename -> openRenameScreen(event.chatId, event.currentTitle)
             is ChatHistoryViewModel.NavigationEvent.ShowDownloadComplete -> showDownloadCompleteSnackbar(event.fileName)
             ChatHistoryViewModel.NavigationEvent.ShowExportError ->

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModel.kt
@@ -20,6 +20,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.dataclearing.api.plugin.ClearableData
 import com.duckduckgo.dataclearing.api.plugin.DataClearingTrigger
 import com.duckduckgo.di.scopes.FragmentScope
@@ -53,6 +55,7 @@ class ChatHistoryViewModel @Inject constructor(
     private val dataClearingTrigger: DataClearingTrigger,
     private val duckAiFeatureState: DuckAiFeatureState,
     private val duckAiModelManager: DuckAiModelManager,
+    @RegularMode private val tabRepository: TabRepository,
 ) : ViewModel() {
 
     private val controls = MutableStateFlow(UiControls())
@@ -88,7 +91,11 @@ class ChatHistoryViewModel @Inject constructor(
         if (controls.value.mode is Mode.Selecting) {
             onSelectionToggled(chatId)
         } else {
-            duckChat.openWithChatId(chatId)
+            // Open the chat as a new tab anchored to the tab the user was on, so closing it returns there.
+            viewModelScope.launch {
+                val sourceTabId = tabRepository.getSelectedTab()?.tabId
+                navigationChannel.trySend(NavigationEvent.OpenChat(url = duckChat.buildChatUrl(chatId), sourceTabId = sourceTabId))
+            }
         }
     }
 
@@ -301,6 +308,7 @@ class ChatHistoryViewModel @Inject constructor(
     )
 
     sealed interface NavigationEvent {
+        data class OpenChat(val url: String, val sourceTabId: String?) : NavigationEvent
         data class OpenRename(val chatId: String, val currentTitle: String) : NavigationEvent
         data class ShowDownloadComplete(val fileName: String) : NavigationEvent
         data object ShowExportError : NavigationEvent

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
@@ -18,6 +18,8 @@ package com.duckduckgo.duckchat.impl.history
 
 import app.cash.turbine.TurbineTestContext
 import app.cash.turbine.test
+import com.duckduckgo.app.tabs.model.TabEntity
+import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.dataclearing.api.plugin.ClearableData
 import com.duckduckgo.dataclearing.api.plugin.DataClearingTrigger
@@ -39,6 +41,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
 class ChatHistoryViewModelTest {
@@ -55,6 +58,7 @@ class ChatHistoryViewModelTest {
         whenever(it.showClearDuckAIChatHistory).thenReturn(showClearDuckAIChatHistoryFlow)
     }
     private val duckAiModelManager = FakeDuckAiModelManager()
+    private val tabRepository: TabRepository = mock()
     private val viewModel = ChatHistoryViewModel(
         repository,
         coroutineRule.testScope,
@@ -62,6 +66,7 @@ class ChatHistoryViewModelTest {
         dataClearingTrigger,
         duckAiFeatureState,
         duckAiModelManager,
+        tabRepository,
     )
 
     @Test
@@ -406,11 +411,19 @@ class ChatHistoryViewModelTest {
     // --- Chat resume / Duck.ai open ---
 
     @Test
-    fun `onChatRowClicked in default mode resumes the chat in DuckAi`() = runTest {
-        viewModel.onChatRowClicked("abc")
+    fun `onChatRowClicked in default mode opens the chat in a new tab anchored to the current tab`() =
+        coroutineRule.testScope.runTest {
+            whenever(tabRepository.getSelectedTab()).thenReturn(TabEntity(tabId = "current-tab"))
 
-        assertEquals(listOf("abc"), duckChat.openWithChatIdCalls)
-    }
+            viewModel.navigationEvents.test {
+                viewModel.onChatRowClicked("abc")
+
+                val event = awaitItem() as ChatHistoryViewModel.NavigationEvent.OpenChat
+                assertEquals("https://duck.ai?chatID=abc", event.url)
+                assertEquals("current-tab", event.sourceTabId)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
 
     @Test
     fun `onChatRowLongClicked in default mode enters select mode with the row pre-selected`() = runTest {
@@ -425,7 +438,7 @@ class ChatHistoryViewModelTest {
             val loaded = awaitItem() as Loaded
             val mode = loaded.mode as ChatHistoryUiState.Mode.Selecting
             assertEquals(setOf("a"), mode.selectedChatIds)
-            assertTrue(duckChat.openWithChatIdCalls.isEmpty())
+            verifyNoInteractions(tabRepository)
         }
     }
 
@@ -460,7 +473,7 @@ class ChatHistoryViewModelTest {
             val loaded = awaitItem() as Loaded
             val mode = loaded.mode as ChatHistoryUiState.Mode.Selecting
             assertEquals(setOf("a"), mode.selectedChatIds)
-            assertTrue(duckChat.openWithChatIdCalls.isEmpty())
+            verifyNoInteractions(tabRepository)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1215230141269186?focus=true 

### Description

Fixes a bug where opening a saved chat from the **Chats** list (menu → Chats → tap a chat) and then closing it (the X in Duck.ai, or the back button) **exits the app** instead of returning to where you were.

Root cause: the Chats screen opened the chat as a brand-new tab with no parent and `skipHome = true`, so on close there was no tab to return to, the activity finished and the app exited. Other entry points (NTP suggestions, browsing to a Duck.ai link) don't hit this because they open within an existing tab.

The fix uses the new `BrowserNav.openInNewTab` from #8741 resolves the currently selected tab, builds the chat URL, and emits an `OpenChat` navigation event; `ChatHistoryFragment` opens it via `openInNewTab`. The new tab is now anchored to the tab the user was on, so closing it returns there.

### Steps to test this PR

_Chats list (the fix)_
- [ ] From an open tab, go to menu → **Chats**, then tap a chat → it opens in Duck.ai.
- [ ] Press the **X** (top-left in Duck.ai) → returns to the tab you were on (does **not** exit the app).
- [ ] Repeat and press the **back button** → also returns to the previous tab.

_No regression on other entry points_
- [ ] Open Duck.ai from an **NTP chat suggestion** → X/back returns to the NTP as before.
- [ ] **Browse** to a Duck.ai link → X/back returns to where you were as before.

### UI changes

https://github.com/user-attachments/assets/fef79b2c-532b-4264-8382-d93f322a89a3





<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped navigation change in chat history only; uses existing BrowserNav.openInNewTab and does not alter auth, data clearing, or other Duck.ai entry points.
> 
> **Overview**
> Fixes **Chats → tap a chat** closing Duck.ai and **exiting the app** instead of returning to the prior screen.
> 
> **`ChatHistoryViewModel`** no longer calls **`openWithChatId`**. On a normal row tap it reads the **currently selected tab**, builds the chat URL, and emits **`NavigationEvent.OpenChat`** with that tab as **`sourceTabId`**. **`ChatHistoryFragment`** handles it via **`BrowserNav.openInNewTab`**, so the Duck.ai tab is parented to where the user was and **X/back** restores that tab.
> 
> Select mode, long-press, and **New chat** are unchanged. Tests assert the new navigation event and that select/long-press do not touch **`TabRepository`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 221d80db72edc08b76897c3ee8e1d42c59b1ed2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->