### PR TITLE
Fix empty config breaking C-S-S

### DIFF
--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
@@ -126,16 +126,22 @@ class RealContentScopeScripts @Inject constructor(
         var preferences = ""
         val plugins = pluginPoint.getPlugins()
         plugins.forEach { plugin ->
-            if (config.isNotEmpty()) {
-                config += ","
+            plugin.config().let { pluginConfig ->
+                if (pluginConfig.isNotEmpty()) {
+                    if (config.isNotEmpty()) {
+                        config += ","
+                    }
+                    config += pluginConfig
+                }
             }
-            config += plugin.config()
 
             plugin.preferences()?.let { pluginPreferences ->
-                if (preferences.isNotEmpty()) {
-                    preferences += ","
+                if (pluginPreferences.isNotEmpty()) {
+                    if (preferences.isNotEmpty()) {
+                        preferences += ","
+                    }
+                    preferences += pluginPreferences
                 }
-                preferences += pluginPreferences
             }
         }
         return PluginParameters(config, preferences)

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
@@ -389,6 +389,49 @@ class RealContentScopeScriptsTest {
         verifyJsScript(js, expectedRegEx)
     }
 
+    @Test
+    fun whenPluginReturnsEmptyConfigBetweenOthersThenNoDanglingCommaInFeatures() {
+        val firstNonEmpty: ContentScopeConfigPlugin = mock()
+        val emptyConfig: ContentScopeConfigPlugin = mock()
+        val secondNonEmpty: ContentScopeConfigPlugin = mock()
+        whenever(firstNonEmpty.config()).thenReturn(config1)
+        whenever(emptyConfig.config()).thenReturn("")
+        whenever(secondNonEmpty.config()).thenReturn(config2)
+        whenever(mockPluginPoint.getPlugins()).thenReturn(listOf(firstNonEmpty, emptyConfig, secondNonEmpty))
+
+        val js = testee.getScript(null, listOf())
+
+        assertFalse("features must not contain a double comma", js.contains(",,"))
+        assertTrue(js.contains("\"features\":{$config1,$config2}"))
+    }
+
+    @Test
+    fun whenFirstPluginReturnsEmptyConfigThenNoLeadingCommaInFeatures() {
+        val emptyConfig: ContentScopeConfigPlugin = mock()
+        val firstNonEmpty: ContentScopeConfigPlugin = mock()
+        val secondNonEmpty: ContentScopeConfigPlugin = mock()
+        whenever(emptyConfig.config()).thenReturn("")
+        whenever(firstNonEmpty.config()).thenReturn(config1)
+        whenever(secondNonEmpty.config()).thenReturn(config2)
+        whenever(mockPluginPoint.getPlugins()).thenReturn(listOf(emptyConfig, firstNonEmpty, secondNonEmpty))
+
+        val js = testee.getScript(null, listOf())
+
+        assertFalse("features must not contain a double comma", js.contains(",,"))
+        assertTrue(js.contains("\"features\":{$config1,$config2}"))
+    }
+
+    @Test
+    fun whenPluginReturnsEmptyPreferencesThenNoDanglingCommaInPreferences() {
+        whenever(mockPlugin1.preferences()).thenReturn("\"globalPrivacyControlValue\":true")
+        whenever(mockPlugin2.preferences()).thenReturn("")
+
+        val js = testee.getScript(null, listOf())
+
+        assertFalse("preferences must not contain a double comma", js.contains(",,"))
+        assertTrue(js.contains("\"globalPrivacyControlValue\":true"))
+    }
+
     private fun verifyJsScript(js: String, regex: Regex = contentScopeRegex) {
         val matchResult = regex.find(js)
         val messageSecret = matchResult!!.groupValues[1]


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1215422278523665?focus=true

### Description
C-S-S retrieves configuration through plugins and then concatenates its contents separated by a comma. The code adds the separator based on the accumulator already being non-empty, not on the current plugin's output, sp if one plugin returns an empty config, we'll still add a comma, breaking the config: 

```
if (config.isNotEmpty()) { config += "," }   // accumulator, not the plugin's output
config += plugin.config()  // if this is empty, nothing follows the comma
```

So an empty plugin leaves a dangling/trailing comma, and the next non-empty plugin adds its own separator → you end up with a double comma (,,), which is the actual malformed token that breaks the JSON.

This is not an issue nowadays, but it's purely a coincidence: `AccessibilityForcedZoomContentScopeConfigPlugin` returns an empty config, but since it's the first one provided (alphabetical sort), the overall config is still empty when it runs, so we don't append a comma. However, the moment we have a plugin that sorts before `AccessibilityForcedZoomContentScopeConfigPlugin`, it breaks the format, and therefore C-S-S stops working.

### Steps to test this PR

_Feature 1_
- [ ] Fresh install, open youtube.com, search for any video, check Duck Player overlay is shown

### UI changes
n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to string assembly for injected script config; behavior for all-non-empty plugins is unchanged and tests cover the edge cases.
> 
> **Overview**
> Fixes **Content Scope Scripts (C-S-S)** JSON assembly in `getPluginParameters()` so commas are only added when a plugin actually returns non-empty **config** or **preferences**, instead of inserting a separator whenever the accumulator was already non-empty.
> 
> That prevents **dangling commas** and `,,` in the `features` object (and the same pattern for user preferences), which could break parsing and disable C-S-S when a plugin returns an empty string but is not first in plugin order.
> 
> Adds unit tests for empty config in the middle or at the start of the plugin list and for empty preferences between non-empty ones.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc7ec763617e570d88d4aaa1fc3920c59111904b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->