### PR TITLE
Update content scope scripts to version 15.1.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -51,6 +51,9 @@
   var Uint16Array = globalThis.Uint16Array;
   var Uint32Array2 = globalThis.Uint32Array;
   var JSONparse = JSON.parse;
+  var atob = globalThis.atob?.bind(globalThis);
+  var DOMException2 = globalThis.DOMException;
+  var charCodeAt = globalThis.String.prototype.charCodeAt;
   var ReflectDeleteProperty = Reflect2.deleteProperty.bind(Reflect2);
   var ReflectApply = Reflect2.apply.bind(Reflect2);
   var getRandomValues = globalThis.crypto?.getRandomValues?.bind(globalThis.crypto);
@@ -616,7 +619,8 @@
       "hover",
       "browserUiLock",
       "trackerProtection",
-      "tabSuspension"
+      "tabSuspension",
+      "autofillPasskeys"
     ]
   );
   var platformSupport = {
@@ -687,7 +691,8 @@
       "pageContext",
       "duckAiDataClearing",
       "performanceMetrics",
-      "duckAiChatHistory"
+      "duckAiChatHistory",
+      "autofillPasskeys"
     ],
     firefox: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webEvents", "webInterferenceDetection", "breakageReporting"],
     chrome: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webEvents", "webInterferenceDetection", "breakageReporting"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -1574,6 +1574,9 @@
   var Uint16Array = globalThis.Uint16Array;
   var Uint32Array = globalThis.Uint32Array;
   var JSONparse = JSON.parse;
+  var atob = globalThis.atob?.bind(globalThis);
+  var DOMException2 = globalThis.DOMException;
+  var charCodeAt = globalThis.String.prototype.charCodeAt;
   var ReflectDeleteProperty = Reflect2.deleteProperty.bind(Reflect2);
   var ReflectApply = Reflect2.apply.bind(Reflect2);
   var getRandomValues = globalThis.crypto?.getRandomValues?.bind(globalThis.crypto);
@@ -2151,7 +2154,8 @@
       "hover",
       "browserUiLock",
       "trackerProtection",
-      "tabSuspension"
+      "tabSuspension",
+      "autofillPasskeys"
     ]
   );
   var platformSupport = {
@@ -2222,7 +2226,8 @@
       "pageContext",
       "duckAiDataClearing",
       "performanceMetrics",
-      "duckAiChatHistory"
+      "duckAiChatHistory",
+      "autofillPasskeys"
     ],
     firefox: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webEvents", "webInterferenceDetection", "breakageReporting"],
     chrome: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webEvents", "webInterferenceDetection", "breakageReporting"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -1574,6 +1574,9 @@
   var Uint16Array = globalThis.Uint16Array;
   var Uint32Array = globalThis.Uint32Array;
   var JSONparse = JSON.parse;
+  var atob = globalThis.atob?.bind(globalThis);
+  var DOMException2 = globalThis.DOMException;
+  var charCodeAt = globalThis.String.prototype.charCodeAt;
   var ReflectDeleteProperty = Reflect2.deleteProperty.bind(Reflect2);
   var ReflectApply = Reflect2.apply.bind(Reflect2);
   var getRandomValues = globalThis.crypto?.getRandomValues?.bind(globalThis.crypto);
@@ -2123,7 +2126,8 @@
       "hover",
       "browserUiLock",
       "trackerProtection",
-      "tabSuspension"
+      "tabSuspension",
+      "autofillPasskeys"
     ]
   );
   var platformSupport = {
@@ -2194,7 +2198,8 @@
       "pageContext",
       "duckAiDataClearing",
       "performanceMetrics",
-      "duckAiChatHistory"
+      "duckAiChatHistory",
+      "autofillPasskeys"
     ],
     firefox: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webEvents", "webInterferenceDetection", "breakageReporting"],
     chrome: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webEvents", "webInterferenceDetection", "breakageReporting"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -814,6 +814,7 @@
   __export(captured_globals_exports, {
     Arrayfrom: () => Arrayfrom,
     CustomEvent: () => CustomEvent2,
+    DOMException: () => DOMException2,
     Error: () => Error2,
     JSONparse: () => JSONparse,
     JSONstringify: () => JSONstringify,
@@ -834,6 +835,8 @@
     Uint32Array: () => Uint32Array2,
     Uint8Array: () => Uint8Array2,
     addEventListener: () => addEventListener,
+    atob: () => atob,
+    charCodeAt: () => charCodeAt,
     console: () => console2,
     consoleError: () => consoleError,
     consoleLog: () => consoleLog,
@@ -898,6 +901,9 @@
   var JSONstringify = JSON.stringify;
   var JSONparse = JSON.parse;
   var Arrayfrom = Array.from;
+  var atob = globalThis.atob?.bind(globalThis);
+  var DOMException2 = globalThis.DOMException;
+  var charCodeAt = globalThis.String.prototype.charCodeAt;
   var ReflectDeleteProperty = Reflect2.deleteProperty.bind(Reflect2);
   var ReflectApply = Reflect2.apply.bind(Reflect2);
   var getRandomValues = globalThis.crypto?.getRandomValues?.bind(globalThis.crypto);
@@ -1485,7 +1491,8 @@
       "hover",
       "browserUiLock",
       "trackerProtection",
-      "tabSuspension"
+      "tabSuspension",
+      "autofillPasskeys"
     ]
   );
   var platformSupport = {
@@ -1556,7 +1563,8 @@
       "pageContext",
       "duckAiDataClearing",
       "performanceMetrics",
-      "duckAiChatHistory"
+      "duckAiChatHistory",
+      "autofillPasskeys"
     ],
     firefox: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webEvents", "webInterferenceDetection", "breakageReporting"],
     chrome: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webEvents", "webInterferenceDetection", "breakageReporting"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
