### PR TITLE
PIR: Add cancellation reason to initial scan wide event

### DIFF
--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -2213,21 +2213,7 @@
                     "unknown_error"
                 ]
             },
-            {
-                "key": "feature.data.ext.cancellation_reason",
-                "description": "Reason a run was cancelled. Only present on CANCELLED events. superseded_by_profile_edit (a profile-edit re-scan replaced this run), superseded_by_new_run (any other newer run replaced it), profile_deleted/foreground_start_failed and the eligibility reasons (feature_disabled, subscription_expired, entitlement_lost, repository_unavailable) are client-attributed; work_stopped is a generic coroutine/WorkManager cancellation. The phase the run was in when it was cancelled is recoverable from last_step.",
-                "enum": [
-                    "superseded_by_new_run",
-                    "superseded_by_profile_edit",
-                    "profile_deleted",
-                    "feature_disabled",
-                    "subscription_expired",
-                    "entitlement_lost",
-                    "repository_unavailable",
-                    "foreground_start_failed",
-                    "work_stopped"
-                ]
-            },
+            "pirCancellationReason",
             {
                 "key": "feature.data.ext.step.started",
                 "description": "Parameter present when the run body actually begins (after the no-profiles early return)",
@@ -2486,21 +2472,7 @@
                     "unknown_error"
                 ]
             },
