### PR TITLE
Android: Update flows to use queryPurchases (behind FF)

### DIFF
--- a/PixelDefinitions/pixels/definitions/wide_subscription-purchase.json5
+++ b/PixelDefinitions/pixels/definitions/wide_subscription-purchase.json5
@@ -37,6 +37,11 @@
                 "type": "boolean"
             },
             {
+                "key": "feature.data.ext.use_query_purchases",
+                "description": "Value of the `useQueryPurchases` feature flag at flow start. When true, storeLogin() reads from PlayBillingManager.getLatestPurchase() (queryPurchases, active subscriptions only) and may surface the new NoActivePurchase / PurchaseInfoNotAvailable failure types. When false, the legacy purchaseHistory path is used.",
+                "type": "boolean"
+            },
+            {
                 "key": "feature.data.ext.creation_latency_ms_bucketed",
                 "description": "Duration of the account-creation step in milliseconds, bucketed using the lower bucket boundary",
                 "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]

--- a/PixelDefinitions/pixels/definitions/wide_subscription_restore.json5
+++ b/PixelDefinitions/pixels/definitions/wide_subscription_restore.json5
@@ -35,6 +35,11 @@
                 "type": "boolean"
             },
             {
+                "key": "feature.data.ext.use_query_purchases",
+                "description": "Value of the `useQueryPurchases` feature flag at flow start. When true, storeLogin() reads from PlayBillingManager.getLatestPurchase() (queryPurchases, active subscriptions only) and may surface the new NoActivePurchase / PurchaseInfoNotAvailable failure types. When false, the legacy purchaseHistory path is used.",
+                "type": "boolean"
+            },
+            {
                 "key": "feature.data.ext.restore_latency_ms_bucketed",
                 "description": "The duration of the restore flow in milliseconds, bucketed using the lower bucket boundary",
                 "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -292,6 +292,9 @@ interface SubscriptionsFeature {
 
     @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.TRUE)
     fun schedulePaywallNotSeenPixels(): Toggle
