### PR TITLE
Fire Mode: Empty state pages

### DIFF
--- a/android-design-system/design-system/src/main/res/drawable/ic_info_solid_16.xml
+++ b/android-design-system/design-system/src/main/res/drawable/ic_info_solid_16.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <group>
+    <clip-path
+        android:pathData="M0,0h16v16h-16z"/>
+    <path
+        android:pathData="M16,8C16,12.418 12.418,16 8,16C3.582,16 0,12.418 0,8C0,3.582 3.582,0 8,0C12.418,0 16,3.582 16,8ZM8.483,3.645C7.74,3.645 7.287,4.243 7.287,4.797C7.287,5.468 7.798,5.686 8.25,5.686C9.081,5.686 9.431,5.059 9.431,4.549C9.431,3.907 8.921,3.645 8.483,3.645ZM8.913,6.546L7.086,6.841C7.031,7.283 6.95,7.73 6.868,8.184C6.711,9.061 6.548,9.964 6.548,10.907C6.548,11.844 7.109,12.355 7.995,12.355C9.006,12.355 9.18,11.72 9.219,11.145C8.38,11.266 8.196,10.888 8.333,9.997C8.47,9.106 8.913,6.546 8.913,6.546Z"
+        android:fillColor="?attr/daxColorPrimaryIcon"
+        android:fillType="evenOdd"/>
+  </group>
+</vector>

--- a/android-design-system/design-system/src/main/res/drawable/ic_multiple_accounts_16.xml
+++ b/android-design-system/design-system/src/main/res/drawable/ic_multiple_accounts_16.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="16dp"
+    android:height="16dp"
+    android:viewportWidth="16"
+    android:viewportHeight="16">
+  <group>
+    <clip-path
+        android:pathData="M0,0h16v16h-16z"/>
+    <path
+        android:pathData="M6,8C9.321,8 12,10.721 12,14.063C12,14.274 11.989,14.482 11.968,14.688L11.911,15.25H4.5C2.663,15.25 1.078,14.179 0.331,12.63L0.222,12.404L0.3,12.166L0.338,12.053C1.157,9.697 3.379,8 6,8ZM10.269,8C12.891,8 15.112,9.697 15.931,12.053L15.969,12.166L16.047,12.404L15.938,12.63C15.506,13.526 14.794,14.262 13.914,14.724C13.589,14.894 13.239,14.609 13.248,14.242C13.252,14.049 13.25,13.856 13.239,13.663C13.849,13.368 14.357,12.895 14.694,12.31C14.164,10.936 13.029,9.872 11.625,9.449C11.177,8.894 10.65,8.406 10.06,8.004C10.13,8.001 10.2,8 10.269,8ZM6,9.25C3.991,9.25 2.268,10.515 1.575,12.31C2.159,13.321 3.251,14 4.5,14H10.749C10.716,11.364 8.596,9.25 6,9.25ZM6,1C7.933,1 9.5,2.567 9.5,4.5C9.5,6.433 7.933,8 6,8C4.067,8 2.5,6.433 2.5,4.5C2.5,2.567 4.067,1 6,1ZM10.625,1.056C12.26,1.35 13.5,2.78 13.5,4.5C13.5,6.415 11.962,7.97 10.054,7.999C9.885,7.884 9.711,7.776 9.532,7.675C9.787,7.393 10.007,7.08 10.188,6.742C11.343,6.647 12.25,5.679 12.25,4.5C12.25,3.321 11.343,2.354 10.188,2.258C10.102,2.098 10.007,1.943 9.904,1.794C9.675,1.464 9.832,0.981 10.234,1.008C10.365,1.016 10.496,1.032 10.625,1.056ZM6,2.25C4.757,2.25 3.75,3.257 3.75,4.5C3.75,5.743 4.757,6.75 6,6.75C7.243,6.75 8.25,5.743 8.25,4.5C8.25,3.257 7.243,2.25 6,2.25Z"
+        android:fillColor="?daxColorPrimaryIcon"/>
+  </group>
+</vector>

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabPageView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabPageView.kt
@@ -272,6 +272,8 @@ class NewTabPageView @JvmOverloads constructor(
             return
         }
         binding.fireTabEmptyState.root.gone()
