### PR TITLE
Android: Update "End Session" to "End Chat"

### DIFF
--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -37,7 +37,7 @@
     <string name="duckAiVoiceNotificationMessage">Microphone is in use by Duck.ai</string>
     <string name="duckAiVoiceNotificationChannelName">Duck.ai Voice Chat</string>
     <string name="duckAiVoiceNotificationActionOpenChat">Open chat</string>
-    <string name="duckAiVoiceNotificationActionEndSession">End session</string>
+    <string name="duckAiVoiceNotificationActionEndSession">End chat</string>
 
     <!-- Start chat icon content description -->
     <string name="duckChatStartChatContentDescription">Start chat</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211654189969294/task/1215469066973313?focus=true 

### Description
Update voice chat notification action from "End session" to  "End chat"

### Steps to test this PR
QA-Optional

<!-- CURSOR_SUMMARY -->
<img width="330" height="140" alt="Screenshot 2026-06-05 at 17 12 13" src="https://github.com/user-attachments/assets/61c6bcfa-8a40-4334-93df-67898d4c11ad" />


---

> [!NOTE]
> **Low Risk**
> Copy-only string change with no logic or resource ID changes.
> 
> **Overview**
> Updates the Duck.ai voice microphone foreground service notification so the secondary action label reads **"End chat"** instead of **"End session"**, aligning wording with **"Open chat"** on the same notification.
> 
> Only `duckAiVoiceNotificationActionEndSession` in `donottranslate.xml` changes; `DuckChatVoiceMicrophoneService` still references the same string resource, so behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c46b6e595a2589874db46a6456fca85c2106ca4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->