+
+    @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.FALSE)
+    fun useQueryPurchases(): Toggle
 }
 
 @ContributesBinding(AppScope::class)

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -806,7 +806,6 @@ class RealSubscriptionsManager @Inject constructor(
 
                         StoreLoginResult.Failure.AccountExternalIdMismatch,
                         StoreLoginResult.Failure.PurchaseHistoryNotAvailable,
-                        StoreLoginResult.Failure.NoActivePurchase,
                         StoreLoginResult.Failure.AuthenticationError,
                         -> {
                             tokenRefreshWideEvent.onPlayLoginFailure(
@@ -815,6 +814,16 @@ class RealSubscriptionsManager @Inject constructor(
                                 loginError = storeLoginResult.javaClass.simpleName,
                             )
                             pixelSender.reportAuthV2InvalidRefreshTokenSignedOut()
+                            signOut()
+                            throw e
+                        }
+
+                        StoreLoginResult.Failure.NoActivePurchase -> {
+                            tokenRefreshWideEvent.onPlayLoginFailure(
+                                signedOut = true,
+                                refreshException = e,
+                                loginError = storeLoginResult.javaClass.simpleName,
+                            )
                             signOut()
                             throw e
                         }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -72,7 +72,6 @@ import com.duckduckgo.subscriptions.impl.repository.toProductList
 import com.duckduckgo.subscriptions.impl.services.AuthService
 import com.duckduckgo.subscriptions.impl.services.ConfirmationBody
 import com.duckduckgo.subscriptions.impl.services.ResponseError
-import com.duckduckgo.subscriptions.impl.services.StoreLoginBody
 import com.duckduckgo.subscriptions.impl.services.SubscriptionsService
 import com.duckduckgo.subscriptions.impl.services.ValidateTokenResponse
 import com.duckduckgo.subscriptions.impl.services.toEntitlements
@@ -976,50 +975,23 @@ class RealSubscriptionsManager @Inject constructor(
     }
 
     override suspend fun recoverSubscriptionFromStore(externalId: String?): RecoverSubscriptionResult {
+        require(externalId == null) { "Use storeLogin() directly to re-authenticate using existing externalId" }
         return try {
-            if (shouldUseAuthV2()) {
-                require(externalId == null) { "Use storeLogin() directly to re-authenticate using existing externalId" }
-                when (val storeLoginResult = storeLogin()) {
-                    is StoreLoginResult.Success -> {
-                        saveTokens(storeLoginResult.tokens)
-                        refreshSubscriptionData()
-                        val subscription = getSubscription()
-                        if (subscription?.isActive() == true) {
-                            RecoverSubscriptionResult.Success(subscription)
-                        } else {
-                            RecoverSubscriptionResult.Failure(SUBSCRIPTION_NOT_FOUND_ERROR)
-                        }
-                    }
-
-                    is StoreLoginResult.Failure -> when (storeLoginResult) {
-                        StoreLoginResult.Failure.NoActivePurchase -> RecoverSubscriptionResult.Failure(SUBSCRIPTION_NOT_FOUND_ERROR)
-                        else -> RecoverSubscriptionResult.Failure(message = "Store login error: ${storeLoginResult.javaClass.simpleName}")
+            when (val storeLoginResult = storeLogin()) {
+                is StoreLoginResult.Success -> {
+                    saveTokens(storeLoginResult.tokens)
+                    refreshSubscriptionData()
+                    val subscription = getSubscription()
+                    if (subscription?.isActive() == true) {
+                        RecoverSubscriptionResult.Success(subscription)
+                    } else {
+                        RecoverSubscriptionResult.Failure(SUBSCRIPTION_NOT_FOUND_ERROR)
                     }
                 }
-            } else {
-                val purchase = playBillingManager.purchaseHistory.lastOrNull()
-                if (purchase != null) {
-                    val signature = purchase.signature
-                    val body = purchase.originalJson
-                    val storeLoginBody = StoreLoginBody(signature = signature, signedData = body, packageName = context.packageName)
-                    val response = authService.storeLogin(storeLoginBody)
-                    if (externalId != null && externalId != response.externalId) return RecoverSubscriptionResult.Failure("")
-                    authRepository.setAccount(Account(externalId = response.externalId, email = null))
-                    authRepository.setAuthToken(response.authToken)
-                    exchangeAuthToken(response.authToken)
-                    if (fetchAndStoreAllData()) {
-                        logcat { "Subs: store login succeeded" }
-                        val subscription = authRepository.getSubscription()
-                        if (subscription?.isActive() == true) {
-                            RecoverSubscriptionResult.Success(subscription)
-                        } else {
-                            RecoverSubscriptionResult.Failure(SUBSCRIPTION_NOT_FOUND_ERROR)
-                        }
-                    } else {
-                        RecoverSubscriptionResult.Failure("")
-                    }
-                } else {
-                    RecoverSubscriptionResult.Failure(SUBSCRIPTION_NOT_FOUND_ERROR)
+
+                is StoreLoginResult.Failure -> when (storeLoginResult) {
+                    StoreLoginResult.Failure.NoActivePurchase -> RecoverSubscriptionResult.Failure(SUBSCRIPTION_NOT_FOUND_ERROR)
+                    else -> RecoverSubscriptionResult.Failure(message = "Store login error: ${storeLoginResult.javaClass.simpleName}")
                 }
             }
         } catch (e: Exception) {
@@ -1232,31 +1204,7 @@ class RealSubscriptionsManager @Inject constructor(
                 is AccessTokenResult.Success -> AuthTokenResult.Success(accessToken.accessToken)
             }
         }
-
-        try {
-            return if (isSignedInV1()) {
-                logcat { "Subs auth token is ${authRepository.getAuthToken()}" }
-                validateToken(authRepository.getAuthToken()!!)
-                AuthTokenResult.Success(authRepository.getAuthToken()!!)
-            } else {
-                AuthTokenResult.Failure.UnknownError
-            }
-        } catch (e: Exception) {
-            return when (extractError(e)) {
-                "expired_token" -> {
-                    logcat { "Subs: auth token expired" }
-                    val result = recoverSubscriptionFromStore(authRepository.getAccount()?.externalId)
-                    if (result is RecoverSubscriptionResult.Success) {
-                        AuthTokenResult.Success(authRepository.getAuthToken()!!)
-                    } else {
-                        AuthTokenResult.Failure.TokenExpired(authRepository.getAuthToken()!!)
-                    }
-                }
-                else -> {
-                    AuthTokenResult.Failure.UnknownError
-                }
-            }
-        }
+        return AuthTokenResult.Failure.UnknownError
     }
 
     override suspend fun getAccessToken(): AccessTokenResult {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -50,6 +50,7 @@ import com.duckduckgo.subscriptions.impl.auth2.BackgroundTokenRefresh
 import com.duckduckgo.subscriptions.impl.auth2.PkceGenerator
 import com.duckduckgo.subscriptions.impl.auth2.RefreshTokenClaims
 import com.duckduckgo.subscriptions.impl.auth2.TokenPair
+import com.duckduckgo.subscriptions.impl.billing.LatestPurchaseResult
 import com.duckduckgo.subscriptions.impl.billing.PlayBillingManager
 import com.duckduckgo.subscriptions.impl.billing.PurchaseState
 import com.duckduckgo.subscriptions.impl.billing.RetryPolicy
@@ -934,14 +935,23 @@ class RealSubscriptionsManager @Inject constructor(
 
     private suspend fun storeLogin(accountExternalId: String? = null): StoreLoginResult {
         return try {
-            val purchase = playBillingManager.purchaseHistory.lastOrNull()
-                ?: return StoreLoginResult.Failure.PurchaseHistoryNotAvailable
+            val signedPurchase = if (subscriptionsFeature.get().useQueryPurchases().isEnabled()) {
+                when (val result = playBillingManager.getLatestPurchase()) {
+                    is LatestPurchaseResult.Present -> SignedPurchase(result.purchase.signature, result.purchase.originalJson)
+                    LatestPurchaseResult.Absent -> return StoreLoginResult.Failure.PurchaseHistoryNotAvailable
+                    LatestPurchaseResult.Unknown -> return StoreLoginResult.Failure.UnknownError
+                }
+            } else {
+                playBillingManager.purchaseHistory.lastOrNull()
+                    ?.let { SignedPurchase(it.signature, it.originalJson) }
+                    ?: return StoreLoginResult.Failure.PurchaseHistoryNotAvailable
+            }
 
             val codeVerifier = pkceGenerator.generateCodeVerifier()
             val codeChallenge = pkceGenerator.generateCodeChallenge(codeVerifier)
             val jwks = authClient.getJwks()
             val sessionId = authClient.authorize(codeChallenge)
-            val authorizationCode = authClient.storeLogin(sessionId, purchase.signature, purchase.originalJson)
+            val authorizationCode = authClient.storeLogin(sessionId, signedPurchase.signature, signedPurchase.originalJson)
             val tokens = authClient.getTokens(sessionId, authorizationCode, codeVerifier)
             val validatedTokens = try {
                 validateTokens(tokens, jwks)
@@ -1365,6 +1375,8 @@ class RealSubscriptionsManager @Inject constructor(
             null
         }
     }
+
+    private data class SignedPurchase(val signature: String, val originalJson: String)
 
     private sealed class StoreLoginResult {
         data class Success(val tokens: ValidatedTokenPair) : StoreLoginResult()

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -807,6 +807,7 @@ class RealSubscriptionsManager @Inject constructor(
 
                         StoreLoginResult.Failure.AccountExternalIdMismatch,
                         StoreLoginResult.Failure.PurchaseHistoryNotAvailable,
+                        StoreLoginResult.Failure.NoActivePurchase,
                         StoreLoginResult.Failure.AuthenticationError,
                         -> {
                             tokenRefreshWideEvent.onPlayLoginFailure(
@@ -820,6 +821,7 @@ class RealSubscriptionsManager @Inject constructor(
                         }
 
                         StoreLoginResult.Failure.TokenValidationFailed,
+                        StoreLoginResult.Failure.PurchaseInfoNotAvailable,
                         StoreLoginResult.Failure.UnknownError,
                         -> {
                             tokenRefreshWideEvent.onPlayLoginFailure(
@@ -938,8 +940,8 @@ class RealSubscriptionsManager @Inject constructor(
             val signedPurchase = if (subscriptionsFeature.get().useQueryPurchases().isEnabled()) {
                 when (val result = playBillingManager.getLatestPurchase()) {
                     is LatestPurchaseResult.Present -> SignedPurchase(result.purchase.signature, result.purchase.originalJson)
-                    LatestPurchaseResult.Absent -> return StoreLoginResult.Failure.PurchaseHistoryNotAvailable
-                    LatestPurchaseResult.Unknown -> return StoreLoginResult.Failure.UnknownError
+                    LatestPurchaseResult.Absent -> return StoreLoginResult.Failure.NoActivePurchase
+                    LatestPurchaseResult.Unknown -> return StoreLoginResult.Failure.PurchaseInfoNotAvailable
                 }
             } else {
                 playBillingManager.purchaseHistory.lastOrNull()
@@ -989,8 +991,9 @@ class RealSubscriptionsManager @Inject constructor(
                         }
                     }
 
-                    is StoreLoginResult.Failure -> {
-                        RecoverSubscriptionResult.Failure(message = "Store login error: ${storeLoginResult.javaClass.simpleName}")
+                    is StoreLoginResult.Failure -> when (storeLoginResult) {
+                        StoreLoginResult.Failure.NoActivePurchase -> RecoverSubscriptionResult.Failure(SUBSCRIPTION_NOT_FOUND_ERROR)
+                        else -> RecoverSubscriptionResult.Failure(message = "Store login error: ${storeLoginResult.javaClass.simpleName}")
                     }
                 }
             } else {
@@ -1382,6 +1385,8 @@ class RealSubscriptionsManager @Inject constructor(
         data class Success(val tokens: ValidatedTokenPair) : StoreLoginResult()
         sealed class Failure : StoreLoginResult() {
             data object PurchaseHistoryNotAvailable : Failure()
+            data object NoActivePurchase : Failure()
+            data object PurchaseInfoNotAvailable : Failure()
             data object AccountExternalIdMismatch : Failure()
             data object AuthenticationError : Failure()
             data object TokenValidationFailed : Failure()

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -807,6 +807,7 @@ class RealSubscriptionsManager @Inject constructor(
                         StoreLoginResult.Failure.AccountExternalIdMismatch,
                         StoreLoginResult.Failure.PurchaseHistoryNotAvailable,
                         StoreLoginResult.Failure.AuthenticationError,
+                        StoreLoginResult.Failure.NoActivePurchase,
                         -> {
                             tokenRefreshWideEvent.onPlayLoginFailure(
                                 signedOut = true,
@@ -814,16 +815,6 @@ class RealSubscriptionsManager @Inject constructor(
                                 loginError = storeLoginResult.javaClass.simpleName,
                             )
                             pixelSender.reportAuthV2InvalidRefreshTokenSignedOut()
-                            signOut()
-                            throw e
-                        }
-
-                        StoreLoginResult.Failure.NoActivePurchase -> {
-                            tokenRefreshWideEvent.onPlayLoginFailure(
-                                signedOut = true,
-                                refreshException = e,
-                                loginError = storeLoginResult.javaClass.simpleName,
-                            )
                             signOut()
                             throw e
                         }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/billing/PlayBillingManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/billing/PlayBillingManager.kt
@@ -105,6 +105,12 @@ interface PlayBillingManager {
      * This is the preferred method over purchase history for getting current tokens
      */
     fun getLatestPurchaseToken(): String?
+
+    /**
+     * Returns the latest active (PURCHASED) subscription purchase.
+     * See [LatestPurchaseResult] for the meaning of each outcome.
+     */
+    fun getLatestPurchase(): LatestPurchaseResult
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -147,6 +153,8 @@ class RealPlayBillingManager @Inject constructor(
 
     // Active Purchases
     override var purchases = emptyList<Purchase>()
+
+    private var latestQueryPurchasesSucceeded = false
 
     override fun onCreate(owner: LifecycleOwner) {
         connectAsyncWithRetry()
@@ -402,9 +410,11 @@ class RealPlayBillingManager @Inject constructor(
         when (val result = billingClient.queryPurchases()) {
             is QueryPurchasesResult.Success -> {
                 purchases = result.purchases
+                latestQueryPurchasesSucceeded = true
                 logcat { "Billing: Loaded ${result.purchases.size} active purchases" }
             }
             is QueryPurchasesResult.Failure -> {
+                latestQueryPurchasesSucceeded = false
                 logcat { "Billing: Failed to load purchases: ${result.billingError} - ${result.debugMessage}" }
             }
         }
@@ -427,6 +437,31 @@ class RealPlayBillingManager @Inject constructor(
             null
         }
     }
+
+    override fun getLatestPurchase(): LatestPurchaseResult {
+        if (!latestQueryPurchasesSucceeded) return LatestPurchaseResult.Unknown
+        val latest = purchases
+            .filter { purchase ->
+                (purchase.products.contains(BASIC_SUBSCRIPTION) || purchase.products.contains(ADVANCED_SUBSCRIPTION)) &&
+                    purchase.purchaseState == Purchase.PurchaseState.PURCHASED
+            }
+            .maxByOrNull { it.purchaseTime }
+        return if (latest != null) LatestPurchaseResult.Present(latest) else LatestPurchaseResult.Absent
+    }
+}
+
+sealed class LatestPurchaseResult {
+    /** An active purchase exists. */
+    data class Present(val purchase: Purchase) : LatestPurchaseResult()
+
+    /** Play Billing has been successfully queried and confirmed no active purchase exists. */
+    data object Absent : LatestPurchaseResult()
+
+    /**
+     * No confirmed answer yet — either we have not queried Play Billing yet,
+     * or the last query failed (connection error, service unavailable, etc.).
+     */
+    data object Unknown : LatestPurchaseResult()
 }
 
 sealed class PurchaseState {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/billing/PlayBillingManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/billing/PlayBillingManager.kt
@@ -107,10 +107,11 @@ interface PlayBillingManager {
     fun getLatestPurchaseToken(): String?
 
     /**
-     * Returns the latest active (PURCHASED) subscription purchase.
+     * Returns the latest active (PURCHASED) subscription purchase. Queries Play Billing
+     * directly on every call so the result reflects current state (no cache staleness).
      * See [LatestPurchaseResult] for the meaning of each outcome.
      */
-    fun getLatestPurchase(): LatestPurchaseResult
+    suspend fun getLatestPurchase(): LatestPurchaseResult
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -153,8 +154,6 @@ class RealPlayBillingManager @Inject constructor(
 
     // Active Purchases
     override var purchases = emptyList<Purchase>()
-
-    private var latestQueryPurchasesSucceeded = false
 
     override fun onCreate(owner: LifecycleOwner) {
         connectAsyncWithRetry()
@@ -410,11 +409,9 @@ class RealPlayBillingManager @Inject constructor(
         when (val result = billingClient.queryPurchases()) {
             is QueryPurchasesResult.Success -> {
                 purchases = result.purchases
-                latestQueryPurchasesSucceeded = true
                 logcat { "Billing: Loaded ${result.purchases.size} active purchases" }
             }
             is QueryPurchasesResult.Failure -> {
-                latestQueryPurchasesSucceeded = false
                 logcat { "Billing: Failed to load purchases: ${result.billingError} - ${result.debugMessage}" }
             }
         }
@@ -438,15 +435,24 @@ class RealPlayBillingManager @Inject constructor(
         }
     }
 
-    override fun getLatestPurchase(): LatestPurchaseResult {
-        if (!latestQueryPurchasesSucceeded) return LatestPurchaseResult.Unknown
-        val latest = purchases
-            .filter { purchase ->
-                (purchase.products.contains(BASIC_SUBSCRIPTION) || purchase.products.contains(ADVANCED_SUBSCRIPTION)) &&
-                    purchase.purchaseState == Purchase.PurchaseState.PURCHASED
+    override suspend fun getLatestPurchase(): LatestPurchaseResult = withContext(dispatcherProvider.io()) {
+        if (!billingClient.ready) return@withContext LatestPurchaseResult.Unknown
+
+        when (val result = billingClient.queryPurchases()) {
+            is QueryPurchasesResult.Success -> {
+                val latest = result.purchases
+                    .filter { purchase ->
+                        (purchase.products.contains(BASIC_SUBSCRIPTION) || purchase.products.contains(ADVANCED_SUBSCRIPTION)) &&
+                            purchase.purchaseState == Purchase.PurchaseState.PURCHASED
+                    }
+                    .maxByOrNull { it.purchaseTime }
+                if (latest != null) LatestPurchaseResult.Present(latest) else LatestPurchaseResult.Absent
             }
-            .maxByOrNull { it.purchaseTime }
-        return if (latest != null) LatestPurchaseResult.Present(latest) else LatestPurchaseResult.Absent
+            is QueryPurchasesResult.Failure -> {
+                logcat { "Billing: getLatestPurchase query failed: ${result.billingError} - ${result.debugMessage}" }
+                LatestPurchaseResult.Unknown
+            }
+        }
     }
 }
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/wideevents/AuthTokenRefreshWideEvent.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/wideevents/AuthTokenRefreshWideEvent.kt
@@ -74,6 +74,7 @@ class AuthTokenRefreshWideEventImpl @Inject constructor(
                     KEY_NETP_IS_ENABLED to runCatching { networkProtectionState.get().isEnabled().toString() }.getOrDefault(""),
                     KEY_NETP_IS_RUNNING to runCatching { networkProtectionState.get().isRunning().toString() }.getOrDefault(""),
                     KEY_PROCESS_NAME to processName,
+                    KEY_USE_QUERY_PURCHASES to subscriptionsFeature.get().useQueryPurchases().isEnabled().toString(),
                 ),
             )
             .getOrNull()
@@ -198,6 +199,7 @@ class AuthTokenRefreshWideEventImpl @Inject constructor(
         const val KEY_NETP_IS_ENABLED = "netp_is_enabled"
         const val KEY_NETP_IS_RUNNING = "netp_is_running"
         const val KEY_PROCESS_NAME = "process_name"
+        const val KEY_USE_QUERY_PURCHASES = "use_query_purchases"
     }
 }
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/wideevents/AuthTokenRefreshWideEvent.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/wideevents/AuthTokenRefreshWideEvent.kt
@@ -40,7 +40,12 @@ interface AuthTokenRefreshWideEvent {
     suspend fun onTokensValidated()
     suspend fun onUnknownAccountError()
     suspend fun onPlayLoginSuccess()
-    suspend fun onPlayLoginFailure(signedOut: Boolean, refreshException: Exception, loginError: String)
+    suspend fun onPlayLoginFailure(
+        signedOut: Boolean,
+        refreshException: Exception,
+        loginError: String,
+    )
+
     suspend fun onSuccess()
     suspend fun onFailure(e: Exception)
 }
@@ -64,7 +69,6 @@ class AuthTokenRefreshWideEventImpl @Inject constructor(
             wideEventClient.intervalEnd(wideEventId = wideEventId, key = INTERVAL_TOTAL_DURATION)
             wideEventClient.flowFinish(wideEventId = wideEventId, status = FlowStatus.Unknown)
         }
-
         ongoingTokenRefreshWideEventId = wideEventClient
             .flowStart(
                 name = AUTH_TOKEN_REFRESH_FEATURE_NAME,
@@ -74,7 +78,7 @@ class AuthTokenRefreshWideEventImpl @Inject constructor(
                     KEY_NETP_IS_ENABLED to runCatching { networkProtectionState.get().isEnabled().toString() }.getOrDefault(""),
                     KEY_NETP_IS_RUNNING to runCatching { networkProtectionState.get().isRunning().toString() }.getOrDefault(""),
                     KEY_PROCESS_NAME to processName,
-                    KEY_USE_QUERY_PURCHASES to subscriptionsFeature.get().useQueryPurchases().isEnabled().toString(),
+                    KEY_USE_QUERY_PURCHASES to subscriptionsFeature.isUseQueryPurchasesEnabled(dispatchers),
                 ),
             )
             .getOrNull()
@@ -131,7 +135,11 @@ class AuthTokenRefreshWideEventImpl @Inject constructor(
         }
     }
 
-    override suspend fun onPlayLoginFailure(signedOut: Boolean, refreshException: Exception, loginError: String) {
+    override suspend fun onPlayLoginFailure(
+        signedOut: Boolean,
+        refreshException: Exception,
+        loginError: String,
+    ) {
         if (!isFeatureEnabled()) return
         ongoingTokenRefreshWideEventId?.let { wideEventId ->
             wideEventClient.flowStep(

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/wideevents/SubscriptionPurchaseWideEvent.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/wideevents/SubscriptionPurchaseWideEvent.kt
@@ -127,6 +127,7 @@ class SubscriptionPurchaseWideEventImpl @Inject constructor(
                 metadata = mapOf(
                     KEY_SUBSCRIPTION_IDENTIFIER to subscriptionIdentifier,
                     KEY_FREE_TRIAL_ELIGIBLE to freeTrialEligible.toString(),
+                    KEY_USE_QUERY_PURCHASES to subscriptionsFeature.get().useQueryPurchases().isEnabled().toString(),
                 ),
                 cleanupPolicy = OnProcessStart(ignoreIfIntervalTimeoutPresent = true),
             )
@@ -381,6 +382,7 @@ class SubscriptionPurchaseWideEventImpl @Inject constructor(
         const val KEY_ACTIVATION_LATENCY_MS_BUCKETED = "activation_latency_ms_bucketed"
         const val KEY_FREE_TRIAL_ELIGIBLE = "free_trial_eligible"
         const val KEY_SUBSCRIPTION_IDENTIFIER = "subscription_identifier"
+        const val KEY_USE_QUERY_PURCHASES = "use_query_purchases"
 
         const val STEP_REFRESH_SUBSCRIPTION = "refresh_subscription"
         const val STEP_CREATE_ACCOUNT = "create_account"

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/wideevents/SubscriptionPurchaseWideEvent.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/wideevents/SubscriptionPurchaseWideEvent.kt
@@ -127,7 +127,7 @@ class SubscriptionPurchaseWideEventImpl @Inject constructor(
                 metadata = mapOf(
                     KEY_SUBSCRIPTION_IDENTIFIER to subscriptionIdentifier,
                     KEY_FREE_TRIAL_ELIGIBLE to freeTrialEligible.toString(),
-                    KEY_USE_QUERY_PURCHASES to subscriptionsFeature.get().useQueryPurchases().isEnabled().toString(),
+                    KEY_USE_QUERY_PURCHASES to subscriptionsFeature.isUseQueryPurchasesEnabled(dispatchers),
                 ),
                 cleanupPolicy = OnProcessStart(ignoreIfIntervalTimeoutPresent = true),
             )

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/wideevents/SubscriptionRestoreWideEvent.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/wideevents/SubscriptionRestoreWideEvent.kt
@@ -131,6 +131,7 @@ class SubscriptionRestoreWideEventImpl @Inject constructor(
                 metadata = mapOf(
                     KEY_RESTORE_PLATFORM to restorePlatform,
                     KEY_IS_PURCHASE_ATTEMPT to purchaseAttempt.toString(),
+                    KEY_USE_QUERY_PURCHASES to subscriptionsFeature.get().useQueryPurchases().isEnabled().toString(),
                 ),
             )
             .getOrNull() ?: return
@@ -160,6 +161,7 @@ class SubscriptionRestoreWideEventImpl @Inject constructor(
         const val INTERVAL_RESTORE_LATENCY = "restore_latency_ms_bucketed"
         const val KEY_RESTORE_PLATFORM = "restore_platform"
         const val KEY_IS_PURCHASE_ATTEMPT = "is_purchase_attempt"
+        const val KEY_USE_QUERY_PURCHASES = "use_query_purchases"
         const val RESTORE_PLATFORM_GOOGLE_PLAY = "google_play"
         const val RESTORE_PLATFORM_EMAIL_ADDRESS = "email_address"
         const val FLOW_ENTRY_POINT_APP_SETTINGS = "funnel_appsettings_android"

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/wideevents/SubscriptionRestoreWideEvent.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/wideevents/SubscriptionRestoreWideEvent.kt
@@ -117,7 +117,11 @@ class SubscriptionRestoreWideEventImpl @Inject constructor(
         }
     }
 
-    private suspend fun onRestoreFlowStarted(restorePlatform: String, purchaseAttempt: Boolean, flowEntryPoint: String?) {
+    private suspend fun onRestoreFlowStarted(
+        restorePlatform: String,
+        purchaseAttempt: Boolean,
+        flowEntryPoint: String?,
+    ) {
         getCurrentWideEventId()?.let { wideEventId ->
             wideEventClient.flowFinish(wideEventId = wideEventId, status = FlowStatus.Unknown)
             cachedFlowId = null
@@ -131,7 +135,7 @@ class SubscriptionRestoreWideEventImpl @Inject constructor(
                 metadata = mapOf(
                     KEY_RESTORE_PLATFORM to restorePlatform,
                     KEY_IS_PURCHASE_ATTEMPT to purchaseAttempt.toString(),
-                    KEY_USE_QUERY_PURCHASES to subscriptionsFeature.get().useQueryPurchases().isEnabled().toString(),
+                    KEY_USE_QUERY_PURCHASES to subscriptionsFeature.isUseQueryPurchasesEnabled(dispatchers),
                 ),
             )
             .getOrNull() ?: return

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/wideevents/WideEventMetadata.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/wideevents/WideEventMetadata.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.wideevents
+
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.subscriptions.impl.SubscriptionsFeature
+import dagger.Lazy
+import kotlinx.coroutines.withContext
+
+internal suspend fun Lazy<SubscriptionsFeature>.isUseQueryPurchasesEnabled(dispatchers: DispatcherProvider): String =
+    withContext(dispatchers.io()) {
+        get().useQueryPurchases().isEnabled().toString()
+    }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
@@ -7,6 +7,7 @@ import com.android.billingclient.api.ProductDetails
 import com.android.billingclient.api.ProductDetails.PricingPhase
 import com.android.billingclient.api.ProductDetails.PricingPhases
 import com.android.billingclient.api.ProductDetails.SubscriptionOfferDetails
+import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.PurchaseHistoryRecord
 import com.duckduckgo.autofill.api.email.EmailManager
 import com.duckduckgo.common.test.CoroutineTestRule
@@ -41,6 +42,7 @@ import com.duckduckgo.subscriptions.impl.auth2.PkceGenerator
 import com.duckduckgo.subscriptions.impl.auth2.PkceGeneratorImpl
 import com.duckduckgo.subscriptions.impl.auth2.RefreshTokenClaims
 import com.duckduckgo.subscriptions.impl.auth2.TokenPair
+import com.duckduckgo.subscriptions.impl.billing.LatestPurchaseResult
 import com.duckduckgo.subscriptions.impl.billing.PlayBillingManager
 import com.duckduckgo.subscriptions.impl.billing.PurchaseState
 import com.duckduckgo.subscriptions.impl.billing.PurchaseState.Canceled
@@ -276,6 +278,111 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
             assertEquals(FAKE_REFRESH_TOKEN_V2, authDataStore.refreshTokenV2)
             cancelAndConsumeRemainingEvents()
         }
+    }
+
+    @Test
+    fun whenRecoverSubscriptionFromStoreWithUseQueryPurchasesAndActivePurchaseThenSuccess() = runTest {
+        givenUseQueryPurchasesEnabled()
+        givenUserIsNotSignedIn()
+        givenActivePurchase()
+        givenStoreLoginSucceeds()
+        givenSubscriptionSucceedsWithEntitlements()
+        givenAccessTokenSucceeds()
+        givenV2AccessTokenRefreshSucceeds()
+
+        val result = subscriptionsManager.recoverSubscriptionFromStore()
+
+        assertTrue(result is RecoverSubscriptionResult.Success)
+        verify(authClient).storeLogin(any(), any(), any())
+        verify(playBillingManager, never()).purchaseHistory
+    }
+
+    @Test
+    fun whenRecoverSubscriptionFromStoreWithUseQueryPurchasesAndNoActivePurchaseThenSubscriptionNotFoundFailure() = runTest {
+        givenUseQueryPurchasesEnabled()
+        givenUserIsNotSignedIn()
+        givenNoActivePurchase()
+
+        val result = subscriptionsManager.recoverSubscriptionFromStore()
+
+        assertTrue(result is RecoverSubscriptionResult.Failure)
+        assertEquals("SubscriptionNotFound", (result as RecoverSubscriptionResult.Failure).message)
+        verify(authClient, never()).storeLogin(any(), any(), any())
+    }
+
+    @Test
+    fun whenRecoverSubscriptionFromStoreWithUseQueryPurchasesAndPurchaseInfoUnknownThenGenericFailure() = runTest {
+        givenUseQueryPurchasesEnabled()
+        givenUserIsNotSignedIn()
+        givenPurchaseInfoUnknown()
+
+        val result = subscriptionsManager.recoverSubscriptionFromStore()
+
+        assertTrue(result is RecoverSubscriptionResult.Failure)
+        assertEquals(
+            "Store login error: PurchaseInfoNotAvailable",
+            (result as RecoverSubscriptionResult.Failure).message,
+        )
+        verify(authClient, never()).storeLogin(any(), any(), any())
+    }
+
+    @Test
+    fun whenRefreshTokenWithUseQueryPurchasesAndNoActivePurchaseThenSignsOutWithoutInvalidRefreshTokenSignedOutPixel() = runTest {
+        assumeTrue(authApiV2Enabled)
+        givenUseQueryPurchasesEnabled()
+        givenUserIsSignedIn()
+        givenSubscriptionExists()
+        givenAccessTokenIsExpired()
+        givenV2AccessTokenRefreshFails(errorCode = "invalid_token")
+        givenNoActivePurchase()
+
+        val result = subscriptionsManager.getAccessToken()
+
+        assertTrue(result is AccessTokenResult.Failure)
+        assertFalse(subscriptionsManager.isSignedIn())
+        assertNull(authRepository.getAccessTokenV2())
+        assertNull(authRepository.getRefreshTokenV2())
+        verify(pixelSender).reportAuthV2InvalidRefreshTokenDetected()
+        verify(pixelSender, never()).reportAuthV2InvalidRefreshTokenSignedOut()
+        verify(pixelSender, never()).reportAuthV2InvalidRefreshTokenRecovered()
+    }
+
+    @Test
+    fun whenRefreshTokenWithUseQueryPurchasesAndPurchaseInfoUnknownThenDoesNotSignOut() = runTest {
+        assumeTrue(authApiV2Enabled)
+        givenUseQueryPurchasesEnabled()
+        givenUserIsSignedIn()
+        givenSubscriptionExists()
+        givenAccessTokenIsExpired()
+        givenV2AccessTokenRefreshFails(errorCode = "invalid_token")
+        givenPurchaseInfoUnknown()
+
+        val result = subscriptionsManager.getAccessToken()
+
+        assertTrue(result is AccessTokenResult.Failure)
+        assertTrue(subscriptionsManager.isSignedIn())
+        assertEquals(FAKE_REFRESH_TOKEN_V2, authDataStore.refreshTokenV2)
+        verify(pixelSender).reportAuthV2InvalidRefreshTokenDetected()
+        verify(pixelSender, never()).reportAuthV2InvalidRefreshTokenSignedOut()
+        verify(pixelSender, never()).reportAuthV2InvalidRefreshTokenRecovered()
+    }
+
+    @Test
+    fun whenRefreshTokenWithUseQueryPurchasesAndActivePurchaseThenRecoversTokens() = runTest {
+        assumeTrue(authApiV2Enabled)
+        givenUseQueryPurchasesEnabled()
+        givenUserIsSignedIn()
+        givenAccessTokenIsExpired()
+        givenV2AccessTokenRefreshFails(errorCode = "invalid_token")
+        givenActivePurchase()
+        givenStoreLoginSucceeds(newAccessToken = "new access token")
+
+        val result = subscriptionsManager.getAccessToken()
+
+        assertTrue(result is AccessTokenResult.Success)
+        assertEquals("new access token", (result as AccessTokenResult.Success).accessToken)
+        verify(pixelSender).reportAuthV2InvalidRefreshTokenDetected()
+        verify(pixelSender).reportAuthV2InvalidRefreshTokenRecovered()
     }
 
     @Test
@@ -1882,6 +1989,27 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         )
         whenever(playBillingManager.products).thenReturn(emptyList())
         whenever(playBillingManager.purchaseHistory).thenReturn(listOf(purchaseRecord))
+    }
+
+    @SuppressLint("DenyListedApi")
+    private fun givenUseQueryPurchasesEnabled() {
+        subscriptionsFeature.useQueryPurchases().setRawStoredState(State(true))
+    }
+
+    private suspend fun givenActivePurchase() {
+        val purchase: Purchase = mock {
+            whenever(it.signature).thenReturn("signature")
+            whenever(it.originalJson).thenReturn("originalJson")
+        }
+        whenever(playBillingManager.getLatestPurchase()).thenReturn(LatestPurchaseResult.Present(purchase))
+    }
+
+    private suspend fun givenNoActivePurchase() {
+        whenever(playBillingManager.getLatestPurchase()).thenReturn(LatestPurchaseResult.Absent)
+    }
+
+    private suspend fun givenPurchaseInfoUnknown() {
+        whenever(playBillingManager.getLatestPurchase()).thenReturn(LatestPurchaseResult.Unknown)
     }
 
     private suspend fun givenStoreLoginSucceeds(newAccessToken: String = FAKE_ACCESS_TOKEN_V2) {

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
@@ -197,14 +197,9 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
 
         subscriptionsManager.recoverSubscriptionFromStore() as RecoverSubscriptionResult.Success
 
-        if (authApiV2Enabled) {
-            verify(authClient).storeLogin(any(), any(), any())
-            assertEquals(FAKE_ACCESS_TOKEN_V2, authDataStore.accessTokenV2)
-            assertEquals(FAKE_REFRESH_TOKEN_V2, authDataStore.refreshTokenV2)
-        } else {
-            verify(authService).storeLogin(any())
-            assertEquals("authToken", authDataStore.authToken)
-        }
+        verify(authClient).storeLogin(any(), any(), any())
+        assertEquals(FAKE_ACCESS_TOKEN_V2, authDataStore.accessTokenV2)
+        assertEquals(FAKE_REFRESH_TOKEN_V2, authDataStore.refreshTokenV2)
         assertTrue(authRepository.getEntitlements().firstOrNull { it.product == NetP.value } != null)
     }
 
@@ -277,12 +272,8 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         subscriptionsManager.recoverSubscriptionFromStore()
         subscriptionsManager.isSignedIn.test {
             assertTrue(awaitItem())
-            if (authApiV2Enabled) {
-                assertEquals(FAKE_ACCESS_TOKEN_V2, authDataStore.accessTokenV2)
-                assertEquals(FAKE_REFRESH_TOKEN_V2, authDataStore.refreshTokenV2)
-            } else {
-                assertEquals("accessToken", authDataStore.accessToken)
-            }
+            assertEquals(FAKE_ACCESS_TOKEN_V2, authDataStore.accessTokenV2)
+            assertEquals(FAKE_REFRESH_TOKEN_V2, authDataStore.refreshTokenV2)
             cancelAndConsumeRemainingEvents()
         }
     }
@@ -546,17 +537,10 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
 
         subscriptionsManager.isSignedIn.test {
             assertTrue(awaitItem())
-            if (authApiV2Enabled) {
-                assertEquals(FAKE_ACCESS_TOKEN_V2, authDataStore.accessTokenV2)
-                assertEquals(FAKE_REFRESH_TOKEN_V2, authDataStore.refreshTokenV2)
-                assertNull(authDataStore.accessToken)
-                assertNull(authDataStore.authToken)
-            } else {
-                assertNull(authDataStore.accessTokenV2)
-                assertNull(authDataStore.refreshTokenV2)
-                assertEquals("accessToken", authDataStore.accessToken)
-                assertEquals("authToken", authDataStore.authToken)
-            }
+            assertEquals(FAKE_ACCESS_TOKEN_V2, authDataStore.accessTokenV2)
+            assertEquals(FAKE_REFRESH_TOKEN_V2, authDataStore.refreshTokenV2)
+            assertNull(authDataStore.accessToken)
+            assertNull(authDataStore.authToken)
             cancelAndConsumeRemainingEvents()
         }
     }
@@ -1047,6 +1031,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
 
     @Test
     fun whenGetAuthTokenIfUserSignedInAndValidTokenThenReturnSuccess() = runTest {
+        assumeTrue(authApiV2Enabled) // getAuthToken() now only returns a token for auth v2 signed-in users
         givenUserIsSignedIn()
         givenValidateTokenSucceedsWithEntitlements()
 
@@ -1055,8 +1040,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         assertTrue(result is AuthTokenResult.Success)
 
         val actualAuthToken = (result as AuthTokenResult.Success).authToken
-        val expectedAuthToken = if (authApiV2Enabled) FAKE_ACCESS_TOKEN_V2 else "authToken"
-        assertEquals(expectedAuthToken, actualAuthToken)
+        assertEquals(FAKE_ACCESS_TOKEN_V2, actualAuthToken)
     }
 
     @Test
@@ -1066,92 +1050,6 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         val result = subscriptionsManager.getAuthToken()
 
         assertTrue(result is AuthTokenResult.Failure)
-    }
-
-    @Test
-    fun whenGetAuthTokenIfUserSignedInWithSubscriptionAndTokenExpiredAndEntitlementsExistsThenReturnSuccess() = runTest {
-        assumeFalse(authApiV2Enabled) // getAuthToken() is deprecated and with auth v2 enabled will just delegate to getAccessToken()
-
-        authDataStore.externalId = "1234"
-        givenUserIsSignedIn()
-        givenSubscriptionSucceedsWithEntitlements()
-        givenValidateTokenFailsAndThenSucceeds("""{ "error": "expired_token" }""")
-        givenPurchaseStored()
-        givenStoreLoginSucceeds()
-        givenAccessTokenSucceeds()
-
-        val result = subscriptionsManager.getAuthToken()
-
-        verify(authService).storeLogin(any())
-        assertTrue(result is AuthTokenResult.Success)
-        assertEquals("authToken", (result as AuthTokenResult.Success).authToken)
-    }
-
-    @Test
-    fun whenGetAuthTokenIfUserSignedInWithSubscriptionAndTokenExpiredAndEntitlementsExistsAndExternalIdDifferentThenReturnFailure() = runTest {
-        assumeFalse(authApiV2Enabled) // getAuthToken() is deprecated and with auth v2 enabled will just delegate to getAccessToken()
-
-        givenUserIsSignedIn()
-        authDataStore.externalId = "test"
-        givenSubscriptionSucceedsWithEntitlements()
-        givenValidateTokenFailsAndThenSucceeds("""{ "error": "expired_token" }""")
-        givenPurchaseStored()
-        givenStoreLoginSucceeds()
-        givenAccessTokenSucceeds()
-
-        val result = subscriptionsManager.getAuthToken()
-
-        verify(authService).storeLogin(any())
-        assertTrue(result is AuthTokenResult.Failure.TokenExpired)
-        assertEquals("authToken", (result as AuthTokenResult.Failure.TokenExpired).authToken)
-    }
-
-    @Test
-    fun whenGetAuthTokenIfUserSignedInWithSubscriptionAndTokenExpiredAndEntitlementsDoNotExistThenReturnFailure() = runTest {
-        assumeFalse(authApiV2Enabled) // getAuthToken() is deprecated and with auth v2 enabled will just delegate to getAccessToken()
-
-        givenUserIsSignedIn()
-        givenValidateTokenSucceedsNoEntitlements()
-        givenValidateTokenFailsAndThenSucceedsWithNoEntitlements("""{ "error": "expired_token" }""")
-        givenPurchaseStored()
-        givenStoreLoginSucceeds()
-        givenAccessTokenSucceeds()
-
-        val result = subscriptionsManager.getAuthToken()
-
-        verify(authService).storeLogin(any())
-        assertTrue(result is AuthTokenResult.Failure.TokenExpired)
-        assertEquals("authToken", (result as AuthTokenResult.Failure.TokenExpired).authToken)
-    }
-
-    @Test
-    fun whenGetAuthTokenIfUserSignedInAndTokenExpiredAndNoPurchaseInTheStoreThenReturnFailure() = runTest {
-        assumeFalse(authApiV2Enabled) // getAuthToken() is deprecated and with auth v2 enabled will just delegate to getAccessToken()
-
-        givenUserIsSignedIn()
-        givenValidateTokenFailsAndThenSucceeds("""{ "error": "expired_token" }""")
-
-        val result = subscriptionsManager.getAuthToken()
-
-        verify(authService, never()).storeLogin(any())
-        assertTrue(result is AuthTokenResult.Failure.TokenExpired)
-        assertEquals("authToken", (result as AuthTokenResult.Failure.TokenExpired).authToken)
-    }
-
-    @Test
-    fun whenGetAuthTokenIfUserSignedInAndTokenExpiredAndPurchaseNotValidThenReturnFailure() = runTest {
-        assumeFalse(authApiV2Enabled) // getAuthToken() is deprecated and with auth v2 enabled will just delegate to getAccessToken()
-
-        givenUserIsSignedIn()
-        givenValidateTokenFailsAndThenSucceeds("""{ "error": "expired_token" }""")
-        givenStoreLoginFails()
-        givenPurchaseStored()
-
-        val result = subscriptionsManager.getAuthToken()
-
-        verify(authService).storeLogin(any())
-        assertTrue(result is AuthTokenResult.Failure.TokenExpired)
-        assertEquals("authToken", (result as AuthTokenResult.Failure.TokenExpired).authToken)
     }
 
     @Test

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
@@ -327,7 +327,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
     }
 
     @Test
-    fun whenRefreshTokenWithUseQueryPurchasesAndNoActivePurchaseThenSignsOutWithoutInvalidRefreshTokenSignedOutPixel() = runTest {
+    fun whenRefreshTokenWithUseQueryPurchasesAndNoActivePurchaseThenSignsOut() = runTest {
         assumeTrue(authApiV2Enabled)
         givenUseQueryPurchasesEnabled()
         givenUserIsSignedIn()
@@ -343,7 +343,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         assertNull(authRepository.getAccessTokenV2())
         assertNull(authRepository.getRefreshTokenV2())
         verify(pixelSender).reportAuthV2InvalidRefreshTokenDetected()
-        verify(pixelSender, never()).reportAuthV2InvalidRefreshTokenSignedOut()
+        verify(pixelSender).reportAuthV2InvalidRefreshTokenSignedOut()
         verify(pixelSender, never()).reportAuthV2InvalidRefreshTokenRecovered()
     }
 

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/billing/RealPlayBillingManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/billing/RealPlayBillingManagerTest.kt
@@ -451,6 +451,89 @@ class RealPlayBillingManagerTest {
             assertEquals(PurchaseState.Failure("BILLING_UNAVAILABLE"), awaitItem())
         }
     }
+
+    @Test
+    fun `getLatestPurchase returns Present when active subscription purchase exists`() = runTest {
+        val activePurchase = mock<Purchase> {
+            whenever(it.products).thenReturn(listOf(BASIC_SUBSCRIPTION))
+            whenever(it.purchaseState).thenReturn(Purchase.PurchaseState.PURCHASED)
+            whenever(it.purchaseTime).thenReturn(1000L)
+        }
+        billingClientAdapter.activePurchases = listOf(activePurchase)
+        processLifecycleOwner.currentState = RESUMED
+
+        val result = subject.getLatestPurchase()
+
+        assertEquals(LatestPurchaseResult.Present(activePurchase), result)
+    }
+
+    @Test
+    fun `getLatestPurchase returns the most recent active purchase when multiple exist`() = runTest {
+        val older = mock<Purchase> {
+            whenever(it.products).thenReturn(listOf(BASIC_SUBSCRIPTION))
+            whenever(it.purchaseState).thenReturn(Purchase.PurchaseState.PURCHASED)
+            whenever(it.purchaseTime).thenReturn(1000L)
+        }
+        val newer = mock<Purchase> {
+            whenever(it.products).thenReturn(listOf(BASIC_SUBSCRIPTION))
+            whenever(it.purchaseState).thenReturn(Purchase.PurchaseState.PURCHASED)
+            whenever(it.purchaseTime).thenReturn(2000L)
+        }
+        billingClientAdapter.activePurchases = listOf(older, newer)
+        processLifecycleOwner.currentState = RESUMED
+
+        val result = subject.getLatestPurchase()
+
+        assertEquals(LatestPurchaseResult.Present(newer), result)
+    }
+
+    @Test
+    fun `getLatestPurchase ignores purchases that are not in PURCHASED state`() = runTest {
+        val pendingPurchase = mock<Purchase> {
+            whenever(it.products).thenReturn(listOf(BASIC_SUBSCRIPTION))
+            whenever(it.purchaseState).thenReturn(Purchase.PurchaseState.PENDING)
+            whenever(it.purchaseTime).thenReturn(1000L)
+        }
+        billingClientAdapter.activePurchases = listOf(pendingPurchase)
+        processLifecycleOwner.currentState = RESUMED
+
+        val result = subject.getLatestPurchase()
+
+        assertEquals(LatestPurchaseResult.Absent, result)
+    }
+
+    @Test
+    fun `getLatestPurchase ignores purchases for unrelated products`() = runTest {
+        val otherProductPurchase = mock<Purchase> {
+            whenever(it.products).thenReturn(listOf("some.other.product"))
+            whenever(it.purchaseState).thenReturn(Purchase.PurchaseState.PURCHASED)
+            whenever(it.purchaseTime).thenReturn(1000L)
+        }
+        billingClientAdapter.activePurchases = listOf(otherProductPurchase)
+        processLifecycleOwner.currentState = RESUMED
+
+        val result = subject.getLatestPurchase()
+
+        assertEquals(LatestPurchaseResult.Absent, result)
+    }
+
+    @Test
+    fun `getLatestPurchase returns Absent when billing client confirms no active purchases`() = runTest {
+        billingClientAdapter.activePurchases = emptyList()
+        processLifecycleOwner.currentState = RESUMED
+
+        val result = subject.getLatestPurchase()
+
+        assertEquals(LatestPurchaseResult.Absent, result)
+    }
+
+    @Test
+    fun `getLatestPurchase returns Unknown when billing client is not ready`() = runTest {
+        // do not connect the billing client (no lifecycle transition to CREATED/RESUMED)
+        val result = subject.getLatestPurchase()
+
+        assertEquals(LatestPurchaseResult.Unknown, result)
+    }
 }
 
 class FakeBillingClientAdapter : BillingClientAdapter {

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/wideevents/AuthTokenRefreshWideEventTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/wideevents/AuthTokenRefreshWideEventTest.kt
@@ -62,6 +62,29 @@ class AuthTokenRefreshWideEventTest {
         )
     }
 
+    @SuppressLint("DenyListedApi")
+    @Test
+    fun `onStart includes use_query_purchases true when feature flag enabled`() = runTest {
+        subscriptionsFeature.useQueryPurchases().setRawStoredState(Toggle.State(true))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any()))
+            .thenReturn(Result.success(123L))
+
+        authWideEvent.onStart(SubscriptionStatus.UNKNOWN)
+
+        verify(wideEventClient).flowStart(
+            name = "auth-token-refresh",
+            flowEntryPoint = null,
+            metadata = mapOf(
+                "subscription_status" to SubscriptionStatus.UNKNOWN.statusName,
+                "netp_is_enabled" to "false",
+                "netp_is_running" to "false",
+                "process_name" to "main",
+                "use_query_purchases" to "true",
+            ),
+            cleanupPolicy = CleanupPolicy.OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
+        )
+    }
+
     @Test
     fun `onStart starts a new flow and total interval`() = runTest {
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any()))
@@ -77,6 +100,7 @@ class AuthTokenRefreshWideEventTest {
                 "netp_is_enabled" to "false",
                 "netp_is_running" to "false",
                 "process_name" to "main",
+                "use_query_purchases" to "false",
             ),
             cleanupPolicy = CleanupPolicy.OnProcessStart(ignoreIfIntervalTimeoutPresent = false),
         )

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/wideevents/SubscriptionPurchaseWideEventTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/wideevents/SubscriptionPurchaseWideEventTest.kt
@@ -57,6 +57,28 @@ class SubscriptionPurchaseWideEventTest {
     }
 
     @Test
+    @SuppressLint("DenyListedApi")
+    fun `onPurchaseFlowStarted includes use_query_purchases true when feature flag enabled`() =
+        runTest {
+            subscriptionsFeature.useQueryPurchases().setRawStoredState(Toggle.State(true))
+            whenever(wideEventClient.flowStart(any(), any(), any(), any()))
+                .thenReturn(Result.success(321L))
+
+            subscriptionPurchaseWideEvent.onPurchaseFlowStarted("sub_id", true, "app_settings")
+
+            verify(wideEventClient).flowStart(
+                name = "subscription-purchase",
+                flowEntryPoint = "app_settings",
+                metadata = mapOf(
+                    "subscription_identifier" to "sub_id",
+                    "free_trial_eligible" to "true",
+                    "use_query_purchases" to "true",
+                ),
+                cleanupPolicy = CleanupPolicy.OnProcessStart(ignoreIfIntervalTimeoutPresent = true),
+            )
+        }
+
+    @Test
     fun `onPurchaseFlowStarted starts a new flow`() =
         runTest {
             whenever(wideEventClient.flowStart(any(), any(), any(), any()))
@@ -70,6 +92,7 @@ class SubscriptionPurchaseWideEventTest {
                 metadata = mapOf(
                     "subscription_identifier" to "sub_id",
                     "free_trial_eligible" to "true",
+                    "use_query_purchases" to "false",
                 ),
                 cleanupPolicy = CleanupPolicy.OnProcessStart(ignoreIfIntervalTimeoutPresent = true),
             )

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/wideevents/SubscriptionRestoreWideEventTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/wideevents/SubscriptionRestoreWideEventTest.kt
@@ -62,6 +62,27 @@ class SubscriptionRestoreWideEventTest {
     }
 
     @Test
+    @SuppressLint("DenyListedApi")
+    fun `onGooglePlayRestoreFlowStarted includes use_query_purchases true when feature flag enabled`() = runTest {
+        subscriptionsFeature.useQueryPurchases().setRawStoredState(Toggle.State(true))
+        whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any()))
+            .thenReturn(Result.success(321L))
+
+        subscriptionRestoreWideEvent.onGooglePlayRestoreFlowStarted(isOriginWeb = false)
+
+        verify(wideEventClient).flowStart(
+            name = "subscription-restore",
+            flowEntryPoint = "funnel_appsettings_android",
+            cleanupPolicy = CleanupPolicy.OnProcessStart(ignoreIfIntervalTimeoutPresent = true),
+            metadata = mapOf(
+                "restore_platform" to "google_play",
+                "is_purchase_attempt" to "false",
+                "use_query_purchases" to "true",
+            ),
+        )
+    }
+
+    @Test
     fun `onEmailRestoreFlowStarted starts a new flow with email platform`() = runTest {
         whenever(wideEventClient.flowStart(any(), anyOrNull(), any(), any()))
             .thenReturn(Result.success(123L))
@@ -75,6 +96,7 @@ class SubscriptionRestoreWideEventTest {
             metadata = mapOf(
                 "restore_platform" to "email_address",
                 "is_purchase_attempt" to "false",
+                "use_query_purchases" to "false",
             ),
         )
         verify(wideEventClient).intervalStart(wideEventId = 123L, key = "restore_latency_ms_bucketed")
@@ -94,6 +116,7 @@ class SubscriptionRestoreWideEventTest {
             metadata = mapOf(
                 "restore_platform" to "google_play",
                 "is_purchase_attempt" to "false",
+                "use_query_purchases" to "false",
             ),
         )
         verify(wideEventClient).intervalStart(wideEventId = 456L, key = "restore_latency_ms_bucketed")
@@ -112,6 +135,7 @@ class SubscriptionRestoreWideEventTest {
             metadata = mapOf(
                 "restore_platform" to "google_play",
                 "is_purchase_attempt" to "true",
+                "use_query_purchases" to "false",
             ),
         )
         verify(wideEventClient).intervalStart(wideEventId = 789L, key = "restore_latency_ms_bucketed")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1214692748990321?focus=true

### Description
See attached task description above

### Steps to test this PR
### Setup 
- Apply patch from https://app.asana.com/1/137249556945/project/1209991789468715/task/1210448620621729?focus=true
-  Install the `internalRelease` build on a device signed into Google Play  

 ### 1. `useQueryPurchases` = OFF (Flow 1 lifecycle, regression)                                                                                                                                                    
  - [x] Purchase a subscription                                                                                                                                                                                      
  - [x] Verify subscription is added to device                                                                                                                                                                     
  - [x] Add email to your subscription                                                                                                                                                                               
  - [x] Cancel subscription
  - [x] Remove subscription from device                                                                                                                                                                              
  - [x] Restore subscription via Play Store                                                                                                                                                                        
  - [x] Verify subscription is added to device and is still active                                                                                                                                                   
  - [x] Wait for subscription to expire
  - [x] Verify subscription shows as expired                                                                                                                                                                         
  - [x] Remove subscription from device                                                                                                                                                                              
  - [x] Restore subscription via email
  - [x] Verify subscription is added to device and is **NOT** active                                                                                                                                                 
                                                                                                                                                                                                                   
  ### 2. `useQueryPurchases` = ON (Flow 1 lifecycle + restore-after-expiry)                                                                                                                                          
  - [x] Go to FF inventory → set `useQueryPurchases` to true and restart the app
  - [x] Purchase a subscription                                                                                                                                                                                      
  - [x] Verify subscription is added to device                                                                                                                                                                     
  - [x] Add email to your subscription                                                                                                                                                                               
  - [x] Cancel subscription                                                                                                                                                                                        
  - [x] Remove subscription from device                                                                                                                                                                              
  - [x] Restore subscription via Play Store                                                                                                                                                                        
  - [x] Verify subscription is added to device and is still active
  - [x] Wait for subscription to expire                                                                                                                                                                              
  - [x] Verify subscription shows as expired
  - [x] Remove subscription from device                                                                                                                                                                              
  - [x] Restore subscription via email                                                                                                                                                                             
  - [x] Verify subscription is added to device and is **NOT** active                                                                                                                                                 
  - [x] Remove subscription from device
  - [x] Restore subscription via Play Store                                                                                                                                                                          
  - [x] Verify that **"Subscription not found"** is shown                                                                                                                                                            
   
  ### 3. `useQueryPurchases` = ON, Flow 2 — logged-out purchase on account with only an expired Play sub                                                                                                             
  - [x] With `useQueryPurchases` ON, ensure the current Google account has an expired/cancelled Privacy Pro Play sub and a known BE email                                                                          
  - [x] Sign out of Privacy Pro and kill the app                                                                                                                                                                     
  - [x] Start a fresh purchase flow (Settings → Privacy Pro → Subscribe) **without** signing in first                                                                                                                
  - [x] Existing BE account is **NOT** silently re-attached                                                                                                                                                          
  - [x] A **new** BE account is created (no email link that was set before)                                                                                                                                           
  - [x] Google Play billing sheet launches for the new purchase                                                                                                                                                      
                                                                                                                                                                                                                     
  ### 4. `useQueryPurchases` = ON, Flow 4 smoke check — token refresh                                                                                                                                                
  - [x] With `useQueryPurchases` ON and an active subscription, force a token refresh (back-date the refresh token or wait for natural expiry) and trigger any authenticated request                                 
  - [x] User stays signed in and the next authenticated request succeeds                                                                                                                                             
  - [x] Repeat with an account whose subscription has expired
  - [x] User **IS** signed out                                                                                                                                                                                       
  - [x] `tokenRefreshWideEvent.onPlayLoginFailure(loginError = "NoActivePurchase")` fires                                                                                                                          
  - [x] `reportAuthV2InvalidRefreshTokenSignedOut` pixel is **NOT** fired                                                                                                                                            
                                                                                                                                                                                                                     
  ### 5. Wide-event metadata spot check                                                                                                                                                                              
  - [x] During the Flow 1 restore in case 2, `subscription-restore` flow-start metadata contains `use_query_purchases = true`                                                                                        
  - [x] During the Flow 2 purchase in case 3, `subscription-purchase` flow-start metadata contains `use_query_purchases = true`                                                                                      
  - [x] During the Flow 4 refresh in case 4, `auth-token-refresh` flow-start metadata contains `use_query_purchases = true`
  - [x] Repeat any one of the above with `useQueryPurchases` OFF and confirm metadata reports `use_query_purchases = false`                                                                                          
                                                                                                                                                                                                                     
  ### Regression checks                                                                                                                                                                                              
  - [x] Fresh purchase by a brand-new user (no prior Play history) completes successfully with the flag OFF and ON                                                                                                   
  - [x] Switching plans (monthly ↔ yearly) still works                                                                                                                                                               
  - [x] Sign out clears all subscription state and entitlements                                                                                                                                                      
  - [x] Existing wide-event keys (`restore_platform`, `is_purchase_attempt`, `subscription_identifier`, `subscription_status`, etc.) are still emitted — `use_query_purchases` is additive


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes subscription authentication, token refresh recovery, and sign-out behavior tied to Play Billing; incorrect handling could lock users out or silently re-link expired subscriptions.
> 
> **Overview**
> Adds a **`useQueryPurchases`** remote feature flag (default off) so **`storeLogin()`** can read the latest **active** Google Play subscription via a fresh **`queryPurchases`** call instead of cached **`purchaseHistory`**.
> 
> When the flag is on, **`PlayBillingManager.getLatestPurchase()`** returns **`Present` / `Absent` / `Unknown`**, and restore/token-refresh flows map **`NoActivePurchase`** and **`PurchaseInfoNotAvailable`** differently (e.g. sign-out on confirmed no active sub vs stay signed in when billing is unknown). **`recoverSubscriptionFromStore`** and deprecated **`getAuthToken()`** drop the legacy auth v1 / **`AuthService.storeLogin`** paths in favor of auth v2 **`storeLogin()`** only.
> 
> Purchase, restore, and auth-token-refresh wide events and pixel schemas gain additive **`use_query_purchases`** metadata for rollout analysis.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b53230258fbd98f7a766de32588f57e190bc77c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->