### PR TITLE
Update native input background color

### DIFF
--- a/android-design-system/design-system/src/main/res/values/design-system-colors.xml
+++ b/android-design-system/design-system/src/main/res/values/design-system-colors.xml
@@ -48,6 +48,7 @@
     <attr name="daxColorSurface" format="color"/>
     <attr name="daxColorContainer" format="color"/>
     <attr name="daxColorWindow" format="color"/>
+    <attr name="daxColorDuckAiBackground" format="color"/>
     <attr name="daxColorCanvas" format="color"/>
     <attr name="daxColorPrimaryText" format="color"/>
     <attr name="daxColorPrimaryInvertedText" format="color"/>
@@ -278,6 +279,7 @@
     <color name="background_background_dark">#282828</color>
     <color name="background_surface_dark">#373737</color>
     <color name="background_window_dark">#3D3D3D</color>
+    <color name="background_duck_ai_dark">#111111</color>
     <color name="background_canvas_dark">#1F1F1F</color>
     <color name="background_container_dark">#404145</color>
 
@@ -312,6 +314,7 @@
     <color name="background_background_light">#F2F2F2</color>
     <color name="background_surface_light">#F9F9F9</color>
     <color name="background_window_light">#FFFFFF</color>
+    <color name="background_duck_ai_light">#FFFFFF</color>
     <color name="background_canvas_light">#FFFFFF</color>
     <color name="background_container_light">#FFFFFF</color>
 

--- a/android-design-system/design-system/src/main/res/values/design-system-theming.xml
+++ b/android-design-system/design-system/src/main/res/values/design-system-theming.xml
@@ -185,6 +185,7 @@
         <item name="daxColorSurface">@color/background_surface_dark</item>
         <item name="daxColorContainer">@color/white12</item>
         <item name="daxColorWindow">@color/background_window_dark</item>
+        <item name="daxColorDuckAiBackground">@color/background_duck_ai_dark</item>
         <item name="daxColorPrimaryText">@color/text_primary_dark</item>
         <item name="daxColorPrimaryInvertedText">@color/black84</item>
         <item name="daxColorSecondaryText">@color/text_secondary_dark</item>
@@ -325,6 +326,7 @@
         <item name="daxColorSurface">@color/background_surface_light</item>
         <item name="daxColorContainer">@color/black6</item>
         <item name="daxColorWindow">@color/background_window_light</item>
+        <item name="daxColorDuckAiBackground">@color/background_duck_ai_light</item>
         <item name="daxColorPrimaryText">@color/text_primary_light</item>
         <item name="daxColorPrimaryInvertedText">@color/white84</item>
         <item name="daxColorSecondaryText">@color/text_secondary_light</item>

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -18,11 +18,13 @@ package com.duckduckgo.app.browser.nativeinput
 
 import android.app.Activity
 import android.content.res.Configuration
+import android.graphics.Outline
 import android.net.Uri
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewOutlineProvider
 import android.webkit.ValueCallback
 import android.widget.FrameLayout
 import androidx.core.net.toUri
@@ -36,6 +38,7 @@ import com.duckduckgo.app.browser.omnibar.Omnibar
 import com.duckduckgo.app.browser.omnibar.QueryUrlPredictor
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion
+import com.duckduckgo.common.ui.view.getColorFromAttr
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.view.toPx
@@ -665,10 +668,32 @@ class RealNativeInputManager @Inject constructor(
         }
     }
 
