### PR TITLE
Gate Duck.ai omnibar icon on native input flag

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/DuckAiIcon.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/DuckAiIcon.kt
@@ -21,12 +21,14 @@ import android.widget.ImageView
 import androidx.core.view.updateLayoutParams
 
 /**
- * Sets the Duck.ai entry icon according to whether the native input field setting is enabled.
- * Native enabled → chevron-down variant with a leading inset and 4dp trailing margin; otherwise
- * the standard chat icon with no leading inset and no trailing margin.
+ * Sets the Duck.ai entry icon according to what tapping it will do.
+ *
+ * Contextual sheet variant (chevron-down with a leading inset and 4dp trailing margin) when a tap
+ * opens the contextual sheet; otherwise the standard chat icon with no leading inset and no
+ * trailing margin, where a tap opens Duck.ai in full screen.
  */
-fun ImageView.applyDuckAiIconStyling(isNativeInputEnabled: Boolean) {
-    if (isNativeInputEnabled) {
+fun ImageView.applyDuckAiIconStyling(showContextualSheetIcon: Boolean) {
+    if (showContextualSheetIcon) {
         setImageResource(com.duckduckgo.duckchat.impl.R.drawable.ic_ai_chat_down_24)
         setPaddingRelative(
             resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.keyline_2),

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -210,7 +210,7 @@ class OmnibarLayout @JvmOverloads constructor(
     lateinit var omnibarRepository: OmnibarRepository
 
     private var previousTransitionState: TransitionState? = null
-    private var lastAppliedNativeInputEnabled: Boolean? = null
+    private var lastAppliedShowContextualSheetIcon: Boolean? = null
 
     private val lifecycleOwner: LifecycleOwner by lazy {
         requireNotNull(findViewTreeLifecycleOwner())
@@ -888,7 +888,7 @@ class OmnibarLayout @JvmOverloads constructor(
         browserMenu.isVisible = newTransitionState.showBrowserMenu
         browserMenuHighlight.isVisible = newTransitionState.showBrowserMenuHighlight
         aiChatMenu?.isVisible = newTransitionState.showChatMenu
-        applyAiChatMenuStyling(viewState.isNativeInputEnabled)
+        applyAiChatMenuStyling(viewState.showContextualSheetIcon)
         aiChatDivider.isVisible = (viewState.showVoiceSearch || viewState.showClearButton) && viewState.showChatMenu
         duckAISidebar.isVisible = newTransitionState.showDuckSidebar
         duckAIBack.isVisible = newTransitionState.showDuckBack
@@ -1560,13 +1560,13 @@ class OmnibarLayout @JvmOverloads constructor(
         view.alpha = if (enabled) 1.0f else LOCKED_INPUT_ALPHA
     }
 
-    private fun applyAiChatMenuStyling(isNativeInputEnabled: Boolean) {
-        // applyTransitionState fires on every view-state update; skip the call when the value
-        // hasn't changed so we don't keep triggering requestLayout() via setPaddingRelative,
+    private fun applyAiChatMenuStyling(showContextualSheetIcon: Boolean) {
+        // renderButtons fires on every view-state update; skip the call when the value hasn't
+        // changed so we don't keep triggering requestLayout() via setPaddingRelative,
         // setImageResource, and updateLayoutParams.
-        if (lastAppliedNativeInputEnabled == isNativeInputEnabled) return
-        lastAppliedNativeInputEnabled = isNativeInputEnabled
-        (aiChatMenu as? android.widget.ImageView)?.applyDuckAiIconStyling(isNativeInputEnabled)
+        if (lastAppliedShowContextualSheetIcon == showContextualSheetIcon) return
+        lastAppliedShowContextualSheetIcon = showContextualSheetIcon
+        (aiChatMenu as? android.widget.ImageView)?.applyDuckAiIconStyling(showContextualSheetIcon)
     }
 
     override fun setInputScreenLaunchListener(listener: InputScreenLaunchListener) {

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -261,6 +261,16 @@ class OmnibarLayoutViewModel @Inject constructor(
         val isProgressBarUpgradeEnabled: Boolean = false,
         val enabledState: EnabledState = EnabledState.ALL,
     ) {
+        /**
+         * The Duck.ai entry icon shows the chevron-down (contextual sheet) variant when the native
+         * input field setting is enabled and we're not on the new-tab page — tapping it then opens
+         * the contextual sheet. In every other case it falls back to the standard chat icon, whose
+         * tap opens Duck.ai in full screen. Derived from the flag + viewMode rather than a stored
+         * flag so it can't drift out of sync with other state-update paths.
+         */
+        val showContextualSheetIcon: Boolean
+            get() = isNativeInputEnabled && viewMode !is NewTab
+
         fun shouldUpdateOmnibarText(
             isFullUrlEnabled: Boolean,
         ): Boolean {

--- a/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/systemsearch/SystemSearchActivity.kt
@@ -49,7 +49,6 @@ import com.duckduckgo.app.browser.R.string
 import com.duckduckgo.app.browser.databinding.ActivitySystemSearchBinding
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.browser.mode.SystemSearchExternal
-import com.duckduckgo.app.browser.nativeinput.applyDuckAiIconStyling
 import com.duckduckgo.app.browser.newtab.FavoritesQuickAccessAdapter
 import com.duckduckgo.app.browser.newtab.FavoritesQuickAccessAdapter.Companion.QUICK_ACCESS_GRID_MAX_COLUMNS
 import com.duckduckgo.app.browser.newtab.FavoritesQuickAccessAdapter.Companion.QUICK_ACCESS_ITEM_MAX_SIZE_DP
@@ -334,11 +333,6 @@ class SystemSearchActivity : DuckDuckGoActivity() {
                 launch {
                     viewModel.favoritesViewState.collectLatest {
                         renderQuickAccessItems(it)
-                    }
-                }
-                launch {
-                    duckChat.observeNativeInputFieldUserSettingEnabled().collect {
-                        duckAi.applyDuckAiIconStyling(it)
                     }
                 }
             }

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarDuckAiIconStateTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarDuckAiIconStateTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.omnibar
+
+import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode
+import com.duckduckgo.app.browser.omnibar.OmnibarLayoutViewModel.ViewState
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class OmnibarDuckAiIconStateTest {
+
+    @Test
+    fun whenNativeInputEnabledAndBrowserModeThenContextualSheetIconShown() {
+        val state = ViewState(isNativeInputEnabled = true, viewMode = ViewMode.Browser(null))
+        assertTrue(state.showContextualSheetIcon)
+    }
+
+    @Test
+    fun whenNativeInputEnabledAndDuckAiModeThenContextualSheetIconShown() {
+        val state = ViewState(isNativeInputEnabled = true, viewMode = ViewMode.DuckAI)
+        assertTrue(state.showContextualSheetIcon)
+    }
+
+    @Test
+    fun whenNativeInputEnabledAndNewTabModeThenContextualSheetIconHidden() {
+        // On the new-tab page we always show the full-screen Duck.ai entry point.
+        val state = ViewState(isNativeInputEnabled = true, viewMode = ViewMode.NewTab)
+        assertFalse(state.showContextualSheetIcon)
+    }
+
+    @Test
+    fun whenNativeInputDisabledThenContextualSheetIconHidden() {
+        val state = ViewState(isNativeInputEnabled = false, viewMode = ViewMode.Browser(null))
+        assertFalse(state.showContextualSheetIcon)
+    }
+
+    @Test
+    fun whenNativeInputDisabledAndNewTabModeThenContextualSheetIconHidden() {
+        val state = ViewState(isNativeInputEnabled = false, viewMode = ViewMode.NewTab)
+        assertFalse(state.showContextualSheetIcon)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1215446841794258?focus=true

### Description

Changes the condition that drives the Duck.ai entry icon in the omnibar.

The chevron-down variant (`ic_ai_chat_down_24`, which opens the contextual sheet) is now shown only when **the native input field setting is enabled** and the omnibar is **not** on the new-tab page. In every other case the standard chat icon (`ic_ai_chat_24`, which opens Duck.ai full screen) is shown.

- The decision is derived as `ViewState.showContextualSheetIcon` (`isNativeInputEnabled && viewMode !is NewTab`), computed rather than stored so it can't drift out of sync with other state-update paths.
- The styling helper `ImageView.applyDuckAiIconStyling(...)` parameter is renamed from `isNativeInputEnabled` to `showContextualSheetIcon` to reflect what it now represents.
- System Search no longer applies any styling to its Duck.ai icon and always shows the standard chat icon (both layouts already default to `ic_ai_chat_24`).

### Steps to test this PR

_Omnibar Duck.ai icon_
- [x] With the native input field setting enabled, open a web page (Browser mode) and confirm the omnibar Duck.ai icon shows the chevron-down variant
- [x] Navigate to the new-tab page and confirm the icon reverts to the standard chat icon
- [x] Disable the native input field setting and confirm the standard chat icon is shown in all modes

_System Search_
- [x] Open the system search screen and confirm the Duck.ai icon always shows the standard chat icon

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only omnibar and system-search icon behavior with derived state and new unit tests; no auth, data, or security paths touched.
> 
> **Overview**
> The omnibar **Duck.ai** shortcut icon now reflects **what a tap does**, not just whether native input is on. A **chevron-down** (contextual sheet) variant appears only when the native input setting is enabled **and** the omnibar is **not** on the new-tab page; otherwise the standard chat icon (full-screen Duck.ai) is used.
> 
> That choice is computed as **`ViewState.showContextualSheetIcon`** (`isNativeInputEnabled && viewMode !is NewTab`) so it stays aligned with view mode changes. **`applyDuckAiIconStyling`** and omnibar styling hooks are renamed to take **`showContextualSheetIcon`** instead of **`isNativeInputEnabled`**.
> 
> **System Search** no longer listens to the native-input setting to swap icons; it always keeps the default chat icon from layout.
> 
> Unit tests cover the derived icon flag across Browser, Duck.ai, and New Tab modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc5ef421dda1aa3f913b42b3b4186b03df7458de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->