-            {
-                "key": "feature.data.ext.cancellation_reason",
-                "description": "Reason a run was cancelled. Only present on CANCELLED events. superseded_by_profile_edit (a profile-edit re-scan replaced this run), superseded_by_new_run (any other newer run replaced it), profile_deleted/foreground_start_failed and the eligibility reasons (feature_disabled, subscription_expired, entitlement_lost, repository_unavailable) are client-attributed; work_stopped is a generic coroutine/WorkManager cancellation. The phase the run was in when it was cancelled is recoverable from last_step.",
-                "enum": [
-                    "superseded_by_new_run",
-                    "superseded_by_profile_edit",
-                    "profile_deleted",
-                    "feature_disabled",
-                    "subscription_expired",
-                    "entitlement_lost",
-                    "repository_unavailable",
-                    "foreground_start_failed",
-                    "work_stopped"
-                ]
-            },
+            "pirCancellationReason",
             {
                 "key": "feature.data.ext.step.started",
                 "description": "Parameter present when the run body actually begins (after the no-profiles early return)",

--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -2214,6 +2214,20 @@
                 ]
             },
             {
+                "key": "feature.data.ext.cancellation_reason",
+                "description": "Reason a run was cancelled. Only present on CANCELLED events. superseded_by_new_run/profile_deleted/foreground_start_failed and the eligibility reasons (feature_disabled, subscription_expired, entitlement_lost, repository_unavailable) are client-attributed; work_stopped is a generic coroutine/WorkManager cancellation. The phase the run was in when it was cancelled is recoverable from last_step.",
+                "enum": [
+                    "superseded_by_new_run",
+                    "profile_deleted",
+                    "feature_disabled",
+                    "subscription_expired",
+                    "entitlement_lost",
+                    "repository_unavailable",
+                    "foreground_start_failed",
+                    "work_stopped"
+                ]
+            },
+            {
                 "key": "feature.data.ext.step.started",
                 "description": "Parameter present when the run body actually begins (after the no-profiles early return)",
                 "type": "boolean"
@@ -2469,6 +2483,20 @@
                     "sqlite_exception",
                     "timeout_cancellation_exception",
                     "unknown_error"
+                ]
+            },
+            {
+                "key": "feature.data.ext.cancellation_reason",
+                "description": "Reason a run was cancelled. Only present on CANCELLED events. superseded_by_new_run/profile_deleted/foreground_start_failed and the eligibility reasons (feature_disabled, subscription_expired, entitlement_lost, repository_unavailable) are client-attributed; work_stopped is a generic coroutine/WorkManager cancellation. The phase the run was in when it was cancelled is recoverable from last_step.",
+                "enum": [
+                    "superseded_by_new_run",
+                    "profile_deleted",
+                    "feature_disabled",
+                    "subscription_expired",
+                    "entitlement_lost",
+                    "repository_unavailable",
+                    "foreground_start_failed",
+                    "work_stopped"
                 ]
             },
             {

--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -2215,9 +2215,10 @@
             },
             {
                 "key": "feature.data.ext.cancellation_reason",
-                "description": "Reason a run was cancelled. Only present on CANCELLED events. superseded_by_new_run/profile_deleted/foreground_start_failed and the eligibility reasons (feature_disabled, subscription_expired, entitlement_lost, repository_unavailable) are client-attributed; work_stopped is a generic coroutine/WorkManager cancellation. The phase the run was in when it was cancelled is recoverable from last_step.",
+                "description": "Reason a run was cancelled. Only present on CANCELLED events. superseded_by_profile_edit (a profile-edit re-scan replaced this run), superseded_by_new_run (any other newer run replaced it), profile_deleted/foreground_start_failed and the eligibility reasons (feature_disabled, subscription_expired, entitlement_lost, repository_unavailable) are client-attributed; work_stopped is a generic coroutine/WorkManager cancellation. The phase the run was in when it was cancelled is recoverable from last_step.",
                 "enum": [
                     "superseded_by_new_run",
+                    "superseded_by_profile_edit",
                     "profile_deleted",
                     "feature_disabled",
                     "subscription_expired",
@@ -2487,9 +2488,10 @@
             },
             {
                 "key": "feature.data.ext.cancellation_reason",
-                "description": "Reason a run was cancelled. Only present on CANCELLED events. superseded_by_new_run/profile_deleted/foreground_start_failed and the eligibility reasons (feature_disabled, subscription_expired, entitlement_lost, repository_unavailable) are client-attributed; work_stopped is a generic coroutine/WorkManager cancellation. The phase the run was in when it was cancelled is recoverable from last_step.",
+                "description": "Reason a run was cancelled. Only present on CANCELLED events. superseded_by_profile_edit (a profile-edit re-scan replaced this run), superseded_by_new_run (any other newer run replaced it), profile_deleted/foreground_start_failed and the eligibility reasons (feature_disabled, subscription_expired, entitlement_lost, repository_unavailable) are client-attributed; work_stopped is a generic coroutine/WorkManager cancellation. The phase the run was in when it was cancelled is recoverable from last_step.",
                 "enum": [
                     "superseded_by_new_run",
+                    "superseded_by_profile_edit",
                     "profile_deleted",
                     "feature_disabled",
                     "subscription_expired",

--- a/PixelDefinitions/pixels/params_dictionary.json
+++ b/PixelDefinitions/pixels/params_dictionary.json
@@ -128,5 +128,21 @@
         "key": "free_trial",
         "type": "boolean",
         "description": "Whether the subscription purchase is a free trial"
+    },
+    "pirCancellationReason": {
+        "key": "feature.data.ext.cancellation_reason",
+        "type": "string",
+        "description": "Reason a PIR run was cancelled. Only present on CANCELLED events. superseded_by_profile_edit (a profile-edit re-scan replaced this run), superseded_by_new_run (any other newer run replaced it), profile_deleted/foreground_start_failed and the eligibility reasons (feature_disabled, subscription_expired, entitlement_lost, repository_unavailable) are client-attributed; work_stopped is a generic coroutine/WorkManager cancellation. The phase the run was in when it was cancelled is recoverable from last_step.",
+        "enum": [
+            "superseded_by_new_run",
+            "superseded_by_profile_edit",
+            "profile_deleted",
+            "feature_disabled",
+            "subscription_expired",
+            "entitlement_lost",
+            "repository_unavailable",
+            "foreground_start_failed",
+            "work_stopped"
+        ]
     }
 }

--- a/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/PirEndToEndTest.kt
+++ b/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/PirEndToEndTest.kt
@@ -1017,7 +1017,9 @@ class PirEndToEndTest {
         override suspend fun onOptOutCompleted(executionType: PirExecutionType, totalOptOutJobs: Int) = Unit
         override suspend fun onOptOutSkipped(executionType: PirExecutionType) = Unit
         override suspend fun onRunFailed(executionType: PirExecutionType, reason: PirScanWideEvent.FailureReason) = Unit
-        override suspend fun onRunCancelled(executionType: PirExecutionType) = Unit
+        override suspend fun onRunCancelled(executionType: PirExecutionType, reason: PirScanWideEvent.CancellationReason) = Unit
+        override suspend fun onWorkCancelled(reason: PirScanWideEvent.CancellationReason) = Unit
+        override suspend fun onRunCancelledBeforeStart(executionType: PirExecutionType, reason: PirScanWideEvent.CancellationReason) = Unit
         override suspend fun onUserReset() = Unit
     }
 

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/PirUserUtils.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/PirUserUtils.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.pir.impl
 
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.pir.impl.checker.PirWorkHandler
+import com.duckduckgo.pir.impl.checker.isEnabled
 import com.duckduckgo.pir.impl.store.PirRepository
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.flow.firstOrNull
@@ -40,6 +41,6 @@ class RealPirUserUtils @Inject constructor(
      * - Has a userprofile set up for scanning
      */
     override suspend fun isActiveUser(): Boolean {
-        return pirWorkHandler.canRunPir().firstOrNull() == true && pirRepository.getValidUserProfileQueries().isNotEmpty()
+        return pirWorkHandler.canRunPir().firstOrNull()?.isEnabled == true && pirRepository.getValidUserProfileQueries().isNotEmpty()
     }
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/brokers/PirDataUpdateObserver.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/brokers/PirDataUpdateObserver.kt
@@ -23,9 +23,11 @@ import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.pir.impl.PirFeatureDataCleaner
+import com.duckduckgo.pir.impl.checker.PirEligibility
 import com.duckduckgo.pir.impl.checker.PirWorkHandler
 import com.duckduckgo.pir.impl.pixels.PirPixelSender
 import com.duckduckgo.pir.impl.store.PirRepository
+import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent.CancellationReason
 import com.squareup.anvil.annotations.ContributesMultibinding
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.collectLatest
@@ -52,30 +54,34 @@ class PirDataUpdateObserver @Inject constructor(
             // Observe when PIR becomes available so we can fetch the broker data or cancel all related work
             pirWorkHandler
                 .canRunPir()
-                .collectLatest { enabled ->
+                .collectLatest { eligibility ->
                     val featureReceiveMs = pirRepository.getFeatureReceivedMs()
-                    if (enabled) {
-                        pirPixelSender.reportCanRunPir()
-                        // We only set the value if it was not set previously
-                        if (featureReceiveMs == 0L) {
-                            pirRepository.setFeatureReceivedMs(currentTimeProvider.currentTimeMillis())
+                    when (eligibility) {
+                        is PirEligibility.Enabled -> {
+                            pirPixelSender.reportCanRunPir()
+                            // We only set the value if it was not set previously
+                            if (featureReceiveMs == 0L) {
+                                pirRepository.setFeatureReceivedMs(currentTimeProvider.currentTimeMillis())
+                            }
+
+                            logcat { "PIR-update: Attempting to update all broker data" }
+                            if (brokerJsonUpdater.update()) {
+                                logcat { "PIR-update: Update successfully completed." }
+                            } else {
+                                logcat { "PIR-update: Failed to complete." }
+                            }
                         }
 
-                        logcat { "PIR-update: Attempting to update all broker data" }
-                        if (brokerJsonUpdater.update()) {
-                            logcat { "PIR-update: Update successfully completed." }
-                        } else {
-                            logcat { "PIR-update: Failed to complete." }
-                        }
-                    } else {
-                        logcat { "PIR-update: PIR not enabled" }
-                        // We also check the etag to handle scenarios where featureReceiveMs was not yet available
-                        if (featureReceiveMs != 0L || pirRepository.getCurrentMainEtag() != null) {
-                            logcat { "PIR-update: resetting feature" }
-                            // This will also cancel any ongoing work that is currently running if PIR is not enabled
-                            // This will also clear the featureReceivedMs
-                            pirWorkHandler.cancelWork()
-                            pirFeatureDataCleaner.removeAllData()
+                        is PirEligibility.Disabled -> {
+                            logcat { "PIR-update: PIR not enabled" }
+                            // We also check the etag to handle scenarios where featureReceiveMs was not yet available
+                            if (featureReceiveMs != 0L || pirRepository.getCurrentMainEtag() != null) {
+                                logcat { "PIR-update: resetting feature" }
+                                // This will also cancel any ongoing work that is currently running if PIR is not enabled
+                                // This will also clear the featureReceivedMs
+                                pirWorkHandler.cancelWork(CancellationReason.fromDisabledReason(eligibility.reason))
+                                pirFeatureDataCleaner.removeAllData()
+                            }
                         }
                     }
                 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/checker/PirEligibility.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/checker/PirEligibility.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.checker
+
+sealed interface PirEligibility {
+    data object Enabled : PirEligibility
+    data class Disabled(val reason: DisabledReason) : PirEligibility
+}
+
+enum class DisabledReason {
+    FEATURE_DISABLED,
+    SUBSCRIPTION_EXPIRED,
+    ENTITLEMENT_LOST,
+    REPOSITORY_UNAVAILABLE,
+}
+
+val PirEligibility.isEnabled: Boolean
+    get() = this is PirEligibility.Enabled

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/checker/PirWorkHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/checker/PirWorkHandler.kt
@@ -26,6 +26,8 @@ import com.duckduckgo.pir.impl.optout.PirForegroundOptOutService
 import com.duckduckgo.pir.impl.scan.PirForegroundScanService
 import com.duckduckgo.pir.impl.scan.PirScanScheduler
 import com.duckduckgo.pir.impl.store.PirRepository
+import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent
+import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent.CancellationReason
 import com.duckduckgo.subscriptions.api.Product.PIR
 import com.duckduckgo.subscriptions.api.SubscriptionStatus
 import com.duckduckgo.subscriptions.api.Subscriptions
@@ -44,16 +46,21 @@ import javax.inject.Inject
  */
 interface PirWorkHandler {
     /**
-     * Checks if PIR can run based on remote features and subscription status.
+     * Checks if PIR can run based on remote features, subscription status, entitlement and
+     * repository availability.
      *
-     * @return Flow that emits true if PIR can run, false otherwise.
+     * @return Flow that emits [PirEligibility.Enabled] when PIR can run, or
+     * [PirEligibility.Disabled] (carrying the failing [DisabledReason]) otherwise.
      */
-    suspend fun canRunPir(): Flow<Boolean>
+    suspend fun canRunPir(): Flow<PirEligibility>
 
     /**
      * Cancels any ongoing PIR work, including foreground services and scheduled scans.
+     *
+     * @param reason why the work is being cancelled, used to attribute any in-flight scan run in
+     * the wide event.
      */
-    suspend fun cancelWork()
+    suspend fun cancelWork(reason: CancellationReason)
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -69,9 +76,10 @@ class RealPirWorkHandler @Inject constructor(
     private val pirScanScheduler: PirScanScheduler,
     private val pirRepository: PirRepository,
     private val pirNotificationManager: PirNotificationManager,
+    private val pirScanWideEvent: PirScanWideEvent,
 ) : PirWorkHandler {
 
-    override suspend fun canRunPir(): Flow<Boolean> {
+    override suspend fun canRunPir(): Flow<PirEligibility> {
         return withContext(dispatcherProvider.io()) {
             if (pirRemoteFeatures.pirBeta().isEnabled()) {
                 // User could have a valid subscription but is not entitled to PIR,
@@ -85,15 +93,17 @@ class RealPirWorkHandler @Inject constructor(
                         }
                         .distinctUntilChanged(),
                 ) { subscriptionStatus, hasValidEntitlement ->
-                    isPirEnabled(hasValidEntitlement, subscriptionStatus) && pirRepository.isRepositoryAvailable()
+                    resolveEligibility(subscriptionStatus, hasValidEntitlement)
                 }
             } else {
-                flowOf(false)
+                flowOf(PirEligibility.Disabled(DisabledReason.FEATURE_DISABLED))
             }
         }
     }
 
-    override suspend fun cancelWork() {
+    override suspend fun cancelWork(reason: CancellationReason) {
+        // Finalize any in-flight wide-event run as Cancelled
+        pirScanWideEvent.onWorkCancelled(reason)
         // Stop any running foreground services
         context.stopService(Intent(context, PirForegroundScanService::class.java))
         context.stopService(Intent(context, PirForegroundOptOutService::class.java))
@@ -102,25 +112,28 @@ class RealPirWorkHandler @Inject constructor(
         pirNotificationManager.cancelNotifications()
     }
 
-    private fun isPirEnabled(
-        hasValidEntitlement: Boolean,
+    private suspend fun resolveEligibility(
         subscriptionStatus: SubscriptionStatus,
-    ): Boolean {
-        return when (subscriptionStatus) {
+        hasValidEntitlement: Boolean,
+    ): PirEligibility {
+        val subscriptionActive = when (subscriptionStatus) {
             SubscriptionStatus.UNKNOWN,
             SubscriptionStatus.INACTIVE,
             SubscriptionStatus.EXPIRED,
             SubscriptionStatus.WAITING,
-            -> {
-                false
-            }
+            -> false
 
             SubscriptionStatus.AUTO_RENEWABLE,
             SubscriptionStatus.NOT_AUTO_RENEWABLE,
             SubscriptionStatus.GRACE_PERIOD,
-            -> {
-                hasValidEntitlement
-            }
+            -> true
+        }
+
+        return when {
+            !subscriptionActive -> PirEligibility.Disabled(DisabledReason.SUBSCRIPTION_EXPIRED)
+            !hasValidEntitlement -> PirEligibility.Disabled(DisabledReason.ENTITLEMENT_LOST)
+            !pirRepository.isRepositoryAvailable() -> PirEligibility.Disabled(DisabledReason.REPOSITORY_UNAVAILABLE)
+            else -> PirEligibility.Enabled
         }
     }
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebDeleteUserProfileHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebDeleteUserProfileHandler.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebMessages.DELET
 import com.duckduckgo.pir.impl.dashboard.messaging.model.PirWebMessageResponse
 import com.duckduckgo.pir.impl.dashboard.state.PirWebProfileStateHolder
 import com.duckduckgo.pir.impl.pixels.PirPixelSender
+import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent.CancellationReason
 import com.squareup.anvil.annotations.ContributesMultibinding
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -57,7 +58,7 @@ class PirWebDeleteUserProfileHandler @Inject constructor(
         appCoroutineScope.launch(dispatcherProvider.io()) {
             runCatching {
                 pirWebProfileStateHolder.clear()
-                workHandler.cancelWork()
+                workHandler.cancelWork(CancellationReason.PROFILE_DELETED)
                 pirFeatureDataCleaner.removeUserData()
             }.onFailure {
                 jsMessaging.sendResponse(

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/email/PirEmailConfirmationRemoteWorker.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/email/PirEmailConfirmationRemoteWorker.kt
@@ -24,7 +24,9 @@ import com.duckduckgo.anvil.annotations.ContributesWorker
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.pir.impl.PirFeatureDataCleaner
+import com.duckduckgo.pir.impl.checker.PirEligibility
 import com.duckduckgo.pir.impl.checker.PirWorkHandler
+import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent.CancellationReason
 import kotlinx.coroutines.flow.firstOrNull
 import logcat.logcat
 import javax.inject.Inject
@@ -49,9 +51,10 @@ class PirEmailConfirmationRemoteWorker(
     override suspend fun doRemoteWork(): Result {
         logcat { "PIR-WORKER ($this}: doRemoteWork ${Process.myPid()}" }
         return try {
-            if (pirWorkHandler.canRunPir().firstOrNull() == false) {
+            val eligibility = pirWorkHandler.canRunPir().firstOrNull()
+            if (eligibility is PirEligibility.Disabled) {
                 logcat { "PIR-WORKER ($this}: PIR not allowed to run!" }
-                pirWorkHandler.cancelWork()
+                pirWorkHandler.cancelWork(CancellationReason.fromDisabledReason(eligibility.reason))
                 pirFeatureDataCleaner.removeAllData()
                 return Result.failure()
             }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/optout/PirForegroundOptOutService.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/optout/PirForegroundOptOutService.kt
@@ -28,8 +28,10 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.di.scopes.ServiceScope
 import com.duckduckgo.pir.impl.PirFeatureDataCleaner
 import com.duckduckgo.pir.impl.R
+import com.duckduckgo.pir.impl.checker.PirEligibility
 import com.duckduckgo.pir.impl.checker.PirWorkHandler
 import com.duckduckgo.pir.impl.notifications.PirNotificationManager
+import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent.CancellationReason
 import dagger.android.AndroidInjection
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.MainScope
@@ -94,9 +96,10 @@ class PirForegroundOptOutService : Service(), CoroutineScope by MainScope() {
         }
 
         launch {
-            if (pirWorkHandler.canRunPir().firstOrNull() == false) {
+            val eligibility = pirWorkHandler.canRunPir().firstOrNull()
+            if (eligibility is PirEligibility.Disabled) {
                 logcat { "PIR-OPT-OUT: PIR opt-out not allowed to run!" }
-                pirWorkHandler.cancelWork()
+                pirWorkHandler.cancelWork(CancellationReason.fromDisabledReason(eligibility.reason))
                 pirFeatureDataCleaner.removeAllData()
                 stopSelf()
                 return@launch

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scan/PirForegroundScanService.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scan/PirForegroundScanService.kt
@@ -30,11 +30,14 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.di.scopes.ServiceScope
 import com.duckduckgo.pir.impl.PirFeatureDataCleaner
 import com.duckduckgo.pir.impl.R
+import com.duckduckgo.pir.impl.checker.PirEligibility
 import com.duckduckgo.pir.impl.checker.PirWorkHandler
 import com.duckduckgo.pir.impl.notifications.PirNotificationManager
 import com.duckduckgo.pir.impl.pixels.PirPixelSender
 import com.duckduckgo.pir.impl.scheduling.PirExecutionType
 import com.duckduckgo.pir.impl.scheduling.PirJobsRunner
+import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent
+import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent.CancellationReason
 import dagger.android.AndroidInjection
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.MainScope
@@ -62,6 +65,9 @@ class PirForegroundScanService : Service(), CoroutineScope by MainScope() {
     @Inject
     lateinit var pirPixelSender: PirPixelSender
 
+    @Inject
+    lateinit var pirScanWideEvent: PirScanWideEvent
+
     override fun onCreate() {
         super.onCreate()
         AndroidInjection.inject(this)
@@ -77,6 +83,8 @@ class PirForegroundScanService : Service(), CoroutineScope by MainScope() {
         startId: Int,
     ): Int {
         logcat { "PIR-SCAN: PIR service started on ${Process.myPid()} thread: ${Thread.currentThread().name}" }
+        val executionType = intent?.getStringExtra(EXTRA_EXECUTION_TYPE)?.let { PirExecutionType.valueOf(it) }
+            ?: PirExecutionType.MANUAL_INITIAL
         val notification: Notification = pirNotificationManager.createScanStatusNotification(
             title = getString(R.string.pirFeatureName),
             message = getString(R.string.pirNotificationMessageInProgress),
@@ -95,22 +103,26 @@ class PirForegroundScanService : Service(), CoroutineScope by MainScope() {
         } catch (_: Exception) {
             logcat(LogPriority.ERROR) { "PIR-SCAN: Could not start the service as foreground!" }
             pirPixelSender.reportManualScanStartFailed()
+            // Record a one-shot Cancelled wide event for the run that never started (no flow is open yet).
+            launch { pirScanWideEvent.onRunCancelledBeforeStart(executionType, CancellationReason.FOREGROUND_START_FAILED) }
             // If we can't start as a foreground service, there's no point in continuing.
             stopSelf()
             return START_NOT_STICKY
         }
 
         launch {
-            if (pirWorkHandler.canRunPir().firstOrNull() == false) {
+            val eligibility = pirWorkHandler.canRunPir().firstOrNull()
+            if (eligibility is PirEligibility.Disabled) {
                 logcat { "PIR-SCAN: PIR scan not allowed to run!" }
-                pirWorkHandler.cancelWork()
+                val reason = CancellationReason.fromDisabledReason(eligibility.reason)
+                // Record a one-shot Cancelled wide event for the run that never started.
+                pirScanWideEvent.onRunCancelledBeforeStart(executionType, reason)
+                pirWorkHandler.cancelWork(reason)
                 pirFeatureDataCleaner.removeAllData()
                 stopSelf()
                 return@launch
             }
 
-            val executionType = intent?.getStringExtra(EXTRA_EXECUTION_TYPE)?.let { PirExecutionType.valueOf(it) }
-                ?: PirExecutionType.MANUAL_INITIAL
             val result = pirJobsRunner.runEligibleJobs(this@PirForegroundScanService, executionType)
             if (result.isSuccess) {
                 pirNotificationManager.showScanStatusNotification(

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scan/PirScheduledScanWorker.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scan/PirScheduledScanWorker.kt
@@ -24,9 +24,11 @@ import com.duckduckgo.anvil.annotations.ContributesWorker
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.pir.impl.PirFeatureDataCleaner
+import com.duckduckgo.pir.impl.checker.PirEligibility
 import com.duckduckgo.pir.impl.checker.PirWorkHandler
 import com.duckduckgo.pir.impl.scheduling.PirExecutionType
 import com.duckduckgo.pir.impl.scheduling.PirJobsRunner
+import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent.CancellationReason
 import kotlinx.coroutines.flow.firstOrNull
 import logcat.logcat
 import javax.inject.Inject
@@ -51,9 +53,10 @@ class PirScheduledScanRemoteWorker(
     override suspend fun doRemoteWork(): Result {
         logcat { "PIR-WORKER ($this}: doRemoteWork ${Process.myPid()}" }
         return try {
-            if (pirWorkHandler.canRunPir().firstOrNull() == false) {
+            val eligibility = pirWorkHandler.canRunPir().firstOrNull()
+            if (eligibility is PirEligibility.Disabled) {
                 logcat { "PIR-WORKER ($this}: PIR not allowed to run!" }
-                pirWorkHandler.cancelWork()
+                pirWorkHandler.cancelWork(CancellationReason.fromDisabledReason(eligibility.reason))
                 pirFeatureDataCleaner.removeAllData()
                 return Result.failure()
             }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
@@ -267,7 +267,7 @@ class RealPirJobsRunner @Inject constructor(
             pirScanWideEvent.onRunFailed(executionType = executionType, reason = FailureReason.TIMEOUT_CANCELLATION_EXCEPTION)
             throw e
         } catch (e: CancellationException) {
-            pirScanWideEvent.onRunCancelled(executionType)
+            pirScanWideEvent.onRunCancelled(executionType, PirScanWideEvent.CancellationReason.WORK_STOPPED)
             throw e
         } catch (e: Exception) {
             pirScanWideEvent.onRunFailed(executionType = executionType, reason = FailureReason.fromException(e))

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEvent.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEvent.kt
@@ -85,6 +85,7 @@ interface PirScanWideEvent {
 
     enum class CancellationReason(val value: String) {
         SUPERSEDED_BY_NEW_RUN("superseded_by_new_run"),
+        SUPERSEDED_BY_PROFILE_EDIT("superseded_by_profile_edit"),
         PROFILE_DELETED("profile_deleted"),
         FEATURE_DISABLED("feature_disabled"),
         SUBSCRIPTION_EXPIRED("subscription_expired"),
@@ -304,12 +305,17 @@ class PirScanWideEventImpl @Inject constructor(
                 // before the previous one finished, so it was superseded.
                 cachedFlowId?.let { staleId ->
                     closeOpenIntervalsLocked(staleId)
+                    val supersededReason = if (executionType == PirExecutionType.MANUAL_EDIT_PROFILE) {
+                        PirScanWideEvent.CancellationReason.SUPERSEDED_BY_PROFILE_EDIT
+                    } else {
+                        PirScanWideEvent.CancellationReason.SUPERSEDED_BY_NEW_RUN
+                    }
                     wideEventClient.flowFinish(
                         wideEventId = staleId,
                         status = FlowStatus.Cancelled,
                         metadata = mapOf(
                             KEY_LAST_STEP to lastStep,
-                            KEY_CANCELLATION_REASON to PirScanWideEvent.CancellationReason.SUPERSEDED_BY_NEW_RUN.value,
+                            KEY_CANCELLATION_REASON to supersededReason.value,
                         ),
                     )
                     clearStateLocked()

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEvent.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEvent.kt
@@ -232,6 +232,10 @@ class PirScanWideEventImpl @Inject constructor(
     ) {
         if (!isFeatureEnabled()) return
 
+        // If a flow for this run is already open, finalize that one
+        if (stateFor(executionType).onRunCancelled(reason)) return
+
+        // No open flow: synthesize a one-shot Cancelled flow to record the never-started run.
         val flowId = wideEventClient.flowStart(
             name = wideEventNameFor(executionType),
             flowEntryPoint = entryPointFor(executionType),
@@ -480,7 +484,12 @@ class PirScanWideEventImpl @Inject constructor(
             }
         }
 
-        suspend fun onRunCancelled(reason: PirScanWideEvent.CancellationReason) {
+        /**
+         * Finishes the open flow (if any) as Cancelled with [reason]. Returns true if a flow was
+         * finalized, false if there was nothing open — letting callers avoid synthesizing a
+         * duplicate flow.
+         */
+        suspend fun onRunCancelled(reason: PirScanWideEvent.CancellationReason): Boolean =
             mutex.withLock {
                 // The flow may have been started in a different process (the :pir scan service) than
                 // the one handling the cancellation (the main process, for profile deletion or
@@ -489,7 +498,7 @@ class PirScanWideEventImpl @Inject constructor(
                 val ownFlowId = cachedFlowId
                 val flowId = ownFlowId
                     ?: wideEventClient.getFlowIds(wideEventName).getOrNull()?.lastOrNull()
-                    ?: return@withLock
+                    ?: return@withLock false
                 closeOpenIntervalsLocked(flowId)
                 wideEventClient.flowFinish(
                     wideEventId = flowId,
@@ -501,8 +510,8 @@ class PirScanWideEventImpl @Inject constructor(
                     },
                 )
                 clearStateLocked()
+                true
             }
-        }
 
         suspend fun onUserReset() {
             mutex.withLock {

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEvent.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEvent.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.statistics.wideevents.WideEventClient
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.pir.impl.PirRemoteFeatures
+import com.duckduckgo.pir.impl.checker.DisabledReason
 import com.duckduckgo.pir.impl.scheduling.PirExecutionType
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
@@ -70,13 +71,38 @@ interface PirScanWideEvent {
 
     suspend fun onRunFailed(executionType: PirExecutionType, reason: FailureReason)
 
-    suspend fun onRunCancelled(executionType: PirExecutionType)
+    suspend fun onRunCancelled(executionType: PirExecutionType, reason: CancellationReason)
+
+    suspend fun onWorkCancelled(reason: CancellationReason)
+
+    suspend fun onRunCancelledBeforeStart(executionType: PirExecutionType, reason: CancellationReason)
 
     /**
      * Aborts any open manual or scheduled flow so they are discarded rather than eventually
      * emitting a stale `FlowStatus.Unknown` record via the cleanup-on-timeout policy.
      */
     suspend fun onUserReset()
+
+    enum class CancellationReason(val value: String) {
+        SUPERSEDED_BY_NEW_RUN("superseded_by_new_run"),
+        PROFILE_DELETED("profile_deleted"),
+        FEATURE_DISABLED("feature_disabled"),
+        SUBSCRIPTION_EXPIRED("subscription_expired"),
+        ENTITLEMENT_LOST("entitlement_lost"),
+        REPOSITORY_UNAVAILABLE("repository_unavailable"),
+        FOREGROUND_START_FAILED("foreground_start_failed"),
+        WORK_STOPPED("work_stopped"),
+        ;
+
+        companion object {
+            fun fromDisabledReason(reason: DisabledReason): CancellationReason = when (reason) {
+                DisabledReason.FEATURE_DISABLED -> FEATURE_DISABLED
+                DisabledReason.SUBSCRIPTION_EXPIRED -> SUBSCRIPTION_EXPIRED
+                DisabledReason.ENTITLEMENT_LOST -> ENTITLEMENT_LOST
+                DisabledReason.REPOSITORY_UNAVAILABLE -> REPOSITORY_UNAVAILABLE
+            }
+        }
+    }
 
     enum class FailureReason(val value: String) {
         NO_ACTIVE_BROKERS("no_active_brokers"),
@@ -189,9 +215,47 @@ class PirScanWideEventImpl @Inject constructor(
         stateFor(executionType).onRunFailed(reason)
     }
 
-    override suspend fun onRunCancelled(executionType: PirExecutionType) {
+    override suspend fun onRunCancelled(executionType: PirExecutionType, reason: PirScanWideEvent.CancellationReason) {
         if (!isFeatureEnabled()) return
-        stateFor(executionType).onRunCancelled()
+        stateFor(executionType).onRunCancelled(reason)
+    }
+
+    override suspend fun onWorkCancelled(reason: PirScanWideEvent.CancellationReason) {
+        manualState.onRunCancelled(reason)
+        scheduledState.onRunCancelled(reason)
+    }
+
+    override suspend fun onRunCancelledBeforeStart(
+        executionType: PirExecutionType,
+        reason: PirScanWideEvent.CancellationReason,
+    ) {
+        if (!isFeatureEnabled()) return
+
+        val flowId = wideEventClient.flowStart(
+            name = wideEventNameFor(executionType),
+            flowEntryPoint = entryPointFor(executionType),
+            metadata = mapOf(
+                KEY_EXECUTION_TYPE to executionType.metadataValue(),
+                KEY_PROFILE_QUERIES_COUNT to "0",
+                KEY_BROKER_COUNT to "0",
+                KEY_TOTAL_SCAN_JOBS to "0",
+                KEY_WEB_VIEW_COUNT to "0",
+            ),
+            cleanupPolicy = CleanupPolicy.OnTimeout(
+                duration = TIMEOUT_DURATION,
+                flowStatus = FlowStatus.Unknown,
+            ),
+        ).getOrNull() ?: return
+
+        wideEventClient.flowStep(wideEventId = flowId, stepName = STEP_STARTED, success = true)
+        wideEventClient.flowFinish(
+            wideEventId = flowId,
+            status = FlowStatus.Cancelled,
+            metadata = mapOf(
+                KEY_LAST_STEP to STEP_STARTED,
+                KEY_CANCELLATION_REASON to reason.value,
+            ),
+        )
     }
 
     override suspend fun onUserReset() {
@@ -236,13 +300,17 @@ class PirScanWideEventImpl @Inject constructor(
         ) {
             mutex.withLock {
                 // Finish any stale in-memory flow with Cancelled so we don't leave two open flows of
-                // the same name in the wide-events DB.
+                // the same name in the wide-events DB. A still-open flow here means a new run started
+                // before the previous one finished, so it was superseded.
                 cachedFlowId?.let { staleId ->
                     closeOpenIntervalsLocked(staleId)
                     wideEventClient.flowFinish(
                         wideEventId = staleId,
                         status = FlowStatus.Cancelled,
-                        metadata = mapOf(KEY_LAST_STEP to lastStep),
+                        metadata = mapOf(
+                            KEY_LAST_STEP to lastStep,
+                            KEY_CANCELLATION_REASON to PirScanWideEvent.CancellationReason.SUPERSEDED_BY_NEW_RUN.value,
+                        ),
                     )
                     clearStateLocked()
                 }
@@ -269,7 +337,7 @@ class PirScanWideEventImpl @Inject constructor(
                         KEY_TRACKER_BLOCKING_STATE to isTrackerBlockingEnabled.toTrackerBlockingState(),
                     ),
                     cleanupPolicy = CleanupPolicy.OnTimeout(
-                        duration = 8.hours,
+                        duration = TIMEOUT_DURATION,
                         flowStatus = FlowStatus.Unknown,
                     ),
                 ).getOrNull() ?: return@withLock
@@ -406,15 +474,25 @@ class PirScanWideEventImpl @Inject constructor(
             }
         }
 
-        suspend fun onRunCancelled() {
+        suspend fun onRunCancelled(reason: PirScanWideEvent.CancellationReason) {
             mutex.withLock {
-                val flowId = cachedFlowId ?: return@withLock
+                // The flow may have been started in a different process (the :pir scan service) than
+                // the one handling the cancellation (the main process, for profile deletion or
+                // eligibility loss). cachedFlowId is per-process in-memory state, so fall back to the
+                // shared wide-events DB to resolve the still-open flow by name.
+                val ownFlowId = cachedFlowId
+                val flowId = ownFlowId
+                    ?: wideEventClient.getFlowIds(wideEventName).getOrNull()?.lastOrNull()
+                    ?: return@withLock
                 closeOpenIntervalsLocked(flowId)
-                val finalStep = lastStep
                 wideEventClient.flowFinish(
                     wideEventId = flowId,
                     status = FlowStatus.Cancelled,
-                    metadata = mapOf(KEY_LAST_STEP to finalStep),
+                    metadata = buildMap {
+                        // last_step is in-memory state, authoritative only when this process owns the flow.
+                        ownFlowId?.let { put(KEY_LAST_STEP, lastStep) }
+                        put(KEY_CANCELLATION_REASON, reason.value)
+                    },
                 )
                 clearStateLocked()
             }
@@ -461,6 +539,11 @@ class PirScanWideEventImpl @Inject constructor(
         PirExecutionType.SCHEDULED -> ENTRY_POINT_SCHEDULED
     }
 
+    private fun wideEventNameFor(executionType: PirExecutionType): String = when (executionType) {
+        PirExecutionType.MANUAL_INITIAL, PirExecutionType.MANUAL_EDIT_PROFILE -> WIDE_EVENT_NAME_MANUAL
+        PirExecutionType.SCHEDULED -> WIDE_EVENT_NAME_SCHEDULED
+    }
+
     private fun PirExecutionType.metadataValue(): String = when (this) {
         PirExecutionType.MANUAL_INITIAL -> EXECUTION_TYPE_MANUAL_INITIAL
         PirExecutionType.MANUAL_EDIT_PROFILE -> EXECUTION_TYPE_MANUAL_EDIT_PROFILE
@@ -474,6 +557,8 @@ class PirScanWideEventImpl @Inject constructor(
     private fun Boolean.toTrackerBlockingState(): String = if (this) "enabled" else "disabled"
 
     companion object {
+        private val TIMEOUT_DURATION = 8.hours
+
         const val WIDE_EVENT_NAME_MANUAL = "pir-initial-scan"
         const val WIDE_EVENT_NAME_SCHEDULED = "pir-scheduled-scan"
 
@@ -497,6 +582,7 @@ class PirScanWideEventImpl @Inject constructor(
         const val KEY_NOTIFICATIONS_PERMISSION_GRANTED = "notifications_permission_granted"
         const val KEY_TRACKER_BLOCKING_STATE = "tracker_blocking_state"
         const val KEY_LAST_STEP = "last_step"
+        const val KEY_CANCELLATION_REASON = "cancellation_reason"
 
         const val STEP_STARTED = "started"
         const val STEP_PROGRESS_PREFIX = "progress_"

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/brokers/PirDataUpdateObserverTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/brokers/PirDataUpdateObserverTest.kt
@@ -21,9 +21,12 @@ import androidx.lifecycle.testing.TestLifecycleOwner
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.pir.impl.PirFeatureDataCleaner
+import com.duckduckgo.pir.impl.checker.DisabledReason
+import com.duckduckgo.pir.impl.checker.PirEligibility
 import com.duckduckgo.pir.impl.checker.PirWorkHandler
 import com.duckduckgo.pir.impl.pixels.PirPixelSender
 import com.duckduckgo.pir.impl.store.PirRepository
+import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent.CancellationReason
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -49,7 +52,7 @@ class PirDataUpdateObserverTest {
     private val pirRepository: PirRepository = mock()
     private val currentTimeProvider: CurrentTimeProvider = mock()
     private val pirPixelSender: PirPixelSender = mock()
-    private val canRunPirFlow = MutableStateFlow(false)
+    private val canRunPirFlow = MutableStateFlow<PirEligibility>(PirEligibility.Disabled(DisabledReason.FEATURE_DISABLED))
 
     private lateinit var pirDataUpdateObserver: PirDataUpdateObserver
 
@@ -75,9 +78,9 @@ class PirDataUpdateObserverTest {
     @Test
     fun whenOnCreateAndPIRWasNeverEnabledAndIsNotEnabledThenDoNotCancelWork() = runTest {
         pirDataUpdateObserver.onCreate(lifecycleOwner)
-        canRunPirFlow.value = false
+        canRunPirFlow.value = PirEligibility.Disabled(DisabledReason.FEATURE_DISABLED)
 
-        verify(pirWorkHandler, never()).cancelWork()
+        verify(pirWorkHandler, never()).cancelWork(any())
         verify(pirFeatureDataCleaner, never()).removeAllData()
         verify(brokerJsonUpdater, never()).update()
     }
@@ -88,12 +91,12 @@ class PirDataUpdateObserverTest {
         // First call (enabled): 0L so featureReceivedMs gets set; second call (disabled): non-zero to trigger cleanup
         whenever(pirRepository.getFeatureReceivedMs()).thenReturn(0L, 1000L)
 
-        canRunPirFlow.value = true
+        canRunPirFlow.value = PirEligibility.Enabled
         pirDataUpdateObserver.onCreate(lifecycleOwner)
         verify(brokerJsonUpdater).update()
 
-        canRunPirFlow.value = false
-        verify(pirWorkHandler).cancelWork()
+        canRunPirFlow.value = PirEligibility.Disabled(DisabledReason.FEATURE_DISABLED)
+        verify(pirWorkHandler).cancelWork(CancellationReason.FEATURE_DISABLED)
         verify(pirFeatureDataCleaner).removeAllData()
     }
 
@@ -104,26 +107,26 @@ class PirDataUpdateObserverTest {
         pirDataUpdateObserver.onCreate(lifecycleOwner)
 
         // PIR starts disabled — featureReceivedMs is 0L so no cleanup should happen
-        canRunPirFlow.value = false
-        verify(pirWorkHandler, never()).cancelWork()
+        canRunPirFlow.value = PirEligibility.Disabled(DisabledReason.FEATURE_DISABLED)
+        verify(pirWorkHandler, never()).cancelWork(any())
         verify(pirFeatureDataCleaner, never()).removeAllData()
 
         // Then enable PIR
-        canRunPirFlow.value = true
+        canRunPirFlow.value = PirEligibility.Enabled
         verify(brokerJsonUpdater).update()
     }
 
     @Test
     fun whenOnCreateCalledMultipleTimesAndPIREnabledThenUpdatesBrokerOnce() = runTest {
         whenever(brokerJsonUpdater.update()).thenReturn(true)
-        canRunPirFlow.value = true
+        canRunPirFlow.value = PirEligibility.Enabled
 
         pirDataUpdateObserver.onCreate(lifecycleOwner)
 
         // MutableStateFlow deduplicates same values, so no additional emissions
-        canRunPirFlow.value = true
-        canRunPirFlow.value = true
-        canRunPirFlow.value = true
+        canRunPirFlow.value = PirEligibility.Enabled
+        canRunPirFlow.value = PirEligibility.Enabled
+        canRunPirFlow.value = PirEligibility.Enabled
 
         verify(brokerJsonUpdater, times(1)).update()
         verifyNoInteractions(pirFeatureDataCleaner)
@@ -133,7 +136,7 @@ class PirDataUpdateObserverTest {
     fun whenOnCreateWithPIRNeverEnabledAndDisabledThenDoNotCancelWork() = runTest {
         pirDataUpdateObserver.onCreate(lifecycleOwner)
 
-        verify(pirWorkHandler, never()).cancelWork()
+        verify(pirWorkHandler, never()).cancelWork(any())
         verify(brokerJsonUpdater, never()).update()
         verify(pirFeatureDataCleaner, never()).removeAllData()
     }
@@ -141,12 +144,12 @@ class PirDataUpdateObserverTest {
     @Test
     fun whenOnCreateWithPIREnabledThenUpdatesBrokers() = runTest {
         whenever(brokerJsonUpdater.update()).thenReturn(true)
-        canRunPirFlow.value = true
+        canRunPirFlow.value = PirEligibility.Enabled
 
         pirDataUpdateObserver.onCreate(lifecycleOwner)
 
         verify(brokerJsonUpdater).update()
-        verify(pirWorkHandler, never()).cancelWork()
+        verify(pirWorkHandler, never()).cancelWork(any())
         verifyNoInteractions(pirFeatureDataCleaner)
     }
 
@@ -156,7 +159,7 @@ class PirDataUpdateObserverTest {
         whenever(pirRepository.getFeatureReceivedMs()).thenReturn(0L)
         whenever(currentTimeProvider.currentTimeMillis()).thenReturn(12345L)
 
-        canRunPirFlow.value = true
+        canRunPirFlow.value = PirEligibility.Enabled
         pirDataUpdateObserver.onCreate(lifecycleOwner)
 
         verify(pirRepository).setFeatureReceivedMs(12345L)
@@ -168,7 +171,7 @@ class PirDataUpdateObserverTest {
         // featureReceivedMs already set from a previous session
         whenever(pirRepository.getFeatureReceivedMs()).thenReturn(5000L)
 
-        canRunPirFlow.value = true
+        canRunPirFlow.value = PirEligibility.Enabled
         pirDataUpdateObserver.onCreate(lifecycleOwner)
 
         verify(pirRepository, never()).setFeatureReceivedMs(any())
@@ -183,7 +186,7 @@ class PirDataUpdateObserverTest {
 
         pirDataUpdateObserver.onCreate(lifecycleOwner)
 
-        verify(pirWorkHandler).cancelWork()
+        verify(pirWorkHandler).cancelWork(CancellationReason.FEATURE_DISABLED)
         verify(pirFeatureDataCleaner).removeAllData()
     }
 
@@ -195,7 +198,7 @@ class PirDataUpdateObserverTest {
 
         pirDataUpdateObserver.onCreate(lifecycleOwner)
 
-        verify(pirWorkHandler, never()).cancelWork()
+        verify(pirWorkHandler, never()).cancelWork(any())
         verify(pirFeatureDataCleaner, never()).removeAllData()
     }
 }

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/checker/RealPirWorkHandlerTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/checker/RealPirWorkHandlerTest.kt
@@ -25,14 +25,15 @@ import com.duckduckgo.pir.impl.PirRemoteFeatures
 import com.duckduckgo.pir.impl.notifications.PirNotificationManager
 import com.duckduckgo.pir.impl.scan.PirScanScheduler
 import com.duckduckgo.pir.impl.store.PirRepository
+import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent
+import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent.CancellationReason
 import com.duckduckgo.subscriptions.api.Product
 import com.duckduckgo.subscriptions.api.SubscriptionStatus
 import com.duckduckgo.subscriptions.api.Subscriptions
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -54,6 +55,7 @@ class RealPirWorkHandlerTest {
     private val pirBetaToggle: Toggle = mock()
     private val pirRepository: PirRepository = mock()
     private val pirNotificationManager: PirNotificationManager = mock()
+    private val pirScanWideEvent: PirScanWideEvent = mock()
 
     private lateinit var pirWorkHandler: RealPirWorkHandler
 
@@ -70,144 +72,145 @@ class RealPirWorkHandlerTest {
             pirScanScheduler = pirScanScheduler,
             pirRepository = pirRepository,
             pirNotificationManager = pirNotificationManager,
+            pirScanWideEvent = pirScanWideEvent,
         )
     }
 
     @Test
-    fun whenPirBetaDisabledThenCanRunPirReturnsFalse() = runTest {
+    fun whenPirBetaDisabledThenCanRunPirDisabledWithFeatureDisabled() = runTest {
         whenever(pirBetaToggle.isEnabled()).thenReturn(false)
 
         pirWorkHandler.canRunPir().test {
-            assertFalse(awaitItem())
+            assertEquals(PirEligibility.Disabled(DisabledReason.FEATURE_DISABLED), awaitItem())
             awaitComplete()
         }
     }
 
     @Test
-    fun whenSubscriptionStatusIsUnknownThenCanRunPirReturnsFalse() = runTest {
+    fun whenSubscriptionStatusIsUnknownThenCanRunPirDisabledWithSubscriptionExpired() = runTest {
         whenever(pirBetaToggle.isEnabled()).thenReturn(true)
         whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.UNKNOWN))
         whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf()))
 
         pirWorkHandler.canRunPir().test {
-            assertFalse(awaitItem())
+            assertEquals(PirEligibility.Disabled(DisabledReason.SUBSCRIPTION_EXPIRED), awaitItem())
             awaitComplete()
         }
     }
 
     @Test
-    fun whenPirBetaEnabledAndPirEntitledAndAutoRenewableThenCanRunPirReturnsTrue() =
+    fun whenPirBetaEnabledAndPirEntitledAndAutoRenewableThenCanRunPirEnabled() =
         runTest {
             whenever(pirBetaToggle.isEnabled()).thenReturn(true)
             whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(Product.PIR)))
             whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.AUTO_RENEWABLE))
 
             pirWorkHandler.canRunPir().test {
-                assertTrue(awaitItem())
+                assertEquals(PirEligibility.Enabled, awaitItem())
                 cancelAndIgnoreRemainingEvents()
             }
         }
 
     @Test
-    fun whenPirBetaEnabledAndPirEntitledAndNotAutoRenewableThenCanRunPirReturnsTrue() =
+    fun whenPirBetaEnabledAndPirEntitledAndNotAutoRenewableThenCanRunPirEnabled() =
         runTest {
             whenever(pirBetaToggle.isEnabled()).thenReturn(true)
             whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(Product.PIR)))
             whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.NOT_AUTO_RENEWABLE))
 
             pirWorkHandler.canRunPir().test {
-                assertTrue(awaitItem())
+                assertEquals(PirEligibility.Enabled, awaitItem())
                 cancelAndIgnoreRemainingEvents()
             }
         }
 
     @Test
-    fun whenPirBetaEnabledAndPirEntitledAndGracePeriodThenCanRunPirReturnsTrue() =
+    fun whenPirBetaEnabledAndPirEntitledAndGracePeriodThenCanRunPirEnabled() =
         runTest {
             whenever(pirBetaToggle.isEnabled()).thenReturn(true)
             whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(Product.PIR)))
             whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.GRACE_PERIOD))
 
             pirWorkHandler.canRunPir().test {
-                assertTrue(awaitItem())
+                assertEquals(PirEligibility.Enabled, awaitItem())
                 cancelAndIgnoreRemainingEvents()
             }
         }
 
     @Test
-    fun whenPirBetaEnabledAndPirEntitledButUnknownStatusThenCanRunPirReturnsFalse() =
+    fun whenPirBetaEnabledAndPirEntitledButUnknownStatusThenCanRunPirDisabledWithSubscriptionExpired() =
         runTest {
             whenever(pirBetaToggle.isEnabled()).thenReturn(true)
             whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(Product.PIR)))
             whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.UNKNOWN))
 
             pirWorkHandler.canRunPir().test {
-                assertFalse(awaitItem())
+                assertEquals(PirEligibility.Disabled(DisabledReason.SUBSCRIPTION_EXPIRED), awaitItem())
                 cancelAndIgnoreRemainingEvents()
             }
         }
 
     @Test
-    fun whenPirBetaEnabledAndPirEntitledButInactiveStatusThenCanRunPirReturnsFalse() =
+    fun whenPirBetaEnabledAndPirEntitledButInactiveStatusThenCanRunPirDisabledWithSubscriptionExpired() =
         runTest {
             whenever(pirBetaToggle.isEnabled()).thenReturn(true)
             whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(Product.PIR)))
             whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.INACTIVE))
 
             pirWorkHandler.canRunPir().test {
-                assertFalse(awaitItem())
+                assertEquals(PirEligibility.Disabled(DisabledReason.SUBSCRIPTION_EXPIRED), awaitItem())
                 cancelAndIgnoreRemainingEvents()
             }
         }
 
     @Test
-    fun whenPirBetaEnabledAndPirEntitledButExpiredStatusThenCanRunPirReturnsFalse() =
+    fun whenPirBetaEnabledAndPirEntitledButExpiredStatusThenCanRunPirDisabledWithSubscriptionExpired() =
         runTest {
             whenever(pirBetaToggle.isEnabled()).thenReturn(true)
             whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(Product.PIR)))
             whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.EXPIRED))
 
             pirWorkHandler.canRunPir().test {
-                assertFalse(awaitItem())
+                assertEquals(PirEligibility.Disabled(DisabledReason.SUBSCRIPTION_EXPIRED), awaitItem())
                 cancelAndIgnoreRemainingEvents()
             }
         }
 
     @Test
-    fun whenPirBetaEnabledAndPirEntitledButWaitingStatusThenCanRunPirReturnsFalse() =
+    fun whenPirBetaEnabledAndPirEntitledButWaitingStatusThenCanRunPirDisabledWithSubscriptionExpired() =
         runTest {
             whenever(pirBetaToggle.isEnabled()).thenReturn(true)
             whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(Product.PIR)))
             whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.WAITING))
 
             pirWorkHandler.canRunPir().test {
-                assertFalse(awaitItem())
+                assertEquals(PirEligibility.Disabled(DisabledReason.SUBSCRIPTION_EXPIRED), awaitItem())
                 cancelAndIgnoreRemainingEvents()
             }
         }
 
     @Test
-    fun whenPirBetaEnabledAndAutoRenewableButNotPirEntitledThenCanRunPirReturnsFalse() =
+    fun whenPirBetaEnabledAndAutoRenewableButNotPirEntitledThenCanRunPirDisabledWithEntitlementLost() =
         runTest {
             whenever(pirBetaToggle.isEnabled()).thenReturn(true)
             whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(Product.NetP))) // Different product
             whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.AUTO_RENEWABLE))
 
             pirWorkHandler.canRunPir().test {
-                assertFalse(awaitItem())
+                assertEquals(PirEligibility.Disabled(DisabledReason.ENTITLEMENT_LOST), awaitItem())
                 cancelAndIgnoreRemainingEvents()
             }
         }
 
     @Test
-    fun whenPirBetaEnabledAndAutoRenewableButNoEntitlementsThenCanRunPirReturnsFalse() =
+    fun whenPirBetaEnabledAndAutoRenewableButNoEntitlementsThenCanRunPirDisabledWithEntitlementLost() =
         runTest {
             whenever(pirBetaToggle.isEnabled()).thenReturn(true)
             whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(emptyList()))
             whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.AUTO_RENEWABLE))
 
             pirWorkHandler.canRunPir().test {
-                assertFalse(awaitItem())
+                assertEquals(PirEligibility.Disabled(DisabledReason.ENTITLEMENT_LOST), awaitItem())
                 cancelAndIgnoreRemainingEvents()
             }
         }
@@ -223,15 +226,15 @@ class RealPirWorkHandlerTest {
 
             pirWorkHandler.canRunPir().test {
                 // Initially enabled
-                assertTrue(awaitItem())
+                assertEquals(PirEligibility.Enabled, awaitItem())
 
                 // Remove PIR entitlement
                 entitlementFlow.value = emptyList()
-                assertFalse(awaitItem())
+                assertEquals(PirEligibility.Disabled(DisabledReason.ENTITLEMENT_LOST), awaitItem())
 
                 // Add PIR entitlement back
                 entitlementFlow.value = listOf(Product.PIR)
-                assertTrue(awaitItem())
+                assertEquals(PirEligibility.Enabled, awaitItem())
 
                 cancelAndIgnoreRemainingEvents()
             }
@@ -247,7 +250,7 @@ class RealPirWorkHandlerTest {
 
         pirWorkHandler.canRunPir().test {
             // Initially enabled
-            assertTrue(awaitItem())
+            assertEquals(PirEligibility.Enabled, awaitItem())
 
             // Emit same value multiple times - should only get one emission due to distinctUntilChanged
             entitlementFlow.value = listOf(Product.PIR)
@@ -262,23 +265,25 @@ class RealPirWorkHandlerTest {
     }
 
     @Test
-    fun whenRepositoryNotAvailableThenCanRunPirReturnsFalse() = runTest {
+    fun whenRepositoryNotAvailableThenCanRunPirDisabledWithRepositoryUnavailable() = runTest {
         whenever(pirBetaToggle.isEnabled()).thenReturn(true)
         whenever(subscriptions.getEntitlementStatus()).thenReturn(flowOf(listOf(Product.PIR)))
         whenever(subscriptions.getSubscriptionStatusFlow()).thenReturn(flowOf(SubscriptionStatus.AUTO_RENEWABLE))
         whenever(pirRepository.isRepositoryAvailable()).thenReturn(false)
 
         pirWorkHandler.canRunPir().test {
-            assertFalse(awaitItem())
+            assertEquals(PirEligibility.Disabled(DisabledReason.REPOSITORY_UNAVAILABLE), awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun whenCancelWorkThenStopsForegroundServicesAndCancelsWorkManager() = runTest {
-        pirWorkHandler.cancelWork()
+    fun whenCancelWorkThenFinalizesWideEventAndStopsForegroundServicesAndCancelsWorkManager() = runTest {
+        pirWorkHandler.cancelWork(CancellationReason.PROFILE_DELETED)
 
-        // Verify that stopService is called 3 times (for each of the 3 services)
+        // Wide event must be finalized before the services hosting the run are torn down
+        verify(pirScanWideEvent).onWorkCancelled(CancellationReason.PROFILE_DELETED)
+        // Verify that stopService is called for each of the 2 foreground services
         verify(context, times(2)).stopService(any<Intent>())
         verify(pirScanScheduler).cancelScheduledScans(context)
         verify(pirNotificationManager).cancelNotifications()

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebDeleteUserProfileHandlerTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebDeleteUserProfileHandlerTest.kt
@@ -27,12 +27,14 @@ import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUti
 import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUtils.verifyResponse
 import com.duckduckgo.pir.impl.dashboard.state.PirWebProfileStateHolder
 import com.duckduckgo.pir.impl.pixels.PirPixelSender
+import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent.CancellationReason
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -80,7 +82,7 @@ class PirWebDeleteUserProfileHandlerTest {
         // Then
         verify(mockPirPixelSender).reportUserReset()
         verify(mockPirWebProfileStateHolder).clear()
-        verify(mockWorkHandler).cancelWork()
+        verify(mockWorkHandler).cancelWork(CancellationReason.PROFILE_DELETED)
         verify(mockPirFeatureDataCleaner).removeUserData()
         verifyResponse(jsMessage, true, mockJsMessaging)
     }
@@ -89,7 +91,7 @@ class PirWebDeleteUserProfileHandlerTest {
     fun whenCancelWorkThrowsExceptionThenSendsErrorResponse() = runTest {
         // Given
         val jsMessage = createJsMessage("""""", PirDashboardWebMessages.DELETE_USER_PROFILE_DATA)
-        whenever(mockWorkHandler.cancelWork()).thenThrow(RuntimeException("Cancel work failed"))
+        whenever(mockWorkHandler.cancelWork(any())).thenThrow(RuntimeException("Cancel work failed"))
 
         // When
         testee.process(jsMessage, mockJsMessaging, mockJsMessageCallback)
@@ -122,7 +124,7 @@ class PirWebDeleteUserProfileHandlerTest {
         // Then
         verify(mockPirPixelSender).reportUserReset()
         verify(mockPirWebProfileStateHolder).clear()
-        verify(mockWorkHandler).cancelWork()
+        verify(mockWorkHandler).cancelWork(CancellationReason.PROFILE_DELETED)
         verify(mockPirFeatureDataCleaner).removeUserData()
         verifyResponse(jsMessage, true, mockJsMessaging)
     }

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEventTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEventTest.kt
@@ -25,7 +25,9 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.pir.impl.PirRemoteFeatures
+import com.duckduckgo.pir.impl.checker.DisabledReason
 import com.duckduckgo.pir.impl.scheduling.PirExecutionType
+import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent.CancellationReason
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent.FailureReason
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.ENTRY_POINT_MANUAL_EDIT_PROFILE
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.ENTRY_POINT_MANUAL_INITIAL
@@ -36,6 +38,7 @@ import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.EXECUTI
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.INTERVAL_OPT_OUT_DURATION
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.KEY_BATTERY_OPTIMIZATIONS
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.KEY_BROKER_COUNT
+import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.KEY_CANCELLATION_REASON
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.KEY_EXECUTION_TYPE
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.KEY_LAST_STEP
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.KEY_NOTIFICATIONS_PERMISSION_GRANTED
@@ -83,7 +86,9 @@ class PirScanWideEventTest {
     private lateinit var testee: PirScanWideEventImpl
 
     @Before
-    fun setUp() {
+    fun setUp() = runTest {
+        // Default: no open flow in the shared wide-events DB. Cross-process tests override this.
+        whenever(wideEventClient.getFlowIds(any())).thenReturn(Result.success(emptyList()))
         testee = PirScanWideEventImpl(
             wideEventClient = wideEventClient,
             pirRemoteFeatures = pirRemoteFeatures,
@@ -382,7 +387,10 @@ class PirScanWideEventTest {
         order.verify(wideEventClient).flowFinish(
             wideEventId = 100L,
             status = FlowStatus.Cancelled,
-            metadata = mapOf(KEY_LAST_STEP to STEP_STARTED),
+            metadata = mapOf(
+                KEY_LAST_STEP to STEP_STARTED,
+                KEY_CANCELLATION_REASON to "superseded_by_new_run",
+            ),
         )
     }
 
@@ -581,13 +589,16 @@ class PirScanWideEventTest {
         testee.onScanJobCompleted(PirExecutionType.MANUAL_INITIAL) // emits progress_90 -> last_step = progress_90
 
         // When
-        testee.onRunCancelled(PirExecutionType.MANUAL_INITIAL)
+        testee.onRunCancelled(PirExecutionType.MANUAL_INITIAL, CancellationReason.WORK_STOPPED)
 
         // Then
         verify(wideEventClient).flowFinish(
             wideEventId = 8L,
             status = FlowStatus.Cancelled,
-            metadata = mapOf(KEY_LAST_STEP to "progress_90"),
+            metadata = mapOf(
+                KEY_LAST_STEP to "progress_90",
+                KEY_CANCELLATION_REASON to "work_stopped",
+            ),
         )
     }
 
@@ -639,7 +650,7 @@ class PirScanWideEventTest {
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 10)
 
         // When
-        testee.onRunCancelled(PirExecutionType.MANUAL_INITIAL)
+        testee.onRunCancelled(PirExecutionType.MANUAL_INITIAL, CancellationReason.WORK_STOPPED)
 
         // Then
         val order = inOrder(wideEventClient)
@@ -647,7 +658,10 @@ class PirScanWideEventTest {
         order.verify(wideEventClient).flowFinish(
             wideEventId = 62L,
             status = FlowStatus.Cancelled,
-            metadata = mapOf(KEY_LAST_STEP to STEP_STARTED),
+            metadata = mapOf(
+                KEY_LAST_STEP to STEP_STARTED,
+                KEY_CANCELLATION_REASON to "work_stopped",
+            ),
         )
     }
 
@@ -660,7 +674,7 @@ class PirScanWideEventTest {
         testee.onOptOutStarted(PirExecutionType.MANUAL_INITIAL)
 
         // When
-        testee.onRunCancelled(PirExecutionType.MANUAL_INITIAL)
+        testee.onRunCancelled(PirExecutionType.MANUAL_INITIAL, CancellationReason.WORK_STOPPED)
 
         // Then
         val order = inOrder(wideEventClient)
@@ -668,7 +682,85 @@ class PirScanWideEventTest {
         order.verify(wideEventClient).flowFinish(
             wideEventId = 63L,
             status = FlowStatus.Cancelled,
-            metadata = mapOf(KEY_LAST_STEP to STEP_OPT_OUT_STARTED),
+            metadata = mapOf(
+                KEY_LAST_STEP to STEP_OPT_OUT_STARTED,
+                KEY_CANCELLATION_REASON to "work_stopped",
+            ),
+        )
+    }
+
+    @Test
+    fun whenOnWorkCancelledThenOpenFlowFinishedWithCancelledAndReason() = runTest {
+        // Given an open manual flow with no scan jobs (so no decile interval is opened)
+        whenever(wideEventClient.flowStart(any(), any(), any(), any())).thenReturn(Result.success(80L))
+        runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 0)
+
+        // When work is cancelled externally (e.g. via PirWorkHandler.cancelWork)
+        testee.onWorkCancelled(CancellationReason.PROFILE_DELETED)
+
+        // Then
+        verify(wideEventClient).flowFinish(
+            wideEventId = 80L,
+            status = FlowStatus.Cancelled,
+            metadata = mapOf(
+                KEY_LAST_STEP to STEP_STARTED,
+                KEY_CANCELLATION_REASON to "profile_deleted",
+            ),
+        )
+    }
+
+    @Test
+    fun whenOnWorkCancelledAndNoOpenFlowThenNothingIsFinished() = runTest {
+        // No flow open in this process or the shared DB (getFlowIds stubbed empty in setUp).
+        testee.onWorkCancelled(CancellationReason.PROFILE_DELETED)
+
+        verify(wideEventClient, never()).flowFinish(any(), any(), any())
+    }
+
+    @Test
+    fun whenOnWorkCancelledAndFlowStartedInAnotherProcessThenResolvesFromDbAndFinishesCancelled() = runTest {
+        // Reproduces the cross-process bug: the scan ran in the :pir process (so cachedFlowId is null
+        // in this process), but the shared wide-events DB has the open manual flow. cancelWork runs in
+        // the main process (profile delete / eligibility loss), so we must resolve the flow from the DB.
+        whenever(wideEventClient.getFlowIds(WIDE_EVENT_NAME_MANUAL)).thenReturn(Result.success(listOf(555L)))
+
+        testee.onWorkCancelled(CancellationReason.PROFILE_DELETED)
+
+        // last_step is omitted: it is per-process in-memory state we don't own here.
+        verify(wideEventClient).flowFinish(
+            wideEventId = 555L,
+            status = FlowStatus.Cancelled,
+            metadata = mapOf(KEY_CANCELLATION_REASON to "profile_deleted"),
+        )
+    }
+
+    @Test
+    fun whenRunCancelledBeforeStartThenOneShotFlowEmittedWithZeroedCountsAndReason() = runTest {
+        whenever(wideEventClient.flowStart(any(), any(), any(), any())).thenReturn(Result.success(90L))
+
+        testee.onRunCancelledBeforeStart(PirExecutionType.MANUAL_INITIAL, CancellationReason.FOREGROUND_START_FAILED)
+
+        val order = inOrder(wideEventClient)
+        order.verify(wideEventClient).flowStart(
+            name = WIDE_EVENT_NAME_MANUAL,
+            flowEntryPoint = ENTRY_POINT_MANUAL_INITIAL,
+            metadata = mapOf(
+                KEY_EXECUTION_TYPE to EXECUTION_TYPE_MANUAL_INITIAL,
+                KEY_PROFILE_QUERIES_COUNT to "0",
+                KEY_BROKER_COUNT to "0",
+                KEY_TOTAL_SCAN_JOBS to "0",
+                KEY_WEB_VIEW_COUNT to "0",
+            ),
+            cleanupPolicy = CleanupPolicy.OnTimeout(duration = 8.hours, flowStatus = FlowStatus.Unknown),
+        )
+        order.verify(wideEventClient).flowStep(wideEventId = 90L, stepName = STEP_STARTED, success = true)
+        order.verify(wideEventClient).flowFinish(
+            wideEventId = 90L,
+            status = FlowStatus.Cancelled,
+            metadata = mapOf(
+                KEY_LAST_STEP to STEP_STARTED,
+                KEY_CANCELLATION_REASON to "foreground_start_failed",
+            ),
         )
     }
 
@@ -702,6 +794,26 @@ class PirScanWideEventTest {
         org.junit.Assert.assertEquals(
             FailureReason.UNKNOWN_ERROR,
             FailureReason.fromException(RuntimeException("boom")),
+        )
+    }
+
+    @Test
+    fun fromDisabledReasonMapsEachEligibilityReasonToBoundedCancellationReason() {
+        org.junit.Assert.assertEquals(
+            CancellationReason.FEATURE_DISABLED,
+            CancellationReason.fromDisabledReason(DisabledReason.FEATURE_DISABLED),
+        )
+        org.junit.Assert.assertEquals(
+            CancellationReason.SUBSCRIPTION_EXPIRED,
+            CancellationReason.fromDisabledReason(DisabledReason.SUBSCRIPTION_EXPIRED),
+        )
+        org.junit.Assert.assertEquals(
+            CancellationReason.ENTITLEMENT_LOST,
+            CancellationReason.fromDisabledReason(DisabledReason.ENTITLEMENT_LOST),
+        )
+        org.junit.Assert.assertEquals(
+            CancellationReason.REPOSITORY_UNAVAILABLE,
+            CancellationReason.fromDisabledReason(DisabledReason.REPOSITORY_UNAVAILABLE),
         )
     }
 

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEventTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEventTest.kt
@@ -395,6 +395,30 @@ class PirScanWideEventTest {
     }
 
     @Test
+    fun whenManualFlowOpenAndProfileEditRunStartsThenStaleFlowFinishedWithSupersededByProfileEdit() = runTest {
+        // Given an open manual flow (the initial scan)
+        whenever(wideEventClient.flowStart(any(), any(), any(), any()))
+            .thenReturn(Result.success(101L))
+            .thenReturn(Result.success(201L))
+        runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 1)
+
+        // When the user edits their profile, triggering a MANUAL_EDIT_PROFILE re-scan that supersedes it
+        runStarted(PirExecutionType.MANUAL_EDIT_PROFILE, 1, 1, 1)
+
+        // Then the stale flow is attributed specifically to the profile edit
+        val order = inOrder(wideEventClient)
+        order.verify(wideEventClient).intervalEnd(wideEventId = 101L, key = "decile_0_10_duration_ms_bucketed")
+        order.verify(wideEventClient).flowFinish(
+            wideEventId = 101L,
+            status = FlowStatus.Cancelled,
+            metadata = mapOf(
+                KEY_LAST_STEP to STEP_STARTED,
+                KEY_CANCELLATION_REASON to "superseded_by_profile_edit",
+            ),
+        )
+    }
+
+    @Test
     fun whenTenJobsCompleteOneAtATimeThenAllNineProgressStepsFire() = runTest {
         // Given
         whenever(wideEventClient.flowStart(any(), any(), any(), any())).thenReturn(Result.success(1L))

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEventTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEventTest.kt
@@ -65,6 +65,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -784,6 +785,35 @@ class PirScanWideEventTest {
             metadata = mapOf(
                 KEY_LAST_STEP to STEP_STARTED,
                 KEY_CANCELLATION_REASON to "foreground_start_failed",
+            ),
+        )
+    }
+
+    @Test
+    fun whenRunCancelledBeforeStartAndManualFlowAlreadyOpenThenReusesItWithoutDoubleEmitting() = runTest {
+        // Reproduces the cause-4 sequence in PirForegroundScanService: a manual flow is still open
+        // when the service is blocked at start. onRunCancelledBeforeStart is followed by cancelWork
+        // (-> onWorkCancelled). The before-start hook must reuse the already-open flow instead of
+        // synthesizing a second one, otherwise the follow-on onWorkCancelled produces a duplicate
+        // cancelled wide event for a single user action.
+        whenever(wideEventClient.flowStart(any(), any(), any(), any()))
+            .thenReturn(Result.success(300L)) // onRunStarted
+            .thenReturn(Result.success(301L)) // any (unwanted) synthetic one-shot would get this id
+        runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 0) // opens manual flow 300L
+
+        testee.onRunCancelledBeforeStart(PirExecutionType.MANUAL_INITIAL, CancellationReason.SUBSCRIPTION_EXPIRED)
+        testee.onWorkCancelled(CancellationReason.SUBSCRIPTION_EXPIRED)
+
+        // No synthetic one-shot was started (only the original onRunStarted flowStart)...
+        verify(wideEventClient, times(1)).flowStart(any(), any(), any(), any())
+        // ...and the run is finished as Cancelled exactly once, reusing the open flow.
+        verify(wideEventClient, times(1)).flowFinish(any(), eq(FlowStatus.Cancelled), any())
+        verify(wideEventClient).flowFinish(
+            wideEventId = 300L,
+            status = FlowStatus.Cancelled,
+            metadata = mapOf(
+                KEY_LAST_STEP to STEP_STARTED,
+                KEY_CANCELLATION_REASON to "subscription_expired",
             ),
         )
     }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/RealPirUserUtilsTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/RealPirUserUtilsTest.kt
@@ -16,6 +16,8 @@
 
 package com.duckduckgo.pir.impl
 
+import com.duckduckgo.pir.impl.checker.DisabledReason
+import com.duckduckgo.pir.impl.checker.PirEligibility
 import com.duckduckgo.pir.impl.checker.PirWorkHandler
 import com.duckduckgo.pir.impl.models.ProfileQuery
 import com.duckduckgo.pir.impl.store.PirRepository
@@ -59,7 +61,7 @@ class RealPirUserUtilsTest {
 
     @Test
     fun whenCanRunPirAndHasProfileQueriesThenIsActiveUserReturnsTrue() = runTest {
-        whenever(mockPirWorkHandler.canRunPir()).thenReturn(flowOf(true))
+        whenever(mockPirWorkHandler.canRunPir()).thenReturn(flowOf(PirEligibility.Enabled))
         whenever(mockPirRepository.getValidUserProfileQueries()).thenReturn(listOf(testProfileQuery))
 
         val result = testee.isActiveUser()
@@ -69,7 +71,7 @@ class RealPirUserUtilsTest {
 
     @Test
     fun whenCannotRunPirThenIsActiveUserReturnsFalse() = runTest {
-        whenever(mockPirWorkHandler.canRunPir()).thenReturn(flowOf(false))
+        whenever(mockPirWorkHandler.canRunPir()).thenReturn(flowOf(PirEligibility.Disabled(DisabledReason.FEATURE_DISABLED)))
         whenever(mockPirRepository.getValidUserProfileQueries()).thenReturn(listOf(testProfileQuery))
 
         val result = testee.isActiveUser()
@@ -79,7 +81,7 @@ class RealPirUserUtilsTest {
 
     @Test
     fun whenCanRunPirButNoProfileQueriesThenIsActiveUserReturnsFalse() = runTest {
-        whenever(mockPirWorkHandler.canRunPir()).thenReturn(flowOf(true))
+        whenever(mockPirWorkHandler.canRunPir()).thenReturn(flowOf(PirEligibility.Enabled))
         whenever(mockPirRepository.getValidUserProfileQueries()).thenReturn(emptyList())
 
         val result = testee.isActiveUser()
@@ -89,7 +91,7 @@ class RealPirUserUtilsTest {
 
     @Test
     fun whenCannotRunPirAndNoProfileQueriesThenIsActiveUserReturnsFalse() = runTest {
-        whenever(mockPirWorkHandler.canRunPir()).thenReturn(flowOf(false))
+        whenever(mockPirWorkHandler.canRunPir()).thenReturn(flowOf(PirEligibility.Disabled(DisabledReason.FEATURE_DISABLED)))
         whenever(mockPirRepository.getValidUserProfileQueries()).thenReturn(emptyList())
 
         val result = testee.isActiveUser()
@@ -121,7 +123,7 @@ class RealPirUserUtilsTest {
             age = 38,
             deprecated = false,
         )
-        whenever(mockPirWorkHandler.canRunPir()).thenReturn(flowOf(true))
+        whenever(mockPirWorkHandler.canRunPir()).thenReturn(flowOf(PirEligibility.Enabled))
         whenever(mockPirRepository.getValidUserProfileQueries()).thenReturn(listOf(testProfileQuery, profileQuery2))
 
         val result = testee.isActiveUser()

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealPirJobsRunnerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealPirJobsRunnerTest.kt
@@ -1316,7 +1316,7 @@ class RealPirJobsRunnerTest {
         verify(mockPirScanWideEvent).onOptOutCompleted(any(), any())
         verify(mockPirScanWideEvent, never()).onOptOutSkipped(any())
         verify(mockPirScanWideEvent, never()).onRunFailed(any(), any())
-        verify(mockPirScanWideEvent, never()).onRunCancelled(any())
+        verify(mockPirScanWideEvent, never()).onRunCancelled(any(), any())
     }
 
     @Test
@@ -1478,7 +1478,7 @@ class RealPirJobsRunnerTest {
             notificationsPermissionGranted = false,
             isTrackerBlockingEnabled = false,
         )
-        verify(mockPirScanWideEvent).onRunCancelled(any())
+        verify(mockPirScanWideEvent).onRunCancelled(any(), any())
         verify(mockPirScanWideEvent, never()).onScanCompleted(any())
         verify(mockPirScanWideEvent, never()).onRunFailed(any(), any())
     }
@@ -1528,7 +1528,7 @@ class RealPirJobsRunnerTest {
         )
         verify(mockPirScanWideEvent).onRunFailed(any(), eq(FailureReason.ILLEGAL_STATE_EXCEPTION))
         verify(mockPirScanWideEvent, never()).onScanCompleted(any())
-        verify(mockPirScanWideEvent, never()).onRunCancelled(any())
+        verify(mockPirScanWideEvent, never()).onRunCancelled(any(), any())
     }
 
     @Test
@@ -1572,7 +1572,7 @@ class RealPirJobsRunnerTest {
 
         // Then
         verify(mockPirScanWideEvent).onRunFailed(any(), eq(FailureReason.TIMEOUT_CANCELLATION_EXCEPTION))
-        verify(mockPirScanWideEvent, never()).onRunCancelled(any())
+        verify(mockPirScanWideEvent, never()).onRunCancelled(any(), any())
     }
 
     @Test
@@ -1610,6 +1610,6 @@ class RealPirJobsRunnerTest {
         verify(mockPirScanWideEvent).onOptOutStarted(any())
         verify(mockPirScanWideEvent).onRunFailed(any(), eq(FailureReason.ILLEGAL_STATE_EXCEPTION))
         verify(mockPirScanWideEvent, never()).onOptOutCompleted(any(), any())
-        verify(mockPirScanWideEvent, never()).onRunCancelled(any())
+        verify(mockPirScanWideEvent, never()).onRunCancelled(any(), any())
     }
 }

--- a/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirDevSettingsActivity.kt
+++ b/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirDevSettingsActivity.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
 import com.duckduckgo.pir.impl.checker.PirWorkHandler
+import com.duckduckgo.pir.impl.checker.isEnabled
 import com.duckduckgo.pir.impl.dashboard.PirDashboardUrlProvider
 import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebConstants
 import com.duckduckgo.pir.impl.notifications.PirNotificationManager
@@ -116,7 +117,8 @@ class PirDevSettingsActivity : DuckDuckGoActivity() {
 
     private fun bindViews() {
         lifecycleScope.launch {
-            pirWorkHandler.canRunPir().collectLatest { canRunPir ->
+            pirWorkHandler.canRunPir().collectLatest { eligibility ->
+                val canRunPir = eligibility.isEnabled
                 binding.pirDebugScan.isEnabled = canRunPir
                 binding.pirDebugOptOut.isEnabled = canRunPir && repository.getBrokersForOptOut(true).isNotEmpty()
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1215357150972204?focus=true

### Description
Adds more specific cancellation reason to PIR initial scan wide event

### Steps to test this PR

- [ ] Smoke test PIR scan works
- [ ] Start scan then turn off PIR via the Dashboard Settings page 
- [ ] Check that `wide_pir-initial-scan` is emitted with CANCELLED status and `cancellation_reason=profile_deleted`
- [ ] Start new scan then go to edit profile
- [ ] Check that `wide_pir-initial-scan` is emitted with CANCELLED status and `cancellation_reason=superseded_by_profile_edit` 
- [ ] Reset PIR
- [ ] Start new scan then remove subscription from device
- [ ] Check that `wide_pir-initial-scan` is emitted with CANCELLED status and `cancellation_reason=subscription_expired` 


### UI changes
No UI changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches PIR work cancellation, eligibility gating, and multi-process wide-event finalization; behavior changes are mostly observability, but incorrect attribution or duplicate cancelled events could skew analytics.
> 
> **Overview**
> PIR manual and scheduled scan **wide events** now include **`feature.data.ext.cancellation_reason`** on **CANCELLED** flows, wired through pixel definitions (`pirCancellationReason`) and a bounded enum (superseded runs, profile delete, eligibility loss, foreground start failure, `work_stopped`, etc.).
> 
> **Eligibility and cancellation plumbing:** `canRunPir()` returns **`PirEligibility`** with **`DisabledReason`** instead of a boolean, so callers can map why PIR stopped to a cancellation reason. **`cancelWork(reason)`** finalizes in-flight wide events via **`onWorkCancelled`** before tearing down services/workers.
> 
> **Wide-event behavior:** Cancelled flows attach the reason to **`flowFinish`** metadata; superseded in-memory flows distinguish **profile edit** vs **new run**; **`onRunCancelledBeforeStart`** records never-started runs (e.g. foreground start failed); cross-process cancellation resolves open flows from the shared wide-events DB when the scan process owns the flow.
> 
> Call sites (foreground scan/opt-out, workers, profile delete, data update observer) pass the appropriate **`CancellationReason`**; coroutine cancellation in **`PirJobsRunner`** uses **`work_stopped`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70586a8400c1169985c6fdc2b9e51b126b271691. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->