### PR TITLE
Fix unit tests

### DIFF
--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModelTest.kt
@@ -211,6 +211,8 @@ class SubscriptionWebViewViewModelTest {
 
     @Test
     fun whenGetUserSettingsThenComputeUserSettingsCommandSent() = runTest {
+        subscriptionsFeature.userSettingsMessaging().setRawStoredState(Toggle.State(enable = true))
+
         viewModel.commands().test {
             viewModel.processJsCallbackMessage("test", "getUserSettings", "msgId", JSONObject("{}"))
             val result = awaitItem()
@@ -240,6 +242,8 @@ class SubscriptionWebViewViewModelTest {
 
     @Test
     fun whenRequestNotificationsPermissionThenRequestNotificationsPermissionCommandSent() = runTest {
+        subscriptionsFeature.notificationsPermissionMessaging().setRawStoredState(Toggle.State(enable = true))
+
         viewModel.commands().test {
             viewModel.processJsCallbackMessage("test", "requestNotificationsPermission", "msgId", JSONObject("{}"))
             val result = awaitItem()
@@ -302,6 +306,7 @@ class SubscriptionWebViewViewModelTest {
 
     @Test
     fun whenPurchaseSucceedsWithScheduleNotificationAndFlagEnabledThenSchedulerCalled() = runTest {
+        subscriptionsFeature.userSettingsMessaging().setRawStoredState(Toggle.State(enable = true))
         subscriptionsFeature.subscriptionExpirationReminderNotification().setRawStoredState(Toggle.State(enable = true))
         val flowTest: MutableSharedFlow<CurrentPurchase> = MutableSharedFlow()
         whenever(subscriptionsManager.currentPurchaseState).thenReturn(flowTest)
@@ -320,6 +325,7 @@ class SubscriptionWebViewViewModelTest {
 
     @Test
     fun whenPurchaseSucceedsWithScheduleNotificationAndFlagDisabledThenSchedulerNotCalled() = runTest {
+        subscriptionsFeature.userSettingsMessaging().setRawStoredState(Toggle.State(enable = true))
         subscriptionsFeature.subscriptionExpirationReminderNotification().setRawStoredState(Toggle.State(enable = false))
         val flowTest: MutableSharedFlow<CurrentPurchase> = MutableSharedFlow()
         whenever(subscriptionsManager.currentPurchaseState).thenReturn(flowTest)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215411813721347?focus=true

### Description
Update tests with toggle default value for new JS messages

### Steps to test this PR
- [ ] CI green

### No UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code; low risk aside from ensuring CI reflects current toggle gating.
> 
> **Overview**
> Updates **SubscriptionWebViewViewModelTest** so tests that expect JS messaging behavior explicitly turn on the relevant feature toggles before exercising the ViewModel.
> 
> **getUserSettings** and **requestNotificationsPermission** tests now set `userSettingsMessaging()` and `notificationsPermissionMessaging()` to enabled, matching the production guard that no-ops when those toggles are off (the fake toggle store defaults to disabled).
> 
> Purchase success tests that assert expiration reminder scheduling now also enable `userSettingsMessaging()`, because `scheduleNotification` from `subscriptionSelected` is only honored when that toggle is on—in addition to the existing `subscriptionExpirationReminderNotification()` setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76cfab04084b67ec92f25008c49830c2989233ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->