### PR TITLE
Fix MULTI_PROFILE exception

### DIFF
--- a/browser-mode/browser-mode-impl/build.gradle
+++ b/browser-mode/browser-mode-impl/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     implementation KotlinX.coroutines.core
     implementation AndroidX.webkit
     implementation AndroidX.dataStore.preferences
+    implementation "com.squareup.logcat:logcat:_"
 
     testImplementation Testing.junit4
     testImplementation KotlinX.coroutines.test

--- a/browser-mode/browser-mode-impl/src/main/java/com/duckduckgo/browsermode/impl/RealFireModeAvailability.kt
+++ b/browser-mode/browser-mode-impl/src/main/java/com/duckduckgo/browsermode/impl/RealFireModeAvailability.kt
@@ -28,6 +28,9 @@ import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import logcat.LogPriority.ERROR
+import logcat.asLog
+import logcat.logcat
 import javax.inject.Inject
 
 @SingleInstanceIn(AppScope::class)
@@ -50,9 +53,16 @@ class RealFireModeAvailability @Inject constructor(
 
     private fun computeAndCache(): Boolean {
         cachedAvailability?.let { return it }
-        val value = WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE) &&
-            fireModeFeature.fireTabs().isEnabled()
+        val value = isMultiProfileSupported() && fireModeFeature.fireTabs().isEnabled()
         cachedAvailability = value
         return value
+    }
+
+    private fun isMultiProfileSupported(): Boolean {
+        return runCatching { WebViewFeature.isFeatureSupported(WebViewFeature.MULTI_PROFILE) }
+            .getOrElse { exception ->
+                logcat(ERROR) { "Failed to check MULTI_PROFILE WebView support: ${exception.asLog()}" }
+                false
+            }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1215356848436599?focus=true

### Description

- Catches `ExceptionInInitializerError` when checking `MULTI_PROFILE`

### Steps to test this PR
- [ ] Code review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change in feature gating; failure path only disables Fire Mode and adds logging.
> 
> **Overview**
> Prevents crashes when **Fire Mode** availability is computed by wrapping the `WebViewFeature.MULTI_PROFILE` support check in `runCatching` instead of calling it inline.
> 
> On failure, the app logs an **ERROR** via logcat (new `com.squareup.logcat:logcat` dependency on `browser-mode-impl`) and treats multi-profile as unsupported, so Fire Mode stays unavailable rather than taking down the process.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caf476b0cf393ea055c04884a0c6ce00d53475d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->