### PR TITLE
Show Duck.ai full-screen UX when Duck.ai disabled

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -940,7 +940,10 @@ class RealDuckChat @Inject constructor(
                     isDuckChatFeatureEnabled && isDuckChatUserEnabled && isVoiceChatEntryPointEnabled
             _showVoiceChatEntry.emit(showVoiceChatEntry)
 
-            val showFullScreenMode = isDuckChatFeatureEnabled && isDuckChatUserEnabled &&
+            // Full screen mode (new Duck.ai header, unified input, hamburger menu) is intentionally NOT gated on
+            // isDuckChatUserEnabled: users who disabled Duck.ai still get the new UX when navigating directly to a
+            // duck.ai tab. It remains gated on the feature rollout flag/setting only.
+            val showFullScreenMode = isDuckChatFeatureEnabled &&
                 (duckChatFeature.fullscreenMode().isEnabled() || duckChatFeatureRepository.isFullScreenModeUserSettingEnabled())
             isFullscreenModeEnabled = showFullScreenMode
             _showFullScreenMode.emit(showFullScreenMode)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -230,6 +230,30 @@ class RealDuckChatTest {
     }
 
     @Test
+    fun whenFeatureEnabledAndUserDisabledThenShowFullScreenModeIsTrue() = runTest {
+        duckChatFeature.self().setRawStoredState(State(true))
+        duckChatFeature.fullscreenMode().setRawStoredState(State(true))
+        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(false)
+
+        testee.onPrivacyConfigDownloaded()
+        advanceUntilIdle()
+
+        assertTrue(testee.showFullScreenMode.value)
+    }
+
+    @Test
+    fun whenFeatureDisabledThenShowFullScreenModeIsFalse() = runTest {
+        duckChatFeature.self().setRawStoredState(State(false))
+        duckChatFeature.fullscreenMode().setRawStoredState(State(true))
+        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
+
+        testee.onPrivacyConfigDownloaded()
+        advanceUntilIdle()
+
+        assertFalse(testee.showFullScreenMode.value)
+    }
+
+    @Test
     fun whenObserveShowInBrowserMenuUserSettingThenEmitCorrectValues() = runTest {
         whenever(mockDuckChatFeatureRepository.observeShowInBrowserMenu()).thenReturn(flowOf(true, false))
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1215344156275513?focus=true

### Description

Following the agreed cross-platform decision, we will **not** hide the new Duck.ai tab UX when a user has Duck.ai disabled. If a user navigates directly to a duck.ai URL with Duck.ai disabled, they should still see the new header, the unified input, and the new hamburger menu.

On Android this was previously hidden because `showFullScreenMode` was gated on `isDuckChatUserEnabled`. When Duck.ai was disabled, the flag went false, so `SpecialUrlDetector` redirected duck.ai to the legacy standalone experience and `evaluateDuckAIPage` never enabled full-screen mode.

This PR decouples `showFullScreenMode` from `isDuckChatUserEnabled`, so the full-screen experience tracks the feature rollout (`fullscreenMode` flag / user setting) rather than the user's global Duck.ai setting — matching iOS, where the unified input is not dependent on the global Duck.ai setting.

Duck.ai entry points (omnibar/menu shortcuts, address-bar option, SERP rewrite) remain gated on the user setting, so we don't surface Duck.ai when it's disabled — only the in-tab experience on direct navigation.

### Steps to test this PR

_Duck.ai disabled, direct navigation_
- [x] Internal build, with the `fullscreenMode` feature flag enabled
- [x] Disable Duck.ai in Settings (global Duck.ai toggle off)
- [x] Navigate directly to `duck.ai` in the address bar
- [x] Confirm the new Duck.ai header, unified input, and new hamburger menu are shown (not the legacy standalone experience)

_Feature flag off still gates_
- [x] With the `fullscreenMode` flag and its user setting off, confirm the new full-screen UX is not shown

### UI changes
| Before  | After |
| ------ | ----- |
|(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small gating change in Duck.ai UX with explicit tests; entry points still respect the user disable setting.
> 
> **Overview**
> **`showFullScreenMode`** in `RealDuckChat` no longer depends on the global **Duck.ai enabled** user setting. It now follows only the Duck.ai feature flag plus **`fullscreenMode`** rollout / user setting, so direct navigation to a duck.ai tab still gets the new header, unified input, and hamburger menu when Duck.ai is turned off in Settings—aligned with iOS.
> 
> Entry points (omnibar, menu, address bar, etc.) are unchanged and still require the user setting. Tests cover full-screen on with feature on + user off, and off when the base feature is disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 282ce51c577a6cfbf34ac0ce84c1d8d411e2093f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->