### PR TITLE
Anchor Duck.ai entry points to the current tab

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -796,10 +796,13 @@ open class BrowserActivity : DuckDuckGoActivity() {
 
             if (duckAiFeatureState.showFullScreenMode.value) {
                 val url = intent.getStringExtra(DUCK_CHAT_URL) ?: duckChat.getDuckChatUrl("", false)
+                // The tab to return to when this Duck.ai tab is closed.
+                // Fallback to the current tab if no explicit tab id is passed.
+                val sourceTabId = intent.getStringExtra(SOURCE_TAB_ID_EXTRA) ?: currentTab?.tabId
                 if (swipingTabsFeature.isEnabled) {
-                    launchNewTab(query = url, skipHome = true)
+                    launchNewTab(query = url, skipHome = true, sourceTabId = sourceTabId)
                 } else {
-                    lifecycleScope.launch { viewModel.onOpenInNewTabRequested(query = url, skipHome = true) }
+                    lifecycleScope.launch { viewModel.onOpenInNewTabRequested(query = url, sourceTabId = sourceTabId, skipHome = true) }
                 }
             } else {
                 val duckChatSessionActive = intent.getBooleanExtra(DUCK_CHAT_SESSION_ACTIVE, false)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1215364312660003?focus=true 

### Description

Fixes the issue where the app **exits** when you open full-screen Duck.ai (from the browser or duck.ai entry point) and then close it (the X in Duck.ai, or the back button). Mainly visible from **New Voice Chat** in the menu, but it affects every entry that opens Duck.ai via the `openDuckChat` intent.

The handler now anchors the new tab to either an explicitly passed `SOURCE_TAB_ID_EXTRA` if present, or the current tab as a fallback:

### Known limitation

Opening from the **New Tab Page** still exits the app. Will address as a follow up if needed.

### Steps to test this PR
- [ ] From an open tab (a page or Duck.ai), open the menu → **New Voice Chat**.
- [ ] Press the **X** (top-left in Duck.ai) → returns to the tab you were on (does **not** exit the app).
- [ ] Repeat and press the **back button** → also returns to the previous tab.
- [ ] Sanity: the omnibar Duck.ai button / other Duck.ai opens from a tab also return on close.

### UI changes

No visual UI changes



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized navigation change in intent handling; reuses existing source-tab plumbing with no auth or data changes.
> 
> **Overview**
> Fixes **full-screen Duck.ai** closing the app instead of returning to the tab you came from (e.g. **New Voice Chat** from the menu).
> 
> When handling `OPEN_DUCK_CHAT` with full-screen mode enabled, the new Duck.ai tab is now opened with a **`sourceTabId`**: from `SOURCE_TAB_ID_EXTRA` on the intent when present, otherwise **`currentTab?.tabId`**. That value is passed through both the swiping-tabs (`launchNewTab`) and legacy (`onOpenInNewTabRequested`) paths so closing the Duck.ai tab can restore the prior tab.
> 
> Opening from the **New Tab Page** without a current tab may still exit the app; called out as a known follow-up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2c7b0fcfb54b8953d2da89a28ba504acc688317. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->