### PR TITLE
Update Compose BOM to 2026.05.01

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -34,7 +34,7 @@ version.androidx.browser=1.8.0
 # Cannot update past 1.0.0-alpha08 because alpha09+ requires Kotlin 2.x
 version.androidx.pdf=1.0.0-alpha08
 
-version.androidx.compose=2026.01.00
+version.androidx.compose=2026.05.01
 
 version.androidx.constraintlayout=2.1.4
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207908166761516/task/1215363216921264

### Description

Updates the AndroidX Compose BOM (`version.androidx.compose` in `versions.properties`) to `2026.05.01`, the latest stable version published to Google's Maven repository.

### Steps to test this PR

_Compose BOM bump_
- [x] Build and install the app and confirm it builds with no dependency-resolution errors
- [x] Smoke-test ADS screens

### UI changes
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> A Compose BOM bump updates many transitive Compose libraries at once, which can cause subtle UI or behavioral regressions across Compose screens despite no direct code changes.
> 
> **Overview**
> Bumps **`version.androidx.compose`** in `versions.properties` from **`2026.01.00`** to **`2026.05.01`**, aligning Jetpack Compose artifacts with the latest published BOM (consumed via `platform(AndroidX.compose.bom)` in modules such as design-system).
> 
> There are **no application or UI code changes**—only the centralized version pin. Validation is build/tests plus Compose screen smoke tests for regressions from updated Compose libraries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f41426969f3cb0e093199abb79e641854371ae0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->