### PR TITLE
Gate chat input hint on chat creation

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -58,6 +58,7 @@ import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
 import com.duckduckgo.subscriptions.api.Product
 import com.duckduckgo.subscriptions.api.Subscriptions
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
@@ -68,8 +69,10 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.update
@@ -212,11 +215,24 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         )
     }
 
+    // chatId lives in the per-tab provider state (written by applyChatId), not in baseState. Fold it
+    // back in here so widget UI that depends on it (e.g. the chat input hint) sees the real value
+    // rather than the baseState default of null. flatMapLatest re-targets on tab switch.
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private val activeChatId: Flow<String?> = activeTabId.filterNotNull()
+        .flatMapLatest { tabId -> nativeInputStateProvider.stateForTab(tabId) }
+        .map { it.chatId }
+        .distinctUntilChanged()
+
     val state: SharedFlow<NativeInputState> = combine(
         baseState,
         duckChatInternal.chatState,
-    ) { state, chatState ->
-        state.copy(isChatStreaming = chatState == ChatState.STREAMING || chatState == ChatState.LOADING)
+        activeChatId,
+    ) { state, chatState, chatId ->
+        state.copy(
+            isChatStreaming = chatState == ChatState.STREAMING || chatState == ChatState.LOADING,
+            chatId = chatId,
+        )
     }.shareIn(
         scope = viewModelScope,
         started = SharingStarted.Eagerly,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -31,6 +31,7 @@ import android.view.inputmethod.InputMethodManager
 import android.webkit.ValueCallback
 import android.widget.EditText
 import android.widget.FrameLayout
+import androidx.annotation.StringRes
 import androidx.core.view.doOnAttach
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
@@ -560,6 +561,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val firstStateEmission = previousState == null
         val contextChanged = previousState?.inputContext != state.inputContext
         val positionChanged = previousState?.isBottom != state.isBottom
+        // chatId flips from null to non-null when a chat is created; the hint depends on it
+        // (see `applyChatInputType`), so re-apply the input type to swap the placeholder.
+        val chatIdChanged = previousState?.chatId != state.chatId
         nativeInputState = state
         findViewById<TabLayout?>(R.id.inputModeSwitch)?.let { toggle ->
             setToggleMatchParent()
@@ -572,10 +576,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
         updateNewLineButtonVisibility()
         updateSendButtonIcon()
         applyOmnibarShape()
-        // Re-apply chat input type whenever the inputs to `applyChatInputType` (context, position)
-        // change, or on the first emission. This corrects stale IME setup from a tab listener
+        // Re-apply chat input type whenever the inputs to `applyChatInputType` (context, position,
+        // chatId) change, or on the first emission. This corrects stale IME setup from a tab listener
         // that fired before the state-flow caught up.
-        if ((firstStateEmission || contextChanged || positionChanged) && isChatTabSelected()) {
+        if ((firstStateEmission || contextChanged || positionChanged || chatIdChanged) && isChatTabSelected()) {
             inputField.applyChatInputType()
             (context.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager).restartInput(inputField)
         }
@@ -713,9 +717,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     override fun EditText.applyChatInputType() {
-        hint = context.getString(
-            if (isDuckAiPageContext()) R.string.native_input_chat_duck_mode_hint else R.string.native_input_chat_hint,
-        )
+        // Placeholder depends on whether a chat already exists (see `NativeInputState.chatHintRes`):
+        // a fresh Duck.ai page starts a new chat and gets "Ask anything privately…" until a chat is
+        // created and `chatId` is populated, at which point it becomes "Reply…".
+        hint = context.getString((nativeInputState ?: NativeInputState.zero()).chatHintRes())
         // Enter inserts a newline when we're on a Duck.ai chat page (existing behavior) or when
         // the widget sits in bottom-bar position with the Duck.ai toggle selected. Bottom-bar
         // mode has no on-screen new-line button, so the IME enter key is the only carriage-
@@ -1263,6 +1268,15 @@ class NativeInputModeWidget @JvmOverloads constructor(
         private const val FOCUS_TRANSITION_DURATION_MS = 100L
     }
 }
+
+/**
+ * Chat input placeholder. A chat only exists once it has been created, which [NativeInputState.chatId]
+ * tells us, so "Reply…" is shown only then. Being on a Duck.ai page is not sufficient — a fresh Duck.ai
+ * page starts a new chat, which gets the "Ask anything privately…" prompt until the first message.
+ */
+@StringRes
+internal fun NativeInputState.chatHintRes(): Int =
+    if (chatId != null) R.string.native_input_chat_duck_mode_hint else R.string.native_input_chat_hint
 
 internal fun NativeInputState.shouldShowToggleRowBack(): Boolean =
     toggleVisible && inputContext == NativeInputState.InputContext.BROWSER

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetChatHintTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetChatHintTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui
+
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputContext
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputMode
+import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.chatHintRes
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NativeInputModeWidgetChatHintTest {
+
+    @Test
+    fun `new chat shows the ask anything hint when no chat id`() {
+        val state = stateOf(InputContext.DUCK_AI, chatId = null)
+
+        assertEquals(R.string.native_input_chat_hint, state.chatHintRes())
+    }
+
+    @Test
+    fun `existing chat shows the reply hint when chat id present`() {
+        val state = stateOf(InputContext.DUCK_AI, chatId = "chat-123")
+
+        assertEquals(R.string.native_input_chat_duck_mode_hint, state.chatHintRes())
+    }
+
+    @Test
+    fun `duck ai page context alone does not switch to the reply hint`() {
+        assertEquals(R.string.native_input_chat_hint, stateOf(InputContext.DUCK_AI, chatId = null).chatHintRes())
+        assertEquals(R.string.native_input_chat_hint, stateOf(InputContext.DUCK_AI_CONTEXTUAL, chatId = null).chatHintRes())
+    }
+
+    @Test
+    fun `browser context with a chat id still shows the reply hint`() {
+        val state = stateOf(InputContext.BROWSER, chatId = "chat-123")
+
+        assertEquals(R.string.native_input_chat_duck_mode_hint, state.chatHintRes())
+    }
+
+    private fun stateOf(inputContext: InputContext, chatId: String?): NativeInputState =
+        NativeInputState(
+            inputMode = InputMode.SEARCH_AND_DUCK_AI,
+            inputContext = inputContext,
+            chatId = chatId,
+        )
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -1228,6 +1228,34 @@ class NativeInputModeWidgetViewModelTest {
         assertEquals("chat-123", nativeInputStateProvider.stateForTab("tab-A").value.chatId)
     }
 
+    @Test
+    fun whenSetActiveChatIdThenStateExposesChatId() = runTest {
+        val tabId = "tab-A"
+        testee.configure(tabId = tabId, isDuckAiMode = true, isBottom = false)
+        advanceUntilIdle()
+
+        assertNull(testee.state.first().chatId)
+
+        testee.setActiveChatId("chat-123")
+        advanceUntilIdle()
+
+        assertEquals("chat-123", testee.state.first { it.chatId != null }.chatId)
+    }
+
+    @Test
+    fun whenSetActiveChatIdWithNullThenStateClearsChatId() = runTest {
+        val tabId = "tab-A"
+        testee.configure(tabId = tabId, isDuckAiMode = true, isBottom = false)
+        testee.setActiveChatId("chat-123")
+        advanceUntilIdle()
+        assertEquals("chat-123", testee.state.first { it.chatId != null }.chatId)
+
+        testee.setActiveChatId(null)
+        advanceUntilIdle()
+
+        assertNull(testee.state.first().chatId)
+    }
+
     // endregion
 
     // region fireChatHistorySelectedPixel


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1215446216726112?focus=true

### Description

The chat input placeholder showed "Reply…" (`native_input_chat_duck_mode_hint`) as soon as the input was in a Duck.ai page context — even when starting a brand-new chat with nothing to reply to. It should show "Ask anything privately…" (`native_input_chat_hint`) until a chat actually exists.

A chat exists once `NativeInputState.chatId` is populated. The widget reads its state from `NativeInputModeWidgetViewModel.state`, which was built from `baseState` and never carried `chatId` (chatId only lived in the per-tab provider state, written by `applyChatId`). So the widget's `chatId` was always `null` and the hint could never flip.

This PR:
- Folds the per-tab `chatId` from the provider back into `viewModel.state` (`flatMapLatest` on the active tab, so it stays per-tab correct across tab switches).
- Extracts `NativeInputState.chatHintRes()` — a testable extension that returns the "Reply…" hint only when `chatId != null`, otherwise the "Ask anything privately…" hint.
- Re-applies the chat input type on `chatId` change so the placeholder swaps the moment a chat is created.

### Steps to test this PR

_New chat shows the new-chat hint_
- [x] Internal build, native input enabled
- [x] Open a new Duck.ai chat (no messages yet) — hint reads "Ask anything privately…"

_Existing chat shows the reply hint_
- [x] Send a message so a chat is created
- [x] Hint switches to "Reply…"
- [x] Reopen an existing chat from history — hint reads "Reply…"

### UI changes
| Before  | After |
| ------ | ----- |
|(new chat showed "Reply…")|(new chat shows "Ask anything privately…", existing chat shows "Reply…")|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized native-input UI and state wiring with unit tests; no auth, data migration, or API contract changes.
> 
> **Overview**
> Fixes the native chat input showing **"Reply…"** on brand-new Duck.ai sessions by driving the placeholder from **`NativeInputState.chatId`** instead of Duck.ai page context.
> 
> **`NativeInputModeWidgetViewModel`** now folds the active tab’s per-provider **`chatId`** into **`state`** (via **`flatMapLatest`** on tab id) so the widget sees the real id after **`setActiveChatId`**, not a permanent **`null`** from **`baseState`**. **`NativeInputState.chatHintRes()`** returns the ask-anything string when **`chatId`** is null and the reply string when it is set; **`applyChatInputType`** uses that helper, and **`applyState`** re-runs it (with **`restartInput`**) when **`chatId`** changes. Unit tests cover hint selection and ViewModel **`state.chatId`** propagation/clearing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ba1f702aa498784760c4740dd63ba5dfcdf8a1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->