### PR TITLE
Show/hide waving Dax and fin on new-tab onboarding bubbles by fit

### DIFF
--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/shape/DaxBubbleBottomEdgeTreatment.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/shape/DaxBubbleBottomEdgeTreatment.kt
@@ -41,7 +41,7 @@ open class DaxBubbleBottomEdgeTreatment(
         shapePath: ShapePath,
     ) {
         val scaleFactor = (heightPx.toFloat() / ORIGINAL_BOTTOM_ARROW_HEIGHT_DP) * depthFraction
-        val arrowWidth = 47.14058f * scaleFactor
+        val arrowWidth = ORIGINAL_BOTTOM_ARROW_WIDTH_DP * scaleFactor
         val arrowStart = center - (arrowWidth / 2)
 
         shapePath.lineTo(arrowStart, 0f)
@@ -132,5 +132,6 @@ open class DaxBubbleBottomEdgeTreatment(
 
     companion object {
         const val ORIGINAL_BOTTOM_ARROW_HEIGHT_DP = 30
+        const val ORIGINAL_BOTTOM_ARROW_WIDTH_DP = 47.14058f
     }
 }

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/shape/DaxOnboardingBubbleBrandDesignUpdateCardView.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/shape/DaxOnboardingBubbleBrandDesignUpdateCardView.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.content.res.ColorStateList
 import android.content.res.Configuration
 import android.graphics.Outline
+import android.graphics.RectF
 import android.os.Build
 import android.util.AttributeSet
 import android.util.TypedValue
@@ -45,6 +46,8 @@ constructor(
     private var animatableEdgeTreatment: AnimatableOffsetEdgeTreatment? = null
     private val cornerRadius: Float
     private var showArrow: Boolean = true
+    private var arrowOffsetStartPx: Int = 0
+    private var arrowOffsetEndPx: Int = 0
     private var bottomEdgeTreatment: EdgeTreatment
     private val baseBottomEdgeTreatment: DaxBubbleBottomEdgeTreatment
     private var originalBottomMargin: Int? = null
@@ -72,6 +75,9 @@ constructor(
             true,
         )
         attr.recycle()
+
+        arrowOffsetStartPx = offsetStart
+        arrowOffsetEndPx = offsetEnd
 
         if (offsetStart != 0 && offsetEnd != 0) {
             throw IllegalArgumentException("Only one of arrowOffsetStart or arrowOffsetEnd can be set")
@@ -224,6 +230,25 @@ constructor(
                 layoutParams = params
             }
         }
+    }
+
+    /**
+     * Full-depth bounding box of the bubble tail (fin) in this view's local coordinates.
+     * `top` is where the fin joins the card body, `bottom` is the fin tip. Full depth
+     * (independent of the animated [arrowDepthFraction]) so callers get a stable reference
+     * while the fin animates. Null when the arrow is disabled.
+     */
+    fun arrowBounds(): RectF? {
+        if (!showArrow) return null
+        val finHeight = DaxBubbleBottomEdgeTreatment.ORIGINAL_BOTTOM_ARROW_HEIGHT_DP.toPx().toFloat()
+        val finWidth = DaxBubbleBottomEdgeTreatment.ORIGINAL_BOTTOM_ARROW_WIDTH_DP *
+            (finHeight / DaxBubbleBottomEdgeTreatment.ORIGINAL_BOTTOM_ARROW_HEIGHT_DP)
+        val centerX = when {
+            arrowOffsetStartPx != 0 -> arrowOffsetStartPx.toFloat()
+            arrowOffsetEndPx != 0 -> width - arrowOffsetEndPx.toFloat()
+            else -> width / 2f
+        }
+        return RectF(centerX - finWidth / 2f, height.toFloat(), centerX + finWidth / 2f, height + finHeight)
     }
 
     private fun resolveOnboardingTheme(context: Context): Context {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -49,6 +49,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams
+import android.view.ViewTreeObserver
 import android.webkit.PermissionRequest
 import android.webkit.SslErrorHandler
 import android.webkit.ValueCallback
@@ -1208,6 +1209,7 @@ class BrowserTabFragment :
         configureNavigationBar()
         configureOmnibar()
         configureBrowserTabKeyboardListener()
+        renderer.configureBrandDesignFitListener()
 
         disableViewStateSaving()
 
@@ -2037,6 +2039,7 @@ class BrowserTabFragment :
         }
         contextualSheetBottomSheetCallback = null
         browserNavigationBarIntegration.onDestroyView()
+        renderer.removeBrandDesignFitListener()
         super.onDestroyView()
     }
 
@@ -5714,6 +5717,7 @@ class BrowserTabFragment :
         private var lastSeenAutoCompleteViewState: AutoCompleteViewState? = null
         private var lastSeenCtaViewState: CtaViewState? = null
         private var lastSeenPrivacyShieldViewState: PrivacyShieldViewState? = null
