### PR TITLE
Change action button to grey (Native Input)

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputScreenButtons.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputScreenButtons.kt
@@ -100,13 +100,6 @@ class InputScreenButtons @JvmOverloads constructor(
         if (actionSend.isEnabled) onSendClick?.invoke()
     }
 
-    private fun resolveThemeColorStateList(attr: Int): android.content.res.ColorStateList? {
-        val attributes = context.obtainStyledAttributes(intArrayOf(attr))
-        val colorStateList = attributes.getColorStateList(0)
-        attributes.recycle()
-        return colorStateList
-    }
-
     fun setSendButtonEnabled(enabled: Boolean) {
         actionSend.isEnabled = enabled
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputScreenButtons.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputScreenButtons.kt
@@ -88,15 +88,11 @@ class InputScreenButtons @JvmOverloads constructor(
     fun showStopButton() {
         actionSend.isEnabled = true
         actionSend.setImageResource(R.drawable.ic_stop_16)
-        actionSend.backgroundTintList = resolveThemeColorStateList(CommonR.attr.daxColorButtonDestructiveContainer)
         actionSend.setOnClickListener { onStopClick?.invoke() }
     }
 
     fun showSendButton() {
-        actionSend.setImageResource(R.drawable.ic_arrow_right_24_inverted)
-        actionSend.backgroundTintList = resolveThemeColorStateList(
-            if (actionSend.isEnabled) CommonR.attr.daxColorButtonPrimaryContainer else CommonR.attr.daxColorContainerDisabled,
-        )
+        actionSend.setImageResource(CommonR.drawable.ic_arrow_right_24)
         actionSend.setOnClickListener { sendIfEnabled() }
     }
 
@@ -113,9 +109,6 @@ class InputScreenButtons @JvmOverloads constructor(
 
     fun setSendButtonEnabled(enabled: Boolean) {
         actionSend.isEnabled = enabled
-        actionSend.backgroundTintList = resolveThemeColorStateList(
-            if (enabled) CommonR.attr.daxColorButtonPrimaryContainer else CommonR.attr.daxColorContainerDisabled,
-        )
     }
 
     fun setSendButtonVisible(visible: Boolean) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -551,6 +551,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     private fun updateSendButtonIcon() {
+        if (isStreaming) return
         val iconResId = if (isDuckAiPageContext()) {
             R.drawable.ic_arrow_up_24
         } else {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -1168,7 +1168,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val toggle = findViewById<TabLayout?>(R.id.inputModeSwitch) ?: return
         val isChatTab = toggle.selectedTabPosition == 1
         setImageButtonVisible(isChatTab && supportsUpload)
-        submitButtons?.setSendButtonIcon(R.drawable.ic_arrow_right_24_inverted)
+        submitButtons?.setSendButtonIcon(com.duckduckgo.mobile.android.R.drawable.ic_arrow_right_24)
         if (isChatTab) {
             inputField.minLines = 1
             inputField.maxLines = MAX_LINES

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -550,6 +550,15 @@ class NativeInputModeWidget @JvmOverloads constructor(
         }
     }
 
+    private fun updateSendButtonIcon() {
+        val iconResId = if (isDuckAiPageContext()) {
+            R.drawable.ic_arrow_up_24
+        } else {
+            com.duckduckgo.mobile.android.R.drawable.ic_arrow_right_24
+        }
+        submitButtons?.setSendButtonIcon(iconResId)
+    }
+
     private fun updateNewLineButtonVisibility() {
         val isBrowserContext = nativeInputState?.inputContext == NativeInputState.InputContext.BROWSER
         val hasText = inputField.text.isNotBlank()
@@ -575,6 +584,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         updateBottomRowVisibility()
         applyVerticalPaddingForFocus()
         updateNewLineButtonVisibility()
+        updateSendButtonIcon()
         applyOmnibarShape()
         // Re-apply chat input type whenever the inputs to `applyChatInputType` (context, position)
         // change, or on the first emission. This corrects stale IME setup from a tab listener
@@ -1168,7 +1178,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val toggle = findViewById<TabLayout?>(R.id.inputModeSwitch) ?: return
         val isChatTab = toggle.selectedTabPosition == 1
         setImageButtonVisible(isChatTab && supportsUpload)
-        submitButtons?.setSendButtonIcon(com.duckduckgo.mobile.android.R.drawable.ic_arrow_right_24)
+        updateSendButtonIcon()
         if (isChatTab) {
             inputField.minLines = 1
             inputField.maxLines = MAX_LINES

--- a/duckchat/duckchat-impl/src/main/res/layout/view_native_input_screen_buttons.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_native_input_screen_buttons.xml
@@ -62,13 +62,10 @@
         android:layout_width="36dp"
         android:layout_height="36dp"
         android:layout_marginStart="8dp"
-        android:background="@drawable/background_input_screen_button"
-        android:backgroundTint="?attr/daxColorButtonPrimaryContainer"
-        android:foreground="@drawable/selectable_circular_ripple"
+        android:background="@drawable/selectable_circular_container_ripple"
         android:importantForAccessibility="no"
         android:scaleType="centerInside"
-        android:src="@drawable/ic_arrow_right_24_inverted"
-        android:visibility="gone"
-        app:tint="?attr/daxColorWhite" />
+        android:src="@drawable/ic_arrow_right_24"
+        android:visibility="gone" />
 
 </LinearLayout>

--- a/duckchat/duckchat-impl/src/main/res/layout/view_native_input_screen_floating_buttons.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_native_input_screen_floating_buttons.xml
@@ -15,7 +15,6 @@
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:clipToPadding="false"
@@ -37,13 +36,10 @@
         android:layout_width="36dp"
         android:layout_height="36dp"
         android:layout_marginStart="8dp"
-        android:background="@drawable/background_input_screen_button"
-        android:backgroundTint="?attr/daxColorButtonPrimaryContainer"
-        android:foreground="@drawable/selectable_circular_ripple"
+        android:background="@drawable/selectable_circular_container_ripple"
         android:importantForAccessibility="no"
         android:scaleType="centerInside"
-        android:src="@drawable/ic_arrow_right_24_inverted"
-        android:visibility="gone"
-        app:tint="?attr/daxColorWhite" />
+        android:src="@drawable/ic_arrow_right_24"
+        android:visibility="gone" />
 
 </LinearLayout>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1215229792439837?focus=true

### Description

- Changes the action (submit) button from blue to grey

### Steps to test this PR

_With native input enabled_
- [ ] Focus the input and type something
- [ ] Verify that the button for grey

### UI changes
| Before  | After |
| ------ | ----- |
<img width="1080" height="444" alt="Screenshot_20260602_211246" src="https://github.com/user-attachments/assets/7c4e96c3-9c28-4272-b0dd-c9ce9491db8a" />|<img width="1080" height="448" alt="Screenshot_20260602_211222" src="https://github.com/user-attachments/assets/06a250fe-9685-4088-9adc-d1f15168d8f6" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and icon-selection changes only in native chat input UI; no auth, data, or submission logic changes.
> 
> **Overview**
> **Native input send/submit** moves from a **blue filled circle with a white arrow** to a **grey circular container** (`selectable_circular_container_ripple`) and the shared **non-inverted** `ic_arrow_right_24` asset in both bottom and floating button layouts.
> 
> **`InputScreenButtons`** no longer applies theme **background tints** for send, stop, or enabled/disabled states (including the removed `resolveThemeColorStateList` helper); stop still swaps to the stop icon only_ only.
> 
> **`NativeInputModeWidget`** adds **`updateSendButtonIcon()`** so Duck.ai contexts use **`ic_arrow_up_24`** and browser/native chat elsewhere keeps the right arrow, invoked from **`applyState`** and **`applyTabUi`** instead of hard-coding one icon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f736535d2a34571e0ed8fb37c33e277987f9ee51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->