### PR TITLE
Remove unused DuckChat.openWithChatId internal API

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -173,11 +173,6 @@ interface DuckChatInternal : DuckChat {
      */
     fun openNewDuckChatSession()
 
-    /**
-     * Opens Duck.ai with [chatId] pre-loaded.
-     */
-    fun openWithChatId(chatId: String)
-
     /** Single source of truth for the Duck.ai chat URL shape. */
     fun buildChatUrl(chatId: String): String
 
@@ -814,10 +809,6 @@ class RealDuckChat @Inject constructor(
         isEnabled() &&
             duckChatFeature.useNativeStorageChatData().isEnabled() &&
             duckChatFeature.historyScreen().isEnabled()
-    }
-
-    override fun openWithChatId(chatId: String) {
-        openDuckChat(parameters = mapOf(CHAT_ID_QUERY_NAME to chatId), forceNewSession = true)
     }
 
     override fun buildChatUrl(chatId: String): String {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -1871,22 +1871,6 @@ class RealDuckChatTest {
         assertFalse(testee.isChatHistoryAvailable())
     }
 
-    @Test
-    fun whenOpenWithChatIdThenDuckChatOpenedWithChatIdUrlParameterAndForcedFreshSession() = runTest {
-        // Stub an active session so the test fails if forceNewSession is not propagated.
-        val thirtyMinutesAgo = System.currentTimeMillis() - (30 * 60 * 1000L)
-        whenever(mockDuckChatFeatureRepository.lastSessionTimestamp()).thenReturn(thirtyMinutesAgo)
-        val urlCaptor = argumentCaptor<String>()
-        val sessionCaptor = argumentCaptor<Boolean>()
-
-        testee.openWithChatId("chat-123")
-        coroutineRule.testScope.advanceUntilIdle()
-
-        verify(mockBrowserNav).openDuckChat(any(), sessionCaptor.capture(), urlCaptor.capture())
-        assertTrue(urlCaptor.firstValue.contains("chatID=chat-123"))
-        assertFalse(sessionCaptor.firstValue)
-    }
-
     private suspend fun enableChatHistoryFlags() {
         duckChatFeature.self().setRawStoredState(State(enable = true))
         duckChatFeature.useNativeStorageChatData().setRawStoredState(State(enable = true))

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -56,7 +56,6 @@ class FakeDuckChatInternal(
     // DuckChat interface methods
     override fun isEnabled(): Boolean = enabled
 
-    val openWithChatIdCalls: MutableList<String> = mutableListOf()
     var openDuckChatCalls: Int = 0
         private set
 
@@ -194,10 +193,6 @@ class FakeDuckChatInternal(
     override fun observeTriggerVoiceChatSessionEnd(): Flow<String> = kotlinx.coroutines.flow.emptyFlow()
 
     override suspend fun isChatHistoryAvailable(): Boolean = false
-
-    override fun openWithChatId(chatId: String) {
-        openWithChatIdCalls += chatId
-    }
 
     override fun buildChatUrl(chatId: String): String = "https://duck.ai?chatID=$chatId"
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1215291263375065?focus=true 

### Description

Removes the unused `DuckChatInternal.openWithChatId(chatId)`.

It became dead code after the Chats fix in #8743 

This is not a public-API change: `openWithChatId` is declared on `DuckChatInternal`, so no API proposal is required.

Removed:
- the method from the `DuckChatInternal` interface and its `RealDuckChat` implementation;
- the obsolete `RealDuckChatTest` case;
- the `openWithChatId` override and `openWithChatIdCalls` recorder in `FakeDuckChatInternal`.

### Steps to test this PR

No behaviour change to test only verify that app builds.


### UI changes

No UI changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dead-code removal with no remaining call sites; no user-facing behavior change.
> 
> **Overview**
> Removes the unused **`DuckChatInternal.openWithChatId(chatId)`** API and its **`RealDuckChat`** implementation (opening Duck.ai via `BrowserNav` with a `chatID` query param and a forced fresh session).
> 
> **`buildChatUrl(chatId)`** is unchanged and remains the way to construct chat URLs. Related test and fake (`openWithChatIdCalls`, `whenOpenWithChatIdThen…`) cleanup only—no public `DuckChat` API change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 469dfab5a7a60b5264f0fc52ab469a59057a5bf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->