### PR TITLE
Cover chat and hatch tab switcher in post-idle wide event

### DIFF
--- a/PixelDefinitions/pixels/definitions/wide_post_idle_session.json5
+++ b/PixelDefinitions/pixels/definitions/wide_post_idle_session.json5
@@ -48,7 +48,14 @@
                 "key": "feature.data.ext.status_reason",
                 "type": "string",
                 "description": "Reason the session ended",
-                "enum": ["bar_used", "return_to_page_tapped", "tab_switcher_selected", "app_backgrounded", "favorite_selected"]
+                "enum": [
+                    "bar_used",
+                    "chat_selected",
+                    "return_to_page_tapped",
+                    "tab_switcher_selected",
+                    "app_backgrounded",
+                    "favorite_selected"
+                ]
             },
             {
                 "key": "feature.data.ext.session_duration_ms_bucketed",

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -5289,6 +5289,7 @@ class BrowserTabViewModel @Inject constructor(
      * fullscreen mode we fall back to the legacy Intent-based path.
      */
     fun openDuckAiQuery(query: String, autoPrompt: Boolean) {
+        browserInteractionsPlugins.getPlugins().forEach { it.onInputSubmitted() }
         if (!duckAiFeatureState.showFullScreenMode.value) {
             if (autoPrompt) {
                 duckChat.openDuckChatWithAutoPrompt(query)
@@ -5307,6 +5308,7 @@ class BrowserTabViewModel @Inject constructor(
      * routed through the normal submit path which lands in the legacy Intent flow.
      */
     fun openDuckAiChatById(chatUrl: String) {
+        browserInteractionsPlugins.getPlugins().forEach { it.onChatSelected() }
         if (!duckAiFeatureState.showFullScreenMode.value) {
             onUserSubmittedQuery(chatUrl)
             return

--- a/app/src/main/java/com/duckduckgo/app/browser/postidle/RealPostIdleSessionWideEvent.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/postidle/RealPostIdleSessionWideEvent.kt
@@ -126,6 +126,10 @@ class RealPostIdleSessionWideEvent @Inject constructor(
         finishSession(statusReason = REASON_BAR_USED, status = FlowStatus.Success)
     }
 
+    override fun onChatSelected() {
+        finishSession(statusReason = REASON_CHAT_SELECTED, status = FlowStatus.Success)
+    }
+
     override fun onReturnToPageTapped() {
         finishSession(statusReason = REASON_RETURN_TO_PAGE_TAPPED, status = FlowStatus.Success)
     }
@@ -220,6 +224,7 @@ class RealPostIdleSessionWideEvent @Inject constructor(
         const val FEATURE_NAME = "post_idle_session"
 
         const val REASON_BAR_USED = "bar_used"
+        const val REASON_CHAT_SELECTED = "chat_selected"
         const val REASON_RETURN_TO_PAGE_TAPPED = "return_to_page_tapped"
         const val REASON_TAB_SWITCHER_SELECTED = "tab_switcher_selected"
         const val REASON_FAVORITE_SELECTED = "favorite_selected"

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -7781,6 +7781,29 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenOpenDuckAiQueryThenFiresOnInputSubmittedOnBrowserInteractionsPlugins() = runTest {
+        val plugin: BrowserInteractionsPlugin = mock()
+        whenever(mockBrowserInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
+        mockDuckAiFeatureStateFullScreenModeFlow.emit(false)
+
+        testee.openDuckAiQuery(query = "hello", autoPrompt = true)
+
+        verify(plugin).onInputSubmitted()
+    }
+
+    @Test
+    fun whenOpenDuckAiChatByIdThenFiresOnChatSelectedOnBrowserInteractionsPlugins() = runTest {
+        val plugin: BrowserInteractionsPlugin = mock()
+        whenever(mockBrowserInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
+        mockDuckAiFeatureStateFullScreenModeFlow.emit(true)
+        setBrowserShowing(true)
+
+        testee.openDuckAiChatById("https://duck.ai/chat?chatId=abc")
+
+        verify(plugin).onChatSelected()
+    }
+
+    @Test
     fun whenNavigationStateChangedCalledThenHandleResolvedUrlIsChecked() =
         runTest {
             testee.navigationStateChanged(buildWebNavigation("https://example.com"))

--- a/app/src/test/java/com/duckduckgo/app/browser/postidle/RealPostIdleSessionWideEventTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/postidle/RealPostIdleSessionWideEventTest.kt
@@ -254,6 +254,30 @@ class RealPostIdleSessionWideEventTest {
     }
 
     @Test
+    fun `when onChatSelected terminates session then flowFinish is Success with chat_selected reason`() = runTest {
+        testee.onHatchShownAfterIdle()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        testee.onChatSelected()
+        coroutineRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(wideEventClient).intervalEnd(123L, "session_duration_ms_bucketed")
+        verify(wideEventClient).flowFinish(
+            wideEventId = eq(123L),
+            status = eq<FlowStatus>(FlowStatus.Success),
+            metadata = eq(
+                mapOf(
+                    "surface" to "ntp",
+                    "status_reason" to "chat_selected",
+                    "page_engaged" to "false",
+                    "toggle_used" to "false",
+                    "back_pressed" to "false",
+                ),
+            ),
+        )
+    }
+
+    @Test
     fun `when onReturnToPageTapped terminates session then flowFinish reason is return_to_page_tapped`() = runTest {
         testee.onHatchShownAfterIdle()
         coroutineRule.testScope.testScheduler.advanceUntilIdle()

--- a/browser-api/src/main/java/com/duckduckgo/browser/api/wideevents/BrowserInteractionsPlugin.kt
+++ b/browser-api/src/main/java/com/duckduckgo/browser/api/wideevents/BrowserInteractionsPlugin.kt
@@ -24,8 +24,11 @@ interface BrowserInteractionsPlugin {
     /** Last used tab (LUT) is shown after an idle return. */
     fun onLutShownAfterIdle() {}
 
-    /** User submitted a search or chat query via the omnibar. */
+    /** User submitted a typed query via the omnibar (search or chat prompt). */
     fun onInputSubmitted() {}
+
+    /** User selected a Duck.ai chat suggestion (without typing a prompt). */
+    fun onChatSelected() {}
 
     /** User opened the tab switcher. */
     fun onTabSwitcherSelected() {}

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModel.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModel.kt
@@ -166,6 +166,7 @@ class NewTabReturnHatchViewModel @Inject constructor(
     fun onTabManagerPressed() {
         pixel.fire(NewTabReturnHatchPixelName.OPTION_SELECTED_TAB_SWITCHER, type = Count)
         pixel.fire(NewTabReturnHatchPixelName.OPTION_SELECTED_TAB_SWITCHER_DAILY, type = Daily())
+        ntpAfterIdleManager.onTabSwitcherSelected()
         commandChannel.trySend(Command.LaunchTabSwitcher)
     }
 

--- a/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModelTest.kt
+++ b/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModelTest.kt
@@ -548,4 +548,11 @@ class NewTabReturnHatchViewModelTest {
         verify(mockPixel).fire(NewTabReturnHatchPixelName.OPTION_SELECTED_TAB_SWITCHER, type = Count)
         verify(mockPixel).fire(NewTabReturnHatchPixelName.OPTION_SELECTED_TAB_SWITCHER_DAILY, type = Daily())
     }
+
+    @Test
+    fun whenOnTabManagerPressedThenNotifiesNtpAfterIdleManager() = runTest {
+        testee.onTabManagerPressed()
+
+        verify(mockNtpAfterIdleManager).onTabSwitcherSelected()
+    }
 }

--- a/new-tab-page/new-tab-page-api/src/main/java/com/duckduckgo/newtabpage/api/NtpAfterIdleManager.kt
+++ b/new-tab-page/new-tab-page-api/src/main/java/com/duckduckgo/newtabpage/api/NtpAfterIdleManager.kt
@@ -31,6 +31,9 @@ interface NtpAfterIdleManager {
     /** Called when the user taps the return-to-page hatch on the NTP. */
     fun onReturnToPageTapped()
 
+    /** Called when the user opens the tab switcher from the hatch. */
+    fun onTabSwitcherSelected()
+
     /** Called when the user submits a search from the NTP. */
     fun onNtpSearchSubmitted()
 

--- a/new-tab-page/new-tab-page-api/src/main/java/com/duckduckgo/newtabpage/api/interactions/HatchInteractionsPlugin.kt
+++ b/new-tab-page/new-tab-page-api/src/main/java/com/duckduckgo/newtabpage/api/interactions/HatchInteractionsPlugin.kt
@@ -27,6 +27,9 @@ interface HatchInteractionsPlugin {
     /** User tapped the return-to-page hatch. */
     fun onReturnToPageTapped() {}
 
+    /** User opened the tab switcher from the hatch. */
+    fun onTabSwitcherSelected() {}
+
     /** User tapped a favorite tile on the NTP. */
     fun onFavoriteSelected() {}
 

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/NtpAfterIdleManagerImpl.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/NtpAfterIdleManagerImpl.kt
@@ -99,6 +99,10 @@ class NtpAfterIdleManagerImpl @Inject constructor(
         hatchInteractionsPlugins.getPlugins().forEach { it.onReturnToPageTapped() }
     }
 
+    override fun onTabSwitcherSelected() {
+        hatchInteractionsPlugins.getPlugins().forEach { it.onTabSwitcherSelected() }
+    }
+
     override fun onNtpSearchSubmitted() {
         if (_isAfterIdleReturn.value) {
             pixel.fire(BAR_USED_FROM_NTP_AFTER_IDLE, type = Count)

--- a/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/NtpAfterIdleManagerImplTest.kt
+++ b/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/NtpAfterIdleManagerImplTest.kt
@@ -40,6 +40,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
 
 class NtpAfterIdleManagerImplTest {
 
@@ -87,6 +88,18 @@ class NtpAfterIdleManagerImplTest {
         verify(pixel).fire(NTP_SHOWN_AFTER_IDLE_DAILY, type = Daily())
         verify(pixel).fire(NTP_SHOWN_USER_INITIATED, type = Count)
         verify(pixel).fire(NTP_SHOWN_USER_INITIATED_DAILY, type = Daily())
+    }
+
+    // --- onTabSwitcherSelected forwarding ---
+
+    @Test
+    fun whenOnTabSwitcherSelectedThenForwardsToHatchPlugins() {
+        val plugin: HatchInteractionsPlugin = mock()
+        whenever(hatchInteractionsPlugins.getPlugins()).thenReturn(listOf(plugin))
+
+        testee.onTabSwitcherSelected()
+
+        verify(plugin).onTabSwitcherSelected()
     }
 
     // --- onReturnToPageTapped classification ---


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1215449563262684?focus=true 

### Description

The post-idle session wide event (`wide_post_idle_session`) now records two user actions it previously missed: selecting a Duck.ai chat suggestion (new `chat_selected` outcome) and opening the tab switcher from the NTP-after-idle hatch (`tab_switcher_selected`). Typed Duck.ai prompts are also now recorded as `bar_used`, like search. This closes instrumentation gaps so the NTP-vs-Last-Used-Tab after-idle comparison stays accurate and matches the equivalent iOS measurement.

### Steps to test this PR

_NTP-after-idle_
- [ ] Background the app past the idle threshold, reopen → confirm a session starts with `surface=ntp`
- [ ] Type a query and submit a search → confirm the session finishes with `reason=bar_used`
- [ ] Trigger a fresh NTP-after-idle, toggle to Duck.ai, type a prompt and submit → confirm `reason=bar_used`
- [ ] Trigger a fresh NTP-after-idle, tap a Duck.ai chat suggestion → confirm `reason=chat_selected`
- [ ] Trigger a fresh NTP-after-idle, open the tab switcher from the hatch's tab button → confirm `reason=tab_switcher_selected`

_LUT-after-idle_
- [ ] Background past the idle threshold, reopen onto the last tab → confirm a session starts with `surface=lut`
- [ ] Submit a search or Duck.ai prompt → confirm `reason=bar_used`
- [ ] Trigger a fresh LUT-after-idle, tap a Duck.ai chat suggestion → confirm `reason=chat_selected`

### UI changes

n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only wiring and pixel enum updates; no auth, navigation, or product behavior changes beyond telemetry callbacks.
> 
> **Overview**
> Extends **post-idle session** wide-event instrumentation so Duck.ai and hatch actions are counted as distinct session endings.
> 
> **Duck.ai from the unified input:** `openDuckAiQuery` now notifies `BrowserInteractionsPlugin.onInputSubmitted()` (same as search → **`bar_used`**). `openDuckAiChatById` calls **`onChatSelected()`**, which ends the session with the new **`chat_selected`** reason. The pixel schema adds `chat_selected` to `feature.data.ext.status_reason`.
> 
> **NTP hatch tab switcher:** Opening the tab switcher from the return hatch calls `NtpAfterIdleManager.onTabSwitcherSelected()`, forwarded to hatch interaction plugins so the existing **`tab_switcher_selected`** terminal reason can fire for that path.
> 
> Plugin APIs gain default `onChatSelected()` on browser interactions and `onTabSwitcherSelected()` on hatch interactions, with unit tests on the view models and `RealPostIdleSessionWideEvent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d9d285d60fd3c119058f4a942cf318977f0183c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->