### PR TITLE
Ensure fire button stays in Duck.ai omnibar for non-native-input users

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -167,6 +167,7 @@ class OmnibarLayout @JvmOverloads constructor(
         val showDuckSidebar: Boolean,
         val showDuckBack: Boolean,
         val isDuckAiMode: Boolean,
+        val isNativeInputEnabled: Boolean,
     )
 
     @Inject
@@ -850,12 +851,14 @@ class OmnibarLayout @JvmOverloads constructor(
                 showDuckSidebar = viewState.showDuckAISidebar,
                 showDuckBack = viewState.showDuckAISidebar,
                 isDuckAiMode = viewState.viewMode is ViewMode.DuckAI,
+                isNativeInputEnabled = viewState.isNativeInputEnabled,
             )
 
         if (omnibarAnimationManager.isFeatureEnabled() && previousTransitionState != null &&
             (
                 newTransitionState.showFireIcon != previousTransitionState?.showFireIcon ||
                     newTransitionState.isDuckAiMode != previousTransitionState?.isDuckAiMode ||
+                    newTransitionState.isNativeInputEnabled != previousTransitionState?.isNativeInputEnabled ||
                     newTransitionState.showTabsMenu != previousTransitionState?.showTabsMenu ||
                     newTransitionState.showBrowserMenu != previousTransitionState?.showBrowserMenu ||
                     newTransitionState.showDuckSidebar != previousTransitionState?.showDuckSidebar
@@ -867,11 +870,21 @@ class OmnibarLayout @JvmOverloads constructor(
         clearTextButton.isVisible = viewState.showClearButton
         voiceSearchButton.isVisible = viewState.showVoiceSearch
         tabsMenu.isVisible = newTransitionState.showTabsMenu
-        // The fire/+ slot is shared: when the user is in a Duck.ai chat the + icon takes
-        // over from fire as the leading action. Driven by viewMode rather than a separate
-        // state flag so it can't drift out of sync with other state-update paths.
-        fireIconMenu.isVisible = newTransitionState.showFireIcon && !newTransitionState.isDuckAiMode
-        plusIconMenu.isVisible = newTransitionState.showFireIcon && newTransitionState.isDuckAiMode
+        // The fire/+ slot is shared: in a Duck.ai chat the + icon takes over from fire as the
+        // leading action, but only when the native input field is enabled. Users with the
+        // nativeInputField flag off keep the fire button even in a Duck.ai view. Driven by
+        // viewMode (plus the flag) rather than a separate state flag so it can't drift out of
+        // sync with other state-update paths.
+        fireIconMenu.isVisible = shouldShowFireIcon(
+            showFireIcon = newTransitionState.showFireIcon,
+            isDuckAiMode = newTransitionState.isDuckAiMode,
+            isNativeInputEnabled = newTransitionState.isNativeInputEnabled,
+        )
+        plusIconMenu.isVisible = shouldShowPlusIcon(
+            showFireIcon = newTransitionState.showFireIcon,
+            isDuckAiMode = newTransitionState.isDuckAiMode,
+            isNativeInputEnabled = newTransitionState.isNativeInputEnabled,
+        )
         browserMenu.isVisible = newTransitionState.showBrowserMenu
         browserMenuHighlight.isVisible = newTransitionState.showBrowserMenuHighlight
         aiChatMenu?.isVisible = newTransitionState.showChatMenu
@@ -1647,3 +1660,26 @@ class OmnibarLayout @JvmOverloads constructor(
         private const val LOCKED_INPUT_ALPHA = 0.4f
     }
 }
+
+/**
+ * Whether the fire icon should occupy the shared fire/+ leading slot in the omnibar.
+ *
+ * Fire is the default leading action. The + icon only replaces it inside a Duck.ai view when the
+ * native input field is enabled; with the nativeInputField flag off the user keeps the fire button
+ * even in a Duck.ai view.
+ */
+internal fun shouldShowFireIcon(
+    showFireIcon: Boolean,
+    isDuckAiMode: Boolean,
+    isNativeInputEnabled: Boolean,
+): Boolean = showFireIcon && !(isDuckAiMode && isNativeInputEnabled)
+
+/**
+ * Whether the + icon should occupy the shared fire/+ leading slot in the omnibar. Only shown inside
+ * a Duck.ai view when the native input field is enabled.
+ */
+internal fun shouldShowPlusIcon(
+    showFireIcon: Boolean,
+    isDuckAiMode: Boolean,
+    isNativeInputEnabled: Boolean,
+): Boolean = showFireIcon && isDuckAiMode && isNativeInputEnabled

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLeadingIconVisibilityTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLeadingIconVisibilityTest.kt
@@ -1,0 +1,53 @@
+package com.duckduckgo.app.browser.omnibar
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OmnibarLeadingIconVisibilityTest {
+
+    @Test
+    fun whenNotDuckAiModeThenFireShownAndPlusHidden() {
+        assertTrue(shouldShowFireIcon(showFireIcon = true, isDuckAiMode = false, isNativeInputEnabled = true))
+        assertFalse(shouldShowPlusIcon(showFireIcon = true, isDuckAiMode = false, isNativeInputEnabled = true))
+    }
+
+    @Test
+    fun whenNotDuckAiModeAndNativeInputDisabledThenFireShownAndPlusHidden() {
+        assertTrue(shouldShowFireIcon(showFireIcon = true, isDuckAiMode = false, isNativeInputEnabled = false))
+        assertFalse(shouldShowPlusIcon(showFireIcon = true, isDuckAiMode = false, isNativeInputEnabled = false))
+    }
+
+    @Test
+    fun whenDuckAiModeAndNativeInputEnabledThenPlusShownAndFireHidden() {
+        assertTrue(shouldShowPlusIcon(showFireIcon = true, isDuckAiMode = true, isNativeInputEnabled = true))
+        assertFalse(shouldShowFireIcon(showFireIcon = true, isDuckAiMode = true, isNativeInputEnabled = true))
+    }
+
+    @Test
+    fun whenDuckAiModeAndNativeInputDisabledThenFireShownAndPlusHidden() {
+        // Regression: a user with the nativeInputField flag off must keep the fire button
+        // in the omnibar, not the + button, even while in a Duck.ai view.
+        assertTrue(shouldShowFireIcon(showFireIcon = true, isDuckAiMode = true, isNativeInputEnabled = false))
+        assertFalse(shouldShowPlusIcon(showFireIcon = true, isDuckAiMode = true, isNativeInputEnabled = false))
+    }
+
+    @Test
+    fun whenFireIconHiddenThenNeitherFireNorPlusShown() {
+        assertFalse(shouldShowFireIcon(showFireIcon = false, isDuckAiMode = true, isNativeInputEnabled = true))
+        assertFalse(shouldShowPlusIcon(showFireIcon = false, isDuckAiMode = true, isNativeInputEnabled = true))
+        assertFalse(shouldShowFireIcon(showFireIcon = false, isDuckAiMode = false, isNativeInputEnabled = false))
+        assertFalse(shouldShowPlusIcon(showFireIcon = false, isDuckAiMode = false, isNativeInputEnabled = false))
+    }
+
+    @Test
+    fun whenFireIconShownThenExactlyOneOfFireOrPlusIsVisible() {
+        for (duckAi in listOf(true, false)) {
+            for (nativeInput in listOf(true, false)) {
+                val fire = shouldShowFireIcon(showFireIcon = true, isDuckAiMode = duckAi, isNativeInputEnabled = nativeInput)
+                val plus = shouldShowPlusIcon(showFireIcon = true, isDuckAiMode = duckAi, isNativeInputEnabled = nativeInput)
+                assertTrue("exactly one leading icon expected for duckAi=$duckAi nativeInput=$nativeInput", fire xor plus)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1215320910196510?focus=true

### Description

PR #8730 replaced the omnibar fire icon with a `+` in `ViewMode.DuckAI`, derived purely from the view mode. As a result the `+` is shown to **all** Duck.ai users, including those with the `nativeInputField` flag **off** (current Production users). Those users have no fire button in the input field, so they were left without any fire affordance in Duck.ai and had to fall back to the sidebar to burn the current chat.

This change gates the fire/`+` swap on the native input flag:

| State | Leading icon |
|---|---|
| Not Duck.ai | fire (unchanged) |
| Duck.ai + `nativeInputField` **on** | `+` |
| Duck.ai + `nativeInputField` **off** | **fire** (restored) |

Implementation notes:
- `isNativeInputEnabled` is threaded through `TransitionState` (populated from `viewState`, included in the transition change-detection) so the swap still animates correctly if the flag changes.
- The decision is extracted into pure `shouldShowFireIcon` / `shouldShowPlusIcon` functions so it can be unit tested without a view harness — the swap previously lived in the View untested, which is how the regression shipped.
- The `leadingIconBarrier` already aligns `tabsMenu` to whichever leading icon is visible, so no layout change is needed.

Scope is the omnibar `+`/fire swap only. The in-input leading fire button (`NativeInputModeWidget`) only renders when native input is on, so non-native-input users are unaffected by it.

### Steps to test this PR

_Native input field OFF (Production users)_
- [x] Disable the `nativeInputField` flag.
- [x] Open Duck.ai. The omnibar shows the **fire** button (not `+`).
- [x] Tapping fire opens the fire / clear-data dialog.
- [x] Switch back to a browser tab — fire still shown, no `+` anywhere.

_Native input field ON_
- [x] Enable the `nativeInputField` flag.
- [x] Open Duck.ai. The omnibar shows the **+** button, which opens the popup menu (unchanged from #8730).
- [x] On a normal browser tab the fire button is shown; `+` never appears outside Duck.ai.

### UI changes
| Before  | After |
| ------ | ----- |
|(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized omnibar toolbar visibility and animation triggers; behavior is covered by new unit tests with no auth or data changes.
> 
> **Overview**
> Restores the omnibar **fire** button for Duck.ai users when **`nativeInputField` is off**, instead of always swapping to **+** in `ViewMode.DuckAI`.
> 
> The fire/+ choice now depends on **`isNativeInputEnabled`** from view state: it is added to **`TransitionState`** and transition change-detection so icon swaps still animate when the flag changes. Visibility is centralized in **`shouldShowFireIcon`** / **`shouldShowPlusIcon`**, with **`OmnibarLeadingIconVisibilityTest`** covering the regression (Duck.ai + native input off → fire, not +).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2e94fd68f793e91d150fcf1b203e27a9d778d25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->