### PR TITLE
Fire Mode: Separate Duck chat data

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/RealNativeInputStateStore.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/RealNativeInputStateStore.kt
@@ -17,7 +17,8 @@
 package com.duckduckgo.duckchat.impl.nativeinput
 
 import com.duckduckgo.app.tabs.model.TabRepository
-import com.duckduckgo.browsermode.api.RegularMode
+import com.duckduckgo.browsermode.api.BrowserModeDataProvider
+import com.duckduckgo.browsermode.api.BrowserModeStateHolder
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
@@ -43,14 +44,11 @@ import javax.inject.Inject
 @ContributesBinding(AppScope::class, boundType = NativeInputStatePublisher::class)
 class RealNativeInputStateStore @Inject constructor(
     // Lazy avoids a Dagger cycle: TabRepository's impl (TabDataRepository) injects
-    // NativeInputStatePublisher to clearTab on tab eviction. Resolving TabRepository
-    // lazily lets Dagger construct both without circularity. The lazy is only
-    // dereferenced when `state` is collected for the first time.
-    //
-    // Qualified @RegularMode because the unqualified TabRepository is only bound in
-    // ActivityScope; AppScope consumers must pick a mode explicitly. Duck.ai native
-    // input state follows regular-mode tabs.
-    @RegularMode private val tabRepository: Lazy<TabRepository>,
+    // NativeInputStatePublisher to clearTab on tab eviction. Resolving the per-mode
+    // repository provider lazily lets Dagger construct both without circularity. The
+    // lazy is only dereferenced when `state` is collected for the first time.
+    private val tabRepositoryProvider: Lazy<BrowserModeDataProvider<TabRepository>>,
+    private val browserModeStateHolder: BrowserModeStateHolder,
 ) :
     NativeInputStateProvider,
     NativeInputStatePublisher {
@@ -58,7 +56,8 @@ class RealNativeInputStateStore @Inject constructor(
     private val flows = ConcurrentHashMap<String, MutableStateFlow<NativeInputState>>()
 
     override val state: Flow<NativeInputState> by lazy {
-        tabRepository.get().flowSelectedTab
+        browserModeStateHolder.currentMode
+            .flatMapLatest { mode -> tabRepositoryProvider.get().forMode(mode).flowSelectedTab }
             .filterNotNull()
             .map { it.tabId }
             .distinctUntilChanged()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/sync/DuckChatSyncDataManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/sync/DuckChatSyncDataManager.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.duckchat.impl.sync
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.appbuildconfig.api.isInternalBuild
+import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.checkMainThread
 import com.duckduckgo.common.utils.formatters.time.SyncDateProvider
@@ -63,7 +64,11 @@ class DuckChatSyncDataManager @Inject constructor(
     private val appBuildConfig: AppBuildConfig,
     private val duckChatFeature: DuckChatFeature,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
-    private val duckAiChatStore: DuckAiChatStore,
+    // Reads the Regular store regardless of the live mode when sync runs: sync is background/WorkManager-driven and
+    // can fire while the user is in Fire mode, where the unqualified (mode-aware) store would return Fire chats and
+    // silently drop pending Regular updates. Complements the Fire guard in RealDuckChatSyncRepository (which keeps
+    // Fire chatIds out of the pending queues) — both are needed; Fire chats must never sync.
+    @RegularMode private val duckAiChatStore: DuckAiChatStore,
 ) : DeletableDataManager, SyncableDataProvider, SyncableDataPersister {
 
     override fun getDeletableType(): DeletableType = DeletableType.DUCK_AI_CHATS

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/sync/DuckChatSyncRepository.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/sync/DuckChatSyncRepository.kt
@@ -16,6 +16,8 @@
 
 package com.duckduckgo.duckchat.impl.sync
 
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeStateHolder
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
 import com.duckduckgo.di.scopes.AppScope
@@ -62,9 +64,11 @@ interface DuckChatSyncRepository {
 class RealDuckChatSyncRepository @Inject constructor(
     private val duckChatSyncMetadataStore: DuckChatSyncMetadataStore,
     private val dispatchers: DispatcherProvider,
+    private val browserModeStateHolder: BrowserModeStateHolder,
 ) : DuckChatSyncRepository {
 
     override suspend fun recordDuckAiChatsDeleted(timestampMillis: Long) {
+        if (isFireMode()) return
         withContext(dispatchers.io()) {
             val isoTimestamp = DatabaseDateFormatter.parseMillisIso8601(timestampMillis)
             duckChatSyncMetadataStore.deletionTimestamp = isoTimestamp
@@ -90,6 +94,7 @@ class RealDuckChatSyncRepository @Inject constructor(
     }
 
     override suspend fun recordSingleChatDeletion(chatId: String) {
+        if (isFireMode()) return
         withContext(dispatchers.io()) {
             val current = duckChatSyncMetadataStore.pendingChatDeletions
             duckChatSyncMetadataStore.pendingChatDeletions = current + chatId
@@ -119,6 +124,7 @@ class RealDuckChatSyncRepository @Inject constructor(
     }
 
     override suspend fun recordSingleChatUpdate(chatId: String) {
+        if (isFireMode()) return
         withContext(dispatchers.io()) {
             val current = duckChatSyncMetadataStore.pendingChatUpdates
             duckChatSyncMetadataStore.pendingChatUpdates = current + chatId
@@ -146,4 +152,6 @@ class RealDuckChatSyncRepository @Inject constructor(
             logcat { "DuckChat-Sync: cleared all pending chat updates" }
         }
     }
+
+    private fun isFireMode(): Boolean = browserModeStateHolder.currentMode.value == BrowserMode.FIRE
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/nativeinput/RealNativeInputStateStoreTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/nativeinput/RealNativeInputStateStoreTest.kt
@@ -19,6 +19,9 @@ package com.duckduckgo.duckchat.impl.nativeinput
 import app.cash.turbine.test
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeDataProvider
+import com.duckduckgo.browsermode.api.BrowserModeStateHolder
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputContext
@@ -40,13 +43,29 @@ class RealNativeInputStateStoreTest {
     @get:Rule
     val coroutineRule = CoroutineTestRule()
 
-    private val selectedTabFlow = MutableStateFlow<TabEntity?>(null)
-    private val tabRepository: TabRepository = mock<TabRepository>().also {
-        whenever(it.flowSelectedTab).thenReturn(selectedTabFlow)
+    private val regularSelectedTabFlow = MutableStateFlow<TabEntity?>(null)
+    private val fireSelectedTabFlow = MutableStateFlow<TabEntity?>(null)
+    private val regularTabRepository: TabRepository = mock<TabRepository>().also {
+        whenever(it.flowSelectedTab).thenReturn(regularSelectedTabFlow)
     }
-    private val lazyTabRepository: dagger.Lazy<TabRepository> = dagger.Lazy { tabRepository }
+    private val fireTabRepository: TabRepository = mock<TabRepository>().also {
+        whenever(it.flowSelectedTab).thenReturn(fireSelectedTabFlow)
+    }
+    private val tabRepositoryProvider = object : BrowserModeDataProvider<TabRepository> {
+        override fun forMode(mode: BrowserMode): TabRepository = when (mode) {
+            BrowserMode.REGULAR -> regularTabRepository
+            BrowserMode.FIRE -> fireTabRepository
+        }
+    }
+    private val currentModeFlow = MutableStateFlow(BrowserMode.REGULAR)
+    private val browserModeStateHolder: BrowserModeStateHolder = mock<BrowserModeStateHolder>().also {
+        whenever(it.currentMode).thenReturn(currentModeFlow)
+    }
 
-    private val testee = RealNativeInputStateStore(lazyTabRepository)
+    private val testee = RealNativeInputStateStore(
+        dagger.Lazy { tabRepositoryProvider },
+        browserModeStateHolder,
+    )
 
     @Test
     fun whenStateForTabCalledTwiceForSameTabThenSameFlowReturned() {
@@ -179,7 +198,7 @@ class RealNativeInputStateStoreTest {
             inputContext = InputContext.DUCK_AI,
         )
         testee.publish("tab-a", published)
-        selectedTabFlow.value = tabEntity("tab-a")
+        regularSelectedTabFlow.value = tabEntity("tab-a")
 
         testee.state.test {
             assertEquals(published, awaitItem())
@@ -199,12 +218,12 @@ class RealNativeInputStateStoreTest {
         )
         testee.publish("tab-a", stateA)
         testee.publish("tab-b", stateB)
-        selectedTabFlow.value = tabEntity("tab-a")
+        regularSelectedTabFlow.value = tabEntity("tab-a")
 
         testee.state.test {
             assertEquals(stateA, awaitItem())
 
-            selectedTabFlow.value = tabEntity("tab-b")
+            regularSelectedTabFlow.value = tabEntity("tab-b")
 
             assertEquals(stateB, awaitItem())
             cancelAndIgnoreRemainingEvents()
@@ -218,7 +237,7 @@ class RealNativeInputStateStoreTest {
             inputContext = InputContext.BROWSER,
         )
         testee.publish("tab-a", initial)
-        selectedTabFlow.value = tabEntity("tab-a")
+        regularSelectedTabFlow.value = tabEntity("tab-a")
 
         testee.state.test {
             assertEquals(initial, awaitItem())
@@ -232,10 +251,57 @@ class RealNativeInputStateStoreTest {
 
     @Test
     fun whenSelectedTabIsNullThenStateDoesNotEmit() = runTest {
-        selectedTabFlow.value = null
+        regularSelectedTabFlow.value = null
 
         testee.state.test {
             expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenModeIsFireThenStateFollowsFireModeSelectedTab() = runTest {
+        val regularState = NativeInputState(
+            inputMode = InputMode.SEARCH_AND_DUCK_AI,
+            inputContext = InputContext.BROWSER,
+        )
+        val fireState = NativeInputState(
+            inputMode = InputMode.SEARCH_ONLY,
+            inputContext = InputContext.DUCK_AI,
+        )
+        testee.publish("regular-tab", regularState)
+        testee.publish("fire-tab", fireState)
+        regularSelectedTabFlow.value = tabEntity("regular-tab")
+        fireSelectedTabFlow.value = tabEntity("fire-tab")
+        currentModeFlow.value = BrowserMode.FIRE
+
+        testee.state.test {
+            assertEquals(fireState, awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenModeSwitchesToFireThenStateReEmitsForFireSelectedTab() = runTest {
+        val regularState = NativeInputState(
+            inputMode = InputMode.SEARCH_AND_DUCK_AI,
+            inputContext = InputContext.BROWSER,
+        )
+        val fireState = NativeInputState(
+            inputMode = InputMode.SEARCH_ONLY,
+            inputContext = InputContext.DUCK_AI,
+        )
+        testee.publish("regular-tab", regularState)
+        testee.publish("fire-tab", fireState)
+        regularSelectedTabFlow.value = tabEntity("regular-tab")
+        fireSelectedTabFlow.value = tabEntity("fire-tab")
+
+        testee.state.test {
+            assertEquals(regularState, awaitItem())
+
+            currentModeFlow.value = BrowserMode.FIRE
+
+            assertEquals(fireState, awaitItem())
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/sync/RealDuckChatSyncRepositoryTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/sync/RealDuckChatSyncRepositoryTest.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.sync
+
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeStateHolder
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+
+class RealDuckChatSyncRepositoryTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    private val metadataStore = object : DuckChatSyncMetadataStore {
+        override var deletionTimestamp: String? = null
+        override var pendingChatDeletions: Set<String> = emptySet()
+        override var pendingChatUpdates: Set<String> = emptySet()
+    }
+    private val modeFlow = MutableStateFlow(BrowserMode.REGULAR)
+    private val browserModeStateHolder = object : BrowserModeStateHolder {
+        override val currentMode: StateFlow<BrowserMode> = modeFlow
+        override fun switchTo(mode: BrowserMode) {
+            modeFlow.value = mode
+        }
+    }
+    private val repository = RealDuckChatSyncRepository(metadataStore, coroutineTestRule.testDispatcherProvider, browserModeStateHolder)
+
+    // --- REGULAR mode: writes flow through ---
+
+    @Test
+    fun `recordSingleChatDeletion enqueues in REGULAR mode`() = runTest {
+        modeFlow.value = BrowserMode.REGULAR
+
+        repository.recordSingleChatDeletion("c1")
+
+        assertEquals(setOf("c1"), metadataStore.pendingChatDeletions)
+    }
+
+    @Test
+    fun `recordSingleChatUpdate enqueues in REGULAR mode`() = runTest {
+        modeFlow.value = BrowserMode.REGULAR
+
+        repository.recordSingleChatUpdate("c1")
+
+        assertEquals(setOf("c1"), metadataStore.pendingChatUpdates)
+    }
+
+    @Test
+    fun `recordDuckAiChatsDeleted records timestamp in REGULAR mode`() = runTest {
+        modeFlow.value = BrowserMode.REGULAR
+
+        repository.recordDuckAiChatsDeleted(1_700_000_000_000L)
+
+        assertNotNull(metadataStore.deletionTimestamp)
+    }
+
+    // --- FIRE mode: writes are dropped (Fire chats must never enter the sync pipeline) ---
+
+    @Test
+    fun `recordSingleChatDeletion is a no-op in FIRE mode`() = runTest {
+        modeFlow.value = BrowserMode.FIRE
+
+        repository.recordSingleChatDeletion("fire-chat")
+
+        assertEquals(emptySet<String>(), metadataStore.pendingChatDeletions)
+    }
+
+    @Test
+    fun `recordSingleChatUpdate is a no-op in FIRE mode`() = runTest {
+        modeFlow.value = BrowserMode.FIRE
+
+        repository.recordSingleChatUpdate("fire-chat")
+
+        assertEquals(emptySet<String>(), metadataStore.pendingChatUpdates)
+    }
+
+    @Test
+    fun `recordDuckAiChatsDeleted is a no-op in FIRE mode`() = runTest {
+        modeFlow.value = BrowserMode.FIRE
+
+        repository.recordDuckAiChatsDeleted(1_700_000_000_000L)
+
+        assertNull(metadataStore.deletionTimestamp)
+    }
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/AttachmentViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/AttachmentViewModelTest.kt
@@ -23,6 +23,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeDataProvider
+import com.duckduckgo.browsermode.api.BrowserModeStateHolder
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.impl.DuckChatInternal
@@ -102,7 +105,16 @@ class AttachmentViewModelTest {
     private val tabRepository: TabRepository = mock<TabRepository>().also {
         whenever(it.flowSelectedTab).thenReturn(selectedTabFlow)
     }
-    private val nativeInputStateStore = RealNativeInputStateStore { tabRepository }
+    private val tabRepositoryProvider = object : BrowserModeDataProvider<TabRepository> {
+        override fun forMode(mode: BrowserMode): TabRepository = tabRepository
+    }
+    private val browserModeStateHolder: BrowserModeStateHolder = mock<BrowserModeStateHolder>().also {
+        whenever(it.currentMode).thenReturn(MutableStateFlow(BrowserMode.REGULAR))
+    }
+    private val nativeInputStateStore = RealNativeInputStateStore(
+        dagger.Lazy { tabRepositoryProvider },
+        browserModeStateHolder,
+    )
 
     private lateinit var viewModel: AttachmentViewModel
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -32,6 +32,9 @@ import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggesti
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteUrlSuggestion.AutoCompleteSwitchToTabSuggestion
 import com.duckduckgo.browser.api.autocomplete.AutoCompleteFactory
 import com.duckduckgo.browser.api.autocomplete.AutoCompleteSettings
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeDataProvider
+import com.duckduckgo.browsermode.api.BrowserModeStateHolder
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.plugins.ActivePluginPoint
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
@@ -118,7 +121,16 @@ class NativeInputModeWidgetViewModelTest {
     private val tabRepository: TabRepository = mock<TabRepository>().also {
         whenever(it.flowSelectedTab).thenReturn(selectedTabFlow)
     }
-    private val realNativeInputStateStore = RealNativeInputStateStore { tabRepository }
+    private val tabRepositoryProvider = object : BrowserModeDataProvider<TabRepository> {
+        override fun forMode(mode: BrowserMode): TabRepository = tabRepository
+    }
+    private val browserModeStateHolder: BrowserModeStateHolder = mock<BrowserModeStateHolder>().also {
+        whenever(it.currentMode).thenReturn(MutableStateFlow(BrowserMode.REGULAR))
+    }
+    private val realNativeInputStateStore = RealNativeInputStateStore(
+        dagger.Lazy { tabRepositoryProvider },
+        browserModeStateHolder,
+    )
     private val nativeInputStatePublisher: NativeInputStatePublisher = realNativeInputStateStore
     private val nativeInputStateProvider: NativeInputStateProvider = realNativeInputStateStore
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsViewModelTest.kt
@@ -18,6 +18,9 @@ package com.duckduckgo.duckchat.impl.ui.nativeinput.views
 
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeDataProvider
+import com.duckduckgo.browsermode.api.BrowserModeStateHolder
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.impl.models.Tool
@@ -49,7 +52,16 @@ class OptionsViewModelTest {
     private val tabRepository: TabRepository = mock<TabRepository>().also {
         whenever(it.flowSelectedTab).thenReturn(selectedTabFlow)
     }
-    private val store = RealNativeInputStateStore { tabRepository }
+    private val tabRepositoryProvider = object : BrowserModeDataProvider<TabRepository> {
+        override fun forMode(mode: BrowserMode): TabRepository = tabRepository
+    }
+    private val browserModeStateHolder: BrowserModeStateHolder = mock<BrowserModeStateHolder>().also {
+        whenever(it.currentMode).thenReturn(MutableStateFlow(BrowserMode.REGULAR))
+    }
+    private val store = RealNativeInputStateStore(
+        dagger.Lazy { tabRepositoryProvider },
+        browserModeStateHolder,
+    )
     private val duckChatPixels: DuckChatPixels = mock()
     private lateinit var testee: OptionsViewModel
 

--- a/duckchat/duckchat-internal/build.gradle
+++ b/duckchat/duckchat-internal/build.gradle
@@ -37,6 +37,7 @@ android {
 dependencies {
     ksp project(':anvil-ksp')
     implementation project(path: ':anvil-annotations')
+    implementation project(path: ':browser-mode-api')
     implementation project(path: ':internal-features-api')
     implementation project(path: ':duckchat-api')
     implementation project(path: ':duckchat-impl')

--- a/duckchat/duckchat-internal/src/main/java/com/duckduckgo/duckchat/internal/store/DuckAiDebugServer.kt
+++ b/duckchat/duckchat-internal/src/main/java/com/duckduckgo/duckchat/internal/store/DuckAiDebugServer.kt
@@ -22,6 +22,7 @@ import androidx.core.content.edit
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
@@ -54,9 +55,10 @@ interface DuckAiDebugServer {
 @SingleInstanceIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 class RealDuckAiDebugServer @Inject constructor(
-    private val settingsDao: DuckAiBridgeSettingsDao,
-    private val chatsDao: DuckAiBridgeChatsDao,
-    private val fileMetaDao: DuckAiBridgeFileMetaDao,
+    // The debug server inspects the Regular-mode store only; it does not surface Fire-mode data.
+    @RegularMode private val settingsDao: DuckAiBridgeSettingsDao,
+    @RegularMode private val chatsDao: DuckAiBridgeChatsDao,
+    @RegularMode private val fileMetaDao: DuckAiBridgeFileMetaDao,
     private val context: Context,
     private val migrationPrefs: DuckAiMigrationPrefs,
     private val sharedPreferencesProvider: SharedPreferencesProvider,

--- a/duckchat/duckchat-store/build.gradle
+++ b/duckchat/duckchat-store/build.gradle
@@ -25,6 +25,7 @@ apply from: "$rootProject.projectDir/gradle/android-library.gradle"
 
 dependencies {
     implementation project(':app-build-config-api')
+    implementation project(':browser-mode-api')
     implementation project(':common-utils')
     implementation project(':data-store-api')
     implementation project(':duckchat-api')

--- a/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/DuckAiBridgeModule.kt
+++ b/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/DuckAiBridgeModule.kt
@@ -18,17 +18,28 @@ package com.duckduckgo.duckchat.store.impl
 
 import android.content.Context
 import androidx.room.Room
+import androidx.room.RoomDatabase
+import com.duckduckgo.browsermode.api.FireMode
+import com.duckduckgo.browsermode.api.RegularMode
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.store.impl.store.DuckAiBridgeChatsDao
 import com.duckduckgo.duckchat.store.impl.store.DuckAiBridgeDatabase
 import com.duckduckgo.duckchat.store.impl.store.DuckAiBridgeFileMetaDao
 import com.duckduckgo.duckchat.store.impl.store.DuckAiBridgeSettingsDao
+import com.duckduckgo.duckchat.store.impl.store.FireModeDuckAiDatabase
 import com.squareup.anvil.annotations.ContributesTo
+import dagger.Lazy
 import dagger.Module
 import dagger.Provides
 import dagger.SingleInstanceIn
 import java.io.File
 
+/**
+ * Provides the per-mode native Duck.ai storage. The regular ([DuckAiBridgeDatabase], `duck_ai_bridge.db`)
+ * and Fire ([FireModeDuckAiDatabase], `fire_mode_duck_ai.db`) databases reuse the same entities and DAO types,
+ * so each DAO and the chat-files directory are qualified with `@RegularMode` / `@FireMode`. Consumers either
+ * inject a qualified [DuckAiBridgeStorage] directly or resolve one via `BrowserModeDataProvider<DuckAiBridgeStorage>`.
+ */
 @Module
 @ContributesTo(AppScope::class)
 object DuckAiBridgeModule {
@@ -41,16 +52,64 @@ object DuckAiBridgeModule {
             .build()
 
     @Provides
-    fun provideChatsDao(db: DuckAiBridgeDatabase): DuckAiBridgeChatsDao = db.chatsDao()
+    @SingleInstanceIn(AppScope::class)
+    fun provideFireDatabase(context: Context): FireModeDuckAiDatabase =
+        Room.databaseBuilder(context, FireModeDuckAiDatabase::class.java, "fire_mode_duck_ai.db")
+            .setJournalMode(RoomDatabase.JournalMode.TRUNCATE)
+            .fallbackToDestructiveMigration(true)
+            .build()
 
     @Provides
-    fun provideSettingsDao(db: DuckAiBridgeDatabase): DuckAiBridgeSettingsDao = db.settingsDao()
+    @RegularMode
+    fun provideRegularChatsDao(db: DuckAiBridgeDatabase): DuckAiBridgeChatsDao = db.chatsDao()
 
     @Provides
-    fun provideFileMetaDao(db: DuckAiBridgeDatabase): DuckAiBridgeFileMetaDao = db.fileMetaDao()
+    @FireMode
+    fun provideFireChatsDao(db: FireModeDuckAiDatabase): DuckAiBridgeChatsDao = db.chatsDao()
+
+    @Provides
+    @RegularMode
+    fun provideRegularSettingsDao(db: DuckAiBridgeDatabase): DuckAiBridgeSettingsDao = db.settingsDao()
+
+    @Provides
+    @FireMode
+    fun provideFireSettingsDao(db: FireModeDuckAiDatabase): DuckAiBridgeSettingsDao = db.settingsDao()
+
+    @Provides
+    @RegularMode
+    fun provideRegularFileMetaDao(db: DuckAiBridgeDatabase): DuckAiBridgeFileMetaDao = db.fileMetaDao()
+
+    @Provides
+    @FireMode
+    fun provideFireFileMetaDao(db: FireModeDuckAiDatabase): DuckAiBridgeFileMetaDao = db.fileMetaDao()
 
     @Provides
     @DuckAiBridgeFilesDir
     fun provideFilesDir(context: Context): File =
         File(context.filesDir, "duck_ai_bridge_files")
+
+    @Provides
+    @FireDuckAiBridgeFilesDir
+    fun provideFireFilesDir(context: Context): File =
+        File(context.filesDir, "fire_mode_duck_ai_files")
+
+    @Provides
+    @SingleInstanceIn(AppScope::class)
+    @RegularMode
+    fun provideRegularStorage(
+        @RegularMode settings: DuckAiBridgeSettingsDao,
+        @RegularMode chats: DuckAiBridgeChatsDao,
+        @RegularMode fileMeta: DuckAiBridgeFileMetaDao,
+        @DuckAiBridgeFilesDir filesDir: Lazy<File>,
+    ): DuckAiBridgeStorage = RealDuckAiBridgeStorage(settings, chats, fileMeta, filesDir)
+
+    @Provides
+    @SingleInstanceIn(AppScope::class)
+    @FireMode
+    fun provideFireStorage(
+        @FireMode settings: DuckAiBridgeSettingsDao,
+        @FireMode chats: DuckAiBridgeChatsDao,
+        @FireMode fileMeta: DuckAiBridgeFileMetaDao,
+        @FireDuckAiBridgeFilesDir filesDir: Lazy<File>,
+    ): DuckAiBridgeStorage = RealDuckAiBridgeStorage(settings, chats, fileMeta, filesDir)
 }

--- a/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/DuckAiBridgeStorage.kt
+++ b/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/DuckAiBridgeStorage.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.store.impl
+
+import com.duckduckgo.duckchat.store.impl.store.DuckAiBridgeChatsDao
+import com.duckduckgo.duckchat.store.impl.store.DuckAiBridgeFileMetaDao
+import com.duckduckgo.duckchat.store.impl.store.DuckAiBridgeSettingsDao
+import dagger.Lazy
+import java.io.File
+
+/**
+ * Groups the per-mode native Duck.ai storage backends (the three DAOs plus the chat-attachment files
+ * directory) so a single mode-resolved bundle can be injected instead of four separately-qualified
+ * dependencies. One instance is bound per [com.duckduckgo.browsermode.api.BrowserMode]; resolve the
+ * right one via `BrowserModeDataProvider<DuckAiBridgeStorage>`.
+ *
+ * Migration state is intentionally NOT part of this facade — migration is a one-time, app-level event
+ * (see [DuckAiMigrationPrefs]) and is shared across modes.
+ */
+interface DuckAiBridgeStorage {
+    val settings: DuckAiBridgeSettingsDao
+    val chats: DuckAiBridgeChatsDao
+    val fileMeta: DuckAiBridgeFileMetaDao
+    val filesDir: File
+}
+
+internal class RealDuckAiBridgeStorage(
+    override val settings: DuckAiBridgeSettingsDao,
+    override val chats: DuckAiBridgeChatsDao,
+    override val fileMeta: DuckAiBridgeFileMetaDao,
+    private val filesDirLazy: Lazy<File>,
+) : DuckAiBridgeStorage {
+    // Deferred so the context.filesDir access isn't done at construction time (kept off whatever
+    // thread first injects the per-mode storage)
+    override val filesDir: File get() = filesDirLazy.get()
+}

--- a/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/FireDuckAiBridgeFilesDir.kt
+++ b/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/FireDuckAiBridgeFilesDir.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.store.impl
+
+import javax.inject.Qualifier
+
+/** Qualifies the directory holding Fire-mode Duck.ai chat-attachment files (counterpart of [DuckAiBridgeFilesDir]). */
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+internal annotation class FireDuckAiBridgeFilesDir

--- a/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/ModeAwareDuckAiChatStore.kt
+++ b/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/ModeAwareDuckAiChatStore.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.store.impl
+
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeStateHolder
+import com.duckduckgo.browsermode.api.FireMode
+import com.duckduckgo.browsermode.api.RegularMode
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesTo
+import dagger.Module
+import dagger.Provides
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flatMapLatest
+import javax.inject.Inject
+
+/**
+ * The unqualified [DuckAiChatStore] binding. Delegates every call to the store of the current
+ * [BrowserMode] (read from [BrowserModeStateHolder]) so existing consumers become mode-aware with no change.
+ *
+ * Reading the global current mode is correct for these native UI surfaces (history, suggestions, the input
+ * widgets): the user is in exactly one mode at a time and a mode switch recreates the hosting activity, so
+ * `currentMode.value` reflects the surface's mode. The Duck.ai JS-bridge storage handler relies on the same
+ * one-mode-per-activity invariant, but being activity-scoped it reads the frozen [BrowserMode] injected into
+ * its activity graph rather than the global state holder.
+ *
+ * Consumers that must NOT follow the current mode (e.g. sync, which must never read Fire chats) inject the
+ * `@RegularMode` / `@FireMode` qualified store directly instead.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class ModeAwareDuckAiChatStore @Inject constructor(
+    @RegularMode private val regular: DuckAiChatStore,
+    @FireMode private val fire: DuckAiChatStore,
+    private val browserModeStateHolder: BrowserModeStateHolder,
+) : DuckAiChatStore {
+
+    private val current: DuckAiChatStore
+        get() = forMode(browserModeStateHolder.currentMode.value)
+
+    private fun forMode(mode: BrowserMode): DuckAiChatStore = when (mode) {
+        BrowserMode.REGULAR -> regular
+        BrowserMode.FIRE -> fire
+    }
+
+    override suspend fun hasMigrated(): Boolean = current.hasMigrated()
+
+    override suspend fun getChats(): List<DuckAiChat> = current.getChats()
+
+    override suspend fun getChatById(chatId: String): DuckAiChat? = current.getChatById(chatId)
+
+    override fun getChatsFlow(): Flow<List<DuckAiChat>> =
+        browserModeStateHolder.currentMode.flatMapLatest { mode -> forMode(mode).getChatsFlow() }
+
+    override suspend fun deleteChat(chatId: String): Boolean = current.deleteChat(chatId)
+
+    override suspend fun deleteAllChats() = current.deleteAllChats()
+
+    override suspend fun renameChat(chatId: String, newTitle: String): Boolean = current.renameChat(chatId, newTitle)
+
+    override suspend fun pinChat(chatId: String) = current.pinChat(chatId)
+
+    override suspend fun unpinChat(chatId: String) = current.unpinChat(chatId)
+
+    override suspend fun getChatContent(chatId: String): String? = current.getChatContent(chatId)
+
+    override suspend fun readFileRef(uuid: String): FileRefContent? = current.readFileRef(uuid)
+}
+
+/**
+ * Provides the per-mode [RealDuckAiChatStore] instances bound to the qualified [DuckAiChatStore]. Migration
+ * prefs are shared across modes (one-time, app-level event).
+ */
+@ContributesTo(AppScope::class)
+@Module
+object DuckAiChatStoreModule {
+
+    @Provides
+    @SingleInstanceIn(AppScope::class)
+    @RegularMode
+    fun provideRegularChatStore(
+        @RegularMode storage: DuckAiBridgeStorage,
+        dispatchers: DispatcherProvider,
+        migrationPrefs: DuckAiMigrationPrefs,
+    ): DuckAiChatStore = RealDuckAiChatStore(storage, dispatchers, migrationPrefs)
+
+    @Provides
+    @SingleInstanceIn(AppScope::class)
+    @FireMode
+    fun provideFireChatStore(
+        @FireMode storage: DuckAiBridgeStorage,
+        dispatchers: DispatcherProvider,
+        migrationPrefs: DuckAiMigrationPrefs,
+    ): DuckAiChatStore = RealDuckAiChatStore(storage, dispatchers, migrationPrefs)
+}

--- a/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/RealDuckAiBridgeStorageProvider.kt
+++ b/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/RealDuckAiBridgeStorageProvider.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.store.impl
+
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeDataProvider
+import com.duckduckgo.browsermode.api.FireMode
+import com.duckduckgo.browsermode.api.RegularMode
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesTo
+import dagger.Binds
+import dagger.Module
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+/**
+ * Resolves the [DuckAiBridgeStorage] backing the given [BrowserMode]. Mirrors
+ * `RealTabRepositoryProvider` — the canonical per-mode data-provider pattern.
+ */
+@SingleInstanceIn(AppScope::class)
+class RealDuckAiBridgeStorageProvider @Inject constructor(
+    @RegularMode private val regular: DuckAiBridgeStorage,
+    @FireMode private val fire: DuckAiBridgeStorage,
+) : BrowserModeDataProvider<DuckAiBridgeStorage> {
+    override fun forMode(mode: BrowserMode): DuckAiBridgeStorage = when (mode) {
+        BrowserMode.REGULAR -> regular
+        BrowserMode.FIRE -> fire
+    }
+}
+
+@ContributesTo(AppScope::class)
+@Module
+abstract class RealDuckAiBridgeStorageProviderModule {
+    @Binds
+    abstract fun bindDuckAiBridgeStorageProvider(
+        impl: RealDuckAiBridgeStorageProvider,
+    ): BrowserModeDataProvider<DuckAiBridgeStorage>
+}

--- a/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStore.kt
+++ b/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStore.kt
@@ -17,13 +17,7 @@
 package com.duckduckgo.duckchat.store.impl
 
 import com.duckduckgo.common.utils.DispatcherProvider
-import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.store.impl.store.DuckAiBridgeChatEntity
-import com.duckduckgo.duckchat.store.impl.store.DuckAiBridgeChatsDao
-import com.duckduckgo.duckchat.store.impl.store.DuckAiBridgeFileMetaDao
-import com.squareup.anvil.annotations.ContributesBinding
-import dagger.Lazy
-import dagger.SingleInstanceIn
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
@@ -31,7 +25,6 @@ import logcat.logcat
 import org.json.JSONObject
 import java.io.File
 import java.util.Base64
-import javax.inject.Inject
 
 /**
  * Stable metadata extracted from FE-owned chat JSON.
@@ -103,15 +96,22 @@ interface DuckAiChatStore {
     suspend fun readFileRef(uuid: String): FileRefContent?
 }
 
-@SingleInstanceIn(AppScope::class)
-@ContributesBinding(AppScope::class)
-class RealDuckAiChatStore @Inject constructor(
-    private val chatsDao: DuckAiBridgeChatsDao,
-    private val fileMetaDao: DuckAiBridgeFileMetaDao,
-    @param:DuckAiBridgeFilesDir private val filesDirLazy: Lazy<File>,
+/**
+ * Reads/writes the native Duck.ai chat store for a single [BrowserMode], backed by the [DuckAiBridgeStorage]
+ * it is given. One instance is provided per mode (`@RegularMode` / `@FireMode`); consumers normally inject the
+ * unqualified [DuckAiChatStore] (the mode-delegating [ModeAwareDuckAiChatStore]) rather than this class directly.
+ *
+ * Migration state ([migrationPrefs]) is shared across modes — migration is a one-time, app-level event.
+ */
+class RealDuckAiChatStore(
+    private val storage: DuckAiBridgeStorage,
     private val dispatchers: DispatcherProvider,
     private val migrationPrefs: DuckAiMigrationPrefs,
 ) : DuckAiChatStore {
+
+    private val chatsDao = storage.chats
+    private val fileMetaDao = storage.fileMeta
+    private val filesDir: File get() = storage.filesDir
 
     override suspend fun hasMigrated(): Boolean =
         withContext(dispatchers.io()) {
@@ -139,7 +139,6 @@ class RealDuckAiChatStore @Inject constructor(
 
             chatsDao.delete(chatId)
 
-            val filesDir = filesDirLazy.get()
             fileRefs.forEach { uuid ->
                 val file = File(filesDir, uuid)
                 if (file.canonicalPath.startsWith(filesDir.canonicalPath + File.separator)) {
@@ -158,7 +157,6 @@ class RealDuckAiChatStore @Inject constructor(
         withContext(dispatchers.io()) {
             logcat { "DuckAI: RealDuckAiChatStore.deleteAllChats()...deleting all chats" }
             chatsDao.deleteAll()
-            val filesDir = filesDirLazy.get()
             fileMetaDao.getAll().forEach { meta ->
                 val file = File(filesDir, meta.uuid)
                 if (file.canonicalPath.startsWith(filesDir.canonicalPath + File.separator)) {
@@ -201,7 +199,6 @@ class RealDuckAiChatStore @Inject constructor(
 
     override suspend fun readFileRef(uuid: String): FileRefContent? =
         withContext(dispatchers.io()) {
-            val filesDir = filesDirLazy.get()
             val file = File(filesDir, uuid)
             // Same path-traversal guard as deleteChat — reject anything resolving outside the dir.
             if (!file.canonicalPath.startsWith(filesDir.canonicalPath + File.separator)) {

--- a/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/handler/DuckAiNativeStorageJsMessageHandler.kt
+++ b/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/handler/DuckAiNativeStorageJsMessageHandler.kt
@@ -16,43 +16,37 @@
 
 package com.duckduckgo.duckchat.store.impl.handler
 
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeDataProvider
 import com.duckduckgo.contentscopescripts.api.ContentScopeJsMessageHandlersPlugin
-import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckchat.api.DuckAiHostProvider
-import com.duckduckgo.duckchat.store.impl.DuckAiBridgeFilesDir
+import com.duckduckgo.duckchat.store.impl.DuckAiBridgeStorage
 import com.duckduckgo.duckchat.store.impl.DuckAiMigrationPrefs
 import com.duckduckgo.duckchat.store.impl.DuckAiNativeStoragePixels
 import com.duckduckgo.duckchat.store.impl.store.DuckAiBridgeChatEntity
-import com.duckduckgo.duckchat.store.impl.store.DuckAiBridgeChatsDao
-import com.duckduckgo.duckchat.store.impl.store.DuckAiBridgeFileMetaDao
 import com.duckduckgo.duckchat.store.impl.store.DuckAiBridgeFileMetaEntity
 import com.duckduckgo.duckchat.store.impl.store.DuckAiBridgeSettingEntity
-import com.duckduckgo.duckchat.store.impl.store.DuckAiBridgeSettingsDao
 import com.duckduckgo.js.messaging.api.JsCallbackData
 import com.duckduckgo.js.messaging.api.JsMessage
 import com.duckduckgo.js.messaging.api.JsMessageCallback
 import com.duckduckgo.js.messaging.api.JsMessageHandler
 import com.duckduckgo.js.messaging.api.JsMessaging
 import com.squareup.anvil.annotations.ContributesMultibinding
-import dagger.Lazy
 import logcat.logcat
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
 import javax.inject.Inject
 
-@ContributesMultibinding(AppScope::class)
+@ContributesMultibinding(ActivityScope::class)
 class DuckAiNativeStorageJsMessageHandler @Inject constructor(
-    private val settingsDao: DuckAiBridgeSettingsDao,
-    private val chatsDao: DuckAiBridgeChatsDao,
-    private val fileMetaDao: DuckAiBridgeFileMetaDao,
-    @DuckAiBridgeFilesDir private val filesDirLazy: Lazy<File>,
+    private val storageProvider: BrowserModeDataProvider<DuckAiBridgeStorage>,
     private val duckAiHostProvider: DuckAiHostProvider,
     private val migrationPrefs: DuckAiMigrationPrefs,
     private val pixels: DuckAiNativeStoragePixels,
+    private val browserMode: BrowserMode,
 ) : ContentScopeJsMessageHandlersPlugin {
-
-    private val filesDir: File get() = filesDirLazy.get()
 
     override fun getJsMessageHandler(): JsMessageHandler =
         object : JsMessageHandler {
@@ -71,6 +65,14 @@ class DuckAiNativeStorageJsMessageHandler @Inject constructor(
 
             // Runs on the JavaBridge thread — DAO/file I/O are safe here.
             override fun process(jsMessage: JsMessage, jsMessaging: JsMessaging, jsMessageCallback: JsMessageCallback?) {
+                // The activity's browsing mode (injected, frozen for the activity's lifetime) selects which per-mode
+                // storage backend this message reads from / writes to.
+                val mode = browserMode
+                val storage = storageProvider.forMode(mode)
+                val settingsDao = storage.settings
+                val chatsDao = storage.chats
+                val fileMetaDao = storage.fileMeta
+                val filesDir = storage.filesDir
                 when (jsMessage.method) {
                     // --- Entries ---
                     "getEntry" -> {
@@ -326,17 +328,24 @@ class DuckAiNativeStorageJsMessageHandler @Inject constructor(
                     }
                     "markMigrationDone" -> {
                         val key = jsMessage.params.optString("key")
-                        if (key.isNotBlank()) {
-                            logcat { "DuckAiNativeStorage: markMigrationDone key=$key" }
-                            try {
-                                migrationPrefs.markMigrationDone(key)
-                                pixels.reportMigrationDone(key)
-                                pixels.reportMigrationStarted()
-                            } catch (e: Exception) {
-                                pixels.reportMigrationError()
+                        when {
+                            // Migration is a one-time, app-level event keyed off the shared migration flag. A Fire
+                            // session runs in a fresh, empty WebView profile, so letting it mark migration "done"
+                            // would flip the shared flag and strand un-migrated Regular chats. Suppress the write in
+                            // Fire mode — Regular still migrates on its first Regular session. isMigrationDone is left
+                            // un-guarded so a Fire FE still reads the real (shared) state.
+                            mode == BrowserMode.FIRE -> logcat { "DuckAiNativeStorage: markMigrationDone ignored in Fire mode" }
+                            key.isNotBlank() -> {
+                                logcat { "DuckAiNativeStorage: markMigrationDone key=$key" }
+                                try {
+                                    migrationPrefs.markMigrationDone(key)
+                                    pixels.reportMigrationDone(key)
+                                    pixels.reportMigrationStarted()
+                                } catch (e: Exception) {
+                                    pixels.reportMigrationError()
+                                }
                             }
-                        } else {
-                            pixels.reportMigrationDoneBlankKey()
+                            else -> pixels.reportMigrationDoneBlankKey()
                         }
                     }
 
@@ -345,7 +354,7 @@ class DuckAiNativeStorageJsMessageHandler @Inject constructor(
                         val uuid = jsMessage.params.optString("uuid")
                         logcat { "DuckAiNativeStorage: getFile $uuid" }
                         try {
-                            val json = if (isValidUuid(uuid)) {
+                            val json = if (isValidUuid(filesDir, uuid)) {
                                 val file = File(filesDir, uuid)
                                 if (file.exists()) file.readText() else null
                             } else {
@@ -379,7 +388,7 @@ class DuckAiNativeStorageJsMessageHandler @Inject constructor(
                     }
                     "putFile" -> {
                         val uuid = jsMessage.params.optString("uuid")
-                        if (isValidUuid(uuid)) {
+                        if (isValidUuid(filesDir, uuid)) {
                             val sizeBytes = jsMessage.params.toString().length
                             logcat { "DuckAiNativeStorage: putFile uuid=$uuid size=${sizeBytes}B" }
                             try {
@@ -401,7 +410,7 @@ class DuckAiNativeStorageJsMessageHandler @Inject constructor(
                     "deleteFile" -> {
                         val uuid = jsMessage.params.optString("uuid")
                         logcat { "DuckAiNativeStorage: deleteFile $uuid" }
-                        if (isValidUuid(uuid)) {
+                        if (isValidUuid(filesDir, uuid)) {
                             logcat { "DuckAiNativeStorage: deleteFile uuid=$uuid" }
                             try {
                                 File(filesDir, uuid).delete()
@@ -418,7 +427,7 @@ class DuckAiNativeStorageJsMessageHandler @Inject constructor(
                             logcat { "DuckAiNativeStorage: deleteFiles chatId=$chatId" }
                             try {
                                 fileMetaDao.getByChatId(chatId).forEach { meta ->
-                                    if (isValidUuid(meta.uuid)) File(filesDir, meta.uuid).delete()
+                                    if (isValidUuid(filesDir, meta.uuid)) File(filesDir, meta.uuid).delete()
                                 }
                                 fileMetaDao.deleteByChatId(chatId)
                             } catch (e: Exception) {
@@ -429,7 +438,7 @@ class DuckAiNativeStorageJsMessageHandler @Inject constructor(
                     "deleteAllFiles" -> {
                         logcat { "DuckAiNativeStorage: deleteAllFiles" }
                         try {
-                            filesDir.listFiles()?.filter { isValidUuid(it.name) }?.forEach { it.delete() }
+                            filesDir.listFiles()?.filter { isValidUuid(filesDir, it.name) }?.forEach { it.delete() }
                             fileMetaDao.deleteAll()
                         } catch (e: Exception) {
                             pixels.reportFileDeleteError()
@@ -477,7 +486,7 @@ class DuckAiNativeStorageJsMessageHandler @Inject constructor(
             }
         }
 
-    private fun isValidUuid(uuid: String): Boolean {
+    private fun isValidUuid(filesDir: File, uuid: String): Boolean {
         if (uuid.contains('/') || uuid.contains('\\') || uuid.contains("..")) return false
         val candidate = File(filesDir, uuid).canonicalFile
         return candidate.parentFile?.canonicalFile == filesDir.canonicalFile

--- a/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/store/DuckAiBridgeDatabase.kt
+++ b/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/store/DuckAiBridgeDatabase.kt
@@ -21,6 +21,13 @@ import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 
+/**
+ * The regular-mode native Duck.ai chat store. Shares [DuckAiBridgeChatEntity], [DuckAiBridgeSettingEntity] and
+ * [DuckAiBridgeFileMetaEntity] with its Fire-mode counterpart [FireModeDuckAiDatabase].
+ *
+ * Any schema change to these entities must bump the version in BOTH databases: add a data-preserving migration
+ * here (and increment the version), and bump the version of [FireModeDuckAiDatabase] too.
+ */
 @Database(
     entities = [DuckAiBridgeChatEntity::class, DuckAiBridgeSettingEntity::class, DuckAiBridgeFileMetaEntity::class],
     version = 3,

--- a/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/store/FireModeDuckAiDatabase.kt
+++ b/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/store/FireModeDuckAiDatabase.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.store.impl.store
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+
+/**
+ * Fire-mode counterpart of [DuckAiBridgeDatabase], backing Duck.ai chat data created while in
+ * [com.duckduckgo.browsermode.api.BrowserMode.FIRE].
+ *
+ * Shares [DuckAiBridgeChatEntity], [DuckAiBridgeSettingEntity] and [DuckAiBridgeFileMetaEntity] with
+ * [DuckAiBridgeDatabase]. Any schema change to these entities must bump the version in BOTH databases — a
+ * data-preserving Migration in [DuckAiBridgeDatabase], and a matching version bump here.
+ */
+@Database(
+    entities = [DuckAiBridgeChatEntity::class, DuckAiBridgeSettingEntity::class, DuckAiBridgeFileMetaEntity::class],
+    version = 1,
+    exportSchema = false,
+)
+abstract class FireModeDuckAiDatabase : RoomDatabase() {
+    abstract fun chatsDao(): DuckAiBridgeChatsDao
+    abstract fun settingsDao(): DuckAiBridgeSettingsDao
+    abstract fun fileMetaDao(): DuckAiBridgeFileMetaDao
+}

--- a/duckchat/duckchat-store/src/test/kotlin/com/duckduckgo/duckchat/store/impl/DuckAiNativeStorageJsMessageHandlerModeTest.kt
+++ b/duckchat/duckchat-store/src/test/kotlin/com/duckduckgo/duckchat/store/impl/DuckAiNativeStorageJsMessageHandlerModeTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.store.impl
+
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeDataProvider
+import com.duckduckgo.duckchat.api.DuckAiHostProvider
+import com.duckduckgo.duckchat.store.impl.handler.DuckAiNativeStorageJsMessageHandler
+import com.duckduckgo.duckchat.store.impl.store.DuckAiBridgeChatsDao
+import com.duckduckgo.js.messaging.api.JsMessage
+import com.duckduckgo.js.messaging.api.JsMessageHandler
+import dagger.Lazy
+import org.json.JSONObject
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+
+/**
+ * Verifies the per-mode routing of the JS write/read bridge: the handler is bound per [BrowserMode]
+ * (injected at construction, frozen for the activity's lifetime) and that mode selects which storage it writes to.
+ */
+class DuckAiNativeStorageJsMessageHandlerModeTest {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    private val regularChats: DuckAiBridgeChatsDao = mock()
+    private val fireChats: DuckAiBridgeChatsDao = mock()
+    private val hostProvider: DuckAiHostProvider = mock<DuckAiHostProvider>().also { whenever(it.getHost()).thenReturn("duck.ai") }
+    private lateinit var provider: BrowserModeDataProvider<DuckAiBridgeStorage>
+
+    @Before
+    fun setup() {
+        val regularDir = tempFolder.newFolder("regular")
+        val fireDir = tempFolder.newFolder("fire")
+        val regularStorage = RealDuckAiBridgeStorage(
+            settings = mock(),
+            chats = regularChats,
+            fileMeta = mock(),
+            filesDirLazy = Lazy { regularDir },
+        )
+        val fireStorage = RealDuckAiBridgeStorage(
+            settings = mock(),
+            chats = fireChats,
+            fileMeta = mock(),
+            filesDirLazy = Lazy { fireDir },
+        )
+        provider = mock<BrowserModeDataProvider<DuckAiBridgeStorage>>().also {
+            whenever(it.forMode(BrowserMode.REGULAR)).thenReturn(regularStorage)
+            whenever(it.forMode(BrowserMode.FIRE)).thenReturn(fireStorage)
+        }
+    }
+
+    @Test
+    fun `putChat in FIRE mode writes only to the fire store`() {
+        handlerForMode(BrowserMode.FIRE).process(putChat("c1"), mock(), null)
+
+        verify(fireChats).upsert(argThat { chatId == "c1" })
+        verifyNoInteractions(regularChats)
+    }
+
+    @Test
+    fun `putChat in REGULAR mode writes only to the regular store`() {
+        handlerForMode(BrowserMode.REGULAR).process(putChat("c1"), mock(), null)
+
+        verify(regularChats).upsert(argThat { chatId == "c1" })
+        verifyNoInteractions(fireChats)
+    }
+
+    private fun handlerForMode(mode: BrowserMode): JsMessageHandler =
+        DuckAiNativeStorageJsMessageHandler(provider, hostProvider, DuckAiMigrationPrefs(mock()), mock(), mode)
+            .getJsMessageHandler()
+
+    private fun putChat(chatId: String): JsMessage =
+        JsMessage(
+            context = "contentScopeScripts",
+            featureName = "duckAiNativeStorage",
+            method = "putChat",
+            params = JSONObject("""{"chatId":"$chatId","data":{"chatId":"$chatId"}}"""),
+            id = null,
+        )
+}

--- a/duckchat/duckchat-store/src/test/kotlin/com/duckduckgo/duckchat/store/impl/DuckAiNativeStorageJsMessageHandlerTest.kt
+++ b/duckchat/duckchat-store/src/test/kotlin/com/duckduckgo/duckchat/store/impl/DuckAiNativeStorageJsMessageHandlerTest.kt
@@ -17,6 +17,8 @@
 package com.duckduckgo.duckchat.store.impl
 
 import android.content.SharedPreferences
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeDataProvider
 import com.duckduckgo.common.test.api.InMemorySharedPreferences
 import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.duckchat.api.DuckAiHostProvider
@@ -64,11 +66,20 @@ class DuckAiNativeStorageJsMessageHandlerTest {
     private val hostProvider: DuckAiHostProvider = mock<DuckAiHostProvider>().also {
         whenever(it.getHost()).thenReturn("duck.ai")
     }
+    private fun storageProviderFor(filesDir: java.io.File): BrowserModeDataProvider<DuckAiBridgeStorage> {
+        val storage = RealDuckAiBridgeStorage(settings = settingsDao, chats = chatsDao, fileMeta = fileMetaDao, filesDirLazy = Lazy { filesDir })
+        return mock<BrowserModeDataProvider<DuckAiBridgeStorage>>().also { whenever(it.forMode(any())).thenReturn(storage) }
+    }
     private val handlerPlugin by lazy {
-        DuckAiNativeStorageJsMessageHandler(settingsDao, chatsDao, fileMetaDao, Lazy { tempFolder.root }, hostProvider, migrationPrefs, pixels)
+        DuckAiNativeStorageJsMessageHandler(storageProviderFor(tempFolder.root), hostProvider, migrationPrefs, pixels, BrowserMode.REGULAR)
     }
     private val handler by lazy { handlerPlugin.getJsMessageHandler() }
     private val jsMessaging: JsMessaging = mock()
+
+    // A handler bound to Fire mode, used by the Fire-specific migration tests below.
+    private fun fireHandler() =
+        DuckAiNativeStorageJsMessageHandler(storageProviderFor(tempFolder.root), hostProvider, migrationPrefs, pixels, BrowserMode.FIRE)
+            .getJsMessageHandler()
 
     // --- metadata ---
 
@@ -109,7 +120,7 @@ class DuckAiNativeStorageJsMessageHandlerTest {
         handler.process(jsMessage("putEntry", """{"key":"theme","value":"dark"}"""), jsMessaging, null)
 
         verify(settingsDao).upsert(argThat { key == "theme" && value == "dark" })
-        verifyNoInteractions(jsMessaging)
+        verify(jsMessaging, never()).onResponse(any())
     }
 
     @Test
@@ -128,7 +139,7 @@ class DuckAiNativeStorageJsMessageHandlerTest {
         handler.process(jsMessage("replaceAllEntries", """{"entries":{"theme":"dark","lang":"en"}}"""), jsMessaging, null)
 
         verify(settingsDao).replaceAll(argThat { size == 2 })
-        verifyNoInteractions(jsMessaging)
+        verify(jsMessaging, never()).onResponse(any())
     }
 
     @Test
@@ -199,7 +210,7 @@ class DuckAiNativeStorageJsMessageHandlerTest {
 
         handler.process(jsMessage("getChat", """{"chatId":"chat-1"}""", id = null), jsMessaging, null)
 
-        verifyNoInteractions(jsMessaging)
+        verify(jsMessaging, never()).onResponse(any())
     }
 
     // --- getAllChats ---
@@ -225,7 +236,7 @@ class DuckAiNativeStorageJsMessageHandlerTest {
 
         handler.process(jsMessage("getAllChats", "{}", id = null), jsMessaging, null)
 
-        verifyNoInteractions(jsMessaging)
+        verify(jsMessaging, never()).onResponse(any())
     }
 
     // --- putChat ---
@@ -239,7 +250,7 @@ class DuckAiNativeStorageJsMessageHandlerTest {
         )
 
         verify(chatsDao).upsert(argThat { chatId == "chat-1" })
-        verifyNoInteractions(jsMessaging)
+        verify(jsMessaging, never()).onResponse(any())
     }
 
     @Test
@@ -273,7 +284,7 @@ class DuckAiNativeStorageJsMessageHandlerTest {
         verify(chatsDao).upsertAll(
             argThat { size == 2 && this[0].chatId == "chat-1" && this[1].chatId == "chat-2" },
         )
-        verifyNoInteractions(jsMessaging)
+        verify(jsMessaging, never()).onResponse(any())
     }
 
     @Test
@@ -342,7 +353,7 @@ class DuckAiNativeStorageJsMessageHandlerTest {
         handler.process(jsMessage("deleteChat", """{"chatId":"chat-1"}"""), jsMessaging, null)
 
         verify(chatsDao).delete("chat-1")
-        verifyNoInteractions(jsMessaging)
+        verify(jsMessaging, never()).onResponse(any())
     }
 
     @Test
@@ -359,7 +370,7 @@ class DuckAiNativeStorageJsMessageHandlerTest {
         handler.process(jsMessage("deleteAllChats", "{}"), jsMessaging, null)
 
         verify(chatsDao).deleteAll()
-        verifyNoInteractions(jsMessaging)
+        verify(jsMessaging, never()).onResponse(any())
     }
 
     // --- isMigrationDone ---
@@ -391,7 +402,7 @@ class DuckAiNativeStorageJsMessageHandlerTest {
     fun `isMigrationDone with no id sends no reply`() {
         handler.process(jsMessage("isMigrationDone", """{"key":"chats"}""", id = null), jsMessaging, null)
 
-        verifyNoInteractions(jsMessaging)
+        verify(jsMessaging, never()).onResponse(any())
     }
 
     // --- markMigrationDone ---
@@ -401,7 +412,7 @@ class DuckAiNativeStorageJsMessageHandlerTest {
         handler.process(jsMessage("markMigrationDone", """{"key":"chats"}"""), jsMessaging, null)
 
         assertTrue(fakePrefs.getBoolean(DuckAiMigrationPrefs.CHATS_KEY, false))
-        verifyNoInteractions(jsMessaging)
+        verify(jsMessaging, never()).onResponse(any())
     }
 
     @Test
@@ -409,7 +420,23 @@ class DuckAiNativeStorageJsMessageHandlerTest {
         handler.process(jsMessage("markMigrationDone", "{}"), jsMessaging, null)
 
         assertFalse(fakePrefs.getBoolean(DuckAiMigrationPrefs.CHATS_KEY, false))
-        verifyNoInteractions(jsMessaging)
+        verify(jsMessaging, never()).onResponse(any())
+    }
+
+    @Test
+    fun `markMigrationDone is ignored in Fire mode`() {
+        fireHandler().process(jsMessage("markMigrationDone", """{"key":"chats"}"""), jsMessaging, null)
+
+        assertFalse(fakePrefs.getBoolean(DuckAiMigrationPrefs.CHATS_KEY, false))
+    }
+
+    @Test
+    fun `isMigrationDone still reads the shared flag in Fire mode`() {
+        fakePrefs.edit().putBoolean(DuckAiMigrationPrefs.CHATS_KEY, true).commit()
+
+        fireHandler().process(jsMessage("isMigrationDone", """{"key":"chats"}""", id = "r1"), jsMessaging, null)
+
+        verify(jsMessaging).onResponse(argThat { method == "isMigrationDone" && params.getBoolean("value") })
     }
 
     @Test
@@ -436,7 +463,7 @@ class DuckAiNativeStorageJsMessageHandlerTest {
         handler.process(jsMessage("putFile", sampleParams), jsMessaging, null)
 
         assertTrue(tempFolder.root.resolve("abc-123").exists())
-        verifyNoInteractions(jsMessaging)
+        verify(jsMessaging, never()).onResponse(any())
     }
 
     @Test
@@ -495,7 +522,7 @@ class DuckAiNativeStorageJsMessageHandlerTest {
     fun `getFile with no id sends no reply`() {
         handler.process(jsMessage("getFile", """{"uuid":"abc-123"}""", id = null), jsMessaging, null)
 
-        verifyNoInteractions(jsMessaging)
+        verify(jsMessaging, never()).onResponse(any())
     }
 
     @Test
@@ -516,7 +543,7 @@ class DuckAiNativeStorageJsMessageHandlerTest {
         handler.process(jsMessage("deleteFile", """{"uuid":"abc-123"}"""), jsMessaging, null)
 
         assertFalse(tempFolder.root.resolve("abc-123").exists())
-        verifyNoInteractions(jsMessaging)
+        verify(jsMessaging, never()).onResponse(any())
     }
 
     @Test
@@ -547,7 +574,7 @@ class DuckAiNativeStorageJsMessageHandlerTest {
 
         assertFalse(fileForChat.exists())
         assertTrue(fileForOtherChat.exists())
-        verifyNoInteractions(jsMessaging)
+        verify(jsMessaging, never()).onResponse(any())
     }
 
     @Test
@@ -564,7 +591,7 @@ class DuckAiNativeStorageJsMessageHandlerTest {
         handler.process(jsMessage("deleteFiles", """{"chatId":""}"""), jsMessaging, null)
 
         verifyNoInteractions(fileMetaDao)
-        verifyNoInteractions(jsMessaging)
+        verify(jsMessaging, never()).onResponse(any())
     }
 
     @Test
@@ -574,7 +601,7 @@ class DuckAiNativeStorageJsMessageHandlerTest {
         handler.process(jsMessage("deleteAllFiles", "{}"), jsMessaging, null)
 
         assertTrue(tempFolder.root.listFiles()?.isEmpty() ?: true)
-        verifyNoInteractions(jsMessaging)
+        verify(jsMessaging, never()).onResponse(any())
     }
 
     @Test
@@ -614,7 +641,7 @@ class DuckAiNativeStorageJsMessageHandlerTest {
 
         handler.process(jsMessage("listFiles", "{}", id = null), jsMessaging, null)
 
-        verifyNoInteractions(jsMessaging)
+        verify(jsMessaging, never()).onResponse(any())
     }
 
     // --- unknown method ---
@@ -626,7 +653,7 @@ class DuckAiNativeStorageJsMessageHandlerTest {
         verifyNoInteractions(settingsDao)
         verifyNoInteractions(chatsDao)
         verifyNoInteractions(fileMetaDao)
-        verifyNoInteractions(jsMessaging)
+        verify(jsMessaging, never()).onResponse(any())
     }
 
     // --- getter error responses ---
@@ -925,13 +952,11 @@ class DuckAiNativeStorageJsMessageHandlerTest {
         }
         val throwingMigrationPrefs = DuckAiMigrationPrefs(provider)
         return DuckAiNativeStorageJsMessageHandler(
-            settingsDao,
-            chatsDao,
-            fileMetaDao,
-            Lazy { tempFolder.root },
+            storageProviderFor(tempFolder.root),
             hostProvider,
             throwingMigrationPrefs,
             pixels,
+            BrowserMode.REGULAR,
         ).getJsMessageHandler()
     }
 

--- a/duckchat/duckchat-store/src/test/kotlin/com/duckduckgo/duckchat/store/impl/GetChatIntegrationTest.kt
+++ b/duckchat/duckchat-store/src/test/kotlin/com/duckduckgo/duckchat/store/impl/GetChatIntegrationTest.kt
@@ -19,11 +19,11 @@ package com.duckduckgo.duckchat.store.impl
 import androidx.room.Room
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeDataProvider
 import com.duckduckgo.duckchat.api.DuckAiHostProvider
 import com.duckduckgo.duckchat.store.impl.handler.DuckAiNativeStorageJsMessageHandler
 import com.duckduckgo.duckchat.store.impl.store.DuckAiBridgeDatabase
-import com.duckduckgo.duckchat.store.impl.store.DuckAiBridgeFileMetaDao
-import com.duckduckgo.duckchat.store.impl.store.DuckAiBridgeSettingsDao
 import com.duckduckgo.js.messaging.api.JsCallbackData
 import com.duckduckgo.js.messaging.api.JsMessage
 import com.duckduckgo.js.messaging.api.JsMessaging
@@ -36,6 +36,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -57,14 +58,21 @@ class GetChatIntegrationTest {
         ).allowMainThreadQueries().build()
 
         val hostProvider = mock<DuckAiHostProvider>().also { whenever(it.getHost()).thenReturn("duck.ai") }
-        val handlerPlugin = DuckAiNativeStorageJsMessageHandler(
-            settingsDao = mock<DuckAiBridgeSettingsDao>(),
-            chatsDao = db.chatsDao(),
-            fileMetaDao = mock<DuckAiBridgeFileMetaDao>(),
+        val storage = RealDuckAiBridgeStorage(
+            settings = mock(),
+            chats = db.chatsDao(),
+            fileMeta = mock(),
             filesDirLazy = Lazy { File("") },
+        )
+        val storageProvider = mock<BrowserModeDataProvider<DuckAiBridgeStorage>>().also {
+            whenever(it.forMode(any())).thenReturn(storage)
+        }
+        val handlerPlugin = DuckAiNativeStorageJsMessageHandler(
+            storageProvider = storageProvider,
             duckAiHostProvider = hostProvider,
             migrationPrefs = DuckAiMigrationPrefs(mock()),
             pixels = mock(),
+            browserMode = BrowserMode.REGULAR,
         )
         handler = handlerPlugin.getJsMessageHandler()
     }

--- a/duckchat/duckchat-store/src/test/kotlin/com/duckduckgo/duckchat/store/impl/ModeAwareDuckAiChatStoreTest.kt
+++ b/duckchat/duckchat-store/src/test/kotlin/com/duckduckgo/duckchat/store/impl/ModeAwareDuckAiChatStoreTest.kt
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.store.impl
+
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeStateHolder
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+
+class ModeAwareDuckAiChatStoreTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    private val regular: DuckAiChatStore = mock()
+    private val fire: DuckAiChatStore = mock()
+    private val modeFlow = MutableStateFlow(BrowserMode.REGULAR)
+    private val stateHolder = object : BrowserModeStateHolder {
+        override val currentMode: StateFlow<BrowserMode> = modeFlow
+        override fun switchTo(mode: BrowserMode) {
+            modeFlow.value = mode
+        }
+    }
+    private val store = ModeAwareDuckAiChatStore(regular, fire, stateHolder)
+
+    @Test
+    fun `delegates to regular store in REGULAR mode`() = runTest {
+        modeFlow.value = BrowserMode.REGULAR
+
+        store.getChats()
+
+        verify(regular).getChats()
+        verifyNoInteractions(fire)
+    }
+
+    @Test
+    fun `delegates to fire store in FIRE mode`() = runTest {
+        modeFlow.value = BrowserMode.FIRE
+
+        store.getChats()
+
+        verify(fire).getChats()
+        verifyNoInteractions(regular)
+    }
+
+    @Test
+    fun `delegates deleteChat to the current mode store`() = runTest {
+        modeFlow.value = BrowserMode.FIRE
+
+        store.deleteChat("c1")
+
+        verify(fire).deleteChat("c1")
+        verifyNoInteractions(regular)
+    }
+
+    @Test
+    fun `delegates writes to the current mode store`() = runTest {
+        modeFlow.value = BrowserMode.FIRE
+        store.renameChat("c1", "new")
+        store.pinChat("c2")
+
+        verify(fire).renameChat("c1", "new")
+        verify(fire).pinChat("c2")
+        verifyNoInteractions(regular)
+    }
+
+    @Test
+    fun `getChatsFlow follows the current mode store`() = runTest {
+        whenever(regular.getChatsFlow()).thenReturn(flowOf(listOf(chat("r"))))
+        whenever(fire.getChatsFlow()).thenReturn(flowOf(listOf(chat("f"))))
+
+        modeFlow.value = BrowserMode.REGULAR
+        assertEquals(listOf("r"), store.getChatsFlow().first().map { it.chatId })
+
+        modeFlow.value = BrowserMode.FIRE
+        assertEquals(listOf("f"), store.getChatsFlow().first().map { it.chatId })
+    }
+
+    @Test
+    fun `delegates hasMigrated to the current mode store`() = runTest {
+        modeFlow.value = BrowserMode.FIRE
+
+        store.hasMigrated()
+
+        verify(fire).hasMigrated()
+        verifyNoInteractions(regular)
+    }
+
+    @Test
+    fun `delegates getChatById to the current mode store`() = runTest {
+        modeFlow.value = BrowserMode.FIRE
+
+        store.getChatById("c1")
+
+        verify(fire).getChatById("c1")
+        verifyNoInteractions(regular)
+    }
+
+    @Test
+    fun `delegates getChatContent to the current mode store`() = runTest {
+        modeFlow.value = BrowserMode.FIRE
+
+        store.getChatContent("c1")
+
+        verify(fire).getChatContent("c1")
+        verifyNoInteractions(regular)
+    }
+
+    @Test
+    fun `delegates readFileRef to the current mode store`() = runTest {
+        modeFlow.value = BrowserMode.FIRE
+
+        store.readFileRef("uuid")
+
+        verify(fire).readFileRef("uuid")
+        verifyNoInteractions(regular)
+    }
+
+    @Test
+    fun `delegates unpinChat and deleteAllChats to the current mode store`() = runTest {
+        modeFlow.value = BrowserMode.FIRE
+
+        store.unpinChat("c1")
+        store.deleteAllChats()
+
+        verify(fire).unpinChat("c1")
+        verify(fire).deleteAllChats()
+        verifyNoInteractions(regular)
+    }
+
+    private fun chat(id: String) = DuckAiChat(chatId = id, title = "", model = "", lastEdit = "", pinned = false)
+}

--- a/duckchat/duckchat-store/src/test/kotlin/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStoreTest.kt
+++ b/duckchat/duckchat-store/src/test/kotlin/com/duckduckgo/duckchat/store/impl/RealDuckAiChatStoreTest.kt
@@ -61,7 +61,8 @@ class RealDuckAiChatStoreTest {
     @Before
     fun setup() {
         filesDir = Files.createTempDirectory("duck_ai_test").toFile()
-        store = RealDuckAiChatStore(chatsDao, fileMetaDao, Lazy { filesDir }, coroutineTestRule.testDispatcherProvider, migrationPrefs)
+        val storage = RealDuckAiBridgeStorage(settings = mock(), chats = chatsDao, fileMeta = fileMetaDao, filesDirLazy = Lazy { filesDir })
+        store = RealDuckAiChatStore(storage, coroutineTestRule.testDispatcherProvider, migrationPrefs)
     }
 
     // --- hasMigrated ---


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1215444465437172?focus=true
Tech Design: https://app.asana.com/1/137249556945/project/1207418217763355/task/1214570322752005?focus=true

### Description

This PR separates the native Duck.ai chat data layer between **Regular** and **Fire** mode. Fire-mode chats are persisted in their own DB, attachment directory, and WebView profile, so they never appear in Regular chat history.

**Deviation from the tech design:** The `JsMessaging` interface change was not needed.

The tech design proposed extending the shared `JsMessaging` interface to thread the active `BrowserMode` through to the native-storage message handler so it could select the correct per-mode store. That turned out to be unnecessary:

- `DuckAiNativeStorageJsMessageHandler` resolves its backend via `BrowserModeDataProvider<DuckAiBridgeStorage>.forMode(browserMode)`, where `browserMode` is injected directly rather than passed through the JS message
- The injected `BrowserMode` is the activity-frozen value (provided once per activity by `provideActivityBrowserMode`, read from `BrowserModeStateHolder.currentMode` at component creation). Because switching mode recreates the activity, the one-mode-per-activity invariant holds and the handler always reads the correct mode's storage
- To inject the activity-scoped `BrowserMode`, the native-storage content-scope message handler plugin (`DuckAiNativeStorageJsMessageHandler`) was moved from `@ContributesMultibinding(AppScope::class)` to `@ContributesMultibinding(ActivityScope::class)` because `BrowserMode` is only bound in `ActivityScope`, not `AppScope`

**Note:** Sync is handled in a [subsequent PR](https://github.com/duckduckgo/Android/pull/8792).

### Steps to test this PR

- [ ] Make sure `fireTabs` FF is enabled in dev settings (requires a restart)
- [ ] In **Regular** mode, open Duck.ai and send a message (e.g. `regular-test`); confirm it shows in Duck.ai chat history.
- [ ] Switch to **Fire** mode (tab switcher → mode toggle, or the "New Fire Tab" menu item). Open Duck.ai chat history → `regular-test` is **not** listed (Fire history is separate).
- [ ] In **Fire** mode, send a message (e.g. `fire-test`); it appears in Fire history.
- [ ] Switch back to **Regular** → `fire-test` is **not** listed; only `regular-test` is.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches chat persistence, sync eligibility, and migration flags across two databases; incorrect mode routing could leak Fire data into Regular history or sync.
> 
> **Overview**
> Introduces **separate native Duck.ai persistence for Regular vs Fire mode**: a second Room DB (`fire_mode_duck_ai.db`), attachment directory, and `@RegularMode` / `@FireMode` qualified DAO bundles behind `DuckAiBridgeStorage`, with `ModeAwareDuckAiChatStore` as the default unqualified store that follows `BrowserModeStateHolder`.
> 
> **WebView / JS bridge:** `DuckAiNativeStorageJsMessageHandler` moves to **ActivityScope**, resolves storage via injected activity-frozen `BrowserMode` + `BrowserModeDataProvider`, and **ignores `markMigrationDone` in Fire** so shared migration flags are not set from ephemeral Fire sessions.
> 
> **Sync & privacy:** `RealDuckChatSyncRepository` **no-ops pending sync metadata writes in Fire**; `DuckChatSyncDataManager` injects **`@RegularMode` `DuckAiChatStore`** so background sync never reads Fire chats. Internal debug server is Regular-only.
> 
> **UI:** `RealNativeInputStateStore` tracks the **selected tab for the current mode** (not hard-coded Regular tabs). Tests updated/added across store, sync, JS handler, and native input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b9a43f92b83b4ff1c403a6315c4109871722efe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


