### PR TITLE
Fix native input crash in bottom omnibar mode

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
@@ -25,6 +25,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.ViewTreeObserver
 import android.widget.FrameLayout
+import android.widget.LinearLayout
 import androidx.interpolator.view.animation.FastOutSlowInInterpolator
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.di.scopes.FragmentScope
@@ -74,6 +75,11 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
     private var widgetCompatPaddingHeight = 0
     private var isBottomCard = false
 
+    // In bottom mode the card is a weighted LinearLayout child (width=0dp), which ignores an
+    // explicit width. We zero the weight for the duration of the morph so the width lerps take
+    // effect, saving the original here to restore the resting layout afterwards.
+    private var savedCardWeight = 0f
+
     override fun init(
         widgetCard: View,
         omnibarCard: View,
@@ -82,13 +88,14 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         isBottom: Boolean,
     ): Margins? {
         if (omnibarWidth <= 0 || omnibarHeight <= 0) return null
-        val params = widgetCard.layoutParams as? FrameLayout.LayoutParams ?: return null
+        val params = widgetCard.layoutParams as? ViewGroup.MarginLayoutParams ?: return null
 
         captureCardProperties(widgetCard, omnibarCard)
         isBottomCard = isBottom
 
         val margins = Margins(params.topMargin, params.bottomMargin)
 
+        detachWeightForMorph(params)
         shrinkCardToMatchOmnibar(params, omnibarWidth, omnibarHeight, isBottom)
 
         animateCornerRadius(widgetCard, omnibarCornerRadius)
@@ -108,8 +115,8 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
     ) {
         cancelAnimation()
 
-        val startWidth = (widgetCard.layoutParams as FrameLayout.LayoutParams).width
-        val startHeight = (widgetCard.layoutParams as FrameLayout.LayoutParams).height
+        val startWidth = (widgetCard.layoutParams as ViewGroup.MarginLayoutParams).width
+        val startHeight = (widgetCard.layoutParams as ViewGroup.MarginLayoutParams).height
         animationCleanup = { omnibarCard.alpha = 1f }
 
         waitForLayout(widgetCard) {
@@ -155,7 +162,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         val omnibarPosition = visibleSurfacePosition(omnibarCard)
         val visibleBounds = stripCompatPadding(widgetCard, isBottom)
 
-        val params = widgetCard.layoutParams as FrameLayout.LayoutParams
+        val params = widgetCard.layoutParams as ViewGroup.MarginLayoutParams
 
         return ExitSnapshot(
             preSurface = preSurface,
@@ -259,7 +266,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
     }
 
     private fun shrinkCardToMatchOmnibar(
-        params: FrameLayout.LayoutParams,
+        params: ViewGroup.MarginLayoutParams,
         omnibarWidth: Int,
         omnibarHeight: Int,
         isBottom: Boolean,
@@ -268,7 +275,11 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         params.height = omnibarHeight + widgetCompatPaddingHeight
         params.topMargin = 0
         params.bottomMargin = 0
-        params.gravity = Gravity.CENTER_HORIZONTAL or if (isBottom) Gravity.BOTTOM else Gravity.TOP
+        // Gravity only applies to FrameLayout children. For the LinearLayout (bottom) case the card's
+        // horizontal placement is driven by translationX toward the omnibar, so no gravity is needed.
+        if (params is FrameLayout.LayoutParams) {
+            params.gravity = Gravity.CENTER_HORIZONTAL or if (isBottom) Gravity.BOTTOM else Gravity.TOP
+        }
     }
 
     private fun waitForLayout(card: View, block: () -> Unit) {
@@ -300,8 +311,12 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         val widgetContent = card.findViewById<View?>(R.id.inputModeWidget)
         widgetContent?.alpha = 0f
 
-        val params = card.layoutParams as FrameLayout.LayoutParams
-        val fullWidth = (card.parent as View).width - params.leftMargin - params.rightMargin
+        val params = card.layoutParams as ViewGroup.MarginLayoutParams
+        // Subtract the parent's horizontal padding as well as the card's margins: in bottom mode
+        // #8730 moved the keyline_2 inset from the card's margins onto the LinearLayout's padding,
+        // so omitting it would land the card 2×keyline_2 too wide. Top-mode parent has no padding.
+        val parent = card.parent as View
+        val fullWidth = parent.width - parent.paddingLeft - parent.paddingRight - params.leftMargin - params.rightMargin
         // MaterialCardView compat padding scales with corner radius, but setRadius doesn't
         // trigger updatePadding — only setMaxCardElevation does. Measure with the final radius
         // (re-set maxCardElevation to force the padding update); otherwise fullHeight is short
@@ -367,7 +382,8 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         materialCard?.useCompatPadding = false
         materialCard?.cardElevation = widgetCardElevation
 
-        val params = card.layoutParams as FrameLayout.LayoutParams
+        val params = card.layoutParams as ViewGroup.MarginLayoutParams
+        detachWeightForMorph(params)
         params.width = visibleWidth
         params.height = visibleHeight
         params.topMargin = 0
@@ -391,15 +407,35 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         materialCard.radius = topRadius
     }
 
-    private fun restoreLayout(card: View, params: FrameLayout.LayoutParams, margins: Margins) {
-        params.width = ViewGroup.LayoutParams.MATCH_PARENT
+    private fun restoreLayout(card: View, params: ViewGroup.MarginLayoutParams, margins: Margins) {
         params.height = ViewGroup.LayoutParams.WRAP_CONTENT
         params.topMargin = margins.top
         params.bottomMargin = margins.bottom
-        params.gravity = FrameLayout.LayoutParams.UNSPECIFIED_GRAVITY
+        when (params) {
+            // Bottom mode: restore the card's XML resting state (width=0dp + weight) and hand width
+            // distribution back to the LinearLayout, undoing detachWeightForMorph.
+            is LinearLayout.LayoutParams -> {
+                params.width = 0
+                params.weight = savedCardWeight
+            }
+            is FrameLayout.LayoutParams -> {
+                params.width = ViewGroup.LayoutParams.MATCH_PARENT
+                params.gravity = FrameLayout.LayoutParams.UNSPECIFIED_GRAVITY
+            }
+            else -> params.width = ViewGroup.LayoutParams.MATCH_PARENT
+        }
         card.layoutParams = params
         card.translationX = 0f
         card.translationY = 0f
+    }
+
+    // Bottom mode: a weighted (width=0dp) child ignores explicit widths, so zero the weight for the
+    // morph and remember it. restoreLayout puts it back (enter); exit ends in widget removal.
+    private fun detachWeightForMorph(params: ViewGroup.MarginLayoutParams) {
+        if (params is LinearLayout.LayoutParams) {
+            savedCardWeight = params.weight
+            params.weight = 0f
+        }
     }
 
     override fun clearLayoutTransitions(widgetView: View) {
@@ -470,7 +506,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         val visibleBounds: Bounds,
         val targetWidth: Int,
         val targetHeight: Int,
-        val params: FrameLayout.LayoutParams,
+        val params: ViewGroup.MarginLayoutParams,
     )
 
     companion object {

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputAnimatorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputAnimatorTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.nativeinput
+
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.view.ViewGroup.LayoutParams.WRAP_CONTENT
+import android.widget.FrameLayout
+import android.widget.LinearLayout
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RealNativeInputAnimatorTest {
+
+    private lateinit var context: Context
+    private lateinit var testee: RealNativeInputAnimator
+
+    @Before
+    fun setUp() {
+        context = InstrumentationRegistry.getInstrumentation().targetContext
+        testee = RealNativeInputAnimator()
+    }
+
+    /**
+     * Bottom-mode hierarchy as introduced by #8730: the card is a weighted child of a horizontal
+     * LinearLayout, so card.layoutParams is LinearLayout.LayoutParams (not FrameLayout.LayoutParams).
+     */
+    private data class Hierarchy(val widgetView: View, val card: View, val omnibarCard: View)
+
+    private fun bottomHierarchy(): Hierarchy {
+        val widgetView = FrameLayout(context)
+        val linear = LinearLayout(context).apply { orientation = LinearLayout.HORIZONTAL }
+        widgetView.addView(linear, FrameLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT))
+        val card = FrameLayout(context)
+        linear.addView(card, LinearLayout.LayoutParams(0, WRAP_CONTENT, 1f))
+        val omnibarCard = FrameLayout(context)
+        widgetView.layout(0, 0, 1000, 200)
+        linear.layout(0, 0, 1000, 200)
+        card.layout(0, 0, 1000, 200)
+        omnibarCard.layout(0, 0, 900, 100)
+        return Hierarchy(widgetView, card, omnibarCard)
+    }
+
+    @Test
+    fun whenAnimateExitInBottomModeWithLinearLayoutParentThenDoesNotThrow() {
+        val (widgetView, card, omnibarCard) = bottomHierarchy()
+
+        // Pre-fix this throws ClassCastException at stripCompatPadding; reaching the end is the assertion.
+        testee.animateExit(
+            widgetCard = card,
+            widgetView = widgetView,
+            omnibarCard = omnibarCard,
+            isBottom = true,
+            onComplete = {},
+        )
+    }
+
+    @Test
+    fun whenInitInBottomModeWithLinearLayoutParentThenReturnsMarginsAndZeroesWeight() {
+        val (_, card, omnibarCard) = bottomHierarchy()
+
+        val margins = testee.init(card, omnibarCard, omnibarCard.width, omnibarCard.height, isBottom = true)
+
+        // Enter morph must no longer be skipped in bottom mode...
+        assertNotNull(margins)
+        // ...and the weight must be zeroed so explicit width lerps take effect.
+        assertEquals(0f, (card.layoutParams as LinearLayout.LayoutParams).weight, 0f)
+    }
+
+    @Test
+    fun whenInitInTopModeWithFrameLayoutParentThenReturnsMargins() {
+        val widgetView = FrameLayout(context)
+        val card = FrameLayout(context)
+        widgetView.addView(card, FrameLayout.LayoutParams(MATCH_PARENT, WRAP_CONTENT))
+        val omnibarCard = FrameLayout(context)
+        widgetView.layout(0, 0, 1000, 200)
+        card.layout(0, 0, 1000, 200)
+        omnibarCard.layout(0, 0, 900, 100)
+
+        val margins = testee.init(card, omnibarCard, omnibarCard.width, omnibarCard.height, isBottom = false)
+
+        assertNotNull(margins)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1215316098826357

### Description

`RealNativeInputAnimator` assumed the widget card (`R.id.inputModeWidgetCard`) is always a direct `FrameLayout` child and hard-cast its `layoutParams` to `FrameLayout.LayoutParams`. #8730 wrapped the card in a horizontal `LinearLayout` (to host the leading fire button) in `input_mode_widget_card_view_bottom.xml`, so in **bottom omnibar mode** the params are `LinearLayout.LayoutParams` and the exit animation threw:

```
java.lang.ClassCastException: android.widget.LinearLayout$LayoutParams cannot be cast to android.widget.FrameLayout$LayoutParams
    at RealNativeInputAnimator.stripCompatPadding(NativeInputAnimator.kt:370)
    at RealNativeInputAnimator.snapshotBeforeExit(NativeInputAnimator.kt:156)
    at RealNativeInputAnimator.animateExit(NativeInputAnimator.kt:146)
    at RealNativeInputManager.hideNativeInput(NativeInputManager.kt:240)
```

This fired on every dismissal of the widget in bottom mode (submit, back on the empty bar, navigating to a URL). The enter path was already defensively safe-cast (`init`), so its morph was silently skipped rather than crashing — meaning bottom mode lost both morphs since #8730.

The fix makes the animator parent-agnostic instead of fighting #8730's structure:
- operate on the shared `ViewGroup.MarginLayoutParams` supertype (covers both `FrameLayout` and `LinearLayout` params);
- zero the card's `LinearLayout` weight for the duration of the morph so explicit width lerps take effect, restoring it afterwards;
- guard gravity writes to the `FrameLayout` case (bottom uses `translationX` for horizontal placement);
- subtract the parent's horizontal padding when measuring full width, so the bottom card no longer lands `2×keyline_2` too wide.

This fixes the crash and restores both the enter and exit morphs in bottom mode. Top omnibar and Duck.ai (which skips the morph) are unaffected.

Adds `RealNativeInputAnimatorTest` covering the regression (exit no longer throws with a `LinearLayout` parent; enter morph no longer skipped) plus a `FrameLayout`-parent guard.

### Steps to test this PR

_Bottom omnibar (internal build)_
- [x] Move the address bar to the bottom
- [x] Focus the address bar, type a query and submit — no crash, widget morphs back into the omnibar
- [x] Focus the empty address bar and press back — no crash, smooth morph
- [x] Navigate to a URL (e.g. booking.com) — no crash
- [x] Confirm the collapsed card lines up with the omnibar (not too wide)

_Regression_
- [x] Repeat with the address bar at the top — morph still correct
- [x] Open a Duck.ai chat — unchanged (morph intentionally skipped)

### UI changes

No static layout changes. Behavioural fix only: the enter/exit morph animation is restored in bottom omnibar mode (previously skipped on enter and crashing on exit).

| Before  | After |
| ------ | ----- |
| Crash on dismiss (bottom omnibar) | Smooth morph, no crash |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dismiss/enter animation layout logic on a frequent user path (address bar), but the change is scoped to param typing and bottom-mode morph behavior with new instrumented tests.
> 
> **Overview**
> Fixes a **bottom omnibar** crash when dismissing native input: `RealNativeInputAnimator` no longer assumes `FrameLayout.LayoutParams` on the widget card after #8730 wrapped it in a horizontal `LinearLayout`.
> 
> The animator now works off **`ViewGroup.MarginLayoutParams`**, temporarily **zeros `LinearLayout` weight** so width morphs apply, **restores `0dp` + weight** after enter, only sets **gravity** for `FrameLayout` children, and **includes parent horizontal padding** in full-width measurement so the morphed card aligns with the omnibar. Enter morph is no longer skipped in bottom mode; exit no longer throws.
> 
> Adds **`RealNativeInputAnimatorTest`** for the `LinearLayout` parent regression and a top-mode `FrameLayout` sanity check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c79a6ea9e8a77c125e202f730758b97da763563c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->