+    private fun suppressShadow(view: View) {
+        view.outlineProvider = object : ViewOutlineProvider() {
+            override fun getOutline(v: View, outline: Outline) {
+                outline.setRect(0, 0, v.width, v.height)
+                outline.alpha = 0f
+            }
+        }
+    }
+
     private fun applyWindowChrome(widgetView: View, isBottom: Boolean) {
         widgetView.translationZ = WIDGET_ELEVATION_DP.toPx()
         if (isBottom) {
             rootView.findViewById<View?>(R.id.navigationBar)?.gone()
+            rootView.findViewById<View?>(R.id.bottomBrowserOutlineStroke)?.gone()
+            if (omnibarController.isBrowserMode()) {
+                widgetView.setBackgroundColor(
+                    widgetView.context.getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorBackground),
+                )
+            } else if (omnibarController.isDuckAiMode()) {
+                widgetView.setBackgroundColor(
+                    widgetView.context.getColorFromAttr(
+                        com.duckduckgo.mobile.android.R.attr.daxColorDuckAiBackground,
+                    ),
+                )
+                suppressShadow(widgetView)
+            }
             rootView.findViewById<View?>(R.id.browserLayout)?.let {
                 it.setPadding(it.paddingLeft, it.paddingTop, it.paddingRight, 0)
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
@@ -202,6 +202,8 @@ class RealNativeInputOmnibarController(
         restoreBottomOmnibarPosition()
         if (omnibar.omnibarType == OmnibarType.SPLIT) {
             rootView.findViewById<View?>(R.id.navigationBar)?.show()
+        } else {
+            rootView.findViewById<View?>(R.id.bottomBrowserOutlineStroke)?.show()
         }
         omnibar.isScrollingEnabled = true
     }

--- a/app/src/main/res/layout/input_mode_widget_card_view_bottom.xml
+++ b/app/src/main/res/layout/input_mode_widget_card_view_bottom.xml
@@ -19,11 +19,14 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_gravity="bottom"
-    android:background="?daxColorSurface">
+    android:clipChildren="false"
+    android:clipToPadding="false">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:clipChildren="false"
+        android:clipToPadding="false"
         android:gravity="center_vertical"
         android:orientation="horizontal"
         android:paddingStart="@dimen/keyline_2"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1215229792439844?focus=true

### Description

- Updates the native input background to match new tab and Duck.ai
- Fixes padding for the bottom configuration

### Steps to test this PR

_With native input enabled_
- [ ] Set bottom omnibar config
- [ ] Focus the input
- [ ] Verify that the background is correct
- [ ] Go to Duck.ai
- [ ] Verify that the background is correct
- [ ] Repeat for dark and light theme

### UI changes
| Before  | After |
| ------ | ----- |
<img width="1080" height="243" alt="Screenshot_20260605_133256" src="https://github.com/user-attachments/assets/3c6fec53-e9f5-4b8e-943f-0b0bb3bc23a3" />|<img width="1080" height="241" alt="Screenshot_20260605_130027" src="https://github.com/user-attachments/assets/d54b67bc-8b62-4d55-b27f-362db312d3ac" />

| Before  | After |
| ------ | ----- |
<img width="1080" height="447" alt="Screenshot_20260605_133248" src="https://github.com/user-attachments/assets/e9ad5d3d-e44b-4a08-b272-5a02d3e6e5bf" />|<img width="1080" height="437" alt="Screenshot_20260605_130210" src="https://github.com/user-attachments/assets/68aa6503-012f-40dd-8682-df78f4652318" />

| Before  | After |
| ------ | ----- |
<img width="1080" height="188" alt="Screenshot_20260605_133311" src="https://github.com/user-attachments/assets/0371926b-a3ed-474b-ae62-ccafb7550bc9" />|<img width="1080" height="172" alt="Screenshot_20260605_130102" src="https://github.com/user-attachments/assets/7e5da914-1c27-4493-836a-0ad97cbeb603" />

| Before  | After |
| ------ | ----- |
<img width="1080" height="438" alt="Screenshot_20260605_133327" src="https://github.com/user-attachments/assets/f3b545eb-bc07-461c-a899-65119a3bde76" />|<img width="1080" height="427" alt="Screenshot_20260605_130200" src="https://github.com/user-attachments/assets/6ec72bbd-9ceb-40db-a120-eda19e240ede" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual and theming-only changes to native input chrome; no auth, data, or business-logic paths touched.
> 
> **Overview**
> Adds a dedicated **`daxColorDuckAiBackground`** design token (dark `#111111`, light `#FFFFFF`) and uses it when the bottom native input is shown in Duck AI mode, instead of relying on the bottom layout’s former **`daxColorSurface`** root background.
> 
> **`NativeInputManager.applyWindowChrome`** now paints the bottom widget container at runtime: **`daxColorBackground`** in browser mode and **`daxColorDuckAiBackground`** in Duck AI mode, hides **`bottomBrowserOutlineStroke`** while the widget is up (along with the nav bar), and in Duck AI mode clears the widget’s elevation shadow via a zero-alpha outline. **`NativeInputOmnibarController.restore`** brings **`bottomBrowserOutlineStroke`** back for non-split omnibar layouts when the widget closes.
> 
> The bottom input layout drops the fixed surface background and enables **`clipChildren` / `clipToPadding`** on the root so shadows and chrome aren’t clipped incorrectly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a7de584c78048b06e11789cc2a507f2515f794b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->