@@ -50,6 +50,9 @@
   var Uint16Array = globalThis.Uint16Array;
   var Uint32Array = globalThis.Uint32Array;
   var JSONparse = JSON.parse;
+  var atob = globalThis.atob?.bind(globalThis);
+  var DOMException2 = globalThis.DOMException;
+  var charCodeAt = globalThis.String.prototype.charCodeAt;
   var ReflectDeleteProperty = Reflect2.deleteProperty.bind(Reflect2);
   var ReflectApply = Reflect2.apply.bind(Reflect2);
   var getRandomValues = globalThis.crypto?.getRandomValues?.bind(globalThis.crypto);
@@ -598,7 +601,8 @@
       "hover",
       "browserUiLock",
       "trackerProtection",
-      "tabSuspension"
+      "tabSuspension",
+      "autofillPasskeys"
     ]
   );
   var platformSupport = {
@@ -669,7 +673,8 @@
       "pageContext",
       "duckAiDataClearing",
       "performanceMetrics",
-      "duckAiChatHistory"
+      "duckAiChatHistory",
+      "autofillPasskeys"
     ],
     firefox: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webEvents", "webInterferenceDetection", "breakageReporting"],
     chrome: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webEvents", "webInterferenceDetection", "breakageReporting"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiDataClearing.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiDataClearing.js
@@ -50,6 +50,9 @@
   var Uint16Array = globalThis.Uint16Array;
   var Uint32Array = globalThis.Uint32Array;
   var JSONparse = JSON.parse;
+  var atob = globalThis.atob?.bind(globalThis);
+  var DOMException2 = globalThis.DOMException;
+  var charCodeAt = globalThis.String.prototype.charCodeAt;
   var ReflectDeleteProperty = Reflect2.deleteProperty.bind(Reflect2);
   var ReflectApply = Reflect2.apply.bind(Reflect2);
   var getRandomValues = globalThis.crypto?.getRandomValues?.bind(globalThis.crypto);
@@ -598,7 +601,8 @@
       "hover",
       "browserUiLock",
       "trackerProtection",
-      "tabSuspension"
+      "tabSuspension",
+      "autofillPasskeys"
     ]
   );
   var platformSupport = {
@@ -669,7 +673,8 @@
       "pageContext",
       "duckAiDataClearing",
       "performanceMetrics",
-      "duckAiChatHistory"
+      "duckAiChatHistory",
+      "autofillPasskeys"
     ],
     firefox: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webEvents", "webInterferenceDetection", "breakageReporting"],
     chrome: ["cookie", ...baseFeatures, "clickToLoad", "webDetection", "webEvents", "webInterferenceDetection", "breakageReporting"],

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
@@ -387,6 +387,9 @@
   var Uint16Array = globalThis.Uint16Array;
   var Uint32Array = globalThis.Uint32Array;
   var JSONparse = JSON.parse;
+  var atob = globalThis.atob?.bind(globalThis);
+  var DOMException2 = globalThis.DOMException;
+  var charCodeAt = globalThis.String.prototype.charCodeAt;
   var ReflectDeleteProperty = Reflect2.deleteProperty.bind(Reflect2);
   var ReflectApply = Reflect2.apply.bind(Reflect2);
   var getRandomValues = globalThis.crypto?.getRandomValues?.bind(globalThis.crypto);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.85.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.0.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.1.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.85.5",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.85.5.tgz",
-      "integrity": "sha512-LmzQGM9K9MWjKMwapqx81RVNgBIt7q2AFIM/4KceHRhXltmbeQZRiFFTBLKHbrNrajYpVcNfsM5XhdkV/s4TLQ==",
+      "version": "14.87.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.87.0.tgz",
+      "integrity": "sha512-0/EYyR2KIBnZPOLj5y4QtBdUb9cvlCJJ7U1iV1PnnjQckbqU4LuWFXA4FFa7FT1ay7AGaLQq/TQ7XbKhudTnTg==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#512a2657dd2f3b73682babf77561068cccd28c41",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#24a5cd08938f22092dcd0c140b153b36d6468736",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.85.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.0.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.1.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/488551667048375/1215353071845743/f 

 ----- 
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches injected page scripts and enables a new autofill/passkeys feature path; regressions would affect WebView behavior rather than native app code directly, but passkey flows are security-sensitive.
> 
> **Overview**
> Bumps **`@duckduckgo/content-scope-scripts`** from **15.0.0** to **15.1.0** in `package.json` / `package-lock.json` and refreshes the vendored Android bundles under `node_modules/@duckduckgo/content-scope-scripts/build/android/`.
> 
> The **15.1.0** script build adds **`autofillPasskeys`** to the shared feature lists and **Android** `platformSupport`, and wires extra **captured globals** (`atob`, `DOMException`, `charCodeAt`) into the injected runtime (including exports in `contentScope.js`) to support passkey-related logic in the content-scope sandbox.
> 
> There are **no first-party Kotlin/Java changes** in this PR—only the dependency pin and copied upstream build output. The lockfile also picks up a minor **`@duckduckgo/autoconsent`** revision as a resolved dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1801282190033dd6b25191f34a20caa4c53d986f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->