### PR TITLE
Opt out of Android 16 predictive back navigation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,6 +47,7 @@
         android:fullBackupContent="@xml/backup_rules_android_11_and_older"
         android:theme="@style/Theme.DuckDuckGo.App"
         android:requestLegacyExternalStorage="true"
+        android:enableOnBackInvokedCallback="false"
         tools:ignore="GoogleAppIndexingWarning,UnusedAttribute">
         <meta-data
             android:name="android.webkit.WebView.MetricsOptOut"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1209431403525952?focus=true

### Description

Opts the app out of the Android 16 (API 36) predictive back gesture by setting `android:enableOnBackInvokedCallback="false"` on the `<application>` element.

At the current `targetSdk` (35) this is a no-op — predictive back is already off below API 36. It pre-emptively keeps predictive back disabled for when the app targets API 36, where the system would otherwise enable it by default. `OnBackPressedCallback` / `OnBackPressedDispatcher` handling is unaffected by this flag; only the system predictive-back animations are suppressed.

### Steps to test this PR

The committed change is inert until the app targets API 36, so testing requires temporarily bumping the SDK. Save the patch below as `predictive-back-sdk36-test.patch` and apply it with `git apply predictive-back-sdk36-test.patch`. It bumps `target`/`compile` SDK to 36, plus a required compile fix for a tightened platform nullability annotation.

Requires an Android 16 (API 36) device/emulator with **gesture navigation** enabled.

```diff
diff --git a/build.gradle b/build.gradle
index 82c1d05fb6..2b30fc9b52 100644
--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,8 @@ buildscript {
 
     ext {
         min_sdk = 26
-        target_sdk = 35
-        compile_sdk = 35
+        target_sdk = 36
+        compile_sdk = 36
 
         // Calculate lint_version (must always be gradle_plugin + 23)
         def gradle_plugin_version = versionFor(project, Android.tools.build.gradlePlugin)
diff --git a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/DisplayModeSyncSetting.kt b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/DisplayModeSyncSetting.kt
index ee998d7f2f..3c87f6ca49 100644
--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/DisplayModeSyncSetting.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/DisplayModeSyncSetting.kt
@@ -61,7 +61,7 @@ class DisplayModeSyncSetting @JvmOverloads constructor(
 
         binding.syncSettingsOptionFavourites.setOnCheckedChangeListener(
             object : OnCheckedChangeListener {
-                override fun onCheckedChanged(buttonView: CompoundButton?, isChecked: Boolean) {
+                override fun onCheckedChanged(buttonView: CompoundButton, isChecked: Boolean) {
                     viewModel.onDisplayModeChanged(isChecked)
                 }
             },
```

_Opt-out active — on API 36_
- [x] With the patch applied, build & install (`./gradlew installInternalDebug`).
- [x] Open several screens (browser/tabs, settings, bookmarks, downloads, autofill) and press / edge-swipe back.
- [x] Back navigation works normally and no predictive-back animation appears.

_Baseline — SDK reverted_
- [x] Revert the patch (`git checkout build.gradle saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/DisplayModeSyncSetting.kt`) so `target`/`compile` SDK return to 35.
- [x] Rebuild, install, repeat the back-navigation smoke test.
- [x] Back behaviour is unchanged from `develop`.

Optional, to confirm the opt-out is doing something: with the patch applied, set the manifest flag to `true`, rebuild — predictive-back animations appear; set it back to `false` and they're gone.

### UI changes

No UI changes. The flag is a no-op at the current `targetSdk` and only suppresses system predictive-back animations once the app targets API 36.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single manifest flag with no behavior change at current targetSdk; low navigation risk aside from future API 36 back-animation behavior.
> 
> **Overview**
> Adds **`android:enableOnBackInvokedCallback="false"`** on the root `<application>` in `AndroidManifest.xml` so the app will not use Android 16’s default predictive back gesture once **`targetSdk` is 36**.
> 
> At the current **`targetSdk` 35** the attribute has no runtime effect; it is forward-looking so a future SDK bump does not suddenly turn on system predictive-back animations. Existing **`OnBackPressedCallback` / `OnBackPressedDispatcher`** behavior is unchanged—only the system predictive-back UI is suppressed when the flag applies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48d58d3b276762b72aee11030d3a32f227416296. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->