### PR TITLE
Support Onboarding theme in Compose UI

### DIFF
--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/ADSComposeTools.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/ADSComposeTools.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoThemeVariant
 
 /**
  * Helper to setup a ComposeView in an XML based layout and properly handle its lifecycle.
@@ -28,9 +29,10 @@ import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
 fun View.setupThemedComposeView(
     id: Int,
     isDarkTheme: Boolean,
+    variant: DuckDuckGoThemeVariant = DuckDuckGoThemeVariant.Default,
     content: @Composable () -> Unit,
 ) {
-    findViewById<ComposeView>(id)?.setupThemedComposeView(isDarkTheme, content)
+    findViewById<ComposeView>(id)?.setupThemedComposeView(isDarkTheme, variant, content)
 }
 
 /**
@@ -38,11 +40,12 @@ fun View.setupThemedComposeView(
  */
 fun ComposeView.setupThemedComposeView(
     isDarkTheme: Boolean,
+    variant: DuckDuckGoThemeVariant = DuckDuckGoThemeVariant.Default,
     content: @Composable () -> Unit,
 ) {
     setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
     setContent {
-        DuckDuckGoTheme(isDarkTheme) {
+        DuckDuckGoTheme(isDarkTheme = isDarkTheme, variant = variant) {
             content()
         }
     }

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/ADSComposeTools.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/ADSComposeTools.kt
@@ -29,7 +29,7 @@ import com.duckduckgo.common.ui.compose.theme.DuckDuckGoThemeVariant
 fun View.setupThemedComposeView(
     id: Int,
     isDarkTheme: Boolean,
-    variant: DuckDuckGoThemeVariant = DuckDuckGoThemeVariant.Default,
+    variant: DuckDuckGoThemeVariant,
     content: @Composable () -> Unit,
 ) {
     findViewById<ComposeView>(id)?.setupThemedComposeView(isDarkTheme, variant, content)
@@ -40,7 +40,7 @@ fun View.setupThemedComposeView(
  */
 fun ComposeView.setupThemedComposeView(
     isDarkTheme: Boolean,
-    variant: DuckDuckGoThemeVariant = DuckDuckGoThemeVariant.Default,
+    variant: DuckDuckGoThemeVariant,
     content: @Composable () -> Unit,
 ) {
     setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/AppComponentsActivity.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/AppComponentsActivity.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.common.ui.internal.ui
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.widget.RadioGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -26,6 +27,8 @@ import androidx.lifecycle.lifecycleScope
 import androidx.viewpager.widget.ViewPager
 import com.duckduckgo.common.ui.DuckDuckGoTheme
 import com.duckduckgo.common.ui.applyTheme
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoThemeVariant
+import com.duckduckgo.common.ui.getThemeId
 import com.duckduckgo.common.ui.internal.R
 import com.duckduckgo.common.ui.internal.ui.store.AppComponentsPrefsDataStore
 import com.duckduckgo.common.ui.internal.ui.store.appComponentsDataStore
@@ -62,13 +65,19 @@ class AppComponentsActivity : AppCompatActivity() {
     private lateinit var viewPager: ViewPager
     private lateinit var tabLayout: TabLayout
     private lateinit var darkThemeSwitch: OneLineListItem
+    private lateinit var themeVariantGroup: RadioGroup
 
     @Suppress("DenyListedApi")
     override fun onCreate(savedInstanceState: Bundle?) {
-        val selectedTheme = runBlocking {
+        val (selectedTheme, selectedVariant) = runBlocking {
             val selectedTheme = appComponentsViewModel.themeFlow.first()
-            applyTheme(selectedTheme)
-            selectedTheme
+            val selectedVariant = appComponentsViewModel.variantFlow.first()
+            if (selectedVariant == DuckDuckGoThemeVariant.Onboarding) {
+                setTheme(onboardingThemeId(selectedTheme))
+            } else {
+                applyTheme(selectedTheme)
+            }
+            selectedTheme to selectedVariant
         }
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_app_components)
@@ -92,6 +101,36 @@ class AppComponentsActivity : AppCompatActivity() {
                 startActivity(intent(this@AppComponentsActivity))
                 finish()
             }
+        }
+
+        themeVariantGroup = findViewById(R.id.theme_variant_group)
+        themeVariantGroup.check(
+            if (selectedVariant == DuckDuckGoThemeVariant.Onboarding) {
+                R.id.radio_theme_onboarding
+            } else {
+                R.id.radio_theme_default
+            },
+        )
+        themeVariantGroup.setOnCheckedChangeListener { _, checkedId ->
+            val newVariant = if (checkedId == R.id.radio_theme_onboarding) {
+                DuckDuckGoThemeVariant.Onboarding
+            } else {
+                DuckDuckGoThemeVariant.Default
+            }
+            lifecycleScope.launch {
+                appComponentsViewModel.setVariant(newVariant)
+                startActivity(intent(this@AppComponentsActivity))
+                finish()
+            }
+        }
+    }
+
+    private fun onboardingThemeId(theme: DuckDuckGoTheme): Int {
+        val dark = getThemeId(theme) == com.duckduckgo.mobile.android.R.style.Theme_DuckDuckGo_Dark
+        return if (dark) {
+            com.duckduckgo.mobile.android.R.style.Theme_DuckDuckGo_Dark_Onboarding
+        } else {
+            com.duckduckgo.mobile.android.R.style.Theme_DuckDuckGo_Light_Onboarding
         }
     }
 

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/AppComponentsViewModel.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/AppComponentsViewModel.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.common.ui.internal.ui
 
 import androidx.lifecycle.ViewModel
 import com.duckduckgo.common.ui.DuckDuckGoTheme
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoThemeVariant
 import com.duckduckgo.common.ui.internal.ui.store.AppComponentsPrefsDataStore
 import kotlinx.coroutines.flow.Flow
 
@@ -29,5 +30,11 @@ class AppComponentsViewModel(
 
     suspend fun setTheme(theme: DuckDuckGoTheme) {
         appComponentsPrefsDataStore.setTheme(theme)
+    }
+
+    val variantFlow: Flow<DuckDuckGoThemeVariant> = appComponentsPrefsDataStore.variantFlow
+
+    suspend fun setVariant(variant: DuckDuckGoThemeVariant) {
+        appComponentsPrefsDataStore.setVariant(variant)
     }
 }

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentAdapter.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentAdapter.kt
@@ -19,9 +19,11 @@ package com.duckduckgo.common.ui.internal.ui.component
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoThemeVariant
 
 class ComponentAdapter(
     private val isDarkTheme: Boolean,
+    private val variant: DuckDuckGoThemeVariant,
 ) : ListAdapter<Component, ComponentViewHolder>(DIFF_CALLBACK) {
 
     override fun getItemViewType(position: Int): Int = getItem(position).ordinal
@@ -30,7 +32,7 @@ class ComponentAdapter(
         parent: ViewGroup,
         viewType: Int,
     ): ComponentViewHolder {
-        return ComponentViewHolder.create(parent, viewType, isDarkTheme)
+        return ComponentViewHolder.create(parent, viewType, isDarkTheme, variant)
     }
 
     override fun onBindViewHolder(

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentFragment.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentFragment.kt
@@ -52,8 +52,9 @@ abstract class ComponentFragment : Fragment() {
         super.onViewCreated(view, savedInstanceBundle)
 
         val isDarkTheme = runBlocking { appComponentsViewModel.themeFlow.first() } == AppTheme.DARK
+        val variant = runBlocking { appComponentsViewModel.variantFlow.first() }
         val recyclerView: RecyclerView = view.findViewById(R.id.recycler_view)
-        val adapter = ComponentAdapter(isDarkTheme = isDarkTheme)
+        val adapter = ComponentAdapter(isDarkTheme = isDarkTheme, variant = variant)
         recyclerView.layoutManager = LinearLayoutManager(requireContext())
         recyclerView.adapter = adapter
         adapter.submitList(getComponents())

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentViewHolder.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentViewHolder.kt
@@ -59,6 +59,7 @@ import com.duckduckgo.common.ui.compose.message.remote.DaxSmallMessage
 import com.duckduckgo.common.ui.compose.radiobutton.DaxRadioButton
 import com.duckduckgo.common.ui.compose.switch.DaxSwitch
 import com.duckduckgo.common.ui.compose.text.DaxText
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoThemeVariant
 import com.duckduckgo.common.ui.internal.R
 import com.duckduckgo.common.ui.internal.ui.setupThemedComposeView
 import com.duckduckgo.common.ui.view.MessageCta
@@ -91,9 +92,10 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
     class SwitchComponentViewHolder(
         parent: ViewGroup,
         private val isDarkTheme: Boolean,
+        private val variant: DuckDuckGoThemeVariant,
     ) : ComponentViewHolder(inflate(parent, R.layout.component_switch)) {
         override fun bind(component: Component) {
-            view.setupThemedComposeView(id = R.id.compose_dax_switch_one, isDarkTheme = isDarkTheme) {
+            view.setupThemedComposeView(id = R.id.compose_dax_switch_one, isDarkTheme = isDarkTheme, variant = variant) {
                 var isChecked by remember { mutableStateOf(false) }
 
                 DaxSwitch(
@@ -103,7 +105,7 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
                     },
                 )
             }
-            view.setupThemedComposeView(id = R.id.compose_dax_switch_two, isDarkTheme = isDarkTheme) {
+            view.setupThemedComposeView(id = R.id.compose_dax_switch_two, isDarkTheme = isDarkTheme, variant = variant) {
                 var isChecked by remember { mutableStateOf(true) }
 
                 DaxSwitch(
@@ -113,10 +115,10 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
                     },
                 )
             }
-            view.setupThemedComposeView(id = R.id.compose_dax_switch_three, isDarkTheme = isDarkTheme) {
+            view.setupThemedComposeView(id = R.id.compose_dax_switch_three, isDarkTheme = isDarkTheme, variant = variant) {
                 DaxSwitch(checked = false, onCheckedChange = {}, enabled = false)
             }
-            view.setupThemedComposeView(id = R.id.compose_dax_switch_four, isDarkTheme = isDarkTheme) {
+            view.setupThemedComposeView(id = R.id.compose_dax_switch_four, isDarkTheme = isDarkTheme, variant = variant) {
                 DaxSwitch(checked = true, onCheckedChange = {}, enabled = false)
             }
         }
@@ -125,9 +127,10 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
     class RadioButtonComponentViewHolder(
         parent: ViewGroup,
         private val isDarkTheme: Boolean,
+        private val variant: DuckDuckGoThemeVariant,
     ) : ComponentViewHolder(inflate(parent, R.layout.component_radio_button)) {
         override fun bind(component: Component) {
-            view.setupThemedComposeView(id = R.id.compose_dax_radio_button, isDarkTheme = isDarkTheme) {
+            view.setupThemedComposeView(id = R.id.compose_dax_radio_button, isDarkTheme = isDarkTheme, variant = variant) {
                 var indexSelected by remember { mutableIntStateOf(0) }
 
                 Row(
@@ -156,9 +159,10 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
     class CheckboxComponentViewHolder(
         parent: ViewGroup,
         private val isDarkTheme: Boolean,
+        private val variant: DuckDuckGoThemeVariant,
     ) : ComponentViewHolder(inflate(parent, R.layout.component_checkbox)) {
         override fun bind(component: Component) {
-            view.setupThemedComposeView(id = R.id.compose_dax_checkbox_one, isDarkTheme = isDarkTheme) {
+            view.setupThemedComposeView(id = R.id.compose_dax_checkbox_one, isDarkTheme = isDarkTheme, variant = variant) {
                 var isChecked by remember { mutableStateOf(false) }
 
                 DaxCheckbox(
@@ -168,7 +172,7 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
                     },
                 )
             }
-            view.setupThemedComposeView(id = R.id.compose_dax_checkbox_two, isDarkTheme = isDarkTheme) {
+            view.setupThemedComposeView(id = R.id.compose_dax_checkbox_two, isDarkTheme = isDarkTheme, variant = variant) {
                 var isChecked by remember { mutableStateOf(true) }
 
                 DaxCheckbox(
@@ -178,21 +182,21 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
                     },
                 )
             }
-            view.setupThemedComposeView(id = R.id.compose_dax_checkbox_three, isDarkTheme = isDarkTheme) {
+            view.setupThemedComposeView(id = R.id.compose_dax_checkbox_three, isDarkTheme = isDarkTheme, variant = variant) {
                 DaxCheckbox(
                     checked = false,
                     enabled = false,
                     onCheckedChange = {},
                 )
             }
-            view.setupThemedComposeView(id = R.id.compose_dax_checkbox_four, isDarkTheme = isDarkTheme) {
+            view.setupThemedComposeView(id = R.id.compose_dax_checkbox_four, isDarkTheme = isDarkTheme, variant = variant) {
                 DaxCheckbox(
                     checked = true,
                     enabled = false,
                     onCheckedChange = {},
                 )
             }
-            view.setupThemedComposeView(id = R.id.compose_dax_checkbox_five, isDarkTheme = isDarkTheme) {
+            view.setupThemedComposeView(id = R.id.compose_dax_checkbox_five, isDarkTheme = isDarkTheme, variant = variant) {
                 var isChecked by remember { mutableStateOf(false) }
 
                 Row(verticalAlignment = Alignment.CenterVertically) {
@@ -218,6 +222,7 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
     class RemoteMessageComponentViewHolder(
         parent: ViewGroup,
         private val isDarkTheme: Boolean,
+        private val variant: DuckDuckGoThemeVariant,
     ) : ComponentViewHolder(inflate(parent, R.layout.component_remote_message)) {
         override fun bind(component: Component) {
             val smallMessage = Message(title = "Small Message", subtitle = "Body text goes here. This component doesn't have buttons")
@@ -281,7 +286,7 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
                 setMessage(promoSingleMessage)
             }
 
-            view.setupThemedComposeView(R.id.promo_single_remote_message_compose, isDarkTheme = isDarkTheme) {
+            view.setupThemedComposeView(R.id.promo_single_remote_message_compose, isDarkTheme = isDarkTheme, variant = variant) {
                 DaxPromoSingleActionMessage(
                     title = "Promo Single Action Message",
                     body = "Body text goes here. This component has one promo button and supports <b>bold</b> text",
@@ -299,7 +304,7 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
                 )
             }
 
-            view.setupThemedComposeView(R.id.small_remote_message_compose, isDarkTheme = isDarkTheme) {
+            view.setupThemedComposeView(R.id.small_remote_message_compose, isDarkTheme = isDarkTheme, variant = variant) {
                 DaxSmallMessage(
                     title = "Compose Small Message",
                     body = "Body text goes here. This component doesn't have buttons",
@@ -310,7 +315,7 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
                 )
             }
 
-            view.setupThemedComposeView(R.id.medium_remote_message_compose, isDarkTheme = isDarkTheme) {
+            view.setupThemedComposeView(R.id.medium_remote_message_compose, isDarkTheme = isDarkTheme, variant = variant) {
                 DaxMediumMessage(
                     title = "Compose Medium Message",
                     body = "Body text goes here. This component doesn't have buttons",
@@ -322,7 +327,7 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
                 )
             }
 
-            view.setupThemedComposeView(R.id.big_single_remote_message_compose, isDarkTheme = isDarkTheme) {
+            view.setupThemedComposeView(R.id.big_single_remote_message_compose, isDarkTheme = isDarkTheme, variant = variant) {
                 DaxBigSingleActionMessage(
                     topIllustration = painterResource(CommonR.drawable.ic_announce),
                     title = "Compose Big Single Message",
@@ -335,7 +340,7 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
                 )
             }
 
-            view.setupThemedComposeView(R.id.big_single_lottie_remote_message_compose, isDarkTheme = isDarkTheme) {
+            view.setupThemedComposeView(R.id.big_single_lottie_remote_message_compose, isDarkTheme = isDarkTheme, variant = variant) {
                 DaxBigSingleActionMessage(
                     topIllustration = {
                         val composition by rememberLottieComposition(LottieCompositionSpec.RawRes(R.raw.anim_password_keys))
@@ -360,7 +365,7 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
                 )
             }
 
-            view.setupThemedComposeView(R.id.big_two_actions_remote_message_compose, isDarkTheme = isDarkTheme) {
+            view.setupThemedComposeView(R.id.big_two_actions_remote_message_compose, isDarkTheme = isDarkTheme, variant = variant) {
                 DaxBigTwoActionsMessage(
                     topIllustration = painterResource(CommonR.drawable.ic_ddg_announce),
                     title = "Compose Big Two Actions",
@@ -374,7 +379,7 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
                 )
             }
 
-            view.setupThemedComposeView(R.id.big_two_actions_update_remote_message_compose, isDarkTheme = isDarkTheme) {
+            view.setupThemedComposeView(R.id.big_two_actions_update_remote_message_compose, isDarkTheme = isDarkTheme, variant = variant) {
                 DaxBigTwoActionsMessage(
                     topIllustration = painterResource(CommonR.drawable.ic_app_update),
                     title = "Compose Big Two Actions",
@@ -388,7 +393,7 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
                 )
             }
 
-            view.setupThemedComposeView(R.id.big_two_actions_server_image_remote_message_compose, isDarkTheme = isDarkTheme) {
+            view.setupThemedComposeView(R.id.big_two_actions_server_image_remote_message_compose, isDarkTheme = isDarkTheme, variant = variant) {
                 DaxBigTwoActionsMessage(
                     topIllustration = rememberAsyncImagePainter(
                         model = "https://staticcdn.duckduckgo.com/remotemessaging/illustrations/image2.png",
@@ -610,6 +615,7 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
     class CardComponentViewHolder(
         parent: ViewGroup,
         private val isDarkTheme: Boolean,
+        private val variant: DuckDuckGoThemeVariant,
     ) : ComponentViewHolder(inflate(parent, R.layout.component_card)) {
         override fun bind(component: Component) {
             view.findViewById<MaterialCardView>(R.id.ticketViewCard).apply {
@@ -625,7 +631,7 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
                 setOnClickListener { Snackbar.make(this, component.name, Snackbar.LENGTH_SHORT).show() }
             }
 
-            view.setupThemedComposeView(R.id.composeCards, isDarkTheme) {
+            view.setupThemedComposeView(R.id.composeCards, isDarkTheme, variant) {
                 Column(
                     verticalArrangement = Arrangement.spacedBy(16.dp),
                     modifier = Modifier.padding(horizontal = 16.dp),
@@ -675,17 +681,18 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
             parent: ViewGroup,
             viewType: Int,
             isDarkTheme: Boolean,
+            variant: DuckDuckGoThemeVariant,
         ): ComponentViewHolder {
             return when (Component.values()[viewType]) {
                 Component.BUTTON -> ButtonComponentViewHolder(parent)
                 Component.TOP_APP_BAR -> TopAppBarComponentViewHolder(parent)
-                Component.SWITCH -> SwitchComponentViewHolder(parent, isDarkTheme)
-                Component.RADIO_BUTTON -> RadioButtonComponentViewHolder(parent, isDarkTheme)
-                Component.CHECKBOX -> CheckboxComponentViewHolder(parent, isDarkTheme)
+                Component.SWITCH -> SwitchComponentViewHolder(parent, isDarkTheme, variant)
+                Component.RADIO_BUTTON -> RadioButtonComponentViewHolder(parent, isDarkTheme, variant)
+                Component.CHECKBOX -> CheckboxComponentViewHolder(parent, isDarkTheme, variant)
                 Component.SLIDER -> SliderComponentViewHolder(parent)
                 Component.SNACKBAR -> SnackbarComponentViewHolder(parent)
                 Component.INFO_PANEL -> InfoPanelComponentViewHolder(parent)
-                Component.REMOTE_MESSAGE -> RemoteMessageComponentViewHolder(parent, isDarkTheme)
+                Component.REMOTE_MESSAGE -> RemoteMessageComponentViewHolder(parent, isDarkTheme, variant)
                 Component.SEARCH_BAR -> SearchBarComponentViewHolder(parent)
                 Component.MENU_ITEM -> MenuItemComponentViewHolder(parent)
                 Component.POPUP_MENU_ITEM -> PopupMenuItemComponentViewHolder(parent)
@@ -693,7 +700,7 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
                 Component.SINGLE_LINE_LIST_ITEM -> OneLineListItemComponentViewHolder(parent)
                 Component.TWO_LINE_LIST_ITEM -> TwoLineItemComponentViewHolder(parent)
                 Component.SECTION_DIVIDER -> DividerComponentViewHolder(parent)
-                Component.CARD -> CardComponentViewHolder(parent, isDarkTheme)
+                Component.CARD -> CardComponentViewHolder(parent, isDarkTheme, variant)
                 Component.SETTINGS_LIST_ITEM -> SettingsListItemComponentViewHolder(parent)
                 else -> {
                     TODO()

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/buttons/ComponentButtonsFragment.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/buttons/ComponentButtonsFragment.kt
@@ -36,6 +36,7 @@ import com.duckduckgo.common.ui.compose.button.DaxGhostButton
 import com.duckduckgo.common.ui.compose.button.DaxIconButton
 import com.duckduckgo.common.ui.compose.button.DaxPrimaryButton
 import com.duckduckgo.common.ui.compose.button.DaxSecondaryButton
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoThemeVariant
 import com.duckduckgo.common.ui.internal.databinding.ComponentButtonsBinding
 import com.duckduckgo.common.ui.internal.ui.appComponentsViewModel
 import com.duckduckgo.common.ui.internal.ui.setupThemedComposeView
@@ -65,18 +66,21 @@ class ComponentButtonsFragment : Fragment() {
     ) {
         super.onViewCreated(view, savedInstanceState)
         val isDarkTheme = runBlocking { appComponentsViewModel.themeFlow.first() } == AppTheme.DARK
-        setupComposeViews(view, isDarkTheme)
+        val variant = runBlocking { appComponentsViewModel.variantFlow.first() }
+        setupComposeViews(view, isDarkTheme, variant)
     }
 
     @Suppress("LongMethod")
     private fun setupComposeViews(
         view: View,
         isDarkTheme: Boolean,
+        variant: DuckDuckGoThemeVariant,
     ) {
         // Primary
         view.setupThemedComposeView(
             id = com.duckduckgo.common.ui.internal.R.id.compose_button_primary,
             isDarkTheme = isDarkTheme,
+            variant = variant,
         ) {
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -107,6 +111,7 @@ class ComponentButtonsFragment : Fragment() {
         view.setupThemedComposeView(
             id = com.duckduckgo.common.ui.internal.R.id.compose_button_secondary,
             isDarkTheme = isDarkTheme,
+            variant = variant,
         ) {
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -137,6 +142,7 @@ class ComponentButtonsFragment : Fragment() {
         view.setupThemedComposeView(
             id = com.duckduckgo.common.ui.internal.R.id.compose_button_destructive_primary,
             isDarkTheme = isDarkTheme,
+            variant = variant,
         ) {
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -167,6 +173,7 @@ class ComponentButtonsFragment : Fragment() {
         view.setupThemedComposeView(
             id = com.duckduckgo.common.ui.internal.R.id.compose_button_ghost,
             isDarkTheme = isDarkTheme,
+            variant = variant,
         ) {
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -197,6 +204,7 @@ class ComponentButtonsFragment : Fragment() {
         view.setupThemedComposeView(
             id = com.duckduckgo.common.ui.internal.R.id.compose_button_destructive_ghost_secondary,
             isDarkTheme = isDarkTheme,
+            variant = variant,
         ) {
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -227,6 +235,7 @@ class ComponentButtonsFragment : Fragment() {
         view.setupThemedComposeView(
             id = com.duckduckgo.common.ui.internal.R.id.compose_button_destructive_ghost,
             isDarkTheme = isDarkTheme,
+            variant = variant,
         ) {
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -257,6 +266,7 @@ class ComponentButtonsFragment : Fragment() {
         view.setupThemedComposeView(
             id = com.duckduckgo.common.ui.internal.R.id.compose_button_ghost_alt,
             isDarkTheme = isDarkTheme,
+            variant = variant,
         ) {
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -287,6 +297,7 @@ class ComponentButtonsFragment : Fragment() {
         view.setupThemedComposeView(
             id = com.duckduckgo.common.ui.internal.R.id.compose_icon_button,
             isDarkTheme = isDarkTheme,
+            variant = variant,
         ) {
             DaxIconButton(
                 onClick = {},

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/templates/TemplatesFragment.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/templates/TemplatesFragment.kt
@@ -40,8 +40,9 @@ class TemplatesFragment : Fragment() {
         savedInstanceState: Bundle?,
     ): View {
         val isDarkTheme = runBlocking { appComponentsViewModel.themeFlow.first() } == DuckDuckGoTheme.DARK
+        val variant = runBlocking { appComponentsViewModel.variantFlow.first() }
         return ComposeView(requireContext()).apply {
-            setupThemedComposeView(isDarkTheme) {
+            setupThemedComposeView(isDarkTheme, variant) {
                 TemplatesPane()
             }
         }

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/textinput/ComponentTextInputFragment.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/textinput/ComponentTextInputFragment.kt
@@ -49,6 +49,7 @@ import com.duckduckgo.common.ui.compose.textfield.DaxTextFieldDefaults
 import com.duckduckgo.common.ui.compose.textfield.DaxTextFieldInputMode
 import com.duckduckgo.common.ui.compose.textfield.DaxTextFieldLineLimits
 import com.duckduckgo.common.ui.compose.textfield.DaxTextFieldTrailingIconScope
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoThemeVariant
 import com.duckduckgo.common.ui.internal.databinding.ComponentTextInputViewBinding
 import com.duckduckgo.common.ui.internal.ui.appComponentsViewModel
 import com.duckduckgo.common.ui.internal.ui.setupThemedComposeView
@@ -117,7 +118,8 @@ class ComponentTextInputFragment : Fragment() {
         }
 
         val isDarkTheme = runBlocking { appComponentsViewModel.themeFlow.first() } == AppTheme.DARK
-        setupComposeViews(view, isDarkTheme)
+        val variant = runBlocking { appComponentsViewModel.variantFlow.first() }
+        setupComposeViews(view, isDarkTheme, variant)
     }
 
     override fun onDestroyView() {
@@ -138,9 +140,10 @@ class ComponentTextInputFragment : Fragment() {
     private fun setupComposeViews(
         view: View,
         isDarkTheme: Boolean,
+        variant: DuckDuckGoThemeVariant,
     ) {
         // Hint text
-        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_1, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_1, isDarkTheme = isDarkTheme, variant = variant) {
             val state = rememberTextFieldState()
             DaxTextField(
                 state = state,
@@ -149,7 +152,7 @@ class ComponentTextInputFragment : Fragment() {
         }
 
         // Single line editable text
-        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_3, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_3, isDarkTheme = isDarkTheme, variant = variant) {
             val state =
                 rememberTextFieldState(
                     "This is an editable text! It has a very long text to show how it behaves when " +
@@ -163,7 +166,7 @@ class ComponentTextInputFragment : Fragment() {
         }
 
         // Multi line editable text
-        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_2, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_2, isDarkTheme = isDarkTheme, variant = variant) {
             val state =
                 rememberTextFieldState(
                     "This is an editable text! It has a very long text to show how it behaves when " +
@@ -177,7 +180,7 @@ class ComponentTextInputFragment : Fragment() {
         }
 
         // Form mode editable text
-        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_40, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_40, isDarkTheme = isDarkTheme, variant = variant) {
             val state =
                 rememberTextFieldState(
                     "This is an editable text! It has a very long text to show how it behaves when " +
@@ -191,7 +194,7 @@ class ComponentTextInputFragment : Fragment() {
         }
 
         // Non-editable text full click listener with end icon
-        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_30, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_30, isDarkTheme = isDarkTheme, variant = variant) {
             val state = rememberTextFieldState("Non-editable text full click listener with end icon.")
 
             val interactionSource = remember { MutableInteractionSource() }
@@ -222,7 +225,7 @@ class ComponentTextInputFragment : Fragment() {
         }
 
         // Non-editable text full click listener
-        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_31, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_31, isDarkTheme = isDarkTheme, variant = variant) {
             val state = rememberTextFieldState("Non-editable text full click listener.")
 
             val interactionSource = remember { MutableInteractionSource() }
@@ -244,7 +247,7 @@ class ComponentTextInputFragment : Fragment() {
         }
 
         // Non-editable text with line truncation and end icon
-        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_32, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_32, isDarkTheme = isDarkTheme, variant = variant) {
             val state =
                 rememberTextFieldState(
                     "Non-editable text with line truncation and end icon. It has a very long text to " +
@@ -268,7 +271,7 @@ class ComponentTextInputFragment : Fragment() {
         }
 
         // Non-editable text with line truncation
-        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_33, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_33, isDarkTheme = isDarkTheme, variant = variant) {
             val state =
                 rememberTextFieldState(
                     "Non-editable text with line truncation. It has a very long text to show how it " +
@@ -284,7 +287,7 @@ class ComponentTextInputFragment : Fragment() {
         }
 
         // Non-editable text with end icon
-        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_4, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_4, isDarkTheme = isDarkTheme, variant = variant) {
             val state = rememberTextFieldState("This is not editable.")
             DaxTextField(
                 state = state,
@@ -304,7 +307,7 @@ class ComponentTextInputFragment : Fragment() {
         }
 
         // Non-editable text without end icon
-        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_5, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_5, isDarkTheme = isDarkTheme, variant = variant) {
             val state =
                 rememberTextFieldState(
                     "This is not editable and has no icon. Lorem ipsum dolor sit amet, consectetur " +
@@ -318,7 +321,7 @@ class ComponentTextInputFragment : Fragment() {
         }
 
         // Editable password that fits in one line
-        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_6, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_6, isDarkTheme = isDarkTheme, variant = variant) {
             val state = rememberTextFieldState("Loremipsumolor")
 
             DaxSecureTextField(
@@ -328,7 +331,7 @@ class ComponentTextInputFragment : Fragment() {
         }
 
         // Editable password that doesn't fit in one line
-        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_9, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_9, isDarkTheme = isDarkTheme, variant = variant) {
             val state = rememberTextFieldState(
                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do " +
                     "eiusmod tempor incididunt ut labore.",
@@ -341,7 +344,7 @@ class ComponentTextInputFragment : Fragment() {
         }
 
         // Non-editable password
-        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_8, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_8, isDarkTheme = isDarkTheme, variant = variant) {
             val state = rememberTextFieldState(
                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do " +
                     "eiusmod tempor incididunt ut labore.",
@@ -355,7 +358,7 @@ class ComponentTextInputFragment : Fragment() {
         }
 
         // Non-editable password with icon
-        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_20, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_20, isDarkTheme = isDarkTheme, variant = variant) {
             val state = rememberTextFieldState(
                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do " +
                     "eiusmod tempor incididunt ut labore.",
@@ -378,7 +381,7 @@ class ComponentTextInputFragment : Fragment() {
         }
 
         // Error
-        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_21, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_21, isDarkTheme = isDarkTheme, variant = variant) {
             val state = rememberTextFieldState("This is an error")
             DaxTextField(
                 state = state,
@@ -389,7 +392,7 @@ class ComponentTextInputFragment : Fragment() {
         }
 
         // Non-editable text with end icon in error state
-        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_41, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_41, isDarkTheme = isDarkTheme, variant = variant) {
             val state = rememberTextFieldState("Non-editable text with end icon in error state")
 
             DaxTextField(
@@ -411,7 +414,7 @@ class ComponentTextInputFragment : Fragment() {
         }
 
         // Disabled text input
-        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_22, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_22, isDarkTheme = isDarkTheme, variant = variant) {
             val state = rememberTextFieldState("This input is disabled")
             DaxTextField(
                 state = state,
@@ -422,7 +425,7 @@ class ComponentTextInputFragment : Fragment() {
         }
 
         // Disabled multi line input
-        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_23, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_23, isDarkTheme = isDarkTheme, variant = variant) {
             val state = rememberTextFieldState("This input is disabled")
             DaxTextField(
                 state = state,
@@ -433,7 +436,7 @@ class ComponentTextInputFragment : Fragment() {
         }
 
         // Disabled password
-        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_24, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_24, isDarkTheme = isDarkTheme, variant = variant) {
             val state = rememberTextFieldState("This password input is disabled")
 
             DaxSecureTextField(
@@ -444,7 +447,7 @@ class ComponentTextInputFragment : Fragment() {
         }
 
         // IP Address
-        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_25, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_25, isDarkTheme = isDarkTheme, variant = variant) {
             val state = rememberTextFieldState("192.168.1.1")
             DaxTextField(
                 state = state,
@@ -456,7 +459,7 @@ class ComponentTextInputFragment : Fragment() {
         }
 
         // URL
-        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_26, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_26, isDarkTheme = isDarkTheme, variant = variant) {
             val state = rememberTextFieldState("https://www.duckduckgo.com")
             DaxTextField(
                 state = state,
@@ -467,7 +470,11 @@ class ComponentTextInputFragment : Fragment() {
         }
 
         // Observable text - option 1
-        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_27a, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(
+            id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_27a,
+            isDarkTheme = isDarkTheme,
+            variant = variant,
+        ) {
             val state = rememberTextFieldState("")
 
             DaxTextField(
@@ -483,7 +490,11 @@ class ComponentTextInputFragment : Fragment() {
         }
 
         // Observable text - option 2
-        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_27b, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(
+            id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_27b,
+            isDarkTheme = isDarkTheme,
+            variant = variant,
+        ) {
             val state = rememberTextFieldState("")
             var error by remember { mutableStateOf<String?>(null) }
 
@@ -510,7 +521,7 @@ class ComponentTextInputFragment : Fragment() {
         }
 
         // Autoselect text on focus
-        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_28, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_28, isDarkTheme = isDarkTheme, variant = variant) {
             val state = rememberTextFieldState("Tap to focus and select all text")
 
             val interactionSource = remember { MutableInteractionSource() }
@@ -532,7 +543,7 @@ class ComponentTextInputFragment : Fragment() {
         }
 
         // Focus programmatically
-        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_29, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = com.duckduckgo.common.ui.internal.R.id.compose_text_input_29, isDarkTheme = isDarkTheme, variant = variant) {
             val focusRequester = remember { FocusRequester() }
             val state = rememberTextFieldState("")
 

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/dialogs/DialogsFragment.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/dialogs/DialogsFragment.kt
@@ -55,6 +55,7 @@ import com.duckduckgo.common.ui.compose.listitem.DaxOneLineListItem
 import com.duckduckgo.common.ui.compose.sheets.DaxActionBottomSheetDialog
 import com.duckduckgo.common.ui.compose.sheets.DaxPromoBottomSheetDialog
 import com.duckduckgo.common.ui.compose.text.DaxText
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoThemeVariant
 import com.duckduckgo.common.ui.internal.R
 import com.duckduckgo.common.ui.internal.ui.appComponentsViewModel
 import com.duckduckgo.common.ui.internal.ui.setupThemedComposeView
@@ -97,6 +98,7 @@ class DialogsFragment : Fragment() {
     ) {
         super.onViewCreated(view, savedInstanceState)
         val isDarkTheme = runBlocking { appComponentsViewModel.themeFlow.first() } == AppTheme.DARK
+        val variant = runBlocking { appComponentsViewModel.variantFlow.first() }
 
         // Common string resources used across dialog demos
         val dialogTitle = getString(CommonR.string.text_dialog_title)
@@ -129,7 +131,12 @@ class DialogsFragment : Fragment() {
             }
         }
 
-        view.setupComposeDialogShowcase(R.id.composeTextAlertDialogWithImageButton, isDarkTheme, "Text Alert Dialog With Image") { onDismiss ->
+        view.setupComposeDialogShowcase(
+            R.id.composeTextAlertDialogWithImageButton,
+            isDarkTheme,
+            variant,
+            "Text Alert Dialog With Image",
+        ) { onDismiss ->
             DaxTextAlertDialog(
                 onDismissRequest = onDismiss,
                 title = dialogTitle,
@@ -167,7 +174,7 @@ class DialogsFragment : Fragment() {
             }
         }
 
-        view.setupComposeDialogShowcase(R.id.composeRadioButtonAlertDialog, isDarkTheme, "Single Choice Alert Dialog") { onDismiss ->
+        view.setupComposeDialogShowcase(R.id.composeRadioButtonAlertDialog, isDarkTheme, variant, "Single Choice Alert Dialog") { onDismiss ->
             var selectedIndex by rememberSaveable { mutableIntStateOf(-1) }
             val options = List(3) { index ->
                 DaxRadioOption(text = optionText, onSelected = { selectedIndex = index })
@@ -218,6 +225,7 @@ class DialogsFragment : Fragment() {
         view.setupComposeDialogShowcase(
             R.id.composeRadioButtonDestructiveAlertDialog,
             isDarkTheme,
+            variant,
             "Single Choice Destructive Alert Dialog",
         ) { onDismiss ->
             var selectedIndex by rememberSaveable { mutableIntStateOf(-1) }
@@ -270,7 +278,7 @@ class DialogsFragment : Fragment() {
             }
         }
 
-        view.setupComposeDialogShowcase(R.id.composeTextAlertDialogButton, isDarkTheme, "Text Alert Dialog") { onDismiss ->
+        view.setupComposeDialogShowcase(R.id.composeTextAlertDialogButton, isDarkTheme, variant, "Text Alert Dialog") { onDismiss ->
             DaxTextAlertDialog(
                 onDismissRequest = onDismiss,
                 title = dialogTitle,
@@ -304,7 +312,12 @@ class DialogsFragment : Fragment() {
             }
         }
 
-        view.setupComposeDialogShowcase(R.id.composeTextAlertDestructiveDialogButton, isDarkTheme, "Text Alert Destructive Dialog") { onDismiss ->
+        view.setupComposeDialogShowcase(
+            R.id.composeTextAlertDestructiveDialogButton,
+            isDarkTheme,
+            variant,
+            "Text Alert Destructive Dialog",
+        ) { onDismiss ->
             DaxAlertDialog(
                 onDismissRequest = onDismiss,
                 title = dialogTitle,
@@ -349,7 +362,12 @@ class DialogsFragment : Fragment() {
             }
         }
 
-        view.setupComposeDialogShowcase(R.id.composeTextAlertSingleDialogButton, isDarkTheme, "Text Alert Single Button Dialog") { onDismiss ->
+        view.setupComposeDialogShowcase(
+            R.id.composeTextAlertSingleDialogButton,
+            isDarkTheme,
+            variant,
+            "Text Alert Single Button Dialog",
+        ) { onDismiss ->
             DaxAlertDialog(
                 onDismissRequest = onDismiss,
                 title = dialogTitle,
@@ -393,7 +411,7 @@ class DialogsFragment : Fragment() {
             }
         }
 
-        view.setupComposeDialogShowcase(R.id.composeTextAlertDialogCancellable, isDarkTheme, "Text Alert Dialog Cancellable") { onDismiss ->
+        view.setupComposeDialogShowcase(R.id.composeTextAlertDialogCancellable, isDarkTheme, variant, "Text Alert Dialog Cancellable") { onDismiss ->
             DaxTextAlertDialog(
                 onDismissRequest = onDismiss,
                 title = dialogTitle,
@@ -424,7 +442,12 @@ class DialogsFragment : Fragment() {
             }
         }
 
-        view.setupComposeDialogShowcase(R.id.composeTextAlertDialogOneButton, isDarkTheme, "Text Alert Dialog With One Button") { onDismiss ->
+        view.setupComposeDialogShowcase(
+            R.id.composeTextAlertDialogOneButton,
+            isDarkTheme,
+            variant,
+            "Text Alert Dialog With One Button",
+        ) { onDismiss ->
             DaxTextAlertDialog(
                 onDismissRequest = onDismiss,
                 title = dialogTitle,
@@ -463,7 +486,7 @@ class DialogsFragment : Fragment() {
             }
         }
 
-        view.setupThemedComposeView(R.id.composeTextAlertDialogCheckbox, isDarkTheme) {
+        view.setupThemedComposeView(R.id.composeTextAlertDialogCheckbox, isDarkTheme, variant) {
             var showDialog by remember { mutableStateOf(false) }
             var checkboxChecked by remember { mutableStateOf(false) }
             DaxSecondaryButton(
@@ -517,6 +540,7 @@ class DialogsFragment : Fragment() {
         view.setupComposeDialogShowcase(
             R.id.composeStackedAlertDialogWithImageButton,
             isDarkTheme,
+            variant,
             "Stacked Text Alert Dialog With Image and 3 buttons",
         ) { onDismiss ->
             DaxAlertDialog(
@@ -567,6 +591,7 @@ class DialogsFragment : Fragment() {
         view.setupComposeDialogShowcase(
             R.id.composeStackedAlertDialogWithButtons,
             isDarkTheme,
+            variant,
             "Stacked Text Alert Dialog With 4 buttons",
         ) { onDismiss ->
             DaxAlertDialog(
@@ -617,6 +642,7 @@ class DialogsFragment : Fragment() {
         view.setupComposeDialogShowcase(
             R.id.composeStackedAlertDestructiveDialogWithButtons,
             isDarkTheme,
+            variant,
             "Stacked Text Alert Destructive Dialog With 4 buttons",
         ) { onDismiss ->
             DaxAlertDialog(
@@ -659,7 +685,7 @@ class DialogsFragment : Fragment() {
             }
         }
 
-        view.setupThemedComposeView(R.id.composeActionBottomSheetButton, isDarkTheme) {
+        view.setupThemedComposeView(R.id.composeActionBottomSheetButton, isDarkTheme, variant) {
             val sheetState = rememberModalBottomSheetState()
             val scope = rememberCoroutineScope()
             var showBottomSheet by remember { mutableStateOf(false) }
@@ -713,7 +739,7 @@ class DialogsFragment : Fragment() {
             }
         }
 
-        view.setupThemedComposeView(R.id.composeActionBottomSheetButtonWithTitle, isDarkTheme) {
+        view.setupThemedComposeView(R.id.composeActionBottomSheetButtonWithTitle, isDarkTheme, variant) {
             val sheetState = rememberModalBottomSheetState()
             val scope = rememberCoroutineScope()
             var showBottomSheet by remember { mutableStateOf(false) }
@@ -787,7 +813,7 @@ class DialogsFragment : Fragment() {
             }
         }
 
-        view.setupThemedComposeView(R.id.composePromoBottomSheetButton, isDarkTheme) {
+        view.setupThemedComposeView(R.id.composePromoBottomSheetButton, isDarkTheme, variant) {
             val sheetState = rememberModalBottomSheetState()
             val scope = rememberCoroutineScope()
             var showBottomSheet by remember { mutableStateOf(false) }
@@ -844,7 +870,7 @@ class DialogsFragment : Fragment() {
             }
         }
 
-        view.setupThemedComposeView(R.id.composePromoBottomSheetButtonWithTitle, isDarkTheme) {
+        view.setupThemedComposeView(R.id.composePromoBottomSheetButtonWithTitle, isDarkTheme, variant) {
             val sheetState = rememberModalBottomSheetState()
             val scope = rememberCoroutineScope()
             var showBottomSheet by remember { mutableStateOf(false) }
@@ -902,7 +928,7 @@ class DialogsFragment : Fragment() {
             }
         }
 
-        view.setupThemedComposeView(R.id.composePromoBottomSheetButtonWithImage, isDarkTheme) {
+        view.setupThemedComposeView(R.id.composePromoBottomSheetButtonWithImage, isDarkTheme, variant) {
             val sheetState = rememberModalBottomSheetState()
             val scope = rememberCoroutineScope()
             var showBottomSheet by remember { mutableStateOf(false) }
@@ -1032,10 +1058,11 @@ class DialogsFragment : Fragment() {
     private fun View.setupComposeDialogShowcase(
         viewId: Int,
         isDarkTheme: Boolean,
+        variant: DuckDuckGoThemeVariant,
         buttonText: String,
         dialogContent: @Composable (onDismiss: () -> Unit) -> Unit,
     ) {
-        setupThemedComposeView(viewId, isDarkTheme) {
+        setupThemedComposeView(viewId, isDarkTheme, variant) {
             var showDialog by remember { mutableStateOf(false) }
             DaxSecondaryButton(
                 text = buttonText,

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/palette/ColorPaletteFragment.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/palette/ColorPaletteFragment.kt
@@ -23,6 +23,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoThemeVariant
 import com.duckduckgo.common.ui.internal.R
 import com.duckduckgo.common.ui.internal.ui.appComponentsViewModel
 import com.duckduckgo.common.ui.internal.ui.setupThemedComposeView
@@ -52,15 +53,17 @@ class ColorPaletteFragment : Fragment() {
         savedInstanceBundle: Bundle?,
     ) {
         val isDarkTheme = runBlocking { appComponentsViewModel.themeFlow.first() } == AppTheme.DARK
+        val variant = runBlocking { appComponentsViewModel.variantFlow.first() }
 
-        setupComposeViews(view, isDarkTheme)
+        setupComposeViews(view, isDarkTheme, variant)
     }
 
     private fun setupComposeViews(
         view: View,
         isDarkTheme: Boolean,
+        variant: DuckDuckGoThemeVariant,
     ) {
-        view.setupThemedComposeView(id = R.id.compose_background, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_background, isDarkTheme = isDarkTheme, variant = variant) {
             DaxColorAttributeListItem(
                 text = "Background",
                 dotColors = DaxColorDotColors(
@@ -70,7 +73,7 @@ class ColorPaletteFragment : Fragment() {
             )
         }
 
-        view.setupThemedComposeView(id = R.id.compose_surface, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_surface, isDarkTheme = isDarkTheme, variant = variant) {
             DaxColorAttributeListItem(
                 text = "Surface",
                 dotColors = DaxColorDotColors(
@@ -81,7 +84,7 @@ class ColorPaletteFragment : Fragment() {
         }
 
         // Container
-        view.setupThemedComposeView(id = R.id.compose_container, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_container, isDarkTheme = isDarkTheme, variant = variant) {
             DaxColorAttributeListItem(
                 text = "Container",
                 dotColors = DaxColorDotColors(
@@ -92,7 +95,7 @@ class ColorPaletteFragment : Fragment() {
         }
 
         // Destructive
-        view.setupThemedComposeView(id = R.id.compose_destructive, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_destructive, isDarkTheme = isDarkTheme, variant = variant) {
             DaxColorAttributeListItem(
                 text = "Destructive",
                 dotColors = DaxColorDotColors(
@@ -103,7 +106,7 @@ class ColorPaletteFragment : Fragment() {
         }
 
         // Container Disabled
-        view.setupThemedComposeView(id = R.id.compose_container_disabled, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_container_disabled, isDarkTheme = isDarkTheme, variant = variant) {
             DaxColorAttributeListItem(
                 text = "Container Disabled",
                 dotColors = DaxColorDotColors(
@@ -114,7 +117,7 @@ class ColorPaletteFragment : Fragment() {
         }
 
         // Lines
-        view.setupThemedComposeView(id = R.id.compose_lines, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_lines, isDarkTheme = isDarkTheme, variant = variant) {
             DaxColorAttributeListItem(
                 text = "Lines",
                 dotColors = DaxColorDotColors(
@@ -125,7 +128,7 @@ class ColorPaletteFragment : Fragment() {
         }
 
         // Accent Blue
-        view.setupThemedComposeView(id = R.id.compose_accent_blue, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_accent_blue, isDarkTheme = isDarkTheme, variant = variant) {
             DaxColorAttributeListItem(
                 text = "Accent Blue",
                 dotColors = DaxColorDotColors(
@@ -136,7 +139,7 @@ class ColorPaletteFragment : Fragment() {
         }
 
         // Accent Yellow
-        view.setupThemedComposeView(id = R.id.compose_accent_yellow, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_accent_yellow, isDarkTheme = isDarkTheme, variant = variant) {
             DaxColorAttributeListItem(
                 text = "Accent Yellow",
                 dotColors = DaxColorDotColors(
@@ -147,7 +150,7 @@ class ColorPaletteFragment : Fragment() {
         }
 
         // Primary Text
-        view.setupThemedComposeView(id = R.id.compose_primary_text, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_primary_text, isDarkTheme = isDarkTheme, variant = variant) {
             DaxColorAttributeListItem(
                 text = "Primary Text",
                 dotColors = DaxColorDotColors(
@@ -158,7 +161,7 @@ class ColorPaletteFragment : Fragment() {
         }
 
         // Secondary Text
-        view.setupThemedComposeView(id = R.id.compose_secondary_text, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_secondary_text, isDarkTheme = isDarkTheme, variant = variant) {
             DaxColorAttributeListItem(
                 text = "Secondary Text",
                 dotColors = DaxColorDotColors(
@@ -169,7 +172,7 @@ class ColorPaletteFragment : Fragment() {
         }
 
         // Text Disabled
-        view.setupThemedComposeView(id = R.id.compose_text_disabled, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_text_disabled, isDarkTheme = isDarkTheme, variant = variant) {
             DaxColorAttributeListItem(
                 text = "Text Disabled",
                 dotColors = DaxColorDotColors(
@@ -180,7 +183,7 @@ class ColorPaletteFragment : Fragment() {
         }
 
         // Primary Icon - Note: There's no direct primaryIcon in DuckDuckGoColors, using text.primary as fallback
-        view.setupThemedComposeView(id = R.id.compose_primary_icon, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_primary_icon, isDarkTheme = isDarkTheme, variant = variant) {
             DaxColorAttributeListItem(
                 text = "Primary Icon",
                 dotColors = DaxColorDotColors(

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/store/AppComponentsPrefsDataStore.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/store/AppComponentsPrefsDataStore.kt
@@ -23,6 +23,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.duckduckgo.common.ui.DuckDuckGoTheme
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoThemeVariant
 import com.duckduckgo.common.ui.isInNightMode
 import com.duckduckgo.common.ui.store.ThemingSharedPreferences
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -63,7 +64,22 @@ class AppComponentsPrefsDataStore(
         }
     }
 
+    val variantFlow: Flow<DuckDuckGoThemeVariant> = store.data.map { preferences ->
+        val savedValue = preferences[stringPreferencesKey(KEY_SELECTED_VARIANT)]
+        runCatching { DuckDuckGoThemeVariant.valueOf(savedValue ?: "") }
+            .getOrDefault(DuckDuckGoThemeVariant.Default)
+    }.flowOn(dispatcherProvider.io())
+
+    suspend fun setVariant(variant: DuckDuckGoThemeVariant) {
+        withContext(dispatcherProvider.io()) {
+            store.edit { preferences ->
+                preferences[stringPreferencesKey(KEY_SELECTED_VARIANT)] = variant.name
+            }
+        }
+    }
+
     companion object {
         const val KEY_SELECTED_THEME = "KEY_SELECTED_THEME"
+        const val KEY_SELECTED_VARIANT = "KEY_SELECTED_VARIANT"
     }
 }

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/typography/TypographyFragment.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/typography/TypographyFragment.kt
@@ -24,6 +24,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import com.duckduckgo.common.ui.compose.text.DaxText
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoThemeVariant
 import com.duckduckgo.common.ui.internal.R
 import com.duckduckgo.common.ui.internal.ui.appComponentsViewModel
 import com.duckduckgo.common.ui.internal.ui.setupThemedComposeView
@@ -60,24 +61,25 @@ class TypographyFragment : Fragment() {
         daxTextView.setTypography(Typography.Body1)
 
         val isDarkTheme = runBlocking { appComponentsViewModel.themeFlow.first() } == AppTheme.DARK
+        val variant = runBlocking { appComponentsViewModel.variantFlow.first() }
 
-        setupComposeViews(view, isDarkTheme)
+        setupComposeViews(view, isDarkTheme, variant)
     }
 
-    private fun setupComposeViews(view: View, isDarkTheme: Boolean) {
+    private fun setupComposeViews(view: View, isDarkTheme: Boolean, variant: DuckDuckGoThemeVariant) {
         // Title
-        view.setupThemedComposeView(id = R.id.compose_title_label, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_title_label, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(text = "Text Appearance Title", style = DuckDuckGoTheme.typography.title)
         }
-        view.setupThemedComposeView(id = R.id.compose_title_lorem, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_title_lorem, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(text = loremIpsumShort, style = DuckDuckGoTheme.typography.title)
         }
 
         // H1
-        view.setupThemedComposeView(id = R.id.compose_h1_label, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_h1_label, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(text = "Text Appearance H1", style = DuckDuckGoTheme.typography.h1)
         }
-        view.setupThemedComposeView(id = R.id.compose_h1_lorem, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_h1_lorem, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(
                 text = loremIpsumLong,
                 style = DuckDuckGoTheme.typography.h1,
@@ -85,10 +87,10 @@ class TypographyFragment : Fragment() {
         }
 
         // H2
-        view.setupThemedComposeView(id = R.id.compose_h2_label, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_h2_label, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(text = "Text Appearance H2", style = DuckDuckGoTheme.typography.h2)
         }
-        view.setupThemedComposeView(id = R.id.compose_h2_lorem, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_h2_lorem, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(
                 text = loremIpsumLong,
                 style = DuckDuckGoTheme.typography.h2,
@@ -96,10 +98,10 @@ class TypographyFragment : Fragment() {
         }
 
         // H3
-        view.setupThemedComposeView(id = R.id.compose_h3_label, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_h3_label, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(text = "Text Appearance H3", style = DuckDuckGoTheme.typography.h3)
         }
-        view.setupThemedComposeView(id = R.id.compose_h3_lorem, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_h3_lorem, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(
                 text = loremIpsumLong,
                 style = DuckDuckGoTheme.typography.h3,
@@ -107,10 +109,10 @@ class TypographyFragment : Fragment() {
         }
 
         // H4
-        view.setupThemedComposeView(id = R.id.compose_h4_label, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_h4_label, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(text = "Text Appearance H4", style = DuckDuckGoTheme.typography.h4)
         }
-        view.setupThemedComposeView(id = R.id.compose_h4_lorem, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_h4_lorem, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(
                 text = loremIpsumLong,
                 style = DuckDuckGoTheme.typography.h4,
@@ -118,10 +120,10 @@ class TypographyFragment : Fragment() {
         }
 
         // H5
-        view.setupThemedComposeView(id = R.id.compose_h5_label, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_h5_label, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(text = "Text Appearance H5", style = DuckDuckGoTheme.typography.h5)
         }
-        view.setupThemedComposeView(id = R.id.compose_h5_lorem, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_h5_lorem, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(
                 text = loremIpsumLong,
                 style = DuckDuckGoTheme.typography.h5,
@@ -129,30 +131,30 @@ class TypographyFragment : Fragment() {
         }
 
         // Body1
-        view.setupThemedComposeView(id = R.id.compose_body1_label, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_body1_label, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(text = "Text Appearance Body1", style = DuckDuckGoTheme.typography.body1)
         }
-        view.setupThemedComposeView(id = R.id.compose_body1_lorem, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_body1_lorem, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(
                 text = loremIpsumLong,
                 style = DuckDuckGoTheme.typography.body1,
             )
         }
 
-        view.setupThemedComposeView(id = R.id.compose_body1_bold_label, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_body1_bold_label, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(text = "Text Appearance Body1 Bold", style = DuckDuckGoTheme.typography.body1Bold)
         }
-        view.setupThemedComposeView(id = R.id.compose_body1_bold_lorem, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_body1_bold_lorem, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(
                 text = loremIpsumLong,
                 style = DuckDuckGoTheme.typography.body1Bold,
             )
         }
 
-        view.setupThemedComposeView(id = R.id.compose_body1_mono_label, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_body1_mono_label, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(text = "Text Appearance Body1 Mono", style = DuckDuckGoTheme.typography.body1Mono)
         }
-        view.setupThemedComposeView(id = R.id.compose_body1_mono_lorem, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_body1_mono_lorem, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(
                 text = loremIpsumLong,
                 style = DuckDuckGoTheme.typography.body1Mono,
@@ -160,20 +162,20 @@ class TypographyFragment : Fragment() {
         }
 
         // Body2
-        view.setupThemedComposeView(id = R.id.compose_body2_label, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_body2_label, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(text = "Text Appearance Body2", style = DuckDuckGoTheme.typography.body2)
         }
-        view.setupThemedComposeView(id = R.id.compose_body2_lorem, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_body2_lorem, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(
                 text = loremIpsumLong,
                 style = DuckDuckGoTheme.typography.body2,
             )
         }
 
-        view.setupThemedComposeView(id = R.id.compose_body2_bold_label, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_body2_bold_label, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(text = "Text Appearance Body2 Bold", style = DuckDuckGoTheme.typography.body2Bold)
         }
-        view.setupThemedComposeView(id = R.id.compose_body2_bold_lorem, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_body2_bold_lorem, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(
                 text = loremIpsumLong,
                 style = DuckDuckGoTheme.typography.body2Bold,
@@ -181,10 +183,10 @@ class TypographyFragment : Fragment() {
         }
 
         // Button
-        view.setupThemedComposeView(id = R.id.compose_button_label, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_button_label, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(text = "Text Appearance Button", style = DuckDuckGoTheme.typography.button)
         }
-        view.setupThemedComposeView(id = R.id.compose_button_lorem, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_button_lorem, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(
                 text = loremIpsumLong,
                 style = DuckDuckGoTheme.typography.button,
@@ -192,27 +194,27 @@ class TypographyFragment : Fragment() {
         }
 
         // Caption
-        view.setupThemedComposeView(id = R.id.compose_caption_label, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_caption_label, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(text = "Text Appearance Caption", style = DuckDuckGoTheme.typography.caption)
         }
-        view.setupThemedComposeView(id = R.id.compose_caption_lorem, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_caption_lorem, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(
                 text = loremIpsumLong,
                 style = DuckDuckGoTheme.typography.caption,
             )
         }
 
-        view.setupThemedComposeView(id = R.id.compose_caption_allcaps_label, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_caption_allcaps_label, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(text = "Text Appearance Caption All Caps".uppercase(), style = DuckDuckGoTheme.typography.caption)
         }
-        view.setupThemedComposeView(id = R.id.compose_caption_allcaps_lorem, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_caption_allcaps_lorem, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(
                 text = loremIpsumLong.uppercase(),
                 style = DuckDuckGoTheme.typography.caption,
             )
         }
 
-        view.setupThemedComposeView(id = R.id.compose_manual_typography, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_manual_typography, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(
                 text = "Text Appearance Body 1 set manually",
                 style = DuckDuckGoTheme.typography.body1,
@@ -221,12 +223,12 @@ class TypographyFragment : Fragment() {
         }
 
         // Onboarding Title
-        view.setupThemedComposeView(id = R.id.compose_onboarding_title, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_onboarding_title, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(text = "Onboarding Title", style = DuckDuckGoTheme.typography.onboardingTitle)
         }
 
         // Onboarding Body
-        view.setupThemedComposeView(id = R.id.compose_onboarding_body, isDarkTheme = isDarkTheme) {
+        view.setupThemedComposeView(id = R.id.compose_onboarding_body, isDarkTheme = isDarkTheme, variant = variant) {
             DaxText(text = "Onboarding Body", style = DuckDuckGoTheme.typography.onboardingBody)
         }
     }

--- a/android-design-system/design-system-internal/src/main/res/layout/activity_app_components.xml
+++ b/android-design-system/design-system-internal/src/main/res/layout/activity_app_components.xml
@@ -64,6 +64,33 @@
                     app:primaryText="Enable Dark Theme"
                     app:showSwitch="true"/>
 
+                <com.duckduckgo.common.ui.view.text.DaxTextView
+                    app:typography="h5"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/keyline_4"
+                    android:text="Theme family" />
+
+                <RadioGroup
+                    android:id="@+id/theme_variant_group"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <RadioButton
+                        android:id="@+id/radio_theme_default"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="Default" />
+
+                    <RadioButton
+                        android:id="@+id/radio_theme_onboarding"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="Onboarding" />
+
+                </RadioGroup>
+
             </LinearLayout>
 
         </com.google.android.material.appbar.CollapsingToolbarLayout>

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/DaxStatusIndicator.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/DaxStatusIndicator.kt
@@ -35,10 +35,8 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.dp
 import com.duckduckgo.common.ui.compose.text.DaxText
-import com.duckduckgo.common.ui.compose.theme.AlertGreen
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTextStyle
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
-import com.duckduckgo.common.ui.compose.theme.Gray50
 import com.duckduckgo.common.ui.compose.tools.PreviewBox
 import com.duckduckgo.mobile.android.R
 
@@ -114,12 +112,12 @@ internal object StatusIndicatorDefaults {
     internal val disabledDotColor: Color
         @Composable
         @ReadOnlyComposable
-        get() = Gray50
+        get() = DuckDuckGoTheme.colors.status.indicatorInactive
 
     internal val activeDotColor: Color
         @Composable
         @ReadOnlyComposable
-        get() = AlertGreen
+        get() = DuckDuckGoTheme.colors.status.indicatorActive
 
     internal val contentColor: Color
         @Composable

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxDestructiveGhostAltButton.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxDestructiveGhostAltButton.kt
@@ -29,11 +29,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import com.duckduckgo.common.ui.compose.theme.Black6
-import com.duckduckgo.common.ui.compose.theme.Black60
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
-import com.duckduckgo.common.ui.compose.theme.White12
-import com.duckduckgo.common.ui.compose.theme.White84
 import com.duckduckgo.common.ui.compose.tools.PreviewBox
 import com.duckduckgo.mobile.android.R
 
@@ -80,25 +76,13 @@ private object DaxDestructiveGhostAltButtonDefaults {
         @Composable @ReadOnlyComposable get() = Color.Transparent
 
     val adsColorButtonGhostAltContainerPressed: Color
-        @Composable @ReadOnlyComposable get() = if (DuckDuckGoTheme.colors.isDark) {
-            White12
-        } else {
-            Black6
-        }
+        @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.colors.button.ghostAltContainerPressed
 
     val adsColorButtonGhostAltText: Color
-        @Composable @ReadOnlyComposable get() = if (DuckDuckGoTheme.colors.isDark) {
-            White84
-        } else {
-            Black60
-        }
+        @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.colors.button.ghostAltText
 
     val adsColorButtonGhostAltTextPressed: Color
-        @Composable @ReadOnlyComposable get() = if (DuckDuckGoTheme.colors.isDark) {
-            White84
-        } else {
-            Black60
-        }
+        @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.colors.button.ghostAltText
 
     val adsColorButtonGhostAltDisabled: Color
         @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.textColors.disabled

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxDestructiveGhostButton.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxDestructiveGhostButton.kt
@@ -29,10 +29,6 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import com.duckduckgo.common.ui.compose.theme.AlertRedOnDarkDefault18
-import com.duckduckgo.common.ui.compose.theme.AlertRedOnDarkTextPressed
-import com.duckduckgo.common.ui.compose.theme.AlertRedOnLightDefault18
-import com.duckduckgo.common.ui.compose.theme.AlertRedOnLightTextPressed
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
 import com.duckduckgo.common.ui.compose.tools.PreviewBox
 import com.duckduckgo.mobile.android.R
@@ -80,21 +76,13 @@ private object DaxDestructiveGhostButtonDefaults {
         @Composable @ReadOnlyComposable get() = Color.Transparent
 
     val adsColorButtonGhostContainerPressed: Color
-        @Composable @ReadOnlyComposable get() = if (DuckDuckGoTheme.colors.isDark) {
-            AlertRedOnDarkDefault18
-        } else {
-            AlertRedOnLightDefault18
-        }
+        @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.colors.button.destructiveGhostContainerPressed
 
     val adsColorButtonGhostText: Color
         @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.colors.status.criticalPrimary
 
     val adsColorButtonGhostTextPressed: Color
-        @Composable @ReadOnlyComposable get() = if (DuckDuckGoTheme.colors.isDark) {
-            AlertRedOnDarkTextPressed
-        } else {
-            AlertRedOnLightTextPressed
-        }
+        @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.colors.button.destructiveGhostTextPressed
 
     val adsColorButtonGhostDisabled: Color
         @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.textColors.disabled

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxDestructiveGhostSecondaryButton.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxDestructiveGhostSecondaryButton.kt
@@ -31,10 +31,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
-import com.duckduckgo.common.ui.compose.theme.AlertRedOnDarkDefault18
-import com.duckduckgo.common.ui.compose.theme.AlertRedOnDarkTextPressed
-import com.duckduckgo.common.ui.compose.theme.AlertRedOnLightDefault18
-import com.duckduckgo.common.ui.compose.theme.AlertRedOnLightTextPressed
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
 import com.duckduckgo.common.ui.compose.tools.PreviewBox
 import com.duckduckgo.mobile.android.R
@@ -83,21 +79,13 @@ private object DaxDestructiveGhostSecondaryButtonDefaults {
         @Composable @ReadOnlyComposable get() = Color.Transparent
 
     val adsColorButtonDestructiveGhostSecondaryContainerPressed: Color
-        @Composable @ReadOnlyComposable get() = if (DuckDuckGoTheme.colors.isDark) {
-            AlertRedOnDarkDefault18
-        } else {
-            AlertRedOnLightDefault18
-        }
+        @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.colors.button.destructiveGhostContainerPressed
 
     val adsColorButtonDestructiveGhostSecondaryText: Color
         @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.colors.status.criticalPrimary
 
     val adsColorButtonDestructiveGhostSecondaryTextPressed: Color
-        @Composable @ReadOnlyComposable get() = if (DuckDuckGoTheme.colors.isDark) {
-            AlertRedOnDarkTextPressed
-        } else {
-            AlertRedOnLightTextPressed
-        }
+        @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.colors.button.destructiveGhostTextPressed
 
     val adsColorButtonDestructiveGhostSecondaryContainerBorder: Color
         @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.colors.status.criticalPrimary

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxDestructivePrimaryButton.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxDestructivePrimaryButton.kt
@@ -29,11 +29,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import com.duckduckgo.common.ui.compose.theme.AlertRedOnDarkPressed
-import com.duckduckgo.common.ui.compose.theme.AlertRedOnLightPressed
-import com.duckduckgo.common.ui.compose.theme.Black84
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
-import com.duckduckgo.common.ui.compose.theme.White
 import com.duckduckgo.common.ui.compose.tools.PreviewBox
 import com.duckduckgo.mobile.android.R
 
@@ -80,18 +76,10 @@ private object DaxDestructivePrimaryButtonDefaults {
         @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.colors.status.criticalPrimary
 
     val adsColorButtonDestructivePrimaryContainerPressed: Color
-        @Composable @ReadOnlyComposable get() = if (DuckDuckGoTheme.colors.isDark) {
-            AlertRedOnDarkPressed
-        } else {
-            AlertRedOnLightPressed
-        }
+        @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.colors.button.destructiveContainerPressed
 
     val adsColorButtonDestructivePrimaryText: Color
-        @Composable @ReadOnlyComposable get() = if (DuckDuckGoTheme.colors.isDark) {
-            Black84
-        } else {
-            White
-        }
+        @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.colors.button.primaryText
 
     val adsColorButtonDestructivePrimaryContainerDisabled: Color
         @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.colors.backgrounds.containerDisabled

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxGhostButton.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxGhostButton.kt
@@ -29,10 +29,6 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import com.duckduckgo.common.ui.compose.theme.Blue20
-import com.duckduckgo.common.ui.compose.theme.Blue30_20
-import com.duckduckgo.common.ui.compose.theme.Blue50_12
-import com.duckduckgo.common.ui.compose.theme.Blue70
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
 import com.duckduckgo.common.ui.compose.tools.PreviewBox
 import com.duckduckgo.mobile.android.R
@@ -80,21 +76,13 @@ private object DaxGhostButtonDefaults {
         @Composable @ReadOnlyComposable get() = Color.Transparent
 
     val adsColorButtonGhostContainerPressed: Color
-        @Composable @ReadOnlyComposable get() = if (DuckDuckGoTheme.colors.isDark) {
-            Blue30_20
-        } else {
-            Blue50_12
-        }
+        @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.colors.button.secondaryContainerPressed
 
     val adsColorButtonGhostText: Color
         @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.colors.brand.accentBlue
 
     val adsColorButtonGhostTextPressed: Color
-        @Composable @ReadOnlyComposable get() = if (DuckDuckGoTheme.colors.isDark) {
-            Blue20
-        } else {
-            Blue70
-        }
+        @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.colors.button.secondaryTextPressed
 
     val adsColorButtonGhostDisabled: Color
         @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.textColors.disabled

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxPrimaryButton.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxPrimaryButton.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoThemeVariant
 import com.duckduckgo.common.ui.compose.tools.PreviewBox
 import com.duckduckgo.mobile.android.R
 
@@ -158,6 +159,17 @@ private fun DaxPrimaryButtonWithIconLargePreview(
             onClick = { },
             enabled = enabled,
             leadingIconPainter = painterResource(R.drawable.ic_add_24_solid_color),
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxPrimaryButtonOnboardingPreview() {
+    PreviewBox(variant = DuckDuckGoThemeVariant.Onboarding) {
+        DaxPrimaryButton(
+            text = "Onboarding Primary",
+            onClick = { },
         )
     }
 }

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxPrimaryButton.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxPrimaryButton.kt
@@ -29,13 +29,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
-import com.duckduckgo.common.ui.compose.theme.Black6
-import com.duckduckgo.common.ui.compose.theme.Black84
-import com.duckduckgo.common.ui.compose.theme.Blue50
-import com.duckduckgo.common.ui.compose.theme.Blue70
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
-import com.duckduckgo.common.ui.compose.theme.White
-import com.duckduckgo.common.ui.compose.theme.White6
 import com.duckduckgo.common.ui.compose.tools.PreviewBox
 import com.duckduckgo.mobile.android.R
 
@@ -79,28 +73,16 @@ fun DaxPrimaryButton(
 private object DaxPrimaryButtonDefaults {
 
     val adsColorButtonPrimaryContainer: Color
-        @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.colors.brand.accentBlue
+        @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.colors.button.primaryContainer
 
     val adsColorButtonPrimaryContainerPressed: Color
-        @Composable @ReadOnlyComposable get() = if (DuckDuckGoTheme.colors.isDark) {
-            Blue50
-        } else {
-            Blue70
-        }
+        @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.colors.button.primaryContainerPressed
 
     val adsColorButtonPrimaryText: Color
-        @Composable @ReadOnlyComposable get() = if (DuckDuckGoTheme.colors.isDark) {
-            Black84
-        } else {
-            White
-        }
+        @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.colors.button.primaryText
 
     val adsColorButtonPrimaryContainerDisabled: Color
-        @Composable @ReadOnlyComposable get() = if (DuckDuckGoTheme.colors.isDark) {
-            White6
-        } else {
-            Black6
-        }
+        @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.colors.button.primaryContainerDisabled
 
     val adsColorButtonPrimaryTextDisabled: Color
         @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.textColors.disabled

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxSecondaryButton.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxSecondaryButton.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoThemeVariant
 import com.duckduckgo.common.ui.compose.tools.PreviewBox
 import com.duckduckgo.mobile.android.R
 
@@ -178,6 +179,17 @@ private fun DaxSecondaryButtonWithIconLargePreview(
             onClick = { },
             enabled = enabled,
             leadingIconPainter = painterResource(R.drawable.ic_add_24_solid_color),
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxSecondaryButtonOnboardingPreview() {
+    PreviewBox(variant = DuckDuckGoThemeVariant.Onboarding) {
+        DaxSecondaryButton(
+            text = "Onboarding Secondary",
+            onClick = { },
         )
     }
 }

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxSecondaryButton.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxSecondaryButton.kt
@@ -31,15 +31,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
-import com.duckduckgo.common.ui.compose.theme.Black12
-import com.duckduckgo.common.ui.compose.theme.Blue20
-import com.duckduckgo.common.ui.compose.theme.Blue30
-import com.duckduckgo.common.ui.compose.theme.Blue30_20
-import com.duckduckgo.common.ui.compose.theme.Blue50
-import com.duckduckgo.common.ui.compose.theme.Blue50_12
-import com.duckduckgo.common.ui.compose.theme.Blue70
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
-import com.duckduckgo.common.ui.compose.theme.White24
 import com.duckduckgo.common.ui.compose.tools.PreviewBox
 import com.duckduckgo.mobile.android.R
 
@@ -87,25 +79,13 @@ private object DaxSecondaryButtonDefaults {
         @Composable @ReadOnlyComposable get() = Color.Transparent
 
     val adsColorButtonSecondaryContainerPressed: Color
-        @Composable @ReadOnlyComposable get() = if (DuckDuckGoTheme.colors.isDark) {
-            Blue30_20
-        } else {
-            Blue50_12
-        }
+        @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.colors.button.secondaryContainerPressed
 
     val adsColorButtonSecondaryText: Color
-        @Composable @ReadOnlyComposable get() = if (DuckDuckGoTheme.colors.isDark) {
-            Blue30
-        } else {
-            Blue50
-        }
+        @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.colors.button.secondaryText
 
     val adsColorButtonSecondaryTextPressed: Color
-        @Composable @ReadOnlyComposable get() = if (DuckDuckGoTheme.colors.isDark) {
-            Blue20
-        } else {
-            Blue70
-        }
+        @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.colors.button.secondaryTextPressed
 
     val adsColorButtonSecondaryContainerBorder: Color
         @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.colors.brand.accentBlue
@@ -114,11 +94,7 @@ private object DaxSecondaryButtonDefaults {
         @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.textColors.disabled
 
     val adsColorButtonSecondaryContainerBorderDisabled: Color
-        @Composable @ReadOnlyComposable get() = if (DuckDuckGoTheme.colors.isDark) {
-            White24
-        } else {
-            Black12
-        }
+        @Composable @ReadOnlyComposable get() = DuckDuckGoTheme.colors.button.secondaryBorderDisabled
 
     @Composable @ReadOnlyComposable
     fun colors(): DaxButtonColors = DaxButtonColors(

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/sheets/DaxBottomSheetDialog.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/sheets/DaxBottomSheetDialog.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.dp
-import com.duckduckgo.common.ui.compose.theme.Black
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
 
 /**
@@ -85,7 +84,7 @@ object DaxBottomSheetDefaults {
         get() = DuckDuckGoTheme.colors.text.primary
 
     val scrimColor: Color
-        @Composable get() = Black.copy(alpha = .6f)
+        @Composable get() = DuckDuckGoTheme.colors.system.scrim
 
     val shape = RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp)
 }

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/theme/Color.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/theme/Color.kt
@@ -40,6 +40,7 @@ data class DuckDuckGoColors(
     val textField: DuckDuckGoTextFieldColors,
     val status: DuckDuckGoStatusColors,
     val system: DuckDuckGoSystemColors,
+    val button: DuckDuckGoButtonColors,
     val isDark: Boolean, // TODO we'll need to do an exploration into using the app pref for Theme switching
 )
 
@@ -109,11 +110,31 @@ data class DuckDuckGoSystemColors(
     val sliderTrackInactive: Color,
     val textInputEnabledOutline: Color,
     val touchFeedback: Color,
+    val scrim: Color,
 )
 
 @Immutable
 data class DuckDuckGoStatusColors(
     val criticalPrimary: Color,
+    val indicatorActive: Color,
+    val indicatorInactive: Color,
+)
+
+@Immutable
+data class DuckDuckGoButtonColors(
+    val primaryContainer: Color,
+    val primaryContainerPressed: Color,
+    val primaryText: Color,
+    val primaryContainerDisabled: Color,
+    val secondaryContainerPressed: Color,
+    val secondaryText: Color,
+    val secondaryTextPressed: Color,
+    val secondaryBorderDisabled: Color,
+    val ghostAltContainerPressed: Color,
+    val ghostAltText: Color,
+    val destructiveContainerPressed: Color,
+    val destructiveGhostContainerPressed: Color,
+    val destructiveGhostTextPressed: Color,
 )
 
 @SuppressLint("ComposeCompositionLocalUsage")
@@ -136,6 +157,7 @@ val Black9 = Color(0x17000000)
 val Black6 = Color(0x0F000000)
 val Black3 = Color(0x08000000)
 val Black = Color(0xFF000000)
+val Scrim = Black.copy(alpha = .6f)
 //endregion
 
 //region White color variants

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/theme/DuckDuckGoThemeVariant.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/theme/DuckDuckGoThemeVariant.kt
@@ -16,10 +16,6 @@
 
 package com.duckduckgo.common.ui.compose.theme
 
-/**
- * Selects which set of colors and typography [DuckDuckGoTheme] provides. The semantic layer
- * ([DuckDuckGoColors], [DuckDuckGoTypography]) is identical across variants — only the instances differ.
- */
 enum class DuckDuckGoThemeVariant {
     Default,
     Onboarding,

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/theme/DuckDuckGoThemeVariant.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/theme/DuckDuckGoThemeVariant.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui.compose.theme
+
+/**
+ * Selects which set of colors and typography [DuckDuckGoTheme] provides. The semantic layer
+ * ([DuckDuckGoColors], [DuckDuckGoTypography]) is identical across variants — only the instances differ.
+ */
+enum class DuckDuckGoThemeVariant {
+    Default,
+    Onboarding,
+}

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/theme/Theme.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/theme/Theme.kt
@@ -77,127 +77,7 @@ fun DuckDuckGoTheme(
     isDarkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit,
 ) {
-    val lightColorPalette = DuckDuckGoColors(
-        backgrounds = DuckDuckGoBackgroundColors(
-            background = colorResource(R.color.background_background_light),
-            backgroundInverted = colorResource(R.color.gray100),
-            surface = colorResource(R.color.background_surface_light),
-            surfaceTransparent = White30,
-            window = colorResource(R.color.background_window_light),
-            container = Black6,
-            containerDisabled = colorResource(R.color.black6),
-        ),
-        text = DuckDuckGoTextColors(
-            primary = colorResource(R.color.text_primary_light),
-            primaryInverted = White84,
-            secondary = colorResource(R.color.text_secondary_light),
-            secondaryInverted = White60,
-            tertiary = Black36,
-            destructive = AlertRedOnLightDefault,
-            disabled = Black40,
-            logoTitle = Gray85,
-            omnibarHighlight = colorResource(R.color.blue50_20),
-        ),
-        textField = DuckDuckGoTextFieldColors(
-            borders = colorResource(R.color.black30),
-        ),
-        brand = DuckDuckGoBrandColors(
-            accentBlue = Blue50,
-            accentYellow = Yellow50,
-            accentBrand50 = Blue50.copy(alpha = .5f),
-            accentBrand20 = Blue50_20,
-        ),
-        icons = DuckDuckGoIconsColors(
-            primary = colorResource(R.color.icon_primary_light),
-            secondary = colorResource(R.color.icon_secondary_light),
-            white = White,
-            destructive = AlertRedOnLightDefault,
-            text = White,
-            disabled = colorResource(R.color.icon_tertiary_light),
-        ),
-        system = DuckDuckGoSystemColors(
-            lines = colorResource(R.color.lines_light),
-            switchTrackOn = Blue50,
-            switchTrackOff = Gray60_50,
-            switchThumb = White,
-            checkboxOn = Blue50,
-            checkboxOff = Blue50,
-            checkboxMark = White,
-            sliderTrackInactive = Gray60_50,
-            textInputEnabledOutline = Black30,
-            touchFeedback = colorResource(R.color.controls_fill_primary_light),
-        ),
-        infoPanel = DuckDuckGoInfoPanelColors(
-            backgroundBlue = Blue0_50,
-            backgroundYellow = Yellow10,
-        ),
-        status = DuckDuckGoStatusColors(
-            criticalPrimary = colorResource(R.color.alertRedOnLightDefault),
-        ),
-        isDark = false,
-    )
-
-    val darkColorPalette = DuckDuckGoColors(
-        backgrounds = DuckDuckGoBackgroundColors(
-            background = colorResource(R.color.background_background_dark),
-            backgroundInverted = colorResource(R.color.gray0),
-            surface = colorResource(R.color.background_surface_dark),
-            surfaceTransparent = Gray90.copy(alpha = .3f),
-            window = colorResource(R.color.background_window_dark),
-            container = White12,
-            containerDisabled = colorResource(R.color.white18),
-        ),
-        text = DuckDuckGoTextColors(
-            primary = colorResource(R.color.text_primary_dark),
-            primaryInverted = colorResource(R.color.black84),
-            secondary = colorResource(R.color.text_secondary_dark),
-            secondaryInverted = colorResource(R.color.black60),
-            tertiary = White36,
-            destructive = AlertRedOnDarkDefault,
-            disabled = White40,
-            logoTitle = White,
-            omnibarHighlight = colorResource(R.color.blue30_20),
-        ),
-        textField = DuckDuckGoTextFieldColors(
-            borders = colorResource(R.color.white30),
-        ),
-        brand = DuckDuckGoBrandColors(
-            accentBlue = Blue30,
-            accentYellow = Yellow50,
-            accentBrand50 = Blue30.copy(alpha = .5f),
-            accentBrand20 = Blue30_20,
-        ),
-        icons = DuckDuckGoIconsColors(
-            primary = colorResource(R.color.icon_primary_dark),
-            secondary = colorResource(R.color.icon_secondary_dark),
-            white = White,
-            destructive = AlertRedOnDarkDefault,
-            text = Black,
-            disabled = colorResource(R.color.icon_tertiary_dark),
-        ),
-        system = DuckDuckGoSystemColors(
-            lines = colorResource(R.color.lines_dark),
-            switchTrackOff = Gray40_50,
-            switchTrackOn = Blue30,
-            switchThumb = White,
-            checkboxOn = Blue30,
-            checkboxOff = Blue30,
-            checkboxMark = colorResource(R.color.background_background_dark),
-            sliderTrackInactive = Gray40_50,
-            textInputEnabledOutline = White30,
-            touchFeedback = colorResource(R.color.controls_fill_primary_dark),
-        ),
-        infoPanel = DuckDuckGoInfoPanelColors(
-            backgroundBlue = Blue50_12,
-            backgroundYellow = Yellow50_14,
-        ),
-        status = DuckDuckGoStatusColors(
-            criticalPrimary = colorResource(R.color.alertRedOnDarkDefault),
-        ),
-        isDark = true,
-    )
-
-    val colors = if (isDarkTheme) darkColorPalette else lightColorPalette
+    val colors = if (isDarkTheme) defaultDarkColors() else defaultLightColors()
 
     ProvideDuckDuckGoTheme(colors = colors) {
         MaterialTheme(
@@ -208,6 +88,166 @@ fun DuckDuckGoTheme(
         )
     }
 }
+
+@Composable
+@ReadOnlyComposable
+internal fun defaultLightColors(): DuckDuckGoColors = DuckDuckGoColors(
+    backgrounds = DuckDuckGoBackgroundColors(
+        background = colorResource(R.color.background_background_light),
+        backgroundInverted = colorResource(R.color.gray100),
+        surface = colorResource(R.color.background_surface_light),
+        surfaceTransparent = White30,
+        window = colorResource(R.color.background_window_light),
+        container = Black6,
+        containerDisabled = colorResource(R.color.black6),
+    ),
+    text = DuckDuckGoTextColors(
+        primary = colorResource(R.color.text_primary_light),
+        primaryInverted = White84,
+        secondary = colorResource(R.color.text_secondary_light),
+        secondaryInverted = White60,
+        tertiary = Black36,
+        destructive = AlertRedOnLightDefault,
+        disabled = Black40,
+        logoTitle = Gray85,
+        omnibarHighlight = colorResource(R.color.blue50_20),
+    ),
+    brand = DuckDuckGoBrandColors(
+        accentBlue = Blue50,
+        accentYellow = Yellow50,
+        accentBrand50 = Blue50.copy(alpha = .5f),
+        accentBrand20 = Blue50_20,
+    ),
+    icons = DuckDuckGoIconsColors(
+        primary = colorResource(R.color.icon_primary_light),
+        secondary = colorResource(R.color.icon_secondary_light),
+        white = White,
+        destructive = AlertRedOnLightDefault,
+        text = White,
+        disabled = colorResource(R.color.icon_tertiary_light),
+    ),
+    infoPanel = DuckDuckGoInfoPanelColors(
+        backgroundBlue = Blue0_50,
+        backgroundYellow = Yellow10,
+    ),
+    textField = DuckDuckGoTextFieldColors(
+        borders = colorResource(R.color.black30),
+    ),
+    status = DuckDuckGoStatusColors(
+        criticalPrimary = colorResource(R.color.alertRedOnLightDefault),
+        indicatorActive = AlertGreen,
+        indicatorInactive = Gray50,
+    ),
+    system = DuckDuckGoSystemColors(
+        lines = colorResource(R.color.lines_light),
+        switchTrackOn = Blue50,
+        switchTrackOff = Gray60_50,
+        switchThumb = White,
+        checkboxOn = Blue50,
+        checkboxOff = Blue50,
+        checkboxMark = White,
+        sliderTrackInactive = Gray60_50,
+        textInputEnabledOutline = Black30,
+        touchFeedback = colorResource(R.color.controls_fill_primary_light),
+        scrim = Scrim,
+    ),
+    button = DuckDuckGoButtonColors(
+        primaryContainer = Blue50,
+        primaryContainerPressed = Blue70,
+        primaryText = White,
+        primaryContainerDisabled = Black6,
+        secondaryContainerPressed = Blue50_12,
+        secondaryText = Blue50,
+        secondaryTextPressed = Blue70,
+        secondaryBorderDisabled = Black12,
+        ghostAltContainerPressed = Black6,
+        ghostAltText = Black60,
+        destructiveContainerPressed = AlertRedOnLightPressed,
+        destructiveGhostContainerPressed = AlertRedOnLightDefault18,
+        destructiveGhostTextPressed = AlertRedOnLightTextPressed,
+    ),
+    isDark = false,
+)
+
+@Composable
+@ReadOnlyComposable
+internal fun defaultDarkColors(): DuckDuckGoColors = DuckDuckGoColors(
+    backgrounds = DuckDuckGoBackgroundColors(
+        background = colorResource(R.color.background_background_dark),
+        backgroundInverted = colorResource(R.color.gray0),
+        surface = colorResource(R.color.background_surface_dark),
+        surfaceTransparent = Gray90.copy(alpha = .3f),
+        window = colorResource(R.color.background_window_dark),
+        container = White12,
+        containerDisabled = colorResource(R.color.white18),
+    ),
+    text = DuckDuckGoTextColors(
+        primary = colorResource(R.color.text_primary_dark),
+        primaryInverted = colorResource(R.color.black84),
+        secondary = colorResource(R.color.text_secondary_dark),
+        secondaryInverted = colorResource(R.color.black60),
+        tertiary = White36,
+        destructive = AlertRedOnDarkDefault,
+        disabled = White40,
+        logoTitle = White,
+        omnibarHighlight = colorResource(R.color.blue30_20),
+    ),
+    brand = DuckDuckGoBrandColors(
+        accentBlue = Blue30,
+        accentYellow = Yellow50,
+        accentBrand50 = Blue30.copy(alpha = .5f),
+        accentBrand20 = Blue30_20,
+    ),
+    icons = DuckDuckGoIconsColors(
+        primary = colorResource(R.color.icon_primary_dark),
+        secondary = colorResource(R.color.icon_secondary_dark),
+        white = White,
+        destructive = AlertRedOnDarkDefault,
+        text = Black,
+        disabled = colorResource(R.color.icon_tertiary_dark),
+    ),
+    infoPanel = DuckDuckGoInfoPanelColors(
+        backgroundBlue = Blue50_12,
+        backgroundYellow = Yellow50_14,
+    ),
+    textField = DuckDuckGoTextFieldColors(
+        borders = colorResource(R.color.white30),
+    ),
+    status = DuckDuckGoStatusColors(
+        criticalPrimary = colorResource(R.color.alertRedOnDarkDefault),
+        indicatorActive = AlertGreen,
+        indicatorInactive = Gray50,
+    ),
+    system = DuckDuckGoSystemColors(
+        lines = colorResource(R.color.lines_dark),
+        switchTrackOff = Gray40_50,
+        switchTrackOn = Blue30,
+        switchThumb = White,
+        checkboxOn = Blue30,
+        checkboxOff = Blue30,
+        checkboxMark = colorResource(R.color.background_background_dark),
+        sliderTrackInactive = Gray40_50,
+        textInputEnabledOutline = White30,
+        touchFeedback = colorResource(R.color.controls_fill_primary_dark),
+        scrim = Scrim,
+    ),
+    button = DuckDuckGoButtonColors(
+        primaryContainer = Blue30,
+        primaryContainerPressed = Blue50,
+        primaryText = Black84,
+        primaryContainerDisabled = White6,
+        secondaryContainerPressed = Blue30_20,
+        secondaryText = Blue30,
+        secondaryTextPressed = Blue20,
+        secondaryBorderDisabled = White24,
+        ghostAltContainerPressed = White12,
+        ghostAltText = White84,
+        destructiveContainerPressed = AlertRedOnDarkPressed,
+        destructiveGhostContainerPressed = AlertRedOnDarkDefault18,
+        destructiveGhostTextPressed = AlertRedOnDarkTextPressed,
+    ),
+    isDark = true,
+)
 
 /**
  * A Material3 [ColorScheme] implementation which sets all colors to [debugColor] to discourage usage of

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/theme/Theme.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/theme/Theme.kt
@@ -258,6 +258,7 @@ internal fun defaultDarkColors(): DuckDuckGoColors = DuckDuckGoColors(
 )
 
 @Composable
+@ReadOnlyComposable
 internal fun onboardingLightColors(): DuckDuckGoColors {
     val base = defaultLightColors()
     val onboardingTextPrimary = Color(0xF5242323)
@@ -289,6 +290,7 @@ internal fun onboardingLightColors(): DuckDuckGoColors {
 }
 
 @Composable
+@ReadOnlyComposable
 internal fun onboardingDarkColors(): DuckDuckGoColors {
     val base = defaultDarkColors()
     return base.copy(

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/theme/Theme.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/theme/Theme.kt
@@ -75,11 +75,19 @@ fun ProvideDuckDuckGoTheme(
 @Composable
 fun DuckDuckGoTheme(
     isDarkTheme: Boolean = isSystemInDarkTheme(),
+    variant: DuckDuckGoThemeVariant = DuckDuckGoThemeVariant.Default,
     content: @Composable () -> Unit,
 ) {
-    val colors = if (isDarkTheme) defaultDarkColors() else defaultLightColors()
+    val colors = when (variant) {
+        DuckDuckGoThemeVariant.Default -> if (isDarkTheme) defaultDarkColors() else defaultLightColors()
+        DuckDuckGoThemeVariant.Onboarding -> if (isDarkTheme) onboardingDarkColors() else onboardingLightColors()
+    }
+    val typography = when (variant) {
+        DuckDuckGoThemeVariant.Default -> Typography
+        DuckDuckGoThemeVariant.Onboarding -> OnboardingTypography
+    }
 
-    ProvideDuckDuckGoTheme(colors = colors) {
+    ProvideDuckDuckGoTheme(colors = colors, typography = typography) {
         MaterialTheme(
             colorScheme = debugColors(),
             typography = debugTypography(),
@@ -248,6 +256,67 @@ internal fun defaultDarkColors(): DuckDuckGoColors = DuckDuckGoColors(
     ),
     isDark = true,
 )
+
+@Composable
+internal fun onboardingLightColors(): DuckDuckGoColors {
+    val base = defaultLightColors()
+    val onboardingTextPrimary = Color(0xF5242323)
+    return base.copy(
+        backgrounds = base.backgrounds.copy(
+            background = White,
+            container = Color(0x17242323),
+        ),
+        text = base.text.copy(
+            primary = onboardingTextPrimary,
+            secondary = Black60,
+        ),
+        brand = base.brand.copy(
+            accentBlue = colorResource(R.color.pondwater50),
+        ),
+        icons = base.icons.copy(
+            primary = Color(0xD6242323),
+            secondary = Color(0x99383838),
+        ),
+        button = base.button.copy(
+            primaryContainer = colorResource(R.color.mandarin50),
+            primaryContainerPressed = colorResource(R.color.mandarin60),
+            primaryText = White,
+            secondaryContainerPressed = Black12,
+            secondaryText = onboardingTextPrimary,
+            secondaryTextPressed = onboardingTextPrimary,
+        ),
+    )
+}
+
+@Composable
+internal fun onboardingDarkColors(): DuckDuckGoColors {
+    val base = defaultDarkColors()
+    return base.copy(
+        backgrounds = base.backgrounds.copy(
+            background = Color(0xFF133E7C),
+            container = White6,
+        ),
+        text = base.text.copy(
+            primary = White,
+            secondary = White60,
+        ),
+        brand = base.brand.copy(
+            accentBlue = colorResource(R.color.pondwater40),
+        ),
+        icons = base.icons.copy(
+            primary = Color(0xD6FBFAF9),
+            secondary = Color(0x7AFBFAF9),
+        ),
+        button = base.button.copy(
+            primaryContainer = colorResource(R.color.pollen30),
+            primaryContainerPressed = colorResource(R.color.pollen40),
+            primaryText = colorResource(R.color.pollen100),
+            secondaryContainerPressed = White24,
+            secondaryText = White,
+            secondaryTextPressed = White,
+        ),
+    )
+}
 
 /**
  * A Material3 [ColorScheme] implementation which sets all colors to [debugColor] to discourage usage of

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/theme/Theme.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/theme/Theme.kt
@@ -72,6 +72,15 @@ fun ProvideDuckDuckGoTheme(
     )
 }
 
+/**
+ * The main entry point for applying the DuckDuckGo theme to an app. This should typically be called from the top level of an app's composable hierarchy.
+ *
+ * @param isDarkTheme Whether to use the dark theme variant. By default, this uses the system setting.
+ * @param variant The theme variant to use, which selects the specific semantic classes instances to provide. By default, this is [DuckDuckGoThemeVariant.Default].
+ * @param content The composable content to which the theme should be applied.
+ *
+ * Asana task: https://app.asana.com/1/137249556945/project/1202857801505092/task/1215345890679455
+ */
 @Composable
 fun DuckDuckGoTheme(
     isDarkTheme: Boolean = isSystemInDarkTheme(),

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/theme/Typography.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/theme/Typography.kt
@@ -179,6 +179,48 @@ data class DuckDuckGoTypography(
 
 val Typography = DuckDuckGoTypography()
 
+val OnboardingTypography = DuckDuckGoTypography(
+    title = DuckDuckGoTextStyle(
+        TextStyle(fontSize = 32.sp, lineHeight = 36.sp, fontWeight = FontWeight.Bold, fontFamily = DuckSansDisplay),
+    ),
+    h1 = DuckDuckGoTextStyle(
+        TextStyle(fontSize = 24.sp, lineHeight = 30.sp, fontWeight = FontWeight.Bold, fontFamily = DuckSansDisplay),
+    ),
+    h2 = DuckDuckGoTextStyle(
+        TextStyle(fontSize = 24.sp, lineHeight = 28.sp, fontWeight = FontWeight.Bold, fontFamily = DuckSansDisplay),
+    ),
+    h3 = DuckDuckGoTextStyle(
+        TextStyle(fontSize = 16.sp, lineHeight = 21.sp, fontWeight = FontWeight.Medium, fontFamily = DuckSansDisplay),
+    ),
+    h4 = DuckDuckGoTextStyle(
+        TextStyle(fontSize = 14.sp, lineHeight = 20.sp, letterSpacing = 0.3.sp, fontWeight = FontWeight.Medium, fontFamily = DuckSansDisplay),
+    ),
+    h5 = DuckDuckGoTextStyle(
+        TextStyle(fontSize = 13.sp, lineHeight = 16.sp, fontWeight = FontWeight.Medium, fontFamily = DuckSansDisplay),
+    ),
+    body1 = DuckDuckGoTextStyle(
+        TextStyle(fontSize = 18.sp, lineHeight = 22.sp, fontFamily = DuckSansProduct),
+    ),
+    body1Bold = DuckDuckGoTextStyle(
+        TextStyle(fontSize = 18.sp, lineHeight = 22.sp, fontWeight = FontWeight.Bold, fontFamily = DuckSansProduct),
+    ),
+    body1Mono = DuckDuckGoTextStyle(
+        TextStyle(fontSize = 16.sp, lineHeight = 20.sp, fontFamily = RobotoMono),
+    ),
+    body2 = DuckDuckGoTextStyle(
+        TextStyle(fontSize = 14.sp, lineHeight = 18.sp, letterSpacing = 0.2.sp, fontFamily = DuckSansProduct),
+    ),
+    body2Bold = DuckDuckGoTextStyle(
+        TextStyle(fontSize = 14.sp, lineHeight = 18.sp, letterSpacing = 0.3.sp, fontWeight = FontWeight.Bold, fontFamily = DuckSansProduct),
+    ),
+    button = DuckDuckGoTextStyle(
+        TextStyle(fontSize = 18.sp, lineHeight = 20.sp, fontWeight = FontWeight.Normal, fontFamily = DuckSansProduct),
+    ),
+    caption = DuckDuckGoTextStyle(
+        TextStyle(fontSize = 12.sp, lineHeight = 16.sp, letterSpacing = 0.2.sp, fontFamily = DuckSansProduct),
+    ),
+)
+
 @SuppressLint("ComposeCompositionLocalUsage")
 val LocalDuckDuckGoTypography = staticCompositionLocalOf<DuckDuckGoTypography> {
     error("No DuckDuckGoTypography provided")

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/tools/PreviewBox.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/tools/PreviewBox.kt
@@ -25,14 +25,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoThemeVariant
 
 @Composable
 fun PreviewBoxInverted(
     modifier: Modifier = Modifier,
+    variant: DuckDuckGoThemeVariant = DuckDuckGoThemeVariant.Default,
     color: @Composable () -> Color = { DuckDuckGoTheme.colors.backgrounds.backgroundInverted },
     content: @Composable BoxScope.() -> Unit,
 ) = PreviewBox(
     modifier = modifier,
+    variant = variant,
     color = color,
     content = content,
 )
@@ -40,10 +43,11 @@ fun PreviewBoxInverted(
 @Composable
 fun PreviewBox(
     modifier: Modifier = Modifier,
+    variant: DuckDuckGoThemeVariant = DuckDuckGoThemeVariant.Default,
     color: @Composable () -> Color = { DuckDuckGoTheme.colors.backgrounds.background },
     content: @Composable BoxScope.() -> Unit,
 ) {
-    DuckDuckGoTheme {
+    DuckDuckGoTheme(variant = variant) {
         Box(
             modifier = modifier
                 .background(color())


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202857801505092/task/1215345726876083?focus=true 

### Description

Adds an `Onboarding` variant to the Compose `DuckDuckGoTheme` — onboarding colours + DuckSans typography, selectable via `DuckDuckGoTheme(variant = Onboarding)` — so Compose onboarding UI can match the existing XML `Theme.DuckDuckGo.*.Onboarding` themes.

### Steps to test this PR

> [!NOTE]
> - [ ] Install the Internal build (`./gradlew installInternalRelease`)
> - [ ] Open the design-system showcase

- [ ] Set the theme-family radio in the header to **Onboarding** → confirm both XML demos and Compose demos (Colours, Buttons, Typography tabs) switch to the onboarding look
- [ ] Toggle **Enable Dark Theme** with **Onboarding** selected → confirm the onboarding dark palette applies
- [ ] Set the radio back to **Default** → confirm components return to the standard theme

### UI changes
https://github.com/user-attachments/assets/2ff44c29-07ef-4ed4-b0a9-fcb6f8b038c9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad theme API and token refactors affect all Compose components that use `DuckDuckGoTheme.colors`; default variant preserves prior behavior, but onboarding palette mistakes would be visible app-wide where the variant is adopted.
> 
> **Overview**
> Introduces **`DuckDuckGoThemeVariant`** (`Default` / `Onboarding`) and extends **`DuckDuckGoTheme(variant = …)`** so Compose can use onboarding-specific **colors** (mandarin/pollen primaries, pondwater accents, onboarding backgrounds) and **`OnboardingTypography`** (DuckSans display/product), aligned with the existing XML onboarding themes.
> 
> Theme construction is split into **`defaultLightColors` / `defaultDarkColors`** and **`onboardingLightColors` / `onboardingDarkColors`**, with new semantic tokens on **`DuckDuckGoColors`**: **`button`**, status **indicator** colors, and **`system.scrim`**. Dax buttons, status indicator, and bottom sheets now read these tokens instead of hard-coded palette constants.
> 
> The **design-system internal showcase** persists variant in DataStore, adds a **Theme family** radio (Default / Onboarding), applies **`Theme_DuckDuckGo_*_Onboarding`** for XML when onboarding is selected, and threads **`variant`** through **`setupThemedComposeView`** and component gallery fragments so previews match the chosen family.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e5edf4d4dc8cb5401472638c9e2f6b5c0fb697f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->