+        private var brandDesignFitLayoutListener: ViewTreeObserver.OnGlobalLayoutListener? = null
 
         fun renderPrivacyShield(viewState: PrivacyShieldViewState) {
             renderIfChanged(viewState, lastSeenPrivacyShieldViewState) {
@@ -6078,10 +6082,26 @@ class BrowserTabFragment :
             if (configuration is DaxBubbleCta.BrandDesignUpdateBubbleCta) {
                 setBrowserBackgroundRes(configuration.backgroundRes, useRebrandBackground = true)
                 setNewTabBackgroundColor(com.duckduckgo.mobile.android.R.attr.onboardingSurfaceBackdrop)
+                brandDesignDialogScrollView.post { configuration.applyFit() }
             } else {
                 viewModel.setBrowserBackground(appTheme.isLightModeEnabled())
             }
             viewModel.onCtaShown()
+        }
+
+        fun configureBrandDesignFitListener() {
+            val listener = ViewTreeObserver.OnGlobalLayoutListener {
+                (lastSeenCtaViewState?.cta as? DaxBubbleCta.BrandDesignUpdateBubbleCta)?.applyFit()
+            }
+            brandDesignFitLayoutListener = listener
+            brandDesignDialogScrollView.viewTreeObserver.addOnGlobalLayoutListener(listener)
+        }
+
+        fun removeBrandDesignFitListener() {
+            brandDesignFitLayoutListener?.let {
+                brandDesignDialogScrollView.viewTreeObserver.removeOnGlobalLayoutListener(it)
+            }
+            brandDesignFitLayoutListener = null
         }
 
         private fun showPrivacyProSkippedOnboardingBottomSheet(configuration: SubscriptionPromoModalCta) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1209,7 +1209,6 @@ class BrowserTabFragment :
         configureNavigationBar()
         configureOmnibar()
         configureBrowserTabKeyboardListener()
-        renderer.configureBrandDesignFitListener()
 
         disableViewStateSaving()
 
@@ -4242,6 +4241,7 @@ class BrowserTabFragment :
 
     private fun hideDaxBubbleCta(cta: DaxBubbleCta?) {
         (cta as? DaxBubbleCta.BrandDesignUpdateBubbleCta)?.cancelRunningAnimations()
+        renderer.removeBrandDesignFitListener()
         newBrowserTab.browserBackground.setImageResource(0)
         val wasBrandDesign = newBrowserTab.rebrandBrowserBackground.isVisible
         newBrowserTab.rebrandBrowserBackground.apply {
@@ -6082,14 +6082,17 @@ class BrowserTabFragment :
             if (configuration is DaxBubbleCta.BrandDesignUpdateBubbleCta) {
                 setBrowserBackgroundRes(configuration.backgroundRes, useRebrandBackground = true)
                 setNewTabBackgroundColor(com.duckduckgo.mobile.android.R.attr.onboardingSurfaceBackdrop)
+                configureBrandDesignFitListener()
                 brandDesignDialogScrollView.post { configuration.applyFit() }
             } else {
+                removeBrandDesignFitListener()
                 viewModel.setBrowserBackground(appTheme.isLightModeEnabled())
             }
             viewModel.onCtaShown()
         }
 
         fun configureBrandDesignFitListener() {
+            removeBrandDesignFitListener()
             val listener = ViewTreeObserver.OnGlobalLayoutListener {
                 (lastSeenCtaViewState?.cta as? DaxBubbleCta.BrandDesignUpdateBubbleCta)?.applyFit()
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -4953,6 +4953,9 @@ class BrowserTabFragment :
         renderer.renderHomeCta()
         recreateBrowserMenu()
         viewModel.onConfigurationChanged(orientationChanged)
+        if (orientationChanged) {
+            renderer.reapplyBubbleForOrientation()
+        }
     }
 
     fun onBackPressed(isCustomTab: Boolean = false): Boolean {
@@ -6105,6 +6108,10 @@ class BrowserTabFragment :
                 brandDesignDialogScrollView.viewTreeObserver.removeOnGlobalLayoutListener(it)
             }
             brandDesignFitLayoutListener = null
+        }
+
+        fun reapplyBubbleForOrientation() {
+            (lastSeenCtaViewState?.cta as? DaxBubbleCta.BrandDesignUpdateBubbleCta)?.onOrientationChanged()
         }
 
         private fun showPrivacyProSkippedOnboardingBottomSheet(configuration: SubscriptionPromoModalCta) {

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -24,6 +24,7 @@ import android.animation.ValueAnimator
 import android.content.Context
 import android.content.res.ColorStateList
 import android.content.res.Configuration
+import android.graphics.RectF
 import android.graphics.drawable.GradientDrawable
 import android.net.Uri
 import android.view.ContextThemeWrapper
@@ -39,6 +40,8 @@ import androidx.annotation.VisibleForTesting
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import androidx.core.view.doOnPreDraw
+import androidx.core.view.isGone
+import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.core.widget.ImageViewCompat
@@ -1585,6 +1588,7 @@ sealed class DaxBubbleCta(
         appInstallStore: AppInstallStore,
         open val isLightTheme: Boolean,
         open val deviceInfo: DeviceInfo,
+        open val onboardingImprovementsEnabled: Boolean = true,
     ) : DaxBubbleCta(
         ctaId = ctaId,
         title = title,
@@ -1609,6 +1613,8 @@ sealed class DaxBubbleCta(
             private const val DIALOG_CONTENT_FADE_IN_DURATION = 200L
             private const val HEADER_IMAGE_FADE_IN_DURATION = 300L
             private const val ARROW_DEPTH_ANIMATION_DURATION = 200L
+            private const val FIT_SETTLE_DELAY_MS = 100L
+            private const val DAX_WAVE_START_FRAME = 17
             private const val TYPING_DELAY_MS = 20L
             private const val TYPING_POST_DELAY_MS = 20L
             private const val DISMISS_BORDER_WIDTH_DP = 1.5f
@@ -1633,6 +1639,9 @@ sealed class DaxBubbleCta(
         private var contentFadeInAnimator: AnimatorSet? = null
         private var fadeOutAnimator: AnimatorSet? = null
         private var arrowDepthAnimator: ValueAnimator? = null
+        private var fitArrowAnimator: ValueAnimator? = null
+        private var lastDaxFits: Boolean? = null
+        private val fitRunnable = Runnable { decideFit() }
 
         protected fun resolveOnboardingContext(context: Context): Context {
             val themeRes = if (isLightTheme) {
@@ -1666,14 +1675,18 @@ sealed class DaxBubbleCta(
             container.findViewById<LottieAnimationView>(R.id.wavingDax)?.let { dax ->
                 if (showsWavingDax != null && !container.isPhoneLandscape()) {
                     showsWavingDax.configureWavingDax(dax, deviceInfo)
-                    if (!dax.isVisible || dax.alpha == 0f) {
-                        dax.progress = 0f
-                        dax.alpha = 1f
-                        dax.isVisible = true
-                        dax.post { dax.playAnimation() }
+                    if (onboardingImprovementsEnabled) {
+                        dax.isInvisible = true
+                    } else {
+                        if (!dax.isVisible || dax.alpha == 0f) {
+                            dax.progress = 0f
+                            dax.alpha = 1f
+                            dax.isVisible = true
+                            dax.post { dax.playAnimation() }
+                        }
                     }
                 } else {
-                    dax.isVisible = false
+                    dax.isGone = true
                 }
             }
         }
@@ -1698,6 +1711,116 @@ sealed class DaxBubbleCta(
             return true
         }
 
+        private fun viewBoundsOnScreen(view: View, out: RectF) {
+            out.set(0f, 0f, view.width.toFloat(), view.height.toFloat())
+            view.matrix.mapRect(out)
+            val loc = IntArray(2)
+            (view.parent as? View)?.getLocationOnScreen(loc)
+            out.offset((loc[0] + view.left).toFloat(), (loc[1] + view.top).toFloat())
+        }
+
+        /**
+         * The fin depth [showCta] should apply, or null when [applyFit] owns the fin (waving-Dax
+         * CTAs in portrait/tablet). The null case mirrors [computeDaxFits]'s ownership guard, so
+         * [showCta] and [applyFit] can never both write the fin.
+         */
+        private fun showCtaFinTarget(container: View): Float? {
+            if (onboardingImprovementsEnabled && this is ShowsWavingDax && !container.isPhoneLandscape()) return null
+            return if (showArrow && !container.isPhoneLandscape()) 1f else 0f
+        }
+
+        /**
+         * Hide eagerly, reveal lazily. A hide (does not fit) applies immediately so the Dax never
+         * lingers or drifts as the keyboard rises; a reveal (fits) is debounced to
+         * [FIT_SETTLE_DELAY_MS] so transient measurements during a content transition or keyboard
+         * settle never flash the Dax/fin in then straight back out. No-op for CTAs without a
+         * waving Dax, in landscape, or when not shown.
+         */
+        fun applyFit() {
+            if (!onboardingImprovementsEnabled) return
+            val container = ctaView ?: return
+            container.removeCallbacks(fitRunnable)
+            val fits = computeDaxFits() ?: return
+            if (fits) {
+                container.postDelayed(fitRunnable, FIT_SETTLE_DELAY_MS)
+            } else {
+                applyFitResult(false)
+            }
+        }
+
+        private fun decideFit() {
+            if (computeDaxFits() == true) applyFitResult(true)
+        }
+
+        private fun computeDaxFits(): Boolean? {
+            if (this !is ShowsWavingDax) return null
+            val container = ctaView ?: return null
+            if (!container.isShown || container.isPhoneLandscape()) return null
+
+            val dax = container.findViewById<LottieAnimationView>(R.id.wavingDax) ?: return null
+            val cardView = container.findViewById<DaxOnboardingBubbleBrandDesignUpdateCardView>(R.id.brandDesignCardView) ?: return null
+            val finBounds = cardView.arrowBounds() ?: return null
+
+            val daxRect = RectF()
+            viewBoundsOnScreen(dax, daxRect)
+
+            val cardLoc = IntArray(2)
+            cardView.getLocationOnScreen(cardLoc)
+
+            return daxFits(
+                daxTop = daxRect.top.toInt(),
+                daxLeft = daxRect.left.toInt(),
+                daxRight = daxRect.right.toInt(),
+                cardBodyBottom = cardLoc[1] + finBounds.top.toInt(),
+                finBottom = cardLoc[1] + finBounds.bottom.toInt(),
+                finLeft = cardLoc[0] + finBounds.left.toInt(),
+                finRight = cardLoc[0] + finBounds.right.toInt(),
+            )
+        }
+
+        private fun applyFitResult(fits: Boolean) {
+            if (fits == lastDaxFits) return
+            lastDaxFits = fits
+
+            val container = ctaView ?: return
+            val dax = container.findViewById<LottieAnimationView>(R.id.wavingDax) ?: return
+            val cardView = container.findViewById<DaxOnboardingBubbleBrandDesignUpdateCardView>(R.id.brandDesignCardView) ?: return
+
+            if (fits) {
+                if (!dax.isVisible) {
+                    dax.setMinFrame(DAX_WAVE_START_FRAME)
+                    dax.progress = 0f
+                    dax.isVisible = true
+                    dax.post { dax.playAnimation() }
+                }
+            } else {
+                dax.isInvisible = true
+            }
+
+            val finTarget = if (fits && showArrow) 1f else 0f
+            val current = cardView.arrowDepthFraction
+            arrowDepthAnimator?.removeAllUpdateListeners()
+            arrowDepthAnimator?.cancel()
+            fitArrowAnimator?.removeAllUpdateListeners()
+            fitArrowAnimator?.cancel()
+            if (current != finTarget) {
+                fitArrowAnimator = buildArrowDepthAnimator(cardView, current, finTarget).apply { start() }
+            } else {
+                cardView.setArrowDepthFraction(finTarget)
+            }
+        }
+
+        private fun buildArrowDepthAnimator(
+            cardView: DaxOnboardingBubbleBrandDesignUpdateCardView,
+            from: Float,
+            to: Float,
+        ): ValueAnimator =
+            ValueAnimator.ofFloat(from, to).apply {
+                duration = ARROW_DEPTH_ANIMATION_DURATION
+                interpolator = FastOutSlowInInterpolator()
+                addUpdateListener { cardView.setArrowDepthFraction(it.animatedValue as Float) }
+            }
+
         private fun resetAllIncludesExcept(view: View, active: View) {
             getAllContentIncludes(view).forEach { include ->
                 if (include == active) {
@@ -1716,10 +1839,10 @@ sealed class DaxBubbleCta(
             ctaView = container
 
             cancelRunningAnimations()
+            lastDaxFits = null
             val isContentTransition = container.alpha > 0f && container.isVisible // card already visible from previous CTA
 
             val cardView = container.findViewById<DaxOnboardingBubbleBrandDesignUpdateCardView>(R.id.brandDesignCardView)
-            val targetDepth = if (showArrow && !container.isPhoneLandscape()) 1f else 0f
 
             val daxTitle = container.context.getString(title)
             val daxDescription = container.context.getString(description).preventWidows()
@@ -1774,14 +1897,15 @@ sealed class DaxBubbleCta(
                         )
                         // Read depth live: the first-show arm synchronously sets it before this lambda runs,
                         // so a value captured at function entry would animate from a stale snapshot.
-                        val currentDepth = cardView.arrowDepthFraction
-                        if (targetDepth != currentDepth) {
-                            arrowDepthAnimator = ValueAnimator.ofFloat(currentDepth, targetDepth).apply {
-                                duration = ARROW_DEPTH_ANIMATION_DURATION
-                                interpolator = FastOutSlowInInterpolator()
-                                addUpdateListener { cardView.setArrowDepthFraction(it.animatedValue as Float) }
+                        val targetDepth = showCtaFinTarget(container)
+                        if (targetDepth != null) {
+                            val currentDepth = cardView.arrowDepthFraction
+                            if (targetDepth > currentDepth) {
+                                arrowDepthAnimator = buildArrowDepthAnimator(cardView, currentDepth, targetDepth)
+                                animators.add(arrowDepthAnimator!!)
+                            } else if (targetDepth != currentDepth) {
+                                cardView.setArrowDepthFraction(targetDepth)
                             }
-                            animators.add(arrowDepthAnimator!!)
                         }
                         contentFadeInAnimator = AnimatorSet().apply {
                             playTogether(animators.toList())
@@ -1827,7 +1951,7 @@ sealed class DaxBubbleCta(
                 if (headerImage?.isVisible == true) {
                     headerImage.alpha = 1f
                 }
-                cardView.setArrowDepthFraction(targetDepth)
+                showCtaFinTarget(container)?.let { cardView.setArrowDepthFraction(it) }
             }
 
             if (isContentTransition) {
@@ -1884,7 +2008,7 @@ sealed class DaxBubbleCta(
                 resetTextAlignment()
                 configureContentViews(container)
                 applyWavingDaxState(container, wavingDax)
-                cardView.setArrowDepthFraction(targetDepth)
+                cardView.setArrowDepthFraction(showCtaFinTarget(container) ?: 0f)
                 container.show()
                 container.animate().alpha(1f).setDuration(DIALOG_FADE_IN_DURATION).setStartDelay(200L)
                     .withEndAction {
@@ -1910,7 +2034,7 @@ sealed class DaxBubbleCta(
                     applySettledState()
                 }
                 contentFadeInAnimator?.let { if (it.isRunning) it.end() }
-                cardView.setArrowDepthFraction(targetDepth)
+                showCtaFinTarget(container)?.let { cardView.setArrowDepthFraction(it) }
                 if (wasAnimating) {
                     onTypingAnimationFinished()
                 }
@@ -1929,6 +2053,11 @@ sealed class DaxBubbleCta(
             arrowDepthAnimator?.removeAllUpdateListeners()
             arrowDepthAnimator?.cancel()
             arrowDepthAnimator = null
+            fitArrowAnimator?.removeAllUpdateListeners()
+            fitArrowAnimator?.cancel()
+            fitArrowAnimator = null
+            lastDaxFits = null
+            ctaView?.removeCallbacks(fitRunnable)
             ctaView?.animate()?.cancel()
         }
 

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -1678,6 +1678,26 @@ sealed class DaxBubbleCta(
             }
         }
 
+        /**
+         * Pure fit test. The Dax fits unless its head intrudes into the card body (above the
+         * top-of-fin line) or its rect overlaps the fin's own region. The Dax may sit in the
+         * fin's vertical band as long as it is horizontally clear of the fin.
+         */
+        internal fun daxFits(
+            daxTop: Int,
+            daxLeft: Int,
+            daxRight: Int,
+            cardBodyBottom: Int,
+            finBottom: Int,
+            finLeft: Int,
+            finRight: Int,
+        ): Boolean {
+            if (daxTop < cardBodyBottom) return false
+            val overlapsFinHorizontally = daxRight > finLeft && daxLeft < finRight
+            if (daxTop < finBottom && overlapsFinHorizontally) return false
+            return true
+        }
+
         private fun resetAllIncludesExcept(view: View, active: View) {
             getAllContentIncludes(view).forEach { include ->
                 if (include == active) {

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -24,7 +24,6 @@ import android.animation.ValueAnimator
 import android.content.Context
 import android.content.res.ColorStateList
 import android.content.res.Configuration
-import android.graphics.RectF
 import android.graphics.drawable.GradientDrawable
 import android.net.Uri
 import android.view.ContextThemeWrapper
@@ -1613,8 +1612,6 @@ sealed class DaxBubbleCta(
             private const val DIALOG_CONTENT_FADE_IN_DURATION = 200L
             private const val HEADER_IMAGE_FADE_IN_DURATION = 300L
             private const val ARROW_DEPTH_ANIMATION_DURATION = 200L
-            private const val FIT_SETTLE_DELAY_MS = 100L
-            private const val DAX_WAVE_START_FRAME = 17
             private const val TYPING_DELAY_MS = 20L
             private const val TYPING_POST_DELAY_MS = 20L
             private const val DISMISS_BORDER_WIDTH_DP = 1.5f
@@ -1639,9 +1636,14 @@ sealed class DaxBubbleCta(
         private var contentFadeInAnimator: AnimatorSet? = null
         private var fadeOutAnimator: AnimatorSet? = null
         private var arrowDepthAnimator: ValueAnimator? = null
-        private var fitArrowAnimator: ValueAnimator? = null
-        private var lastDaxFits: Boolean? = null
-        private val fitRunnable = Runnable { decideFit() }
+
+        private val wavingDaxController: WavingDaxController? by lazy {
+            if (onboardingImprovementsEnabled && this is ShowsWavingDax) {
+                WavingDaxController(showArrow, deviceInfo)
+            } else {
+                null
+            }
+        }
 
         protected fun resolveOnboardingContext(context: Context): Context {
             val themeRes = if (isLightTheme) {
@@ -1692,134 +1694,19 @@ sealed class DaxBubbleCta(
         }
 
         /**
-         * Pure fit test. The Dax fits unless its head intrudes into the card body (above the
-         * top-of-fin line) or its rect overlaps the fin's own region. The Dax may sit in the
-         * fin's vertical band as long as it is horizontally clear of the fin.
-         */
-        internal fun daxFits(
-            daxTop: Int,
-            daxLeft: Int,
-            daxRight: Int,
-            cardBodyBottom: Int,
-            finBottom: Int,
-            finLeft: Int,
-            finRight: Int,
-        ): Boolean {
-            if (daxTop < cardBodyBottom) return false
-            val overlapsFinHorizontally = daxRight > finLeft && daxLeft < finRight
-            if (daxTop < finBottom && overlapsFinHorizontally) return false
-            return true
-        }
-
-        private fun viewBoundsOnScreen(view: View, out: RectF) {
-            out.set(0f, 0f, view.width.toFloat(), view.height.toFloat())
-            view.matrix.mapRect(out)
-            val loc = IntArray(2)
-            (view.parent as? View)?.getLocationOnScreen(loc)
-            out.offset((loc[0] + view.left).toFloat(), (loc[1] + view.top).toFloat())
-        }
-
-        /**
-         * The fin depth [showCta] should apply, or null when [applyFit] owns the fin (waving-Dax
-         * CTAs in portrait/tablet). The null case mirrors [computeDaxFits]'s ownership guard, so
-         * [showCta] and [applyFit] can never both write the fin.
+         * The fin depth [showCta] should apply, or null when the controller owns the fin (waving-Dax
+         * CTAs in portrait/tablet). The null case mirrors the controller's portrait/tablet ownership
+         * guard, so [showCta] and the controller can never both write the fin.
          */
         private fun showCtaFinTarget(container: View): Float? {
             if (onboardingImprovementsEnabled && this is ShowsWavingDax && !container.isPhoneLandscape()) return null
             return if (showArrow && !container.isPhoneLandscape()) 1f else 0f
         }
 
-        /**
-         * Hide eagerly, reveal lazily. A hide (does not fit) applies immediately so the Dax never
-         * lingers or drifts as the keyboard rises; a reveal (fits) is debounced to
-         * [FIT_SETTLE_DELAY_MS] so transient measurements during a content transition or keyboard
-         * settle never flash the Dax/fin in then straight back out. No-op for CTAs without a
-         * waving Dax, in landscape, or when not shown.
-         */
         fun applyFit() {
-            if (!onboardingImprovementsEnabled) return
             val container = ctaView ?: return
-            container.removeCallbacks(fitRunnable)
-            val fits = computeDaxFits() ?: return
-            if (fits) {
-                container.postDelayed(fitRunnable, FIT_SETTLE_DELAY_MS)
-            } else {
-                applyFitResult(false)
-            }
+            wavingDaxController?.applyFit(container)
         }
-
-        private fun decideFit() {
-            if (computeDaxFits() == true) applyFitResult(true)
-        }
-
-        private fun computeDaxFits(): Boolean? {
-            if (this !is ShowsWavingDax) return null
-            val container = ctaView ?: return null
-            if (!container.isShown || container.isPhoneLandscape()) return null
-
-            val dax = container.findViewById<LottieAnimationView>(R.id.wavingDax) ?: return null
-            val cardView = container.findViewById<DaxOnboardingBubbleBrandDesignUpdateCardView>(R.id.brandDesignCardView) ?: return null
-            val finBounds = cardView.arrowBounds() ?: return null
-
-            val daxRect = RectF()
-            viewBoundsOnScreen(dax, daxRect)
-
-            val cardLoc = IntArray(2)
-            cardView.getLocationOnScreen(cardLoc)
-
-            return daxFits(
-                daxTop = daxRect.top.toInt(),
-                daxLeft = daxRect.left.toInt(),
-                daxRight = daxRect.right.toInt(),
-                cardBodyBottom = cardLoc[1] + finBounds.top.toInt(),
-                finBottom = cardLoc[1] + finBounds.bottom.toInt(),
-                finLeft = cardLoc[0] + finBounds.left.toInt(),
-                finRight = cardLoc[0] + finBounds.right.toInt(),
-            )
-        }
-
-        private fun applyFitResult(fits: Boolean) {
-            if (fits == lastDaxFits) return
-            lastDaxFits = fits
-
-            val container = ctaView ?: return
-            val dax = container.findViewById<LottieAnimationView>(R.id.wavingDax) ?: return
-            val cardView = container.findViewById<DaxOnboardingBubbleBrandDesignUpdateCardView>(R.id.brandDesignCardView) ?: return
-
-            if (fits) {
-                if (!dax.isVisible) {
-                    dax.setMinFrame(DAX_WAVE_START_FRAME)
-                    dax.progress = 0f
-                    dax.isVisible = true
-                    dax.post { dax.playAnimation() }
-                }
-            } else {
-                dax.isInvisible = true
-            }
-
-            val finTarget = if (fits && showArrow) 1f else 0f
-            val current = cardView.arrowDepthFraction
-            arrowDepthAnimator?.removeAllUpdateListeners()
-            arrowDepthAnimator?.cancel()
-            fitArrowAnimator?.removeAllUpdateListeners()
-            fitArrowAnimator?.cancel()
-            if (current != finTarget) {
-                fitArrowAnimator = buildArrowDepthAnimator(cardView, current, finTarget).apply { start() }
-            } else {
-                cardView.setArrowDepthFraction(finTarget)
-            }
-        }
-
-        private fun buildArrowDepthAnimator(
-            cardView: DaxOnboardingBubbleBrandDesignUpdateCardView,
-            from: Float,
-            to: Float,
-        ): ValueAnimator =
-            ValueAnimator.ofFloat(from, to).apply {
-                duration = ARROW_DEPTH_ANIMATION_DURATION
-                interpolator = FastOutSlowInInterpolator()
-                addUpdateListener { cardView.setArrowDepthFraction(it.animatedValue as Float) }
-            }
 
         private fun resetAllIncludesExcept(view: View, active: View) {
             getAllContentIncludes(view).forEach { include ->
@@ -1839,7 +1726,7 @@ sealed class DaxBubbleCta(
             ctaView = container
 
             cancelRunningAnimations()
-            lastDaxFits = null
+            wavingDaxController?.reset()
             val isContentTransition = container.alpha > 0f && container.isVisible // card already visible from previous CTA
 
             val cardView = container.findViewById<DaxOnboardingBubbleBrandDesignUpdateCardView>(R.id.brandDesignCardView)
@@ -1900,11 +1787,13 @@ sealed class DaxBubbleCta(
                         val targetDepth = showCtaFinTarget(container)
                         if (targetDepth != null) {
                             val currentDepth = cardView.arrowDepthFraction
-                            if (targetDepth > currentDepth) {
-                                arrowDepthAnimator = buildArrowDepthAnimator(cardView, currentDepth, targetDepth)
+                            if (targetDepth != currentDepth) {
+                                arrowDepthAnimator = ValueAnimator.ofFloat(currentDepth, targetDepth).apply {
+                                    duration = ARROW_DEPTH_ANIMATION_DURATION
+                                    interpolator = FastOutSlowInInterpolator()
+                                    addUpdateListener { cardView.setArrowDepthFraction(it.animatedValue as Float) }
+                                }
                                 animators.add(arrowDepthAnimator!!)
-                            } else if (targetDepth != currentDepth) {
-                                cardView.setArrowDepthFraction(targetDepth)
                             }
                         }
                         contentFadeInAnimator = AnimatorSet().apply {
@@ -2053,11 +1942,7 @@ sealed class DaxBubbleCta(
             arrowDepthAnimator?.removeAllUpdateListeners()
             arrowDepthAnimator?.cancel()
             arrowDepthAnimator = null
-            fitArrowAnimator?.removeAllUpdateListeners()
-            fitArrowAnimator?.cancel()
-            fitArrowAnimator = null
-            lastDaxFits = null
-            ctaView?.removeCallbacks(fitRunnable)
+            ctaView?.let { wavingDaxController?.cancel(it) }
             ctaView?.animate()?.cancel()
         }
 

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -1708,6 +1708,17 @@ sealed class DaxBubbleCta(
             wavingDaxController?.applyFit(container)
         }
 
+        fun onOrientationChanged() {
+            if (!onboardingImprovementsEnabled) return
+            val container = ctaView ?: return
+            val cardView = container.findViewById<DaxOnboardingBubbleBrandDesignUpdateCardView>(R.id.brandDesignCardView) ?: return
+
+            applyWavingDaxState(container, this as? ShowsWavingDax)
+            cardView.setArrowDepthFraction(showCtaFinTarget(container) ?: 0f)
+            wavingDaxController?.reset()
+            container.post { applyFit() }
+        }
+
         private fun resetAllIncludesExcept(view: View, active: View) {
             getAllContentIncludes(view).forEach { include ->
                 if (include == active) {

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -119,6 +119,10 @@ class CtaViewModel @Inject constructor(
         onboardingBrandDesignUpdateToggles.brandDesignUpdate().isEnabled()
     }
 
+    private suspend fun isOnboardingImprovementsEnabled(): Boolean = withContext(dispatchers.io()) {
+        onboardingBrandDesignUpdateToggles.onboardingImprovements().isEnabled()
+    }
+
     // Exposed for onboarding dev settings and tests. Used internally for completion checks
     @VisibleForTesting
     suspend fun requiredDaxOnboardingCtas(): List<CtaId> {
@@ -365,7 +369,13 @@ class CtaViewModel @Inject constructor(
             // Site suggestions
             canShowDaxIntroVisitSiteCta() && !extendedOnboardingFeatureToggles.noBrowserCtas().isEnabled() -> {
                 if (isBrandDesignUpdateEnabled()) {
-                    DaxVisitSiteOptionsBrandDesignUpdateBubbleCta(onboardingStore, appInstallStore, appTheme.isLightModeEnabled(), deviceInfo)
+                    DaxVisitSiteOptionsBrandDesignUpdateBubbleCta(
+                        onboardingStore,
+                        appInstallStore,
+                        appTheme.isLightModeEnabled(),
+                        deviceInfo,
+                        onboardingImprovementsEnabled = isOnboardingImprovementsEnabled(),
+                    )
                 } else {
                     DaxBubbleCta.DaxIntroVisitSiteOptionsCta(onboardingStore, appInstallStore)
                 }
@@ -374,7 +384,13 @@ class CtaViewModel @Inject constructor(
             // End
             canShowDaxCtaEndOfJourney() && !extendedOnboardingFeatureToggles.noBrowserCtas().isEnabled() -> {
                 if (isBrandDesignUpdateEnabled()) {
-                    DaxEndBrandDesignUpdateBubbleCta(onboardingStore, appInstallStore, appTheme.isLightModeEnabled(), deviceInfo)
+                    DaxEndBrandDesignUpdateBubbleCta(
+                        onboardingStore,
+                        appInstallStore,
+                        appTheme.isLightModeEnabled(),
+                        deviceInfo,
+                        onboardingImprovementsEnabled = isOnboardingImprovementsEnabled(),
+                    )
                 } else {
                     DaxBubbleCta.DaxEndCta(onboardingStore, appInstallStore)
                 }
@@ -389,6 +405,7 @@ class CtaViewModel @Inject constructor(
                         appTheme.isLightModeEnabled(),
                         deviceInfo,
                         isFreeTrialCopy = freeTrialCopyAvailable(),
+                        onboardingImprovementsEnabled = isOnboardingImprovementsEnabled(),
                     )
                 } else {
                     DaxBubbleCta.DaxSubscriptionCta(

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateBubbleCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateBubbleCta.kt
@@ -34,6 +34,7 @@ data class DaxEndBrandDesignUpdateBubbleCta(
     override val appInstallStore: AppInstallStore,
     override val isLightTheme: Boolean,
     override val deviceInfo: DeviceInfo,
+    override val onboardingImprovementsEnabled: Boolean = true,
 ) : DaxBubbleCta.BrandDesignUpdateBubbleCta(
     ctaId = CtaId.DAX_END,
     title = R.string.onboardingEndDaxDialogTitle,
@@ -50,6 +51,7 @@ data class DaxEndBrandDesignUpdateBubbleCta(
     appInstallStore = appInstallStore,
     isLightTheme = isLightTheme,
     deviceInfo = deviceInfo,
+    onboardingImprovementsEnabled = onboardingImprovementsEnabled,
 ),
     DaxBubbleCta.ShowsWavingDax {
     override val activeIncludeId: Int = R.id.primaryCta

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateBubbleCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateBubbleCta.kt
@@ -34,7 +34,7 @@ data class DaxEndBrandDesignUpdateBubbleCta(
     override val appInstallStore: AppInstallStore,
     override val isLightTheme: Boolean,
     override val deviceInfo: DeviceInfo,
-    override val onboardingImprovementsEnabled: Boolean = true,
+    override val onboardingImprovementsEnabled: Boolean,
 ) : DaxBubbleCta.BrandDesignUpdateBubbleCta(
     ctaId = CtaId.DAX_END,
     title = R.string.onboardingEndDaxDialogTitle,

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxSubscriptionBrandDesignUpdateBubbleCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxSubscriptionBrandDesignUpdateBubbleCta.kt
@@ -37,6 +37,7 @@ data class DaxSubscriptionBrandDesignUpdateBubbleCta(
     override val isLightTheme: Boolean,
     override val deviceInfo: DeviceInfo,
     val isFreeTrialCopy: Boolean,
+    override val onboardingImprovementsEnabled: Boolean = true,
 ) : DaxBubbleCta.BrandDesignUpdateBubbleCta(
     ctaId = CtaId.DAX_INTRO_PRIVACY_PRO,
     title = R.string.onboardingPrivacyProDaxDialogTitle,
@@ -53,6 +54,7 @@ data class DaxSubscriptionBrandDesignUpdateBubbleCta(
     appInstallStore = appInstallStore,
     isLightTheme = isLightTheme,
     deviceInfo = deviceInfo,
+    onboardingImprovementsEnabled = onboardingImprovementsEnabled,
 ),
     DaxBubbleCta.ShowsWavingDax {
     override val activeIncludeId: Int = R.id.primaryCta

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxSubscriptionBrandDesignUpdateBubbleCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxSubscriptionBrandDesignUpdateBubbleCta.kt
@@ -37,7 +37,7 @@ data class DaxSubscriptionBrandDesignUpdateBubbleCta(
     override val isLightTheme: Boolean,
     override val deviceInfo: DeviceInfo,
     val isFreeTrialCopy: Boolean,
-    override val onboardingImprovementsEnabled: Boolean = true,
+    override val onboardingImprovementsEnabled: Boolean,
 ) : DaxBubbleCta.BrandDesignUpdateBubbleCta(
     ctaId = CtaId.DAX_INTRO_PRIVACY_PRO,
     title = R.string.onboardingPrivacyProDaxDialogTitle,

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxVisitSiteOptionsBrandDesignUpdateBubbleCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxVisitSiteOptionsBrandDesignUpdateBubbleCta.kt
@@ -29,6 +29,7 @@ data class DaxVisitSiteOptionsBrandDesignUpdateBubbleCta(
     override val appInstallStore: AppInstallStore,
     override val isLightTheme: Boolean,
     override val deviceInfo: DeviceInfo,
+    override val onboardingImprovementsEnabled: Boolean = true,
 ) : OptionsBubbleCta(
     ctaId = CtaId.DAX_INTRO_VISIT_SITE,
     title = R.string.onboardingSitesDaxDialogTitle,
@@ -40,6 +41,7 @@ data class DaxVisitSiteOptionsBrandDesignUpdateBubbleCta(
     appInstallStore = appInstallStore,
     isLightTheme = isLightTheme,
     deviceInfo = deviceInfo,
+    onboardingImprovementsEnabled = onboardingImprovementsEnabled,
     showArrow = true,
 ),
     DaxBubbleCta.ShowsWavingDax {

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxVisitSiteOptionsBrandDesignUpdateBubbleCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxVisitSiteOptionsBrandDesignUpdateBubbleCta.kt
@@ -29,7 +29,7 @@ data class DaxVisitSiteOptionsBrandDesignUpdateBubbleCta(
     override val appInstallStore: AppInstallStore,
     override val isLightTheme: Boolean,
     override val deviceInfo: DeviceInfo,
-    override val onboardingImprovementsEnabled: Boolean = true,
+    override val onboardingImprovementsEnabled: Boolean,
 ) : OptionsBubbleCta(
     ctaId = CtaId.DAX_INTRO_VISIT_SITE,
     title = R.string.onboardingSitesDaxDialogTitle,

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/OptionsBubbleCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/OptionsBubbleCta.kt
@@ -48,6 +48,7 @@ abstract class OptionsBubbleCta(
     appInstallStore: AppInstallStore,
     isLightTheme: Boolean,
     deviceInfo: DeviceInfo,
+    onboardingImprovementsEnabled: Boolean = true,
     showArrow: Boolean,
 ) : DaxBubbleCta.BrandDesignUpdateBubbleCta(
     ctaId = ctaId,
@@ -62,6 +63,7 @@ abstract class OptionsBubbleCta(
     appInstallStore = appInstallStore,
     isLightTheme = isLightTheme,
     deviceInfo = deviceInfo,
+    onboardingImprovementsEnabled = onboardingImprovementsEnabled,
 ) {
     override val activeIncludeId: Int = R.id.optionsContent
     override val showArrow: Boolean = showArrow

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/WavingDaxController.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/WavingDaxController.kt
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.cta.ui
+
+import android.animation.ValueAnimator
+import android.content.res.Configuration
+import android.graphics.RectF
+import android.view.View
+import androidx.core.view.isInvisible
+import androidx.core.view.isVisible
+import androidx.interpolator.view.animation.FastOutSlowInInterpolator
+import com.airbnb.lottie.LottieAnimationView
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.common.ui.view.shape.DaxOnboardingBubbleBrandDesignUpdateCardView
+import com.duckduckgo.common.utils.device.DeviceInfo
+import com.duckduckgo.common.utils.device.isTablet
+
+/**
+ * Keeps the waving Dax below a new-tab bubble in sync with the space available: decides whether the
+ * Dax fits beneath the card, drives its show/hide, and is the single writer of the shark-fin depth.
+ *
+ * Hide eagerly, reveal lazily: a hide (does not fit) applies immediately so the Dax never lingers
+ * as the keyboard rises; a reveal (fits) is debounced by [FIT_SETTLE_DELAY_MS] so transient
+ * measurements during a content transition or keyboard settle never flash the Dax/fin in then out.
+ */
+internal class WavingDaxController(
+    private val showArrow: Boolean,
+    private val deviceInfo: DeviceInfo,
+) {
+
+    private var fitArrowAnimator: ValueAnimator? = null
+    private var lastDaxFits: Boolean? = null
+    private var container: View? = null
+    private val fitRunnable = Runnable { container?.let { decideFit(it) } }
+
+    fun applyFit(container: View) {
+        this.container = container
+        container.removeCallbacks(fitRunnable)
+        val fits = computeDaxFits(container) ?: return
+        if (fits) {
+            container.postDelayed(fitRunnable, FIT_SETTLE_DELAY_MS)
+        } else {
+            applyFitResult(container, false)
+        }
+    }
+
+    fun cancel(container: View) {
+        fitArrowAnimator?.removeAllUpdateListeners()
+        fitArrowAnimator?.cancel()
+        fitArrowAnimator = null
+        lastDaxFits = null
+        container.removeCallbacks(fitRunnable)
+        this.container = null
+    }
+
+    fun reset() {
+        lastDaxFits = null
+    }
+
+    /**
+     * Pure fit test. The Dax fits unless its head intrudes into the card body (above the
+     * top-of-fin line) or its rect overlaps the fin's own region. The Dax may sit in the
+     * fin's vertical band as long as it is horizontally clear of the fin.
+     */
+    internal fun daxFits(
+        daxTop: Int,
+        daxLeft: Int,
+        daxRight: Int,
+        cardBodyBottom: Int,
+        finBottom: Int,
+        finLeft: Int,
+        finRight: Int,
+    ): Boolean {
+        if (daxTop < cardBodyBottom) return false
+        val overlapsFinHorizontally = daxRight > finLeft && daxLeft < finRight
+        if (daxTop < finBottom && overlapsFinHorizontally) return false
+        return true
+    }
+
+    private fun decideFit(container: View) {
+        if (computeDaxFits(container) == true) applyFitResult(container, true)
+    }
+
+    private fun computeDaxFits(container: View): Boolean? {
+        if (!container.isShown || container.isPhoneLandscape()) return null
+
+        val dax = container.findViewById<LottieAnimationView>(R.id.wavingDax) ?: return null
+        val cardView = container.findViewById<DaxOnboardingBubbleBrandDesignUpdateCardView>(R.id.brandDesignCardView) ?: return null
+        val finBounds = cardView.arrowBounds() ?: return null
+
+        val daxRect = RectF()
+        viewBoundsOnScreen(dax, daxRect)
+
+        val cardLoc = IntArray(2)
+        cardView.getLocationOnScreen(cardLoc)
+
+        return daxFits(
+            daxTop = daxRect.top.toInt(),
+            daxLeft = daxRect.left.toInt(),
+            daxRight = daxRect.right.toInt(),
+            cardBodyBottom = cardLoc[1] + finBounds.top.toInt(),
+            finBottom = cardLoc[1] + finBounds.bottom.toInt(),
+            finLeft = cardLoc[0] + finBounds.left.toInt(),
+            finRight = cardLoc[0] + finBounds.right.toInt(),
+        )
+    }
+
+    private fun applyFitResult(container: View, fits: Boolean) {
+        if (fits == lastDaxFits) return
+        lastDaxFits = fits
+
+        val dax = container.findViewById<LottieAnimationView>(R.id.wavingDax) ?: return
+        val cardView = container.findViewById<DaxOnboardingBubbleBrandDesignUpdateCardView>(R.id.brandDesignCardView) ?: return
+
+        if (fits) {
+            if (!dax.isVisible) {
+                dax.setMinFrame(DAX_WAVE_START_FRAME)
+                dax.progress = 0f
+                dax.isVisible = true
+                dax.post { dax.playAnimation() }
+            }
+        } else {
+            dax.isInvisible = true
+        }
+
+        val finTarget = if (fits && showArrow) 1f else 0f
+        val current = cardView.arrowDepthFraction
+        fitArrowAnimator?.removeAllUpdateListeners()
+        fitArrowAnimator?.cancel()
+        if (current != finTarget) {
+            fitArrowAnimator = buildArrowDepthAnimator(cardView, current, finTarget).apply { start() }
+        } else {
+            cardView.setArrowDepthFraction(finTarget)
+        }
+    }
+
+    private fun buildArrowDepthAnimator(
+        cardView: DaxOnboardingBubbleBrandDesignUpdateCardView,
+        from: Float,
+        to: Float,
+    ): ValueAnimator =
+        ValueAnimator.ofFloat(from, to).apply {
+            duration = ARROW_DEPTH_ANIMATION_DURATION
+            interpolator = FastOutSlowInInterpolator()
+            addUpdateListener { cardView.setArrowDepthFraction(it.animatedValue as Float) }
+        }
+
+    private fun viewBoundsOnScreen(view: View, out: RectF) {
+        out.set(0f, 0f, view.width.toFloat(), view.height.toFloat())
+        view.matrix.mapRect(out)
+        val loc = IntArray(2)
+        (view.parent as? View)?.getLocationOnScreen(loc)
+        out.offset((loc[0] + view.left).toFloat(), (loc[1] + view.top).toFloat())
+    }
+
+    private fun View.isPhoneLandscape(): Boolean =
+        !deviceInfo.isTablet() &&
+            context.resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+
+    companion object {
+        private const val FIT_SETTLE_DELAY_MS = 100L
+        private const val DAX_WAVE_START_FRAME = 17
+        private const val ARROW_DEPTH_ANIMATION_DURATION = 200L
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
@@ -39,4 +39,11 @@ interface OnboardingBrandDesignUpdateToggles {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun fireAnimationUpdate(): Toggle
+
+    /**
+     * Gates new-tab onboarding bubble improvements: showing/hiding the waving Dax and shark fin
+     * based on whether they fit below the bubble (keyboard state, orientation, per-bubble sizing).
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun onboardingImprovements(): Toggle
 }

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/BrandDesignUpdateBubbleCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/BrandDesignUpdateBubbleCtaTest.kt
@@ -85,6 +85,36 @@ class BrandDesignUpdateBubbleCtaTest {
         verify(dax).isVisible = false
     }
 
+    @Test
+    fun daxFits_false_whenHeadIntrudesIntoCardBody() {
+        val cta = TestableBubbleCta()
+        assertEquals(false, cta.daxFits(daxTop = 90, daxLeft = 0, daxRight = 40, cardBodyBottom = 100, finBottom = 130, finLeft = 50, finRight = 100))
+    }
+
+    @Test
+    fun daxFits_false_whenInFinBandAndOverlapsFinHorizontally() {
+        val cta = TestableBubbleCta()
+        assertEquals(
+            false,
+            cta.daxFits(daxTop = 110, daxLeft = 60, daxRight = 90, cardBodyBottom = 100, finBottom = 130, finLeft = 50, finRight = 100),
+        )
+    }
+
+    @Test
+    fun daxFits_true_whenInFinBandButHorizontallyClearOfFin() {
+        val cta = TestableBubbleCta()
+        assertEquals(true, cta.daxFits(daxTop = 110, daxLeft = 0, daxRight = 40, cardBodyBottom = 100, finBottom = 130, finLeft = 50, finRight = 100))
+    }
+
+    @Test
+    fun daxFits_true_whenEntirelyBelowFinTip() {
+        val cta = TestableBubbleCta()
+        assertEquals(
+            true,
+            cta.daxFits(daxTop = 140, daxLeft = 60, daxRight = 90, cardBodyBottom = 100, finBottom = 130, finLeft = 50, finRight = 100),
+        )
+    }
+
     private fun configureContainer(orientation: Int, formFactor: FormFactor) {
         val configuration = Configuration().apply { this.orientation = orientation }
         val resources: Resources = mock()

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/BrandDesignUpdateBubbleCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/BrandDesignUpdateBubbleCtaTest.kt
@@ -21,6 +21,7 @@ import android.content.res.Configuration
 import android.content.res.Resources
 import android.view.View
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import com.airbnb.lottie.LottieAnimationView
 import com.duckduckgo.app.browser.R
@@ -64,16 +65,15 @@ class BrandDesignUpdateBubbleCtaTest {
     }
 
     @Test
-    fun applyWavingDaxState_notPhoneLandscape_showsAndConfiguresDax_whenCtaOptsIn() {
+    fun applyWavingDaxState_notPhoneLandscape_configuresDaxAndStartsInvisible_whenCtaOptsIn() {
         configureContainerForPhonePortrait()
-        whenever(dax.alpha).thenReturn(0f)
         val cta = TestableBubbleCta()
         val showsWavingDax: DaxBubbleCta.ShowsWavingDax = mock()
 
         cta.applyWavingDaxState(container, showsWavingDax)
 
         verify(showsWavingDax).configureWavingDax(dax, mockDeviceInfo)
-        verify(dax).isVisible = true
+        verify(dax).isInvisible = true
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/BrandDesignUpdateBubbleCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/BrandDesignUpdateBubbleCtaTest.kt
@@ -77,6 +77,20 @@ class BrandDesignUpdateBubbleCtaTest {
     }
 
     @Test
+    fun applyWavingDaxState_notPhoneLandscape_playsDaxImmediately_whenImprovementsDisabled() {
+        configureContainerForPhonePortrait()
+        val cta = TestableBubbleCta(onboardingImprovementsEnabled = false)
+        val showsWavingDax: DaxBubbleCta.ShowsWavingDax = mock()
+
+        cta.applyWavingDaxState(container, showsWavingDax)
+
+        verify(showsWavingDax).configureWavingDax(dax, mockDeviceInfo)
+        verify(dax).progress = 0f
+        verify(dax).alpha = 1f
+        verify(dax).isVisible = true
+    }
+
+    @Test
     fun applyWavingDaxState_nullCtaOptIn_hidesDax_noOrientationLookup() {
         val cta = TestableBubbleCta()
 
@@ -171,6 +185,7 @@ class BrandDesignUpdateBubbleCtaTest {
             isLightTheme = true,
             deviceInfo = mockDeviceInfo,
             isFreeTrialCopy = false,
+            onboardingImprovementsEnabled = true,
         )
 
         cta.configureWavingDax(dax, mockDeviceInfo)
@@ -190,6 +205,7 @@ class BrandDesignUpdateBubbleCtaTest {
             appInstallStore = appInstallStore,
             isLightTheme = true,
             deviceInfo = mockDeviceInfo,
+            onboardingImprovementsEnabled = true,
         )
 
         cta.configureWavingDax(dax, mockDeviceInfo)
@@ -208,6 +224,7 @@ class BrandDesignUpdateBubbleCtaTest {
             isLightTheme = true,
             deviceInfo = mockDeviceInfo,
             isFreeTrialCopy = false,
+            onboardingImprovementsEnabled = true,
         )
 
         cta.configureWavingDax(dax, mockDeviceInfo)
@@ -231,7 +248,9 @@ class BrandDesignUpdateBubbleCtaTest {
         return lp
     }
 
-    private inner class TestableBubbleCta : DaxBubbleCta.BrandDesignUpdateBubbleCta(
+    private inner class TestableBubbleCta(
+        onboardingImprovementsEnabled: Boolean = true,
+    ) : DaxBubbleCta.BrandDesignUpdateBubbleCta(
         ctaId = CtaId.DAX_END,
         title = R.string.onboardingEndDaxDialogTitle,
         description = R.string.onboardingEndDaxDialogDescription,
@@ -242,6 +261,7 @@ class BrandDesignUpdateBubbleCtaTest {
         appInstallStore = this@BrandDesignUpdateBubbleCtaTest.appInstallStore,
         isLightTheme = true,
         deviceInfo = this@BrandDesignUpdateBubbleCtaTest.mockDeviceInfo,
+        onboardingImprovementsEnabled = onboardingImprovementsEnabled,
     ) {
         override val activeIncludeId: Int = R.id.primaryCta
         override val showArrow: Boolean = false

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/BrandDesignUpdateBubbleCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/BrandDesignUpdateBubbleCtaTest.kt
@@ -99,36 +99,6 @@ class BrandDesignUpdateBubbleCtaTest {
         verify(dax).isVisible = false
     }
 
-    @Test
-    fun daxFits_false_whenHeadIntrudesIntoCardBody() {
-        val cta = TestableBubbleCta()
-        assertEquals(false, cta.daxFits(daxTop = 90, daxLeft = 0, daxRight = 40, cardBodyBottom = 100, finBottom = 130, finLeft = 50, finRight = 100))
-    }
-
-    @Test
-    fun daxFits_false_whenInFinBandAndOverlapsFinHorizontally() {
-        val cta = TestableBubbleCta()
-        assertEquals(
-            false,
-            cta.daxFits(daxTop = 110, daxLeft = 60, daxRight = 90, cardBodyBottom = 100, finBottom = 130, finLeft = 50, finRight = 100),
-        )
-    }
-
-    @Test
-    fun daxFits_true_whenInFinBandButHorizontallyClearOfFin() {
-        val cta = TestableBubbleCta()
-        assertEquals(true, cta.daxFits(daxTop = 110, daxLeft = 0, daxRight = 40, cardBodyBottom = 100, finBottom = 130, finLeft = 50, finRight = 100))
-    }
-
-    @Test
-    fun daxFits_true_whenEntirelyBelowFinTip() {
-        val cta = TestableBubbleCta()
-        assertEquals(
-            true,
-            cta.daxFits(daxTop = 140, daxLeft = 60, daxRight = 90, cardBodyBottom = 100, finBottom = 130, finLeft = 50, finRight = 100),
-        )
-    }
-
     private fun configureContainer(orientation: Int, formFactor: FormFactor) {
         val configuration = Configuration().apply { this.orientation = orientation }
         val resources: Resources = mock()

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/BrandDesignUpdateBubbleCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/BrandDesignUpdateBubbleCtaTest.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.ui.view.shape.DaxOnboardingBubbleBrandDesignUpdateCardView
 import com.duckduckgo.common.utils.device.DeviceInfo
 import com.duckduckgo.common.utils.device.DeviceInfo.FormFactor
 import org.junit.Assert.assertEquals
@@ -37,12 +38,14 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
 class BrandDesignUpdateBubbleCtaTest {
 
     private val container: View = mock()
     private val dax: LottieAnimationView = mock()
+    private val cardView: DaxOnboardingBubbleBrandDesignUpdateCardView = mock()
 
     private val onboardingStore: OnboardingStore = mock()
     private val appInstallStore: AppInstallStore = mock()
@@ -97,6 +100,40 @@ class BrandDesignUpdateBubbleCtaTest {
         cta.applyWavingDaxState(container, showsWavingDax = null)
 
         verify(dax).isVisible = false
+    }
+
+    @Test
+    fun onOrientationChanged_flagOn_phoneLandscape_hidesWavingDax() {
+        configureContainerForPhoneLandscape()
+        whenever(container.findViewById<DaxOnboardingBubbleBrandDesignUpdateCardView>(R.id.brandDesignCardView)).thenReturn(cardView)
+        val cta = WavingDaxBubbleCta().apply { attachCtaView(container) }
+
+        cta.onOrientationChanged()
+
+        verify(dax).isVisible = false
+    }
+
+    @Test
+    fun onOrientationChanged_flagOn_phoneLandscape_retractsFin() {
+        configureContainerForPhoneLandscape()
+        whenever(container.findViewById<DaxOnboardingBubbleBrandDesignUpdateCardView>(R.id.brandDesignCardView)).thenReturn(cardView)
+        val cta = WavingDaxBubbleCta().apply { attachCtaView(container) }
+
+        cta.onOrientationChanged()
+
+        verify(cardView).setArrowDepthFraction(0f)
+    }
+
+    @Test
+    fun onOrientationChanged_flagOff_isNoOp() {
+        configureContainerForPhoneLandscape()
+        whenever(container.findViewById<DaxOnboardingBubbleBrandDesignUpdateCardView>(R.id.brandDesignCardView)).thenReturn(cardView)
+        val cta = WavingDaxBubbleCta(onboardingImprovementsEnabled = false).apply { attachCtaView(container) }
+
+        cta.onOrientationChanged()
+
+        verifyNoInteractions(dax)
+        verifyNoInteractions(cardView)
     }
 
     private fun configureContainer(orientation: Int, formFactor: FormFactor) {
@@ -239,19 +276,21 @@ class BrandDesignUpdateBubbleCtaTest {
         override fun configureContentViews(view: View) {}
     }
 
-    private inner class WavingDaxBubbleCta :
-        DaxBubbleCta.BrandDesignUpdateBubbleCta(
-            ctaId = CtaId.DAX_END,
-            title = R.string.onboardingEndDaxDialogTitle,
-            description = R.string.onboardingEndDaxDialogDescription,
-            shownPixel = AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
-            okPixel = AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
-            ctaPixelParam = Pixel.PixelValues.DAX_END_CTA,
-            onboardingStore = this@BrandDesignUpdateBubbleCtaTest.onboardingStore,
-            appInstallStore = this@BrandDesignUpdateBubbleCtaTest.appInstallStore,
-            isLightTheme = true,
-            deviceInfo = this@BrandDesignUpdateBubbleCtaTest.mockDeviceInfo,
-        ),
+    private inner class WavingDaxBubbleCta(
+        onboardingImprovementsEnabled: Boolean = true,
+    ) : DaxBubbleCta.BrandDesignUpdateBubbleCta(
+        ctaId = CtaId.DAX_END,
+        title = R.string.onboardingEndDaxDialogTitle,
+        description = R.string.onboardingEndDaxDialogDescription,
+        shownPixel = AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
+        okPixel = AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
+        ctaPixelParam = Pixel.PixelValues.DAX_END_CTA,
+        onboardingStore = this@BrandDesignUpdateBubbleCtaTest.onboardingStore,
+        appInstallStore = this@BrandDesignUpdateBubbleCtaTest.appInstallStore,
+        isLightTheme = true,
+        deviceInfo = this@BrandDesignUpdateBubbleCtaTest.mockDeviceInfo,
+        onboardingImprovementsEnabled = onboardingImprovementsEnabled,
+    ),
         DaxBubbleCta.ShowsWavingDax {
         override val activeIncludeId: Int = R.id.primaryCta
         override val showArrow: Boolean = false
@@ -264,5 +303,9 @@ class BrandDesignUpdateBubbleCtaTest {
         )
 
         override fun configureContentViews(view: View) {}
+
+        fun attachCtaView(view: View) {
+            ctaView = view
+        }
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -182,6 +182,7 @@ class CtaViewModelTest {
         whenever(mockBrokenSitePrompt.getUserRefreshPatterns()).thenReturn(emptySet())
         whenever(mockSubscriptions.isEligible()).thenReturn(false)
         whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockDisabledToggle)
+        whenever(mockOnboardingBrandDesignUpdateToggles.onboardingImprovements()).thenReturn(mockEnabledToggle)
 
         testee = CtaViewModel(
             appInstallStore = mockAppInstallStore,
@@ -1129,6 +1130,30 @@ class CtaViewModelTest {
 
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
         assertTrue(value is DaxVisitSiteOptionsBrandDesignUpdateBubbleCta)
+    }
+
+    @Test
+    fun whenOnboardingImprovementsDisabledThenVisitSiteBrandCtaHasFlagFalse() = runTest {
+        givenDaxOnboardingActive()
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
+        whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockEnabledToggle)
+        whenever(mockOnboardingBrandDesignUpdateToggles.onboardingImprovements()).thenReturn(mockDisabledToggle)
+
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        assertTrue(value is DaxVisitSiteOptionsBrandDesignUpdateBubbleCta)
+        assertFalse((value as DaxVisitSiteOptionsBrandDesignUpdateBubbleCta).onboardingImprovementsEnabled)
+    }
+
+    @Test
+    fun whenOnboardingImprovementsEnabledThenVisitSiteBrandCtaHasFlagTrue() = runTest {
+        givenDaxOnboardingActive()
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
+        whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockEnabledToggle)
+        whenever(mockOnboardingBrandDesignUpdateToggles.onboardingImprovements()).thenReturn(mockEnabledToggle)
+
+        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+        assertTrue(value is DaxVisitSiteOptionsBrandDesignUpdateBubbleCta)
+        assertTrue((value as DaxVisitSiteOptionsBrandDesignUpdateBubbleCta).onboardingImprovementsEnabled)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/WavingDaxControllerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/WavingDaxControllerTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.cta.ui
+
+import com.duckduckgo.common.utils.device.DeviceInfo
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+class WavingDaxControllerTest {
+
+    private val deviceInfo: DeviceInfo = mock()
+    private val controller = WavingDaxController(showArrow = true, deviceInfo = deviceInfo)
+
+    @Test
+    fun daxFits_false_whenHeadIntrudesIntoCardBody() {
+        assertEquals(
+            false,
+            controller.daxFits(daxTop = 90, daxLeft = 0, daxRight = 40, cardBodyBottom = 100, finBottom = 130, finLeft = 50, finRight = 100),
+        )
+    }
+
+    @Test
+    fun daxFits_false_whenInFinBandAndOverlapsFinHorizontally() {
+        assertEquals(
+            false,
+            controller.daxFits(daxTop = 110, daxLeft = 60, daxRight = 90, cardBodyBottom = 100, finBottom = 130, finLeft = 50, finRight = 100),
+        )
+    }
+
+    @Test
+    fun daxFits_true_whenInFinBandButHorizontallyClearOfFin() {
+        assertEquals(
+            true,
+            controller.daxFits(daxTop = 110, daxLeft = 0, daxRight = 40, cardBodyBottom = 100, finBottom = 130, finLeft = 50, finRight = 100),
+        )
+    }
+
+    @Test
+    fun daxFits_true_whenEntirelyBelowFinTip() {
+        assertEquals(
+            true,
+            controller.daxFits(daxTop = 140, daxLeft = 60, daxRight = 90, cardBodyBottom = 100, finBottom = 130, finLeft = 50, finRight = 100),
+        )
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207908166761516/task/1215297293922291?focus=true

### Description

On the brand-design new-tab onboarding bubbles, the waving Dax and shark fin now show only when the Dax fits below the bubble, and hide when it doesn't (driven by keyboard state, orientation and per-bubble sizing). The behaviour sits behind the `onboardingImprovements` kill switch (default ON); when OFF the Dax and fin always show, matching previous behaviour.

### Steps to test this PR

Patches below are valid unified diffs. Save one to a file and run `git apply <file>.patch`, or use Android Studio → **Git → Apply Patch from Clipboard**. Reinstall after applying. To revert, run `git apply -R <file>.patch` or discard the change.

**Turn the `onboardingImprovements` flag OFF** (apply turns it off; revert/`-R` turns it back on):

```diff
diff --git a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
index 39d58c206c..2dcf101b9a 100644
--- a/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboardingbranddesignupdate/OnboardingBrandDesignUpdateToggles.kt
@@ -44,6 +44,6 @@ interface OnboardingBrandDesignUpdateToggles {
      * Gates new-tab onboarding bubble improvements: showing/hiding the waving Dax and shark fin
      * based on whether they fit below the bubble (keyboard state, orientation, per-bubble sizing).
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun onboardingImprovements(): Toggle
 }
```

**Optional — force the subscription onboarding bubble to show** without Privacy Pro eligibility (debug-only testing aid, **do not commit**):

```diff
diff --git a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
index b4d10cffe3..244d32ef03 100644
--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -113,7 +113,7 @@ class CtaViewModel @Inject constructor(
             }
 
     private suspend fun isSubscriptionCtaAvailable(): Boolean =
-        subscriptions.isEligible() && hasNoSubscription() && extendedOnboardingFeatureToggles.privacyProCta().isEnabled()
+        true
 
     private suspend fun isBrandDesignUpdateEnabled(): Boolean = withContext(dispatchers.io()) {
         onboardingBrandDesignUpdateToggles.brandDesignUpdate().isEnabled()
```

_Flag ON (default)_
- [ ] Reonboard and advance to the new-tab onboarding bubbles (visit-site, end, subscription).
- [ ] Confirm the waving Dax + shark fin appear only when there's room below the bubble.
- [ ] Raise the keyboard: the Dax + fin retract; dismiss it: they reappear.

_Flag OFF_
- [ ] Apply the flag-OFF patch, reinstall, reonboard.
- [ ] Confirm the waving Dax + fin always show on the waving CTAs, with no fit-based hiding and no keyboard-driven retract.
- [ ] Confirm non-waving CTAs (search options) and phone-landscape are unchanged in both states.

### UI changes

See [here](https://app.asana.com/1/137249556945/task/1215297293922291/comment/1215392643886830?focus=true) for a demo


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches onboarding CTA presentation and animation coordination across fragment lifecycle and orientation; behavior is kill-switchable but default-on affects first-run UX.
> 
> **Overview**
> Adds **fit-aware** waving Dax and shark-fin behavior on brand-design new-tab onboarding bubbles, gated by a new **`onboardingImprovements`** feature toggle (default ON). When enabled, a new **`WavingDaxController`** is the sole writer of fin depth for waving-Dax CTAs in portrait/tablet; it measures whether Dax overlaps the card body or fin (via **`arrowBounds()`** on the bubble card) and hides Dax immediately while debouncing reveal; fin depth animates with fit. **`showCta`** no longer always drives the fin when improvements are on—ownership is split so keyboard/layout churn does not fight animations.
> 
> **`BrowserTabFragment`** registers a scroll-view global layout listener to call **`applyFit()`**, re-applies on orientation change, and tears the listener down on dismiss/destroy. Design-system tweaks: shared **`ORIGINAL_BOTTOM_ARROW_WIDTH_DP`** and **`arrowBounds()`** for stable fin geometry during depth animation.
> 
> With the toggle OFF, waving Dax and fin behave as before (always shown when applicable).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90c7f6683342e88688a063d14b224f0c50a350c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->




