### PR TITLE
Fix print IllegalArgumentException

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2871,7 +2871,7 @@ class BrowserTabFragment :
                 notifyEmailSignEvent()
             }
 
-            is Command.PrintLink -> launchPrint(it.url, it.mediaSize)
+            is Command.PrintLink -> launchPrint(it.documentName, it.mediaSize)
             is Command.ShowSitePermissionsDialog -> showSitePermissionsDialog(it.permissionsToRequest, it.request)
             is Command.ShowUserCredentialSavedOrUpdatedConfirmation ->
                 showAuthenticationSavedOrUpdatedSnackbar(
@@ -6363,20 +6363,20 @@ class BrowserTabFragment :
     }
 
     private fun launchPrint(
-        url: String,
+        documentName: String,
         defaultMediaSize: PrintAttributes.MediaSize,
     ) {
         if (viewModel.isPrinting()) return
 
         val printManager = activity?.getSystemService(Context.PRINT_SERVICE) as? PrintManager ?: return
-        val sourceAdapter = pdfPrintDocumentAdapterOrNull() ?: webView?.createSafePrintDocumentAdapter(url) ?: return
+        val sourceAdapter = pdfPrintDocumentAdapterOrNull() ?: webView?.createSafePrintDocumentAdapter(documentName) ?: return
         val printAdapter = PrintDocumentAdapterFactory.createPrintDocumentAdapter(
             sourceAdapter,
             onStartCallback = { viewModel.onStartPrint() },
             onFinishCallback = { viewModel.onFinishPrint() },
         )
         printManager.print(
-            url,
+            documentName,
             printAdapter,
             PrintAttributes.Builder().setMediaSize(defaultMediaSize).build(),
         )

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3713,10 +3713,11 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun onPrintSelected() {
-        url?.let {
-            pixel.fire(AppPixelName.MENU_ACTION_PRINT_PRESSED)
-            command.value = PrintLink(removeAtbAndSourceParamsFromSearch(it), defaultMediaSize())
-        }
+        val documentName = url?.let { removeAtbAndSourceParamsFromSearch(it) }?.takeIf { it.isNotBlank() }
+            ?: currentBrowserViewState().currentPdfFileName?.takeIf { it.isNotBlank() }
+            ?: return
+        pixel.fire(AppPixelName.MENU_ACTION_PRINT_PRESSED)
+        command.value = PrintLink(documentName, defaultMediaSize())
     }
 
     fun printFromWebView() {

--- a/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
@@ -162,7 +162,7 @@ sealed class Command {
     ) : Command()
 
     class PrintLink(
-        val url: String,
+        val documentName: String,
         val mediaSize: MediaSize,
     ) : Command()
 

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -4889,7 +4889,7 @@ class BrowserTabViewModelTest {
         loadUrl("foo.com")
         testee.onPrintSelected()
         val command = captureCommands().lastValue as Command.PrintLink
-        assertEquals("foo.com", command.url)
+        assertEquals("foo.com", command.documentName)
         assertEquals(PrintAttributes.MediaSize.NA_LETTER, command.mediaSize)
     }
 
@@ -4899,7 +4899,7 @@ class BrowserTabViewModelTest {
         loadUrl("foo.com")
         testee.onPrintSelected()
         val command = captureCommands().lastValue as Command.PrintLink
-        assertEquals("foo.com", command.url)
+        assertEquals("foo.com", command.documentName)
         assertEquals(PrintAttributes.MediaSize.ISO_A4, command.mediaSize)
     }
 
@@ -4909,7 +4909,7 @@ class BrowserTabViewModelTest {
         loadUrl("foo.com")
         testee.onPrintSelected()
         val command = captureCommands().lastValue as Command.PrintLink
-        assertEquals("foo.com", command.url)
+        assertEquals("foo.com", command.documentName)
         assertEquals(PrintAttributes.MediaSize.ISO_A4, command.mediaSize)
     }
 
@@ -4918,6 +4918,38 @@ class BrowserTabViewModelTest {
         whenever(mockDeviceInfo.country).thenReturn("US")
         loadUrl("foo.com")
         testee.onPrintSelected()
+        verify(mockPixel).fire(AppPixelName.MENU_ACTION_PRINT_PRESSED)
+    }
+
+    @Test
+    fun whenUserSelectsToPrintPageAndUrlIsBlankAndNoPdfShownThenNoPrintLinkCommandOrPixelSent() {
+        whenever(mockDeviceInfo.country).thenReturn("US")
+        loadUrl("")
+        testee.onPrintSelected()
+        assertCommandNotIssued<Command.PrintLink>()
+        verify(mockPixel, never()).fire(AppPixelName.MENU_ACTION_PRINT_PRESSED)
+    }
+
+    @Test
+    fun whenUserSelectsToPrintPageAndUrlIsNullAndNoPdfShownThenNoPrintLinkCommandOrPixelSent() {
+        whenever(mockDeviceInfo.country).thenReturn("US")
+        loadUrl(null)
+        testee.onPrintSelected()
+        assertCommandNotIssued<Command.PrintLink>()
+        verify(mockPixel, never()).fire(AppPixelName.MENU_ACTION_PRINT_PRESSED)
+    }
+
+    @Test
+    fun whenUserSelectsToPrintPageAndUrlIsBlankButPdfShownThenPrintLinkCommandSentWithPdfNameAsJobName() {
+        whenever(mockDeviceInfo.country).thenReturn("US")
+        loadUrl("")
+        testee.browserViewState.value = browserViewState().copy(
+            currentPdfCachedUri = Uri.parse("file:///cache/doc.pdf"),
+            currentPdfFileName = "doc.pdf",
+        )
+        testee.onPrintSelected()
+        val command = captureCommands().lastValue as Command.PrintLink
+        assertEquals("doc.pdf", command.documentName)
         verify(mockPixel).fire(AppPixelName.MENU_ACTION_PRINT_PRESSED)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1215356848436615?focus=true

### Description

- When printing, uses the `currentPdfFileName` (if available) as the `printJobName`.
- This avoids passing an empty string to `printManager.print`, which throws an `IllegalArgumentException`.

### Steps to test this PR

- [x] Test printing a website
- [x] Verify it prints successfully with the correct file name
- [x] Test printing a PDF
- [x] Verify it prints successfully with the correct file name

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized browser print flow with early-return guards and renamed command field; behavior change is limited to edge cases (blank URL / inline PDF).
> 
> **Overview**
> Fixes crashes when **Print** runs with a blank or missing tab URL by **bailing out** before issuing `PrintLink` or firing the print pixel.
> 
> `PrintLink` now carries **`documentName`** (used for the Android print job title and WebView adapter) instead of treating the field as a URL. **`onPrintSelected`** picks a sanitized page URL when present, otherwise the **inline PDF filename** from browser view state, and only then starts print.
> 
> Tests cover no-op when URL is null/blank with no PDF, and printing with **`doc.pdf`** when the URL is empty but an inline PDF is shown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d40106b1329ca42bd09f4e9e3af231fe6b20a597. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->