### PR TITLE
Update Unified Input E2E reply hint assertion

### DIFF
--- a/.maestro/unified_input_screen/shared/flow_ask_duckai_suggestion.yaml
+++ b/.maestro/unified_input_screen/shared/flow_ask_duckai_suggestion.yaml
@@ -35,7 +35,7 @@ appId: com.duckduckgo.mobile.android
 - runFlow: reload_duckai_if_needed.yaml
 
 # verify Duck.ai opened with the query submitted — the Duck.ai header replaces the
-# omnibar and the bottom input shows the chat placeholder
+# omnibar and, with a chat now active, the bottom input shows the reply hint
 - extendedWaitUntil:
     visible:
       id: "duckAIHeader"
@@ -43,4 +43,4 @@ appId: com.duckduckgo.mobile.android
 - assertVisible:
     id: "duckAIHeader"
 - assertVisible:
-    text: "Ask anything privately…"
+    text: "Reply…"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1157893581871903/task/1215405426981252?focus=true

### Description

After a copy review, the Duck.ai chat input hint changed: once a chat is active, the bottom input shows the reply hint rather than the idle placeholder.

The E2E flow `flow_ask_duckai_suggestion.yaml` (shared by the "UnifiedInput: ask duck.ai suggestion opens chat × omnibar positions" test across the top/bottom/split omnibar positions) still asserted the old idle copy `"Ask anything privately…"`. After opening Duck.ai with a query submitted, the hint is now `"Reply…"` (`native_input_chat_duck_mode_hint`).

This updates the assertion to match the new copy and clarifies the surrounding comment.

### Steps to test this PR

_UnifiedInput ask duck.ai suggestion flow_
- [ ] Build and install an internal release with `nativeInputToggle` + `inputWithAiToggle` enabled
- [ ] Run `maestro test .maestro/unified_input_screen/unified_input_ask_duckai_suggestion.yaml`
- [ ] Confirm all three iterations (omnibar top/bottom/split) pass and the flow asserts `"Reply…"` is visible after Duck.ai opens

### UI changes
No UI changes — Maestro test assertion only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Maestro E2E assertion and comment only; no production code or UI behavior changes.
> 
> **Overview**
> Updates the shared Maestro flow **`flow_ask_duckai_suggestion.yaml`** so it matches post–copy-review Duck.ai input hints: after opening Duck.ai with a query, the bottom input is expected to show **`Reply…`** (active chat / `native_input_chat_duck_mode_hint`) instead of the idle **`Ask anything privately…`** placeholder.
> 
> The comment above the Duck.ai header assertions is tweaked to note that an active chat drives the reply hint. No app code changes—test assertion and comment only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 94b3a0449920af730e5ed069d80d6c3bb3a650e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->