### PR TITLE
Remove hard coded gpt reasoning access

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
@@ -133,7 +133,7 @@ class RealDuckAiModelManager @Inject constructor(
         withContext(dispatcherProvider.io()) {
             try {
                 val userTier = resolveUserTier()
-                val response = fetchModelsResponse().withHardcodedReasoningGates()
+                val response = fetchModelsResponse()
                 val models = response.models
                     .map { resolveModel(it, userTier) }
                     .filterNot { it.accessTier.isEmpty() && !it.isAccessible }
@@ -325,26 +325,6 @@ class RealDuckAiModelManager @Inject constructor(
         return currentSelectedId
     }
 }
-
-// TODO: Remove this hardcoded gate once the backend ships per-effort `reasoningEffortAccess` for gpt-5.2.
-//  EXTENDED_REASONING on gpt-5.2 is PRO-only. We gate every candidate effort of EXTENDED_REASONING.
-//  To remove: delete this function and the `.withHardcodedReasoningGates()` call in fetchModels.
-//  Follow up task: https://app.asana.com/1/137249556945/project/1212810093780571/task/1214980387692321?focus=true
-private fun AIChatModelsResponse.withHardcodedReasoningGates(): AIChatModelsResponse = copy(
-    models = models.map { model ->
-        if (model.id != "gpt-5.2") return@map model
-        // Server entries win, hardcode only fills gaps. Lets the gate auto-deactivate as
-        // the backend rolls out, and avoids dropping unrelated server-side data.
-        val existing = model.reasoningEffortAccess.orEmpty()
-        val existingIds = existing.mapTo(mutableSetOf()) { it.id }
-        val hardcoded = ReasoningMode.EXTENDED_REASONING.candidateEfforts
-            .filter { it.rawValue !in existingIds }
-            .map { effort ->
-                RemoteReasoningEffortAccess(id = effort.rawValue, accessTier = listOf("pro"), entityHasAccess = false)
-            }
-        model.copy(reasoningEffortAccess = existing + hardcoded)
-    },
-)
 
 private fun com.duckduckgo.subscriptions.api.SubscriptionStatus.isActiveOrWaiting(): Boolean {
     return this == com.duckduckgo.subscriptions.api.SubscriptionStatus.AUTO_RENEWABLE ||

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/RealDuckAiModelManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/RealDuckAiModelManagerTest.kt
@@ -729,67 +729,6 @@ class RealDuckAiModelManagerTest {
     }
 
     @Test
-    fun whenModelIsGpt52AndServerProvidesAccessForExtendedCandidateThenHardcodeDoesNotOverwriteIt() = runTest {
-        // Guards the merge: when the backend ships an entry for an EXTENDED candidate, the hardcode
-        // must defer to it. MEDIUM has no server entry, so the hardcode still fills that gap.
-        whenever(dataStore.getSelectedModel()).thenReturn(null)
-        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.INACTIVE)
-        whenever(modelsService.getModels(any())).thenReturn(
-            AIChatModelsResponse(
-                listOf(
-                    remoteModel(
-                        "gpt-5.2",
-                        accessTier = listOf("free", "plus", "pro"),
-                        entityHasAccess = true,
-                        supportedReasoningEffort = listOf("medium", "high"),
-                        reasoningEffortAccess = listOf(
-                            RemoteReasoningEffortAccess(id = "high", accessTier = listOf("free", "plus", "pro"), entityHasAccess = true),
-                        ),
-                    ),
-                ),
-            ),
-        )
-
-        testee = createManager()
-        testee.fetchModels()
-
-        val access = testee.modelState.value.models.single().reasoningEffortAccess
-        val high = access.single { it.effort == ReasoningEffort.HIGH }
-        val medium = access.single { it.effort == ReasoningEffort.MEDIUM }
-        assertEquals(listOf("free", "plus", "pro"), high.accessTier)
-        assertEquals(listOf("pro"), medium.accessTier)
-    }
-
-    @Test
-    fun whenModelIsGpt52ThenExtendedReasoningCandidatesAreHardcodedToPro() = runTest {
-        // Locks in the temporary hardcoded gate for gpt-5.2 — catches a slug rename or refactor that
-        // silently drops the gate. Remove this test when `withHardcodedReasoningGates` is removed.
-        whenever(dataStore.getSelectedModel()).thenReturn(null)
-        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.INACTIVE)
-        whenever(modelsService.getModels(any())).thenReturn(
-            AIChatModelsResponse(
-                listOf(
-                    remoteModel(
-                        "gpt-5.2",
-                        accessTier = listOf("free", "plus", "pro"),
-                        entityHasAccess = true,
-                        supportedReasoningEffort = listOf("none", "low", "medium", "high"),
-                    ),
-                ),
-            ),
-        )
-
-        testee = createManager()
-        testee.fetchModels()
-
-        val access = testee.modelState.value.models.single().reasoningEffortAccess
-        ReasoningMode.EXTENDED_REASONING.candidateEfforts.forEach { effort ->
-            val entry = access.single { it.effort == effort }
-            assertEquals(listOf("pro"), entry.accessTier)
-        }
-    }
-
-    @Test
     fun whenRemoteReasoningEffortAccessMissingThenDomainListIsEmpty() = runTest {
         whenever(dataStore.getSelectedModel()).thenReturn(null)
         whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.INACTIVE)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1214980387692321?focus=true 

### Description

Removes the temporary client-side reasoning effort gate that was hardcoded for `gpt-5.2`.

When per-effort `reasoningEffortAccess` wasn't yet shipped by the backend, `DuckAiModelManager` patched the models response to mark `EXTENDED_REASONING` efforts on `gpt-5.2` as PRO-only. The backend now drives reasoning effort access for all models, and `gpt-5.2` has since been removed and replaced by `gpt-5.4`, so the hardcoded gate is dead code.

### Steps to test this PR

- [x] On a FREE (no subscription) account
- [x] Confirm any model in PLUS/PRO routes to the correct upsell tier on tap.
- [x] On a PLUS account
- [x] Select gpt-5.4 and open the reasoning picker.
- [x] Confirm Extended Reasoning trigger the upsell to PRO flow, but no the others


### UI changes
No UI changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Subscription gating for extended reasoning on gpt-5.2 now depends entirely on backend `reasoningEffortAccess`; a rollout gap could change who can select those modes until the server data is correct.
> 
> **Overview**
> Removes the temporary client-side override that forced **gpt-5.2** extended-reasoning efforts to **pro** when the models API omitted `reasoningEffortAccess`. `fetchModels()` now uses the API response as-is; per-effort tiers and accessibility still flow through existing `resolveModel` / `ReasoningResolver` logic.
> 
> The `withHardcodedReasoningGates()` helper and the two unit tests that locked in that behavior are deleted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ec5531f75b25d86822e995150d64e6deba9298d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->