### PR TITLE
Fix flaky unit tests in ChatHistoryViewModelTest

### DIFF
--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryViewModelTest.kt
@@ -64,16 +64,24 @@ class ChatHistoryViewModelTest {
     private val duckAiModelManager = FakeDuckAiModelManager()
     private val tabRepository: TabRepository = mock()
     private val pixel: Pixel = mock()
-    private val viewModel = ChatHistoryViewModel(
-        repository,
-        coroutineRule.testScope,
-        duckChat,
-        dataClearingTrigger,
-        duckAiFeatureState,
-        duckAiModelManager,
-        tabRepository,
-        pixel,
-    )
+
+    // Build the ViewModel lazily so it's created inside the test, not as a field. The rule that
+    // swaps in the test dispatcher runs after fields are initialized, so an eagerly-built ViewModel
+    // ends up running its coroutines on real background threads. That makes the init block's
+    // fetchModels() call race the test. Lazy construction happens after the rule, keeping everything
+    // on the test thread.
+    private val viewModel by lazy {
+        ChatHistoryViewModel(
+            repository,
+            coroutineRule.testScope,
+            duckChat,
+            dataClearingTrigger,
+            duckAiFeatureState,
+            duckAiModelManager,
+            tabRepository,
+            pixel,
+        )
+    }
 
     @Test
     fun `initial state is Loading`() = coroutineRule.testScope.runTest {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1215387666050466?focus=true 

### Description

Fix flaky ChatHistoryViewModelTest.init warms the model manager cache by calling fetchModels

**Problem**
init warms the model manager cache by calling fetchModels fails intermittently with a bare AssertionError at the `assertEquals(1, duckAiModelManager.fetchModelsCount)` line. It passes most of the time or after retries with no code changes in between.

**Possible Root cause**
The viewModel was created as a field, which runs before the test rule sets up the test dispatcher. As a result the ViewModel's coroutines ran on real background threads instead of the test thread. The init block's fetchModels() call then races the test's assertion, so the result depends on timing.

**Fix**
Create the viewModel lazily so it's built inside the test, after the rule is set up. Everything now runs on the test thread and fetchModels() is called before the assertion, every time.

**Verification**

Ran the full test class multiple times with --rerun-tasks. All passed, no other tests affected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code or behavior modifications.
> 
> **Overview**
> Fixes **flaky** `ChatHistoryViewModelTest` by deferring `ChatHistoryViewModel` creation until each test runs, instead of building it as a class field.
> 
> `CoroutineTestRule` installs the test dispatcher **after** field initialization, so an eagerly constructed ViewModel ran its `init` coroutine (`fetchModels()`) on real background threads and raced assertions. **`by lazy`** ensures the ViewModel is created only after the rule is active, so init work stays on the test scheduler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fb691044c1938a23c4898b1e266c54674957b46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->