### PR TITLE
Run nightly Maestro suites on API 34

### DIFF
--- a/.github/workflows/e2e-nightly-full-suite.yml
+++ b/.github/workflows/e2e-nightly-full-suite.yml
@@ -84,7 +84,7 @@ jobs:
           maestro_test_name: binary_internal_upload${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_file: ${{ steps.assemble.outputs.internal_apk_path }}
-          maestro_api_level: 30
+          maestro_api_level: 34
           maestro_include_tags: binaryUpload
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -102,7 +102,7 @@ jobs:
           maestro_test_name: binary_release_upload${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_file: ${{ steps.assemble.outputs.play_apk_path }}
-          maestro_api_level: 30
+          maestro_api_level: 34
           maestro_include_tags: binaryUpload
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -120,7 +120,7 @@ jobs:
           maestro_test_name: customTabs${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-internal-binary.outputs.maestro_app_binary_id }}
-          maestro_api_level: 30
+          maestro_api_level: 34
           maestro_include_tags: customTabsTest
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -164,7 +164,7 @@ jobs:
           maestro_test_name: onboardingTest${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-release-binary.outputs.maestro_app_binary_id }}
-          maestro_api_level: 30
+          maestro_api_level: 34
           maestro_include_tags: onboardingTest
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -186,7 +186,7 @@ jobs:
           maestro_test_name: navigationTest${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-release-binary.outputs.maestro_app_binary_id }}
-          maestro_api_level: 30
+          maestro_api_level: 34
           maestro_include_tags: navigationTest
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -208,7 +208,7 @@ jobs:
           maestro_test_name: adClickTest${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-release-binary.outputs.maestro_app_binary_id }}
-          maestro_api_level: 30
+          maestro_api_level: 34
           maestro_include_tags: adClickTest
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -230,7 +230,7 @@ jobs:
           maestro_test_name: privacyTest${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-release-binary.outputs.maestro_app_binary_id }}
-          maestro_api_level: 30
+          maestro_api_level: 34
           maestro_include_tags: privacyTest
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -252,7 +252,7 @@ jobs:
           maestro_test_name: securityTest${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-release-binary.outputs.maestro_app_binary_id }}
-          maestro_api_level: 30
+          maestro_api_level: 34
           maestro_include_tags: securityTest
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -274,7 +274,7 @@ jobs:
           maestro_test_name: releaseTest${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-release-binary.outputs.maestro_app_binary_id }}
-          maestro_api_level: 30
+          maestro_api_level: 34
           maestro_include_tags: releaseTest
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}

--- a/.github/workflows/e2e-nightly-non-blockers-suite.yml
+++ b/.github/workflows/e2e-nightly-non-blockers-suite.yml
@@ -46,7 +46,7 @@ jobs:
           maestro_test_name: binary_internal_upload_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_file: ${{ steps.assemble.outputs.internal_apk_path }}
-          maestro_api_level: 30
+          maestro_api_level: 34
           maestro_include_tags: binaryUpload
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -63,7 +63,7 @@ jobs:
           maestro_test_name: binary_release_upload_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_file: ${{ steps.assemble.outputs.play_apk_path }}
-          maestro_api_level: 30
+          maestro_api_level: 34
           maestro_include_tags: binaryUpload
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -81,7 +81,7 @@ jobs:
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-release-binary.outputs.maestro_app_binary_id }}
           maestro_include_tags: omnibarTest
-          maestro_api_level: 30
+          maestro_api_level: 34
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
@@ -115,7 +115,7 @@ jobs:
           maestro_app_binary_id: ${{ steps.maestro-upload-internal-binary.outputs.maestro_app_binary_id }}
           maestro_include_tags: androidDesignSystemTest
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          maestro_api_level: 30
+          maestro_api_level: 34
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
           test_suite_name: Android Design System (Nightly)
@@ -132,7 +132,7 @@ jobs:
           maestro_app_binary_id: ${{ steps.maestro-upload-internal-binary.outputs.maestro_app_binary_id }}
           maestro_include_tags: unifiedInputTest
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          maestro_api_level: 30
+          maestro_api_level: 34
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
           test_suite_name: Unified Input Field
@@ -148,7 +148,7 @@ jobs:
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-internal-binary.outputs.maestro_app_binary_id }}
           maestro_include_tags: preonboardingTest
-          maestro_api_level: 30
+          maestro_api_level: 34
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}

--- a/.github/workflows/e2e-nightly-sync-critical-path.yml
+++ b/.github/workflows/e2e-nightly-sync-critical-path.yml
@@ -52,7 +52,7 @@ jobs:
           maestro_app_file: ${{ steps.assemble.outputs.internal_apk_path }}
           maestro_include_tags: syncCriticalPathTest
           test_suite_name: Sync Critical Path
-          maestro_api_level: 30
+          maestro_api_level: 34
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1215444934487882?focus=true

### Description

We see frequent Maestro flakiness on API 30. The Internal Privacy suite and the autofill/Duck Player suites already run reliably on API 34 (the latter via the reporter action's default level), so this moves the remaining explicitly-pinned API 30 suites to API 34 to reduce flakiness.

Changed the explicit `maestro_api_level: 30` entries to `34` across the nightly workflows:
- `e2e-nightly-full-suite.yml`
- `e2e-nightly-non-blockers-suite.yml`
- `e2e-nightly-sync-critical-path.yml`

Left untouched:
- The notification permissions step on API 33 — it asserts the Android 13+ runtime permission dialog.
- The Internal Privacy step already on API 34.

API 36 testing will be trialled separately in its own branch.

### Steps to test this PR

_Verification on API 34_
- [x] Dispatched `e2e-maestro.yml` with `privacyTest` on API 34 — passed: https://github.com/duckduckgo/Android/actions/runs/27004278143
- [x] Dispatched `e2e-maestro.yml` with `releaseTest` on API 34 — passed: https://github.com/duckduckgo/Android/actions/runs/27006977365

### UI changes

No UI changes — CI configuration only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow input changes with no app or production code; main risk is different emulator behavior surfacing new test failures or hiding API-30-specific issues.
> 
> **Overview**
> Nightly Maestro jobs that were explicitly pinned to **API 30** now use **API 34**, aligning them with suites that already run reliably on that level and aiming to cut CI flakiness.
> 
> The update touches **`e2e-nightly-full-suite.yml`** (binary uploads plus custom tabs, onboarding, deeplink, ad click, privacy, security, and release flows), **`e2e-nightly-non-blockers-suite.yml`** (uploads, omnibar, design system, unified input, preonboarding), and **`e2e-nightly-sync-critical-path.yml`**. Steps that must stay on a specific API level are unchanged—notification permissions remain on **33**, and internal privacy stays on **34**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 763e9b5500fc3d78e12cb259ae9b2fbc32a88c5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->