### PR TITLE
Update Duck.ai chat input and attachment copy

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -730,7 +730,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     override fun EditText.applyChatInputType() {
-        hint = context.getString(R.string.native_input_chat_hint)
+        hint = context.getString(
+            if (isDuckAiPageContext()) R.string.native_input_chat_duck_mode_hint else R.string.native_input_chat_hint,
+        )
         // Enter inserts a newline when we're on a Duck.ai chat page (existing behavior) or when
         // the widget sits in bottom-bar position with the Duck.ai toggle selected. Bottom-bar
         // mode has no on-screen new-line button, so the IME enter key is the only carriage-

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -18,6 +18,7 @@
     <string name="duckAiChatSearchDuckDuckGo">Search DuckDuckGo</string>
     <string name="duckAiChatHistoryViewAllChats">View all Chats</string>
     <string name="native_input_chat_hint">Ask anything privately…</string>
+    <string name="native_input_chat_duck_mode_hint">Reply…</string>
 
     <!-- Model Picker -->
     <string name="duckAiModelPickerPlusModels" translatable="false">Plus</string>
@@ -56,8 +57,8 @@
 
     <!-- File/image attachment menu options -->
     <string name="attachmentTakePhoto">Take Photo</string>
-    <string name="attachmentAttachPhoto">Attach Photo</string>
-    <string name="attachmentAttachFile">Attach File</string>
+    <string name="attachmentAttachPhoto">Add Image</string>
+    <string name="attachmentAttachFile">Add File</string>
 
     <!-- File attachment -->
     <string name="duckChatFileAttachmentRemoveContentDescription">Remove file</string>


### PR DESCRIPTION
 Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1215028469217686?focus=true

  ### Description

  Show a context-specific hint in the Duck.ai native input field. When the input is shown on a Duck.ai chat page (`DUCK_AI` or `DUCK_AI_CONTEXTUAL` context), the hint now reads "Reply…" instead of "Ask anything privately…". The hint is selected in `NativeInputModeWidget.applyChatInputType()` via the existing `isDuckAiPageContext()` predicate, and is re-applied when
  the input context changes, so it updates live. In the browser address-bar / new-tab toggle (BROWSER context) the hint is unchanged.

  Also relabels the attachment menu options: "Attach Photo" → "Add Image" and "Attach File" → "Add File".

  ### Steps to test this PR
  
  _Duck.ai chat hint_
  - [ ] Open a Duck.ai chat (full screen) and confirm the input hint reads "Reply…"
  - [ ] On the new tab page / address bar with the Search⇄Duck.ai toggle, select Duck.ai and confirm the hint still reads "Ask anything privately…"
  - [ ] Open the contextual Duck.ai input (e.g. Summarize This Page) and confirm the hint reads "Reply…"

  _Attachment labels_
  - [ ] In a Duck.ai chat, open the attachment menu and confirm the options read "Add Image" and "Add File"

  ### UI changes
  | Before  | After |
  | ------ | ----- |
  !(Upload before screenshot)|(Upload after screenshot)|

  Done:
  - PR #8756 open against develop, not draft, with just the two intended files committed (co-author trailer included).
  - :duckchat-impl spotless passed before push.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String and hint-selection only; no auth, data, or behavioral logic changes beyond which placeholder text is shown.
> 
> **Overview**
> Updates Duck.ai native input **placeholder copy** and attachment menu labels for clearer, context-appropriate wording.
> 
> When the chat tab is active, **`applyChatInputType`** now picks the hint from **`isDuckAiPageContext()`**: fullscreen Duck.ai and contextual Duck.ai show **"Reply…"** (`native_input_chat_duck_mode_hint`); browser omnibar chat keeps **"Ask anything privately…"**. IME and multiline behavior are unchanged.
> 
> Attachment popup labels in **`donottranslate.xml`** are renamed from "Attach Photo" / "Attach File" to **"Add Image"** and **"Add File"** (same string resources used by **`AttachmentView`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 676e2f6ac3541a6cc41dead19ef8bb2e69194289. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->