### PR TITLE
Fix Duck.ai tab logo flash and vertical shift

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -210,8 +210,8 @@ class NativeInputLayoutCoordinator(
         fun isLogoOnlyContent(view: View): Boolean {
             if (view != newTabContent) return false
             val logoVisible = rootView.findViewById<View?>(R.id.ddgLogo)?.visibility == View.VISIBLE
-            val hatchVisible = rootView.findViewById<View?>(R.id.newTabReturnHatchView)?.visibility == View.VISIBLE
-            return logoVisible && !hatchVisible
+            val hatchHeightPx = rootView.findViewById<View?>(R.id.newTabReturnHatchView)?.height ?: 0
+            return isLogoOnly(logoVisible, hatchHeightPx)
         }
 
         fun computeDeltaTop(view: View, anchorBottomInWindow: Int): Int {
@@ -337,3 +337,17 @@ class NativeInputLayoutCoordinator(
         )
     }
 }
+
+/**
+ * Whether the new-tab page's only content is the dax logo. When true the content is NOT offset below
+ * the input widget (it stays centered), so the logo keeps a fixed vertical position regardless of the
+ * widget's height — otherwise it would sit lower on the Duck.ai tab (whose widget is taller than
+ * Search's) and appear to shift when switching tabs.
+ *
+ * A real return-hatch is detected via [hatchHeightPx] rather than visibility: the NewTabReturnHatchView
+ * container is always VISIBLE and merely collapses to zero height when no hatch is shown (its inner
+ * content is what's toggled), so a visibility check would always report "hatch present" and defeat
+ * this guard.
+ */
+internal fun isLogoOnly(logoVisible: Boolean, hatchHeightPx: Int): Boolean =
+    logoVisible && hatchHeightPx <= 0

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/LogoOnlyContentTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/LogoOnlyContentTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.nativeinput
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LogoOnlyContentTest {
+
+    @Test
+    fun `logo-only when the logo is visible and no hatch occupies space`() {
+        // The NewTabReturnHatchView container is always VISIBLE and collapses to zero height when no
+        // hatch is shown. A height of 0 must NOT count as a hatch - otherwise the logo would be
+        // pinned below the input widget and shift vertically between the Search and Duck.ai tabs.
+        assertTrue(isLogoOnly(logoVisible = true, hatchHeightPx = 0))
+    }
+
+    @Test
+    fun `not logo-only when the logo is not visible`() {
+        assertFalse(isLogoOnly(logoVisible = false, hatchHeightPx = 0))
+    }
+
+    @Test
+    fun `not logo-only when a real hatch occupies space`() {
+        assertFalse(isLogoOnly(logoVisible = true, hatchHeightPx = 120))
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -114,6 +114,17 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     @Volatile
     private var lastChatUrlSuggestions: List<AutoCompleteSuggestion> = emptyList()
 
+    // Whether the most recent empty-query chat-history fetch returned any chats. Read synchronously
+    // (via [hadRecentChats]) by the widget to decide whether to show the suggestions cover when the
+    // Duck.ai tab is selected with empty input. Covering only when content will actually appear keeps
+    // the morphing logo from being briefly covered then revealed (a flash) when there are no chats.
+    // Stale until the first empty-query fetch completes, so the first such transition will not cover.
+    @Volatile
+    private var lastEmptyQueryHadChats: Boolean = false
+
+    /** @see lastEmptyQueryHadChats */
+    fun hadRecentChats(): Boolean = lastEmptyQueryHadChats
+
     sealed class Command {
         data class UpdatePluginVisibility(val containerIds: List<Int>, val visible: Boolean) : Command()
     }
@@ -373,8 +384,13 @@ class NativeInputModeWidgetViewModel @Inject constructor(
                 AutoCompleteResult(query, emptyList())
             }
         }
+        val chatHistory = chatHistoryDeferred.await()
+        if (query.isEmpty()) {
+            // Remember whether an empty query yields chats so the cover decision can predict it next time.
+            lastEmptyQueryHadChats = chatHistory.isNotEmpty()
+        }
         val result = ChatTabSuggestions(
-            chatHistory = chatHistoryDeferred.await(),
+            chatHistory = chatHistory,
             urlSuggestions = urlSuggestionsDeferred.await(),
         )
         lastChatUrlSuggestions = result.urlSuggestions.suggestions

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -1063,11 +1063,16 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val previousOnChatSelected = this.onChatSelected
         this.onChatSelected = { animate ->
             previousOnChatSelected?.invoke(animate)
-            // Show the chat list adapter synchronously so async chat-history fetch doesn't leave a
-            // gap. On NTP the focusedView never covers the page (browserShowing=false), so the gap
+            // Show the chat list adapter synchronously so the async chat-history fetch doesn't leave
+            // a gap. On NTP the focusedView never covers the page (browserShowing=false), so the gap
             // exposes the NTP logo. The list's match_parent overlay background covers it even with
-            // zero items; real chat history populates when the WebView-backed fetch returns.
-            onShowSuggestions(ensureBinding().adapter)
+            // zero items; real chat history populates when the WebView-backed fetch returns. Only
+            // cover when there will be content to show (see [shouldShowChatSuggestionsCoverOnSelect]);
+            // covering an empty result and then clearing it produces a visible flash.
+            val recentChatsExpected = chatSuggestionsUserEnabled && viewModel.hadRecentChats()
+            if (shouldShowChatSuggestionsCoverOnSelect(inputText = text, recentChatsExpected = recentChatsExpected)) {
+                onShowSuggestions(ensureBinding().adapter)
+            }
             showSuggestions(text)
         }
 
@@ -1273,6 +1278,21 @@ internal fun NativeInputState.shouldShowToggleRowBack(): Boolean =
 
 internal fun NativeInputState.shouldShowCardRowBack(): Boolean =
     !toggleVisible && inputContext == NativeInputState.InputContext.BROWSER
+
+/**
+ * Whether to synchronously show the chat-suggestions list (an opaque overlay) when the Duck.ai tab is
+ * selected, to cover the NTP logo while the async chat-history fetch runs.
+ *
+ * Cover only when content will actually appear, otherwise the just-shown overlay is cleared ~200ms
+ * later when the fetch returns nothing — a visible flash of the list and of the NTP logo it briefly
+ * covered. Content appears when there is input text (the "Search for [query]" row at minimum), or
+ * when an empty query is expected to yield recent chats ([recentChatsExpected], cached from the
+ * previous empty-query fetch — see NativeInputModeWidgetViewModel.hadRecentChats).
+ */
+internal fun shouldShowChatSuggestionsCoverOnSelect(
+    inputText: String,
+    recentChatsExpected: Boolean,
+): Boolean = inputText.isNotEmpty() || recentChatsExpected
 
 /** Fire button placed inside the input field card at the leading edge — only in a fullscreen Duck.ai chat. */
 internal fun NativeInputState.shouldShowLeadingFireButton(): Boolean =

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetChatSuggestionsCoverTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetChatSuggestionsCoverTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui
+
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.shouldShowChatSuggestionsCoverOnSelect
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NativeInputModeWidgetChatSuggestionsCoverTest {
+
+    @Test
+    fun `cover is shown when the input has text, regardless of chat history`() {
+        // With text the fetch always yields content (at minimum the "Search for [query]" row), so the
+        // cover is filled and stays - no flash.
+        assertTrue(shouldShowChatSuggestionsCoverOnSelect(inputText = "weather", recentChatsExpected = false))
+        assertTrue(shouldShowChatSuggestionsCoverOnSelect(inputText = "a", recentChatsExpected = false))
+    }
+
+    @Test
+    fun `cover is shown when empty input is expected to yield recent chats`() {
+        // Empty input but recent chats will load, so covering avoids briefly exposing the logo.
+        assertTrue(shouldShowChatSuggestionsCoverOnSelect(inputText = "", recentChatsExpected = true))
+    }
+
+    @Test
+    fun `cover is not shown when empty input yields no content`() {
+        // Regression: covering an empty input with no chats meant the overlay was shown then cleared
+        // ~200ms later, flashing the list and the NTP logo behind it on search -> Duck.ai.
+        assertFalse(shouldShowChatSuggestionsCoverOnSelect(inputText = "", recentChatsExpected = false))
+    }
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -255,6 +255,52 @@ class NativeInputModeWidgetViewModelTest {
     }
 
     @Test
+    fun whenEmptyQueryFetchReturnsChatsThenHadRecentChatsTrue() = runTest {
+        whenever(chatSuggestionsReader.fetchSuggestions("")).thenReturn(
+            listOf(ChatSuggestion(chatId = "id", title = "t", lastEdit = LocalDateTime.now(), pinned = false)),
+        )
+
+        testee.fetchChatTabSuggestions(query = "", chatSuggestionsEnabled = true)
+
+        assertTrue(testee.hadRecentChats())
+    }
+
+    @Test
+    fun whenEmptyQueryFetchReturnsNoChatsThenHadRecentChatsFalse() = runTest {
+        whenever(chatSuggestionsReader.fetchSuggestions("")).thenReturn(emptyList())
+
+        testee.fetchChatTabSuggestions(query = "", chatSuggestionsEnabled = true)
+
+        assertFalse(testee.hadRecentChats())
+    }
+
+    @Test
+    fun whenChatSuggestionsDisabledThenEmptyQueryDoesNotReportRecentChats() = runTest {
+        whenever(chatSuggestionsReader.fetchSuggestions("")).thenReturn(
+            listOf(ChatSuggestion(chatId = "id", title = "t", lastEdit = LocalDateTime.now(), pinned = false)),
+        )
+
+        testee.fetchChatTabSuggestions(query = "", chatSuggestionsEnabled = false)
+
+        assertFalse(testee.hadRecentChats())
+    }
+
+    @Test
+    fun whenNonEmptyQueryFetchedThenCachedRecentChatsUnchanged() = runTest {
+        whenever(chatSuggestionsReader.fetchSuggestions("")).thenReturn(
+            listOf(ChatSuggestion(chatId = "id", title = "t", lastEdit = LocalDateTime.now(), pinned = false)),
+        )
+        whenever(chatSuggestionsReader.fetchSuggestions("weather")).thenReturn(emptyList())
+
+        testee.fetchChatTabSuggestions(query = "", chatSuggestionsEnabled = true)
+        assertTrue(testee.hadRecentChats())
+
+        testee.fetchChatTabSuggestions(query = "weather", chatSuggestionsEnabled = true)
+
+        assertTrue(testee.hadRecentChats())
+    }
+
+    @Test
     fun whenSearchAndDuckAiThenToggleVisible() = runTest {
         setIsEnabled(true)
         inputScreenUserSettingFlow.value = true


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/project/1212608036467427/task/1215279708895831?focus=true

### Description
Two issues fixed

Tab switch blinking: showed the chat-suggestions overlay synchronously to cover the morphing logo during the async fetch, then cleared it ~200ms later when an empty input returned no content, flashing the list and the logo behind it. Now only cover when there is input text (content is then guaranteed), via shouldShowChatSuggestionsCoverOnSelect.

Logo vertical shift between tabs: isLogoOnlyContent treated the NewTabReturnHatchView as present whenever it was VISIBLE, but that container is always VISIBLE and collapses to zero height when empty, so the logo was pinned below the taller Duck.ai widget. Now detect a real hatch via height > 0 (extracted as isLogoOnly), keeping the logo at a fixed vertical position.


### Steps to test this PR
- enable unified input toggle
- switch between tabs and observe smooth animation
- try the same but with existing recent chats in duck.ai

### UI changes
<img width="280" height="607" alt="output" src="https://github.com/user-attachments/assets/a366f8b6-5b75-45ab-9070-15f609489ae5" />