+        binding.indonesiaNewTabSectionView.show()
+        binding.appTrackingProtectionStateView.show()
 
         if (viewState.shouldShowLogo) {
             homeBackgroundLogo.showLogo()

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabPageView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabPageView.kt
@@ -262,6 +262,17 @@ class NewTabPageView @JvmOverloads constructor(
 
         onHasContent?.invoke(viewState.hasContent)
 
+        if (viewState.showFireTabEmptyState) {
+            binding.fireTabEmptyState.root.show()
+            binding.indonesiaNewTabSectionView.gone()
+            binding.appTrackingProtectionStateView.gone()
+            binding.ddgLogo.gone()
+            binding.messageCta.gone()
+            binding.focusedFavourites.gone()
+            return
+        }
+        binding.fireTabEmptyState.root.gone()
+
         if (viewState.shouldShowLogo) {
             homeBackgroundLogo.showLogo()
         } else {

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabPageViewModel.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardi
 import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.playstore.PlayStoreUtils
 import com.duckduckgo.mobile.android.app.tracking.AppTrackingProtection
@@ -77,11 +78,13 @@ class NewTabPageViewModel @AssistedInject constructor(
     private val pixel: Pixel,
     private val onboardingBrandDesignUpdateToggles: OnboardingBrandDesignUpdateToggles,
     private val ctaViewModel: CtaViewModel,
+    browserMode: BrowserMode,
 ) : ViewModel(), DefaultLifecycleObserver {
 
     data class ViewState(
         private val showDaxLogo: Boolean,
         private val appTpEnabled: Boolean = false,
+        val isFireMode: Boolean = false,
         val message: RemoteMessage? = null,
         val messageImageFilePath: String? = null,
         val newMessage: Boolean = false,
@@ -96,8 +99,11 @@ class NewTabPageViewModel @AssistedInject constructor(
             favourites?.isNotEmpty() == true
         private val hasLowPriorityMessage = lowPriorityMessage != null
 
-        val shouldShowLogo = !isLoadingContent && !hasContentThatDisplacesHomeLogo && showDaxLogo
-        val hasContent = isLoadingContent || (shouldShowLogo || hasContentThatDisplacesHomeLogo || appTpEnabled || hasLowPriorityMessage)
+        val showFireTabEmptyState = isFireMode
+        val shouldShowLogo = !isFireMode && !isLoadingContent && !hasContentThatDisplacesHomeLogo && showDaxLogo
+        val hasContent = isFireMode ||
+            isLoadingContent ||
+            (shouldShowLogo || hasContentThatDisplacesHomeLogo || appTpEnabled || hasLowPriorityMessage)
     }
 
     private data class ViewStateSnapshot(
@@ -125,7 +131,9 @@ class NewTabPageViewModel @AssistedInject constructor(
     }
 
     private var lastRemoteMessageSeen: RemoteMessage? = null
-    private val _viewState = MutableStateFlow(ViewState(showDaxLogo = showDaxLogo))
+    private val _viewState = MutableStateFlow(
+        ViewState(showDaxLogo = showDaxLogo, isFireMode = browserMode == BrowserMode.FIRE),
+    )
     val viewState = _viewState.asStateFlow()
 
     private val command = Channel<Command>(1, BufferOverflow.DROP_OLDEST)

--- a/app/src/main/java/com/duckduckgo/app/browser/tabs/DefaultTabManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/tabs/DefaultTabManager.kt
@@ -21,6 +21,8 @@ import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
 import com.duckduckgo.app.browser.tabs.TabManager.TabModel
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeStateHolder
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.squareup.anvil.annotations.ContributesBinding
@@ -59,6 +61,8 @@ class DefaultTabManager @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val queryUrlConverter: OmnibarEntryConverter,
     private val skipUrlConversionOnNewTabFeature: SkipUrlConversionOnNewTabFeature,
+    private val browserMode: BrowserMode,
+    private val browserModeStateHolder: BrowserModeStateHolder,
 ) : TabManager {
     private lateinit var onTabsUpdated: (List<TabModel>) -> Unit
     private var selectedTabId: String? = null
@@ -80,6 +84,9 @@ class DefaultTabManager @Inject constructor(
         onTabsUpdated(updatedTabIds)
 
         if (updatedTabIds.isEmpty()) {
+            if (browserMode == BrowserMode.FIRE && browserModeStateHolder.currentMode.value != BrowserMode.FIRE) {
+                return
+            }
             withContext(dispatchers.io()) {
                 logcat(INFO) { "Tabs list is null or empty; adding default tab" }
                 tabRepository.addDefaultTab()

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -505,6 +505,15 @@ class TabSwitcherActivity :
         if (fadingOutForRecreate) return
         fadingOutForRecreate = true
 
+        // In the Fire tabs empty state the recycler is hidden and empty, so there is nothing to
+        // fade out. Animate nothing and just switch mode and recreate immediately; the recreated
+        // activity still fades the new mode's tabs in via the saved fadingInAfterRecreate flag.
+        if (tabsRecycler.visibility != View.VISIBLE) {
+            viewModel.onBrowserModeToggled(newMode)
+            recreate()
+            return
+        }
+
         tabsRecycler.animate()
             .alpha(0f)
             .setDuration(MODE_SWITCH_FADE_OUT_MS)

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -304,6 +304,7 @@ class TabSwitcherActivity :
         setupToolbar(toolbar)
         configureRecycler()
         configureNavigationBar()
+        configureFireTabsEmptyState()
 
         if (edgeToEdgeEnabled) {
             configureEdgeToEdgeInsets()
@@ -364,6 +365,12 @@ class TabSwitcherActivity :
             binding.navigationBar.show()
         } else {
             binding.navigationBar.gone()
+        }
+    }
+
+    private fun configureFireTabsEmptyState() {
+        binding.fireTabsEmptyState.newFireTabButton.setOnClickListener {
+            onNewTabRequested(fromOverflowMenu = false)
         }
     }
 
@@ -562,30 +569,37 @@ class TabSwitcherActivity :
     private fun configureObservers() {
         lifecycleScope.launch {
             viewModel.viewState.flowWithLifecycle(lifecycle).collectLatest {
-                it.layoutType?.let(::updateLayoutType)
+                if (it.showFireTabsEmptyState && !fadingOutForRecreate) {
+                    binding.fireTabsEmptyState.root.show()
+                    tabsRecycler.gone()
+                } else {
+                    binding.fireTabsEmptyState.root.gone()
 
-                tabsRecycler.invalidateItemDecorations()
+                    it.layoutType?.let(::updateLayoutType)
 
-                val shouldTryScroll = it.tabs.isNotEmpty() &&
-                    (firstTimeLoadingTabsList || fadingInAfterRecreate)
+                    tabsRecycler.invalidateItemDecorations()
 
-                tabsAdapter.updateData(it.tabSwitcherItems) {
-                    pendingToggleScrollAnchor?.let { anchor -> scrollPositionToTop(anchor) }
+                    val shouldTryScroll = it.tabs.isNotEmpty() &&
+                        (firstTimeLoadingTabsList || fadingInAfterRecreate)
 
-                    val scrolled = shouldTryScroll && scrollToActiveTab(it.tabSwitcherItems)
-                    if (scrolled) firstTimeLoadingTabsList = false
+                    tabsAdapter.updateData(it.tabSwitcherItems) {
+                        pendingToggleScrollAnchor?.let { anchor -> scrollPositionToTop(anchor) }
 
-                    if (fadingInAfterRecreate && !fadeInAnimationStarted && it.tabs.isNotEmpty()) {
-                        fadeInAnimationStarted = true
-                        tabsRecycler.show()
-                        tabsRecycler.animate()
-                            .alpha(1f)
-                            .setDuration(MODE_SWITCH_FADE_IN_MS)
-                            .withEndAction {
-                                fadingInAfterRecreate = false
-                                tabsRecycler.itemAnimator = DefaultItemAnimator()
-                            }
-                            .start()
+                        val scrolled = shouldTryScroll && scrollToActiveTab(it.tabSwitcherItems)
+                        if (scrolled) firstTimeLoadingTabsList = false
+
+                        if (fadingInAfterRecreate && !fadeInAnimationStarted && it.tabs.isNotEmpty()) {
+                            fadeInAnimationStarted = true
+                            tabsRecycler.show()
+                            tabsRecycler.animate()
+                                .alpha(1f)
+                                .setDuration(MODE_SWITCH_FADE_IN_MS)
+                                .withEndAction {
+                                    fadingInAfterRecreate = false
+                                    tabsRecycler.itemAnimator = DefaultItemAnimator()
+                                }
+                                .start()
+                        }
                     }
                 }
 
@@ -787,6 +801,7 @@ class TabSwitcherActivity :
             DismissAnimatedTileDismissalDialog -> tabSwitcherAnimationTileRemovalDialog!!.dismiss()
             Command.ShowFireBottomSheet -> onFireButtonClicked()
             Command.DismissSnackbar -> lastSnackbar?.dismiss()
+            Command.SwitchToRegularMode -> fadeOutTabsThenRecreate(BrowserMode.REGULAR)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -73,11 +73,11 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
@@ -114,8 +114,6 @@ class TabSwitcherViewModel @Inject constructor(
 
     private val fireModeAvailable = fireModeAvailability.isAvailable()
 
-    // When fire mode is unavailable the toggle is never shown, so the view model ignores the
-    // shared browser-mode state and always operates on the regular profile.
     private val currentMode: StateFlow<BrowserMode> =
         if (fireModeAvailable) {
             browserModeStateHolder.currentMode
@@ -136,24 +134,21 @@ class TabSwitcherViewModel @Inject constructor(
 
     val command: SingleLiveEvent<Command> = SingleLiveEvent()
 
-    private val tabSwitcherItemsFlow = tabRepositoryFlow.flatMapLatest { repo ->
-        repo.flowTabs
-            .debounce(100.milliseconds)
-            .conflate()
-            .flatMapLatest { tabEntities ->
-                combine(
-                    repo.flowSelectedTab,
-                    _viewState,
-                    tabSwitcherDataStore.isTrackersAnimationInfoTileHidden(),
-                    currentMode,
-                ) { activeTab, viewState, isAnimationTileDismissed, browserMode ->
-                    getTabItems(tabEntities, activeTab, isAnimationTileDismissed, viewState.mode, browserMode)
-                }
-            }
-            .onStart { emit(emptyList()) }
+    private val tabSwitcherItemsFlow: Flow<TabItems> = tabRepositoryFlow.flatMapLatest { repo ->
+        combine(
+            repo.flowTabs.debounce(100.milliseconds),
+            repo.flowSelectedTab,
+            _viewState,
+            tabSwitcherDataStore.isTrackersAnimationInfoTileHidden(),
+            currentMode,
+        ) { tabEntities, activeTab, viewState, isAnimationTileDismissed, browserMode ->
+            getTabItems(tabEntities, activeTab, isAnimationTileDismissed, viewState.mode, browserMode)
+        }
+            .map<List<TabSwitcherItem>, TabItems> { TabItems.Loaded(it) }
+            .onStart { emit(TabItems.NotInitialized) }
     }
 
-    val tabSwitcherItemsLiveData: LiveData<List<TabSwitcherItem>> = tabSwitcherItemsFlow.asLiveData()
+    val tabSwitcherItemsLiveData: LiveData<List<TabSwitcherItem>> = tabSwitcherItemsFlow.map { it.itemsOrEmpty }.asLiveData()
 
     private val _viewState = MutableStateFlow(
         ViewState(
@@ -169,9 +164,9 @@ class TabSwitcherViewModel @Inject constructor(
         duckAiFeatureState.showOmnibarShortcutOnNtpAndOnFocus,
         currentMode,
         tabRepositoryProvider.forMode(BrowserMode.REGULAR).flowTabs.map { it.size },
-    ) { viewState, tabSwitcherItems, tabSwitcherData, showDuckAiButton, browserMode, regularTabCount ->
+    ) { viewState, tabItems, tabSwitcherData, showDuckAiButton, browserMode, regularTabCount ->
         viewState.copy(
-            tabSwitcherItems = tabSwitcherItems,
+            tabItems = tabItems,
             layoutType = tabSwitcherData.layoutType,
             isDuckAIButtonVisible = showDuckAiButton,
             browserMode = browserMode,
@@ -219,6 +214,7 @@ class TabSwitcherViewModel @Inject constructor(
         data class ShowUndoDeleteTabsMessage(val tabIds: List<String>) : Command()
         data object ShowFireBottomSheet : Command()
         data object DismissSnackbar : Command()
+        data object SwitchToRegularMode : Command()
     }
 
     fun onNewTabRequested(fromOverflowMenu: Boolean = false) = viewModelScope.launch {
@@ -449,7 +445,11 @@ class TabSwitcherViewModel @Inject constructor(
         swipeGestureUsed: Boolean = false,
     ) {
         viewModelScope.launch {
-            if (tabs.size == 1) {
+            val isLastTab = tabs.size == 1
+            if (isLastTab && fireModeAvailable && currentMode.value == BrowserMode.FIRE) {
+                markTabAsDeletable(tab, swipeGestureUsed)
+                command.value = Command.SwitchToRegularMode
+            } else if (isLastTab) {
                 // mark the tab as deletable, the undo snackbar will be shown after tab switcher is closed
                 markTabAsDeletable(tab, swipeGestureUsed)
                 command.value = Command.CloseAndShowUndoMessage(listOf(tab.id))
@@ -677,8 +677,16 @@ class TabSwitcherViewModel @Inject constructor(
         }
     }
 
+    sealed class TabItems {
+        data object NotInitialized : TabItems()
+        data class Loaded(val items: List<TabSwitcherItem>) : TabItems()
+
+        val itemsOrEmpty: List<TabSwitcherItem>
+            get() = (this as? Loaded)?.items.orEmpty()
+    }
+
     data class ViewState(
-        val tabSwitcherItems: List<TabSwitcherItem> = emptyList(),
+        val tabItems: TabItems = TabItems.NotInitialized,
         val mode: Mode = Normal,
         val layoutType: LayoutType? = null,
         val isDuckAIButtonVisible: Boolean = false,
@@ -687,8 +695,11 @@ class TabSwitcherViewModel @Inject constructor(
         val regularTabCount: Int? = null,
         val isBrowserModeToggleVisible: Boolean = false,
     ) {
+        val tabSwitcherItems: List<TabSwitcherItem> = tabItems.itemsOrEmpty
         val tabs: List<Tab> = tabSwitcherItems.filterIsInstance<Tab>()
         val numSelectedTabs: Int = (mode as? Selection)?.selectedTabs?.size ?: 0
+
+        val showFireTabsEmptyState: Boolean = browserMode == BrowserMode.FIRE && tabItems is TabItems.Loaded && tabs.isEmpty()
 
         val dynamicInterface = when (mode) {
             is Normal -> {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -421,9 +421,16 @@ class TabSwitcherViewModel @Inject constructor(
                 pixel.fire(AppPixelName.TAB_MANAGER_MENU_CLOSE_ALL_TABS_CONFIRMED)
                 pixel.fire(AppPixelName.TAB_MANAGER_MENU_CLOSE_ALL_TABS_CONFIRMED_DAILY, type = Daily())
 
-                // mark tabs as deletable, the undo snackbar will be displayed when the tab switcher is closed
                 tabRepository.markDeletable(tabIds)
-                command.value = Command.CloseAndShowUndoMessage(tabIds)
+
+                if (fireModeAvailable && currentMode.value == BrowserMode.FIRE) {
+                    // emptying all Fire tabs returns the user to Regular mode, matching the single-tab
+                    // close path; the tab switcher stays open instead of closing with an undo snackbar
+                    command.value = Command.SwitchToRegularMode
+                } else {
+                    // the undo snackbar will be displayed when the tab switcher is closed
+                    command.value = Command.CloseAndShowUndoMessage(tabIds)
+                }
             } else {
                 pixel.fire(AppPixelName.TAB_MANAGER_CLOSE_TABS_CONFIRMED)
                 pixel.fire(AppPixelName.TAB_MANAGER_CLOSE_TABS_CONFIRMED_DAILY, type = Daily())

--- a/app/src/main/res/drawable/background_fire_tabs_card.xml
+++ b/app/src/main/res/drawable/background_fire_tabs_card.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="?attr/daxColorSurface" />
+    <corners android:radius="@dimen/largeShapeCornerRadius" />
+</shape>

--- a/app/src/main/res/layout/activity_tab_switcher.xml
+++ b/app/src/main/res/layout/activity_tab_switcher.xml
@@ -61,6 +61,12 @@
             android:background="?attr/daxColorShadeSolid"
             android:layout_gravity="bottom" />
 
+        <include
+            android:id="@+id/fireTabsEmptyState"
+            layout="@layout/view_fire_tabs_empty_state"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
     </FrameLayout>
 
     <include

--- a/app/src/main/res/layout/view_fire_new_tab_empty_state.xml
+++ b/app/src/main/res/layout/view_fire_new_tab_empty_state.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:gravity="center_horizontal"
+    android:visibility="gone"
+    android:paddingStart="@dimen/keyline_5"
+    android:paddingEnd="@dimen/keyline_5"
+    android:paddingTop="@dimen/keyline_5">
+
+    <ImageView
+        android:layout_width="96dp"
+        android:layout_height="96dp"
+        android:importantForAccessibility="no"
+        android:src="@drawable/ic_fire_tab_placeholder_96" />
+
+    <com.duckduckgo.common.ui.view.text.DaxTextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="@string/fireTabNewTabPageTitle"
+        app:typography="h2" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/keyline_4"
+        android:background="@drawable/background_fire_tabs_card"
+        android:orientation="horizontal"
+        android:padding="@dimen/keyline_5">
+
+        <ImageView
+            android:layout_width="16dp"
+            android:layout_height="16dp"
+            android:layout_marginTop="@dimen/keyline_1"
+            android:layout_marginEnd="@dimen/keyline_2"
+            android:importantForAccessibility="no"
+            android:src="@drawable/ic_info_solid_16" />
+
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/fireTabsExplainer"
+            app:typography="body1" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/view_fire_tabs_empty_state.xml
+++ b/app/src/main/res/layout/view_fire_tabs_empty_state.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true"
+    android:visibility="gone">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:orientation="vertical"
+        android:paddingStart="@dimen/keyline_5"
+        android:paddingEnd="@dimen/keyline_5"
+        android:paddingTop="@dimen/keyline_5"
+        android:paddingBottom="@dimen/keyline_5">
+
+        <ImageView
+            android:layout_width="96dp"
+            android:layout_height="96dp"
+            android:importantForAccessibility="no"
+            android:src="@drawable/ic_fire_tab_placeholder_96" />
+
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:text="@string/fireTabsEmptyStateTitle"
+            app:typography="h2" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/keyline_4"
+            android:background="@drawable/background_fire_tabs_card"
+            android:orientation="vertical"
+            android:padding="@dimen/keyline_5">
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:drawableStart="@drawable/ic_history_16"
+                android:drawablePadding="@dimen/keyline_2"
+                android:text="@string/fireTabsFeatureNoHistory"
+                app:typography="body1" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/keyline_3"
+                android:drawableStart="@drawable/ic_multiple_accounts_16"
+                android:drawablePadding="@dimen/keyline_2"
+                android:text="@string/fireTabsFeatureDifferentAccount"
+                app:typography="body1" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/keyline_3"
+                android:drawableStart="@drawable/ic_globe_16"
+                android:drawablePadding="@dimen/keyline_2"
+                android:text="@string/fireTabsFeatureTroubleshoot"
+                app:typography="body1" />
+
+            <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:layout_marginTop="@dimen/keyline_5"
+                android:background="?attr/daxColorLines" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/keyline_5"
+                android:orientation="horizontal">
+
+                <ImageView
+                    android:layout_width="16dp"
+                    android:layout_height="16dp"
+                    android:layout_marginTop="@dimen/keyline_1"
+                    android:layout_marginEnd="@dimen/keyline_2"
+                    android:importantForAccessibility="no"
+                    android:src="@drawable/ic_info_solid_16" />
+
+                <com.duckduckgo.common.ui.view.text.DaxTextView
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:text="@string/fireTabsExplainer"
+                    app:typography="body1" />
+
+            </LinearLayout>
+
+            <!-- TEMPORARY: restyle the design-system secondary button into a "filled secondary"
+                 (neutral-grey fill, no stroke) to match the Fire Tabs design. Uses existing control
+                 tokens. Remove these overrides (and the lint suppression) once the design system
+                 ships a first-class filled-secondary button. The textColor override is what trips
+                 the DaxButton styling lint rule, hence the suppression. -->
+            <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
+                android:id="@+id/newFireTabButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginTop="@dimen/keyline_5"
+                android:text="@string/fireTabsNewTabButton"
+                android:textColor="?attr/daxColorPrimaryText"
+                app:backgroundTint="?attr/daxColorContainer"
+                app:daxButtonSize="small"
+                app:icon="@drawable/ic_add_16"
+                app:iconTint="?attr/daxColorPrimaryText"
+                app:rippleColor="?attr/daxColorRipple"
+                app:strokeWidth="0dp"
+                tools:ignore="InvalidDaxButtonProperty" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/layout/view_new_tab.xml
+++ b/app/src/main/res/layout/view_new_tab.xml
@@ -22,6 +22,12 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
+    <include
+        android:id="@+id/fireTabEmptyState"
+        layout="@layout/view_fire_new_tab_empty_state"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
     <com.duckduckgo.app.browser.indonesiamessage.IndonesiaNewTabSectionView
         android:id="@+id/indonesiaNewTabSectionView"
         android:layout_width="match_parent"

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -112,6 +112,13 @@
     <string name="browserModeToggleRegularDescription">Switch to regular tabs</string>
     <string name="browserModeToggleTabCountInfinite">∞</string>
     <string name="fireTabMenuItem">Fire Tab</string>
+    <string name="fireTabNewTabPageTitle">Fire Tab</string>
+    <string name="fireTabsEmptyStateTitle">Fire Tabs</string>
+    <string name="fireTabsFeatureNoHistory">Browse without saving local history</string>
+    <string name="fireTabsFeatureDifferentAccount">Sign in to a site with a different account</string>
+    <string name="fireTabsFeatureTroubleshoot">Troubleshoot websites</string>
+    <string name="fireTabsExplainer">Fire Tabs are isolated from other browser data. Their data is burned when you close them all. They give you the same tracking protection as other tabs.</string>
+    <string name="fireTabsNewTabButton">New Fire Tab</string>
 
     <!-- Custom AI onboarding flow -->
     <!-- Pre-onboarding: AI comparison chart screen. -->

--- a/app/src/test/java/com/duckduckgo/app/browser/newtab/NewTabPageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/newtab/NewTabPageViewModelTest.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardi
 import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.ui.view.MessageCta
 import com.duckduckgo.common.utils.playstore.PlayStoreUtils
@@ -93,7 +94,10 @@ class NewTabPageViewModelTest {
         testee = createTestee()
     }
 
-    private fun createTestee(showLogo: Boolean = true): NewTabPageViewModel {
+    private fun createTestee(
+        showLogo: Boolean = true,
+        browserMode: BrowserMode = BrowserMode.REGULAR,
+    ): NewTabPageViewModel {
         return NewTabPageViewModel(
             showDaxLogo = showLogo,
             dispatchers = coroutinesTestRule.testDispatcherProvider,
@@ -110,7 +114,33 @@ class NewTabPageViewModelTest {
             pixel = pixel,
             onboardingBrandDesignUpdateToggles = mockOnboardingBrandDesignUpdateToggles,
             ctaViewModel = mockCtaViewModel,
+            browserMode = browserMode,
         )
+    }
+
+    @Test
+    fun whenFireModeThenShowFireTabEmptyStateAndLogoHidden() = runTest {
+        testee = createTestee(browserMode = BrowserMode.FIRE)
+        testee.onStart(mockLifecycleOwner)
+
+        testee.viewState.test {
+            expectMostRecentItem().also {
+                assertTrue(it.showFireTabEmptyState)
+                assertFalse(it.shouldShowLogo)
+            }
+        }
+    }
+
+    @Test
+    fun whenRegularModeThenDoesNotShowFireTabEmptyState() = runTest {
+        testee = createTestee(browserMode = BrowserMode.REGULAR)
+        testee.onStart(mockLifecycleOwner)
+
+        testee.viewState.test {
+            expectMostRecentItem().also {
+                assertFalse(it.showFireTabEmptyState)
+            }
+        }
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/tabs/DefaultTabManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/tabs/DefaultTabManagerTest.kt
@@ -6,9 +6,12 @@ import com.duckduckgo.app.browser.omnibar.OmnibarEntryConverter
 import com.duckduckgo.app.browser.tabs.TabManager.TabModel
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeStateHolder
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -29,22 +32,28 @@ class DefaultTabManagerTest {
     private val tabRepository: TabRepository = mock()
     private val omnibarEntryConverter: OmnibarEntryConverter = mock()
     private val skipUrlConversionOnNewTabFeature = FakeFeatureToggleFactory.create(SkipUrlConversionOnNewTabFeature::class.java)
+    private val currentModeFlow = MutableStateFlow(BrowserMode.REGULAR)
+    private val browserModeStateHolder: BrowserModeStateHolder = mock()
 
     private lateinit var testee: DefaultTabManager
 
     @Before
     fun setup() {
         skipUrlConversionOnNewTabFeature.self().setRawStoredState(State(enable = false))
+        whenever(browserModeStateHolder.currentMode).thenReturn(currentModeFlow)
 
-        testee = DefaultTabManager(
-            tabRepository = tabRepository,
-            dispatchers = coroutineTestRule.testDispatcherProvider,
-            queryUrlConverter = omnibarEntryConverter,
-            skipUrlConversionOnNewTabFeature = skipUrlConversionOnNewTabFeature,
-        )
-
+        testee = createTabManager(BrowserMode.REGULAR)
         testee.registerCallbacks({})
     }
+
+    private fun createTabManager(browserMode: BrowserMode) = DefaultTabManager(
+        tabRepository = tabRepository,
+        dispatchers = coroutineTestRule.testDispatcherProvider,
+        queryUrlConverter = omnibarEntryConverter,
+        skipUrlConversionOnNewTabFeature = skipUrlConversionOnNewTabFeature,
+        browserMode = browserMode,
+        browserModeStateHolder = browserModeStateHolder,
+    )
 
     @Test
     fun whenOnSelectedTabChangedThenSelectedTabIdIsUpdated() = runTest {
@@ -71,6 +80,26 @@ class DefaultTabManagerTest {
     @Test
     fun whenOnTabsChangedAndNoTabsThenAddDefaultTabCalled() = runTest {
         testee.onTabsChanged(emptyList())
+
+        verify(tabRepository).addDefaultTab()
+    }
+
+    @Test
+    fun whenOnTabsChangedAndNoTabsInFireModeButGlobalModeRegularThenDefaultTabNotAdded() = runTest {
+        currentModeFlow.value = BrowserMode.REGULAR
+        val fireManager = createTabManager(BrowserMode.FIRE).also { it.registerCallbacks({}) }
+
+        fireManager.onTabsChanged(emptyList())
+
+        verify(tabRepository, never()).addDefaultTab()
+    }
+
+    @Test
+    fun whenOnTabsChangedAndNoTabsInFireModeAndGlobalModeFireThenAddDefaultTabCalled() = runTest {
+        currentModeFlow.value = BrowserMode.FIRE
+        val fireManager = createTabManager(BrowserMode.FIRE).also { it.registerCallbacks({}) }
+
+        fireManager.onTabsChanged(emptyList())
 
         verify(tabRepository).addDefaultTab()
     }

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -2000,6 +2000,32 @@ class TabSwitcherViewModelTest {
     }
 
     @Test
+    fun `when closing all fire tabs then switches to regular mode instead of showing undo`() = runTest {
+        val fireTabs = listOf(
+            TabEntity("fire-1", url = "https://fire.example/1", position = 1),
+            TabEntity("fire-2", url = "https://fire.example/2", position = 2),
+        )
+        whenever(mockTabRepositoryProvider.forMode(BrowserMode.FIRE)).thenReturn(mockFireTabRepository)
+        whenever(mockFireTabRepository.flowTabs).thenReturn(flowOf(fireTabs))
+        whenever(mockFireTabRepository.flowSelectedTab).thenReturn(flowOf(fireTabs.first()))
+        whenever(mockFireTabRepository.flowDeletableTabs).thenReturn(flowOf(emptyList()))
+        whenever(mockFireTabRepository.tabSwitcherData).thenReturn(flowOf(tabSwitcherData))
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            testee.viewState.collect()
+        }
+        currentModeFlow.value = BrowserMode.FIRE
+        advanceUntilIdle()
+
+        testee.onCloseAllTabsConfirmed()
+        advanceUntilIdle()
+
+        verify(mockFireTabRepository).markDeletable(fireTabs.map { it.tabId })
+        verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+        assertEquals(Command.SwitchToRegularMode, commandCaptor.lastValue)
+    }
+
+    @Test
     fun `when fire mode unavailable then disabled viewmodel ignores state holder and only resolves regular repo`() = runTest {
         // Use isolated mocks so the @Before viewmodel (which subscribed to currentModeFlow) does not interfere.
         val isolatedProvider = mock<BrowserModeDataProvider<TabRepository>>()

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -44,6 +44,7 @@ import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab.DuckAiTab
 import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab.NormalTab
 import com.duckduckgo.app.tabs.ui.TabSwitcherItem.Tab.SelectableTab
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.Command
+import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.TabItems
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.ViewState
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.ViewState.BackButtonType
 import com.duckduckgo.app.tabs.ui.TabSwitcherViewModel.ViewState.DynamicInterface
@@ -794,7 +795,7 @@ class TabSwitcherViewModelTest {
 
     @Test
     fun whenNormalModeAndNoTabsThenVerifyDynamicInterface() {
-        val viewState = ViewState(tabSwitcherItems = emptyList(), mode = Normal, layoutType = null, isDuckAIButtonVisible = true)
+        val viewState = ViewState(tabItems = TabItems.Loaded(emptyList()), mode = Normal, layoutType = null, isDuckAIButtonVisible = true)
         val expected = DynamicInterface(
             isFireButtonVisible = true,
             isNewTabButtonVisible = true,
@@ -1156,7 +1157,7 @@ class TabSwitcherViewModelTest {
     @Test
     fun whenNormalModeAndNoTabsAndNewToolbarEnabledThenVerifyDynamicInterface() {
         val viewState = ViewState(
-            tabSwitcherItems = emptyList(),
+            tabItems = TabItems.Loaded(emptyList()),
             mode = Normal,
             layoutType = null,
             isDuckAIButtonVisible = true,
@@ -1927,6 +1928,75 @@ class TabSwitcherViewModelTest {
 
         assertTrue(items.any { it is NormalTab && it.tabEntity.tabId == "fire-1" })
         verify(mockTabRepositoryProvider, atLeastOnce()).forMode(BrowserMode.FIRE)
+    }
+
+    @Test
+    fun `when fire mode and no fire tabs then showFireTabsEmptyState is true`() = runTest {
+        whenever(mockTabRepositoryProvider.forMode(BrowserMode.FIRE)).thenReturn(mockFireTabRepository)
+        whenever(mockFireTabRepository.flowTabs).thenReturn(flowOf(emptyList()))
+        whenever(mockFireTabRepository.flowSelectedTab).thenReturn(flowOf<TabEntity?>(null))
+        whenever(mockFireTabRepository.flowDeletableTabs).thenReturn(flowOf(emptyList()))
+        whenever(mockFireTabRepository.tabSwitcherData).thenReturn(flowOf(tabSwitcherData))
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            testee.viewState.collect()
+        }
+        currentModeFlow.value = BrowserMode.FIRE
+        advanceUntilIdle()
+
+        assertTrue(testee.viewState.value.showFireTabsEmptyState)
+    }
+
+    @Test
+    fun `when fire mode and fire tabs present then showFireTabsEmptyState is false`() = runTest {
+        val fireTabList = listOf(TabEntity("fire-1", url = "https://fire.example", position = 1))
+        whenever(mockTabRepositoryProvider.forMode(BrowserMode.FIRE)).thenReturn(mockFireTabRepository)
+        whenever(mockFireTabRepository.flowTabs).thenReturn(flowOf(fireTabList))
+        whenever(mockFireTabRepository.flowSelectedTab).thenReturn(flowOf(fireTabList.first()))
+        whenever(mockFireTabRepository.flowDeletableTabs).thenReturn(flowOf(emptyList()))
+        whenever(mockFireTabRepository.tabSwitcherData).thenReturn(flowOf(tabSwitcherData))
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            testee.viewState.collect()
+        }
+        currentModeFlow.value = BrowserMode.FIRE
+        advanceUntilIdle()
+
+        assertFalse(testee.viewState.value.showFireTabsEmptyState)
+    }
+
+    @Test
+    fun `when regular mode then showFireTabsEmptyState is false`() = runTest {
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            testee.viewState.collect()
+        }
+        advanceUntilIdle()
+
+        assertFalse(testee.viewState.value.showFireTabsEmptyState)
+    }
+
+    @Test
+    fun `when closing the last fire tab then switches to regular mode`() = runTest {
+        val fireTab = TabEntity("fire-1", url = "https://fire.example", position = 1)
+        whenever(mockTabRepositoryProvider.forMode(BrowserMode.FIRE)).thenReturn(mockFireTabRepository)
+        whenever(mockFireTabRepository.flowTabs).thenReturn(flowOf(listOf(fireTab)))
+        whenever(mockFireTabRepository.flowSelectedTab).thenReturn(flowOf(fireTab))
+        whenever(mockFireTabRepository.flowDeletableTabs).thenReturn(flowOf(emptyList()))
+        whenever(mockFireTabRepository.tabSwitcherData).thenReturn(flowOf(tabSwitcherData))
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            testee.viewState.collect()
+        }
+        currentModeFlow.value = BrowserMode.FIRE
+        advanceUntilIdle()
+
+        val tab = testee.tabs.first { it.id == "fire-1" }
+        testee.onTabCloseInNormalModeRequested(tab)
+        advanceUntilIdle()
+
+        verify(mockFireTabRepository).markDeletable(fireTab)
+        verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+        assertEquals(Command.SwitchToRegularMode, commandCaptor.lastValue)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -822,7 +822,7 @@ class TabSwitcherViewModelTest {
     @Test
     fun whenNormalModeAndOneNewTabPageThenVerifyDynamicInterface() {
         val tabItems = listOf(NormalTab(TabEntity("1"), true))
-        val viewState = ViewState(tabSwitcherItems = tabItems, mode = Normal, layoutType = null, isDuckAIButtonVisible = true)
+        val viewState = ViewState(tabItems = TabItems.Loaded(tabItems), mode = Normal, layoutType = null, isDuckAIButtonVisible = true)
         val expected = DynamicInterface(
             isFireButtonVisible = true,
             isNewTabButtonVisible = true,
@@ -850,7 +850,7 @@ class TabSwitcherViewModelTest {
     fun whenNormalModeAndMultipleTabsThenVerifyDynamicInterface() {
         val tabItems = listOf(NormalTab(TabEntity("1"), true), NormalTab(TabEntity("2"), false))
         val viewState = ViewState(
-            tabSwitcherItems = tabItems,
+            tabItems = TabItems.Loaded(tabItems),
             mode = Normal,
             layoutType = null,
             isDuckAIButtonVisible = true,
@@ -882,7 +882,7 @@ class TabSwitcherViewModelTest {
     fun whenNormalModeAndNewVisualDesignEnabledAndDuckChatDisabledThenVerifyDynamicInterface() {
         val tabItems = listOf(NormalTab(TabEntity("1"), true), NormalTab(TabEntity("2"), false))
         val viewState = ViewState(
-            tabSwitcherItems = tabItems,
+            tabItems = TabItems.Loaded(tabItems),
             mode = Normal,
             layoutType = null,
             isDuckAIButtonVisible = false,
@@ -914,7 +914,7 @@ class TabSwitcherViewModelTest {
     fun whenNormalModeAndNewVisualDesignDisabledAndDuckChatDisabledThenVerifyDynamicInterface() {
         val tabItems = listOf(NormalTab(TabEntity("1"), true), NormalTab(TabEntity("2"), false))
         val viewState = ViewState(
-            tabSwitcherItems = tabItems,
+            tabItems = TabItems.Loaded(tabItems),
             mode = Normal,
             layoutType = null,
             isDuckAIButtonVisible = false,
@@ -945,7 +945,7 @@ class TabSwitcherViewModelTest {
     @Test
     fun whenNormalModeAndMultipleTabsAndLayoutIsGridThenVerifyDynamicInterface() {
         val tabItems = listOf(NormalTab(TabEntity("1"), true), NormalTab(TabEntity("2"), false))
-        val viewState = ViewState(tabSwitcherItems = tabItems, mode = Normal, layoutType = GRID, isDuckAIButtonVisible = true)
+        val viewState = ViewState(tabItems = TabItems.Loaded(tabItems), mode = Normal, layoutType = GRID, isDuckAIButtonVisible = true)
         val expected = DynamicInterface(
             isFireButtonVisible = true,
             isNewTabButtonVisible = true,
@@ -973,7 +973,7 @@ class TabSwitcherViewModelTest {
     fun whenNormalModeAndMultipleTabsAndLayoutIsListThenVerifyDynamicInterface() {
         val tabItems = listOf(NormalTab(TabEntity("1", "http://cnn.com"), true), NormalTab(TabEntity("2"), false))
         val viewState = ViewState(
-            tabSwitcherItems = tabItems,
+            tabItems = TabItems.Loaded(tabItems),
             mode = Normal,
             layoutType = LIST,
             isDuckAIButtonVisible = true,
@@ -1007,7 +1007,7 @@ class TabSwitcherViewModelTest {
             SelectableTab(TabEntity("1", "http://cnn.com"), false),
             SelectableTab(TabEntity("2"), false),
         )
-        val viewState = ViewState(tabSwitcherItems = tabItems, mode = Selection(emptyList()), layoutType = null)
+        val viewState = ViewState(tabItems = TabItems.Loaded(tabItems), mode = Selection(emptyList()), layoutType = null)
         val expected = DynamicInterface(
             isFireButtonVisible = false,
             isNewTabButtonVisible = false,
@@ -1037,7 +1037,7 @@ class TabSwitcherViewModelTest {
             SelectableTab(TabEntity("1", "http://cnn.com"), true),
             SelectableTab(TabEntity("2"), false),
         )
-        val viewState = ViewState(tabSwitcherItems = tabItems, mode = Selection(listOf("1")), layoutType = null)
+        val viewState = ViewState(tabItems = TabItems.Loaded(tabItems), mode = Selection(listOf("1")), layoutType = null)
         val expected = DynamicInterface(
             isFireButtonVisible = false,
             isNewTabButtonVisible = false,
@@ -1067,7 +1067,7 @@ class TabSwitcherViewModelTest {
             SelectableTab(TabEntity("1"), true),
             SelectableTab(TabEntity("2", url = "cnn.com"), false),
         )
-        val viewState = ViewState(tabSwitcherItems = tabItems, mode = Selection(listOf("1")), layoutType = null)
+        val viewState = ViewState(tabItems = TabItems.Loaded(tabItems), mode = Selection(listOf("1")), layoutType = null)
         val expected = DynamicInterface(
             isFireButtonVisible = false,
             isNewTabButtonVisible = false,
@@ -1098,7 +1098,7 @@ class TabSwitcherViewModelTest {
             SelectableTab(TabEntity("2", "http://cnn.com"), true),
             SelectableTab(TabEntity("3"), false),
         )
-        val viewState = ViewState(tabSwitcherItems = tabItems, mode = Selection(listOf("1", "2")), layoutType = null)
+        val viewState = ViewState(tabItems = TabItems.Loaded(tabItems), mode = Selection(listOf("1", "2")), layoutType = null)
         val expected = DynamicInterface(
             isFireButtonVisible = false,
             isNewTabButtonVisible = false,
@@ -1128,7 +1128,7 @@ class TabSwitcherViewModelTest {
             SelectableTab(TabEntity("1", "http://cnn.com"), true),
             SelectableTab(TabEntity("2"), true),
         )
-        val viewState = ViewState(tabSwitcherItems = tabItems, mode = Selection(listOf("1", "2")), layoutType = null)
+        val viewState = ViewState(tabItems = TabItems.Loaded(tabItems), mode = Selection(listOf("1", "2")), layoutType = null)
         val expected = DynamicInterface(
             isFireButtonVisible = false,
             isNewTabButtonVisible = false,
@@ -1189,7 +1189,7 @@ class TabSwitcherViewModelTest {
     fun whenNormalModeAndOneNewTabPageAndNewToolbarEnabledThenVerifyDynamicInterface() {
         val tabItems = listOf(NormalTab(TabEntity("1"), true))
         val viewState = ViewState(
-            tabSwitcherItems = tabItems,
+            tabItems = TabItems.Loaded(tabItems),
             mode = Normal,
             layoutType = null,
             isDuckAIButtonVisible = true,
@@ -1221,7 +1221,7 @@ class TabSwitcherViewModelTest {
     fun whenNormalModeAndMultipleTabsAndNewToolbarEnabledThenVerifyDynamicInterface() {
         val tabItems = listOf(NormalTab(TabEntity("1"), true), NormalTab(TabEntity("2"), false))
         val viewState = ViewState(
-            tabSwitcherItems = tabItems,
+            tabItems = TabItems.Loaded(tabItems),
             mode = Normal,
             layoutType = null,
             isDuckAIButtonVisible = true,
@@ -1253,7 +1253,7 @@ class TabSwitcherViewModelTest {
     fun whenNormalModeAndNewVisualDesignEnabledAndDuckChatDisabledAndNewToolbarEnabledThenVerifyDynamicInterface() {
         val tabItems = listOf(NormalTab(TabEntity("1"), true), NormalTab(TabEntity("2"), false))
         val viewState = ViewState(
-            tabSwitcherItems = tabItems,
+            tabItems = TabItems.Loaded(tabItems),
             mode = Normal,
             layoutType = null,
             isDuckAIButtonVisible = false,
@@ -1285,7 +1285,7 @@ class TabSwitcherViewModelTest {
     fun whenNormalModeAndNewVisualDesignDisabledAndDuckChatDisabledAndNewToolbarEnabledThenVerifyDynamicInterface() {
         val tabItems = listOf(NormalTab(TabEntity("1"), true), NormalTab(TabEntity("2"), false))
         val viewState = ViewState(
-            tabSwitcherItems = tabItems,
+            tabItems = TabItems.Loaded(tabItems),
             mode = Normal,
             layoutType = null,
             isDuckAIButtonVisible = false,
@@ -1317,7 +1317,7 @@ class TabSwitcherViewModelTest {
     fun whenNormalModeAndMultipleTabsAndLayoutIsGridAndNewToolbarEnabledThenVerifyDynamicInterface() {
         val tabItems = listOf(NormalTab(TabEntity("1"), true), NormalTab(TabEntity("2"), false))
         val viewState = ViewState(
-            tabSwitcherItems = tabItems,
+            tabItems = TabItems.Loaded(tabItems),
             mode = Normal,
             layoutType = GRID,
             isDuckAIButtonVisible = true,
@@ -1349,7 +1349,7 @@ class TabSwitcherViewModelTest {
     fun whenNormalModeAndMultipleTabsAndLayoutIsListAndNewToolbarEnabledThenVerifyDynamicInterface() {
         val tabItems = listOf(NormalTab(TabEntity("1", "http://cnn.com"), true), NormalTab(TabEntity("2"), false))
         val viewState = ViewState(
-            tabSwitcherItems = tabItems,
+            tabItems = TabItems.Loaded(tabItems),
             mode = Normal,
             layoutType = LIST,
             isDuckAIButtonVisible = true,
@@ -1384,7 +1384,7 @@ class TabSwitcherViewModelTest {
             SelectableTab(TabEntity("2"), false),
         )
         val viewState = ViewState(
-            tabSwitcherItems = tabItems,
+            tabItems = TabItems.Loaded(tabItems),
             mode = Selection(emptyList()),
             layoutType = null,
         )
@@ -1418,7 +1418,7 @@ class TabSwitcherViewModelTest {
             SelectableTab(TabEntity("2"), false),
         )
         val viewState = ViewState(
-            tabSwitcherItems = tabItems,
+            tabItems = TabItems.Loaded(tabItems),
             mode = Selection(listOf("1")),
             layoutType = null,
         )
@@ -1452,7 +1452,7 @@ class TabSwitcherViewModelTest {
             SelectableTab(TabEntity("2", url = "cnn.com"), false),
         )
         val viewState = ViewState(
-            tabSwitcherItems = tabItems,
+            tabItems = TabItems.Loaded(tabItems),
             mode = Selection(listOf("1")),
             layoutType = null,
         )
@@ -1486,7 +1486,7 @@ class TabSwitcherViewModelTest {
             SelectableTab(TabEntity("2"), true),
         )
         val viewState = ViewState(
-            tabSwitcherItems = tabItems,
+            tabItems = TabItems.Loaded(tabItems),
             mode = Selection(listOf("1", "2")),
             layoutType = null,
         )
@@ -1520,7 +1520,7 @@ class TabSwitcherViewModelTest {
             SelectableTab(TabEntity("2"), true),
         )
         val viewState = ViewState(
-            tabSwitcherItems = tabItems,
+            tabItems = TabItems.Loaded(tabItems),
             mode = Selection(listOf("1", "2")),
             layoutType = null,
         )
@@ -1657,7 +1657,7 @@ class TabSwitcherViewModelTest {
     fun whenNormalModeAndSplitOmnibarEnabledThenMenuButtonHiddenAndBottomBarVisible() {
         val tabItems = listOf(NormalTab(TabEntity("1"), true), NormalTab(TabEntity("2"), false))
         val viewState = ViewState(
-            tabSwitcherItems = tabItems,
+            tabItems = TabItems.Loaded(tabItems),
             mode = Normal,
             layoutType = null,
             isDuckAIButtonVisible = true,
@@ -1690,7 +1690,7 @@ class TabSwitcherViewModelTest {
     fun whenNormalModeAndSplitOmnibarEnabledAndDuckAIDisabledThenMenuButtonHiddenAndBottomBarVisible() {
         val tabItems = listOf(NormalTab(TabEntity("1"), true), NormalTab(TabEntity("2"), false))
         val viewState = ViewState(
-            tabSwitcherItems = tabItems,
+            tabItems = TabItems.Loaded(tabItems),
             mode = Normal,
             layoutType = null,
             isDuckAIButtonVisible = false,
@@ -1726,7 +1726,7 @@ class TabSwitcherViewModelTest {
             SelectableTab(TabEntity("2"), false),
         )
         val viewState = ViewState(
-            tabSwitcherItems = tabItems,
+            tabItems = TabItems.Loaded(tabItems),
             mode = Selection(listOf("1")),
             layoutType = null,
             isDuckAIButtonVisible = false,
@@ -1762,7 +1762,7 @@ class TabSwitcherViewModelTest {
             SelectableTab(TabEntity("2"), false),
         )
         val viewState = ViewState(
-            tabSwitcherItems = tabItems,
+            tabItems = TabItems.Loaded(tabItems),
             mode = Selection(emptyList()),
             layoutType = null,
             isDuckAIButtonVisible = false,
@@ -1798,7 +1798,7 @@ class TabSwitcherViewModelTest {
             SelectableTab(TabEntity("2"), true),
         )
         val viewState = ViewState(
-            tabSwitcherItems = tabItems,
+            tabItems = TabItems.Loaded(tabItems),
             mode = Selection(listOf("1", "2")),
             layoutType = null,
             isDuckAIButtonVisible = false,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1215327489156969?focus=true

Figma: [Tab switcher](https://www.figma.com/design/9S33EK9qIxZdN1FOIFHM5W/%F0%9F%94%A5-Fire-Mode-Tabs--iOS-Android-?node-id=1851-24549&m=dev)
Figma: [Browser](https://www.figma.com/design/9S33EK9qIxZdN1FOIFHM5W/%F0%9F%94%A5-Fire-Mode-Tabs--iOS-Android-?node-id=1851-26427&m=dev)

### Description

This PR adds Fire mode empty state for Fire tabs in the browser and the Tab switcher.

### Steps to test this PR

- [x] Enable the Fire tabs FF in the dev settings (and restart the app)
- [x] Go to the Tab switcher
- [x] Switch to Fire mode
- [x] Verify the new empty state screen is displayed (compare with Figma design)
- [x] Tap on the New Fire tab button
- [x] Verify a new Fire tab is opened
- [x] Verify the new empty tab screen is displayed instead of Dax (compare with Figma design)
- [x] Go back to the Tab switcher
- [x] Close all Fire tabs using the X button
- [x] After the last Fire tab is closed, verify that the app automatically changes modes to Regular

| Tab switch | Browser |
|--------|--------|
| <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/c7a494e2-5301-4ef4-97ce-7efce13cb1a9" /> | <img width="1080" height="2400" alt="image" src="https://github.com/user-attachments/assets/78f1bf60-d390-47b0-b03f-498523b27909" /> |


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tab close and mode-switch behavior for Fire mode and tab auto-creation edge cases, but scope is limited to Fire mode with new unit tests covering the main paths.
> 
> **Overview**
> Adds **Fire mode empty states** on the tab switcher and Fire new-tab page, replacing the normal Dax/NTP chrome when Fire mode is active.
> 
> In the **tab switcher**, when Fire mode has zero tabs, a dedicated empty state (feature bullets, explainer, **New Fire Tab**) is shown instead of the tab grid; **New Fire Tab** opens a tab via the existing new-tab flow. **Mode-switch fade** skips animating a hidden recycler so toggling modes from the empty state still recreates cleanly.
> 
> On the **Fire new tab page**, Fire mode shows a simpler empty state and hides logo, messages, favourites, and related NTP sections.
> 
> **Closing the last or all Fire tabs** now emits **`SwitchToRegularMode`** (activity recreates in Regular mode) instead of the close-all undo snackbar path used for regular tabs.
> 
> **`DefaultTabManager`** stops auto-adding a default tab when the Fire tab list is empty but global browser mode is already Regular, avoiding a stray tab during mode transitions. Tab switcher loading uses a **`TabItems`** loaded vs not-initialized distinction so the Fire empty state only appears after tabs have loaded, not during initial load.
> 
> New layouts, strings, and design-system icons support the UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e04a96c25644519930e4f62ac465cf0e3e7d0145. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->