### PR TITLE
Fix app exits when chat navigates back to NTP

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -797,12 +797,13 @@ open class BrowserActivity : DuckDuckGoActivity() {
             if (duckAiFeatureState.showFullScreenMode.value) {
                 val url = intent.getStringExtra(DUCK_CHAT_URL) ?: duckChat.getDuckChatUrl("", false)
                 // The tab to return to when this Duck.ai tab is closed.
-                // Fallback to the current tab if no explicit tab id is passed.
+                // Use to the current tab if no explicit tab id is passed.
+                // Falls back to NTP otherwise.
                 val sourceTabId = intent.getStringExtra(SOURCE_TAB_ID_EXTRA) ?: currentTab?.tabId
                 if (swipingTabsFeature.isEnabled) {
-                    launchNewTab(query = url, skipHome = true, sourceTabId = sourceTabId)
+                    launchNewTab(query = url, skipHome = false, sourceTabId = sourceTabId)
                 } else {
-                    lifecycleScope.launch { viewModel.onOpenInNewTabRequested(query = url, sourceTabId = sourceTabId, skipHome = true) }
+                    lifecycleScope.launch { viewModel.onOpenInNewTabRequested(query = url, sourceTabId = sourceTabId, skipHome = false) }
                 }
             } else {
                 val duckChatSessionActive = intent.getBooleanExtra(DUCK_CHAT_SESSION_ACTIVE, false)
@@ -863,7 +864,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
                 }
                 val selectedText = intent.getBooleanExtra(SELECTED_TEXT_EXTRA, false)
                 val sourceTabId = intent.getStringExtra(SOURCE_TAB_ID_EXTRA) ?: if (selectedText) currentTab?.tabId else null
-                val skipHome = !selectedText
+                val skipHome = !selectedText && sourceTabId == null
                 if (swipingTabsFeature.isEnabled) {
                     val query =
                         if (isExternal) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1848,6 +1848,11 @@ class BrowserTabViewModel @Inject constructor(
         isLinkOpenedInNewTab && hasSourceTab && !isCustomTab && site?.url.isNullOrEmpty()
 
     private fun navigateHome() {
+        // Going home reuses this tab, so an active Duck.ai voice session would keep
+        // running with the mic open. End it here so the frontend cleans it up.
+        if (duckChat.isVoiceChatSessionActive(tabId)) {
+            duckChat.endVoiceChatSession(tabId)
+        }
         pdfDownloadJob.cancel()
         site = null
         onSiteChanged()

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -2462,6 +2462,26 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenBackToHomeWithActiveVoiceSessionThenEndsVoiceChatSession() {
+        setupNavigation(isBrowsing = true, canGoBack = false)
+        whenever(mockDuckChat.isVoiceChatSessionActive(any())).thenReturn(true)
+
+        testee.onUserPressedBack()
+
+        verify(mockDuckChat).endVoiceChatSession(any())
+    }
+
+    @Test
+    fun whenBackToHomeWithNoActiveVoiceSessionThenDoesNotEndVoiceChatSession() {
+        setupNavigation(isBrowsing = true, canGoBack = false)
+        whenever(mockDuckChat.isVoiceChatSessionActive(any())).thenReturn(false)
+
+        testee.onUserPressedBack()
+
+        verify(mockDuckChat, never()).endVoiceChatSession(any())
+    }
+
+    @Test
     fun whenHomeShowingByPressingBackOnInvalidatedBrowserThenForwardButtonInactive() {
         setupNavigation(isBrowsing = true)
         givenInvalidatedGlobalLayout()

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
@@ -138,6 +138,13 @@ interface DuckChat {
     fun observeTriggerVoiceChatSessionEnd(): Flow<String>
 
     /**
+     * Requests that the active voice session on the tab with the given [tabId] end. This drives the web
+     * frontend to tear down the session (stop recording, release the mic) and report it ended, which in
+     * turn releases the native voice resources.
+     */
+    fun endVoiceChatSession(tabId: String)
+
+    /**
      * Returns `true` when the native Duck.ai chat history surface is enabled by all gating feature flags.
      * Suspending because the underlying feature-flag reads must not block the main thread.
      */

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -805,6 +805,8 @@ class RealDuckChat @Inject constructor(
 
     override fun observeTriggerVoiceChatSessionEnd(): Flow<String> = voiceSessionStateManager.observeTriggerVoiceSessionEnd()
 
+    override fun endVoiceChatSession(tabId: String) = voiceSessionStateManager.triggerVoiceSessionEnd(tabId)
+
     override suspend fun isChatHistoryAvailable(): Boolean = withContext(dispatchers.io()) {
         isEnabled() &&
             duckChatFeature.useNativeStorageChatData().isEnabled() &&

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -798,6 +798,13 @@ class RealDuckChatTest {
     }
 
     @Test
+    fun whenEndVoiceChatSessionThenTriggersVoiceSessionEndForTab() = runTest {
+        testee.endVoiceChatSession("tab-123")
+
+        verify(mockVoiceSessionStateManager).triggerVoiceSessionEnd("tab-123")
+    }
+
+    @Test
     fun whenSetEnableDuckChatUserSettingTrueThenRepositoryUpdated() = runTest {
         whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -1614,6 +1614,7 @@ class DuckChatContextualViewModelTest {
         override fun isVoiceChatSessionActive(tabId: String): Boolean = false
         override val activeVoiceChatSessions: Flow<Set<String>> = flowOf(emptySet())
         override fun observeTriggerVoiceChatSessionEnd(): Flow<String> = kotlinx.coroutines.flow.emptyFlow()
+        override fun endVoiceChatSession(tabId: String) { }
         override suspend fun isChatHistoryAvailable(): Boolean = false
     }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
@@ -112,6 +112,7 @@ class FakeDuckChat(
     override fun isVoiceChatSessionActive(tabId: String): Boolean = false
     override val activeVoiceChatSessions: Flow<Set<String>> = MutableStateFlow(emptySet())
     override fun observeTriggerVoiceChatSessionEnd(): Flow<String> = kotlinx.coroutines.flow.emptyFlow()
+    override fun endVoiceChatSession(tabId: String) { }
 
     override suspend fun isChatHistoryAvailable(): Boolean = false
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -191,6 +191,7 @@ class FakeDuckChatInternal(
     override fun isVoiceChatSessionActive(tabId: String): Boolean = false
     override val activeVoiceChatSessions: Flow<Set<String>> = MutableStateFlow(emptySet())
     override fun observeTriggerVoiceChatSessionEnd(): Flow<String> = kotlinx.coroutines.flow.emptyFlow()
+    override fun endVoiceChatSession(tabId: String) { }
 
     override suspend fun isChatHistoryAvailable(): Boolean = false
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1215450633419080?focus=true 

### Description

Tech design: https://app.asana.com/1/137249556945/project/481882893211075/task/1215385485860821

When Duck chat is loaded from NTP (Via the menu, or native input icon), closing falls back to the NTP instead of exiting.
The voice session now ends on the NTP fallback. Added a public `DuckChat.endVoiceChatSession(tabId)` and call it from `BrowserTabViewModel.navigateHome()` when the tab has an active voice session. It drives the existing frontend teardown (`END_VOICE_SESSION` JS → web stops recording/releases mic → native cleanup). This only runs for *this* tab going home, not on tab switches.

### Steps to test this PR

_NTP fallback + voice cleanup_
- [ ] On the **NTP**, menu → **New Voice Chat** → While voice chat is active, press **back** → lands on the NTP **and** the voice session ends (mic released, no lingering mic notification).

_Chats list from the NTP_
- [ ] On the **NTP**, menu → **Chats** → tap a chat → press **back** → returns to the NTP (does not exit the app).

_Normal chat from the NTP_
- [ ] On the **NTP**, menu → **New Chat** → press **back** → returns to the NTP (does not exit the app).


### UI changes

No visual UI changes — behavioural fix.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches back-stack and tab lifecycle for full-screen Duck.ai plus voice session teardown on home navigation; behavior is localized but user-visible on back and mic usage.
> 
> **Overview**
> Fixes **app exit when leaving full-screen Duck.ai** by opening the chat tab with **`skipHome = false`** instead of `true`, so back navigation lands on the **NTP** on the source tab rather than treating the tab as “skip home” and falling through to exit.
> 
> When the user **returns home on the same tab**, **`navigateHome()`** now ends an active **Duck.ai voice session** via new **`DuckChat.endVoiceChatSession(tabId)`** (wired through **`RealDuckChat`** to the voice session manager) so the mic is not left open after the WebView is cleared.
> 
> Adds unit tests for voice teardown on back-to-home and for **`endVoiceChatSession`** delegation; test fakes implement the new API method.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f65aaa181a1761389d408213db8ce009a66a0a37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->