### PR TITLE
Close current tab and open new one on hatch burn

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -87,6 +87,7 @@ import com.duckduckgo.app.global.rating.PromptCount
 import com.duckduckgo.app.global.sanitize
 import com.duckduckgo.app.global.view.ClearDataAction
 import com.duckduckgo.app.global.view.ORIGIN_DUCK_AI_CONTEXTUAL_CHAT
+import com.duckduckgo.app.global.view.ORIGIN_HATCH
 import com.duckduckgo.app.global.view.renderIfChanged
 import com.duckduckgo.app.onboarding.ui.page.DefaultBrowserPage
 import com.duckduckgo.app.pixels.AppPixelName
@@ -488,7 +489,8 @@ open class BrowserActivity : DuckDuckGoActivity() {
                     }
                 }
                 FireDialog.EVENT_ON_SINGLE_TAB_CLEAR_COMPLETE -> {
-                    val isDuckAiContextual = bundle.getString(FireDialog.RESULT_KEY_ORIGIN) == ORIGIN_DUCK_AI_CONTEXTUAL_CHAT
+                    val origin = bundle.getString(FireDialog.RESULT_KEY_ORIGIN)
+                    val isDuckAiContextual = origin == ORIGIN_DUCK_AI_CONTEXTUAL_CHAT
                     val message = if (isDuckAiContextual) {
                         getString(R.string.duckAiChatDeletedSnackbar)
                     } else {
@@ -496,6 +498,12 @@ open class BrowserActivity : DuckDuckGoActivity() {
                     }
                     showSnackbar(message)
                     if (isDuckAiContextual) currentTab?.onContextualSheetFireComplete()
+                    // Burning a tab from the return hatch closes the tab the user is on and opens a
+                    // fresh new tab, so they land on a clean tab rather than back on the burned one.
+                    if (origin == ORIGIN_HATCH) {
+                        currentTab?.closeCurrentTab()
+                        launchNewTab()
+                    }
                     if (pendingDuckAiOnboardingFire) {
                         pendingDuckAiOnboardingFire = false
                         closeDuckChatFullScreen()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3729,6 +3729,7 @@ class BrowserTabFragment :
         newTabReturnHatchView.setHatchListener(
             object : NewTabReturnHatchView.HatchListener {
                 override fun onHatchPressed() {
+                    hideKeyboard()
                     ntpAfterIdleManager.onReturnToPageTapped()
                     browserActivity?.openExistingTab(newTabReturnHatchView.tabId)
                 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1215390332092907?focus=true

### Description

When a tab is burned from the New Tab Page **return hatch** (`ORIGIN_HATCH`), the app now also **closes the tab the user is on and opens a fresh new tab**, so they land on a clean tab instead of staying on the burned page.

`BrowserActivity` handles this on `FireDialog.EVENT_ON_SINGLE_TAB_CLEAR_COMPLETE`: it reads the `origin` once, and for `ORIGIN_HATCH` calls `closeCurrentTab()` followed by `launchNewTab()` (after the existing cleared-tab snackbar).

### Steps to test this PR

_Hatch burn closes the current tab and opens a new one_
- [ ] Get the New Tab Page to show the return hatch (open a tab, let the app go idle, then return).
- [ ] Tap the hatch's fire/burn button and let the burn complete.
- [ ] Confirm the tab you were on is closed and you land on a fresh new tab — not back on the burned page.

### UI changes
No UI changes — tab/navigation behaviour only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tab lifecycle on a specific fire-dialog completion path; scope is narrow but affects which tab the user lands on after hatch burn.
> 
> **Overview**
> When a tab is burned from the **NTP return hatch** (`ORIGIN_HATCH`), completing the fire dialog now **closes the active tab and opens a fresh new tab** so the user is not left on the cleared page.
> 
> `BrowserActivity` handles this on `FireDialog.EVENT_ON_SINGLE_TAB_CLEAR_COMPLETE` by reading the fire `origin` once and, for hatch burns, calling `closeCurrentTab()` then `launchNewTab()` after the existing cleared-tab snackbar.
> 
> `BrowserTabFragment` also calls **`hideKeyboard()`** when the return hatch is tapped (before navigating back to the prior tab).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edb258e06121090917a26780f495f25b1cd76666. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->