### PR TITLE
Sync v2: exchange-v2 protocol model + state machine

### DIFF
--- a/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -1,0 +1,319 @@
+{
+    "sync_setup_barcode_screen_shown": {
+        "description": "The sync setup barcode (QR) screen was shown to the user",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow the screen belongs to",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_manual_code_entry_screen_shown": {
+        "description": "The sync setup manual code entry screen was shown to the user",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow the screen belongs to",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_barcode_scanner_success": {
+        "description": "A scanned sync code was recognized successfully",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow the scan belongs to",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "code_version",
+                "type": "string",
+                "description": "Protocol version of the code that was scanned",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "code_type",
+                "type": "string",
+                "description": "Kind of recognized code. Sent on the v2 path only",
+                "enum": ["recovery", "linking"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_manual_code_entered_success": {
+        "description": "A manually entered/pasted sync code was recognized successfully",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow the code entry belongs to",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "code_version",
+                "type": "string",
+                "description": "Protocol version of the code that was entered",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "code_type",
+                "type": "string",
+                "description": "Kind of recognized code. Sent on the v2 path only",
+                "enum": ["recovery", "linking"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_barcode_scanner_failed": {
+        "description": "A scanned sync code could not be parsed/recognized",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow the scan belongs to",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_manual_code_entered_failed": {
+        "description": "A manually entered/pasted sync code could not be parsed/recognized",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow the code entry belongs to",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_ended_successful": {
+        "description": "Sync setup completed successfully (recovery-code login or device pairing). For a v2 pairing the host reports it after sending the recovery code, the joiner after login",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow completed",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            },
+            {
+                "key": "path",
+                "type": "string",
+                "description": "Whether the v2 setup was a recovery-code login or a device pairing. Sent on the v2 path only",
+                "enum": ["recovery", "pairing"]
+            },
+            {
+                "key": "my_role",
+                "type": "string",
+                "description": "This device's elected role in a v2 pairing. Sent for v2 pairings only",
+                "enum": ["host", "joiner"]
+            },
+            {
+                "key": "peer_kind",
+                "type": "string",
+                "description": "The peer device's credential kind in a v2 pairing. Sent for v2 pairings only",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_ended_failed": {
+        "description": "A v2 sync setup that started (code recognized) failed with an error, not a user cancellation",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Why the v2 setup failed, aligned with the error codes we handle",
+                "enum": [
+                    "needs_upgrade",
+                    "already_upgraded",
+                    "invalid_credentials",
+                    "pairing_unavailable",
+                    "protocol_error",
+                    "transport_failure",
+                    "unexpected_failure"
+                ]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on. Always v2 for this pixel",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            },
+            {
+                "key": "path",
+                "type": "string",
+                "description": "Whether the failed setup was a recovery-code login or a device pairing. Best-effort, omitted when unknown",
+                "enum": ["recovery", "pairing"]
+            },
+            {
+                "key": "my_role",
+                "type": "string",
+                "description": "This device's elected role in a v2 pairing. Best-effort, omitted when unknown",
+                "enum": ["host", "joiner"]
+            },
+            {
+                "key": "peer_kind",
+                "type": "string",
+                "description": "The peer device's credential kind in a v2 pairing. Best-effort, omitted when unknown",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_ended_abandoned": {
+        "description": "Sync setup was cancelled by the user (back navigation or denying the sync confirmation prompt)",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow was cancelled",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Why the setup was cancelled, based on the v2 protocol state at cancellation",
+                "enum": ["scanning_cancelled", "sync_confirmation_denied", "cancelled_before_finished"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ProtectedKeyManager.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ProtectedKeyManager.kt
@@ -42,9 +42,14 @@ interface ProtectedKeyManager {
      * Generates an RSA keypair for [purpose] (e.g. "ai_chats"), libsodium-encrypts the private key
      * with the account secret key, and POSTs the entry via /sync/keys/.../set-if-absent.
      *
-     * No-op success if the server already has a key for [purpose] (set-if-absent semantics).
+     * Returns the authoritative [ProtectedKeyEntry] taken from the server's response. In the
+     * we-wrote-it case the returned entry equals the one we POSTed; in the race-loser case the
+     * server's `set-if-absent` returns its pre-existing entry instead, and we surface that so
+     * the caller reflects the truth on the server rather than the local key we minted.
+     *
+     * Returns the entry for [purpose] only — not all keys for the account.
      */
-    fun create(purpose: String): Result<Boolean>
+    fun create(purpose: String): Result<ProtectedKeyEntry>
 }
 
 @ContributesBinding(AppScope::class)
@@ -58,7 +63,7 @@ class RealProtectedKeyManager @Inject constructor(
     private val syncFeature: SyncFeature,
 ) : ProtectedKeyManager {
 
-    override fun create(purpose: String): Result<Boolean> {
+    override fun create(purpose: String): Result<ProtectedKeyEntry> {
         if (!syncFeature.canUseV2ConnectFlow().isEnabled()) {
             return Error(reason = "Scoped access credentials feature is disabled")
         }
@@ -97,10 +102,21 @@ class RealProtectedKeyManager @Inject constructor(
             publicKey = RsaJwk(n = n, e = e),
         )
 
-        return when (val result = syncApi.setProtectedKeyIfAbsent(token, purpose, key)) {
+        return when (val result = syncApi.setProtectedKeyIfAbsent(token, purpose, listOf(key))) {
             is Success -> {
-                logcat { "Sync-ScopedToken: protected key for $purpose created (kid=$kid)" }
-                Success(true)
+                val entry = result.data.firstOrNull { it.purpose == purpose && it.encryptedWith == CREDENTIAL_ID_DDG }
+                    ?: return Error(reason = "CreateProtectedKey: server response missing created key for $purpose")
+                if (entry.kid != kid) {
+                    // Server returned a pre-existing entry — another device created the key for this
+                    // purpose between our (implicit) check and our POST. The server's entry wins.
+                    logcat {
+                        "Sync-ScopedToken: protected key for $purpose already existed on server " +
+                            "(server kid=${entry.kid}, our kid=$kid) — adopting server entry"
+                    }
+                } else {
+                    logcat { "Sync-ScopedToken: protected key for $purpose created (kid=$kid)" }
+                }
+                Success(entry)
             }
             is Error -> {
                 logcat(ERROR) { "Sync-ScopedToken: failed to create protected key: ${result.reason}" }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
@@ -1,0 +1,538 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import android.util.Base64
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN
+import com.duckduckgo.sync.impl.AccountErrorCodes.NEGOTIATION_ABORTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.NO_RECOVERY_CODE
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_UNAVAILABLE
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
+import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.moshi.Moshi
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.transformWhile
+import logcat.logcat
+import org.json.JSONObject
+import javax.inject.Inject
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealSyncCodeDispatcher @Inject constructor(
+    private val syncFeature: SyncFeature,
+    private val syncAccountRepository: SyncAccountRepository,
+    private val qrCode: ExchangeV2QrCode,
+    private val runner: ExchangeV2Runner,
+) : SyncCodeDispatcher {
+
+    override fun confirmJoiner() {
+        logcat { "$TAG: user confirmed Joiner side" }
+        runner.localTrigger(LocalTrigger.UserConfirmedJoiner)
+    }
+
+    override fun denyJoiner() {
+        logcat { "$TAG: user denied Joiner side" }
+        runner.localTrigger(LocalTrigger.UserDeniedJoiner)
+    }
+
+    override fun confirmHost() {
+        logcat { "$TAG: user confirmed Host side" }
+        runner.localTrigger(LocalTrigger.UserConfirmedHost)
+    }
+
+    override fun denyHost() {
+        logcat { "$TAG: user denied Host side" }
+        runner.localTrigger(LocalTrigger.UserDeniedHost)
+    }
+
+    /**
+     * Drive a v2 Presenter session: start the runner via [ExchangeV2Runner.startPresent] and map
+     * each event to a [DispatchOutcome] via [mapV2PresentEventToOutcome]. Role election may elect
+     * this device as either Host or Joiner.
+     */
+    override fun presentV2(): Flow<DispatchOutcome> = flow {
+        val sessionStartMs = System.currentTimeMillis()
+        logcat { "$TAG: V2 Presenter starting runner.startPresent (scoped to events since $sessionStartMs)" }
+        runner.startPresent()
+        var ownChannelId: String? = null
+        // Snapshot the peer kind while the session is live; the runner clears it on terminal teardown,
+        // so by the time we map the terminal event runner.peerKind is already null.
+        var peerKind: PeerKind? = null
+        emitAll(
+            runner.eventsSince(sessionStartMs)
+                .transformWhile { event ->
+                    // A later SessionStarted with a different channelId means another caller has
+                    // preempted the shared runner; terminate silently so its Flow owns the runner.
+                    if (event is ExchangeV2Event.SessionStarted) {
+                        if (ownChannelId == null) {
+                            ownChannelId = event.ownChannelId
+                        } else if (event.ownChannelId != ownChannelId) {
+                            logcat { "$TAG: V2 Presenter flow preempted (own=$ownChannelId, new=${event.ownChannelId}); terminating silently" }
+                            return@transformWhile false
+                        }
+                    }
+                    runner.peerKind.toPeerKind()?.let { peerKind = it }
+                    val outcome = (mapV2PresentEventToOutcome(event, peerKind) ?: return@transformWhile true)
+                        .withFailureContext(SetupPath.PAIRING, roleFromTerminalState(event), peerKind)
+                    emit(outcome)
+                    !outcome.isTerminal()
+                },
+        )
+        logcat { "$TAG: V2 Presenter flow completed" }
+    }.onCompletion { cause ->
+        if (cause != null) {
+            // Cancelled/threw before a terminal state — tear down the session so the channel
+            // DELETE fires. Spec: Unified Algorithm §Aborting.
+            logcat { "$TAG: V2 Presenter flow completed with cause=${cause::class.simpleName}; cancelling runner" }
+            runner.cancel()
+        }
+    }
+
+    /**
+     * Translate one runner event into a [DispatchOutcome] for the v2 Presenter flow,
+     * or null for intermediate events the caller should ignore. Both Host and Joiner roles are
+     * reachable here; mirrors [mapV2LinkingEventToOutcome] (login on Joiner.Done, preserve abort reason).
+     */
+    private fun mapV2PresentEventToOutcome(event: ExchangeV2Event, peerKind: PeerKind?): DispatchOutcome? = when (event) {
+        is ExchangeV2Event.SessionStarted -> event.linkingCode?.let { DispatchOutcome.LinkingCodeReady(it) }
+        is ExchangeV2Event.Transition -> when (event.to) {
+            ExchangeV2State.Joiner.Confirming ->
+                DispatchOutcome.JoinerConfirmationRequested(peerName = runner.peerName, peerKind = peerKind)
+            ExchangeV2State.Host.Confirming ->
+                DispatchOutcome.HostConfirmationRequested(peerName = runner.peerName, peerKind = peerKind)
+            ExchangeV2State.Host.Done -> DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST, peerKind)
+            ExchangeV2State.Host.Aborted -> hostAbortedToOutcome(event.localTrigger)
+            ExchangeV2State.SameAccountAbort -> DispatchOutcome.AlreadyConnected
+            ExchangeV2State.Joiner.Done -> {
+                val received = (event.trigger as? ExchangeV2Message.RecoveryCodeResponse)?.recoveryCode
+                if (received.isNullOrBlank()) {
+                    DispatchOutcome.Failed("Pairing completed without a recovery code", NO_RECOVERY_CODE.code)
+                } else {
+                    loginWithV2RecoveryCode(received, peerKind)
+                }
+            }
+            ExchangeV2State.Joiner.AbortedByHost -> when (event.trigger) {
+                is ExchangeV2Message.RecoveryCodeDenied ->
+                    DispatchOutcome.Failed("Pairing declined by peer", PAIRING_REJECTED.code)
+                is ExchangeV2Message.RecoveryCodeUnavailable ->
+                    DispatchOutcome.Failed("Peer has no recovery code", PAIRING_UNAVAILABLE.code)
+                else -> DispatchOutcome.Failed("Pairing aborted by peer", PAIRING_REJECTED.code)
+            }
+            ExchangeV2State.Joiner.AbortedLocal -> DispatchOutcome.Failed("Pairing cancelled on this device", PAIRING_CANCELLED.code)
+            ExchangeV2State.Aborted -> DispatchOutcome.Failed("negotiation_aborted", NEGOTIATION_ABORTED.code)
+            else -> null
+        }
+        is ExchangeV2Event.SessionError -> sessionErrorToOutcome(event.message)
+        else -> null
+    }
+
+    override fun isV2ExchangeUnderway(): Boolean = when (runner.currentState) {
+        null, ExchangeV2State.Bootstrapped -> false
+        else -> true
+    }
+
+    override fun route(pastedCode: String): RouteDecision {
+        val v2Enabled = syncFeature.canUseV2ConnectFlow().isEnabled()
+        logcat { "$TAG: route() called, canUseV2ConnectFlow=$v2Enabled" }
+        if (!v2Enabled) {
+            // Flag off → never look at v2 shapes; defer entirely to the v1 path.
+            return legacy(pastedCode, reason = "FF off")
+        }
+        return classifyV2(pastedCode)
+    }
+
+    private fun classifyV2(pastedCode: String): RouteDecision {
+        val parsed = qrCode.parse(pastedCode)
+        logcat { "$TAG: v2 parse=${parsed::class.simpleName}" }
+        return when (parsed) {
+            is ExchangeV2CodeParseResult.LinkingV2 -> {
+                logcat { "$TAG: routing → V2 LinkingV2 (runner.startScan)" }
+                RouteDecision.V2InProgress(SyncCodeType.LINKING, driveV2Linking(pastedCode))
+            }
+            is ExchangeV2CodeParseResult.RecoveryCode -> {
+                val cid = parsed.rawJson.optString("cid", "ddg")
+                logcat { "$TAG: routing → V2 RecoveryCode (cid=$cid)" }
+                RouteDecision.V2InProgress(SyncCodeType.RECOVERY, driveV2Recovery(parsed, cid))
+            }
+            ExchangeV2CodeParseResult.LinkingV1,
+            ExchangeV2CodeParseResult.Unknown,
+            -> legacy(pastedCode, reason = "v2 parser=${parsed::class.simpleName}, falling through to legacy")
+        }
+    }
+
+    private fun legacy(pastedCode: String, reason: String): RouteDecision.Legacy {
+        val authCode = syncAccountRepository.parseSyncAuthCode(pastedCode)
+        logcat { "$TAG: routing → legacy v1 ($reason); parseSyncAuthCode=${authCode::class.simpleName}" }
+        return RouteDecision.Legacy(authCode)
+    }
+
+    /**
+     * V2 recovery code (the new `{recovery:{user_id, secret, cid, v}}` shape). cid=ddg drives
+     * the existing v1 Recovery login (same fields, just renamed). cid=3party drives the
+     * 3party-join upgrade flow on [SyncAccountRepository]. Anything else → error.
+     */
+    private fun driveV2Recovery(parsed: ExchangeV2CodeParseResult.RecoveryCode, cid: String): Flow<DispatchOutcome> = flow {
+        when (cid) {
+            CID_DDG -> {
+                val userId = parsed.rawJson.optString("user_id").takeIf { it.isNotEmpty() }
+                val secret = parsed.rawJson.optString("secret").takeIf { it.isNotEmpty() }
+                if (userId == null || secret == null) {
+                    logcat { "$TAG: v2 recovery (ddg) missing user_id or secret" }
+                    emit(DispatchOutcome.Failed("v2 recovery code missing required fields"))
+                    return@flow
+                }
+                val primaryKey = v2SecretToV1PrimaryKey(secret)
+                if (primaryKey == null) {
+                    logcat { "$TAG: v2 recovery (ddg) secret is not valid base64" }
+                    emit(DispatchOutcome.Failed("v2 recovery code has a malformed secret"))
+                    return@flow
+                }
+                val authCode = SyncAuthCode.Recovery(RecoveryCode(primaryKey = primaryKey, userId = userId))
+                logcat { "$TAG: v2 recovery (ddg) → processCode(Recovery)" }
+                emit(
+                    syncAccountRepository.processCode(authCode, existingDeviceId = null).toOutcome(
+                        label = "v2 recovery (ddg)",
+                        path = SetupPath.RECOVERY,
+                        codeForAccountSwitch = encodeV1RecoveryCodeAsB64(userId = userId, secret = primaryKey),
+                    ),
+                )
+            }
+            CID_3PARTY -> {
+                // joinAccountFromThirdPartyRecoveryCode takes the bare b64 code; re-encode the
+                // inner recovery JSON. Mint via Moshi (not org.json) to match the Moshi consumer
+                // parseThirdPartyRecoveryCode and avoid non-canonical JSON escaping.
+                val rewrapped = thirdPartyRecoveryCodeAdapter.toJson(
+                    ThirdPartyRecoveryCodeWrapper(
+                        recovery = ThirdPartyRecoveryCode(
+                            userId = parsed.rawJson.optString("user_id"),
+                            secret = parsed.rawJson.optString("secret"),
+                            cid = parsed.rawJson.optString("cid", CID_3PARTY),
+                            v = parsed.rawJson.optString("v", RECOVERY_CODE_V2),
+                        ),
+                    ),
+                )
+                val b64 = Base64.encodeToString(
+                    rewrapped.toByteArray(Charsets.UTF_8),
+                    Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP,
+                )
+                logcat { "$TAG: v2 recovery (3party) → joinAccountFromThirdPartyRecoveryCode" }
+                emit(
+                    syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(
+                        b64,
+                    ).toOutcome(label = "v2 recovery (3party)", path = SetupPath.RECOVERY),
+                )
+            }
+            else -> {
+                logcat { "$TAG: v2 recovery: unknown cid='$cid'" }
+                emit(DispatchOutcome.Failed("Unknown v2 credential type: $cid"))
+            }
+        }
+    }.map { it.withFailureContext(SetupPath.RECOVERY, myRole = null, peerKind = null) }
+
+    /**
+     * V2 LinkingV2 (`code2=…`) scanner side. Starts [ExchangeV2Runner.startScan] and maps its
+     * events to outcomes via [mapV2LinkingEventToOutcome]: confirmation requests (caller shows a
+     * prompt and calls [confirmJoiner]/[denyJoiner] or [confirmHost]/[denyHost]) then a single
+     * terminal outcome that completes the Flow.
+     */
+    private fun driveV2Linking(pastedCode: String): Flow<DispatchOutcome> = flow {
+        val sessionStartMs = System.currentTimeMillis()
+        logcat { "$TAG: V2 LinkingV2 starting runner.startScan (scoped to events since $sessionStartMs)" }
+        runner.startScan(pastedCode)
+        var ownChannelId: String? = null
+        // Snapshot the peer kind while the session is live (see presentV2): the runner clears it on
+        // terminal teardown, before we map the terminal event.
+        var peerKind: PeerKind? = null
+        emitAll(
+            runner.eventsSince(sessionStartMs)
+                .transformWhile { event ->
+                    // Same preemption guard as presentV2(): bail if another caller takes over the
+                    // shared runner mid-flow.
+                    if (event is ExchangeV2Event.SessionStarted) {
+                        if (ownChannelId == null) {
+                            ownChannelId = event.ownChannelId
+                        } else if (event.ownChannelId != ownChannelId) {
+                            logcat { "$TAG: V2 LinkingV2 flow preempted (own=$ownChannelId, new=${event.ownChannelId}); terminating silently" }
+                            return@transformWhile false
+                        }
+                    }
+                    runner.peerKind.toPeerKind()?.let { peerKind = it }
+                    val outcome = (mapV2LinkingEventToOutcome(event, peerKind) ?: return@transformWhile true)
+                        .withFailureContext(SetupPath.PAIRING, roleFromTerminalState(event), peerKind)
+                    emit(outcome)
+                    !outcome.isTerminal()
+                },
+        )
+        logcat { "$TAG: V2 LinkingV2 flow completed" }
+    }.onCompletion { cause ->
+        if (cause != null) {
+            // Cancelled/threw before a terminal state — tear down the session so the channel
+            // DELETE fires. Spec: Unified Algorithm §Aborting.
+            logcat { "$TAG: V2 LinkingV2 flow completed with cause=${cause::class.simpleName}; cancelling runner" }
+            runner.cancel()
+        }
+    }
+
+    private fun DispatchOutcome.isTerminal(): Boolean = when (this) {
+        is DispatchOutcome.LinkingCodeReady,
+        is DispatchOutcome.JoinerConfirmationRequested,
+        is DispatchOutcome.HostConfirmationRequested,
+        -> false
+        is DispatchOutcome.LoggedIn,
+        is DispatchOutcome.AlreadyConnected,
+        is DispatchOutcome.UpgradeRequired,
+        is DispatchOutcome.Failed,
+        -> true
+    }
+
+    /**
+     * Translate one runner event into a terminal [DispatchOutcome] for the v2 scanner flow,
+     * or null for intermediate events the caller should ignore.
+     */
+    private fun mapV2LinkingEventToOutcome(event: ExchangeV2Event, peerKind: PeerKind?): DispatchOutcome? = when (event) {
+        is ExchangeV2Event.Transition -> when (event.to) {
+            ExchangeV2State.Joiner.Confirming ->
+                DispatchOutcome.JoinerConfirmationRequested(peerName = runner.peerName, peerKind = peerKind)
+            ExchangeV2State.Host.Confirming ->
+                DispatchOutcome.HostConfirmationRequested(peerName = runner.peerName, peerKind = peerKind)
+            ExchangeV2State.Joiner.Done -> {
+                val received = (event.trigger as? ExchangeV2Message.RecoveryCodeResponse)?.recoveryCode
+                if (received.isNullOrBlank()) {
+                    DispatchOutcome.Failed("Pairing completed without a recovery code", NO_RECOVERY_CODE.code)
+                } else {
+                    loginWithV2RecoveryCode(received, peerKind)
+                }
+            }
+            ExchangeV2State.Joiner.AbortedByHost -> when (event.trigger) {
+                is ExchangeV2Message.RecoveryCodeDenied ->
+                    DispatchOutcome.Failed("Pairing declined by peer", PAIRING_REJECTED.code)
+                is ExchangeV2Message.RecoveryCodeUnavailable ->
+                    DispatchOutcome.Failed("Peer has no recovery code", PAIRING_UNAVAILABLE.code)
+                else -> DispatchOutcome.Failed("Pairing aborted by peer", PAIRING_REJECTED.code)
+            }
+            ExchangeV2State.Joiner.AbortedLocal -> DispatchOutcome.Failed("Pairing cancelled on this device", PAIRING_CANCELLED.code)
+            ExchangeV2State.Host.Aborted -> hostAbortedToOutcome(event.localTrigger)
+            // Per spec §"Same-account case": not an abort; both devices share an account already.
+            ExchangeV2State.SameAccountAbort -> DispatchOutcome.AlreadyConnected
+            // Elected Host and shared a recovery code — success from this device's perspective.
+            ExchangeV2State.Host.Done -> DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST, peerKind)
+            ExchangeV2State.Aborted -> DispatchOutcome.Failed("negotiation_aborted", NEGOTIATION_ABORTED.code)
+            else -> null
+        }
+        is ExchangeV2Event.SessionError -> sessionErrorToOutcome(event.message)
+        else -> null
+    }
+
+    private fun sessionErrorToOutcome(message: String): DispatchOutcome {
+        val match = VERSION_TOO_NEW_REGEX.find(message)
+        return if (match != null) {
+            DispatchOutcome.UpgradeRequired(codeMajor = match.groupValues[1].toIntOrNull() ?: -1)
+        } else {
+            DispatchOutcome.Failed(message, PAIRING_FAILED.code)
+        }
+    }
+
+    private fun hostAbortedToOutcome(localTrigger: LocalTrigger?): DispatchOutcome = when (localTrigger) {
+        LocalTrigger.UserDeniedHost -> DispatchOutcome.Failed("user_denied", PAIRING_CANCELLED.code)
+        LocalTrigger.HostUnavailable -> DispatchOutcome.Failed("host_unavailable", PAIRING_UNAVAILABLE.code)
+        else -> DispatchOutcome.Failed("host_aborted", NEGOTIATION_ABORTED.code)
+    }
+
+    /**
+     * Apply a v2 recovery code received over the LinkingV2 channel (raw base64
+     * `{recovery:{user_id, secret, cid, v}}`). Per spec §"Exchange Share Recovery Code → Joiner":
+     * cid=ddg logs in directly; cid=3party upgrades the account via
+     * [SyncAccountRepository.joinAccountFromThirdPartyRecoveryCode].
+     */
+    private fun loginWithV2RecoveryCode(b64: String, peerKind: PeerKind?): DispatchOutcome {
+        val parsed = decodeV2Recovery(b64) ?: return DispatchOutcome.Failed("Couldn't parse received recovery code as v2.0")
+        return when (parsed.cid) {
+            CID_DDG -> {
+                val primaryKey = v2SecretToV1PrimaryKey(parsed.secret)
+                    ?: return DispatchOutcome.Failed("Received recovery code has a malformed secret")
+                val recovery = SyncAuthCode.Recovery(RecoveryCode(primaryKey = primaryKey, userId = parsed.userId))
+                logcat { "$TAG: v2 LinkingV2 received ddg code → $recovery" }
+                syncAccountRepository.processCode(recovery, existingDeviceId = null)
+                    .toOutcome(
+                        label = "v2 LinkingV2 login (ddg)",
+                        path = SetupPath.PAIRING,
+                        myRole = SetupRole.JOINER,
+                        peerKind = peerKind,
+                        codeForAccountSwitch = encodeV1RecoveryCodeAsB64(userId = parsed.userId, secret = primaryKey),
+                    )
+            }
+            CID_3PARTY -> {
+                logcat { "$TAG: v2 LinkingV2 received 3party code → joinAccountFromThirdPartyRecoveryCode" }
+                syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(b64)
+                    .toOutcome(
+                        label = "v2 LinkingV2 login (3party upgrade)",
+                        path = SetupPath.PAIRING,
+                        myRole = SetupRole.JOINER,
+                        peerKind = peerKind,
+                    )
+            }
+            else -> DispatchOutcome.Failed("Received unknown credential type '${parsed.cid}' over v2 linking")
+        }
+    }
+
+    private data class ParsedV2Recovery(val userId: String, val secret: String, val cid: String, val v: String)
+
+    private fun decodeV2Recovery(b64: String): ParsedV2Recovery? = runCatching {
+        val decoded = runCatching { java.util.Base64.getUrlDecoder().decode(b64) }
+            .recoverCatching { java.util.Base64.getDecoder().decode(b64) }
+            .getOrThrow()
+        val root = JSONObject(String(decoded, Charsets.UTF_8))
+        val rec = root.getJSONObject("recovery")
+        ParsedV2Recovery(
+            userId = rec.getString("user_id"),
+            secret = rec.getString("secret"),
+            cid = rec.optString("cid", CID_DDG),
+            v = rec.optString("v", "2.0"),
+        )
+    }.getOrNull()
+
+    /**
+     * v2 wire `secret` is base64url (spec 1214802412121967); re-encode to standard base64 for the
+     * v1 native login, normalising the alphabet first to also tolerate an already-standard secret.
+     * Returns null if the secret isn't valid base64.
+     */
+    private fun v2SecretToV1PrimaryKey(secret: String): String? = runCatching {
+        val bytes = Base64.decode(secret.replace('-', '+').replace('_', '/'), Base64.NO_WRAP)
+        Base64.encodeToString(bytes, Base64.NO_WRAP)
+    }.getOrNull()
+
+    /**
+     * Map a repo [Result] to a [DispatchOutcome].
+     *
+     * If [codeForAccountSwitch] is supplied and the repo failed with [ALREADY_SIGNED_IN], switch
+     * accounts transparently via [SyncAccountRepository.logoutAndJoinNewAccount] with no prompt:
+     * the Confirmations phase is already the consent step, so the v1 `AskToSwitchAccount` dialog
+     * does not apply.
+     *
+     * [codeForAccountSwitch] must be a v1 b64 shape [SyncAccountRepository.parseSyncAuthCode] can
+     * re-parse, so v2 callers convert first (see [encodeV1RecoveryCodeAsB64]).
+     */
+    /** Map the runner's raw peer credential id ("ddg"/"3party") to the telemetry [PeerKind], or null. */
+    private fun String?.toPeerKind(): PeerKind? = when (this) {
+        CID_DDG -> PeerKind.DDG
+        CID_3PARTY -> PeerKind.THIRD_PARTY
+        else -> null
+    }
+
+    /** Elected role implied by a terminal transition's target state, for "Setup failed" telemetry. */
+    private fun roleFromTerminalState(event: ExchangeV2Event): SetupRole? =
+        when ((event as? ExchangeV2Event.Transition)?.to) {
+            is ExchangeV2State.Host -> SetupRole.HOST
+            is ExchangeV2State.Joiner -> SetupRole.JOINER
+            else -> null
+        }
+
+    /**
+     * Attach best-effort failure telemetry ([path]/[myRole]/[peerKind]) to a terminal error outcome.
+     * No-op for non-error outcomes, so a [DispatchOutcome.LoggedIn] keeps the context set at its source.
+     */
+    private fun DispatchOutcome.withFailureContext(
+        path: SetupPath,
+        myRole: SetupRole?,
+        peerKind: PeerKind?,
+    ): DispatchOutcome = when (this) {
+        is DispatchOutcome.Failed -> copy(path = path, myRole = myRole, peerKind = peerKind)
+        is DispatchOutcome.UpgradeRequired -> copy(path = path, myRole = myRole, peerKind = peerKind)
+        else -> this
+    }
+
+    private fun Result<Boolean>.toOutcome(
+        label: String,
+        path: SetupPath,
+        myRole: SetupRole? = null,
+        peerKind: PeerKind? = null,
+        codeForAccountSwitch: String? = null,
+    ): DispatchOutcome = when (this) {
+        is Result.Success -> {
+            logcat { "$TAG: $label → success" }
+            DispatchOutcome.LoggedIn(path, myRole, peerKind)
+        }
+        is Result.Error -> {
+            logcat { "$TAG: $label → error: $reason (code=$code)" }
+            if (code == ALREADY_SIGNED_IN.code && codeForAccountSwitch != null) {
+                logcat { "$TAG: $label → ALREADY_SIGNED_IN, performing transparent logout+rejoin" }
+                when (val switched = syncAccountRepository.logoutAndJoinNewAccount(codeForAccountSwitch)) {
+                    is Result.Success -> {
+                        logcat { "$TAG: $label → logout+rejoin success" }
+                        DispatchOutcome.LoggedIn(path, myRole, peerKind)
+                    }
+                    is Result.Error -> {
+                        logcat { "$TAG: $label → logout+rejoin failed: ${switched.reason} (code=${switched.code})" }
+                        DispatchOutcome.Failed(switched.reason, switched.code)
+                    }
+                }
+            } else {
+                DispatchOutcome.Failed(reason, code)
+            }
+        }
+    }
+
+    /**
+     * Re-encode a v2 ddg recovery (userId + secret) as a v1-shape `{recovery:{primary_key,
+     * user_id}}` base64-url string so [SyncAccountRepository.logoutAndJoinNewAccount] (v1-only
+     * [SyncAccountRepository.parseSyncAuthCode]) can consume it on account switch.
+     */
+    private fun encodeV1RecoveryCodeAsB64(userId: String, secret: String): String {
+        // Mint via Moshi (not org.json) and reuse the v1 LinkCode shape, keeping this byte-identical
+        // to a genuine v1 code so the parseSyncAuthCode round-trip stays robust.
+        val v1Json = v1RecoveryCodeAdapter.toJson(LinkCode(recovery = RecoveryCode(primaryKey = secret, userId = userId)))
+        return Base64.encodeToString(
+            v1Json.toByteArray(Charsets.UTF_8),
+            Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP,
+        )
+    }
+
+    private val v1RecoveryCodeAdapter by lazy {
+        Moshi.Builder().build().adapter(LinkCode::class.java)
+    }
+
+    private val thirdPartyRecoveryCodeAdapter by lazy {
+        Moshi.Builder().build().adapter(ThirdPartyRecoveryCodeWrapper::class.java)
+    }
+
+    companion object {
+        private const val TAG = "Sync-CodeDispatch"
+        private const val CID_DDG = "ddg"
+        private const val CID_3PARTY = "3party"
+
+        // Extracts the major version from the EnvelopeVersionTooNew SessionError message.
+        private val VERSION_TOO_NEW_REGEX = Regex("""protocol v(\d+)""")
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.sync.impl
 
+import android.util.Base64
 import androidx.annotation.*
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -109,6 +110,23 @@ interface SyncAccountRepository {
     fun refreshThirdPartyCredential(): Result<Boolean>
 
     /**
+     * Joins this device to an existing account using a 3party recovery code, executing the
+     * "Native joining a 3party account" upgrade flow per the Unified Algorithm (Asana
+     * 1214739740392701). Two network calls:
+     *
+     *   1. POST /sync/login with scope=ai_chats — authenticates against the existing 3party
+     *      credential and returns a short-lived token + the protected keys to re-wrap.
+     *   2. POST /access-credentials/ddg — mints a fresh DDG credential on the account, attached
+     *      alongside the existing 3party entry (which gets decorated with encrypted_3party_credential
+     *      so future ddg-side logins can re-derive SP).
+     *
+     * On success the device ends in a normal Native signed-in state: full primaryKey / secretKey
+     * populated, credentialId=ddg, scopedPassword populated with SP. SyncStore is written
+     * atomically only after both network calls succeed; observers never see an intermediate state.
+     */
+    fun joinAccountFromThirdPartyRecoveryCode(pastedCode: String): Result<Boolean>
+
+    /**
      * Returns a recovery code that a 3rd-party browser can use to sign in and access this
      * account's scoped data. Requires the 3party credential to already exist locally — call
      * [createThirdPartyCredential] (or [refreshThirdPartyCredential]) first.
@@ -158,6 +176,9 @@ class AppSyncAccountRepository @Inject constructor(
     private val protectedKeyManager: ProtectedKeyManager,
     private val thirdPartyDeviceListDecryptor: ThirdPartyDeviceListDecryptor,
 ) : SyncAccountRepository {
+
+    // Bounded backoff for the 3party→ddg upgrade network calls.
+    internal var upgradeRetryDelayMillis: Long = DEFAULT_UPGRADE_RETRY_DELAY_MILLIS
 
     /**
      * If there is a key-exchange flow in progress, we need to keep a reference to them
@@ -248,9 +269,33 @@ class AppSyncAccountRepository @Inject constructor(
         }
     }
 
+    // `primaryKey` and `userId` are declared non-null but reflection-based Moshi can populate them with null when the JSON keys are missing
+    @Suppress("SENSELESS_COMPARISON")
     private fun canParseAsRecoveryCode(decodedCode: String) = Adapters.recoveryCodeAdapter.fromJson(decodedCode)?.recovery
+        ?.takeIf { it.primaryKey != null && it.userId != null }
     private fun canParseAsExchangeCode(decodedCode: String) = Adapters.invitationCodeAdapter.fromJson(decodedCode)?.exchangeKey
     private fun canParseAsConnectCode(decodedCode: String) = Adapters.recoveryCodeAdapter.fromJson(decodedCode)?.connect
+
+    /**
+     * Parse a base64url-encoded 3party recovery code (v2 format per the Recovery Payload Shape
+     * RFC, Asana 1214804486778180). Returns the inner payload if it's a structurally-valid 3party
+     * code, null otherwise. Errors (bad base64, bad JSON, missing fields) are swallowed and turned
+     * into null — callers translate null into a user-facing error.
+     *
+     * Discrimination: `recovery.cid == "3party"` AND `recovery.v` is major version 2 — bare "2"
+     * (the common shorthand) or any "2.x" — AND `secret`/`user_id` are non-empty.
+     */
+    private fun parseThirdPartyRecoveryCode(pastedCode: String): ThirdPartyRecoveryCode? {
+        return kotlin.runCatching {
+            val decodedBytes = Base64.decode(pastedCode, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
+            val decodedJson = decodedBytes.toString(Charsets.UTF_8)
+            val parsed = Adapters.thirdPartyRecoveryCodeAdapter.fromJson(decodedJson)?.recovery ?: return@runCatching null
+            if (parsed.cid != CREDENTIAL_ID_3PARTY) return@runCatching null
+            if (parsed.v.substringBefore(".") != RECOVERY_CODE_MAJOR_V2) return@runCatching null
+            if (parsed.secret.isEmpty() || parsed.userId.isEmpty()) return@runCatching null
+            parsed
+        }.getOrNull()
+    }
 
     private fun onInvitationCodeReceived(invitationCode: InvitationCode): Result<Boolean> {
         // Sync: InviteFlow - B (https://app.asana.com/0/72649045549333/1209571867429615)
@@ -590,7 +635,262 @@ class AppSyncAccountRepository @Inject constructor(
 
     override fun refreshThirdPartyCredential(): Result<Boolean> = thirdPartyCredentialManager.refresh()
 
-    override fun createProtectedKey(purpose: String): Result<Boolean> = protectedKeyManager.create(purpose)
+    override fun createProtectedKey(purpose: String): Result<Boolean> =
+        when (val r = protectedKeyManager.create(purpose)) {
+            is Result.Success -> Result.Success(true)
+            is Result.Error -> r
+        }
+
+    /**
+     * Bundle produced by [buildThirdPartyUpgradePackage] and consumed by the upgrade POST +
+     * SyncStore commit step. Keeps the locally-generated DDG account material together with the
+     * request body and the re-wrapped keys list, so the caller can perform a single atomic write.
+     */
+    private data class ThirdPartyUpgradePackage(
+        val newDdgKeys: AccountKeys,
+        val rewrappedKeys: List<ProtectedKeyEntry>,
+        val request: CreateAccessCredentialRequest,
+    )
+
+    /**
+     * Step 3 + 4 + 5 of the "Native joining a 3party account" upgrade flow. Given a parsed
+     * 3party recovery code and the protected keys returned by the prior /sync/login (encrypted
+     * by FE with the 3party MEK in JWE format), build everything needed for POST
+     * /access-credentials/ddg:
+     *
+     *   - generate a fresh DDG credential locally (new MP/SK/PSK/PH via libsodium)
+     *   - re-wrap each FE-written key with the new DDG secretKey using libsodium (Native pattern,
+     *     encrypted_with="ddg"). Source format is RFC 7516 JWE compact; target is libsodium-secretbox
+     *     base64url-encoded — same asymmetry as the reverse direction in [createThirdPartyCredential].
+     *   - encrypt SP with the new DDG MEK in a JWE-dir-A256GCM envelope with kid="ddg" (the
+     *     `encrypted_3party_credential` field that decorates the *existing* 3party entry so a
+     *     future ddg-side login can derive SP back from MP).
+     *
+     * Reference: Sync API docs POST /access-credentials/{id} ("upgrades a 3party-only account into
+     * a native one") and Encryption Algorithms TD (Asana 1214802412121967).
+     *
+     * No network calls and no SyncStore writes — both are the responsibility of the caller.
+     */
+    private fun buildThirdPartyUpgradePackage(
+        parsed: ThirdPartyRecoveryCode,
+        keysFromLogin: List<ProtectedKeyEntry>,
+    ): Result<ThirdPartyUpgradePackage> {
+        // SP travels in the recovery code as base64url; nativeLib + hkdfDerive* helpers expect
+        // standard base64. Compute once at the boundary, reuse for all derivations.
+        val spStandardB64 = kotlin.runCatching { base64UrlStringToStandardBase64(parsed.secret) }
+            .getOrElse { return Error(reason = "Upgrade: failed to decode SP") }
+        val hkdfSalt = parsed.userId.toByteArray(Charsets.UTF_8)
+
+        // SP-derived MEK: used to decrypt FE-written (JWE) keys we received from /sync/login.
+        val spMek = kotlin.runCatching { syncJweCrypto.hkdfDeriveBytes(spStandardB64, hkdfSalt, "Main Key", 32) }
+            .getOrElse { return Error(reason = "Upgrade: failed to derive SP MEK") }
+
+        // Fresh DDG credential generated locally. nativeLib.generateAccountKeys returns a tuple
+        // where `primaryKey` is the new account's MP (the seed for all spec-side derivations) and
+        // `secretKey` is the libsodium secretbox key used to wrap encrypted_private_key entries.
+        val newDdgKeys = kotlin.runCatching {
+            nativeLib.generateAccountKeys(userId = parsed.userId).also {
+                it.checkResult("Upgrade: DDG account key generation failed")
+            }
+        }.getOrElse { return it.asErrorResult() }
+
+        // DDG-derived MEK: used to encrypt `encrypted_3party_credential` (the SP-decorates-3party
+        // payload). Per Encryption Algorithms TD §"How do we encrypt the 3party secret using the
+        // DDG's MEK?", this is HKDF(MP, salt=user_id, info="Main Key", 32 bytes) imported as
+        // AES-GCM-256. Pinned against the TD's test3 vector in SyncJweCryptoTdVectorsTest.
+        val ddgMek = kotlin.runCatching { syncJweCrypto.hkdfDeriveBytes(newDdgKeys.primaryKey, hkdfSalt, "Main Key", 32) }
+            .getOrElse { return Error(reason = "Upgrade: failed to derive DDG MEK") }
+
+        // encrypted_3party_credential: JWE compact (alg=dir, enc=A256GCM, kid="ddg") of the SP
+        // base64url STRING (matches the reverse direction in createThirdPartyCredential, which
+        // encrypts the base64url SP string — not the raw SP bytes — so the wire is symmetrical).
+        val encryptedThreePartyCredential = kotlin.runCatching {
+            syncJweCrypto.jweEncryptSymmetric(parsed.secret.toByteArray(Charsets.UTF_8), ddgMek, kid = CREDENTIAL_ID_DDG)
+        }.getOrElse { return Error(reason = "Upgrade: failed to encrypt encrypted_3party_credential") }
+
+        // Re-wrap each FE-written key from /sync/login. Decrypt via JWE using SP MEK, then
+        // re-encrypt with libsodium-secretbox using the new DDG secretKey, matching the Native
+        // wire format (base64-encoded encrypted bytes with URL safety applied — mirrors
+        // createProtectedKey at line ~955 and the reverse direction at line ~770).
+        val rewrappedKeys = keysFromLogin.map { srcKey ->
+            kotlin.runCatching {
+                // FE-only accounts always write keys with encrypted_with="3party". A defensive
+                // skip-or-fail decision: bail if we see anything else, since re-wrapping a key we
+                // can't decrypt would silently break ai_chats sync after upgrade.
+                if (srcKey.encryptedWith != CREDENTIAL_ID_3PARTY) {
+                    error("Upgrade: cannot re-wrap key kid=${srcKey.kid} encrypted_with=${srcKey.encryptedWith}; expected 3party")
+                }
+                val rawPrivateKeyBytes = syncJweCrypto.jweDecryptSymmetric(srcKey.encryptedPrivateKey, spMek)
+                val encryptedResult = nativeLib.encryptData(rawPrivateKeyBytes, newDdgKeys.secretKey).also {
+                    it.checkResult("Upgrade: libsodium encryption of re-wrapped key kid=${srcKey.kid} failed")
+                }
+                val wireEncryptedPrivateKey =
+                    Base64.encodeToString(encryptedResult.encryptedData, Base64.NO_WRAP).applyUrlSafetyFromB64()
+                ProtectedKeyEntry(
+                    kid = srcKey.kid,
+                    purpose = srcKey.purpose,
+                    encryptedWith = CREDENTIAL_ID_DDG,
+                    encryptedPrivateKey = wireEncryptedPrivateKey,
+                    publicKey = srcKey.publicKey,
+                )
+            }
+        }
+        val firstFailure = rewrappedKeys.firstOrNull { it.isFailure }
+        if (firstFailure != null) {
+            val cause = firstFailure.exceptionOrNull()
+            logcat(ERROR) { "Sync-ScopedToken: failed to re-wrap one or more protected keys for upgrade: ${cause?.message}" }
+            return Error(reason = "Upgrade: re-wrap key failed: ${cause?.message}")
+        }
+        val rewrappedKeysList = rewrappedKeys.map { it.getOrThrow() }
+
+        // hashedPassword (re-auth against the existing 3party credential) — same HKDF derivation
+        // we used at /sync/login. Per Sync API docs, the POST /access-credentials/{id} body carries
+        // hashed_password as a re-auth of ANY existing credential, allowing the server to decrypt
+        // the e2ee_id and accept the new credential atomically.
+        val hashedPasswordForReauth = kotlin.runCatching { syncJweCrypto.hkdfDeriveBase64Url(spStandardB64, hkdfSalt, "Password", 32) }
+            .getOrElse { return Error(reason = "Upgrade: failed to derive 3party hashed_password: ${it.message}") }
+
+        // credentialHashedPassword for the new DDG credential — HKDF(MP, salt=user_id, info="Password", 32).
+        // The server stores twice_hash(this) and validates future /login submissions against it.
+        // Pinned against the TD's test1 vector in SyncJweCryptoTdVectorsTest.
+        val credentialHashedPassword = kotlin.runCatching {
+            syncJweCrypto.hkdfDeriveBase64Url(newDdgKeys.primaryKey, hkdfSalt, "Password", 32)
+        }.getOrElse { return Error(reason = "Upgrade: failed to derive new DDG credential_hashed_password: ${it.message}") }
+
+        val request = CreateAccessCredentialRequest(
+            hashedPassword = hashedPasswordForReauth,
+            credentialHashedPassword = credentialHashedPassword,
+            protectedEncryptionKey = newDdgKeys.protectedSecretKey,
+            encrypted3partyCredential = encryptedThreePartyCredential,
+            keys = rewrappedKeysList.ifEmpty { null },
+        )
+
+        return Success(
+            ThirdPartyUpgradePackage(
+                newDdgKeys = newDdgKeys,
+                rewrappedKeys = rewrappedKeysList,
+                request = request,
+            ),
+        )
+    }
+
+    override fun joinAccountFromThirdPartyRecoveryCode(pastedCode: String): Result<Boolean> {
+        if (!syncFeature.canUseV2ConnectFlow().isEnabled()) {
+            return Error(reason = "JoinFrom3party: canUseV2ConnectFlow is disabled")
+        }
+
+        logcat { "Sync-ScopedToken: joining account via 3party recovery code" }
+
+        val parsed = parseThirdPartyRecoveryCode(pastedCode)
+            ?: return Error(reason = "JoinFrom3party: code is not a valid 3party recovery code")
+
+        val deviceId = syncDeviceIds.deviceId()
+        val deviceName = syncDeviceIds.deviceName()
+
+        // Step 2 — authenticate against the 3party credential.
+        val loginResponse = when (val loginResult = performThirdPartyLogin(parsed, deviceId)) {
+            is Error -> return loginResult.copy(reason = "JoinFrom3party: ${loginResult.reason}")
+            is Success -> loginResult.data
+        }
+
+        // Step 2a — "Does it need an upgrade?" check per Unified Algorithm (Asana 1214739740392701,
+        // "Native only - Upgrading 3party account"). The /sync/login response includes the account's
+        // current access_credentials, so we can detect a pre-existing ddg credential without a
+        // separate GET. If ddg already exists, abort with the spec-defined error rather than letting
+        // the flow fail downstream with a misleading message.
+        val accountAlreadyHasDdg = loginResponse.accessCredentials.orEmpty().any { it.id == CREDENTIAL_ID_DDG }
+        if (accountAlreadyHasDdg) {
+            logcat(WARN) { "Sync-ScopedToken: account already has a ddg credential — cannot re-upgrade from 3party" }
+            return Error(
+                code = AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED.code,
+                reason = "JoinFrom3party: account already upgraded. " +
+                    "Please use one of the already connected Native DDG Applications to add another one.",
+            )
+        }
+
+        // Only 3party-encrypted keys are re-wrappable from this login. Defensive filter: the BE
+        // returns every key the account has, including any encrypted_with=ddg entries from a prior
+        // upgrade attempt. Without the Step 2a check above those would be caught here too, but
+        // filtering also future-proofs against unknown credential types appearing in the response.
+        val keysFromLogin = loginResponse.keys.orEmpty().filter { it.encryptedWith == CREDENTIAL_ID_3PARTY }
+        logcat { "Sync-ScopedToken: 3party /sync/login OK, ${keysFromLogin.size} key(s) to re-wrap" }
+
+        // Steps 3 + 4 + 5 — build the upgrade payload locally.
+        val upgradePackage = when (val pkg = buildThirdPartyUpgradePackage(parsed, keysFromLogin)) {
+            is Error -> return pkg.copy(reason = "JoinFrom3party: ${pkg.reason}")
+            is Success -> pkg.data
+        }
+
+        // Step 6 — POST /access-credentials/ddg. If interrupted mid-flight, the BE's 5-minute TTL
+        // on newly-minted credentials cleans up the orphan automatically (Unified Algorithm,
+        // Backend-supported Alternative). No client-side reconcile needed.
+        val postResult = retryingOnTransientError {
+            syncApi.createAccessCredential(loginResponse.token, CREDENTIAL_ID_DDG, upgradePackage.request)
+        }
+        if (postResult is Error) {
+            if (postResult.code == API_CODE.COUNT_LIMIT.code) {
+                // 409 credential_already_exists: either another device beat us to creating a ddg
+                // credential, OR a previous attempt by this device crashed mid-flight and the BE
+                // will auto-remove the orphan after its 5-minute TTL.
+                logcat(WARN) { "Sync-ScopedToken: 409 — account already has a ddg credential" }
+                return Error(
+                    code = AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED.code,
+                    reason = "JoinFrom3party: account already has a ddg credential. " +
+                        "Please use one of the already connected Native DDG Applications to add another one.",
+                )
+            }
+            logcat(ERROR) { "Sync-ScopedToken: /access-credentials/ddg POST failed: ${postResult.reason}" }
+            return postResult.copy(reason = "JoinFrom3party: ${postResult.reason}")
+        }
+
+        // Step 7a — Flow 4 native login with the new ddg credential. This is the BE-side commit
+        // for the credential just POSTed: without a login inside the 5-minute TTL the server
+        // auto-removes the credential. It also yields the unrestricted ddg-scoped token that
+        // device-management endpoints need (the 3party login token at this point is ai_chats-only).
+        val ddgLoginResponse = when (
+            val ddgLogin = performDdgLoginForUpgrade(
+                userId = parsed.userId,
+                deviceId = deviceId,
+                deviceName = deviceName,
+                primaryKey = upgradePackage.newDdgKeys.primaryKey,
+            )
+        ) {
+            is Error -> {
+                if (ddgLogin.code == API_CODE.INVALID_LOGIN_CREDENTIALS.code) {
+                    logcat(ERROR) {
+                        "Sync-ScopedToken: ddg login after upgrade returned 401 — credential 5-minute TTL likely expired"
+                    }
+                } else {
+                    logcat(ERROR) { "Sync-ScopedToken: ddg login after upgrade failed: ${ddgLogin.reason}" }
+                }
+                return ddgLogin.copy(reason = "JoinFrom3party: post-upgrade ddg login failed: ${ddgLogin.reason}")
+            }
+            is Success -> ddgLogin.data
+        }
+
+        // Step 7b — atomic SyncStore commit. Everything above has either failed (returning Error
+        // without mutating SyncStore) or succeeded. External observers see the device as
+        // pre-upgrade until this block runs.
+        val spStandardB64 = kotlin.runCatching { base64UrlStringToStandardBase64(parsed.secret) }
+            .getOrElse { return Error(reason = "JoinFrom3party: failed to decode SP: ${it.message}") }
+        syncStore.storeCredentials(
+            userId = parsed.userId,
+            deviceId = deviceId,
+            deviceName = deviceName,
+            primaryKey = upgradePackage.newDdgKeys.primaryKey,
+            secretKey = upgradePackage.newDdgKeys.secretKey,
+            token = ddgLoginResponse.token,
+        )
+        syncStore.credentialId = CREDENTIAL_ID_DDG
+        syncStore.scopedPassword = ScopedPassword(spStandardB64)
+
+        logcat { "Sync-ScopedToken: 3party→ddg upgrade complete; account joined as ddg" }
+
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            syncEngine.triggerSync(ACCOUNT_LOGIN)
+        }
+        return Success(true)
+    }
 
     override fun logout(deviceId: String): Result<Boolean> {
         val token = syncStore.token.takeUnless { it.isNullOrEmpty() }
@@ -875,6 +1175,109 @@ class AppSyncAccountRepository @Inject constructor(
         }
     }
 
+    /**
+     * Authenticates against the server using a parsed 3party recovery code
+     * and returns the LoginResponse so the caller can use the token + keys[] to perform the
+     * subsequent POST /access-credentials/ddg upgrade.
+     *
+     * The returned token is short-lived and ONLY used to mint the new ddg credential — it is
+     * never persisted to SyncStore (atomic commit happens after the full upgrade succeeds).
+     *
+     * Wire body per Sync API docs (POST /sync/login):
+     *   hashed_password = HKDF-SHA-256(SP, salt=user_id_utf8, info="Password", 32) → base64url
+     *                     (Encryption Algorithms TD, Asana 1214802412121967, §"Hashed password derivation")
+     *   scope           = "ai_chats" — the canonical scope for 3party-restricted credentials
+     *   device_name,
+     *   device_type     = libsodium-encrypted with SP-as-key (mirrors the existing ddg pattern;
+     *                     server treats these as opaque blobs)
+     *
+     * Response carries token + keys[] for downstream re-wrap. NO protected_encryption_key —
+     * 3party credentials don't carry one (Sync API docs, POST /sync/login Notes).
+     */
+    private fun performThirdPartyLogin(
+        parsed: ThirdPartyRecoveryCode,
+        deviceId: String,
+    ): Result<LoginResponse> {
+        // SP travels in the recovery code as base64url; nativeLib + hkdfDerive* helpers expect
+        // standard base64 input. Convert at the boundary.
+        val spStandardB64 = kotlin.runCatching { base64UrlStringToStandardBase64(parsed.secret) }
+            .getOrElse { return Error(reason = "3party login: failed to decode SP: ${it.message}") }
+
+        val hkdfSalt = parsed.userId.toByteArray(Charsets.UTF_8)
+        val hashedPassword = kotlin.runCatching { syncJweCrypto.hkdfDeriveBase64Url(spStandardB64, hkdfSalt, "Password", 32) }
+            .getOrElse { return Error(reason = "3party login: failed to derive hashed_password: ${it.message}") }
+
+        val deviceName = syncDeviceIds.deviceName()
+        val deviceType = syncDeviceIds.deviceType()
+        val encryptedDeviceName = kotlin.runCatching {
+            nativeLib.encryptData(deviceName, spStandardB64).also {
+                it.checkResult("3party login: encrypting device name failed")
+            }.encryptedData
+        }.getOrElse { return it.asErrorResult() }
+        val encryptedDeviceType = kotlin.runCatching {
+            nativeLib.encryptData(deviceType.deviceFactor, spStandardB64).also {
+                it.checkResult("3party login: encrypting device type failed")
+            }.encryptedData
+        }.getOrElse { return it.asErrorResult() }
+
+        return syncApi.login(
+            userID = parsed.userId,
+            hashedPassword = hashedPassword,
+            deviceId = deviceId,
+            deviceName = encryptedDeviceName,
+            deviceType = encryptedDeviceType,
+            scope = SYNC_SCOPE_AI_CHATS,
+        )
+    }
+
+    /**
+     * This login acts as the BE-side *commit* for the newly minted credential —
+     * without it, the server removes the credential after a 5-minute TTL. It is also what
+     * yields an unrestricted ddg-scoped token; the 3party token from [performThirdPartyLogin]
+     * is `scope=ai_chats` and cannot drive device-management endpoints.
+     *
+     * Returns the [LoginResponse] for the caller to commit alongside the new local key
+     * material.
+     */
+    private fun performDdgLoginForUpgrade(
+        userId: String,
+        deviceId: String,
+        deviceName: String,
+        primaryKey: String,
+    ): Result<LoginResponse> {
+        // HKDF-derived hashed_password matching the `credentialHashedPassword` we POSTed in
+        // [buildThirdPartyUpgradePackage] — the upgrade-created ddg credential was registered with
+        // the v2 cross-platform algorithm (Encryption Algorithms TD: HKDF(MP, salt=user_id,
+        // info="Password", 32)), NOT v1's, using nativeLib.prepareForLogin(...) would 401
+        val hkdfSalt = userId.toByteArray(Charsets.UTF_8)
+        val hashedPassword = kotlin.runCatching {
+            syncJweCrypto.hkdfDeriveBase64Url(primaryKey, hkdfSalt, "Password", 32)
+        }.getOrElse { return Error(reason = "Upgrade ddg login: derive hashed_password failed: ${it.message}") }
+
+        val deviceType = syncDeviceIds.deviceType()
+        val encryptedDeviceName = kotlin.runCatching {
+            nativeLib.encryptData(deviceName, primaryKey).also {
+                it.checkResult("Upgrade ddg login: encrypt device name failed")
+            }.encryptedData
+        }.getOrElse { return it.asErrorResult() }
+        val encryptedDeviceType = kotlin.runCatching {
+            nativeLib.encryptData(deviceType.deviceFactor, primaryKey).also {
+                it.checkResult("Upgrade ddg login: encrypt device type failed")
+            }.encryptedData
+        }.getOrElse { return it.asErrorResult() }
+
+        return retryingOnTransientError {
+            syncApi.login(
+                userID = userId,
+                hashedPassword = hashedPassword,
+                deviceId = deviceId,
+                deviceName = encryptedDeviceName,
+                deviceType = encryptedDeviceType,
+                scope = null,
+            )
+        }
+    }
+
     private fun performLogin(
         userId: String,
         deviceId: String,
@@ -910,8 +1313,12 @@ class AppSyncAccountRepository @Inject constructor(
             }
 
             is Success -> {
+                // protectedEncryptionKey is required for ddg logins (it carries the protected secretKey).
+                // Absence here is not recoverable.
+                val protectedEncryptionKey = result.data.protected_encryption_key
+                    ?: return Error(reason = "Login: server returned no protected_encryption_key for ddg credential")
                 val decryptResult = kotlin.runCatching {
-                    nativeLib.decrypt(result.data.protected_encryption_key, preLogin.stretchedPrimaryKey).also {
+                    nativeLib.decrypt(protectedEncryptionKey, preLogin.stretchedPrimaryKey).also {
                         it.checkResult("Login: decrypt protection keys failed")
                     }
                 }.getOrElse { throwable ->
@@ -944,9 +1351,6 @@ class AppSyncAccountRepository @Inject constructor(
                     }
                     result.data.keys?.let { keys ->
                         logcat { "Sync-ScopedToken: ${keys.size} protected key(s) in response" }
-                        val ddgKeys = keys.filter { it.encryptedWith == CREDENTIAL_ID_DDG }
-                        val keysJson = Adapters.protectedKeysAdapter.toJson(ddgKeys)
-                        syncStore.protectedKeysJson = keysJson
                     }
                 }
 
@@ -1013,6 +1417,32 @@ class AppSyncAccountRepository @Inject constructor(
         return this
     }
 
+    private fun <T> retryingOnTransientError(block: () -> Result<T>): Result<T> {
+        var attempt = 0
+        while (true) {
+            val result = block()
+            val code = (result as? Error)?.code
+            if (code != null && isRetryableTransient(code) && attempt < MAX_UPGRADE_RETRIES) {
+                attempt++
+                logcat { "Sync-ScopedToken: upgrade call transient error (code=$code); retry $attempt/$MAX_UPGRADE_RETRIES" }
+                runCatching { Thread.sleep(upgradeRetryDelayMillis * attempt) }
+                continue
+            }
+            return result
+        }
+    }
+
+    private fun isRetryableTransient(code: Int): Boolean =
+        code == API_CODE.TOO_MANY_REQUESTS_1.code || // 429
+            code == API_CODE.TOO_MANY_REQUESTS_2.code || // 418
+            code in 500..599 || // server errors
+            code == AccountErrorCodes.GENERIC_ERROR.code // -1 == transport/IO exception in this context
+
+    companion object {
+        const val MAX_UPGRADE_RETRIES = 3
+        private const val DEFAULT_UPGRADE_RETRY_DELAY_MILLIS = 1_000L
+    }
+
     private class Adapters {
         companion object {
             private val moshi = Moshi.Builder().build()
@@ -1021,8 +1451,6 @@ class AppSyncAccountRepository @Inject constructor(
 
             val invitationCodeAdapter: JsonAdapter<InvitationCodeWrapper> = moshi.adapter(InvitationCodeWrapper::class.java)
             val invitedDeviceAdapter: JsonAdapter<InvitedDeviceDetails> = moshi.adapter(InvitedDeviceDetails::class.java)
-            val protectedKeysAdapter: JsonAdapter<List<ProtectedKeyEntry>> =
-                moshi.adapter(Types.newParameterizedType(List::class.java, ProtectedKeyEntry::class.java))
         }
     }
 }
@@ -1033,10 +1461,16 @@ class AppSyncAccountRepository @Inject constructor(
 internal const val CREDENTIAL_ID_DDG = "ddg"
 internal const val CREDENTIAL_ID_3PARTY = "3party"
 
+// Scope values for the /sync/login `scope` parameter. Absent / null means unrestricted (defaults
+// to "sync"). Per Sync API docs (POST /sync/login Notes), "ai_chats" is the canonical scope used
+// when authenticating against a 3party-restricted credential.
+internal const val SYNC_SCOPE_AI_CHATS = "ai_chats"
+
 // Recovery code version emitted in v2 recovery codes per the Recovery Payload Shape RFC
 // (Asana 1214804486778180). Format is "major.minor" — clients in major version 2 accept 2.x
 // codes (ignoring unknown fields) and must reject codes with major version >2.
 internal const val RECOVERY_CODE_V2 = "2.0"
+internal const val RECOVERY_CODE_MAJOR_V2 = "2"
 
 internal fun SyncCryptoResult.checkResult(errorMessage: String) {
     if (result != 0) {
@@ -1084,8 +1518,10 @@ data class ThirdPartyRecoveryCodeWrapper(
 )
 
 /**
- * 3party recovery code v2 payload per Asana 1214804486778180. Outer JSON is base64url-encoded
- * for transport; `secret` is base64url of the 32 raw SP bytes.
+ * v2 recovery code payload per Asana 1214804486778180, used for both `cid` values. Outer JSON is
+ * base64url-encoded for transport. The `secret` encoding depends on the credential: 3party uses
+ * base64url of the 32 raw SP bytes; ddg carries the v1 primary_key verbatim (standard base64).
+ * Serialized with Moshi (never org.json) so forward slashes in the secret are not escaped to `\/`.
  */
 data class ThirdPartyRecoveryCode(
     @field:Json(name = "user_id") val userId: String,
@@ -1129,6 +1565,13 @@ enum class AccountErrorCodes(val code: Int) {
     CONNECT_FAILED(54),
     INVALID_CODE(55),
     EXCHANGE_FAILED(56),
+    THIRD_PARTY_ALREADY_UPGRADED(57),
+    PAIRING_REJECTED(58),
+    PAIRING_UNAVAILABLE(59),
+    PAIRING_CANCELLED(60),
+    NEGOTIATION_ABORTED(61),
+    NO_RECOVERY_CODE(62),
+    PAIRING_FAILED(63),
 }
 
 sealed interface SyncAuthCode {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncCodeDispatcher.kt
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Routes a pasted/scanned sync code to either the v1 stack or the v2 exchange protocol, gated by
+ * [SyncFeature.canUseV2ConnectFlow]. With the flag off, [route] behaves identically to
+ * [SyncAccountRepository.parseSyncAuthCode]; v2 work is exposed via [RouteDecision.V2InProgress].
+ */
+interface SyncCodeDispatcher {
+
+    /**
+     * Inspects the pasted code and decides who handles it: [RouteDecision.Legacy] (caller processes
+     * the [SyncAuthCode] as today) or [RouteDecision.V2InProgress] (dispatcher owns the work; caller
+     * collects the returned Flow). See [DispatchOutcome] for the v2 emitted sequence.
+     */
+    fun route(pastedCode: String): RouteDecision
+
+    /**
+     * User confirmed the Joiner-side prompt ("Sync your data with …?"). Drives the SM out of
+     * Joiner.Confirming. No-op if no session is in that state.
+     */
+    fun confirmJoiner()
+
+    /**
+     * User denied the Joiner-side prompt. Drives the SM to Joiner.AbortedLocal. No message
+     * sent to peer (per spec). No-op if no session is in Joiner.Confirming.
+     */
+    fun denyJoiner()
+
+    /**
+     * User confirmed the Host-side prompt ("Allow … to join your sync & backup?"). Drives the
+     * SM out of Host.Confirming into Host.Sending. No-op if no session is in that state.
+     */
+    fun confirmHost()
+
+    /**
+     * User denied the Host-side prompt. Drives the SM to Host.Aborted and sends
+     * recovery_code_denied to the peer. No-op if no session is in Host.Confirming.
+     */
+    fun denyHost()
+
+    /**
+     * Starts a v2 Presenter session. The returned Flow emits exactly one
+     * [DispatchOutcome.LinkingCodeReady] (the URL to render as a QR), then the v2 emitted sequence
+     * (see [DispatchOutcome]). Role election runs in the runner, so the Presenter may be elected
+     * Host or Joiner. Cancelling the collecting coroutine cancels the underlying runner session.
+     */
+    fun presentV2(): Flow<DispatchOutcome>
+
+    /**
+     * Whether a v2 exchange has engaged a peer and is mid-protocol (past Bootstrapped, before a
+     * terminal).
+     */
+    fun isV2ExchangeUnderway(): Boolean
+}
+
+sealed interface RouteDecision {
+    /** Caller MUST process [authCode] as it would have today — no behaviour change from FF off. */
+    data class Legacy(val authCode: SyncAuthCode) : RouteDecision
+
+    /**
+     * Dispatcher owns the work. [codeType] is the kind of v2 code that was recognized.
+     * [outcomes] is a cold Flow that drives the v2 work when collected (see [DispatchOutcome] for the
+     * emitted sequence). Cancelling the collector cancels the work.
+     */
+    data class V2InProgress(
+        val codeType: SyncCodeType,
+        val outcomes: Flow<DispatchOutcome>,
+    ) : RouteDecision
+}
+
+enum class SyncCodeType { RECOVERY, LINKING }
+
+/**
+ * Outcomes emitted by a v2-owned dispatch, used by both [SyncCodeDispatcher.route] (Scanner) and
+ * [SyncCodeDispatcher.presentV2] (Presenter). Emitted sequence per side:
+ *
+ * Scanner (via [RouteDecision.V2InProgress.outcomes]): zero or one [JoinerConfirmationRequested] /
+ * [HostConfirmationRequested] (caller prompts and resumes via the confirm/deny calls), then exactly
+ * one terminal ([LoggedIn] / [UpgradeRequired] / [Failed]).
+ *
+ * Presenter: exactly one [LinkingCodeReady], then zero or one [JoinerConfirmationRequested] /
+ * [HostConfirmationRequested] (role is elected by the runner), then exactly one terminal
+ * ([LoggedIn] / [AlreadyConnected] / [Failed]).
+ *
+ * v2 RecoveryCode flows (cid=ddg, cid=3party) have no confirmation phase — only a terminal outcome.
+ *
+ * v2 does not surface a v1-style `AskToSwitchAccount` prompt; the spec's Confirmations phase is the
+ * consent step. On `ALREADY_SIGNED_IN` the dispatcher logs out and rejoins transparently, emitting
+ * [LoggedIn] (or [Failed] if the switch fails).
+ */
+sealed interface DispatchOutcome {
+    /**
+     * SM reached Joiner.Confirming. Caller must prompt the user ("Sync your data with [peerName]?")
+     * then call [SyncCodeDispatcher.confirmJoiner] or [SyncCodeDispatcher.denyJoiner] to resume.
+     */
+    data class JoinerConfirmationRequested(val peerName: String?, val peerKind: PeerKind? = null) : DispatchOutcome
+
+    /**
+     * SM reached Host.Confirming. Caller must prompt the user ("Allow [peerName] to join your
+     * sync & backup?") then call [SyncCodeDispatcher.confirmHost] or [SyncCodeDispatcher.denyHost].
+     */
+    data class HostConfirmationRequested(val peerName: String?, val peerKind: PeerKind? = null) : DispatchOutcome
+
+    /**
+     * Emitted once per [SyncCodeDispatcher.presentV2] session, before any confirmation or
+     * terminal outcome. [linkingCode] is the URL the caller renders as a QR for the peer
+     * to scan. Non-terminal — the Flow continues.
+     */
+    data class LinkingCodeReady(val linkingCode: String) : DispatchOutcome
+
+    /**
+     * Terminal — login completed (recovery code applied; account state updated). Carries telemetry
+     * for the "Setup success" pixel: [path] (recovery vs pairing) and, for a pairing, the elected
+     * [myRole] and the [peerKind]. [myRole]/[peerKind] are null for recovery.
+     */
+    data class LoggedIn(
+        val path: SetupPath,
+        val myRole: SetupRole? = null,
+        val peerKind: PeerKind? = null,
+    ) : DispatchOutcome
+
+    /**
+     * Terminal — peer and this device are already on the same account. Per spec §"Same-account
+     * case" this is not a failure: show a "Connected" confirmation. No account state change.
+     */
+    data object AlreadyConnected : DispatchOutcome
+
+    /**
+     * Terminal — the pasted code requires a protocol major version higher than this app supports.
+     * [path]/[myRole]/[peerKind] are best-effort telemetry for the "Setup failed" pixel (see [Failed]).
+     */
+    data class UpgradeRequired(
+        val codeMajor: Int,
+        val path: SetupPath? = null,
+        val myRole: SetupRole? = null,
+        val peerKind: PeerKind? = null,
+    ) : DispatchOutcome
+
+    /**
+     * Terminal — transport error, missing credentials on this device, BE rejection, denial, etc.
+     * [code] carries the originating [AccountErrorCodes] code (defaults to GENERIC_ERROR) so callers
+     * can map specific failures (e.g. THIRD_PARTY_ALREADY_UPGRADED) to user-facing copy.
+     * [path]/[myRole]/[peerKind] are best-effort telemetry for the "Setup failed" pixel: [path] is the
+     * flow kind, and [myRole]/[peerKind] are populated when known at the point of failure.
+     */
+    data class Failed(
+        val reason: String,
+        val code: Int = AccountErrorCodes.GENERIC_ERROR.code,
+        val path: SetupPath? = null,
+        val myRole: SetupRole? = null,
+        val peerKind: PeerKind? = null,
+    ) : DispatchOutcome
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncService.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncService.kt
@@ -28,6 +28,7 @@ import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.PATCH
 import retrofit2.http.POST
+import retrofit2.http.PUT
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -140,7 +141,7 @@ interface SyncService {
         @Header("Authorization") token: String,
         @Path("purpose") purpose: String,
         @Body request: SetProtectedKeyIfAbsentRequest,
-    ): Call<Void>
+    ): Call<ProtectedKeysResponse>
 
     @GET("$SYNC_PROD_ENVIRONMENT_URL/sync/access-credentials")
     fun getAccessCredentials(
@@ -152,6 +153,29 @@ interface SyncService {
         @Header("Authorization") token: String,
         @Path("id") credentialId: String,
         @Body request: CreateAccessCredentialRequest,
+    ): Call<Void>
+
+    @PUT("$SYNC_PROD_ENVIRONMENT_URL/sync/v2/exchange/{channelId}")
+    fun createExchangeChannel(
+        @Path("channelId") channelId: String,
+        @Body body: ExchangeChannelCreateRequest,
+    ): Call<Void>
+
+    @POST("$SYNC_PROD_ENVIRONMENT_URL/sync/v2/exchange/{channelId}/messages")
+    fun postExchangeMessages(
+        @Path("channelId") channelId: String,
+        @Body body: ExchangeMessagesRequest,
+    ): Call<Void>
+
+    @GET("$SYNC_PROD_ENVIRONMENT_URL/sync/v2/exchange/{channelId}/messages")
+    fun pollExchangeMessages(
+        @Path("channelId") channelId: String,
+        @Query("after") after: Int,
+    ): Call<ExchangeMessagesResponse>
+
+    @DELETE("$SYNC_PROD_ENVIRONMENT_URL/sync/v2/exchange/{channelId}")
+    fun deleteExchangeChannel(
+        @Path("channelId") channelId: String,
     ): Call<Void>
 
     companion object {
@@ -166,6 +190,7 @@ data class Login(
     @field:Json(name = "device_id") val deviceId: String,
     @field:Json(name = "device_name") val deviceName: String,
     @field:Json(name = "device_type") val deviceType: String,
+    @field:Json(name = "scope") val scope: String? = null,
 )
 
 data class Signup(
@@ -205,7 +230,9 @@ data class AccountCreatedResponse(
 // `devices` from this response either — the device list is sourced from GET /devices instead.
 data class LoginResponse(
     val token: String,
-    val protected_encryption_key: String,
+    // Absent when the matched access credential is 3party-restricted; populated for ddg/legacy
+    // credentials. Callers on the ddg path must null-check before use.
+    val protected_encryption_key: String? = null,
     val devices: List<Device>,
     @field:Json(name = "access_credentials") val accessCredentials: List<AccessCredentialEntry>? = null,
     val keys: List<ProtectedKeyEntry>? = null,
@@ -256,7 +283,7 @@ data class ProtectedKeysResponse(
 
 /** Body for POST /sync/keys/purpose/{purpose}/set-if-absent — adds a protected key only if no key exists for that purpose. */
 data class SetProtectedKeyIfAbsentRequest(
-    val key: ProtectedKeyEntry,
+    val keys: List<ProtectedKeyEntry>,
 )
 
 data class AccessCredentialsResponse(
@@ -296,6 +323,36 @@ data class ProtectedKeyEntry(
     @field:Json(name = "encrypted_with") val encryptedWith: String,
     @field:Json(name = "encrypted_private_key") val encryptedPrivateKey: String,
     @field:Json(name = "public_key") val publicKey: RsaJwk? = null,
+)
+
+/**
+ * Outer envelope sent on the v2 exchange relay. The [version] field is unencrypted and used
+ * for protocol version negotiation. [payload] is a JWE compact string (RSA-OAEP-256 +
+ * A256GCM) containing the actual message JSON. (Asana 1214486492252757).
+ */
+data class ExchangeEnvelope(
+    val version: String,
+    val payload: String,
+)
+
+/** Body for PUT /sync/v2/exchange/{channelId} — opens the channel. Empty per spec. */
+class ExchangeChannelCreateRequest
+
+/** Body for POST /sync/v2/exchange/{channelId}/messages — batch send. */
+data class ExchangeMessagesRequest(
+    val messages: List<ExchangeEnvelope>,
+)
+
+/** Response from GET /sync/v2/exchange/{channelId}/messages?after={seq}. */
+data class ExchangeMessagesResponse(
+    val messages: List<ExchangeMessageEntry>,
+)
+
+/** Server-assigned [seq] plus the envelope contents. */
+data class ExchangeMessageEntry(
+    val seq: Int,
+    val version: String,
+    val payload: String,
 )
 
 /** RSA-OAEP-256 public key in JWK format (RFC 7517) for sync protected key entries. */

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
@@ -47,6 +47,7 @@ interface SyncApi {
         deviceId: String,
         deviceName: String,
         deviceType: String,
+        scope: String? = null,
     ): Result<LoginResponse>
 
     fun logout(
@@ -119,7 +120,7 @@ interface SyncApi {
     fun getProtectedKeys(token: String): Result<List<ProtectedKeyEntry>>
 
     /** Atomically claim [purpose] with [key] or no-op if one already exists. */
-    fun setProtectedKeyIfAbsent(token: String, purpose: String, key: ProtectedKeyEntry): Result<Boolean>
+    fun setProtectedKeyIfAbsent(token: String, purpose: String, keys: List<ProtectedKeyEntry>): Result<List<ProtectedKeyEntry>>
 
     fun getAccessCredentials(token: String): Result<List<AccessCredentialEntry>>
 
@@ -128,6 +129,18 @@ interface SyncApi {
         credentialId: String,
         request: CreateAccessCredentialRequest,
     ): Result<Boolean>
+
+    /** Open a relay channel for the v2 pairing flow. Returns Error(code=409) on UUID collision. */
+    fun createExchangeChannel(channelId: String): Result<Unit>
+
+    /** Send a batch of encrypted envelopes to [channelId]. */
+    fun sendExchangeMessages(channelId: String, envelopes: List<ExchangeEnvelope>): Result<Unit>
+
+    /** Poll [channelId] for messages with seq > [after]. Returns Error(code=404) if channel is gone. */
+    fun pollExchangeMessages(channelId: String, after: Int): Result<List<ExchangeMessageEntry>>
+
+    /** Best-effort DELETE of our own channel — discards relay state. */
+    fun deleteExchangeChannel(channelId: String): Result<Unit>
 }
 
 @ContributesBinding(AppScope::class)
@@ -294,6 +307,7 @@ class SyncServiceRemote @Inject constructor(
         deviceId: String,
         deviceName: String,
         deviceType: String,
+        scope: String?,
     ): Result<LoginResponse> {
         val response = runCatching {
             val call = syncService.login(
@@ -303,6 +317,7 @@ class SyncServiceRemote @Inject constructor(
                     deviceId = deviceId,
                     deviceName = deviceName,
                     deviceType = deviceType,
+                    scope = scope,
                 ),
             )
             call.execute()
@@ -313,8 +328,9 @@ class SyncServiceRemote @Inject constructor(
         return onSuccess(response) {
             val body = response.body() ?: return@onSuccess Result.Error(reason = "Login: empty body")
             val token = body.token.takeUnless { it.isEmpty() } ?: return@onSuccess Result.Error(reason = "Login: empty token in Body")
-            val protectedEncryptionKey =
-                body.protected_encryption_key.takeUnless { it.isEmpty() } ?: return@onSuccess Result.Error(reason = "Login: empty PEK in Body")
+            // PEK is absent on 3party logins (server omits the field). Callers downstream are
+            // responsible for null-checking before use on the ddg path.
+            val protectedEncryptionKey = body.protected_encryption_key?.takeUnless { it.isEmpty() }
 
             Result.Success(
                 LoginResponse(
@@ -523,16 +539,17 @@ class SyncServiceRemote @Inject constructor(
         }
     }
 
-    override fun setProtectedKeyIfAbsent(token: String, purpose: String, key: ProtectedKeyEntry): Result<Boolean> {
+    override fun setProtectedKeyIfAbsent(token: String, purpose: String, keys: List<ProtectedKeyEntry>): Result<List<ProtectedKeyEntry>> {
         val response = runCatching {
-            val call = syncService.setProtectedKeyIfAbsent("Bearer $token", purpose, SetProtectedKeyIfAbsentRequest(key))
+            val call = syncService.setProtectedKeyIfAbsent("Bearer $token", purpose, SetProtectedKeyIfAbsentRequest(keys))
             call.execute()
         }.getOrElse { throwable ->
             return Result.Error(reason = throwable.message.toString())
         }
 
         return onSuccess(response) {
-            Result.Success(true)
+            val keys = response.body()?.keys ?: emptyList()
+            Result.Success(keys)
         }
     }
 
@@ -581,6 +598,37 @@ class SyncServiceRemote @Inject constructor(
         return onSuccess(response) {
             Result.Success(true)
         }
+    }
+
+    override fun createExchangeChannel(channelId: String): Result<Unit> {
+        val response = runCatching {
+            syncService.createExchangeChannel(channelId, ExchangeChannelCreateRequest()).execute()
+        }.getOrElse { throwable -> return Result.Error(reason = throwable.message.toString()) }
+        return onSuccess(response) { Result.Success(Unit) }
+    }
+
+    override fun sendExchangeMessages(channelId: String, envelopes: List<ExchangeEnvelope>): Result<Unit> {
+        val response = runCatching {
+            syncService.postExchangeMessages(channelId, ExchangeMessagesRequest(envelopes)).execute()
+        }.getOrElse { throwable -> return Result.Error(reason = throwable.message.toString()) }
+        return onSuccess(response) { Result.Success(Unit) }
+    }
+
+    override fun pollExchangeMessages(channelId: String, after: Int): Result<List<ExchangeMessageEntry>> {
+        val response = runCatching {
+            syncService.pollExchangeMessages(channelId, after).execute()
+        }.getOrElse { throwable -> return Result.Error(reason = throwable.message.toString()) }
+        return onSuccess(response) {
+            val messages = response.body()?.messages ?: emptyList()
+            Result.Success(messages)
+        }
+    }
+
+    override fun deleteExchangeChannel(channelId: String): Result<Unit> {
+        val response = runCatching {
+            syncService.deleteExchangeChannel(channelId).execute()
+        }.getOrElse { throwable -> return Result.Error(reason = throwable.message.toString()) }
+        return onSuccess(response) { Result.Success(Unit) }
     }
 
     private fun Result.Error.removeKeysIfInvalid() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ThirdPartyCredentialManager.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ThirdPartyCredentialManager.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.sync.impl
 
 import android.util.Base64
+import androidx.annotation.VisibleForTesting
 import androidx.annotation.WorkerThread
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.crypto.SyncLib
@@ -71,7 +72,12 @@ class RealThirdPartyCredentialManager @Inject constructor(
     private val syncJweCrypto: SyncJweCrypto,
     private val nativeLib: SyncLib,
     private val syncFeature: SyncFeature,
+    private val protectedKeyManager: ProtectedKeyManager,
 ) : ThirdPartyCredentialManager {
+
+    /** Base linear-backoff between rate-limit retries. Overridable in tests to keep them fast. */
+    @VisibleForTesting
+    internal var rateLimitRetryDelayMillis: Long = DEFAULT_RATE_LIMIT_RETRY_DELAY_MILLIS
 
     override fun create(): Result<Boolean> {
         val inputs = when (val r = validateCreatePreconditions()) {
@@ -218,12 +224,25 @@ class RealThirdPartyCredentialManager @Inject constructor(
         val accountSecretKey = syncStore.secretKey
             ?: return Error(reason = "CreateThirdPartyCredential: no account secret key for ddg-side decrypt")
 
-        val ddgKeys = when (val r = syncApi.getProtectedKeys(token)) {
+        var ddgKeys = when (val r = retryingOnRateLimit { syncApi.getProtectedKeys(token) }) {
             is Success -> r.data.filter { it.encryptedWith == CREDENTIAL_ID_DDG }
             is Error -> {
                 // Fail rather than create a credential without its protected keys.
-                logcat(ERROR) { "Sync-ScopedToken: getKeys failed, aborting 3party credential creation: ${r.reason}" }
-                return Error(reason = "CreateThirdPartyCredential: getKeys failed: ${r.reason}")
+                logcat(ERROR) { "Sync-ScopedToken: getKeys failed (code=${r.code}), aborting 3party credential creation: ${r.reason}" }
+                return Error(code = r.code, reason = "CreateThirdPartyCredential: getKeys failed (code=${r.code}): ${r.reason}")
+            }
+        }
+
+        // We ensure ai_chats (the scope's required purpose) exists, then re-wrap every
+        // ddg-wrapped key — preserving any other purposes already on the account.
+        if (ddgKeys.none { it.purpose == SYNC_SCOPE_AI_CHATS }) {
+            logcat { "Sync-ScopedToken: no ddg $SYNC_SCOPE_AI_CHATS key; generating before 3party extend" }
+            when (val gen = protectedKeyManager.create(SYNC_SCOPE_AI_CHATS)) {
+                is Success -> ddgKeys = ddgKeys + gen.data
+                is Error -> {
+                    logcat(ERROR) { "Sync-ScopedToken: failed to generate $SYNC_SCOPE_AI_CHATS protected key: ${gen.reason}" }
+                    return Error(code = gen.code, reason = "CreateThirdPartyCredential: generate $SYNC_SCOPE_AI_CHATS key failed: ${gen.reason}")
+                }
             }
         }
         logcat { "Sync-ScopedToken: ${ddgKeys.size} ddg key(s) to re-encrypt for 3party" }
@@ -373,5 +392,30 @@ class RealThirdPartyCredentialManager @Inject constructor(
 
     private val recoveryCodeAdapter by lazy {
         Moshi.Builder().build().adapter(ThirdPartyRecoveryCodeWrapper::class.java)
+    }
+
+    /**
+     * Retry an idempotent scoped-credential call on rate-limit.
+     * A bounded linear backoff recovers since the limit is per-window and the call is idempotent.
+     */
+    private fun <T> retryingOnRateLimit(block: () -> Result<T>): Result<T> {
+        var attempt = 0
+        while (true) {
+            val result = block()
+            val code = (result as? Error)?.code
+            val rateLimited = code == API_CODE.TOO_MANY_REQUESTS_1.code || code == API_CODE.TOO_MANY_REQUESTS_2.code
+            if (rateLimited && attempt < MAX_RATE_LIMIT_RETRIES) {
+                attempt++
+                logcat { "Sync-ScopedToken: rate-limited (code=$code); retry $attempt/$MAX_RATE_LIMIT_RETRIES" }
+                runCatching { Thread.sleep(rateLimitRetryDelayMillis * attempt) }
+                continue
+            }
+            return result
+        }
+    }
+
+    companion object {
+        const val MAX_RATE_LIMIT_RETRIES = 3
+        private const val DEFAULT_RATE_LIMIT_RETRY_DELAY_MILLIS = 1_000L
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Channel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Channel.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.ExchangeEnvelope
+import com.duckduckgo.sync.impl.Result
+import com.duckduckgo.sync.impl.SyncApi
+import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import logcat.LogPriority.ERROR
+import logcat.logcat
+import javax.inject.Inject
+
+/**
+ * Wraps the BE relay endpoints with envelope encryption/decryption + a polling Flow.
+ *
+ * Spec: Transport TD (Asana 1214486492252757) §BE Relay + §Polling for messages.
+ */
+interface ExchangeV2Channel {
+
+    /**
+     * Create [channelId] on the relay. Returns Success on 2xx. Returns Error with code=409 on
+     * UUID collision (caller should retry with a fresh UUID).
+     */
+    fun createChannel(channelId: String): Result<Unit>
+
+    /**
+     * Encrypt [messageJson] and send it to [peerChannelId]. Sender's kid is [ownChannelId].
+     */
+    fun sendMessage(
+        messageJson: String,
+        peerChannelId: String,
+        peerPublicKeyBase64: String,
+        ownChannelId: String,
+    ): Result<Unit>
+
+    /**
+     * Poll loop on [ownChannelId], emitting decrypted + parsed messages. See spec §Polling.
+     *  - Completes on a non-recoverable HTTP status; transient statuses keep polling.
+     *  - Throws [EnvelopeVersionTooNew] (too-new version) and [EnvelopeDecryptFailure]
+     *    (decrypt failure) as terminal; drops unknown message types (forward-compat).
+     */
+    fun poll(ownChannelId: String, ownPrivateKeyBase64: String): Flow<ExchangeV2Message>
+
+    /** Best-effort DELETE of our own channel. Used on user-cancel + terminal SM states. */
+    fun deleteChannel(channelId: String): Result<Unit>
+}
+
+@ContributesBinding(AppScope::class)
+class RealExchangeV2Channel @Inject constructor(
+    private val syncApi: SyncApi,
+    private val envelope: ExchangeV2Envelope,
+    private val messageParser: ExchangeV2MessageParser,
+) : ExchangeV2Channel {
+
+    override fun createChannel(channelId: String): Result<Unit> {
+        logcat { "Sync-ExchangeV2: PUT /sync/v2/exchange/$channelId" }
+        return syncApi.createExchangeChannel(channelId)
+    }
+
+    override fun sendMessage(
+        messageJson: String,
+        peerChannelId: String,
+        peerPublicKeyBase64: String,
+        ownChannelId: String,
+    ): Result<Unit> {
+        val sealed = runCatching {
+            envelope.seal(messageJson, peerPublicKeyBase64, ownChannelId)
+        }.getOrElse {
+            logcat(ERROR) { "Sync-ExchangeV2: seal failed: ${it.message}" }
+            return Result.Error(reason = "Failed to seal envelope: ${it.message}")
+        }
+        logcat { "Sync-ExchangeV2: POST /sync/v2/exchange/$peerChannelId/messages" }
+        return syncApi.sendExchangeMessages(peerChannelId, listOf(sealed))
+    }
+
+    override fun poll(ownChannelId: String, ownPrivateKeyBase64: String): Flow<ExchangeV2Message> = flow {
+        var cursor = 0
+        while (true) {
+            when (val outcome = syncApi.pollExchangeMessages(ownChannelId, cursor)) {
+                is Result.Success -> {
+                    for (entry in outcome.data) {
+                        val decoded = decode(entry, ownPrivateKeyBase64)
+                        cursor = entry.seq
+                        emit(decoded)
+                    }
+                }
+                is Result.Error -> {
+                    if (outcome.code in NON_RECOVERABLE_HTTP_CODES) {
+                        // Re-polling won't recover; stop.
+                        logcat { "Sync-ExchangeV2: ending poll on $ownChannelId — non-recoverable status ${outcome.code} (${outcome.reason})" }
+                        return@flow
+                    }
+                    logcat(ERROR) { "Sync-ExchangeV2: transient poll error ${outcome.code}: ${outcome.reason}, retrying" }
+                }
+            }
+            delay(POLL_INTERVAL_MS)
+        }
+    }
+
+    override fun deleteChannel(channelId: String): Result<Unit> {
+        logcat { "Sync-ExchangeV2: DELETE /sync/v2/exchange/$channelId (best effort)" }
+        return syncApi.deleteExchangeChannel(channelId)
+    }
+
+    private fun decode(entry: com.duckduckgo.sync.impl.ExchangeMessageEntry, ownPrivateKeyBase64: String): ExchangeV2Message {
+        val inner = runCatching {
+            envelope.open(ExchangeEnvelope(entry.version, entry.payload), ownPrivateKeyBase64)
+        }.getOrElse {
+            if (it is EnvelopeVersionTooNew) throw it
+            // Permanent: the same bytes fail the same way every poll, so surface as terminal.
+            logcat(ERROR) { "Sync-ExchangeV2: envelope open failed seq=${entry.seq}: ${it.message}" }
+            throw EnvelopeDecryptFailure(entry.seq, it)
+        }
+        return messageParser.parse(inner)
+    }
+
+    companion object {
+        private const val POLL_INTERVAL_MS: Long = 1_000L
+
+        // Statuses that won't recover by re-polling; transient ones (5xx / 429 / 418 / timeouts)
+        // are deliberately absent so they keep polling.
+        private val NON_RECOVERABLE_HTTP_CODES = setOf(
+            400, // Bad Request — malformed poll
+            401, // Unauthorized
+            403, // Forbidden
+            404, // Not Found — channel gone (the normal end when the peer/server closed it)
+            410, // Gone — channel permanently removed
+        )
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Envelope.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Envelope.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.ExchangeEnvelope
+import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+/**
+ * Wire-level envelope wrapping for relay messages. The outer object is `{version, payload}`
+ * with [version] unencrypted (used for protocol version negotiation) and [payload] a JWE
+ * compact string carrying the encrypted message JSON.
+ *
+ * Spec: Transport TD (Asana 1214486492252757) §Message Envelope + §Encryption.
+ *  - alg = RSA-OAEP-256 (wraps an ephemeral A256GCM key)
+ *  - enc = A256GCM
+ *  - kid = sender's channel_id
+ */
+interface ExchangeV2Envelope {
+
+    /**
+     * Build an outbound envelope encrypting [messageJson] to the recipient's [peerPublicKeyBase64].
+     * [senderChannelId] is written as the JWE `kid` header so the recipient knows the sender.
+     */
+    fun seal(messageJson: String, peerPublicKeyBase64: String, senderChannelId: String): ExchangeEnvelope
+
+    /**
+     * Decrypt an inbound envelope with our ephemeral private key, returning the inner message JSON.
+     *
+     * @throws EnvelopeVersionTooNew if the envelope's major version is higher than ours.
+     */
+    fun open(envelope: ExchangeEnvelope, ownPrivateKeyBase64: String): String
+}
+
+/** Thrown when an envelope requires a protocol version we don't support. */
+class EnvelopeVersionTooNew(val version: String) : RuntimeException(
+    "Envelope requires protocol v$version; we only support v$OUR_MAJOR",
+)
+
+/**
+ * Thrown when an envelope's payload can't be decrypted or parsed. Permanent (the same bytes
+ * fail identically on retry), so the runner treats it as terminal rather than retrying.
+ */
+class EnvelopeDecryptFailure(val seq: Int, cause: Throwable) : RuntimeException(
+    "Failed to decrypt envelope seq=$seq: ${cause.message}",
+    cause,
+)
+
+const val OUR_MAJOR: Int = 2
+const val OUR_VERSION_STRING: String = "2"
+
+@ContributesBinding(AppScope::class)
+class RealExchangeV2Envelope @Inject constructor(
+    private val jweCrypto: SyncJweCrypto,
+) : ExchangeV2Envelope {
+
+    override fun seal(messageJson: String, peerPublicKeyBase64: String, senderChannelId: String): ExchangeEnvelope {
+        val jwe = jweCrypto.jweEncryptRsaOaep(
+            plaintext = messageJson.toByteArray(Charsets.UTF_8),
+            recipientPublicKeyBase64 = peerPublicKeyBase64,
+            kid = senderChannelId,
+        )
+        return ExchangeEnvelope(version = OUR_VERSION_STRING, payload = jwe)
+    }
+
+    override fun open(envelope: ExchangeEnvelope, ownPrivateKeyBase64: String): String {
+        val major = parseMajor(envelope.version)
+        if (major > OUR_MAJOR) throw EnvelopeVersionTooNew(envelope.version)
+        if (major < OUR_MAJOR) throw IllegalArgumentException("Obsolete envelope version ${envelope.version}")
+        val decrypted = jweCrypto.jweDecryptRsaOaep(envelope.payload, ownPrivateKeyBase64)
+        return String(decrypted, Charsets.UTF_8)
+    }
+
+    private fun parseMajor(version: String): Int {
+        val majorPart = version.substringBefore('.')
+        return majorPart.toIntOrNull()
+            ?: throw IllegalArgumentException("Malformed envelope version: $version")
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Event.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Event.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+/**
+ * Observable events emitted by the v2 exchange runner. Downstream consumers
+ * subscribe to the runner's event flow and react.
+ */
+sealed interface ExchangeV2Event {
+    val timestampMs: Long
+
+    data class Transition(
+        override val timestampMs: Long,
+        val from: ExchangeV2State,
+        val to: ExchangeV2State,
+        val trigger: ExchangeV2Message?,
+        val localTrigger: LocalTrigger?,
+    ) : ExchangeV2Event
+
+    data class MessageSent(
+        override val timestampMs: Long,
+        val message: ExchangeV2Message,
+    ) : ExchangeV2Event
+
+    data class MessageRejected(
+        override val timestampMs: Long,
+        val message: ExchangeV2Message,
+        val state: ExchangeV2State,
+        val reason: RejectReason,
+    ) : ExchangeV2Event
+
+    /**
+     * Bootstrap completed: own channel created on the relay, ephemeral keypair generated.
+     * Presenter-side: [linkingCode] carries the URL to display as QR. Scanner-side: null.
+     */
+    data class SessionStarted(
+        override val timestampMs: Long,
+        val pairingRole: PairingRole,
+        val ownChannelId: String,
+        val linkingCode: String?,
+    ) : ExchangeV2Event
+
+    /** A transport or protocol-level failure during bootstrap / poll / send. */
+    data class SessionError(
+        override val timestampMs: Long,
+        val message: String,
+    ) : ExchangeV2Event
+}
+
+enum class RejectReason { ImplicitAbort, SameAccount, UnknownMessageDropped }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Message.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Message.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+/**
+ * Wire messages exchanged over the v2 /sync/v2/exchange/{channelId} channel.
+ *
+ * Spec: Asana 1215056232572322 (Exchange V2 Message Sequence State Machine).
+ * Each subtype carries its raw JSON for replay/inspection.
+ */
+sealed interface ExchangeV2Message {
+    val rawJson: String
+    val messageType: String
+
+    /**
+     * Sent by the Scanner to the Presenter's relay channel to open the session.
+     *
+     * @param channelId Scanner's own relay channel ID — the Presenter learns this here and uses
+     *  it as the address for replies.
+     * @param publicKey Scanner's session public key (base64url-encoded SPKI DER); used to
+     *  encrypt all subsequent messages addressed to the Scanner.
+     * @param version Sender's minimum protocol version (e.g. "2", "2.1").
+     */
+    data class Hello(
+        override val rawJson: String,
+        val channelId: String = "",
+        val publicKey: String = "",
+        val version: String = "2",
+    ) : ExchangeV2Message {
+        override val messageType: String = TYPE
+
+        companion object {
+            const val TYPE = "hello"
+        }
+    }
+
+    /**
+     * Sender has a sync account. Carries [userId] for same-account detection, [kind] (ddg
+     * or 3party) for cross-kind role election, and human-readable [name] for the user UI.
+     */
+    data class RecoveryCodeAvailable(
+        override val rawJson: String,
+        val userId: String,
+        val name: String,
+        val kind: String,
+    ) : ExchangeV2Message {
+        override val messageType: String = TYPE
+
+        companion object {
+            const val TYPE = "recovery_code_available"
+        }
+    }
+
+    /**
+     * Sender has no sync account. Carries [kind] and [name]; user_id is implied null.
+     */
+    data class RecoveryCodeRequest(
+        override val rawJson: String,
+        val name: String,
+        val kind: String,
+    ) : ExchangeV2Message {
+        override val messageType: String = TYPE
+
+        companion object {
+            const val TYPE = "recovery_code_request"
+        }
+    }
+
+    data class RecoveryCodeAwaitingConfirmation(
+        override val rawJson: String,
+    ) : ExchangeV2Message {
+        override val messageType: String = TYPE
+
+        companion object {
+            const val TYPE = "recovery_code_awaiting_confirmation"
+        }
+    }
+
+    data class RecoveryCodeConfirmed(
+        override val rawJson: String,
+    ) : ExchangeV2Message {
+        override val messageType: String = TYPE
+
+        companion object {
+            const val TYPE = "recovery_code_confirmed"
+        }
+    }
+
+    data class RecoveryCodeDenied(
+        override val rawJson: String,
+    ) : ExchangeV2Message {
+        override val messageType: String = TYPE
+
+        companion object {
+            const val TYPE = "recovery_code_denied"
+        }
+    }
+
+    data class RecoveryCodeUnavailable(
+        override val rawJson: String,
+    ) : ExchangeV2Message {
+        override val messageType: String = TYPE
+
+        companion object {
+            const val TYPE = "recovery_code_unavailable"
+        }
+    }
+
+    /**
+     * Sent by the Host carrying the actual recovery code. Terminal happy-path message.
+     *
+     * @param recoveryCode base64url-encoded recovery code payload.
+     */
+    data class RecoveryCodeResponse(
+        override val rawJson: String,
+        val recoveryCode: String = "",
+    ) : ExchangeV2Message {
+        override val messageType: String = TYPE
+
+        companion object {
+            const val TYPE = "recovery_code_response"
+        }
+    }
+
+    /**
+     * Forward-compatibility variant: a message whose type field doesn't match any known
+     * value. The SM drops these without changing state per the spec's forward-compat rule.
+     */
+    data class Unknown(
+        override val rawJson: String,
+        override val messageType: String,
+    ) : ExchangeV2Message
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2MessageParser.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2MessageParser.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import org.json.JSONObject
+import javax.inject.Inject
+
+interface ExchangeV2MessageParser {
+    fun parse(rawJson: String): ExchangeV2Message
+}
+
+@ContributesBinding(AppScope::class)
+class JsonExchangeV2MessageParser @Inject constructor() : ExchangeV2MessageParser {
+
+    override fun parse(rawJson: String): ExchangeV2Message {
+        val json = runCatching { JSONObject(rawJson) }.getOrNull()
+            ?: return ExchangeV2Message.Unknown(rawJson = rawJson, messageType = "")
+        return when (val type = json.optString(FIELD_TYPE, "")) {
+            ExchangeV2Message.Hello.TYPE -> ExchangeV2Message.Hello(
+                rawJson = rawJson,
+                channelId = json.optString(FIELD_CHANNEL_ID, ""),
+                publicKey = json.optString(FIELD_PUBLIC_KEY, ""),
+                version = json.optString(FIELD_VERSION, DEFAULT_VERSION),
+            )
+            // NOTE: a recovery_code_available semantically must carry a user_id (the sender has
+            // an account), but we currently accept a missing/blank one as userId="" rather than
+            // rejecting it — downstream this affects same-account detection and role election.
+            // Hardening (reject or drop as malformed) is tracked separately in Asana
+            // 1215414930715623; left lenient here for forward-compat.
+            ExchangeV2Message.RecoveryCodeAvailable.TYPE -> ExchangeV2Message.RecoveryCodeAvailable(
+                rawJson = rawJson,
+                userId = json.optString(FIELD_USER_ID, ""),
+                name = json.optString(FIELD_NAME, ""),
+                kind = json.optString(FIELD_KIND, ""),
+            )
+            ExchangeV2Message.RecoveryCodeRequest.TYPE -> ExchangeV2Message.RecoveryCodeRequest(
+                rawJson = rawJson,
+                name = json.optString(FIELD_NAME, ""),
+                kind = json.optString(FIELD_KIND, ""),
+            )
+            ExchangeV2Message.RecoveryCodeAwaitingConfirmation.TYPE -> ExchangeV2Message.RecoveryCodeAwaitingConfirmation(rawJson)
+            ExchangeV2Message.RecoveryCodeConfirmed.TYPE -> ExchangeV2Message.RecoveryCodeConfirmed(rawJson)
+            ExchangeV2Message.RecoveryCodeDenied.TYPE -> ExchangeV2Message.RecoveryCodeDenied(rawJson)
+            ExchangeV2Message.RecoveryCodeUnavailable.TYPE -> ExchangeV2Message.RecoveryCodeUnavailable(rawJson)
+            ExchangeV2Message.RecoveryCodeResponse.TYPE -> ExchangeV2Message.RecoveryCodeResponse(
+                rawJson = rawJson,
+                recoveryCode = json.optString(FIELD_RECOVERY_CODE, ""),
+            )
+            else -> ExchangeV2Message.Unknown(rawJson = rawJson, messageType = type)
+        }
+    }
+
+    companion object {
+        private const val FIELD_TYPE = "type"
+        private const val FIELD_USER_ID = "user_id"
+        private const val FIELD_NAME = "name"
+        private const val FIELD_KIND = "kind"
+        private const val FIELD_CHANNEL_ID = "channel_id"
+        private const val FIELD_PUBLIC_KEY = "public_key"
+        private const val FIELD_VERSION = "version"
+        private const val FIELD_RECOVERY_CODE = "recovery_code"
+        private const val DEFAULT_VERSION = "2"
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2QrCode.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2QrCode.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import android.util.Base64
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.moshi.Json
+import com.squareup.moshi.Moshi
+import org.json.JSONObject
+import javax.inject.Inject
+
+/**
+ * Generates and parses v2 linking codes (the QR/URL exchanged during pairing bootstrap).
+ *
+ * Wire format per Transport TD (Asana 1214486492252757):
+ *   https://duckduckgo.com/sync/pairing/#&code2=<base64(JSON)>
+ *   JSON = {"version":"2", "channel_id":"<UUID>", "public_key":"<base64url SPKI DER>"}
+ *
+ * The outer `code2` value is URL-safe + no-padding base64 (the fragment isn't safe for `+`/`/`/`=`).
+ */
+interface ExchangeV2QrCode {
+    fun buildLinkingCode(channelId: String, publicKeyBase64Url: String, version: String = "2"): String
+    fun parse(text: String): ExchangeV2CodeParseResult
+}
+
+sealed interface ExchangeV2CodeParseResult {
+    /** Successfully parsed v2 linking code — drives the Scanner-side flow. */
+    data class LinkingV2(
+        val channelId: String,
+        val publicKey: String,
+        val version: String,
+    ) : ExchangeV2CodeParseResult
+
+    /** v1 linking code (legacy <code=...>); fall back to v1 stack. */
+    data object LinkingV1 : ExchangeV2CodeParseResult
+
+    /** A recovery code — no URL prefix. Caller routes to recovery-handling path. */
+    data class RecoveryCode(val rawJson: JSONObject) : ExchangeV2CodeParseResult
+
+    /** Anything we couldn't interpret. */
+    data object Unknown : ExchangeV2CodeParseResult
+}
+
+@ContributesBinding(AppScope::class)
+class RealExchangeV2QrCode @Inject constructor() : ExchangeV2QrCode {
+
+    override fun buildLinkingCode(channelId: String, publicKeyBase64Url: String, version: String): String {
+        val payload = linkingCodeAdapter.toJson(
+            V2LinkingCodePayload(version = version, channelId = channelId, publicKey = publicKeyBase64Url),
+        )
+        val encoded = Base64.encodeToString(
+            payload.toByteArray(Charsets.UTF_8),
+            Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP,
+        )
+        return "$URL_PREFIX#&$PARAM_V2=$encoded"
+    }
+
+    private val linkingCodeAdapter by lazy {
+        Moshi.Builder().build().adapter(V2LinkingCodePayload::class.java)
+    }
+
+    override fun parse(text: String): ExchangeV2CodeParseResult {
+        val trimmed = text.trim()
+        val httpIndex = sequenceOf("https://", "http://").mapNotNull { trimmed.indexOf(it).takeIf { i -> i >= 0 } }.minOrNull()
+        val candidate = if (httpIndex != null) trimmed.substring(httpIndex) else trimmed
+        // No alphabet pre-check: the Base64.decode + JSONObject below already reject non-base64url/non-JSON as Unknown.
+        val b64url = extractFragmentParam(candidate) ?: candidate
+
+        val decoded = runCatching {
+            Base64.decode(b64url, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
+        }.getOrNull() ?: return ExchangeV2CodeParseResult.Unknown
+
+        val json = runCatching { JSONObject(String(decoded, Charsets.UTF_8)) }.getOrNull()
+            ?: return ExchangeV2CodeParseResult.Unknown
+
+        // Recovery code: {"recovery": { user_id, secret, ... }}
+        if (json.has("recovery")) {
+            val recovery = json.optJSONObject("recovery") ?: return ExchangeV2CodeParseResult.Unknown
+            if (recovery.has("user_id") && recovery.has("secret")) {
+                return ExchangeV2CodeParseResult.RecoveryCode(rawJson = recovery)
+            }
+        }
+
+        // Accept any same-major (2.x) version per Transport TD 1214486492252757 §Versioning.
+        val version = json.optString("version")
+        val channelId = json.optString("channel_id")
+        val publicKey = json.optString("public_key")
+        if (majorVersion(version) == 2 && channelId.isNotEmpty() && publicKey.isNotEmpty()) {
+            return ExchangeV2CodeParseResult.LinkingV2(
+                channelId = channelId,
+                publicKey = publicKey,
+                version = version,
+            )
+        }
+
+        // v1 linking code: {"connect": {"device_id": ..., "secret_key": ...}}
+        if (json.has("connect")) {
+            return ExchangeV2CodeParseResult.LinkingV1
+        }
+
+        return ExchangeV2CodeParseResult.Unknown
+    }
+
+    /**
+     * Pull the `code2` or `code` value from a URL fragment, or return null for non-URL input.
+     * Fragment may begin with `&` (v2 uses `#&code2=…`) or be bare (v1 uses `#code=…`).
+     */
+    private fun extractFragmentParam(text: String): String? {
+        if (!text.startsWith("http://") && !text.startsWith("https://")) return null
+        if ('#' !in text) return null
+        // A leading '&' (the v2 '#&code2=' form) yields an empty first split element that firstOrNull skips.
+        return text.substringAfter('#').split('&')
+            .firstOrNull { it.startsWith("$PARAM_V2=") || it.startsWith("$PARAM_V1=") }
+            ?.substringAfter('=')
+    }
+
+    /** Major component of a "major.minor" version string (e.g. "2.1" → 2), or null if unparseable. */
+    private fun majorVersion(version: String): Int? = version.substringBefore(".").toIntOrNull()
+
+    companion object {
+        private const val URL_PREFIX = "https://duckduckgo.com/sync/pairing/"
+        private const val PARAM_V2 = "code2"
+        private const val PARAM_V1 = "code"
+    }
+}
+
+/** v2 linking-code payload. Field order is irrelevant: the code is parse-only, never byte-compared. */
+internal data class V2LinkingCodePayload(
+    val version: String,
+    @field:Json(name = "channel_id") val channelId: String,
+    @field:Json(name = "public_key") val publicKey: String,
+)

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -1,0 +1,813 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.Result
+import com.duckduckgo.sync.impl.SyncDeviceIds
+import com.duckduckgo.sync.impl.crypto.RsaKeyPair
+import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.Host
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.Joiner
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.SameAccountAbort
+import com.duckduckgo.sync.store.SyncStore
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
+import logcat.LogPriority.ERROR
+import logcat.logcat
+import org.json.JSONObject
+import java.util.UUID
+import javax.inject.Inject
+
+/**
+ * Drives a single Exchange V2 protocol session.
+ *
+ * Two entry points: [startPresent] generates a v2 linking code (surfaced via [SessionStarted]);
+ * [startScan] parses a peer's code and joins their session. From there the runner manages the
+ * wire I/O, drives the SM, and auto-elects role per the Unified Algorithm.
+ */
+interface ExchangeV2Runner {
+    val events: SharedFlow<ExchangeV2Event>
+
+    /**
+     * Events emitted at or after [sinceMs]. Lets a consumer scope observation to one session,
+     * since [events] has a replay buffer that persists stale events across sessions.
+     */
+    fun eventsSince(sinceMs: Long): Flow<ExchangeV2Event> = events.filter { it.timestampMs >= sinceMs }
+
+    val currentState: ExchangeV2State?
+
+    val pairingRole: PairingRole?
+
+    /** Linking code URL for the Presenter side — populated after [startPresent] completes bootstrap. */
+    val linkingCode: String?
+
+    /**
+     * Whether this device can start as Presenter. Always true: per spec §"Exchange Share Recovery
+     * Code" a fresh device creates an account mid-flow. UI may read it to vary copy.
+     */
+    val canStartAsPresenter: Boolean
+
+    /** Peer device's human-readable name, learned from `recovery_code_available` / `recovery_code_request`. */
+    val peerName: String?
+
+    /** Peer device's credential kind ("ddg" / "3party"), learned during role election. Null before then. */
+    val peerKind: String?
+
+    fun startScan(pastedUrl: String)
+
+    fun startPresent()
+
+    /**
+     * Tear down the active session. Suspends until done, so callers can sequence work after it
+     * (e.g. sign-out, which invalidates the recovery code).
+     */
+    suspend fun cancel()
+
+    suspend fun deliverIncomingMessage(message: ExchangeV2Message)
+
+    suspend fun deliverIncomingMessageJson(rawJson: String)
+
+    fun localTrigger(trigger: LocalTrigger)
+
+    fun recordSentMessage(message: ExchangeV2Message)
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealExchangeV2Runner @Inject constructor(
+    private val smFactory: ExchangeV2StateMachineFactory,
+    private val messageParser: ExchangeV2MessageParser,
+    private val clock: ExchangeV2Clock,
+    private val syncStore: SyncStore,
+    private val jweCrypto: SyncJweCrypto,
+    private val channel: ExchangeV2Channel,
+    private val qrCode: ExchangeV2QrCode,
+    private val recoveryCodeProvider: RecoveryCodeProvider,
+    private val syncDeviceIds: SyncDeviceIds,
+    @AppCoroutineScope private val appScope: CoroutineScope,
+    private val dispatchers: DispatcherProvider,
+) : ExchangeV2Runner {
+
+    private val _events = MutableSharedFlow<ExchangeV2Event>(replay = REPLAY, extraBufferCapacity = REPLAY)
+    override val events: SharedFlow<ExchangeV2Event> = _events.asSharedFlow()
+
+    // Mutex serialises SM mutations + peer-state writes across the poll loop + user clicks.
+    private val mutex = Mutex()
+
+    @Volatile private var session: ExchangeV2StateMachine? = null
+
+    @Volatile private var _pairingRole: PairingRole? = null
+
+    @Volatile private var ownChannelId: String? = null
+
+    @Volatile private var ownKeyPair: RsaKeyPair? = null
+
+    @Volatile private var peerChannelId: String? = null
+
+    @Volatile private var peerPublicKey: String? = null
+
+    @Volatile private var _peerKind: String? = null
+
+    @Volatile private var peerUserId: String? = null
+
+    @Volatile private var _peerName: String? = null
+
+    @Volatile private var _linkingCode: String? = null
+
+    @Volatile private var pollJob: Job? = null
+
+    @Volatile private var timeoutJob: Job? = null
+
+    @Volatile private var sentOwnAvailability: Boolean = false
+
+    /**
+     * Host-side messages arriving while the Joiner is still at the user-confirm prompt, buffered
+     * and replayed on confirm (Joiner.Confirming → Joiner.Waiting) so the SM doesn't reject them
+     * as implicit aborts. Cleared on cancel, terminal, or user-deny.
+     */
+    private val pendingJoinerWaitingMessages = mutableListOf<ExchangeV2Message>()
+
+    override val currentState: ExchangeV2State? get() = session?.currentState
+    override val pairingRole: PairingRole? get() = _pairingRole
+    override val linkingCode: String? get() = _linkingCode
+    override val canStartAsPresenter: Boolean get() = true
+    override val peerName: String? get() = _peerName
+    override val peerKind: String? get() = _peerKind
+
+    // -----------------------------------------------------------------------
+    // Entry points
+    // -----------------------------------------------------------------------
+
+    override fun startScan(pastedUrl: String) {
+        appScope.launch(dispatchers.io()) {
+            logcat { "Sync-ExchangeV2: startScan (parsing pasted URL)" }
+            val parsed = qrCode.parse(pastedUrl)
+            if (parsed !is ExchangeV2CodeParseResult.LinkingV2) {
+                emitSessionError("Pasted code is not a v2 linking code: $parsed")
+                return@launch
+            }
+            mutex.withLock {
+                cancelLocked() // abandon any prior session
+                _pairingRole = PairingRole.Scanner
+                peerChannelId = parsed.channelId
+                peerPublicKey = parsed.publicKey
+                bootstrapLocked(PairingRole.Scanner) ?: run {
+                    cancelLocked() // bootstrap already emitted the error; just clear the half-set state
+                    return@launch
+                }
+                // Scanner already knows the peer; SM starts directly in Negotiating.
+                session = smFactory.create(
+                    localUserId = syncStore.userId,
+                    initialState = ExchangeV2State.Negotiating,
+                )
+            }
+            emitSessionStarted()
+            if (!sendHello()) {
+                // Couldn't reach the Presenter (their channel TTL'd out, or a stale/typo'd code) — abort.
+                failSession(
+                    "Pairing aborted — couldn't reach the Presenter. Their session may have expired (5-min TTL). " +
+                        "Ask them to Start as Presenter again.",
+                )
+                return@launch
+            }
+            sendOwnAvailability()
+            startPolling()
+            startSessionTimer()
+        }
+    }
+
+    override fun startPresent() {
+        appScope.launch(dispatchers.io()) {
+            logcat { "Sync-ExchangeV2: startPresent (signedIn=${syncStore.userId != null})" }
+            // No pre-flight account check: per spec §"Exchange Share Recovery Code" a Host without
+            // an account creates one mid-flow ([sendRecoveryCodeResponse] at Host.Sending).
+            mutex.withLock {
+                cancelLocked() // abandon any prior session
+                _pairingRole = PairingRole.Presenter
+                val keyPair = bootstrapLocked(PairingRole.Presenter) ?: run {
+                    cancelLocked() // bootstrap already emitted the error; just clear the half-set state
+                    return@launch
+                }
+                _linkingCode = qrCode.buildLinkingCode(
+                    channelId = ownChannelId!!,
+                    publicKeyBase64Url = keyPair.publicKeyBase64,
+                )
+                // Presenter waits to receive hello before transitioning out of Bootstrapped.
+                session = smFactory.create(
+                    localUserId = syncStore.userId,
+                    initialState = ExchangeV2State.Bootstrapped,
+                )
+            }
+            emitSessionStarted()
+            startPolling()
+            startSessionTimer()
+        }
+    }
+
+    /**
+     * Caller must hold [mutex]. Generates ephemeral keypair, allocates channel_id, and creates
+     * the relay channel (with 409 retry). Returns the new keypair on success, null on error
+     * (in which case an error event was already emitted).
+     */
+    private suspend fun bootstrapLocked(role: PairingRole): RsaKeyPair? {
+        val keyPair = jweCrypto.generateRsaKeyPair()
+        ownKeyPair = keyPair
+        repeat(MAX_CHANNEL_CREATE_RETRIES) { attempt ->
+            val candidate = UUID.randomUUID().toString()
+            when (val r = channel.createChannel(candidate)) {
+                is Result.Success -> {
+                    ownChannelId = candidate
+                    logcat { "Sync-ExchangeV2: bootstrap as $role channel_id=$candidate" }
+                    return keyPair
+                }
+                is Result.Error -> {
+                    if (r.code == HTTP_CONFLICT) {
+                        logcat { "Sync-ExchangeV2: channel_id $candidate already taken, retrying (${attempt + 1}/$MAX_CHANNEL_CREATE_RETRIES)" }
+                    } else {
+                        emitSessionError("Failed to create channel")
+                        return null
+                    }
+                }
+            }
+        }
+        emitSessionError("Could not allocate unique channel_id after $MAX_CHANNEL_CREATE_RETRIES attempts")
+        return null
+    }
+
+    override suspend fun cancel() {
+        // NonCancellable: teardown must finish even when the caller's coroutine is itself being
+        // cancelled (e.g. the dispatcher cancels this from a flow's onCompletion).
+        withContext(NonCancellable) { mutex.withLock { cancelLocked() } }
+    }
+
+    /** Emit one error, then tear down. No-ops if the session already ended, so a late timeout or
+     *  poll error can't surface a spurious error over a completed session. */
+    private suspend fun failSession(reason: String) {
+        withContext(NonCancellable) {
+            mutex.withLock {
+                if (session == null) return@withLock
+                emitSessionError(reason)
+                cancelLocked()
+            }
+        }
+    }
+
+    /** Caller MUST hold [mutex]. The single teardown path, so field resets can't drift between
+     *  call sites: stop the jobs, best-effort DELETE the channel, discard keys, clear all state. */
+    private fun cancelLocked() {
+        if (session != null || pollJob != null) {
+            logcat { "Sync-ExchangeV2: teardown (was in state ${session?.currentState})" }
+        }
+        pollJob?.cancel()
+        pollJob = null
+        timeoutJob?.cancel()
+        timeoutJob = null
+        val toDelete = ownChannelId
+        if (toDelete != null) {
+            // Best-effort DELETE.
+            appScope.launch(dispatchers.io()) {
+                runCatching { channel.deleteChannel(toDelete) }
+            }
+        }
+        session = null
+        _pairingRole = null
+        ownChannelId = null
+        ownKeyPair = null
+        peerChannelId = null
+        peerPublicKey = null
+        _peerKind = null
+        peerUserId = null
+        _peerName = null
+        _linkingCode = null
+        sentOwnAvailability = false
+        pendingJoinerWaitingMessages.clear()
+    }
+
+    // -----------------------------------------------------------------------
+    // Polling
+    // -----------------------------------------------------------------------
+
+    private fun startPolling() {
+        val ch = ownChannelId ?: return
+        val key = ownKeyPair ?: return
+        pollJob = appScope.launch(dispatchers.io()) {
+            try {
+                // collect suspends per message so envelopes are handled in poll() seq order. A
+                // message driving the SM terminal cancels this very poll job; that
+                // self-cancellation surfaces as the CancellationException caught below.
+                channel.poll(ch, key.privateKeyBase64).collect { incoming ->
+                    deliverIncomingMessage(incoming)
+                }
+            } catch (versionTooNew: EnvelopeVersionTooNew) {
+                failSession("Peer requires protocol v${versionTooNew.version}; please update this app")
+            } catch (decryptFailure: EnvelopeDecryptFailure) {
+                // Permanent — the cursor would just re-pull the same broken bytes forever.
+                failSession(
+                    "Couldn't decrypt a message from the peer (seq=${decryptFailure.seq}): " +
+                        "${decryptFailure.cause?.message}. The keys probably don't match — try restarting pairing.",
+                )
+            } catch (cancellation: CancellationException) {
+                throw cancellation // normal teardown (cancel() / scope cancellation) — let it propagate
+            } catch (t: Throwable) {
+                // Fail fast rather than dying silently and lingering until the 5-min timeout.
+                logcat(ERROR) { "Sync-ExchangeV2: poll loop failed: ${t.message}" }
+                failSession("Pairing failed: ${t.message}")
+            }
+        }
+    }
+
+    /**
+     * Client-side session deadline. Per Transport TD 1214486492252757 §Session Lifecycle, abort the
+     * session 5 minutes after the QR code is generated (a single fixed deadline, NOT reset by
+     * activity). Cancelled when the session ends (terminal state or [cancel]) — which subsumes the
+     * spec's per-event cancel conditions, since those all drive the SM to a terminal state.
+     */
+    private fun startSessionTimer() {
+        timeoutJob = appScope.launch(dispatchers.io()) {
+            delay(SESSION_TIMEOUT_MS)
+            logcat { "Sync-ExchangeV2: session deadline (${SESSION_TIMEOUT_MS}ms) reached" }
+            failSession("Session timed out")
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Inbound message handling + orchestration
+    // -----------------------------------------------------------------------
+
+    override suspend fun deliverIncomingMessage(message: ExchangeV2Message) {
+        // Suspends until processing completes so the poll loop processes messages in wire order;
+        // a fire-and-forget launch here would let a poll batch race to the SM out of sequence.
+        mutex.withLock { processIncomingLocked(message) }
+    }
+
+    private suspend fun processIncomingLocked(message: ExchangeV2Message) {
+        val sm = session ?: run {
+            logcat { "Sync-ExchangeV2: deliverIncomingMessage ${message.messageType} ignored — no active session" }
+            return
+        }
+
+        // Race guard: a Host with auto-approve enabled can finish sending its messages before
+        // the Joiner's user has tapped Confirm. Stash them and replay after the SM enters Waiting.
+        if (sm.currentState == ExchangeV2State.Joiner.Confirming && message.isJoinerWaitingPhase()) {
+            logcat { "Sync-ExchangeV2: buffering ${message.messageType} (Joiner still in Confirming; will replay after user confirms)" }
+            pendingJoinerWaitingMessages.add(message)
+            return
+        }
+
+        logcat { "Sync-ExchangeV2: deliverIncomingMessage ${message.messageType} in state ${sm.currentState}" }
+        val result = sm.receive(message)
+        emit(result.event)
+
+        recordPeerContext(message)
+        result.sideEffects.forEach { applySideEffectLocked(it) }
+
+        if (canAutoElectRole(sm, message, result)) {
+            autoElectRoleLocked(sm)
+        }
+        if (canSendOwnAvailability(sm)) {
+            sendOwnAvailability()
+        }
+
+        if (sm.currentState.isTerminal()) onTerminalReachedLocked(sm.currentState)
+    }
+
+    /**
+     * Execute one spec-defined [SideEffect] emitted by the state machine. Each effect maps
+     * directly to a wire-protocol action or to a composite runner workflow (e.g.
+     * [SideEffect.RequestRecoveryCodeShare] kicks off the fetch+send+advance dance).
+     */
+    private fun applySideEffectLocked(effect: SideEffect) {
+        when (effect) {
+            SideEffect.SendAwaitingConfirmation -> {
+                logcat { "Sync-ExchangeV2: side effect → SendAwaitingConfirmation" }
+                sendMessageJson("""{"type":"recovery_code_awaiting_confirmation"}""")
+            }
+            SideEffect.SendConfirmed -> {
+                logcat { "Sync-ExchangeV2: side effect → SendConfirmed" }
+                sendMessageJson("""{"type":"recovery_code_confirmed"}""")
+            }
+            SideEffect.SendDenied -> {
+                logcat { "Sync-ExchangeV2: side effect → SendDenied" }
+                sendMessageJson("""{"type":"recovery_code_denied"}""")
+            }
+            SideEffect.RequestRecoveryCodeShare -> {
+                logcat { "Sync-ExchangeV2: side effect → RequestRecoveryCodeShare" }
+                shareRecoveryCodeAndAdvanceLocked()
+            }
+        }
+    }
+
+    /**
+     * Composite of [SideEffect.RequestRecoveryCodeShare]: fetch + send the recovery code
+     * (or `recovery_code_unavailable` if it can't be produced), then advance the SM.
+     */
+    private fun shareRecoveryCodeAndAdvanceLocked() {
+        val responseOk = sendRecoveryCodeResponse()
+        appScope.launch(dispatchers.io()) {
+            mutex.withLock {
+                val s = session ?: return@withLock
+                if (s.currentState != ExchangeV2State.Host.Sending) return@withLock
+                val terminalTrigger = if (responseOk) LocalTrigger.HostSendComplete else LocalTrigger.HostUnavailable
+                val r = s.localTrigger(terminalTrigger)
+                emit(r.event)
+                r.sideEffects.forEach { applySideEffectLocked(it) }
+                if (s.currentState.isTerminal()) onTerminalReachedLocked(s.currentState)
+            }
+        }
+    }
+
+    /**
+     * Only the success-path messages get buffered when received during Joiner.Confirming:
+     * if the peer is telling us they're aborting (denied / unavailable), we let the SM act on
+     * that immediately rather than holding the prompt open over a dead session.
+     */
+    private fun ExchangeV2Message.isJoinerWaitingPhase(): Boolean = when (this) {
+        is ExchangeV2Message.RecoveryCodeAwaitingConfirmation,
+        is ExchangeV2Message.RecoveryCodeConfirmed,
+        is ExchangeV2Message.RecoveryCodeResponse,
+        -> true
+        else -> false
+    }
+
+    private fun recordPeerContext(message: ExchangeV2Message) {
+        when (message) {
+            is ExchangeV2Message.Hello -> {
+                peerChannelId = message.channelId
+                peerPublicKey = message.publicKey
+            }
+            is ExchangeV2Message.RecoveryCodeAvailable -> {
+                _peerKind = message.kind
+                peerUserId = message.userId
+                _peerName = message.name
+            }
+            is ExchangeV2Message.RecoveryCodeRequest -> {
+                _peerKind = message.kind
+                peerUserId = null
+                _peerName = message.name
+            }
+            else -> Unit
+        }
+    }
+
+    /**
+     * Can we auto-elect a role now? Requires an accepted transition, SM in Negotiating, and a
+     * peer availability message ([RecoveryCodeAvailable]/[RecoveryCodeRequest]) carrying peer kind/userId.
+     */
+    private fun canAutoElectRole(
+        sm: ExchangeV2StateMachine,
+        message: ExchangeV2Message,
+        receiveResult: TransitionResult,
+    ): Boolean {
+        if (receiveResult.outcome !is TransitionOutcome.Accepted) return false
+        if (sm.currentState != ExchangeV2State.Negotiating) return false
+        if (message !is ExchangeV2Message.RecoveryCodeAvailable &&
+            message !is ExchangeV2Message.RecoveryCodeRequest
+        ) {
+            return false
+        }
+        return true
+    }
+
+    /**
+     * Perform auto-election (preconditions via [canAutoElectRole]). Drives the SM via
+     * [LocalTrigger.RoleElected], emits the transition event, and runs its side effects.
+     */
+    private fun autoElectRoleLocked(sm: ExchangeV2StateMachine) {
+        val elected = electRole() ?: run {
+            logcat { "Sync-ExchangeV2: cannot auto-elect role yet (role=${_pairingRole}, peerKind=$_peerKind)" }
+            return
+        }
+        logcat {
+            "Sync-ExchangeV2: auto-electing $elected " +
+                "(own role=${_pairingRole}, own userId=${syncStore.userId}, peer kind=$_peerKind, peer userId=$peerUserId)"
+        }
+        val electResult = sm.localTrigger(LocalTrigger.RoleElected(elected))
+        emit(electResult.event)
+        electResult.sideEffects.forEach { applySideEffectLocked(it) }
+    }
+
+    /**
+     * True when we should send our own availability/request now: SM is in Negotiating, peer
+     * has been identified, and we haven't sent already.
+     */
+    private fun canSendOwnAvailability(sm: ExchangeV2StateMachine): Boolean {
+        if (sentOwnAvailability) return false
+        if (sm.currentState != ExchangeV2State.Negotiating) return false
+        if (peerChannelId == null || peerPublicKey == null) return false
+        return true
+    }
+
+    private fun electRole(): Role? {
+        val ownRole = _pairingRole ?: return null
+        val ownUserId = syncStore.userId
+        val pKind = _peerKind ?: return null
+        val pUserId = peerUserId
+        return when {
+            ownUserId != null && pUserId == null -> Role.Host
+            ownUserId == null && pUserId != null -> Role.Joiner
+            OWN_DEVICE_KIND == "ddg" && pKind == "3party" -> Role.Host
+            OWN_DEVICE_KIND == "3party" && pKind == "ddg" -> Role.Joiner
+            ownRole == PairingRole.Presenter -> Role.Host
+            else -> Role.Joiner
+        }
+    }
+
+    override suspend fun deliverIncomingMessageJson(rawJson: String) {
+        deliverIncomingMessage(messageParser.parse(rawJson))
+    }
+
+    // -----------------------------------------------------------------------
+    // Local triggers — drive SM + send outbound messages on Host transitions
+    // -----------------------------------------------------------------------
+
+    override fun localTrigger(trigger: LocalTrigger) {
+        appScope.launch(dispatchers.io()) {
+            mutex.withLock { processLocalTriggerLocked(trigger) }
+        }
+    }
+
+    private suspend fun processLocalTriggerLocked(trigger: LocalTrigger) {
+        val sm = session ?: run {
+            logcat { "Sync-ExchangeV2: localTrigger $trigger ignored — no active session" }
+            return
+        }
+        logcat { "Sync-ExchangeV2: localTrigger $trigger in state ${sm.currentState}" }
+        val priorState = sm.currentState
+        val result = sm.localTrigger(trigger)
+        emit(result.event)
+        result.sideEffects.forEach { applySideEffectLocked(it) }
+        if (priorState == ExchangeV2State.Joiner.Confirming) {
+            replayBufferedJoinerMessagesLocked(newState = sm.currentState)
+        }
+        if (sm.currentState.isTerminal()) onTerminalReachedLocked(sm.currentState)
+    }
+
+    /** On a terminal SM state, tear down via [cancelLocked]. Caller holds [mutex]. */
+    private fun onTerminalReachedLocked(terminal: ExchangeV2State) {
+        logcat { "Sync-ExchangeV2: session reached terminal state $terminal, tearing down" }
+        cancelLocked()
+    }
+
+    /**
+     * Caller must have come from [ExchangeV2State.Joiner.Confirming]. On confirm (→ Joiner.Waiting)
+     * replay buffered host-side messages; on any other exit discard them.
+     */
+    private suspend fun replayBufferedJoinerMessagesLocked(newState: ExchangeV2State) {
+        if (pendingJoinerWaitingMessages.isEmpty()) return
+        if (newState == ExchangeV2State.Joiner.Waiting) {
+            val buffered = pendingJoinerWaitingMessages.toList()
+            pendingJoinerWaitingMessages.clear()
+            logcat { "Sync-ExchangeV2: replaying ${buffered.size} buffered Joiner message(s) now that user confirmed" }
+            for (m in buffered) {
+                processIncomingLocked(m)
+                if (session == null) return // terminal reached, stop replay
+            }
+        } else {
+            logcat { "Sync-ExchangeV2: discarding ${pendingJoinerWaitingMessages.size} buffered Joiner message(s) (user denied)" }
+            pendingJoinerWaitingMessages.clear()
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Outbound message helpers
+    // -----------------------------------------------------------------------
+
+    /** Returns true if hello reached the relay; false signals a fatal abort to the caller. */
+    private fun sendHello(): Boolean {
+        val own = ownChannelId ?: return false
+        val peer = peerChannelId ?: return false
+        val peerKey = peerPublicKey ?: return false
+        val ourKey = ownKeyPair ?: return false
+        val json = JSONObject().apply {
+            put("type", "hello")
+            put("channel_id", own)
+            put("public_key", ourKey.publicKeyBase64)
+            put("version", OUR_VERSION_STRING)
+        }.toString()
+        return sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.Hello(json, own, ourKey.publicKeyBase64, OUR_VERSION_STRING))
+    }
+
+    private fun sendOwnAvailability() {
+        if (sentOwnAvailability) return
+        val own = ownChannelId ?: return
+        val peer = peerChannelId ?: return
+        val peerKey = peerPublicKey ?: return
+        val userId = syncStore.userId
+        val deviceName = syncDeviceIds.deviceName()
+        if (userId != null) {
+            val json = JSONObject().apply {
+                put("type", "recovery_code_available")
+                put("name", deviceName)
+                put("kind", OWN_DEVICE_KIND)
+                put("user_id", userId)
+            }.toString()
+            sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.RecoveryCodeAvailable(json, userId, deviceName, OWN_DEVICE_KIND))
+        } else {
+            val json = JSONObject().apply {
+                put("type", "recovery_code_request")
+                put("name", deviceName)
+                put("kind", OWN_DEVICE_KIND)
+            }.toString()
+            sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.RecoveryCodeRequest(json, deviceName, OWN_DEVICE_KIND))
+        }
+        sentOwnAvailability = true
+        // Re-elect in case the peer's availability arrived before we sent ours.
+        // REVIEW: likely unreachable under eager-send ordering — confirm against the ordering spec
+        // (Unified Algorithm 1214739740392701) and delete if dead.
+        val sm = session ?: return
+        if (sm.currentState == ExchangeV2State.Negotiating && _peerKind != null) {
+            autoElectRoleLocked(sm)
+        }
+    }
+
+    /**
+     * Send `recovery_code_response` carrying a real recovery code. Returns true on success;
+     * false if we couldn't produce a code (in which case we've already sent
+     * `recovery_code_unavailable` to the peer + emitted a SessionError event, and the SM
+     * should be driven to [ExchangeV2State.Host.Aborted] rather than Done).
+     */
+    private fun sendRecoveryCodeResponse(): Boolean {
+        val peer = peerChannelId ?: return false
+        val peerKey = peerPublicKey ?: return false
+        // Recovery code per peer kind. Per spec §"Exchange Share Recovery Code": create the host
+        // account if absent; extend it with a 3party credential when peer is 3party. Provisioning
+        // failure falls through to recovery_code_unavailable below.
+        // peerKind is set during role election; reaching Host.Sending without it means something
+        // upstream is broken — bail rather than silently assuming ddg.
+        val codeResult = when (_peerKind) {
+            "ddg" -> provisionForDdgPeer()
+            "3party" -> provisionForThirdPartyPeer()
+            null -> Result.Error(reason = "Host.Sending reached without a known peer kind")
+            else -> Result.Error(reason = "Unsupported peer kind '$_peerKind'")
+        }
+        return when (codeResult) {
+            is Result.Success -> {
+                val recoveryCode = codeResult.data
+                val json = JSONObject().apply {
+                    put("type", "recovery_code_response")
+                    put("recovery_code", recoveryCode)
+                }.toString()
+                // Propagate the send result
+                sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.RecoveryCodeResponse(json, recoveryCode))
+            }
+            is Result.Error -> {
+                logcat(ERROR) { "Sync-ExchangeV2: recovery code unavailable for peerKind=$_peerKind: ${codeResult.reason}" }
+                val json = """{"type":"recovery_code_unavailable"}"""
+                sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.RecoveryCodeUnavailable(json))
+                emitSessionError("Couldn't generate a recovery code: ${codeResult.reason}")
+                false
+            }
+        }
+    }
+
+    private fun provisionForDdgPeer(): Result<String> =
+        when (val provision = recoveryCodeProvider.createDdgAccountIfNeeded()) {
+            is Result.Success -> {
+                logcat { "Sync-ExchangeV2: ddg account ready, fetching ddg recovery code" }
+                recoveryCodeProvider.getDdgRecoveryCode()
+            }
+            is Result.Error -> {
+                logcat(ERROR) { "Sync-ExchangeV2: failed to provision ddg account: ${provision.reason}" }
+                Result.Error(reason = "Couldn't create a sync account: ${provision.reason}")
+            }
+        }
+
+    private fun provisionForThirdPartyPeer(): Result<String> {
+        when (val ddg = recoveryCodeProvider.createDdgAccountIfNeeded()) {
+            is Result.Success -> Unit
+            is Result.Error -> {
+                logcat(ERROR) { "Sync-ExchangeV2: failed to provision ddg account for 3party flow: ${ddg.reason}" }
+                return Result.Error(reason = "Couldn't create a sync account: ${ddg.reason}")
+            }
+        }
+        when (val extend = recoveryCodeProvider.createThirdPartyCredentialIfNeeded()) {
+            is Result.Success -> Unit
+            is Result.Error -> {
+                logcat(ERROR) { "Sync-ExchangeV2: failed to extend account with 3party credential: ${extend.reason}" }
+                return Result.Error(reason = "Couldn't extend account with 3party credential: ${extend.reason}")
+            }
+        }
+        logcat { "Sync-ExchangeV2: ddg account + 3party credential ready, fetching 3party recovery code" }
+        return recoveryCodeProvider.getThirdPartyRecoveryCode()
+    }
+
+    private fun sendMessageJson(json: String) {
+        val peer = peerChannelId ?: return
+        val peerKey = peerPublicKey ?: return
+        val parsed = messageParser.parse(json)
+        sendOnWireAndRecord(json, peer, peerKey, parsed)
+    }
+
+    /** Returns true on successful POST, false on transport error (caller decides if fatal). */
+    private fun sendOnWireAndRecord(
+        messageJson: String,
+        peerChannel: String,
+        peerKey: String,
+        outboundMessage: ExchangeV2Message,
+    ): Boolean {
+        val own = ownChannelId ?: return false
+        return when (val r = channel.sendMessage(messageJson, peerChannel, peerKey, own)) {
+            is Result.Success -> {
+                recordSentMessage(outboundMessage)
+                true
+            }
+            is Result.Error -> {
+                emitSessionError("Failed to send message to peer over channel")
+                false
+            }
+        }
+    }
+
+    override fun recordSentMessage(message: ExchangeV2Message) {
+        logcat { "Sync-ExchangeV2: recordSentMessage ${message.messageType}" }
+        emit(ExchangeV2Event.MessageSent(clock.nowMs(), message))
+    }
+
+    // -----------------------------------------------------------------------
+    // Event emission
+    // -----------------------------------------------------------------------
+
+    private fun emit(event: ExchangeV2Event) {
+        when (event) {
+            is ExchangeV2Event.Transition -> logcat {
+                "Sync-ExchangeV2: transition ${event.from} → ${event.to} " +
+                    "(trigger=${event.trigger?.messageType ?: event.localTrigger})"
+            }
+            is ExchangeV2Event.MessageRejected -> logcat {
+                "Sync-ExchangeV2: rejected ${event.message.messageType} in ${event.state} reason=${event.reason}"
+            }
+            is ExchangeV2Event.MessageSent -> Unit
+            is ExchangeV2Event.SessionStarted -> logcat {
+                val codeLine = event.linkingCode?.let { " linkingCode=$it" } ?: ""
+                "Sync-ExchangeV2: session started role=${event.pairingRole} channel_id=${event.ownChannelId}$codeLine"
+            }
+            is ExchangeV2Event.SessionError -> logcat(ERROR) { "Sync-ExchangeV2: session error: ${event.message}" }
+        }
+        _events.tryEmit(event)
+    }
+
+    private fun emitSessionStarted() {
+        val ch = ownChannelId ?: return
+        val role = _pairingRole ?: return
+        emit(ExchangeV2Event.SessionStarted(clock.nowMs(), role, ch, _linkingCode))
+    }
+
+    private fun emitSessionError(message: String) {
+        emit(ExchangeV2Event.SessionError(clock.nowMs(), message))
+    }
+
+    private fun ExchangeV2State.isTerminal(): Boolean = when (this) {
+        SameAccountAbort,
+        ExchangeV2State.Aborted,
+        Host.Aborted,
+        Host.Done,
+        Joiner.AbortedLocal,
+        Joiner.AbortedByHost,
+        Joiner.Done,
+        -> true
+        else -> false
+    }
+
+    companion object {
+        private const val REPLAY = 100
+
+        // Transport TD 1214486492252757 §Session Lifecycle: 5-minute client session deadline.
+        private const val SESSION_TIMEOUT_MS = 5 * 60 * 1000L
+
+        // Android is always a ddg-kind device.
+        private const val OWN_DEVICE_KIND = "ddg"
+        private const val MAX_CHANNEL_CREATE_RETRIES = 3
+        private const val HTTP_CONFLICT = 409
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2State.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2State.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+/**
+ * State machine nodes for the v2 exchange protocol.
+ *
+ * Spec: Asana 1215056232572322. The machine starts in [Bootstrapped], shares a
+ * negotiation phase with the peer, then forks into [Host] or [Joiner] after role election.
+ */
+sealed interface ExchangeV2State {
+    data object Bootstrapped : ExchangeV2State
+    data object Negotiating : ExchangeV2State
+
+    /**
+     * Detected during Negotiating that the peer reports the same `user_id` as us — both
+     * devices are already on the same account. Per spec §"Same-account case" this is **not
+     * an abort**: callers should surface a friendly "Connected" finish, not an error. The
+     * dispatcher maps this state to [com.duckduckgo.sync.impl.DispatchOutcome.AlreadyConnected].
+     * Name retained for historical continuity; treat semantically as a success terminal.
+     */
+    data object SameAccountAbort : ExchangeV2State
+
+    /**
+     * Negotiation aborted before role election — e.g. an unexpected or duplicate `hello`
+     * received while in [Negotiating] (a second hello, or the double-scan race). Terminal.
+     * Per Unified Algorithm 1214739740392701 §Handshake Note: "abort and close the channel".
+     */
+    data object Aborted : ExchangeV2State
+
+    sealed interface Host : ExchangeV2State {
+        data object Confirming : Host
+        data object Sending : Host
+        data object Aborted : Host
+        data object Done : Host
+    }
+
+    sealed interface Joiner : ExchangeV2State {
+        data object Confirming : Joiner
+        data object Waiting : Joiner
+        data object AbortedLocal : Joiner
+        data object AbortedByHost : Joiner
+        data object Done : Joiner
+    }
+}
+
+enum class Role {
+    Host,
+    Joiner,
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachine.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachine.kt
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Hello
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAvailable
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAwaitingConfirmation
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeConfirmed
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeDenied
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeRequest
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeUnavailable
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Unknown
+import javax.inject.Inject
+
+/**
+ * Pure validator for the Exchange V2 wire protocol. Stateful (it tracks [currentState] and the
+ * local account's user_id for same-account detection) but performs no side effects itself: every
+ * input returns a [TransitionResult] that the runner forwards to the event sink and whose declared
+ * [SideEffect]s the runner executes.
+ *
+ * Spec: Asana 1215056232572322 — Exchange V2 Message Sequence State Machine.
+ */
+interface ExchangeV2StateMachine {
+    val currentState: ExchangeV2State
+    fun receive(msg: ExchangeV2Message): TransitionResult
+    fun localTrigger(trigger: LocalTrigger): TransitionResult
+}
+
+class ExchangeV2StateMachineFactory @Inject constructor(
+    private val clock: ExchangeV2Clock,
+) {
+    /**
+     * Create a fresh state machine.
+     *
+     * @param localUserId own account user_id (or null when no account), used for same-account detection.
+     * @param initialState where to start. Presenter starts in [ExchangeV2State.Bootstrapped]
+     *  and transitions to [ExchangeV2State.Negotiating] on receiving a hello. Scanner has
+     *  already parsed the peer's code and is ready to negotiate; it starts in
+     *  [ExchangeV2State.Negotiating] directly. (See Transport TD Notes[2]: messages you send
+     *  do not return to your own inbox, so a Scanner can never "receive" its own hello.)
+     */
+    fun create(
+        localUserId: String?,
+        initialState: ExchangeV2State = ExchangeV2State.Bootstrapped,
+    ): ExchangeV2StateMachine =
+        RealExchangeV2StateMachine(localUserId = localUserId, clock = clock, initialState = initialState)
+}
+
+/** Indirection so tests can supply a fixed timestamp. */
+fun interface ExchangeV2Clock {
+    fun nowMs(): Long
+}
+
+internal class RealExchangeV2StateMachine(
+    private val localUserId: String?,
+    private val clock: ExchangeV2Clock,
+    initialState: ExchangeV2State = ExchangeV2State.Bootstrapped,
+) : ExchangeV2StateMachine {
+
+    override var currentState: ExchangeV2State = initialState
+        private set
+
+    override fun receive(msg: ExchangeV2Message): TransitionResult {
+        if (msg is Unknown) return drop(msg)
+        return when (val state = currentState) {
+            ExchangeV2State.Bootstrapped -> receiveInBootstrapped(state, msg)
+            ExchangeV2State.Negotiating -> receiveInNegotiating(state, msg)
+            ExchangeV2State.Joiner.Confirming -> receiveInJoinerConfirming(state, msg)
+            ExchangeV2State.Joiner.Waiting -> receiveInJoinerWaiting(state, msg)
+            // All other states: any known incoming message is an implicit abort.
+            else -> abort(state, msg, RejectReason.ImplicitAbort)
+        }
+    }
+
+    override fun localTrigger(trigger: LocalTrigger): TransitionResult {
+        return when (val state = currentState) {
+            ExchangeV2State.Negotiating -> localTriggerInNegotiating(state, trigger)
+            ExchangeV2State.Host.Confirming -> localTriggerInHostConfirming(state, trigger)
+            ExchangeV2State.Host.Sending -> localTriggerInHostSending(state, trigger)
+            ExchangeV2State.Joiner.Confirming -> localTriggerInJoinerConfirming(state, trigger)
+            else -> abortLocal(state, trigger)
+        }
+    }
+
+    private fun receiveInBootstrapped(state: ExchangeV2State, msg: ExchangeV2Message): TransitionResult {
+        return if (msg is Hello) accept(state, ExchangeV2State.Negotiating, msg) else abort(state, msg, RejectReason.ImplicitAbort)
+    }
+
+    private fun receiveInNegotiating(state: ExchangeV2State, msg: ExchangeV2Message): TransitionResult {
+        return when (msg) {
+            // By the time we are in Negotiating the peer hello is already established
+            // (Scanner: by scanning the QR; Presenter: consumed in receiveInBootstrapped).
+            // Any further hello is a duplicate or the double-scan race → abort and close the
+            // channel. Deliberate "record a pixel; abort (scope-cut)" (pixel deferred: Asana 1215473364991760).
+            is Hello -> abort(state, msg, RejectReason.ImplicitAbort, newState = ExchangeV2State.Aborted)
+            is RecoveryCodeAvailable -> {
+                if (localUserId != null && msg.userId == localUserId) {
+                    abort(state, msg, RejectReason.SameAccount, newState = ExchangeV2State.SameAccountAbort)
+                } else {
+                    // Role election lives in the runner: this device records the peer's
+                    // availability and stays in Negotiating until LocalTrigger.RoleElected fires.
+                    accept(state, ExchangeV2State.Negotiating, msg)
+                }
+            }
+            // Both availability messages keep us in Negotiating; the runner combines them
+            // with own account state, own/peer kind, scan order, and channel_id tiebreak
+            // before electing a role (see Asana Unified Algorithm 1214739740392701).
+            is RecoveryCodeRequest -> accept(state, ExchangeV2State.Negotiating, msg)
+            is RecoveryCodeAwaitingConfirmation,
+            is RecoveryCodeConfirmed,
+            is RecoveryCodeDenied,
+            is RecoveryCodeUnavailable,
+            is RecoveryCodeResponse,
+            -> abort(state, msg, RejectReason.ImplicitAbort)
+            is Unknown -> drop(msg)
+        }
+    }
+
+    /**
+     * The SM-spec diagram (1215056232572322) lists no valid *incoming wire message* in
+     * Joiner.Confirming — the only expected transitions out are the local UserConfirmedJoiner /
+     * UserDeniedJoiner — so per the implicit-abort rule every received message here would abort.
+     * We extend that: if the peer explicitly tells us they're aborting (recovery_code_denied /
+     * recovery_code_unavailable), we accept it and end the session instead of making the user
+     * confirm a doomed pairing first. The remaining host-side messages (awaiting_confirmation,
+     * confirmed, response) are still rejected here; the runner buffers them and replays after
+     * the user confirms.
+     */
+    private fun receiveInJoinerConfirming(state: ExchangeV2State, msg: ExchangeV2Message): TransitionResult {
+        return when (msg) {
+            is RecoveryCodeDenied -> accept(state, ExchangeV2State.Joiner.AbortedByHost, msg)
+            is RecoveryCodeUnavailable -> accept(state, ExchangeV2State.Joiner.AbortedByHost, msg)
+            else -> abort(state, msg, RejectReason.ImplicitAbort)
+        }
+    }
+
+    private fun receiveInJoinerWaiting(state: ExchangeV2State, msg: ExchangeV2Message): TransitionResult {
+        return when (msg) {
+            is RecoveryCodeAwaitingConfirmation -> accept(state, ExchangeV2State.Joiner.Waiting, msg)
+            is RecoveryCodeConfirmed -> accept(state, ExchangeV2State.Joiner.Waiting, msg)
+            is RecoveryCodeDenied -> accept(state, ExchangeV2State.Joiner.AbortedByHost, msg)
+            is RecoveryCodeUnavailable -> accept(state, ExchangeV2State.Joiner.AbortedByHost, msg)
+            is RecoveryCodeResponse -> accept(state, ExchangeV2State.Joiner.Done, msg)
+            is Hello,
+            is RecoveryCodeAvailable,
+            is RecoveryCodeRequest,
+            -> abort(state, msg, RejectReason.ImplicitAbort)
+            is Unknown -> drop(msg)
+        }
+    }
+
+    private fun localTriggerInNegotiating(state: ExchangeV2State, trigger: LocalTrigger): TransitionResult {
+        return when (trigger) {
+            is LocalTrigger.RoleElected -> when (trigger.role) {
+                // Spec "Exchange Confirmations → Host" step 1: send awaiting_confirmation
+                // on entry to Confirming, BEFORE the user prompt fires, so the peer can show
+                // its "confirm on the other device" UX in parallel.
+                Role.Host -> acceptLocal(
+                    state,
+                    ExchangeV2State.Host.Confirming,
+                    trigger,
+                    sideEffects = listOf(SideEffect.SendAwaitingConfirmation),
+                )
+                Role.Joiner -> acceptLocal(state, ExchangeV2State.Joiner.Confirming, trigger)
+            }
+            else -> abortLocal(state, trigger)
+        }
+    }
+
+    private fun localTriggerInHostConfirming(state: ExchangeV2State, trigger: LocalTrigger): TransitionResult {
+        return when (trigger) {
+            // Spec "Exchange Confirmations → Host" step 3 (confirm branch): send confirmed,
+            // then proceed to share the recovery code.
+            LocalTrigger.UserConfirmedHost -> acceptLocal(
+                state,
+                ExchangeV2State.Host.Sending,
+                trigger,
+                sideEffects = listOf(SideEffect.SendConfirmed, SideEffect.RequestRecoveryCodeShare),
+            )
+            // Spec "Exchange Confirmations → Host" step 3 (deny branch): send denied, abort.
+            LocalTrigger.UserDeniedHost -> acceptLocal(
+                state,
+                ExchangeV2State.Host.Aborted,
+                trigger,
+                sideEffects = listOf(SideEffect.SendDenied),
+            )
+            else -> abortLocal(state, trigger)
+        }
+    }
+
+    private fun localTriggerInHostSending(state: ExchangeV2State, trigger: LocalTrigger): TransitionResult {
+        return when (trigger) {
+            LocalTrigger.HostSendComplete -> acceptLocal(state, ExchangeV2State.Host.Done, trigger)
+            // Host couldn't produce a recovery code (no account, no 3party credential, etc.).
+            // Runner has already sent recovery_code_unavailable to peer; this just tears down.
+            LocalTrigger.HostUnavailable -> acceptLocal(state, ExchangeV2State.Host.Aborted, trigger)
+            else -> abortLocal(state, trigger)
+        }
+    }
+
+    private fun localTriggerInJoinerConfirming(state: ExchangeV2State, trigger: LocalTrigger): TransitionResult {
+        return when (trigger) {
+            LocalTrigger.UserConfirmedJoiner -> acceptLocal(state, ExchangeV2State.Joiner.Waiting, trigger)
+            LocalTrigger.UserDeniedJoiner -> acceptLocal(state, ExchangeV2State.Joiner.AbortedLocal, trigger)
+            else -> abortLocal(state, trigger)
+        }
+    }
+
+    private fun accept(
+        from: ExchangeV2State,
+        to: ExchangeV2State,
+        msg: ExchangeV2Message,
+    ): TransitionResult {
+        currentState = to
+        return TransitionResult(
+            newState = to,
+            event = ExchangeV2Event.Transition(clock.nowMs(), from, to, trigger = msg, localTrigger = null),
+            outcome = TransitionOutcome.Accepted,
+        )
+    }
+
+    private fun acceptLocal(
+        from: ExchangeV2State,
+        to: ExchangeV2State,
+        trigger: LocalTrigger,
+        sideEffects: List<SideEffect> = emptyList(),
+    ): TransitionResult {
+        currentState = to
+        return TransitionResult(
+            newState = to,
+            event = ExchangeV2Event.Transition(clock.nowMs(), from, to, trigger = null, localTrigger = trigger),
+            outcome = TransitionOutcome.Accepted,
+            sideEffects = sideEffects,
+        )
+    }
+
+    /**
+     * The SM rejected [msg] in state [from]. When [newState] == [from] the SM stays put (e.g.
+     * a duplicate `hello` in Negotiating) and the event is a [MessageRejected]; when [newState]
+     * differs the SM is actually transitioning into [newState] driven by [msg] (e.g. same-account
+     * detected, per Asana state-machine spec `1215056232572322`), and we emit a [Transition] so
+     * downstream consumers can react to the new terminal state.
+     */
+    private fun abort(
+        from: ExchangeV2State,
+        msg: ExchangeV2Message,
+        reason: RejectReason,
+        newState: ExchangeV2State = from,
+    ): TransitionResult {
+        currentState = newState
+        val event = if (newState == from) {
+            ExchangeV2Event.MessageRejected(clock.nowMs(), msg, from, reason)
+        } else {
+            ExchangeV2Event.Transition(
+                timestampMs = clock.nowMs(),
+                from = from,
+                to = newState,
+                trigger = msg,
+                localTrigger = null,
+            )
+        }
+        return TransitionResult(
+            newState = newState,
+            event = event,
+            outcome = TransitionOutcome.Aborted(reason),
+        )
+    }
+
+    private fun abortLocal(
+        from: ExchangeV2State,
+        trigger: LocalTrigger,
+    ): TransitionResult {
+        // Local triggers that are out-of-sequence are protocol misuse from the runner. We
+        // surface them as a synthetic rejection rather than crashing
+        return TransitionResult(
+            newState = from,
+            event = ExchangeV2Event.Transition(clock.nowMs(), from, from, trigger = null, localTrigger = trigger),
+            outcome = TransitionOutcome.Aborted(RejectReason.ImplicitAbort),
+        )
+    }
+
+    private fun drop(msg: ExchangeV2Message): TransitionResult {
+        return TransitionResult(
+            newState = currentState,
+            event = ExchangeV2Event.MessageRejected(clock.nowMs(), msg, currentState, RejectReason.UnknownMessageDropped),
+            outcome = TransitionOutcome.Dropped,
+        )
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/LocalTrigger.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/LocalTrigger.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+/**
+ * Side-effect-free transitions driven by something other than an inbound wire message
+ * (user input, role election by the runner, completion of an outbound send).
+ */
+sealed interface LocalTrigger {
+    data object UserConfirmedHost : LocalTrigger
+    data object UserDeniedHost : LocalTrigger
+    data object UserConfirmedJoiner : LocalTrigger
+    data object UserDeniedJoiner : LocalTrigger
+    data class RoleElected(val role: Role) : LocalTrigger
+
+    /**
+     * Host has finished delivering [ExchangeV2Message.RecoveryCodeResponse] (or one of its
+     * negative siblings) and is leaving the [ExchangeV2State.Host.Sending] state.
+     */
+    data object HostSendComplete : LocalTrigger
+
+    /**
+     * Host couldn't produce a recovery code for the peer (e.g. not signed in, or no 3party
+     * credential exists for a 3party peer). The runner has already sent
+     * [ExchangeV2Message.RecoveryCodeUnavailable] on the wire; this drives the SM to
+     * [ExchangeV2State.Host.Aborted] so the session terminates cleanly.
+     */
+    data object HostUnavailable : LocalTrigger
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/PairingRole.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/PairingRole.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+/**
+ * Whether this device displayed the QR code (Presenter) or scanned the peer's QR code
+ * (Scanner). One of the inputs to automatic role election in [ExchangeV2Runner].
+ *
+ * Spec: Unified Algorithm "Exchange Introduction v2 - host/joiner decision".
+ */
+enum class PairingRole { Presenter, Scanner }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/RecoveryCodeProvider.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/RecoveryCodeProvider.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.RECOVERY_CODE_V2
+import com.duckduckgo.sync.impl.Result
+import com.duckduckgo.sync.impl.SyncAccountRepository
+import com.duckduckgo.sync.impl.ThirdPartyRecoveryCode
+import com.duckduckgo.sync.impl.ThirdPartyRecoveryCodeWrapper
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.moshi.Moshi
+import org.json.JSONObject
+import java.util.Base64
+import javax.inject.Inject
+
+/**
+ * Indirection over [SyncAccountRepository] so [ExchangeV2Runner] can fetch the recovery code for
+ * a peer kind without depending on the wider repository surface. Returns the wire `rawCode` form,
+ * not the QR form (kept distinct so a future spec tweak is a one-line change).
+ */
+interface RecoveryCodeProvider {
+
+    /** Own DDG recovery code — used when peer is a `ddg` device joining our account. */
+    fun getDdgRecoveryCode(): Result<String>
+
+    /**
+     * Own 3party access credential's recovery code — used when peer is a `3party` device.
+     * Fails if the 3party credential doesn't exist yet; the runner then reports
+     * `recovery_code_unavailable` to the peer.
+     */
+    fun getThirdPartyRecoveryCode(): Result<String>
+
+    /**
+     * Spec: Unified Algorithm §"Exchange Share Recovery Code" — *"If host has no account yet,
+     * create it first."* No-op if already signed in; [Result.Error] if account creation fails.
+     */
+    fun createDdgAccountIfNeeded(): Result<Unit>
+
+    /**
+     * Spec: Unified Algorithm §"Exchange Share Recovery Code" — *"If this is ddg and peer is
+     * 3party, if needed, extend the account."* No-op if a 3party credential already exists locally
+     * ([SyncStore.scopedPassword] set); otherwise creates one. Failure surfaces as [Result.Error].
+     */
+    fun createThirdPartyCredentialIfNeeded(): Result<Unit>
+}
+
+@ContributesBinding(AppScope::class)
+class RealRecoveryCodeProvider @Inject constructor(
+    private val syncAccountRepository: SyncAccountRepository,
+    private val syncStore: com.duckduckgo.sync.store.SyncStore,
+) : RecoveryCodeProvider {
+
+    override fun createDdgAccountIfNeeded(): Result<Unit> {
+        if (syncStore.userId != null) return Result.Success(Unit)
+        return when (val r = syncAccountRepository.createAccount()) {
+            is Result.Success -> Result.Success(Unit)
+            is Result.Error -> r
+        }
+    }
+
+    override fun createThirdPartyCredentialIfNeeded(): Result<Unit> {
+        if (syncStore.scopedPassword != null) return Result.Success(Unit)
+        return when (val r = syncAccountRepository.createThirdPartyCredential()) {
+            is Result.Success -> Result.Success(Unit)
+            is Result.Error -> r
+        }
+    }
+
+    /**
+     * Account stores v1 shape (`{recovery:{primary_key, user_id}}`); the v2 wire requires v2.0
+     * shape (`{recovery:{user_id, secret, cid, v}}`). Convert before handing off to the runner.
+     */
+    override fun getDdgRecoveryCode(): Result<String> =
+        when (val r = syncAccountRepository.getRecoveryCode()) {
+            is Result.Success -> runCatching { toV2RecoveryCode(r.data.rawCode, cid = "ddg") }
+                .fold(
+                    onSuccess = { Result.Success(it) },
+                    onFailure = { Result.Error(reason = "Failed to convert ddg recovery code to v2.0: ${it.message}") },
+                )
+            is Result.Error -> r
+        }
+
+    /** Already emits v2.0 shape — no conversion. */
+    override fun getThirdPartyRecoveryCode(): Result<String> =
+        when (val r = syncAccountRepository.getThirdPartyRecoveryCode()) {
+            is Result.Success -> Result.Success(r.data.rawCode)
+            is Result.Error -> r
+        }
+
+    private fun toV2RecoveryCode(v1Base64: String, cid: String): String {
+        val decoded = decodePermissiveBase64(v1Base64)
+        val v1 = JSONObject(String(decoded, Charsets.UTF_8)).getJSONObject("recovery")
+        val userId = v1.getString("user_id")
+        // v2 wire `secret` is base64url per spec 1214802412121967; re-encode the standard-base64 primary_key.
+        val secret = Base64.getUrlEncoder().withoutPadding().encodeToString(decodePermissiveBase64(v1.getString("primary_key")))
+        val v2Json = recoveryCodeAdapter.toJson(
+            ThirdPartyRecoveryCodeWrapper(
+                recovery = ThirdPartyRecoveryCode(userId = userId, secret = secret, cid = cid, v = RECOVERY_CODE_V2),
+            ),
+        )
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(v2Json.toByteArray(Charsets.UTF_8))
+    }
+
+    private val recoveryCodeAdapter by lazy {
+        Moshi.Builder().build().adapter(ThirdPartyRecoveryCodeWrapper::class.java)
+    }
+
+    /** Accept either standard or URL-safe base64 (with or without padding). */
+    private fun decodePermissiveBase64(s: String): ByteArray {
+        return runCatching { Base64.getUrlDecoder().decode(s) }
+            .recoverCatching { Base64.getDecoder().decode(s) }
+            .getOrThrow()
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/SideEffect.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/SideEffect.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+/**
+ * Spec-defined protocol actions that accompany a state transition. The state machine attaches
+ * these to its [TransitionResult]; the runner executes them. Keeping side effects declared at
+ * the transition (rather than scattered across the runner's post-trigger hooks) means each
+ * spec rule lives in exactly one place and is easy to audit against the Unified Algorithm.
+ *
+ * Spec source: Asana Unified Algorithm 1214739740392701, §"Exchange Confirmations" and
+ * §"Exchange Share Recovery Code".
+ */
+sealed interface SideEffect {
+
+    data object SendAwaitingConfirmation : SideEffect
+    data object SendConfirmed : SideEffect
+    data object SendDenied : SideEffect
+    data object RequestRecoveryCodeShare : SideEffect
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/SystemExchangeV2Clock.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/SystemExchangeV2Clock.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+@ContributesBinding(AppScope::class)
+class SystemExchangeV2Clock @Inject constructor() : ExchangeV2Clock {
+    override fun nowMs(): Long = System.currentTimeMillis()
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/TransitionResult.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/TransitionResult.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+data class TransitionResult(
+    val newState: ExchangeV2State,
+    val event: ExchangeV2Event,
+    val outcome: TransitionOutcome,
+    /**
+     * Spec-defined protocol actions that accompany this transition. The runner is the
+     * executor — see [SideEffect] subtypes for the per-effect contract. Default empty for
+     * transitions with no side effects (most non-Host transitions).
+     */
+    val sideEffects: List<SideEffect> = emptyList(),
+)
+
+sealed interface TransitionOutcome {
+    object Accepted : TransitionOutcome
+    data class Aborted(val reason: RejectReason) : TransitionOutcome
+    object Dropped : TransitionOutcome
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixelParamRemovalPlugin.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixelParamRemovalPlugin.kt
@@ -57,6 +57,7 @@ class SyncPixelParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugi
             SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_SUCCESS.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_SETUP_ENDED_ABANDONED.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_SETUP_ENDED_SUCCESS.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_SETUP_ENDED_FAILED.pixelName to PixelParameter.removeAtb(),
 
             SyncPixelName.SYNC_AUTO_RESTORE_TOGGLE_SHOWN.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_AUTO_RESTORE_TOGGLE_OPTED_OUT.pixelName to PixelParameter.removeAtb(),

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -26,14 +26,32 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.api.engine.DeletableType
 import com.duckduckgo.sync.api.engine.SyncFeatureType
 import com.duckduckgo.sync.impl.API_CODE
+import com.duckduckgo.sync.impl.AccountErrorCodes
+import com.duckduckgo.sync.impl.DispatchOutcome
 import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.SyncCodeType
+import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_DAILY
 import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_DAILY_SUCCESS_RATE_PIXEL
 import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_OBJECT_LIMIT_EXCEEDED_DAILY
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.CONNECTED_DEVICES_WHEN_DELETING
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_FEATURE_PROMOTION_SOURCE
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_CODE_TYPE
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_CODE_VERSION
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_FLOW_VERSION
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_MY_KIND
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_MY_ROLE
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_PATH
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_PEER_KIND
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_REASON
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupFailureReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
 import com.duckduckgo.sync.impl.stats.SyncStatsRepository
 import com.duckduckgo.sync.store.SharedPrefsProvider
 import com.squareup.anvil.annotations.ContributesBinding
@@ -98,18 +116,80 @@ interface SyncPixels {
     fun fireUserSwitchedLoginError()
     fun fireTimeoutOnDeepLinkSetup()
     fun fireSyncBarcodeScreenShown(screenType: ScreenType)
-    fun fireSyncSetupFinishedSuccessfully(screenType: ScreenType)
-    fun fireSyncSetupAbandoned(screenType: ScreenType)
+    fun fireSyncSetupFinishedSuccessfully(
+        screenType: ScreenType,
+        path: SetupPath? = null,
+        myRole: SetupRole? = null,
+        peerKind: PeerKind? = null,
+    )
+    fun fireSyncSetupAbandoned(screenType: ScreenType, reason: CancellationReason? = null)
     fun fireSyncSetupManualCodeScreenShown(screenType: ScreenType)
-    fun fireSyncSetupCodePastedParseSuccess(screenType: ScreenType)
+    fun fireSyncSetupCodePastedParseSuccess(screenType: ScreenType, codeVersion: CodeVersion, codeType: SyncCodeType? = null)
     fun fireSyncSetupCodePastedParseFailure(screenType: ScreenType)
     fun fireSyncSetupCodeCopiedToClipboard(screenType: ScreenType)
     fun fireBarcodeScannerParseError(screenType: ScreenType)
-    fun fireBarcodeScannerParseSuccess(screenType: ScreenType)
+    fun fireBarcodeScannerParseSuccess(screenType: ScreenType, codeVersion: CodeVersion, codeType: SyncCodeType? = null)
+
+    /**
+     * "Setup failed" — a v2 setup that started (code recognized) then failed with an error (not a
+     * user cancellation). [path]/[myRole]/[peerKind] are best-effort and omitted when unknown.
+     */
+    fun fireSyncSetupFailed(
+        reason: SetupFailureReason,
+        path: SetupPath? = null,
+        myRole: SetupRole? = null,
+        peerKind: PeerKind? = null,
+    )
 
     enum class ScreenType(val value: String) {
         SYNC_CONNECT("connect"),
         SYNC_EXCHANGE("exchange"),
+    }
+
+    /** Protocol version of the code that was scanned/pasted, per the "Code recognized" telemetry. */
+    enum class CodeVersion(val value: String) {
+        V1("v1"),
+        V2("v2"),
+    }
+
+    /** Whether a successful setup was a recovery-code login or a device pairing. v2 only. */
+    enum class SetupPath(val value: String) {
+        RECOVERY("recovery"),
+        PAIRING("pairing"),
+    }
+
+    /** This device's elected role in a v2 pairing. */
+    enum class SetupRole(val value: String) {
+        HOST("host"),
+        JOINER("joiner"),
+    }
+
+    /** The peer device's credential kind in a v2 pairing. */
+    enum class PeerKind(val value: String) {
+        DDG("ddg"),
+        THIRD_PARTY("3party"),
+    }
+
+    /**
+     * Why a setup was cancelled, per the "Cancellation" telemetry. Based on the v2 protocol state at
+     * the moment of cancellation: [SCANNING_CANCELLED] before the exchange engages a peer,
+     * [CANCELLED_BEFORE_FINISHED] mid-exchange, [CONFIRMATION_DENIED] when this device denied the prompt.
+     */
+    enum class CancellationReason(val value: String) {
+        SCANNING_CANCELLED("scanning_cancelled"),
+        CONFIRMATION_DENIED("sync_confirmation_denied"),
+        CANCELLED_BEFORE_FINISHED("cancelled_before_finished"),
+    }
+
+    /** Why a v2 setup failed, per the "Setup failed" telemetry. Aligned with the error codes we handle. */
+    enum class SetupFailureReason(val value: String) {
+        NEEDS_UPGRADE("needs_upgrade"),
+        ALREADY_UPGRADED("already_upgraded"),
+        INVALID_CREDENTIALS("invalid_credentials"),
+        PAIRING_UNAVAILABLE("pairing_unavailable"),
+        PROTOCOL_ERROR("protocol_error"),
+        TRANSPORT_FAILURE("transport_failure"),
+        UNEXPECTED_FAILURE("unexpected_failure"),
     }
     fun fireSetupDeepLinkFlowStarted()
     fun fireSetupDeepLinkFlowSuccess()
@@ -145,10 +225,62 @@ class RealSyncPixels @Inject constructor(
     private val pixel: Pixel,
     private val statsRepository: SyncStatsRepository,
     private val sharedPrefsProvider: SharedPrefsProvider,
+    private val syncFeature: SyncFeature,
 ) : SyncPixels {
 
     private val preferences: SharedPreferences by lazy {
         sharedPrefsProvider.getSharedPrefs(SYNC_PIXELS_PREF_FILE)
+    }
+
+    /**
+     * Common metadata describing the setup flow this device is opening:
+     * - [SYNC_SETUP_FLOW_VERSION]: "v2" when the device is on the v2 connect/exchange stack
+     *   ([SyncFeature.canUseV2ConnectFlow]), "v1" otherwise. Independent of which code version is
+     *   actually displayed (that is gated separately by [SyncFeature.canShowV2ConnectCode]).
+     * - [SYNC_SETUP_MY_KIND]: always "ddg" — this is the native DuckDuckGo client.
+     */
+    private fun setupFlowMetadata(): Map<String, String> = mapOf(
+        SYNC_SETUP_FLOW_VERSION to if (syncFeature.canUseV2ConnectFlow().isEnabled()) FLOW_VERSION_V2 else FLOW_VERSION_V1,
+        SYNC_SETUP_MY_KIND to MY_KIND_DDG,
+    )
+
+    /**
+     * Params for the "Code recognized" pixels (scanner/manual-entry success): the screen [source],
+     * the recognized [codeVersion] (what was scanned/pasted), the common [setupFlowMetadata]
+     * (flow_version + my_kind), and — only when known — the [codeType]. The legacy/v1 path does not
+     * report a code type, so [codeType] is omitted there; the v2 path always supplies it.
+     */
+    private fun recognizedCodeParams(
+        screenType: ScreenType,
+        codeVersion: CodeVersion,
+        codeType: SyncCodeType?,
+    ): Map<String, String> = buildMap {
+        put(SYNC_SETUP_SCREEN_TYPE, screenType.value)
+        put(SYNC_SETUP_CODE_VERSION, codeVersion.value)
+        when (codeType) {
+            SyncCodeType.RECOVERY -> put(SYNC_SETUP_CODE_TYPE, CODE_TYPE_RECOVERY)
+            SyncCodeType.LINKING -> put(SYNC_SETUP_CODE_TYPE, CODE_TYPE_LINKING)
+            null -> {}
+        }
+        putAll(setupFlowMetadata())
+    }
+
+    /**
+     * Params for the "Setup success" pixel: the screen [source], the common [setupFlowMetadata]
+     * (flow_version + my_kind), and — v2 only — the [path] (recovery/pairing) plus, for pairing, the
+     * elected [myRole] and the [peerKind]. Each is omitted when null.
+     */
+    private fun setupSuccessParams(
+        screenType: ScreenType,
+        path: SetupPath?,
+        myRole: SetupRole?,
+        peerKind: PeerKind?,
+    ): Map<String, String> = buildMap {
+        put(SYNC_SETUP_SCREEN_TYPE, screenType.value)
+        if (path != null) put(SYNC_SETUP_PATH, path.value)
+        if (myRole != null) put(SYNC_SETUP_MY_ROLE, myRole.value)
+        if (peerKind != null) put(SYNC_SETUP_PEER_KIND, peerKind.value)
+        putAll(setupFlowMetadata())
     }
 
     override fun fireDailyPixel() {
@@ -378,32 +510,57 @@ class RealSyncPixels @Inject constructor(
     }
 
     override fun fireSyncBarcodeScreenShown(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value) + setupFlowMetadata()
         pixel.fire(SyncPixelName.SYNC_SETUP_BARCODE_SCREEN_SHOWN, parameters = params)
     }
 
-    override fun fireSyncSetupAbandoned(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+    override fun fireSyncSetupAbandoned(screenType: ScreenType, reason: CancellationReason?) {
+        val params = buildMap {
+            put(SYNC_SETUP_SCREEN_TYPE, screenType.value)
+            if (reason != null) put(SYNC_SETUP_REASON, reason.value)
+            putAll(setupFlowMetadata())
+        }
         pixel.fire(SyncPixelName.SYNC_SETUP_ENDED_ABANDONED, parameters = params)
     }
 
-    override fun fireSyncSetupFinishedSuccessfully(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+    override fun fireSyncSetupFinishedSuccessfully(
+        screenType: ScreenType,
+        path: SetupPath?,
+        myRole: SetupRole?,
+        peerKind: PeerKind?,
+    ) {
+        val params = setupSuccessParams(screenType, path, myRole, peerKind)
         pixel.fire(SyncPixelName.SYNC_SETUP_ENDED_SUCCESS, parameters = params)
     }
 
+    override fun fireSyncSetupFailed(
+        reason: SetupFailureReason,
+        path: SetupPath?,
+        myRole: SetupRole?,
+        peerKind: PeerKind?,
+    ) {
+        val params = buildMap {
+            put(SYNC_SETUP_REASON, reason.value)
+            if (path != null) put(SYNC_SETUP_PATH, path.value)
+            if (myRole != null) put(SYNC_SETUP_MY_ROLE, myRole.value)
+            if (peerKind != null) put(SYNC_SETUP_PEER_KIND, peerKind.value)
+            putAll(setupFlowMetadata())
+        }
+        pixel.fire(SyncPixelName.SYNC_SETUP_ENDED_FAILED, parameters = params)
+    }
+
     override fun fireSyncSetupManualCodeScreenShown(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value) + setupFlowMetadata()
         pixel.fire(SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTRY_SCREEN_SHOWN, parameters = params)
     }
 
-    override fun fireSyncSetupCodePastedParseSuccess(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+    override fun fireSyncSetupCodePastedParseSuccess(screenType: ScreenType, codeVersion: CodeVersion, codeType: SyncCodeType?) {
+        val params = recognizedCodeParams(screenType, codeVersion, codeType)
         pixel.fire(SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_SUCCESS, parameters = params)
     }
 
     override fun fireSyncSetupCodePastedParseFailure(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value) + setupFlowMetadata()
         pixel.fire(SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_FAILED, parameters = params)
     }
 
@@ -412,13 +569,13 @@ class RealSyncPixels @Inject constructor(
         pixel.fire(SyncPixelName.SYNC_SETUP_BARCODE_CODE_COPIED, parameters = params)
     }
 
-    override fun fireBarcodeScannerParseSuccess(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+    override fun fireBarcodeScannerParseSuccess(screenType: ScreenType, codeVersion: CodeVersion, codeType: SyncCodeType?) {
+        val params = recognizedCodeParams(screenType, codeVersion, codeType)
         pixel.fire(SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_SUCCESS, parameters = params)
     }
 
     override fun fireBarcodeScannerParseError(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value) + setupFlowMetadata()
         pixel.fire(SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_FAILED, parameters = params)
     }
 
@@ -506,6 +663,11 @@ class RealSyncPixels @Inject constructor(
 
     companion object {
         private const val SYNC_PIXELS_PREF_FILE = "com.duckduckgo.sync.pixels.v1"
+        private const val FLOW_VERSION_V1 = "v1"
+        private const val FLOW_VERSION_V2 = "v2"
+        private const val MY_KIND_DDG = "ddg"
+        private const val CODE_TYPE_RECOVERY = "recovery"
+        private const val CODE_TYPE_LINKING = "linking"
     }
 }
 
@@ -573,6 +735,7 @@ enum class SyncPixelName(override val pixelName: String) : Pixel.PixelName {
     SYNC_SETUP_MANUAL_CODE_ENTERED_FAILED("sync_setup_manual_code_entered_failed"),
     SYNC_SETUP_ENDED_ABANDONED("sync_setup_ended_abandoned"),
     SYNC_SETUP_ENDED_SUCCESS("sync_setup_ended_successful"),
+    SYNC_SETUP_ENDED_FAILED("sync_setup_ended_failed"),
     SYNC_USER_CONFIRMED_TO_TURN_OFF_SYNC("sync_disabled"),
     SYNC_USER_CONFIRMED_TO_TURN_OFF_SYNC_AND_DELETE("sync_disabledanddeleted"),
     SYNC_SETUP_PROMO_BOOKMARK_ADDED_DIALOG_SHOWN("sync_setup_promo_bookmark_added_dialog_shown"),
@@ -615,6 +778,14 @@ object SyncPixelParameters {
     const val SYNC_FEATURE_PROMOTION_SOURCE = "source"
     const val GET_OTHER_DEVICES_SCREEN_LAUNCH_SOURCE = "source"
     const val SYNC_SETUP_SCREEN_TYPE = "source"
+    const val SYNC_SETUP_FLOW_VERSION = "flow_version"
+    const val SYNC_SETUP_MY_KIND = "my_kind"
+    const val SYNC_SETUP_CODE_VERSION = "code_version"
+    const val SYNC_SETUP_CODE_TYPE = "code_type"
+    const val SYNC_SETUP_PATH = "path"
+    const val SYNC_SETUP_MY_ROLE = "my_role"
+    const val SYNC_SETUP_PEER_KIND = "peer_kind"
+    const val SYNC_SETUP_REASON = "reason"
     const val CONNECTED_DEVICES_WHEN_DELETING = "connected_devices"
 
     const val AUTO_RESTORE_SOURCE = "source"
@@ -642,5 +813,55 @@ object SyncPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
             SyncPixelName.SYNC_RESCOPE_TOKEN_FAILURE.pixelName to removeAtb(),
             SyncPixelName.SYNC_AI_CHAT_ACTIVE.pixelName to removeAtb(),
         )
+    }
+}
+
+/**
+ * Maps a v2 [com.duckduckgo.sync.impl.DispatchOutcome.Failed] error code to the "Setup failed"
+ * telemetry [SetupFailureReason], aligned with the error codes we already handle. Cancellation codes
+ * (`PAIRING_CANCELLED`, `PAIRING_REJECTED`) are excluded by the caller, so they fall to the catch-all.
+ */
+internal fun Int.toSetupFailureReason(): SetupFailureReason = when (this) {
+    AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED.code -> SetupFailureReason.ALREADY_UPGRADED
+    AccountErrorCodes.LOGIN_FAILED.code,
+    AccountErrorCodes.INVALID_CODE.code,
+    AccountErrorCodes.EXCHANGE_FAILED.code,
+    -> SetupFailureReason.INVALID_CREDENTIALS
+    AccountErrorCodes.PAIRING_UNAVAILABLE.code -> SetupFailureReason.PAIRING_UNAVAILABLE
+    AccountErrorCodes.NEGOTIATION_ABORTED.code,
+    AccountErrorCodes.NO_RECOVERY_CODE.code,
+    -> SetupFailureReason.PROTOCOL_ERROR
+    AccountErrorCodes.PAIRING_FAILED.code -> SetupFailureReason.TRANSPORT_FAILURE
+    else -> SetupFailureReason.UNEXPECTED_FAILURE
+}
+
+/**
+ * Fire the "Setup failed" pixel for a v2 error [outcome]. No-op for non-error outcomes. User
+ * cancellations (`PAIRING_CANCELLED`, `PAIRING_REJECTED`) are intentionally skipped — they are not
+ * setup errors (the latter pending the cancellation-telemetry follow-up).
+ */
+
+internal fun SyncPixels.fireSetupFailed(outcome: DispatchOutcome) {
+    when (outcome) {
+        is DispatchOutcome.UpgradeRequired ->
+            fireSyncSetupFailed(SetupFailureReason.NEEDS_UPGRADE, outcome.path, outcome.myRole, outcome.peerKind)
+        is DispatchOutcome.Failed -> {
+            if (outcome.code == AccountErrorCodes.PAIRING_CANCELLED.code || outcome.code == AccountErrorCodes.PAIRING_REJECTED.code) {
+                return
+            }
+            fireSyncSetupFailed(outcome.code.toSetupFailureReason(), outcome.path, outcome.myRole, outcome.peerKind)
+        }
+        else -> {}
+    }
+}
+
+/**
+ * Fire the "Cancellation" pixel (sync_setup_ended_abandoned) when a v2 outcome is this device's own
+ * confirmation denial ([AccountErrorCodes.PAIRING_CANCELLED]). Peer denials (`PAIRING_REJECTED`) are
+ * intentionally ignored — the peer reports its own cancel. No-op for any other outcome.
+ */
+internal fun SyncPixels.fireSetupCancelledIfDenied(outcome: DispatchOutcome, screenType: SyncPixels.ScreenType) {
+    if (outcome is DispatchOutcome.Failed && outcome.code == AccountErrorCodes.PAIRING_CANCELLED.code) {
+        fireSyncSetupAbandoned(screenType, CancellationReason.CONFIRMATION_DENIED)
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.databinding.ActivityEnterCodeBinding
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState.Idle
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState.Loading
@@ -113,6 +114,8 @@ class EnterCodeActivity : DuckDuckGoActivity() {
                 showError(command)
             }
 
+            is Command.ShowV2Error -> showV2PairingError(command.content) { viewModel.onErrorDialogDismissed() }
+
             is AskToSwitchAccount -> askUserToSwitchAccount(command)
             SwitchAccountSuccess -> {
                 val resultIntent = Intent()
@@ -120,7 +123,41 @@ class EnterCodeActivity : DuckDuckGoActivity() {
                 setResult(RESULT_OK, resultIntent)
                 finish()
             }
+            is Command.AskJoinerConfirmation -> askJoinerConfirmation(command.peerName, command.peerKind)
+            is Command.AskHostConfirmation -> askHostConfirmation(command.peerName, command.peerKind)
+            Command.FinishWithError -> {
+                setResult(RESULT_CANCELED)
+                finish()
+            }
         }
+    }
+
+    private fun askJoinerConfirmation(peerName: String?, peerKind: PeerKind?) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_joiner_confirmation_title)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
+            .setPositiveButton(R.string.sync_v2_joiner_confirmation_positive)
+            .setNegativeButton(R.string.sync_v2_joiner_confirmation_negative)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() { viewModel.onJoinerConfirmed() }
+                    override fun onNegativeButtonClicked() { viewModel.onJoinerDenied() }
+                },
+            ).show()
+    }
+
+    private fun askHostConfirmation(peerName: String?, peerKind: PeerKind?) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_host_confirmation_title)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
+            .setPositiveButton(R.string.sync_v2_host_confirmation_positive)
+            .setNegativeButton(R.string.sync_v2_host_confirmation_negative)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() { viewModel.onHostConfirmed() }
+                    override fun onNegativeButtonClicked() { viewModel.onHostDenied() }
+                },
+            ).show()
     }
 
     private fun showError(it: ShowError) {
@@ -130,8 +167,7 @@ class EnterCodeActivity : DuckDuckGoActivity() {
             .setPositiveButton(R.string.sync_dialog_error_ok)
             .addEventListener(
                 object : TextAlertDialogBuilder.EventListener() {
-                    override fun onPositiveButtonClicked() {
-                    }
+                    override fun onPositiveButtonClicked() { viewModel.onErrorDialogDismissed() }
                 },
             ).show()
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
@@ -27,20 +27,29 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.CONNECT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.CREATE_ACCOUNT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.INVALID_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED
 import com.duckduckgo.sync.impl.Clipboard
+import com.duckduckgo.sync.impl.DispatchOutcome
 import com.duckduckgo.sync.impl.ExchangeResult.AccountSwitchingRequired
 import com.duckduckgo.sync.impl.ExchangeResult.LoggedIn
 import com.duckduckgo.sync.impl.ExchangeResult.Pending
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.RouteDecision
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode
+import com.duckduckgo.sync.impl.SyncCodeDispatcher
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.onFailure
 import com.duckduckgo.sync.impl.onSuccess
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
+import com.duckduckgo.sync.impl.pixels.fireSetupFailed
 import com.duckduckgo.sync.impl.ui.EnterCodeActivity.Companion.Code
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.AskToSwitchAccount
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.LoginSuccess
@@ -52,8 +61,10 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import logcat.logcat
 import javax.inject.*
 
 @ContributesViewModel(ActivityScope::class)
@@ -63,6 +74,7 @@ class EnterCodeViewModel @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val syncFeature: SyncFeature,
     private val syncPixels: SyncPixels,
+    private val codeDispatcher: SyncCodeDispatcher,
 ) : ViewModel() {
 
     private val command = Channel<Command>(1, DROP_OLDEST)
@@ -89,6 +101,15 @@ class EnterCodeViewModel @Inject constructor(
         data class AskToSwitchAccount(val encodedStringCode: String) : Command()
         data class ShowError(@StringRes val message: Int, val reason: String = "") : Command()
         data object SwitchAccountSuccess : Command()
+
+        /** v2 §"Exchange Confirmations": prompt user "Sync your data with [peerName]?". */
+        data class AskJoinerConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
+
+        /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
+        data class AskHostConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
+
+        data object FinishWithError : Command()
+        internal data class ShowV2Error(val content: V2PairingErrorContent) : Command()
     }
 
     fun onPasteCodeClicked() {
@@ -103,22 +124,78 @@ class EnterCodeViewModel @Inject constructor(
         pastedCode: String,
     ) {
         val previousPrimaryKey = syncAccountRepository.getAccountInfo().primaryKey
-        val codeType = syncAccountRepository.parseSyncAuthCode(pastedCode).also { it.onCodePasted() }
-        when (val result = syncAccountRepository.processCode(codeType)) {
-            is Result.Success -> {
-                if (codeType is SyncAuthCode.Exchange) {
-                    pollForRecoveryKey(previousPrimaryKey = previousPrimaryKey, code = pastedCode)
-                } else {
-                    onLoginSuccess(previousPrimaryKey)
+        // FF off → Legacy (v1 path below); FF on → v2 codes surface as DispatchOutcome.
+        when (val decision = codeDispatcher.route(pastedCode)) {
+            is RouteDecision.Legacy -> {
+                logcat { "Sync-CodeDispatch: EnterCodeViewModel handling Legacy(${decision.authCode::class.simpleName})" }
+                val codeType = decision.authCode.also { it.onCodePasted() }
+                when (val result = syncAccountRepository.processCode(codeType)) {
+                    is Result.Success -> {
+                        if (codeType is SyncAuthCode.Exchange) {
+                            pollForRecoveryKey(previousPrimaryKey = previousPrimaryKey, code = pastedCode)
+                        } else {
+                            onLoginSuccess(previousPrimaryKey)
+                        }
+                    }
+                    is Result.Error -> {
+                        processError(result, pastedCode)
+                    }
                 }
             }
-            is Result.Error -> {
-                processError(result, pastedCode)
+            is RouteDecision.V2InProgress -> {
+                logcat { "Sync-CodeDispatch: EnterCodeViewModel observing V2InProgress" }
+                syncPixels.fireSyncSetupCodePastedParseSuccess(codeType.asScreenType(), CodeVersion.V2, decision.codeType)
+                decision.outcomes.collect { outcome -> handleV2Outcome(outcome, previousPrimaryKey) }
             }
         }
     }
 
-    private suspend fun onLoginSuccess(previousPrimaryKey: String) {
+    /** Map a v2 [DispatchOutcome] onto the same command/error hooks the v1 path uses. */
+    private suspend fun handleV2Outcome(
+        outcome: DispatchOutcome,
+        previousPrimaryKey: String,
+    ) {
+        syncPixels.fireSetupFailed(outcome)
+        when (outcome) {
+            is DispatchOutcome.LoggedIn -> onLoginSuccess(previousPrimaryKey, outcome.path, outcome.myRole, outcome.peerKind)
+            is DispatchOutcome.AlreadyConnected -> {
+                viewState.value = viewState.value.copy(authState = AuthState.Idle)
+                command.send(Command.ShowV2Error(v2AlreadyPairedError))
+            }
+            is DispatchOutcome.UpgradeRequired -> {
+                viewState.value = viewState.value.copy(authState = AuthState.Idle)
+                logcat { "Sync v2: upgrade required, peer needs protocol v${outcome.codeMajor}" }
+                command.send(Command.ShowV2Error(v2UpgradeRequiredError))
+            }
+            is DispatchOutcome.Failed -> {
+                viewState.value = viewState.value.copy(authState = AuthState.Idle)
+                command.send(Command.ShowV2Error(outcome.code.toV2PairingError()))
+            }
+            is DispatchOutcome.JoinerConfirmationRequested ->
+                command.send(Command.AskJoinerConfirmation(outcome.peerName, outcome.peerKind))
+            is DispatchOutcome.HostConfirmationRequested ->
+                command.send(Command.AskHostConfirmation(outcome.peerName, outcome.peerKind))
+            is DispatchOutcome.LinkingCodeReady -> {} // No-op; used only by presentV2() flow
+        }
+    }
+
+    fun onJoinerConfirmed() { codeDispatcher.confirmJoiner() }
+    fun onJoinerDenied() { codeDispatcher.denyJoiner() }
+    fun onHostConfirmed() { codeDispatcher.confirmHost() }
+    fun onHostDenied() { codeDispatcher.denyHost() }
+
+    fun onErrorDialogDismissed() {
+        viewModelScope.launch(dispatchers.io()) {
+            command.send(Command.FinishWithError)
+        }
+    }
+
+    private suspend fun onLoginSuccess(
+        previousPrimaryKey: String,
+        path: SetupPath? = null,
+        myRole: SetupRole? = null,
+        peerKind: PeerKind? = null,
+    ) {
         val postProcessCodePK = syncAccountRepository.getAccountInfo().primaryKey
         val userSwitchedAccount = previousPrimaryKey.isNotBlank() && previousPrimaryKey != postProcessCodePK
         val commandSuccess = if (userSwitchedAccount) {
@@ -127,6 +204,9 @@ class EnterCodeViewModel @Inject constructor(
         } else {
             LoginSuccess
         }
+        // Owns the "Setup success" pixel for codes entered here; the launching screen fires only its
+        // login pixel on the result, so this does not double-count.
+        syncPixels.fireSyncSetupFinishedSuccessfully(codeType.asScreenType(), path, myRole, peerKind)
         command.send(commandSuccess)
     }
 
@@ -178,6 +258,8 @@ class EnterCodeViewModel @Inject constructor(
                 CONNECT_FAILED.code -> R.string.sync_connect_generic_error
                 CREATE_ACCOUNT_FAILED.code -> R.string.sync_create_account_generic_error
                 INVALID_CODE.code -> R.string.sync_invalid_code_error
+                // 3party→ddg upgrade on an already-upgraded account; generic error for now. (follow-up: 1215295182909247)
+                THIRD_PARTY_ALREADY_UPGRADED.code -> R.string.sync_connect_generic_error
                 else -> null
             }?.let { message ->
                 viewState.value = viewState.value.copy(authState = AuthState.Idle)
@@ -235,7 +317,7 @@ class EnterCodeViewModel @Inject constructor(
     private fun SyncAuthCode.onCodePasted() {
         when (this) {
             is SyncAuthCode.Unknown -> syncPixels.fireSyncSetupCodePastedParseFailure(codeType.asScreenType())
-            else -> syncPixels.fireSyncSetupCodePastedParseSuccess(codeType.asScreenType())
+            else -> syncPixels.fireSyncSetupCodePastedParseSuccess(codeType.asScreenType(), CodeVersion.V1)
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectActivity.kt
@@ -37,8 +37,11 @@ import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.databinding.ActivityConnectSyncBinding
 import com.duckduckgo.sync.impl.databinding.ActivityConnectSyncNewBinding
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.ui.EnterCodeActivity.Companion.Code.CONNECT_CODE
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command
+import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.AskHostConfirmation
+import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.AskJoinerConfirmation
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.FinishWithError
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.LoginSuccess
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.ReadTextCode
@@ -129,6 +132,8 @@ class SyncConnectActivity : DuckDuckGoActivity() {
     private fun observeUiEvents() {
         viewModel
             .viewState(extractSource())
+            // Observe at CREATED, not STARTED: STARTED re-subscribes on every foreground, re-firing
+            // viewState.onStart and regenerating the pairing code. CREATED also avoids dropping terminal commands.
             .flowWithLifecycle(lifecycle, Lifecycle.State.CREATED)
             .onEach { render(it) }
             .launchIn(lifecycleScope)
@@ -165,6 +170,9 @@ class SyncConnectActivity : DuckDuckGoActivity() {
 
             is ShowMessage -> Snackbar.make(binding.root, it.messageId, Snackbar.LENGTH_SHORT).show()
             is ShowError -> showError(it)
+            is Command.ShowV2Error -> showV2PairingError(it.content) { viewModel.onErrorDialogDismissed() }
+            is AskJoinerConfirmation -> askJoinerConfirmation(it.peerName, it.peerKind)
+            is AskHostConfirmation -> askHostConfirmation(it.peerName, it.peerKind)
         }
     }
 
@@ -187,6 +195,34 @@ class SyncConnectActivity : DuckDuckGoActivity() {
                     override fun onPositiveButtonClicked() {
                         viewModel.onErrorDialogDismissed()
                     }
+                },
+            ).show()
+    }
+
+    private fun askJoinerConfirmation(peerName: String?, peerKind: PeerKind?) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_joiner_confirmation_title)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
+            .setPositiveButton(R.string.sync_v2_joiner_confirmation_positive)
+            .setNegativeButton(R.string.sync_v2_joiner_confirmation_negative)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() { viewModel.onJoinerConfirmed() }
+                    override fun onNegativeButtonClicked() { viewModel.onJoinerDenied() }
+                },
+            ).show()
+    }
+
+    private fun askHostConfirmation(peerName: String?, peerKind: PeerKind?) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_host_confirmation_title)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
+            .setPositiveButton(R.string.sync_v2_host_confirmation_positive)
+            .setNegativeButton(R.string.sync_v2_host_confirmation_negative)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() { viewModel.onHostConfirmed() }
+                    override fun onNegativeButtonClicked() { viewModel.onHostDenied() }
                 },
             ).show()
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.CREATE_ACCOUNT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.INVALID_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
 import com.duckduckgo.sync.impl.Clipboard
+import com.duckduckgo.sync.impl.DispatchOutcome
 import com.duckduckgo.sync.impl.ExchangeResult.AccountSwitchingRequired
 import com.duckduckgo.sync.impl.ExchangeResult.LoggedIn
 import com.duckduckgo.sync.impl.ExchangeResult.Pending
@@ -37,15 +38,23 @@ import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.R.dimen
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.impl.RouteDecision
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode
 import com.duckduckgo.sync.impl.SyncAuthCode.Exchange
 import com.duckduckgo.sync.impl.SyncAuthCode.Unknown
+import com.duckduckgo.sync.impl.SyncCodeDispatcher
+import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.getOrNull
 import com.duckduckgo.sync.impl.onFailure
 import com.duckduckgo.sync.impl.onSuccess
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_CONNECT
+import com.duckduckgo.sync.impl.pixels.fireSetupCancelledIfDenied
+import com.duckduckgo.sync.impl.pixels.fireSetupFailed
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.FinishWithError
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.LoginSuccess
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.ReadTextCode
@@ -70,9 +79,17 @@ class SyncConnectViewModel @Inject constructor(
     private val clipboard: Clipboard,
     private val syncPixels: SyncPixels,
     private val dispatchers: DispatcherProvider,
+    private val syncFeature: SyncFeature,
+    private val codeDispatcher: SyncCodeDispatcher,
 ) : ViewModel() {
     private val command = Channel<Command>(1, DROP_OLDEST)
     fun commands(): Flow<Command> = command.receiveAsFlow()
+
+    // Cached v2 linking code so onCopyCodeClicked can return it for the v2 path. Null on the v1 path.
+    private var v2LinkingCode: String? = null
+
+    // Start the session exactly once per ViewModel instance.
+    private var sessionStarted = false
 
     private val viewState = MutableStateFlow(ViewState())
     fun viewState(source: String?): Flow<ViewState> = viewState.onStart {
@@ -80,7 +97,19 @@ class SyncConnectViewModel @Inject constructor(
     }
 
     private fun pollConnectionKeys(source: String?) {
+        if (sessionStarted) return
+        sessionStarted = true
         viewModelScope.launch(dispatchers.io()) {
+            // Don't start a fresh v2 session for a user already signed in via EnterCode while this
+            // activity is mid-finish (onStart can re-fire before onLoginSuccess() finishes it).
+            if (syncAccountRepository.getAccountInfo().isSignedIn) {
+                logcat { "Sync: SyncConnect already signed in; skipping new session" }
+                return@launch
+            }
+            if (shouldUseV2()) {
+                startV2Present()
+                return@launch
+            }
             showQRCode()
             var polling = true
             while (polling) {
@@ -102,6 +131,47 @@ class SyncConnectViewModel @Inject constructor(
                     }
             }
         }
+    }
+
+    private fun shouldUseV2(): Boolean =
+        syncFeature.canUseV2ConnectFlow().isEnabled() &&
+            syncFeature.canShowV2ConnectCode().isEnabled()
+
+    /** Drive a v2 Presenter session via the dispatcher. Role election may elect this device Host or Joiner. */
+    private suspend fun startV2Present() {
+        codeDispatcher.presentV2().collect { handleV2Outcome(it) }
+    }
+
+    /** Map one v2 [DispatchOutcome] onto this VM's command pipeline. Shared by the Presenter and Scanner paths. */
+    private suspend fun handleV2Outcome(outcome: DispatchOutcome) {
+        syncPixels.fireSetupFailed(outcome)
+        syncPixels.fireSetupCancelledIfDenied(outcome, SYNC_CONNECT)
+        when (outcome) {
+            is DispatchOutcome.LinkingCodeReady -> renderV2QrCode(outcome.linkingCode)
+            is DispatchOutcome.HostConfirmationRequested -> command.send(Command.AskHostConfirmation(outcome.peerName, outcome.peerKind))
+            is DispatchOutcome.JoinerConfirmationRequested -> command.send(Command.AskJoinerConfirmation(outcome.peerName, outcome.peerKind))
+            is DispatchOutcome.LoggedIn -> {
+                syncPixels.fireLoginPixel()
+                syncPixels.fireSyncSetupFinishedSuccessfully(SYNC_CONNECT, outcome.path, outcome.myRole, outcome.peerKind)
+                command.send(LoginSuccess)
+            }
+            is DispatchOutcome.AlreadyConnected ->
+                command.send(Command.ShowV2Error(v2AlreadyPairedError))
+            is DispatchOutcome.UpgradeRequired -> {
+                logcat { "Sync v2: upgrade required, peer needs protocol v${outcome.codeMajor}" }
+                command.send(Command.ShowV2Error(v2UpgradeRequiredError))
+            }
+            is DispatchOutcome.Failed ->
+                command.send(Command.ShowV2Error(outcome.code.toV2PairingError()))
+        }
+    }
+
+    private suspend fun renderV2QrCode(linkingCode: String) {
+        v2LinkingCode = linkingCode
+        val bitmap = withContext(dispatchers.io()) {
+            qrEncoder.encodeAsBitmap(linkingCode, dimen.qrSizeSmall, dimen.qrSizeSmall)
+        }
+        viewState.emit(viewState.value.copy(qrCodeBitmap = bitmap))
     }
 
     private suspend fun pollForRecoveryKey() {
@@ -149,6 +219,13 @@ class SyncConnectViewModel @Inject constructor(
 
     fun onCopyCodeClicked() {
         viewModelScope.launch(dispatchers.io()) {
+            val v2Code = v2LinkingCode
+            if (v2Code != null) {
+                clipboard.copyToClipboard(v2Code)
+                command.send(ShowMessage(R.string.sync_code_copied_message))
+                syncPixels.fireSyncSetupCodeCopiedToClipboard(SYNC_CONNECT)
+                return@launch
+            }
             syncAccountRepository.getConnectQR().getOrNull()?.let { code ->
                 logcat { "Sync: code available for sharing manually: $code" }
                 clipboard.copyToClipboard(code.rawCode)
@@ -168,6 +245,14 @@ class SyncConnectViewModel @Inject constructor(
         data class ShowMessage(val messageId: Int) : Command()
         data object FinishWithError : Command()
         data class ShowError(@StringRes val message: Int, val reason: String = "") : Command()
+
+        /** v2 §"Exchange Confirmations": prompt user "Sync your data with [peerName]?". */
+        data class AskJoinerConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
+
+        /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
+        data class AskHostConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
+
+        internal data class ShowV2Error(val content: V2PairingErrorContent) : Command()
     }
 
     fun onReadTextCodeClicked() {
@@ -178,19 +263,29 @@ class SyncConnectViewModel @Inject constructor(
 
     fun onQRCodeScanned(qrCode: String) {
         viewModelScope.launch(dispatchers.io()) {
-            val codeType = syncAccountRepository.parseSyncAuthCode(qrCode).also { it.onCodeScanned() }
-            when (val result = syncAccountRepository.processCode(codeType)) {
-                is Error -> {
-                    processError(result)
-                }
+            // Route via SyncCodeDispatcher: FF off → Legacy (v1 path unchanged); FF on → v2 codes surface via DispatchOutcome.
+            when (val decision = codeDispatcher.route(qrCode)) {
+                is RouteDecision.Legacy -> {
+                    val codeType = decision.authCode.also { it.onCodeScanned() }
+                    when (val result = syncAccountRepository.processCode(codeType)) {
+                        is Error -> {
+                            processError(result)
+                        }
 
-                is Success -> {
-                    if (codeType is Exchange) {
-                        pollForRecoveryKey()
-                    } else {
-                        fireLoginPixels()
-                        command.send(LoginSuccess)
+                        is Success -> {
+                            if (codeType is Exchange) {
+                                pollForRecoveryKey()
+                            } else {
+                                fireLoginPixels()
+                                command.send(LoginSuccess)
+                            }
+                        }
                     }
+                }
+                is RouteDecision.V2InProgress -> {
+                    logcat { "Sync-CodeDispatch: SyncConnectViewModel observing V2InProgress" }
+                    syncPixels.fireBarcodeScannerParseSuccess(SYNC_CONNECT, CodeVersion.V2, decision.codeType)
+                    decision.outcomes.collect { handleV2Outcome(it) }
                 }
             }
         }
@@ -201,7 +296,12 @@ class SyncConnectViewModel @Inject constructor(
     }
 
     fun onUserCancelledWithoutSyncSetup() {
-        syncPixels.fireSyncSetupAbandoned(SYNC_CONNECT)
+        val reason = if (codeDispatcher.isV2ExchangeUnderway()) {
+            CancellationReason.CANCELLED_BEFORE_FINISHED
+        } else {
+            CancellationReason.SCANNING_CANCELLED
+        }
+        syncPixels.fireSyncSetupAbandoned(SYNC_CONNECT, reason)
     }
 
     private suspend fun processError(result: Error) {
@@ -219,10 +319,17 @@ class SyncConnectViewModel @Inject constructor(
 
     fun onLoginSuccess() {
         viewModelScope.launch {
-            fireLoginPixels()
+            // Manual code entry: EnterCodeViewModel fires the "Setup success" pixel (it has the v2
+            // path/role/peer); here we only fire the login pixel to avoid double-counting.
+            syncPixels.fireLoginPixel()
             command.send(LoginSuccess)
         }
     }
+
+    fun onJoinerConfirmed() { codeDispatcher.confirmJoiner() }
+    fun onJoinerDenied() { codeDispatcher.denyJoiner() }
+    fun onHostConfirmed() { codeDispatcher.confirmHost() }
+    fun onHostDenied() { codeDispatcher.denyHost() }
 
     private fun fireLoginPixels() {
         syncPixels.fireLoginPixel()
@@ -232,7 +339,7 @@ class SyncConnectViewModel @Inject constructor(
     private fun SyncAuthCode.onCodeScanned() {
         when (this) {
             is Unknown -> syncPixels.fireBarcodeScannerParseError(SYNC_CONNECT)
-            else -> syncPixels.fireBarcodeScannerParseSuccess(SYNC_CONNECT)
+            else -> syncPixels.fireBarcodeScannerParseSuccess(SYNC_CONNECT, CodeVersion.V1)
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginActivity.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.databinding.ActivityLoginSyncBinding
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.ui.EnterCodeActivity.Companion.Code.RECOVERY_CODE
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command.Error
@@ -95,7 +96,38 @@ class SyncLoginActivity : DuckDuckGoActivity() {
             }
 
             is ShowError -> showError(it)
+            is Command.ShowV2Error -> showV2PairingError(it.content) { viewModel.onErrorDialogDismissed() }
+            is Command.AskJoinerConfirmation -> askJoinerConfirmation(it.peerName, it.peerKind)
+            is Command.AskHostConfirmation -> askHostConfirmation(it.peerName, it.peerKind)
         }
+    }
+
+    private fun askJoinerConfirmation(peerName: String?, peerKind: PeerKind?) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_joiner_confirmation_title)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
+            .setPositiveButton(R.string.sync_v2_joiner_confirmation_positive)
+            .setNegativeButton(R.string.sync_v2_joiner_confirmation_negative)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() { viewModel.onJoinerConfirmed() }
+                    override fun onNegativeButtonClicked() { viewModel.onJoinerDenied() }
+                },
+            ).show()
+    }
+
+    private fun askHostConfirmation(peerName: String?, peerKind: PeerKind?) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_host_confirmation_title)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
+            .setPositiveButton(R.string.sync_v2_host_confirmation_positive)
+            .setNegativeButton(R.string.sync_v2_host_confirmation_negative)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() { viewModel.onHostConfirmed() }
+                    override fun onNegativeButtonClicked() { viewModel.onHostDenied() }
+                },
+            ).show()
     }
 
     private fun configureListeners() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
@@ -27,17 +27,22 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.CONNECT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.CREATE_ACCOUNT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.INVALID_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
+import com.duckduckgo.sync.impl.DispatchOutcome
 import com.duckduckgo.sync.impl.ExchangeResult.AccountSwitchingRequired
 import com.duckduckgo.sync.impl.ExchangeResult.LoggedIn
 import com.duckduckgo.sync.impl.ExchangeResult.Pending
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.impl.RouteDecision
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode
+import com.duckduckgo.sync.impl.SyncCodeDispatcher
 import com.duckduckgo.sync.impl.onFailure
 import com.duckduckgo.sync.impl.onSuccess
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import com.duckduckgo.sync.impl.pixels.fireSetupFailed
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Companion.POLLING_INTERVAL_EXCHANGE_FLOW
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command.LoginSucess
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command.ReadTextCode
@@ -46,8 +51,10 @@ import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import logcat.logcat
 import javax.inject.*
 
 @ContributesViewModel(ActivityScope::class)
@@ -55,6 +62,7 @@ class SyncLoginViewModel @Inject constructor(
     private val syncAccountRepository: SyncAccountRepository,
     private val syncPixels: SyncPixels,
     private val dispatchers: DispatcherProvider,
+    private val codeDispatcher: SyncCodeDispatcher,
 ) : ViewModel() {
     private val command = Channel<Command>(1, DROP_OLDEST)
     fun commands(): Flow<Command> = command.receiveAsFlow()
@@ -64,6 +72,14 @@ class SyncLoginViewModel @Inject constructor(
         data object LoginSucess : Command()
         data object Error : Command()
         data class ShowError(@StringRes val message: Int, val reason: String = "") : Command()
+
+        /** v2 §"Exchange Confirmations": prompt user "Sync your data with [peerName]?". */
+        data class AskJoinerConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
+
+        /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
+        data class AskHostConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
+
+        internal data class ShowV2Error(val content: V2PairingErrorContent) : Command()
     }
 
     fun onReadTextCodeClicked() {
@@ -87,23 +103,61 @@ class SyncLoginViewModel @Inject constructor(
 
     fun onQRCodeScanned(qrCode: String) {
         viewModelScope.launch(dispatchers.io()) {
-            val codeType = syncAccountRepository.parseSyncAuthCode(qrCode)
-            when (val result = syncAccountRepository.processCode(codeType)) {
-                is Error -> {
-                    processError(result)
-                }
-
-                is Success -> {
-                    if (codeType is SyncAuthCode.Exchange) {
-                        pollForRecoveryKey()
-                    } else {
-                        syncPixels.fireLoginPixel()
-                        command.send(LoginSucess)
+            // FF off → Legacy runs the existing v1 control flow; FF on → v2 codes surface via DispatchOutcome.
+            when (val decision = codeDispatcher.route(qrCode)) {
+                is RouteDecision.Legacy -> {
+                    logcat { "Sync-CodeDispatch: SyncLoginViewModel handling Legacy(${decision.authCode::class.simpleName})" }
+                    val codeType = decision.authCode
+                    when (val result = syncAccountRepository.processCode(codeType)) {
+                        is Error -> processError(result)
+                        is Success -> {
+                            if (codeType is SyncAuthCode.Exchange) {
+                                pollForRecoveryKey()
+                            } else {
+                                syncPixels.fireLoginPixel()
+                                command.send(LoginSucess)
+                            }
+                        }
                     }
+                }
+                is RouteDecision.V2InProgress -> {
+                    logcat { "Sync-CodeDispatch: SyncLoginViewModel observing V2InProgress" }
+                    decision.outcomes.collect { outcome -> handleV2Outcome(outcome) }
                 }
             }
         }
     }
+
+    /** Map one v2 [DispatchOutcome] onto this VM's existing command pipeline. */
+    private suspend fun handleV2Outcome(outcome: DispatchOutcome) {
+        syncPixels.fireSetupFailed(outcome)
+        when (outcome) {
+            is DispatchOutcome.LoggedIn -> {
+                syncPixels.fireLoginPixel()
+                command.send(LoginSucess)
+            }
+            is DispatchOutcome.AlreadyConnected ->
+                command.send(Command.ShowV2Error(v2AlreadyPairedError))
+            is DispatchOutcome.UpgradeRequired -> {
+                logcat { "Sync v2: upgrade required, peer needs protocol v${outcome.codeMajor}" }
+                command.send(Command.ShowV2Error(v2UpgradeRequiredError))
+            }
+            is DispatchOutcome.Failed -> {
+                val content = outcome.code.toV2PairingError()
+                command.send(Command.ShowV2Error(content))
+            }
+            is DispatchOutcome.JoinerConfirmationRequested ->
+                command.send(Command.AskJoinerConfirmation(outcome.peerName, outcome.peerKind))
+            is DispatchOutcome.HostConfirmationRequested ->
+                command.send(Command.AskHostConfirmation(outcome.peerName, outcome.peerKind))
+            is DispatchOutcome.LinkingCodeReady -> {} // No-op; used only by presentV2() flow
+        }
+    }
+
+    fun onJoinerConfirmed() { codeDispatcher.confirmJoiner() }
+    fun onJoinerDenied() { codeDispatcher.denyJoiner() }
+    fun onHostConfirmed() { codeDispatcher.confirmHost() }
+    fun onHostDenied() { codeDispatcher.denyHost() }
 
     private suspend fun processError(result: Error) {
         when (result.code) {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncV2ConfirmationCopy.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncV2ConfirmationCopy.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui
+
+import android.content.Context
+import androidx.annotation.StringRes
+import com.duckduckgo.sync.impl.R
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+
+@StringRes
+internal fun syncV2ConfirmationMessageRes(
+    unknownPeer: Boolean,
+    peerKind: PeerKind?,
+): Int {
+    val thirdParty = peerKind == PeerKind.THIRD_PARTY
+    return when {
+        unknownPeer && thirdParty -> R.string.sync_v2_confirmation_message_unknown_peer_3p
+        unknownPeer -> R.string.sync_v2_confirmation_message_unknown_peer_ddg
+        thirdParty -> R.string.sync_v2_confirmation_message_3p
+        else -> R.string.sync_v2_confirmation_message_ddg
+    }
+}
+
+internal fun Context.syncV2ConfirmationMessage(
+    peerName: String?,
+    peerKind: PeerKind?,
+): String {
+    val res = syncV2ConfirmationMessageRes(unknownPeer = peerName.isNullOrBlank(), peerKind = peerKind)
+    return if (peerName.isNullOrBlank()) getString(res) else getString(res, peerName)
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.CREATE_ACCOUNT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.INVALID_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
 import com.duckduckgo.sync.impl.Clipboard
+import com.duckduckgo.sync.impl.DispatchOutcome
 import com.duckduckgo.sync.impl.ExchangeResult.AccountSwitchingRequired
 import com.duckduckgo.sync.impl.ExchangeResult.LoggedIn
 import com.duckduckgo.sync.impl.ExchangeResult.Pending
@@ -38,15 +39,24 @@ import com.duckduckgo.sync.impl.R.dimen
 import com.duckduckgo.sync.impl.R.string
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.impl.RouteDecision
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAccountRepository.AuthCode
 import com.duckduckgo.sync.impl.SyncAuthCode
 import com.duckduckgo.sync.impl.SyncAuthCode.Unknown
+import com.duckduckgo.sync.impl.SyncCodeDispatcher
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.onFailure
 import com.duckduckgo.sync.impl.onSuccess
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_EXCHANGE
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
+import com.duckduckgo.sync.impl.pixels.fireSetupCancelledIfDenied
+import com.duckduckgo.sync.impl.pixels.fireSetupFailed
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Companion.POLLING_INTERVAL_EXCHANGE_FLOW
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.AskToSwitchAccount
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.FinishWithError
@@ -77,6 +87,7 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
     private val syncPixels: SyncPixels,
     private val dispatchers: DispatcherProvider,
     private val syncFeature: SyncFeature,
+    private val codeDispatcher: SyncCodeDispatcher,
 ) : ViewModel() {
     private val command = Channel<Command>(1, DROP_OLDEST)
     fun commands(): Flow<Command> = command.receiveAsFlow()
@@ -89,6 +100,10 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
     private var canTimeout = false
     private var isDeepLink = false
 
+    // viewState.onStart re-fires on every re-collection; guard so the session starts once and
+    // re-fires don't regenerate the invitation/channel, orphaning the code the user already shared.
+    private var sessionStarted = false
+
     private val viewState = MutableStateFlow(ViewState())
     fun viewState(isDeepLink: Boolean = false): Flow<ViewState> = viewState.onStart {
         this@SyncWithAnotherActivityViewModel.canTimeout = isDeepLink
@@ -97,7 +112,13 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
     }
 
     private fun startExchangeProcess() {
+        if (sessionStarted) return
+        sessionStarted = true
         viewModelScope.launch(dispatchers.io()) {
+            if (shouldUseV2()) {
+                startV2Present()
+                return@launch
+            }
             showQRCode()
             var polling = syncFeature.exchangeKeysToSyncWithAnotherDevice().isEnabled()
             val startTime = System.currentTimeMillis()
@@ -128,6 +149,29 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
                     }
             }
         }
+    }
+
+    private fun shouldUseV2(): Boolean =
+        syncFeature.canUseV2ConnectFlow().isEnabled() &&
+            syncFeature.canShowV2ConnectCode().isEnabled()
+
+    /** Drive a v2 Presenter session via the dispatcher. On this signed-in surface role election elects Host. */
+    private suspend fun startV2Present() {
+        val previousPrimaryKey = syncAccountRepository.getAccountInfo().primaryKey
+        codeDispatcher.presentV2().collect { outcome ->
+            when (outcome) {
+                is DispatchOutcome.LinkingCodeReady -> renderV2QrCode(outcome.linkingCode)
+                else -> handleV2Outcome(outcome, previousPrimaryKey)
+            }
+        }
+    }
+
+    private suspend fun renderV2QrCode(linkingCode: String) {
+        barcodeContents = AuthCode(qrCode = linkingCode, rawCode = linkingCode)
+        val bitmap = withContext(dispatchers.io()) {
+            qrEncoder.encodeAsBitmap(linkingCode, dimen.qrSizeSmall, dimen.qrSizeSmall)
+        }
+        viewState.emit(viewState.value.copy(qrCodeBitmap = bitmap))
     }
 
     private suspend fun showQRCode() {
@@ -183,6 +227,14 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
         ) : Command()
 
         data class AskToSwitchAccount(val encodedStringCode: String) : Command()
+
+        /** v2 §"Exchange Confirmations": prompt user "Sync your data with [peerName]?". */
+        data class AskJoinerConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
+
+        /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
+        data class AskHostConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
+
+        internal data class ShowV2Error(val content: V2PairingErrorContent) : Command()
     }
 
     fun onReadTextCodeClicked() {
@@ -200,29 +252,89 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
     fun onQRCodeScanned(qrCode: String) {
         viewModelScope.launch(dispatchers.io()) {
             val previousPrimaryKey = syncAccountRepository.getAccountInfo().primaryKey
-            val codeType = syncAccountRepository.parseSyncAuthCode(qrCode).also { it.onCodeScanned() }
-            when (val result = syncAccountRepository.processCode(codeType)) {
-                is Error -> {
-                    logcat(WARN) { "Sync: error processing code ${result.reason}" }
-                    emitError(result, qrCode)
-                }
+            // Route via SyncCodeDispatcher. FF off → Legacy(parseSyncAuthCode(...)); FF on →
+            // v2-shaped codes are taken into ownership and surfaced through DispatchOutcome.
+            when (val decision = codeDispatcher.route(qrCode)) {
+                is RouteDecision.Legacy -> {
+                    logcat { "Sync-CodeDispatch: SyncWithAnotherActivityViewModel handling Legacy(${decision.authCode::class.simpleName})" }
+                    val codeType = decision.authCode.also { it.onCodeScanned() }
+                    when (val result = syncAccountRepository.processCode(codeType)) {
+                        is Error -> {
+                            logcat(WARN) { "Sync: error processing code ${result.reason}" }
+                            emitError(result, qrCode)
+                        }
 
-                is Success -> {
-                    if (codeType is SyncAuthCode.Exchange) {
-                        pollForRecoveryKey(previousPrimaryKey = previousPrimaryKey, qrCode = qrCode)
-                    } else {
-                        // Show recovery screen if QR scanned is Connect and user was not previously logged in (empty PK)
-                        val showRecovery = codeType is SyncAuthCode.Connect && previousPrimaryKey.isEmpty()
-                        onLoginSuccess(previousPrimaryKey, showRecovery)
+                        is Success -> {
+                            if (codeType is SyncAuthCode.Exchange) {
+                                pollForRecoveryKey(previousPrimaryKey = previousPrimaryKey, qrCode = qrCode)
+                            } else {
+                                // Show recovery screen if QR scanned is Connect and user was not previously logged in (empty PK)
+                                val showRecovery = codeType is SyncAuthCode.Connect && previousPrimaryKey.isEmpty()
+                                onLoginSuccess(previousPrimaryKey, showRecovery)
+                            }
+                        }
                     }
+                }
+                is RouteDecision.V2InProgress -> {
+                    logcat { "Sync-CodeDispatch: SyncWithAnotherActivityViewModel observing V2InProgress" }
+                    if (!isDeepLink) {
+                        syncPixels.fireBarcodeScannerParseSuccess(SYNC_EXCHANGE, CodeVersion.V2, decision.codeType)
+                    }
+                    decision.outcomes.collect { handleV2Outcome(it, previousPrimaryKey) }
                 }
             }
         }
     }
 
-    private suspend fun onLoginSuccess(previousPrimaryKey: String, showRecovery: Boolean) {
+    /** Map one v2 [DispatchOutcome] onto this VM's existing command pipeline. */
+    private suspend fun handleV2Outcome(
+        outcome: DispatchOutcome,
+        previousPrimaryKey: String,
+    ) {
+        syncPixels.fireSetupFailed(outcome)
+        syncPixels.fireSetupCancelledIfDenied(outcome, SYNC_EXCHANGE)
+        // Cancel the deep-link timeout only on terminal outcomes; keep it running across confirmation prompts.
+        when (outcome) {
+            is DispatchOutcome.LoggedIn -> {
+                cancelTimeout()
+                val showRecovery = previousPrimaryKey.isEmpty()
+                onLoginSuccess(previousPrimaryKey, showRecovery, outcome.path, outcome.myRole, outcome.peerKind)
+            }
+            is DispatchOutcome.AlreadyConnected -> {
+                cancelTimeout()
+                command.send(Command.ShowV2Error(v2AlreadyPairedError))
+            }
+            is DispatchOutcome.UpgradeRequired -> {
+                cancelTimeout()
+                logcat { "Sync v2: upgrade required, peer needs protocol v${outcome.codeMajor}" }
+                command.send(Command.ShowV2Error(v2UpgradeRequiredError))
+            }
+            is DispatchOutcome.Failed -> {
+                cancelTimeout()
+                command.send(Command.ShowV2Error(outcome.code.toV2PairingError()))
+            }
+            is DispatchOutcome.JoinerConfirmationRequested ->
+                command.send(Command.AskJoinerConfirmation(outcome.peerName, outcome.peerKind))
+            is DispatchOutcome.HostConfirmationRequested ->
+                command.send(Command.AskHostConfirmation(outcome.peerName, outcome.peerKind))
+            is DispatchOutcome.LinkingCodeReady -> {} // No-op; used only by presentV2() flow
+        }
+    }
+
+    fun onJoinerConfirmed() { codeDispatcher.confirmJoiner() }
+    fun onJoinerDenied() { codeDispatcher.denyJoiner() }
+    fun onHostConfirmed() { codeDispatcher.confirmHost() }
+    fun onHostDenied() { codeDispatcher.denyHost() }
+
+    private suspend fun onLoginSuccess(
+        previousPrimaryKey: String,
+        showRecovery: Boolean,
+        path: SetupPath? = null,
+        myRole: SetupRole? = null,
+        peerKind: PeerKind? = null,
+    ) {
         val postProcessCodePK = syncAccountRepository.getAccountInfo().primaryKey
-        fireLoginPixels()
+        fireLoginPixels(path, myRole, peerKind)
         val userSwitchedAccount = previousPrimaryKey.isNotBlank() && previousPrimaryKey != postProcessCodePK
         val commandSuccess = if (userSwitchedAccount) {
             syncPixels.fireUserSwitchedAccount()
@@ -233,13 +345,17 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
         command.send(commandSuccess)
     }
 
-    private fun fireLoginPixels() {
+    private fun fireLoginPixels(
+        path: SetupPath? = null,
+        myRole: SetupRole? = null,
+        peerKind: PeerKind? = null,
+    ) {
         syncPixels.fireLoginPixel()
 
         if (isDeepLink) {
             syncPixels.fireSetupDeepLinkFlowSuccess()
         } else {
-            syncPixels.fireSyncSetupFinishedSuccessfully(SYNC_EXCHANGE)
+            syncPixels.fireSyncSetupFinishedSuccessfully(SYNC_EXCHANGE, path, myRole, peerKind)
         }
     }
 
@@ -327,11 +443,12 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
             when (result) {
                 EnterCodeContractOutput.Error -> {}
                 EnterCodeContractOutput.LoginSuccess -> {
-                    fireLoginPixels()
+                    // Manual entry: EnterCodeViewModel fires "Setup success"; only fire login pixel here.
+                    syncPixels.fireLoginPixel()
                     command.send(LoginSuccess(showRecovery = true))
                 }
                 EnterCodeContractOutput.SwitchAccountSuccess -> {
-                    fireLoginPixels()
+                    syncPixels.fireLoginPixel()
                     command.send(SwitchAccountSuccess)
                 }
             }
@@ -354,7 +471,12 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
         if (isDeepLink) {
             syncPixels.fireSetupDeepLinkFlowAbandoned()
         } else {
-            syncPixels.fireSyncSetupAbandoned(SYNC_EXCHANGE)
+            val reason = if (codeDispatcher.isV2ExchangeUnderway()) {
+                CancellationReason.CANCELLED_BEFORE_FINISHED
+            } else {
+                CancellationReason.SCANNING_CANCELLED
+            }
+            syncPixels.fireSyncSetupAbandoned(SYNC_EXCHANGE, reason)
         }
     }
 
@@ -363,7 +485,7 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
 
         when (this) {
             is Unknown -> syncPixels.fireBarcodeScannerParseError(SYNC_EXCHANGE)
-            else -> syncPixels.fireBarcodeScannerParseSuccess(SYNC_EXCHANGE)
+            else -> syncPixels.fireBarcodeScannerParseSuccess(SYNC_EXCHANGE, CodeVersion.V1)
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.databinding.ActivityConnectSyncBinding
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.ui.EnterCodeActivity.Companion.Code.RECOVERY_CODE
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.AskToSwitchAccount
@@ -114,6 +115,8 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
     private fun observeUiEvents() {
         viewModel
             .viewState(isDeepLink = isDeepLinkSetup())
+            // Observe at CREATED, not STARTED: STARTED re-subscribes on every foreground, re-firing
+            // viewState.onStart and regenerating the pairing code. CREATED also avoids dropping terminal commands.
             .flowWithLifecycle(lifecycle, Lifecycle.State.CREATED)
             .onEach { render(it) }
             .launchIn(lifecycleScope)
@@ -154,6 +157,7 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
 
             is ShowMessage -> Snackbar.make(binding.root, it.messageId, Snackbar.LENGTH_SHORT).show()
             is ShowError -> showError(it)
+            is Command.ShowV2Error -> showV2PairingError(it.content) { viewModel.onErrorDialogDismissed() }
             is AskToSwitchAccount -> askUserToSwitchAccount(it)
             SwitchAccountSuccess -> {
                 val resultIntent = Intent()
@@ -161,7 +165,37 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
                 setResult(RESULT_OK, resultIntent)
                 finish()
             }
+            is Command.AskJoinerConfirmation -> askJoinerConfirmation(it.peerName, it.peerKind)
+            is Command.AskHostConfirmation -> askHostConfirmation(it.peerName, it.peerKind)
         }
+    }
+
+    private fun askJoinerConfirmation(peerName: String?, peerKind: PeerKind?) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_joiner_confirmation_title)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
+            .setPositiveButton(R.string.sync_v2_joiner_confirmation_positive)
+            .setNegativeButton(R.string.sync_v2_joiner_confirmation_negative)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() { viewModel.onJoinerConfirmed() }
+                    override fun onNegativeButtonClicked() { viewModel.onJoinerDenied() }
+                },
+            ).show()
+    }
+
+    private fun askHostConfirmation(peerName: String?, peerKind: PeerKind?) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_host_confirmation_title)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
+            .setPositiveButton(R.string.sync_v2_host_confirmation_positive)
+            .setNegativeButton(R.string.sync_v2_host_confirmation_negative)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() { viewModel.onHostConfirmed() }
+                    override fun onNegativeButtonClicked() { viewModel.onHostDenied() }
+                },
+            ).show()
     }
 
     private fun configureListeners() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/V2PairingError.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/V2PairingError.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui
+
+import android.content.Context
+import androidx.annotation.StringRes
+import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED
+import com.duckduckgo.sync.impl.R
+
+/** Dialog copy for a v2 pairing terminal outcome. A null [message] renders a title-only dialog. */
+internal data class V2PairingErrorContent(
+    @StringRes val title: Int,
+    @StringRes val message: Int?,
+)
+
+/**
+ * Maps a v2 pairing [com.duckduckgo.sync.impl.DispatchOutcome.Failed] error code to dialog copy.
+ */
+internal fun Int.toV2PairingError(): V2PairingErrorContent = when (this) {
+    PAIRING_REJECTED.code -> V2PairingErrorContent(
+        title = R.string.sync_v2_error_pairing_rejected,
+        message = R.string.sync_v2_error_try_again,
+    )
+    PAIRING_CANCELLED.code -> V2PairingErrorContent(
+        title = R.string.sync_v2_error_pairing_canceled,
+        message = null,
+    )
+    THIRD_PARTY_ALREADY_UPGRADED.code -> V2PairingErrorContent(
+        title = R.string.sync_v2_error_pairing_failed,
+        message = R.string.sync_v2_error_third_party_already_upgraded,
+    )
+    else -> V2PairingErrorContent(
+        title = R.string.sync_v2_error_pairing_failed,
+        message = R.string.sync_v2_error_try_again,
+    )
+}
+
+/** Fixed copy for [com.duckduckgo.sync.impl.DispatchOutcome.UpgradeRequired] */
+internal val v2UpgradeRequiredError = V2PairingErrorContent(
+    title = R.string.sync_v2_error_upgrade_required,
+    message = null,
+)
+
+/** Fixed copy for the same-account [com.duckduckgo.sync.impl.DispatchOutcome.AlreadyConnected] outcome. */
+internal val v2AlreadyPairedError = V2PairingErrorContent(
+    title = R.string.sync_v2_already_paired_title,
+    message = R.string.sync_v2_already_paired_message,
+)
+
+/**
+ * Renders a v2 pairing error dialog: the scenario line as the title, an optional supporting
+ * [V2PairingErrorContent.message].
+ */
+internal fun Context.showV2PairingError(
+    content: V2PairingErrorContent,
+    onDismissed: () -> Unit,
+) {
+    TextAlertDialogBuilder(this)
+        .setTitle(content.title)
+        .apply { content.message?.let { setMessage(it) } }
+        .setPositiveButton(R.string.sync_v2_error_got_it)
+        .addEventListener(
+            object : TextAlertDialogBuilder.EventListener() {
+                override fun onPositiveButtonClicked() {
+                    onDismissed()
+                }
+            },
+        )
+        .show()
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/qrcode/SyncBarcodeUrl.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/qrcode/SyncBarcodeUrl.kt
@@ -32,12 +32,21 @@ data class SyncBarcodeUrl(
      * The human readable device name (i.e., not URL-encoded). This is optional and can be null.
      */
     val deviceName: String? = null,
+    /**
+     * Which protocol version the URL fragment carries. v1 uses `code=`, v2 uses `code2=`.
+     * Determines the param name used by [asUrl]; downstream code (the [SyncCodeDispatcher])
+     * does the actual content-level discrimination.
+     */
+    val protocolVersion: ProtocolVersion = ProtocolVersion.V1,
 ) : Parcelable {
 
+    enum class ProtocolVersion { V1, V2 }
+
     fun asUrl(): String {
+        val codeParam = if (protocolVersion == ProtocolVersion.V2) CODE_PARAM_V2 else CODE_PARAM_V1
         val sb = StringBuilder(URL_BASE)
             .append("&")
-            .append(CODE_PARAM).append("=").append(webSafeB64EncodedCode)
+            .append(codeParam).append("=").append(webSafeB64EncodedCode)
 
         // Encode device name to make it URL safe
         getEncodedDeviceName()?.let { encodedDeviceName ->
@@ -62,7 +71,8 @@ data class SyncBarcodeUrl(
 
     companion object {
         const val URL_BASE = "https://duckduckgo.com/sync/pairing/#"
-        private const val CODE_PARAM = "code"
+        private const val CODE_PARAM_V1 = "code"
+        private const val CODE_PARAM_V2 = "code2"
         private const val DEVICE_NAME_PARAM = "deviceName"
 
         fun parseUrl(fullSyncUrl: String): SyncBarcodeUrl? {
@@ -75,17 +85,26 @@ data class SyncBarcodeUrl(
                 val fragment = uri.fragment ?: return null
                 val fragmentParts = fragment.split("&")
 
-                val code = fragmentParts
-                    .find { it.startsWith("code=") }
-                    ?.substringAfter("code=")
-                    ?: return null
+                // Prefer v2 (`code2=`) when present; only fall back to v1 (`code=`) otherwise.
+                // A URL carrying both is malformed, but in that order we'd treat it as v2.
+                val v2Code = fragmentParts
+                    .find { it.startsWith("$CODE_PARAM_V2=") }
+                    ?.substringAfter("$CODE_PARAM_V2=")
+                val v1Code = fragmentParts
+                    .find { it.startsWith("$CODE_PARAM_V1=") }
+                    ?.substringAfter("$CODE_PARAM_V1=")
+                val (code, version) = when {
+                    v2Code != null -> v2Code to ProtocolVersion.V2
+                    v1Code != null -> v1Code to ProtocolVersion.V1
+                    else -> return null
+                }
 
                 val deviceName = fragmentParts
-                    .find { it.startsWith("deviceName=") }
-                    ?.substringAfter("deviceName=")
+                    .find { it.startsWith("$DEVICE_NAME_PARAM=") }
+                    ?.substringAfter("$DEVICE_NAME_PARAM=")
                     ?.urlDecode()
 
-                SyncBarcodeUrl(webSafeB64EncodedCode = code, deviceName = deviceName)
+                SyncBarcodeUrl(webSafeB64EncodedCode = code, deviceName = deviceName, protocolVersion = version)
             }.getOrNull()
         }
 

--- a/sync/sync-impl/src/main/res/values/donottranslate.xml
+++ b/sync/sync-impl/src/main/res/values/donottranslate.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
+    <string name="sync_v2_joiner_confirmation_title">Sync your data?</string>
+    <string name="sync_v2_joiner_confirmation_positive">Sync Now</string>
+    <string name="sync_v2_joiner_confirmation_negative">Cancel</string>
+
+    <string name="sync_v2_host_confirmation_title">Sync your data?</string>
+    <string name="sync_v2_host_confirmation_positive">Sync Now</string>
+    <string name="sync_v2_host_confirmation_negative">Cancel</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">\"%1$s\" will be able to access your synced DuckDuckGo passwords, autofill data, and Duck.ai chats.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">\"%1$s\" will be able to access your synced Duck.ai chats.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">The other device will be able to access your synced DuckDuckGo passwords, autofill data, and Duck.ai chats.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">The other device will be able to access your synced Duck.ai chats.</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
+    <string name="sync_v2_error_pairing_failed">Sync failed.</string>
+    <string name="sync_v2_error_pairing_rejected">Sync canceled from your other device.</string>
+    <string name="sync_v2_error_pairing_canceled">Sync canceled.</string>
+    <string name="sync_v2_error_upgrade_required">Update the DuckDuckGo browser and try again.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Please Sync this device from an already-connected DuckDuckGo browser on another device</string>
+    <string name="sync_v2_error_try_again">Please try again.</string>
+    <string name="sync_v2_error_got_it">Got It</string>
+    <string name="sync_v2_already_paired_title">Already synced.</string>
+    <string name="sync_v2_already_paired_message">These devices are already connected to Sync &amp; Backup.</string>
+</resources>

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/AppSyncDeviceIdsTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/AppSyncDeviceIdsTest.kt
@@ -112,7 +112,6 @@ class AppSyncDeviceIdsTest {
             override var secretKey: String? = "secretKey"
             override var credentialId: String? = null
             override var scopedPassword: ScopedPassword? = null
-            override var protectedKeysJson: String? = null
             override fun isEncryptionSupported() = true
 
             override fun isSignedInFlow() = emptyFlow<Boolean>()
@@ -147,7 +146,6 @@ class AppSyncDeviceIdsTest {
             override var secretKey: String? = null
             override var credentialId: String? = null
             override var scopedPassword: ScopedPassword? = null
-            override var protectedKeysJson: String? = null
             override fun isEncryptionSupported() = true
 
             override fun isSignedInFlow() = emptyFlow<Boolean>()

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
@@ -153,6 +153,7 @@ class AppSyncAccountRepositoryTest {
             protectedKeyManager = protectedKeyManager,
             thirdPartyDeviceListDecryptor = thirdPartyDeviceListDecryptor,
         )
+        (syncRepo as AppSyncAccountRepository).upgradeRetryDelayMillis = 0L // keep retry-path tests instant
 
         // passthrough by default (no modifications)
         whenever(syncCodeUrlWrapper.wrapCodeInUrl(any())).thenAnswer { it.arguments[0] as String }
@@ -952,7 +953,7 @@ class AppSyncAccountRepositoryTest {
 
         val result = syncRepo.renameDevice(connectedDevice)
 
-        verify(syncApi).login(anyString(), anyString(), eq(connectedDevice.deviceId), anyString(), anyString())
+        verify(syncApi).login(anyString(), anyString(), eq(connectedDevice.deviceId), anyString(), anyString(), anyOrNull())
         assertTrue(result is Success)
     }
 
@@ -1160,13 +1161,12 @@ class AppSyncAccountRepositoryTest {
             accessCredentials = listOf(AccessCredentialEntry(id = "ddg", scope = null)),
             keys = listOf(ProtectedKeyEntry(kid = "k1", purpose = "ai_chats", encryptedWith = "ddg", encryptedPrivateKey = "jwe_data")),
         )
-        whenever(syncApi.login(anyString(), anyString(), anyString(), anyString(), anyString())).thenReturn(Success(loginResponseWithV2))
+        whenever(syncApi.login(anyString(), anyString(), anyString(), anyString(), anyString(), anyOrNull())).thenReturn(Success(loginResponseWithV2))
 
         val result = syncRepo.processCode(SyncAuthCode.Recovery(RecoveryCode(primaryKey = primaryKey, userId = userId)))
 
         assertEquals(Success(true), result)
         verify(syncStore, times(0)).credentialId = any()
-        verify(syncStore, times(0)).protectedKeysJson = any()
     }
 
     @Test
@@ -1194,14 +1194,13 @@ class AppSyncAccountRepositoryTest {
                 ProtectedKeyEntry(kid = "k1", purpose = "ai_chats", encryptedWith = "3party", encryptedPrivateKey = "jwe_3p"),
             ),
         )
-        whenever(syncApi.login(anyString(), anyString(), anyString(), anyString(), anyString())).thenReturn(Success(loginResponseWithV2))
+        whenever(syncApi.login(anyString(), anyString(), anyString(), anyString(), anyString(), anyOrNull())).thenReturn(Success(loginResponseWithV2))
 
         val result = syncRepo.processCode(SyncAuthCode.Recovery(RecoveryCode(primaryKey = primaryKey, userId = userId)))
 
         assertEquals(Success(true), result)
         verify(syncStore).credentialId = "ddg"
         verify(syncStore).scopedPassword = ScopedPassword("/+//")
-        verify(syncStore).protectedKeysJson = any()
     }
 
     @Test
@@ -1210,7 +1209,7 @@ class AppSyncAccountRepositoryTest {
         prepareToProvideDeviceIds()
         prepareForEncryption()
         whenever(nativeLib.prepareForLogin(primaryKey)).thenReturn(validLoginKeys)
-        whenever(syncApi.login(anyString(), anyString(), anyString(), anyString(), anyString())).thenReturn(loginSuccess)
+        whenever(syncApi.login(anyString(), anyString(), anyString(), anyString(), anyString(), anyOrNull())).thenReturn(loginSuccess)
 
         val result = syncRepo.processCode(SyncAuthCode.Recovery(RecoveryCode(primaryKey = primaryKey, userId = userId)))
 
@@ -1288,11 +1287,299 @@ class AppSyncAccountRepositoryTest {
 
     @Test
     fun whenCreateProtectedKeyThenDelegatesToManager() {
-        whenever(protectedKeyManager.create("ai_chats")).thenReturn(Success(true))
+        val createdKey = ProtectedKeyEntry(
+            kid = "k1",
+            purpose = "ai_chats",
+            encryptedWith = "ddg",
+            encryptedPrivateKey = "enc",
+            publicKey = RsaJwk(n = "mod", e = "AQAB"),
+        )
+        whenever(protectedKeyManager.create("ai_chats")).thenReturn(Success(createdKey))
 
         val result = syncRepo.createProtectedKey("ai_chats")
 
         assertEquals(Success(true), result)
         verify(protectedKeyManager).create("ai_chats")
+    }
+
+    // joinAccountFromThirdPartyRecoveryCode
+
+    @Test
+    fun whenJoinAccountFromThirdPartyAndAllStepsSucceedThenAtomicStoreUsesDdgTokenFromSecondLogin() {
+        val pastedCode = prepareForJoinAccountFromThirdPartyRecoveryCode()
+
+        val result = syncRepo.joinAccountFromThirdPartyRecoveryCode(pastedCode)
+
+        assertEquals(Success(true), result)
+        // Commits the ddg token from Step 7a, not the ai_chats-scoped Step 2 token (else 403).
+        verify(syncStore).storeCredentials(
+            userId = userId,
+            deviceId = deviceId,
+            deviceName = deviceName,
+            primaryKey = primaryKey,
+            secretKey = secretKey,
+            token = "ddg_token_step7a",
+        )
+    }
+
+    @Test
+    fun whenJoinAccountFromThirdPartyThenStep7aPostUpgradeLoginUsesUnrestrictedScope() {
+        val pastedCode = prepareForJoinAccountFromThirdPartyRecoveryCode()
+
+        syncRepo.joinAccountFromThirdPartyRecoveryCode(pastedCode)
+
+        verify(syncApi).login(
+            userID = eq(userId),
+            hashedPassword = anyString(),
+            deviceId = eq(deviceId),
+            deviceName = anyString(),
+            deviceType = anyString(),
+            scope = eq("ai_chats"),
+        )
+        // Step 7a must use scope=null — the unscoped ddg token is needed for device-management endpoints.
+        verify(syncApi).login(
+            userID = eq(userId),
+            hashedPassword = anyString(),
+            deviceId = eq(deviceId),
+            deviceName = anyString(),
+            deviceType = anyString(),
+            scope = eq<String?>(null),
+        )
+    }
+
+    @Test
+    fun whenStep7aPostUpgradeLoginReturns401ThenAbortsWithoutAtomicStore() {
+        val pastedCode = prepareForJoinAccountFromThirdPartyRecoveryCode(step7aResult = step7aLoginUnauthorized)
+
+        val result = syncRepo.joinAccountFromThirdPartyRecoveryCode(pastedCode)
+
+        assertTrue(result is Error)
+        // 401 => BE removed the credential (TTL); must not persist any local state.
+        verify(syncStore, times(0)).storeCredentials(any(), any(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun whenStep7aPostUpgradeLoginFailsWithNon401ThenAbortsWithoutAtomicStore() {
+        val pastedCode = prepareForJoinAccountFromThirdPartyRecoveryCode(step7aResult = step7aLoginServerError)
+
+        val result = syncRepo.joinAccountFromThirdPartyRecoveryCode(pastedCode)
+
+        assertTrue(result is Error)
+        verify(
+            syncApi,
+            times(AppSyncAccountRepository.MAX_UPGRADE_RETRIES + 1),
+        ).login(eq(userId), any(), eq(deviceId), any(), any(), eq<String?>(null))
+        verify(syncStore, times(0)).storeCredentials(any(), any(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun whenJoinAccountFromThirdPartyAndAccountAlreadyHasDdgCredentialThenAbortsBeforePost() {
+        val pastedCode = prepareForJoinAccountFromThirdPartyRecoveryCode(accountAlreadyHasDdg = true)
+
+        val result = syncRepo.joinAccountFromThirdPartyRecoveryCode(pastedCode)
+
+        assertTrue(result is Error)
+        // Aborts before the POST when the login response already shows a ddg credential.
+        verify(syncApi, times(0)).createAccessCredential(anyString(), eq("ddg"), any())
+        verify(syncApi, times(0)).login(any(), any(), any(), any(), any(), eq<String?>(null))
+        verify(syncStore, times(0)).storeCredentials(any(), any(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun whenStep7PostRateLimitedThenRetriesAndSucceeds() {
+        val pastedCode = prepareForJoinAccountFromThirdPartyRecoveryCode()
+        whenever(syncApi.createAccessCredential(anyString(), eq("ddg"), any()))
+            .thenReturn(Error(code = API_CODE.TOO_MANY_REQUESTS_2.code, reason = "rate limited"), Success(true))
+
+        val result = syncRepo.joinAccountFromThirdPartyRecoveryCode(pastedCode)
+
+        assertEquals(Success(true), result)
+        verify(syncApi, times(2)).createAccessCredential(anyString(), eq("ddg"), any())
+    }
+
+    @Test
+    fun whenStep7aLoginServerErrorThenRetriesAndSucceeds() {
+        val pastedCode = prepareForJoinAccountFromThirdPartyRecoveryCode()
+        whenever(syncApi.login(eq(userId), any(), eq(deviceId), any(), any(), eq<String?>(null)))
+            .thenReturn(step7aLoginServerError, step7aLoginSuccess)
+
+        val result = syncRepo.joinAccountFromThirdPartyRecoveryCode(pastedCode)
+
+        assertEquals(Success(true), result)
+        verify(syncApi, times(2)).login(eq(userId), any(), eq(deviceId), any(), any(), eq<String?>(null))
+        verify(syncStore).storeCredentials(
+            userId = userId,
+            deviceId = deviceId,
+            deviceName = deviceName,
+            primaryKey = primaryKey,
+            secretKey = secretKey,
+            token = "ddg_token_step7a",
+        )
+    }
+
+    @Test
+    fun whenStep7aLoginTransportErrorThenRetriesAndSucceeds() {
+        val pastedCode = prepareForJoinAccountFromThirdPartyRecoveryCode()
+        whenever(syncApi.login(eq(userId), any(), eq(deviceId), any(), any(), eq<String?>(null)))
+            .thenReturn(step7aLoginTransportError, step7aLoginSuccess)
+
+        val result = syncRepo.joinAccountFromThirdPartyRecoveryCode(pastedCode)
+
+        assertEquals(Success(true), result)
+        verify(syncApi, times(2)).login(eq(userId), any(), eq(deviceId), any(), any(), eq<String?>(null))
+    }
+
+    @Test
+    fun whenStep7aLogin401ThenAbortsWithoutRetry() {
+        val pastedCode = prepareForJoinAccountFromThirdPartyRecoveryCode(step7aResult = step7aLoginUnauthorized)
+
+        val result = syncRepo.joinAccountFromThirdPartyRecoveryCode(pastedCode)
+
+        assertTrue(result is Error)
+        verify(syncApi, times(1)).login(eq(userId), any(), eq(deviceId), any(), any(), eq<String?>(null))
+        verify(syncStore, times(0)).storeCredentials(any(), any(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun whenStep7Post409AlreadyExistsThenAbortsWithoutRetry() {
+        val pastedCode = prepareForJoinAccountFromThirdPartyRecoveryCode()
+        whenever(syncApi.createAccessCredential(anyString(), eq("ddg"), any()))
+            .thenReturn(Error(code = API_CODE.COUNT_LIMIT.code, reason = "already exists"))
+
+        val result = syncRepo.joinAccountFromThirdPartyRecoveryCode(pastedCode)
+
+        assertTrue(result is Error)
+        assertEquals(AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED.code, (result as Error).code)
+        verify(syncApi, times(1)).createAccessCredential(anyString(), eq("ddg"), any())
+    }
+
+    @Test
+    fun whenStep7PostRateLimitedBeyondRetryLimitThenAbortsWithoutStore() {
+        val pastedCode = prepareForJoinAccountFromThirdPartyRecoveryCode()
+        whenever(syncApi.createAccessCredential(anyString(), eq("ddg"), any()))
+            .thenReturn(Error(code = API_CODE.TOO_MANY_REQUESTS_1.code, reason = "rate limited"))
+
+        val result = syncRepo.joinAccountFromThirdPartyRecoveryCode(pastedCode)
+
+        assertTrue(result is Error)
+        verify(syncApi, times(AppSyncAccountRepository.MAX_UPGRADE_RETRIES + 1))
+            .createAccessCredential(anyString(), eq("ddg"), any())
+        verify(syncStore, times(0)).storeCredentials(any(), any(), any(), any(), any(), any())
+    }
+
+    @Test
+    fun whenJoinAccountFromThirdPartyAndCodeIsLaterMinorVersionThenAccepted() {
+        val pastedCode = prepareForJoinAccountFromThirdPartyRecoveryCode(version = "2.5")
+
+        val result = syncRepo.joinAccountFromThirdPartyRecoveryCode(pastedCode)
+
+        assertTrue(result is Success)
+    }
+
+    @Test
+    fun whenJoinAccountFromThirdPartyAndCodeIsBareMajorVersionThenAccepted() {
+        // "2" is the spec's common shorthand for "2.0" (Transport TD 1214486492252757).
+        val pastedCode = prepareForJoinAccountFromThirdPartyRecoveryCode(version = "2")
+
+        val result = syncRepo.joinAccountFromThirdPartyRecoveryCode(pastedCode)
+
+        assertTrue(result is Success)
+    }
+
+    @Test
+    fun whenJoinAccountFromThirdPartyAndCodeIsMajorVersion3ThenRejectedWithoutNetwork() {
+        val pastedCode = prepareForJoinAccountFromThirdPartyRecoveryCode(version = "3.0")
+
+        val result = syncRepo.joinAccountFromThirdPartyRecoveryCode(pastedCode)
+
+        assertTrue(result is Error)
+        verify(syncApi, times(0)).login(any(), any(), any(), any(), any(), anyOrNull())
+    }
+
+    @Test
+    fun whenJoinAccountFromThirdPartyAndCodeCidIsNotThirdPartyThenRejectedWithoutNetwork() {
+        val pastedCode = prepareForJoinAccountFromThirdPartyRecoveryCode(cid = "ddg")
+
+        val result = syncRepo.joinAccountFromThirdPartyRecoveryCode(pastedCode)
+
+        assertTrue(result is Error)
+        verify(syncApi, times(0)).login(any(), any(), any(), any(), any(), anyOrNull())
+    }
+
+    @Test
+    fun whenV2ThirdPartyCodeParsedAsAuthCodeThenNotTreatedAsRecovery() {
+        val v2ThirdPartyJson =
+            """{"recovery":{"user_id":"$userId","secret":"rUzlGqLLlbonAC_zIeh1nrCmuDsDAn6UooUUDz-6x3o","cid":"3party","v":"2.0"}}"""
+
+        val type = syncRepo.parseSyncAuthCode(v2ThirdPartyJson.encodeB64())
+
+        assertTrue(type is SyncAuthCode.Unknown)
+    }
+
+    private val step7aLoginUnauthorized = Error(code = API_CODE.INVALID_LOGIN_CREDENTIALS.code, reason = "invalid credentials")
+    private val step7aLoginServerError = Error(code = 500, reason = "server error")
+    private val step7aLoginTransportError = Error(code = AccountErrorCodes.GENERIC_ERROR.code, reason = "timeout")
+    private val step7aLoginSuccess = Success(
+        LoginResponse(
+            token = "ddg_token_step7a",
+            protected_encryption_key = null,
+            devices = emptyList(),
+            accessCredentials = null,
+            keys = null,
+        ),
+    )
+
+    private fun prepareForJoinAccountFromThirdPartyRecoveryCode(
+        accountAlreadyHasDdg: Boolean = false,
+        step7aResult: Result<LoginResponse>? = null,
+        version: String = "2.0",
+        cid: String = "3party",
+    ): String {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncDeviceIds.deviceId()).thenReturn(deviceId)
+        whenever(syncDeviceIds.deviceName()).thenReturn(deviceName)
+        whenever(syncDeviceIds.deviceType()).thenReturn(deviceType)
+
+        val recoveryJson =
+            """{"recovery":{"user_id":"$userId","secret":"rUzlGqLLlbonAC_zIeh1nrCmuDsDAn6UooUUDz-6x3o","cid":"$cid","v":"$version"}}"""
+        val pastedCode = java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(recoveryJson.toByteArray(Charsets.UTF_8))
+
+        whenever(nativeLib.encryptData(anyString(), anyString())).thenReturn(EncryptResult(0, "encrypted"))
+        whenever(syncJweCrypto.hkdfSha256SingleBlock(any(), any(), any(), any())).thenReturn(ByteArray(32))
+        whenever(syncJweCrypto.jweEncryptSymmetric(any(), any(), any())).thenReturn("encrypted_3party_credential")
+        whenever(nativeLib.generateAccountKeys(userId = eq(userId), password = anyString())).thenReturn(accountKeys)
+
+        // Step 2 response; optionally includes ddg to drive the "already upgraded" path.
+        val accessCredentialsInResponse = buildList {
+            add(AccessCredentialEntry(id = "3party", scope = "ai_chats"))
+            if (accountAlreadyHasDdg) add(AccessCredentialEntry(id = "ddg", scope = null))
+        }
+        val step2LoginResponse = LoginResponse(
+            token = "scoped_token_step2",
+            protected_encryption_key = null,
+            devices = emptyList(),
+            accessCredentials = accessCredentialsInResponse,
+            keys = emptyList(),
+        )
+
+        val step7aResponse = step7aResult ?: Success(
+            LoginResponse(
+                token = "ddg_token_step7a",
+                protected_encryption_key = null,
+                devices = emptyList(),
+                accessCredentials = null,
+                keys = null,
+            ),
+        )
+
+        // Differentiate the two /sync/login calls by scope.
+        whenever(syncApi.login(eq(userId), any(), eq(deviceId), any(), any(), anyOrNull())).doAnswer { invocation ->
+            val scope = invocation.getArgument<String?>(5)
+            if (scope == "ai_chats") Success(step2LoginResponse) else step7aResponse
+        }
+
+        whenever(syncApi.createAccessCredential(anyString(), eq("ddg"), any())).thenReturn(Success(true))
+
+        return pastedCode
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ProtectedKeyManagerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ProtectedKeyManagerTest.kt
@@ -91,20 +91,76 @@ class ProtectedKeyManagerTest {
         whenever(syncJweCrypto.generateRsaKeyPair()).thenReturn(RsaKeyPair("pubKey", "cHJpdktleQ"))
         whenever(syncJweCrypto.extractJwkComponents(anyString())).thenReturn("modulus" to "AQAB")
         whenever(nativeLib.encryptData(any<ByteArray>(), eq(secretKey))).thenReturn(EncryptBytesResult(0, "encrypted".toByteArray()))
-        whenever(syncApi.setProtectedKeyIfAbsent(eq(token), eq("ai_chats"), any())).thenReturn(Success(true))
+        // Happy path: server's response contains our entry (we wrote it).
+        val serverKey = ProtectedKeyEntry(
+            kid = "server-kid",
+            purpose = "ai_chats",
+            encryptedWith = "ddg",
+            encryptedPrivateKey = "encrypted",
+            publicKey = RsaJwk(n = "modulus", e = "AQAB"),
+        )
+        whenever(syncApi.setProtectedKeyIfAbsent(eq(token), eq("ai_chats"), any())).thenReturn(Success(listOf(serverKey)))
 
         val result = manager.create("ai_chats")
 
-        assertEquals(Success(true), result)
+        assertTrue(result is Success)
+        // create() returns the server's authoritative entry, not the local one.
+        assertEquals(serverKey, (result as Success).data)
         verify(syncApi).setProtectedKeyIfAbsent(
             eq(token),
             eq("ai_chats"),
             check { sent ->
-                assertEquals("ai_chats", sent.purpose)
-                assertEquals("ddg", sent.encryptedWith)
-                assertEquals(RsaJwk(n = "modulus", e = "AQAB"), sent.publicKey)
+                assertEquals(1, sent.size)
+                val first = sent.first()
+                assertEquals("ai_chats", first.purpose)
+                assertEquals("ddg", first.encryptedWith)
+                assertEquals(RsaJwk(n = "modulus", e = "AQAB"), first.publicKey)
             },
         )
+    }
+
+    @Test
+    fun whenSetProtectedKeyIfAbsentReturnsExistingServerEntryThenCreateReturnsServerEntry() {
+        // Race-loser: server returns a different kid for the same (purpose, encrypted_with).
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+        whenever(syncStore.secretKey).thenReturn(secretKey)
+        whenever(nativeLib.prepareForLogin(primaryKey)).thenReturn(validLoginKeys)
+        whenever(syncJweCrypto.generateRsaKeyPair()).thenReturn(RsaKeyPair("pubKey", "cHJpdktleQ"))
+        whenever(syncJweCrypto.extractJwkComponents(anyString())).thenReturn("modulus" to "AQAB")
+        whenever(nativeLib.encryptData(any<ByteArray>(), eq(secretKey))).thenReturn(EncryptBytesResult(0, "encrypted".toByteArray()))
+        val serverKey = ProtectedKeyEntry(
+            kid = "kid-from-server",
+            purpose = "ai_chats",
+            encryptedWith = "ddg",
+            encryptedPrivateKey = "server-jwe",
+            publicKey = RsaJwk(n = "server-modulus", e = "AQAB"),
+        )
+        whenever(syncApi.setProtectedKeyIfAbsent(eq(token), eq("ai_chats"), any())).thenReturn(Success(listOf(serverKey)))
+
+        val result = manager.create("ai_chats")
+
+        assertTrue(result is Success)
+        assertEquals(serverKey, (result as Success).data)
+    }
+
+    @Test
+    fun whenServerResponseMissingPurposeEntryThenError() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+        whenever(syncStore.secretKey).thenReturn(secretKey)
+        whenever(nativeLib.prepareForLogin(primaryKey)).thenReturn(validLoginKeys)
+        whenever(syncJweCrypto.generateRsaKeyPair()).thenReturn(RsaKeyPair("pubKey", "cHJpdktleQ"))
+        whenever(syncJweCrypto.extractJwkComponents(anyString())).thenReturn("modulus" to "AQAB")
+        whenever(nativeLib.encryptData(any<ByteArray>(), eq(secretKey))).thenReturn(EncryptBytesResult(0, "encrypted".toByteArray()))
+        // Server returns a list that doesn't include an entry for our (purpose, ddg) slot.
+        whenever(syncApi.setProtectedKeyIfAbsent(eq(token), eq("ai_chats"), any())).thenReturn(Success(emptyList()))
+
+        val result = manager.create("ai_chats")
+
+        assertTrue(result is Error)
     }
 
     @Test

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
@@ -1,0 +1,1177 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.sync.impl.AccountErrorCodes.NEGOTIATION_ABORTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.NO_RECOVERY_CODE
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_UNAVAILABLE
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
+import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
+import com.duckduckgo.sync.impl.exchange.v2.PairingRole
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
+import org.json.JSONObject
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class RealSyncCodeDispatcherTest {
+
+    private val syncFeature: SyncFeature = mock()
+    private val canUseV2: Toggle = mock()
+    private val syncAccountRepository: SyncAccountRepository = mock()
+    private val qrCode: ExchangeV2QrCode = mock()
+
+    private val runnerEventsFlow = MutableSharedFlow<com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event>(replay = 0)
+    private val runner: ExchangeV2Runner = mock<ExchangeV2Runner>().also {
+        whenever(it.events).thenReturn(runnerEventsFlow)
+        whenever(it.eventsSince(any())).thenAnswer { invocation ->
+            val sinceMs = invocation.getArgument<Long>(0)
+            runnerEventsFlow.filter { event -> event.timestampMs >= sinceMs }
+        }
+    }
+
+    private val dispatcher = RealSyncCodeDispatcher(
+        syncFeature = syncFeature,
+        syncAccountRepository = syncAccountRepository,
+        qrCode = qrCode,
+        runner = runner,
+    )
+
+    private fun setV2(enabled: Boolean) {
+        whenever(syncFeature.canUseV2ConnectFlow()).thenReturn(canUseV2)
+        whenever(canUseV2.isEnabled()).thenReturn(enabled)
+    }
+
+    @Test fun `FF off - returns Legacy with whatever parseSyncAuthCode returned, and never touches qrCode parse`() {
+        setV2(false)
+        val expectedAuthCode = SyncAuthCode.Recovery(RecoveryCode(primaryKey = "pk", userId = "u"))
+        whenever(syncAccountRepository.parseSyncAuthCode("the-code")).thenReturn(expectedAuthCode)
+
+        val decision = dispatcher.route("the-code") as RouteDecision.Legacy
+
+        assertSame(expectedAuthCode, decision.authCode)
+        verify(qrCode, never()).parse(any())
+    }
+
+    @Test fun `FF off - v1 Connect codes return Legacy(Connect) unchanged`() {
+        setV2(false)
+        val connect = SyncAuthCode.Connect(mock())
+        whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(connect)
+
+        val decision = dispatcher.route("connect-shape-code") as RouteDecision.Legacy
+
+        assertSame(connect, decision.authCode)
+    }
+
+    @Test fun `FF off - v1 Exchange codes return Legacy(Exchange) unchanged`() {
+        setV2(false)
+        val exchange = SyncAuthCode.Exchange(mock())
+        whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(exchange)
+
+        val decision = dispatcher.route("exchange-shape-code") as RouteDecision.Legacy
+
+        assertSame(exchange, decision.authCode)
+    }
+
+    @Test fun `FF off - Unknown codes still bubble back as Legacy(Unknown)`() {
+        setV2(false)
+        val unknown = SyncAuthCode.Unknown("garbage")
+        whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(unknown)
+
+        val decision = dispatcher.route("garbage") as RouteDecision.Legacy
+
+        assertSame(unknown, decision.authCode)
+    }
+
+    @Test fun `FF off - even a v2-shaped code is routed via legacy parseSyncAuthCode (no v2 parser touched)`() {
+        setV2(false)
+        whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(SyncAuthCode.Unknown("v2-shaped-input"))
+
+        dispatcher.route("https://duckduckgo.com/sync/pairing/#&code2=anything")
+
+        verify(qrCode, never()).parse(any())
+        verify(syncAccountRepository).parseSyncAuthCode("https://duckduckgo.com/sync/pairing/#&code2=anything")
+    }
+
+    @Test fun `FF on but v2 parser returns LinkingV1 - falls back to legacy stack`() {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.LinkingV1)
+        val connect = SyncAuthCode.Connect(mock())
+        whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(connect)
+
+        val decision = dispatcher.route("v1-code") as RouteDecision.Legacy
+
+        assertSame(connect, decision.authCode)
+    }
+
+    @Test fun `FF on but v2 parser returns Unknown - falls back to legacy stack`() {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.Unknown)
+        val recovery = SyncAuthCode.Recovery(RecoveryCode(primaryKey = "pk", userId = "u"))
+        whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(recovery)
+
+        val decision = dispatcher.route("recovery-code") as RouteDecision.Legacy
+
+        assertSame(recovery, decision.authCode)
+    }
+
+    @Test fun `FF on, v2 LinkingV2 - returns V2InProgress and does NOT call parseSyncAuthCode`() {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+
+        val decision = dispatcher.route("v2-link-url")
+
+        assertTrue("expected V2InProgress, got $decision", decision is RouteDecision.V2InProgress)
+        assertEquals(SyncCodeType.LINKING, (decision as RouteDecision.V2InProgress).codeType)
+        verify(syncAccountRepository, never()).parseSyncAuthCode(any())
+    }
+
+    @Test fun `isV2ExchangeUnderway is false at Bootstrapped or no session, true once exchanging`() {
+        whenever(runner.currentState).thenReturn(null)
+        assertFalse(dispatcher.isV2ExchangeUnderway())
+        whenever(runner.currentState).thenReturn(ExchangeV2State.Bootstrapped)
+        assertFalse(dispatcher.isV2ExchangeUnderway())
+        whenever(runner.currentState).thenReturn(ExchangeV2State.Negotiating)
+        assertTrue(dispatcher.isV2ExchangeUnderway())
+        whenever(runner.currentState).thenReturn(ExchangeV2State.Joiner.Waiting)
+        assertTrue(dispatcher.isV2ExchangeUnderway())
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=ddg - flow emits LoggedIn after processCode succeeds`() = runTest {
+        setV2(true)
+        val rawJson = JSONObject().apply {
+            put("user_id", "u-1")
+            put("secret", "s-1")
+            put("cid", "ddg")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
+
+        val decision = dispatcher.route("any") as RouteDecision.V2InProgress
+        assertEquals(SyncCodeType.RECOVERY, decision.codeType)
+        val outcomes = decision.outcomes.toList()
+
+        assertEquals(1, outcomes.size)
+        assertEquals(DispatchOutcome.LoggedIn(SetupPath.RECOVERY), outcomes.single())
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=ddg - base64url secret is normalised to standard base64 for v1 login`() = runTest {
+        // Spec 1214802412121967: the v2 wire `secret` is base64url; v1 login decodes as standard base64.
+        setV2(true)
+        val base64urlSecret = "rUzlGqLLlbonAC_zIeh1nrCmuDsDAn6UooUUDz-6x3o"
+        val expectedBytes = java.util.Base64.getUrlDecoder().decode(base64urlSecret)
+        val rawJson = JSONObject().apply {
+            put("user_id", "u-1")
+            put("secret", base64urlSecret)
+            put("cid", "ddg")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
+
+        (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.toList()
+
+        val captor = org.mockito.kotlin.argumentCaptor<SyncAuthCode>()
+        verify(syncAccountRepository).processCode(captor.capture(), anyOrNull())
+        val primaryKey = (captor.firstValue as SyncAuthCode.Recovery).b64Code.primaryKey
+        assertFalse("primaryKey must be standard base64 (no '-'): $primaryKey", primaryKey.contains('-'))
+        assertFalse("primaryKey must be standard base64 (no '_'): $primaryKey", primaryKey.contains('_'))
+        assertArrayEquals(expectedBytes, java.util.Base64.getDecoder().decode(primaryKey))
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=ddg with missing user_id - emits Failed without calling processCode`() = runTest {
+        setV2(true)
+        val rawJson = JSONObject().apply {
+            put("secret", "s-1")
+            put("cid", "ddg")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+
+        val decision = dispatcher.route("any") as RouteDecision.V2InProgress
+        val outcome = decision.outcomes.first()
+
+        assertTrue("expected Failed, got $outcome", outcome is DispatchOutcome.Failed)
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=3party - flow calls joinAccountFromThirdPartyRecoveryCode`() = runTest {
+        setV2(true)
+        val rawJson = JSONObject().apply {
+            put("user_id", "u-3p")
+            put("secret", "s-3p")
+            put("cid", "3party")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(any())).thenReturn(Result.Success(true))
+
+        val decision = dispatcher.route("any") as RouteDecision.V2InProgress
+        val outcomes = decision.outcomes.toList()
+
+        assertEquals(DispatchOutcome.LoggedIn(SetupPath.RECOVERY), outcomes.single())
+        verify(syncAccountRepository).joinAccountFromThirdPartyRecoveryCode(any())
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=3party - re-encoded code is canonical JSON without escaped slashes`() = runTest {
+        setV2(true)
+        val secretWithSlashes = "apZ+7PAe89rDhuG4DRyi/M3zU2/D5DZNdRsR3RM6Ujw="
+        val rawJson = JSONObject().apply {
+            put("user_id", "u-3p")
+            put("secret", secretWithSlashes)
+            put("cid", "3party")
+            put("v", "2.0")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(any())).thenReturn(Result.Success(true))
+
+        (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.toList()
+
+        val captor = org.mockito.kotlin.argumentCaptor<String>()
+        verify(syncAccountRepository).joinAccountFromThirdPartyRecoveryCode(captor.capture())
+        val decodedJson = String(java.util.Base64.getUrlDecoder().decode(captor.firstValue), Charsets.UTF_8)
+        assertFalse("re-wrapped 3party JSON must not contain escaped slashes (\\/): $decodedJson", decodedJson.contains("\\/"))
+        val recovery = JSONObject(decodedJson).getJSONObject("recovery")
+        assertEquals(secretWithSlashes, recovery.getString("secret"))
+        assertEquals("u-3p", recovery.getString("user_id"))
+        assertEquals("3party", recovery.getString("cid"))
+        assertEquals("2.0", recovery.getString("v"))
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=ddg - ALREADY_SIGNED_IN triggers logoutAndJoinNewAccount and emits LoggedIn`() = runTest {
+        setV2(true)
+        val base64urlSecret = "rUzlGqLLlbonAC_zIeh1nrCmuDsDAn6UooUUDz-6x3o"
+        val rawJson = JSONObject().apply {
+            put("user_id", "u-other")
+            put("secret", base64urlSecret)
+            put("cid", "ddg")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(
+            Result.Error(
+                code = com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN.code,
+                reason = "Already signed in",
+            ),
+        )
+        whenever(syncAccountRepository.logoutAndJoinNewAccount(any())).thenReturn(Result.Success(true))
+
+        val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
+
+        assertEquals(DispatchOutcome.LoggedIn(SetupPath.RECOVERY), outcome)
+
+        val captor = org.mockito.kotlin.argumentCaptor<String>()
+        verify(syncAccountRepository).logoutAndJoinNewAccount(captor.capture())
+        val decoded = java.util.Base64.getUrlDecoder().decode(captor.firstValue)
+        val recovery = JSONObject(String(decoded)).getJSONObject("recovery")
+        assertArrayEquals(
+            java.util.Base64.getUrlDecoder().decode(base64urlSecret),
+            java.util.Base64.getDecoder().decode(recovery.getString("primary_key")),
+        )
+        assertEquals("u-other", recovery.getString("user_id"))
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=ddg - account-switch code is canonical v1 JSON without escaped slashes`() = runTest {
+        setV2(true)
+        val secretWithSlashes = "apZ+7PAe89rDhuG4DRyi/M3zU2/D5DZNdRsR3RM6Ujw="
+        val rawJson = JSONObject().apply {
+            put("user_id", "u-other")
+            put("secret", secretWithSlashes)
+            put("cid", "ddg")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(
+            Result.Error(
+                code = com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN.code,
+                reason = "Already signed in",
+            ),
+        )
+        whenever(syncAccountRepository.logoutAndJoinNewAccount(any())).thenReturn(Result.Success(true))
+
+        (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
+
+        val captor = org.mockito.kotlin.argumentCaptor<String>()
+        verify(syncAccountRepository).logoutAndJoinNewAccount(captor.capture())
+        val decodedJson = String(java.util.Base64.getUrlDecoder().decode(captor.firstValue), Charsets.UTF_8)
+        assertFalse("v1 account-switch JSON must not contain escaped slashes (\\/): $decodedJson", decodedJson.contains("\\/"))
+        val recovery = JSONObject(decodedJson).getJSONObject("recovery")
+        assertEquals(secretWithSlashes, recovery.getString("primary_key"))
+        assertEquals("u-other", recovery.getString("user_id"))
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=ddg - ALREADY_SIGNED_IN then logoutAndJoinNewAccount failure surfaces as Failed`() = runTest {
+        setV2(true)
+        val rawJson = JSONObject().apply {
+            put("user_id", "u-other")
+            put("secret", "s-other")
+            put("cid", "ddg")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(
+            Result.Error(
+                code = com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN.code,
+                reason = "Already signed in",
+            ),
+        )
+        whenever(syncAccountRepository.logoutAndJoinNewAccount(any())).thenReturn(
+            Result.Error(code = com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED.code, reason = "Login failed"),
+        )
+
+        val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
+
+        assertEquals(
+            DispatchOutcome.Failed("Login failed", com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED.code, path = SetupPath.RECOVERY),
+            outcome,
+        )
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=3party - ALREADY_SIGNED_IN does NOT trigger transparent switch (fails as Failed)`() = runTest {
+        setV2(true)
+        val rawJson = JSONObject().apply {
+            put("user_id", "u-3p")
+            put("secret", "s-3p")
+            put("cid", "3party")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(any())).thenReturn(
+            Result.Error(
+                code = com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN.code,
+                reason = "Already signed in",
+            ),
+        )
+
+        val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
+
+        assertEquals(
+            DispatchOutcome.Failed(
+                "Already signed in",
+                com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN.code,
+                path = SetupPath.RECOVERY,
+            ),
+            outcome,
+        )
+        verify(syncAccountRepository, never()).logoutAndJoinNewAccount(any())
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=ddg - non-ALREADY_SIGNED_IN error still becomes Failed`() = runTest {
+        setV2(true)
+        val rawJson = JSONObject().apply {
+            put("user_id", "u")
+            put("secret", "AQID") // valid base64 so decoding succeeds and processCode is reached
+            put("cid", "ddg")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(
+            Result.Error(code = -1, reason = "Some other error"),
+        )
+
+        val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
+
+        assertEquals(DispatchOutcome.Failed("Some other error", path = SetupPath.RECOVERY), outcome)
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=3party - repository error becomes Failed with reason preserved`() = runTest {
+        setV2(true)
+        val rawJson = JSONObject().apply {
+            put("user_id", "u-3p")
+            put("secret", "s-3p")
+            put("cid", "3party")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(any())).thenReturn(
+            Result.Error(reason = "BE rejected"),
+        )
+
+        val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
+
+        assertEquals(DispatchOutcome.Failed("BE rejected", path = SetupPath.RECOVERY), outcome)
+    }
+
+    @Test fun `FF on, v2 RecoveryCode with unknown cid - emits Failed with the cid in the reason`() = runTest {
+        setV2(true)
+        val rawJson = JSONObject().apply {
+            put("user_id", "u")
+            put("secret", "s")
+            put("cid", "future-credential")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+
+        val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
+
+        assertTrue("expected Failed, got $outcome", outcome is DispatchOutcome.Failed)
+        assertTrue((outcome as DispatchOutcome.Failed).reason.contains("future-credential"))
+    }
+
+    @Test fun `Legacy path - dispatcher never invokes processCode (caller owns that)`() {
+        setV2(false)
+        whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(SyncAuthCode.Recovery(mock()))
+
+        dispatcher.route("any")
+
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
+        verify(syncAccountRepository, never()).joinAccountFromThirdPartyRecoveryCode(any())
+    }
+
+    @Test fun `Legacy path - dispatcher does not start the v2 runner`() {
+        setV2(false)
+        whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(SyncAuthCode.Unknown("x"))
+
+        dispatcher.route("any")
+
+        verify(runner, never()).startScan(any())
+    }
+
+    @Test fun `FF on, LinkingV2 - ignores stale terminal events from prior sessions in the replay cache`() = runTest {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        val staleJoinerDone = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event.Transition(
+            timestampMs = 1L,
+            from = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.Joiner.Waiting,
+            to = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.Joiner.Done,
+            trigger = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse(
+                rawJson = "{}",
+                recoveryCode = "stale-code-from-prior-session",
+            ),
+            localTrigger = null,
+        )
+        val staleFlow = MutableSharedFlow<com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event>(replay = 10)
+        staleFlow.tryEmit(staleJoinerDone)
+        whenever(runner.events).thenReturn(staleFlow)
+        whenever(runner.eventsSince(any())).thenAnswer { invocation ->
+            val sinceMs = invocation.getArgument<Long>(0)
+            staleFlow.filter { event -> event.timestampMs >= sinceMs }
+        }
+
+        val decision = dispatcher.route("v2-url") as RouteDecision.V2InProgress
+
+        val outcome = kotlinx.coroutines.withTimeoutOrNull(100) { decision.outcomes.first() }
+        assertEquals(null, outcome)
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
+    }
+
+    @Test fun `FF on, LinkingV2 - runner_startScan deferred until Flow is collected (cold)`() = runTest {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+
+        val decision = dispatcher.route("v2-url") as RouteDecision.V2InProgress
+
+        verify(runner, never()).startScan(any())
+
+        kotlinx.coroutines.withTimeoutOrNull(50) { decision.outcomes.first() }
+        verify(runner).startScan(eq("v2-url"))
+    }
+
+    @Test fun `FF on, LinkingV2 exchange - base64url recovery secret is normalised to standard base64 for v1 login`() = runTest {
+        // Spec 1214802412121967: the v2 wire `secret` is base64url; v1 login decodes as standard base64.
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
+        val base64urlSecret = "rUzlGqLLlbonAC_zIeh1nrCmuDsDAn6UooUUDz-6x3o"
+        val payloadJson = JSONObject().apply {
+            put(
+                "recovery",
+                JSONObject().apply {
+                    put("user_id", "u-1")
+                    put("secret", base64urlSecret)
+                    put("cid", "ddg")
+                    put("v", "2.0")
+                },
+            )
+        }.toString()
+        val recoveryCodeB64 = java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(payloadJson.toByteArray())
+
+        val flow = (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { flow.take(1).toList() }
+        runnerEventsFlow.emit(
+            ExchangeV2Event.Transition(
+                timestampMs = System.currentTimeMillis(),
+                from = ExchangeV2State.Joiner.Waiting,
+                to = ExchangeV2State.Joiner.Done,
+                trigger = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse(
+                    rawJson = payloadJson,
+                    recoveryCode = recoveryCodeB64,
+                ),
+                localTrigger = null,
+            ),
+        )
+        job.join()
+
+        val captor = org.mockito.kotlin.argumentCaptor<SyncAuthCode>()
+        verify(syncAccountRepository).processCode(captor.capture(), anyOrNull())
+        val primaryKey = (captor.firstValue as SyncAuthCode.Recovery).b64Code.primaryKey
+        assertFalse("primaryKey must be standard base64 (no '-'): $primaryKey", primaryKey.contains('-'))
+        assertFalse("primaryKey must be standard base64 (no '_'): $primaryKey", primaryKey.contains('_'))
+        assertArrayEquals(
+            java.util.Base64.getUrlDecoder().decode(base64urlSecret),
+            java.util.Base64.getDecoder().decode(primaryKey),
+        )
+    }
+
+    private fun transition(
+        from: ExchangeV2State,
+        to: ExchangeV2State,
+        trigger: ExchangeV2Message? = null,
+        localTrigger: LocalTrigger? = null,
+        timestampMs: Long = System.currentTimeMillis(),
+    ): ExchangeV2Event.Transition = ExchangeV2Event.Transition(
+        timestampMs = timestampMs,
+        from = from,
+        to = to,
+        trigger = trigger,
+        localTrigger = localTrigger,
+    )
+
+    private fun sessionStarted(linkingCode: String?, timestampMs: Long = System.currentTimeMillis()) =
+        ExchangeV2Event.SessionStarted(
+            timestampMs = timestampMs,
+            pairingRole = PairingRole.Presenter,
+            ownChannelId = "own-channel",
+            linkingCode = linkingCode,
+        )
+
+    @Test fun `presentV2 emits LinkingCodeReady when runner emits SessionStarted with a linkingCode`() = runTest {
+        val flow = dispatcher.presentV2()
+        val outcomes = mutableListOf<DispatchOutcome>()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+            flow.take(1).collect { outcomes += it }
+        }
+        runnerEventsFlow.emit(sessionStarted(linkingCode = "https://duckduckgo.com/sync/pairing?code2=abc"))
+        job.join()
+
+        assertEquals(1, outcomes.size)
+        assertEquals(
+            DispatchOutcome.LinkingCodeReady("https://duckduckgo.com/sync/pairing?code2=abc"),
+            outcomes.single(),
+        )
+    }
+
+    @Test fun `presentV2 ignores SessionStarted with null linkingCode (Scanner side leakage protection)`() = runTest {
+        val outcomes = mutableListOf<DispatchOutcome>()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().take(1).collect { outcomes += it } }
+        runnerEventsFlow.emit(sessionStarted(linkingCode = null))
+        runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Done))
+        job.join()
+
+        assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST), outcomes.single())
+    }
+
+    @Test fun `presentV2 emits HostConfirmationRequested with peerName when runner reaches Host_Confirming`() = runTest {
+        whenever(runner.peerName).thenReturn("Peer Phone")
+        val outcomes = mutableListOf<DispatchOutcome>()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().take(1).collect { outcomes += it } }
+        runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Confirming))
+        job.join()
+
+        assertEquals(DispatchOutcome.HostConfirmationRequested(peerName = "Peer Phone"), outcomes.single())
+    }
+
+    @Test fun `presentV2 carries third-party peer kind on HostConfirmationRequested`() = runTest {
+        whenever(runner.peerName).thenReturn("Peer Phone")
+        whenever(runner.peerKind).thenReturn("3party")
+        val outcomes = mutableListOf<DispatchOutcome>()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().take(1).collect { outcomes += it } }
+        runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Confirming))
+        job.join()
+
+        assertEquals(
+            DispatchOutcome.HostConfirmationRequested(peerName = "Peer Phone", peerKind = PeerKind.THIRD_PARTY),
+            outcomes.single(),
+        )
+    }
+
+    @Test fun `presentV2 carries ddg peer kind on JoinerConfirmationRequested`() = runTest {
+        whenever(runner.peerName).thenReturn("Peer Phone")
+        whenever(runner.peerKind).thenReturn("ddg")
+        val outcomes = mutableListOf<DispatchOutcome>()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().take(1).collect { outcomes += it } }
+        runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Joiner.Confirming))
+        job.join()
+
+        assertEquals(
+            DispatchOutcome.JoinerConfirmationRequested(peerName = "Peer Phone", peerKind = PeerKind.DDG),
+            outcomes.single(),
+        )
+    }
+
+    @Test fun `presentV2 emits LoggedIn with Host role and peer kind when runner reaches Host_Done`() = runTest {
+        whenever(runner.peerKind).thenReturn("3party")
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+                dispatcher.presentV2().first { it is DispatchOutcome.LoggedIn || it is DispatchOutcome.Failed }
+            }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Host.Sending, to = ExchangeV2State.Host.Done))
+            job.await()
+        }
+        assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST, PeerKind.THIRD_PARTY), outcome)
+    }
+
+    @Test fun `presentV2 maps a version-too-new SessionError to UpgradeRequired`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(
+                ExchangeV2Event.SessionError(
+                    timestampMs = System.currentTimeMillis(),
+                    message = "Peer requires protocol v3; please update this app",
+                ),
+            )
+            job.await()
+        }
+        assertEquals(DispatchOutcome.UpgradeRequired(codeMajor = 3, path = SetupPath.PAIRING), outcome)
+    }
+
+    @Test fun `route LinkingV2 maps a version-too-new SessionError to UpgradeRequired`() = runTest {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        val outcome = withTimeoutOrNull(1000) {
+            val flow = (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { flow.first() }
+            runnerEventsFlow.emit(
+                ExchangeV2Event.SessionError(
+                    timestampMs = System.currentTimeMillis(),
+                    message = "Peer requires protocol v3; please update this app",
+                ),
+            )
+            job.await()
+        }
+        assertEquals(DispatchOutcome.UpgradeRequired(codeMajor = 3, path = SetupPath.PAIRING), outcome)
+    }
+
+    @Test fun `route LinkingV2 - Host_Aborted with UserDeniedHost maps to Failed PAIRING_CANCELLED`() = runTest {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        val outcome = withTimeoutOrNull(1000) {
+            val flow = (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { flow.first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Host.Confirming,
+                    to = ExchangeV2State.Host.Aborted,
+                    localTrigger = LocalTrigger.UserDeniedHost,
+                ),
+            )
+            job.await()
+        }
+        assertEquals(
+            DispatchOutcome.Failed("user_denied", PAIRING_CANCELLED.code, path = SetupPath.PAIRING, myRole = SetupRole.HOST),
+            outcome,
+        )
+    }
+
+    @Test fun `route LinkingV2 - Host_Aborted with HostUnavailable maps to Failed PAIRING_UNAVAILABLE`() = runTest {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        val outcome = withTimeoutOrNull(1000) {
+            val flow = (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { flow.first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Host.Sending,
+                    to = ExchangeV2State.Host.Aborted,
+                    localTrigger = LocalTrigger.HostUnavailable,
+                ),
+            )
+            job.await()
+        }
+        assertEquals(
+            DispatchOutcome.Failed("host_unavailable", PAIRING_UNAVAILABLE.code, path = SetupPath.PAIRING, myRole = SetupRole.HOST),
+            outcome,
+        )
+    }
+
+    @Test fun `presentV2 emits Failed user_denied when Host_Aborted carries UserDeniedHost trigger`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Host.Confirming,
+                    to = ExchangeV2State.Host.Aborted,
+                    localTrigger = LocalTrigger.UserDeniedHost,
+                ),
+            )
+            job.await()
+        }
+        assertEquals(
+            DispatchOutcome.Failed("user_denied", PAIRING_CANCELLED.code, path = SetupPath.PAIRING, myRole = SetupRole.HOST),
+            outcome,
+        )
+    }
+
+    @Test fun `presentV2 emits Failed host_unavailable when Host_Aborted carries HostUnavailable trigger`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Host.Sending,
+                    to = ExchangeV2State.Host.Aborted,
+                    localTrigger = LocalTrigger.HostUnavailable,
+                ),
+            )
+            job.await()
+        }
+        assertEquals(
+            DispatchOutcome.Failed("host_unavailable", PAIRING_UNAVAILABLE.code, path = SetupPath.PAIRING, myRole = SetupRole.HOST),
+            outcome,
+        )
+    }
+
+    @Test fun `presentV2 emits AlreadyConnected when runner reaches SameAccountAbort`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.SameAccountAbort))
+            job.await()
+        }
+        assertEquals(DispatchOutcome.AlreadyConnected, outcome)
+    }
+
+    @Test fun `presentV2 emits Failed when runner emits SessionError`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(
+                ExchangeV2Event.SessionError(timestampMs = System.currentTimeMillis(), message = "channel 5xx"),
+            )
+            job.await()
+        }
+        assertEquals(DispatchOutcome.Failed("channel 5xx", PAIRING_FAILED.code, path = SetupPath.PAIRING), outcome)
+    }
+
+    @Test fun `presentV2 emits Failed when Joiner_Done arrives without a recovery code`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+                dispatcher.presentV2().first { it !is DispatchOutcome.LinkingCodeReady }
+            }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Joiner.Waiting, to = ExchangeV2State.Joiner.Done))
+            job.await()
+        }
+        assertEquals(
+            DispatchOutcome.Failed(
+                "Pairing completed without a recovery code",
+                NO_RECOVERY_CODE.code,
+                path = SetupPath.PAIRING,
+                myRole = SetupRole.JOINER,
+            ),
+            outcome,
+        )
+    }
+
+    @Test fun `presentV2 emits LoggedIn when Joiner_Done carries a cid=ddg recovery code`() = runTest {
+        setV2(true)
+        val recoveryJson = JSONObject().apply {
+            put(
+                "recovery",
+                JSONObject().apply {
+                    put("user_id", "u-1")
+                    put("secret", "s-1")
+                    put("cid", "ddg")
+                    put("v", "2.0")
+                },
+            )
+        }.toString()
+        val b64 = android.util.Base64.encodeToString(
+            recoveryJson.toByteArray(Charsets.UTF_8),
+            android.util.Base64.URL_SAFE or android.util.Base64.NO_PADDING or android.util.Base64.NO_WRAP,
+        )
+        val responseMessage = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse(
+            rawJson = "{}",
+            recoveryCode = b64,
+        )
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
+        whenever(runner.peerKind).thenReturn("ddg")
+
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+                dispatcher.presentV2().first { it !is DispatchOutcome.LinkingCodeReady }
+            }
+            runnerEventsFlow.emit(
+                ExchangeV2Event.Transition(
+                    timestampMs = System.currentTimeMillis(),
+                    from = ExchangeV2State.Joiner.Waiting,
+                    to = ExchangeV2State.Joiner.Done,
+                    trigger = responseMessage,
+                    localTrigger = null,
+                ),
+            )
+            job.await()
+        }
+        assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.JOINER, PeerKind.DDG), outcome)
+        verify(syncAccountRepository).processCode(any(), anyOrNull())
+        verify(syncAccountRepository, never()).joinAccountFromThirdPartyRecoveryCode(any())
+    }
+
+    @Test fun `presentV2 emits LoggedIn via 3party upgrade when Joiner_Done carries a cid=3party recovery code`() = runTest {
+        setV2(true)
+        val recoveryJson = JSONObject().apply {
+            put(
+                "recovery",
+                JSONObject().apply {
+                    put("user_id", "u-3p")
+                    put("secret", "s-3p")
+                    put("cid", "3party")
+                    put("v", "2.0")
+                },
+            )
+        }.toString()
+        val b64 = android.util.Base64.encodeToString(
+            recoveryJson.toByteArray(Charsets.UTF_8),
+            android.util.Base64.URL_SAFE or android.util.Base64.NO_PADDING or android.util.Base64.NO_WRAP,
+        )
+        val responseMessage = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse(
+            rawJson = "{}",
+            recoveryCode = b64,
+        )
+        whenever(syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(any())).thenReturn(Result.Success(true))
+
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+                dispatcher.presentV2().first { it !is DispatchOutcome.LinkingCodeReady }
+            }
+            runnerEventsFlow.emit(
+                ExchangeV2Event.Transition(
+                    timestampMs = System.currentTimeMillis(),
+                    from = ExchangeV2State.Joiner.Waiting,
+                    to = ExchangeV2State.Joiner.Done,
+                    trigger = responseMessage,
+                    localTrigger = null,
+                ),
+            )
+            job.await()
+        }
+        assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.JOINER), outcome)
+        verify(syncAccountRepository).joinAccountFromThirdPartyRecoveryCode(any())
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
+    }
+
+    @Test fun `presentV2 emits Failed with cancelled-on-this-device reason when Joiner reaches AbortedLocal`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedLocal,
+                    localTrigger = LocalTrigger.UserDeniedJoiner,
+                ),
+            )
+            job.await()
+        }
+        assertEquals(
+            DispatchOutcome.Failed(
+                "Pairing cancelled on this device",
+                PAIRING_CANCELLED.code,
+                path = SetupPath.PAIRING,
+                myRole = SetupRole.JOINER,
+            ),
+            outcome,
+        )
+    }
+
+    @Test fun `presentV2 calls runner_startPresent when Flow is collected`() = runTest {
+        val flow = dispatcher.presentV2()
+        verify(runner, never()).startPresent()
+
+        withTimeoutOrNull(50) { flow.first() }
+        verify(runner).startPresent()
+    }
+
+    @Test fun `presentV2 cancels runner when collecting coroutine is cancelled`() = runTest {
+        val flow = dispatcher.presentV2()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+            flow.collect { /* no-op */ }
+        }
+        verify(runner).startPresent()
+
+        job.cancel()
+        job.join()
+
+        verify(runner).cancel()
+    }
+
+    @Test fun `driveV2Linking cancels runner when collecting coroutine is cancelled`() = runTest {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult.LinkingV2(
+                channelId = "c",
+                publicKey = "k",
+                version = "2",
+            ),
+        )
+        val decision = dispatcher.route("v2-url") as RouteDecision.V2InProgress
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+            decision.outcomes.collect { /* no-op */ }
+        }
+        verify(runner).startScan(any())
+
+        job.cancel()
+        job.join()
+
+        verify(runner).cancel()
+    }
+
+    @Test fun `presentV2 terminates silently when another SessionStarted with different channel arrives`() = runTest {
+        val outcomes = mutableListOf<DispatchOutcome>()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+            dispatcher.presentV2().toList(outcomes)
+        }
+        runnerEventsFlow.emit(sessionStarted(linkingCode = "code-for-own-channel"))
+        runnerEventsFlow.emit(
+            ExchangeV2Event.SessionStarted(
+                timestampMs = System.currentTimeMillis(),
+                pairingRole = PairingRole.Scanner,
+                ownChannelId = "other-channel",
+                linkingCode = null,
+            ),
+        )
+        job.join()
+
+        assertEquals(1, outcomes.size)
+        assertEquals(DispatchOutcome.LinkingCodeReady("code-for-own-channel"), outcomes.single())
+    }
+
+    @Test fun `driveV2Linking terminates silently when another SessionStarted with different channel arrives`() = runTest {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult.LinkingV2(
+                channelId = "peer-channel",
+                publicKey = "k",
+                version = "2",
+            ),
+        )
+        val decision = dispatcher.route("v2-url") as RouteDecision.V2InProgress
+
+        val outcomes = mutableListOf<DispatchOutcome>()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+            decision.outcomes.toList(outcomes)
+        }
+        runnerEventsFlow.emit(
+            ExchangeV2Event.SessionStarted(
+                timestampMs = System.currentTimeMillis(),
+                pairingRole = PairingRole.Scanner,
+                ownChannelId = "scanner-own-channel",
+                linkingCode = null,
+            ),
+        )
+        runnerEventsFlow.emit(
+            ExchangeV2Event.SessionStarted(
+                timestampMs = System.currentTimeMillis(),
+                pairingRole = PairingRole.Presenter,
+                ownChannelId = "different-channel",
+                linkingCode = "code",
+            ),
+        )
+        job.join()
+
+        assertTrue("expected no outcomes, got $outcomes", outcomes.isEmpty())
+    }
+
+    @Test fun `presentV2 emits Failed when runner reaches Aborted (hello during negotiating)`() = runTest {
+        val outcomes = mutableListOf<DispatchOutcome>()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+            dispatcher.presentV2().take(1).collect { outcomes += it }
+        }
+        runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Aborted))
+        job.join()
+
+        assertTrue("expected Failed, got ${outcomes.single()}", outcomes.single() is DispatchOutcome.Failed)
+    }
+
+    @Test fun `linking flow emits Failed when runner reaches Aborted (hello during negotiating)`() = runTest {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        val decision = dispatcher.route("v2-url") as RouteDecision.V2InProgress
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+                decision.outcomes.first { it is DispatchOutcome.Failed }
+            }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Aborted))
+            job.await()
+        }
+        assertTrue("expected Failed, got $outcome", outcome is DispatchOutcome.Failed)
+    }
+
+    @Test fun `presentV2 filters out events from before session start`() = runTest {
+        val staleFlow = MutableSharedFlow<ExchangeV2Event>(replay = 10)
+        staleFlow.tryEmit(
+            ExchangeV2Event.Transition(
+                timestampMs = 1L,
+                from = ExchangeV2State.Host.Sending,
+                to = ExchangeV2State.Host.Done,
+                trigger = null,
+                localTrigger = null,
+            ),
+        )
+        whenever(runner.events).thenReturn(staleFlow)
+        whenever(runner.eventsSince(any())).thenAnswer { inv ->
+            val since = inv.getArgument<Long>(0)
+            staleFlow.filter { it.timestampMs >= since }
+        }
+
+        val outcome = withTimeoutOrNull(100) { dispatcher.presentV2().first() }
+        assertEquals(null, outcome)
+    }
+
+    private fun startLinking(): kotlinx.coroutines.flow.Flow<DispatchOutcome> {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        return (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
+    }
+
+    @Test fun `linking - AbortedByHost with RecoveryCodeDenied maps to Failed PAIRING_REJECTED`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                ),
+            )
+            job.await()
+        }
+        assertTrue("expected Failed, got $outcome", outcome is DispatchOutcome.Failed)
+        assertEquals(PAIRING_REJECTED.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `linking - AbortedByHost with RecoveryCodeUnavailable maps to Failed PAIRING_UNAVAILABLE`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.RecoveryCodeUnavailable(rawJson = "{}"),
+                ),
+            )
+            job.await()
+        }
+        assertEquals(PAIRING_UNAVAILABLE.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `linking - Joiner AbortedLocal maps to Failed PAIRING_CANCELLED`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Joiner.Confirming, to = ExchangeV2State.Joiner.AbortedLocal))
+            job.await()
+        }
+        assertEquals(PAIRING_CANCELLED.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `linking - Aborted maps to Failed NEGOTIATION_ABORTED`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Aborted))
+            job.await()
+        }
+        assertEquals(NEGOTIATION_ABORTED.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `linking - Joiner Done without recovery code maps to Failed NO_RECOVERY_CODE`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Joiner.Waiting, to = ExchangeV2State.Joiner.Done))
+            job.await()
+        }
+        assertEquals(NO_RECOVERY_CODE.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `linking - SessionError maps to Failed PAIRING_FAILED`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(ExchangeV2Event.SessionError(timestampMs = System.currentTimeMillis(), message = "channel 500"))
+            job.await()
+        }
+        assertEquals(PAIRING_FAILED.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `linking - Host Aborted maps to Failed NEGOTIATION_ABORTED`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Host.Confirming, to = ExchangeV2State.Host.Aborted))
+            job.await()
+        }
+        assertEquals(NEGOTIATION_ABORTED.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `present - AbortedByHost with RecoveryCodeDenied maps to Failed PAIRING_REJECTED`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                ),
+            )
+            job.await()
+        }
+        assertEquals(PAIRING_REJECTED.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `present - Host Aborted with no localTrigger maps to Failed NEGOTIATION_ABORTED`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Host.Confirming, to = ExchangeV2State.Host.Aborted))
+            job.await()
+        }
+        assertEquals(NEGOTIATION_ABORTED.code, (outcome as DispatchOutcome.Failed).code)
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ThirdPartyCredentialManagerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ThirdPartyCredentialManagerTest.kt
@@ -60,12 +60,22 @@ class ThirdPartyCredentialManagerTest {
     private val syncJweCrypto: SyncJweCrypto = mock()
     private val nativeLib: SyncLib = mock()
     private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
+    private val protectedKeyManager: ProtectedKeyManager = mock()
+
+    // A ddg-wrapped key already on the account; used by the happy-path tests.
+    private val existingDdgKey = ProtectedKeyEntry(
+        kid = "k-existing",
+        purpose = "ai_chats",
+        encryptedWith = "ddg",
+        encryptedPrivateKey = "AAAA",
+        publicKey = RsaJwk(n = "mod", e = "AQAB"),
+    )
 
     private lateinit var manager: ThirdPartyCredentialManager
 
     @Before
     fun before() {
-        manager = RealThirdPartyCredentialManager(syncStore, syncApi, syncJweCrypto, nativeLib, syncFeature)
+        manager = RealThirdPartyCredentialManager(syncStore, syncApi, syncJweCrypto, nativeLib, syncFeature, protectedKeyManager)
     }
 
     // ---- create() ----
@@ -126,7 +136,7 @@ class ThirdPartyCredentialManagerTest {
     @Test
     fun whenCreateSucceedsThenStoresScopedPassword() {
         primeCreate()
-        whenever(syncApi.getProtectedKeys(token)).thenReturn(Success(emptyList()))
+        whenever(syncApi.getProtectedKeys(token)).thenReturn(Success(listOf(existingDdgKey)))
 
         val result = manager.create()
 
@@ -140,7 +150,7 @@ class ThirdPartyCredentialManagerTest {
         // salt=user_id_bytes, info="Password", 32) re-encoded as base64url (no padding). Per
         // Encryption Algorithms TD §"Hashed password derivation" (Asana 1214802412121967).
         primeCreate()
-        whenever(syncApi.getProtectedKeys(token)).thenReturn(Success(emptyList()))
+        whenever(syncApi.getProtectedKeys(token)).thenReturn(Success(listOf(existingDdgKey)))
         // Use the real HKDF impl so we can compute the expected output.
         val realJweCrypto = com.duckduckgo.sync.impl.crypto.RealSyncJweCrypto()
         whenever(syncJweCrypto.hkdfSha256SingleBlock(any(), any(), any(), any())).doAnswer { invocation ->
@@ -203,7 +213,7 @@ class ThirdPartyCredentialManagerTest {
     @Test
     fun whenCreateAccessCredentialApiFailsThenError() {
         primeCreate()
-        whenever(syncApi.getProtectedKeys(token)).thenReturn(Success(emptyList()))
+        whenever(syncApi.getProtectedKeys(token)).thenReturn(Success(listOf(existingDdgKey)))
         whenever(syncApi.createAccessCredential(anyString(), anyString(), any())).thenReturn(
             Error(code = 500, reason = "server error"),
         )
@@ -211,6 +221,71 @@ class ThirdPartyCredentialManagerTest {
         val result = manager.create()
 
         assertTrue(result is Error)
+    }
+
+    @Test
+    fun whenNoDdgProtectedKeysThenGeneratesAiChatsKeyAndIncludesItInThirdPartyCredential() {
+        // BUG-C: a freshly-created ddg account has no protected keys. Per Unified Algorithm
+        // §"Obtaining 3party secret": "if there are no Protected Keys, generate new ones for
+        // ai_chat purpose". Otherwise POST /access-credentials/3party carries no keys and the real
+        // FE browser's login returns no ai_chat key. (1215297327538410)
+        primeCreate()
+        val generatedDdgKey = ProtectedKeyEntry(
+            kid = "k-ai",
+            purpose = "ai_chats",
+            encryptedWith = "ddg",
+            encryptedPrivateKey = "AAAA",
+            publicKey = RsaJwk(n = "mod", e = "AQAB"),
+        )
+        whenever(syncApi.getProtectedKeys(token)).thenReturn(Success(emptyList()))
+        whenever(protectedKeyManager.create("ai_chats")).thenReturn(Success(generatedDdgKey))
+        whenever(nativeLib.decryptData(any<ByteArray>(), eq(secretKey))).thenReturn(DecryptBytesResult(0, "raw_key".toByteArray()))
+
+        val result = manager.create()
+
+        assertEquals(Success(true), result)
+        verify(protectedKeyManager).create("ai_chats")
+        // getProtectedKeys is called once (initial check); generation does NOT trigger a re-fetch.
+        verify(syncApi, times(1)).getProtectedKeys(token)
+        verify(syncApi).createAccessCredential(
+            eq(token),
+            eq("3party"),
+            check { request ->
+                assertEquals(1, request.keys?.size)
+                assertEquals("k-ai", request.keys?.first()?.kid)
+                assertEquals("3party", request.keys?.first()?.encryptedWith)
+            },
+        )
+    }
+
+    @Test
+    fun whenGetKeysRateLimitedThenRetriesAndSucceeds() {
+        // BUG-B: the no-account Host provisioning burst gets HTTP 418 (TOO_MANY_REQUESTS_2) on
+        // GET /keys. The call is idempotent, so a bounded retry-on-rate-limit should recover.
+        (manager as RealThirdPartyCredentialManager).rateLimitRetryDelayMillis = 0L
+        primeCreate()
+        whenever(syncApi.getProtectedKeys(token)).thenReturn(
+            Error(code = API_CODE.TOO_MANY_REQUESTS_2.code),
+            Success(listOf(existingDdgKey)),
+        )
+
+        val result = manager.create()
+
+        assertEquals(Success(true), result)
+        verify(syncApi, times(2)).getProtectedKeys(token)
+    }
+
+    @Test
+    fun whenGetKeysRateLimitedBeyondRetryLimitThenError() {
+        (manager as RealThirdPartyCredentialManager).rateLimitRetryDelayMillis = 0L
+        primeCreate()
+        whenever(syncApi.getProtectedKeys(token)).thenReturn(Error(code = API_CODE.TOO_MANY_REQUESTS_2.code))
+
+        val result = manager.create()
+
+        assertTrue(result is Error)
+        // 1 initial attempt + MAX_RATE_LIMIT_RETRIES retries.
+        verify(syncApi, times(RealThirdPartyCredentialManager.MAX_RATE_LIMIT_RETRIES + 1)).getProtectedKeys(token)
     }
 
     @Test
@@ -224,7 +299,7 @@ class ThirdPartyCredentialManagerTest {
             Success(emptyList()),
             Success(listOf(AccessCredentialEntry(id = "3party", scope = "ai_chats", encryptedCredential = "encrypted_sp_from_server"))),
         )
-        whenever(syncApi.getProtectedKeys(token)).thenReturn(Success(emptyList()))
+        whenever(syncApi.getProtectedKeys(token)).thenReturn(Success(listOf(existingDdgKey)))
         whenever(syncApi.createAccessCredential(anyString(), anyString(), any())).thenReturn(
             Error(code = 409, reason = "credential already exists"),
         )
@@ -241,7 +316,7 @@ class ThirdPartyCredentialManagerTest {
     @Test
     fun whenCreate409ConflictButCredentialStillMissingThenError() {
         primeCreate()
-        whenever(syncApi.getProtectedKeys(token)).thenReturn(Success(emptyList()))
+        whenever(syncApi.getProtectedKeys(token)).thenReturn(Success(listOf(existingDdgKey)))
         whenever(syncApi.createAccessCredential(anyString(), anyString(), any())).thenReturn(
             Error(code = 409, reason = "credential already exists"),
         )
@@ -414,7 +489,7 @@ class ThirdPartyCredentialManagerTest {
     @Test
     fun whenCreateAccessCredentialPostedThenRequestJsonMatchesSpec() {
         primeCreate()
-        whenever(syncApi.getProtectedKeys(token)).thenReturn(Success(emptyList()))
+        whenever(syncApi.getProtectedKeys(token)).thenReturn(Success(listOf(existingDdgKey)))
 
         manager.create()
 
@@ -450,5 +525,6 @@ class ThirdPartyCredentialManagerTest {
         whenever(syncJweCrypto.jweEncryptSymmetric(any(), any(), anyOrNull())).thenReturn("encrypted_sp")
         whenever(syncApi.getAccessCredentials(token)).thenReturn(Success(emptyList()))
         whenever(syncApi.createAccessCredential(anyString(), anyString(), any())).thenReturn(Success(true))
+        whenever(nativeLib.decryptData(any<ByteArray>(), eq(secretKey))).thenReturn(DecryptBytesResult(0, "raw_key".toByteArray()))
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachineTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachineTest.kt
@@ -285,6 +285,58 @@ class ExchangeV2StateMachineTest {
         assertSame(ExchangeV2State.Joiner.AbortedLocal, machine.currentState)
     }
 
+    @Test fun `when denied received in Joiner Confirming then transitions to Joiner AbortedByHost`() {
+        val machine = inJoinerConfirming()
+        val result = machine.receive(RecoveryCodeDenied("{}"))
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Joiner.AbortedByHost, machine.currentState)
+    }
+
+    @Test fun `when unavailable received in Joiner Confirming then transitions to Joiner AbortedByHost`() {
+        val machine = inJoinerConfirming()
+        val result = machine.receive(RecoveryCodeUnavailable("{}"))
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Joiner.AbortedByHost, machine.currentState)
+    }
+
+    @Test fun `when host success-phase message received in Joiner Confirming then aborts and stays put`() {
+        val hostSuccessPhase: List<ExchangeV2Message> = listOf(
+            RecoveryCodeAwaitingConfirmation("{}"),
+            RecoveryCodeConfirmed("{}"),
+            RecoveryCodeResponse("{}"),
+        )
+        for (msg in hostSuccessPhase) {
+            val machine = inJoinerConfirming()
+            val result = machine.receive(msg)
+            assertTrue("recv $msg in Joiner.Confirming should abort, got ${result.outcome}", result.outcome is TransitionOutcome.Aborted)
+            assertEquals(RejectReason.ImplicitAbort, (result.outcome as TransitionOutcome.Aborted).reason)
+            assertSame("recv $msg should leave the SM in Joiner.Confirming", ExchangeV2State.Joiner.Confirming, machine.currentState)
+        }
+    }
+
+    @Test fun `when negotiation-phase message received in Joiner Confirming then aborts`() {
+        val negotiationPhase: List<ExchangeV2Message> = listOf(
+            Hello("{}"),
+            availableFromPeer(),
+            requestFromPeer(),
+        )
+        for (msg in negotiationPhase) {
+            val machine = inJoinerConfirming()
+            val result = machine.receive(msg)
+            assertTrue("recv $msg in Joiner.Confirming should abort, got ${result.outcome}", result.outcome is TransitionOutcome.Aborted)
+        }
+    }
+
+    @Test fun `when unknown message received in Joiner Confirming then dropped`() {
+        val machine = inJoinerConfirming()
+        val result = machine.receive(Unknown("{}", "future"))
+
+        assertSame(TransitionOutcome.Dropped, result.outcome)
+        assertSame(ExchangeV2State.Joiner.Confirming, machine.currentState)
+    }
+
     @Test fun `when awaiting_confirmation received in Joiner Waiting then stays in Joiner Waiting`() {
         val machine = inJoinerWaiting()
         val result = machine.receive(RecoveryCodeAwaitingConfirmation("{}"))

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachineTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachineTest.kt
@@ -1,0 +1,436 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Hello
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAvailable
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeAwaitingConfirmation
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeConfirmed
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeDenied
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeRequest
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeUnavailable
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Unknown
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ExchangeV2StateMachineTest {
+
+    private val clock = ExchangeV2Clock { 1_000L }
+
+    private fun sm(localUserId: String? = "local-user"): ExchangeV2StateMachine =
+        RealExchangeV2StateMachine(localUserId = localUserId, clock = clock)
+
+    private fun scannerSm(localUserId: String? = "local-user"): ExchangeV2StateMachine =
+        RealExchangeV2StateMachine(localUserId = localUserId, clock = clock, initialState = ExchangeV2State.Negotiating)
+
+    private fun availableFromPeer(userId: String = "other", name: String = "Peer", kind: String = "3party") =
+        RecoveryCodeAvailable(rawJson = "{}", userId = userId, name = name, kind = kind)
+
+    private fun requestFromPeer(name: String = "Peer", kind: String = "3party") =
+        RecoveryCodeRequest(rawJson = "{}", name = name, kind = kind)
+
+    @Test fun `when hello received in Bootstrapped then transitions to Negotiating`() {
+        val machine = sm()
+        val result = machine.receive(Hello("{}"))
+
+        assertSame(ExchangeV2State.Negotiating, result.newState)
+        assertSame(ExchangeV2State.Negotiating, machine.currentState)
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        val transition = result.event as ExchangeV2Event.Transition
+        assertSame(ExchangeV2State.Bootstrapped, transition.from)
+        assertSame(ExchangeV2State.Negotiating, transition.to)
+        assertTrue(transition.trigger is Hello)
+    }
+
+    @Test fun `when non-hello known message received in Bootstrapped then aborts`() {
+        val known: List<ExchangeV2Message> = listOf(
+            availableFromPeer(),
+            requestFromPeer(),
+            RecoveryCodeAwaitingConfirmation("{}"),
+            RecoveryCodeConfirmed("{}"),
+            RecoveryCodeDenied("{}"),
+            RecoveryCodeUnavailable("{}"),
+            RecoveryCodeResponse("{}"),
+        )
+        for (msg in known) {
+            val machine = sm()
+            val result = machine.receive(msg)
+            assertTrue("expected abort for $msg, got ${result.outcome}", result.outcome is TransitionOutcome.Aborted)
+            assertEquals(RejectReason.ImplicitAbort, (result.outcome as TransitionOutcome.Aborted).reason)
+        }
+    }
+
+    @Test fun `when unknown message received in Bootstrapped then dropped and state unchanged`() {
+        val machine = sm()
+        val result = machine.receive(Unknown("{}", "future_message"))
+
+        assertSame(TransitionOutcome.Dropped, result.outcome)
+        assertSame(ExchangeV2State.Bootstrapped, machine.currentState)
+        val event = result.event as ExchangeV2Event.MessageRejected
+        assertEquals(RejectReason.UnknownMessageDropped, event.reason)
+    }
+
+    @Test fun `when out-of-sequence local trigger in Bootstrapped then aborts`() {
+        val machine = sm()
+        val result = machine.localTrigger(LocalTrigger.UserConfirmedHost)
+        assertTrue(result.outcome is TransitionOutcome.Aborted)
+    }
+
+    @Test fun `when presenter receives second hello in Negotiating then aborts to terminal Aborted`() {
+        val machine = sm()
+        assertSame(ExchangeV2State.Negotiating, machine.receive(Hello("{}")).newState)
+
+        val result = machine.receive(Hello("{}"))
+
+        assertSame(ExchangeV2State.Aborted, machine.currentState)
+        assertTrue(result.outcome is TransitionOutcome.Aborted)
+        assertEquals(RejectReason.ImplicitAbort, (result.outcome as TransitionOutcome.Aborted).reason)
+        val transition = result.event as ExchangeV2Event.Transition
+        assertSame(ExchangeV2State.Negotiating, transition.from)
+        assertSame(ExchangeV2State.Aborted, transition.to)
+    }
+
+    @Test fun `when scanner receives hello in Negotiating then aborts to terminal Aborted`() {
+        val machine = scannerSm()
+
+        val result = machine.receive(Hello("{}"))
+
+        assertSame(ExchangeV2State.Aborted, machine.currentState)
+        assertTrue(result.outcome is TransitionOutcome.Aborted)
+        assertEquals(RejectReason.ImplicitAbort, (result.outcome as TransitionOutcome.Aborted).reason)
+        val transition = result.event as ExchangeV2Event.Transition
+        assertSame(ExchangeV2State.Negotiating, transition.from)
+        assertSame(ExchangeV2State.Aborted, transition.to)
+    }
+
+    @Test fun `when message received in Aborted then state unchanged and aborts`() {
+        val machine = scannerSm()
+        machine.receive(Hello("{}"))
+        assertSame(ExchangeV2State.Aborted, machine.currentState)
+
+        val result = machine.receive(availableFromPeer())
+
+        assertSame(ExchangeV2State.Aborted, machine.currentState)
+        assertTrue(result.outcome is TransitionOutcome.Aborted)
+    }
+
+    @Test fun `when recovery_code_available with matching user_id received in Negotiating then transitions to SameAccountAbort`() {
+        val machine = sm(localUserId = "shared-user")
+        machine.receive(Hello("{}"))
+        val msg = availableFromPeer(userId = "shared-user")
+        val result = machine.receive(msg)
+
+        assertEquals(ExchangeV2State.SameAccountAbort, machine.currentState)
+        assertEquals(ExchangeV2State.SameAccountAbort, result.newState)
+        assertTrue(result.outcome is TransitionOutcome.Aborted)
+        assertEquals(RejectReason.SameAccount, (result.outcome as TransitionOutcome.Aborted).reason)
+        val event = result.event
+        assertTrue("expected Transition event, got ${event::class.simpleName}", event is ExchangeV2Event.Transition)
+        event as ExchangeV2Event.Transition
+        assertEquals(ExchangeV2State.Negotiating, event.from)
+        assertEquals(ExchangeV2State.SameAccountAbort, event.to)
+        assertSame(msg, event.trigger)
+        assertEquals(null, event.localTrigger)
+    }
+
+    @Test fun `when recovery_code_available with different user_id received in Negotiating then stays in Negotiating`() {
+        val machine = sm(localUserId = "local-user")
+        machine.receive(Hello("{}"))
+        val result = machine.receive(availableFromPeer(userId = "other-user"))
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Negotiating, machine.currentState)
+        val transition = result.event as ExchangeV2Event.Transition
+        assertTrue(transition.trigger is RecoveryCodeAvailable)
+    }
+
+    @Test fun `when recovery_code_request received in Negotiating then stays in Negotiating`() {
+        val machine = sm()
+        machine.receive(Hello("{}"))
+        val result = machine.receive(requestFromPeer())
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Negotiating, machine.currentState)
+    }
+
+    @Test fun `when finalise-phase message received in Negotiating then aborts`() {
+        val finalise: List<ExchangeV2Message> = listOf(
+            RecoveryCodeAwaitingConfirmation("{}"),
+            RecoveryCodeConfirmed("{}"),
+            RecoveryCodeDenied("{}"),
+            RecoveryCodeUnavailable("{}"),
+            RecoveryCodeResponse("{}"),
+        )
+        for (msg in finalise) {
+            val machine = sm()
+            machine.receive(Hello("{}"))
+            val result = machine.receive(msg)
+            assertTrue("expected abort for $msg in Negotiating, got ${result.outcome}", result.outcome is TransitionOutcome.Aborted)
+        }
+    }
+
+    @Test fun `when RoleElected Host in Negotiating then transitions to Host Confirming`() {
+        val machine = sm()
+        machine.receive(Hello("{}"))
+        val result = machine.localTrigger(LocalTrigger.RoleElected(Role.Host))
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Host.Confirming, machine.currentState)
+    }
+
+    @Test fun `when RoleElected Joiner in Negotiating then transitions to Joiner Confirming`() {
+        val machine = sm()
+        machine.receive(Hello("{}"))
+        val result = machine.localTrigger(LocalTrigger.RoleElected(Role.Joiner))
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Joiner.Confirming, machine.currentState)
+    }
+
+    @Test fun `when RoleElected fires after peer availability then transitions to Joiner Confirming`() {
+        val machine = sm()
+        machine.receive(Hello("{}"))
+        machine.receive(availableFromPeer(userId = "other-user"))
+        val result = machine.localTrigger(LocalTrigger.RoleElected(Role.Joiner))
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Joiner.Confirming, machine.currentState)
+    }
+
+    @Test fun `when user confirms in Host Confirming then advances to Host Sending`() {
+        val machine = inHostConfirming()
+        val result = machine.localTrigger(LocalTrigger.UserConfirmedHost)
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Host.Sending, machine.currentState)
+    }
+
+    @Test fun `when user denies in Host Confirming then advances to Host Aborted`() {
+        val machine = inHostConfirming()
+        val result = machine.localTrigger(LocalTrigger.UserDeniedHost)
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Host.Aborted, machine.currentState)
+    }
+
+    @Test fun `when HostSendComplete in Host Sending then advances to Host Done`() {
+        val machine = inHostConfirming()
+        machine.localTrigger(LocalTrigger.UserConfirmedHost)
+        val result = machine.localTrigger(LocalTrigger.HostSendComplete)
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Host.Done, machine.currentState)
+    }
+
+    @Test fun `when wire message received in Host states then aborts`() {
+        val hostStateBuilders: List<Pair<String, () -> ExchangeV2StateMachine>> = listOf(
+            "Host.Confirming" to ::inHostConfirming,
+            "Host.Sending" to {
+                inHostConfirming().also { it.localTrigger(LocalTrigger.UserConfirmedHost) }
+            },
+        )
+        val knownIncoming: List<ExchangeV2Message> = listOf(
+            Hello("{}"),
+            availableFromPeer(),
+            requestFromPeer(),
+            RecoveryCodeResponse("{}"),
+        )
+        for ((label, build) in hostStateBuilders) {
+            for (msg in knownIncoming) {
+                val machine = build()
+                val result = machine.receive(msg)
+                assertTrue("$label recv $msg should abort, got ${result.outcome}", result.outcome is TransitionOutcome.Aborted)
+            }
+        }
+    }
+
+    @Test fun `when unknown message received in Host Confirming then dropped`() {
+        val machine = inHostConfirming()
+        val result = machine.receive(Unknown("{}", "future"))
+
+        assertSame(TransitionOutcome.Dropped, result.outcome)
+        assertSame(ExchangeV2State.Host.Confirming, machine.currentState)
+    }
+
+    @Test fun `when user confirms in Joiner Confirming then advances to Joiner Waiting`() {
+        val machine = inJoinerConfirming()
+        val result = machine.localTrigger(LocalTrigger.UserConfirmedJoiner)
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Joiner.Waiting, machine.currentState)
+    }
+
+    @Test fun `when user denies in Joiner Confirming then advances to Joiner AbortedLocal`() {
+        val machine = inJoinerConfirming()
+        val result = machine.localTrigger(LocalTrigger.UserDeniedJoiner)
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Joiner.AbortedLocal, machine.currentState)
+    }
+
+    @Test fun `when awaiting_confirmation received in Joiner Waiting then stays in Joiner Waiting`() {
+        val machine = inJoinerWaiting()
+        val result = machine.receive(RecoveryCodeAwaitingConfirmation("{}"))
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Joiner.Waiting, machine.currentState)
+    }
+
+    @Test fun `when confirmed received in Joiner Waiting then stays in Joiner Waiting`() {
+        val machine = inJoinerWaiting()
+        val result = machine.receive(RecoveryCodeConfirmed("{}"))
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Joiner.Waiting, machine.currentState)
+    }
+
+    @Test fun `when denied received in Joiner Waiting then transitions to Joiner AbortedByHost`() {
+        val machine = inJoinerWaiting()
+        val result = machine.receive(RecoveryCodeDenied("{}"))
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Joiner.AbortedByHost, machine.currentState)
+    }
+
+    @Test fun `when unavailable received in Joiner Waiting then transitions to Joiner AbortedByHost`() {
+        val machine = inJoinerWaiting()
+        val result = machine.receive(RecoveryCodeUnavailable("{}"))
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Joiner.AbortedByHost, machine.currentState)
+    }
+
+    @Test fun `when response received in Joiner Waiting then transitions to Joiner Done`() {
+        val machine = inJoinerWaiting()
+        val result = machine.receive(RecoveryCodeResponse("{}"))
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Joiner.Done, machine.currentState)
+    }
+
+    @Test fun `when negotiation-phase message received in Joiner Waiting then aborts`() {
+        val negotiationPhase: List<ExchangeV2Message> = listOf(
+            Hello("{}"),
+            availableFromPeer(),
+            requestFromPeer(),
+        )
+        for (msg in negotiationPhase) {
+            val machine = inJoinerWaiting()
+            val result = machine.receive(msg)
+            assertTrue("recv $msg in Joiner.Waiting should abort, got ${result.outcome}", result.outcome is TransitionOutcome.Aborted)
+        }
+    }
+
+    @Test fun `when unknown message received in Joiner Waiting then dropped`() {
+        val machine = inJoinerWaiting()
+        val result = machine.receive(Unknown("{}", "future"))
+
+        assertSame(TransitionOutcome.Dropped, result.outcome)
+        assertSame(ExchangeV2State.Joiner.Waiting, machine.currentState)
+    }
+
+    @Test fun `when message received in SameAccountAbort then aborts and state unchanged`() {
+        val machine = sm(localUserId = "shared-user")
+        machine.receive(Hello("{}"))
+        machine.receive(availableFromPeer(userId = "shared-user"))
+        val before = machine.currentState
+        val result = machine.receive(RecoveryCodeResponse("{}"))
+
+        assertTrue(result.outcome is TransitionOutcome.Aborted)
+        assertSame(before, machine.currentState)
+    }
+
+    @Test fun `when recovery_code_available received and local user is null then stays in Negotiating`() {
+        val machine = sm(localUserId = null)
+        machine.receive(Hello("{}"))
+        val result = machine.receive(availableFromPeer(userId = "anything"))
+
+        assertSame(TransitionOutcome.Accepted, result.outcome)
+        assertSame(ExchangeV2State.Negotiating, machine.currentState)
+    }
+
+    @Test fun `when RoleElected Host then emits SendAwaitingConfirmation side effect`() {
+        val machine = sm()
+        machine.receive(Hello("{}"))
+        machine.receive(requestFromPeer())
+
+        val result = machine.localTrigger(LocalTrigger.RoleElected(Role.Host))
+
+        assertEquals(listOf(SideEffect.SendAwaitingConfirmation), result.sideEffects)
+    }
+
+    @Test fun `when RoleElected Joiner then emits no side effects`() {
+        val machine = sm()
+        machine.receive(Hello("{}"))
+        machine.receive(availableFromPeer(userId = "other"))
+
+        val result = machine.localTrigger(LocalTrigger.RoleElected(Role.Joiner))
+
+        assertTrue("expected no side effects, got ${result.sideEffects}", result.sideEffects.isEmpty())
+    }
+
+    @Test fun `when user confirms as Host then emits SendConfirmed and RequestRecoveryCodeShare`() {
+        val machine = inHostConfirming()
+
+        val result = machine.localTrigger(LocalTrigger.UserConfirmedHost)
+
+        assertEquals(
+            listOf(SideEffect.SendConfirmed, SideEffect.RequestRecoveryCodeShare),
+            result.sideEffects,
+        )
+    }
+
+    @Test fun `when user denies as Host then emits SendDenied`() {
+        val machine = inHostConfirming()
+
+        val result = machine.localTrigger(LocalTrigger.UserDeniedHost)
+
+        assertEquals(listOf(SideEffect.SendDenied), result.sideEffects)
+    }
+
+    @Test fun `when Joiner confirms or denies then emits no side effects`() {
+        val confirming = inJoinerConfirming()
+        val confirmed = confirming.localTrigger(LocalTrigger.UserConfirmedJoiner)
+        assertTrue(confirmed.sideEffects.isEmpty())
+
+        val denying = inJoinerConfirming()
+        val denied = denying.localTrigger(LocalTrigger.UserDeniedJoiner)
+        assertTrue(denied.sideEffects.isEmpty())
+    }
+
+    private fun inHostConfirming(): ExchangeV2StateMachine =
+        sm().also {
+            it.receive(Hello("{}"))
+            it.receive(requestFromPeer())
+            it.localTrigger(LocalTrigger.RoleElected(Role.Host))
+        }
+
+    private fun inJoinerConfirming(): ExchangeV2StateMachine =
+        sm().also {
+            it.receive(Hello("{}"))
+            it.receive(availableFromPeer(userId = "other"))
+            it.localTrigger(LocalTrigger.RoleElected(Role.Joiner))
+        }
+
+    private fun inJoinerWaiting(): ExchangeV2StateMachine =
+        inJoinerConfirming().also {
+            it.localTrigger(LocalTrigger.UserConfirmedJoiner)
+        }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/JsonExchangeV2MessageParserTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/JsonExchangeV2MessageParserTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class JsonExchangeV2MessageParserTest {
+
+    private val parser = JsonExchangeV2MessageParser()
+
+    @Test fun `parses hello with channel_id+public_key+version`() {
+        val json = """{"type":"hello","channel_id":"abc","public_key":"key","version":"2.1"}"""
+
+        val parsed = parser.parse(json) as ExchangeV2Message.Hello
+
+        assertEquals("abc", parsed.channelId)
+        assertEquals("key", parsed.publicKey)
+        assertEquals("2.1", parsed.version)
+        assertEquals(json, parsed.rawJson)
+    }
+
+    @Test fun `hello defaults version to 2 when omitted`() {
+        val parsed = parser.parse("""{"type":"hello"}""") as ExchangeV2Message.Hello
+        assertEquals("2", parsed.version)
+    }
+
+    @Test fun `parses recovery_code_available with user_id+name+kind`() {
+        val json = """{"type":"recovery_code_available","user_id":"u","name":"Alice","kind":"ddg"}"""
+
+        val parsed = parser.parse(json) as ExchangeV2Message.RecoveryCodeAvailable
+
+        assertEquals("u", parsed.userId)
+        assertEquals("Alice", parsed.name)
+        assertEquals("ddg", parsed.kind)
+    }
+
+    @Test fun `parses recovery_code_request without user_id`() {
+        val json = """{"type":"recovery_code_request","name":"Bob","kind":"3party"}"""
+
+        val parsed = parser.parse(json) as ExchangeV2Message.RecoveryCodeRequest
+
+        assertEquals("Bob", parsed.name)
+        assertEquals("3party", parsed.kind)
+    }
+
+    @Test fun `parses recovery_code_response with embedded recovery_code`() {
+        val json = """{"type":"recovery_code_response","recovery_code":"the-code"}"""
+
+        val parsed = parser.parse(json) as ExchangeV2Message.RecoveryCodeResponse
+
+        assertEquals("the-code", parsed.recoveryCode)
+    }
+
+    @Test fun `parses bodyless types awaiting_confirmation confirmed denied unavailable`() {
+        assertTrue(parser.parse("""{"type":"recovery_code_awaiting_confirmation"}""") is ExchangeV2Message.RecoveryCodeAwaitingConfirmation)
+        assertTrue(parser.parse("""{"type":"recovery_code_confirmed"}""") is ExchangeV2Message.RecoveryCodeConfirmed)
+        assertTrue(parser.parse("""{"type":"recovery_code_denied"}""") is ExchangeV2Message.RecoveryCodeDenied)
+        assertTrue(parser.parse("""{"type":"recovery_code_unavailable"}""") is ExchangeV2Message.RecoveryCodeUnavailable)
+    }
+
+    @Test fun `unknown type becomes Unknown with type preserved (forward-compat)`() {
+        val json = """{"type":"future_message_v3","extra":"data"}"""
+
+        val parsed = parser.parse(json) as ExchangeV2Message.Unknown
+
+        assertEquals("future_message_v3", parsed.messageType)
+        assertEquals(json, parsed.rawJson)
+    }
+
+    @Test fun `missing type field is treated as Unknown with empty messageType`() {
+        val parsed = parser.parse("""{"no":"type"}""") as ExchangeV2Message.Unknown
+        assertEquals("", parsed.messageType)
+    }
+
+    @Test fun `malformed JSON becomes Unknown rather than throwing`() {
+        val parsed = parser.parse("{not valid json") as ExchangeV2Message.Unknown
+        assertEquals("", parsed.messageType)
+    }
+
+    @Test fun `missing fields in a typed message default to empty string`() {
+        // Defensive against partial peers — we should never NPE on missing fields.
+        val parsed = parser.parse("""{"type":"recovery_code_available"}""") as ExchangeV2Message.RecoveryCodeAvailable
+
+        assertEquals("", parsed.userId)
+        assertEquals("", parsed.name)
+        assertEquals("", parsed.kind)
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2ChannelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2ChannelTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import com.duckduckgo.sync.impl.Result
+import com.duckduckgo.sync.impl.SyncApi
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class RealExchangeV2ChannelTest {
+
+    private val syncApi: SyncApi = mock()
+    private val envelope: ExchangeV2Envelope = mock()
+    private val messageParser: ExchangeV2MessageParser = mock()
+
+    private val channel = RealExchangeV2Channel(
+        syncApi = syncApi,
+        envelope = envelope,
+        messageParser = messageParser,
+    )
+
+    @Test fun `poll stops without retrying when the relay returns a non-recoverable status`() = runTest {
+        whenever(syncApi.pollExchangeMessages(any(), any())).thenReturn(
+            Result.Error(code = 403, reason = "Forbidden"),
+            Result.Error(code = 404, reason = "should not be reached"),
+        )
+
+        val received = channel.poll("own-channel", "own-priv").toList()
+
+        assertTrue(received.isEmpty())
+        verify(syncApi, times(1)).pollExchangeMessages(any(), any())
+    }
+
+    @Test fun `poll keeps polling after a transient status and ends on 404`() = runTest {
+        whenever(syncApi.pollExchangeMessages(any(), any())).thenReturn(
+            Result.Error(code = 500, reason = "Server error"),
+            Result.Error(code = 404, reason = "channel gone"),
+        )
+
+        val received = channel.poll("own-channel", "own-priv").toList()
+
+        assertTrue(received.isEmpty())
+        verify(syncApi, times(2)).pollExchangeMessages(any(), any())
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2EnvelopeTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2EnvelopeTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import com.duckduckgo.sync.impl.ExchangeEnvelope
+import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class RealExchangeV2EnvelopeTest {
+
+    private val jweCrypto: SyncJweCrypto = mock()
+    private val envelope = RealExchangeV2Envelope(jweCrypto)
+
+    @Test fun `seal produces envelope with our version and JWE payload`() {
+        whenever(jweCrypto.jweEncryptRsaOaep(any(), any(), any())).thenReturn("jwe-bytes")
+
+        val result = envelope.seal(
+            messageJson = """{"type":"hello"}""",
+            peerPublicKeyBase64 = "peer-pub",
+            senderChannelId = "our-channel",
+        )
+
+        assertEquals(OUR_VERSION_STRING, result.version)
+        assertEquals("jwe-bytes", result.payload)
+        verify(jweCrypto).jweEncryptRsaOaep(
+            plaintext = """{"type":"hello"}""".toByteArray(Charsets.UTF_8),
+            recipientPublicKeyBase64 = "peer-pub",
+            kid = "our-channel",
+        )
+    }
+
+    @Test fun `open decrypts payload and returns plaintext when version matches`() {
+        whenever(jweCrypto.jweDecryptRsaOaep("payload-jwe", "our-priv"))
+            .thenReturn("""{"type":"hello"}""".toByteArray(Charsets.UTF_8))
+
+        val plain = envelope.open(ExchangeEnvelope(version = "2", payload = "payload-jwe"), "our-priv")
+
+        assertEquals("""{"type":"hello"}""", plain)
+    }
+
+    @Test fun `open tolerates 2_x minor versions (forward-compat within major)`() {
+        whenever(jweCrypto.jweDecryptRsaOaep(any(), any())).thenReturn("ok".toByteArray())
+
+        val plain = envelope.open(ExchangeEnvelope(version = "2.5", payload = "p"), "k")
+
+        assertEquals("ok", plain)
+    }
+
+    @Test fun `open throws EnvelopeVersionTooNew for major above ours`() {
+        val ex = assertThrows(EnvelopeVersionTooNew::class.java) {
+            envelope.open(ExchangeEnvelope(version = "3", payload = "anything"), "k")
+        }
+        assertEquals("3", ex.version)
+    }
+
+    @Test fun `open throws EnvelopeVersionTooNew even when minor is set`() {
+        val ex = assertThrows(EnvelopeVersionTooNew::class.java) {
+            envelope.open(ExchangeEnvelope(version = "4.2", payload = "anything"), "k")
+        }
+        assertEquals("4.2", ex.version)
+    }
+
+    @Test fun `open rejects obsolete (lower major) versions`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            envelope.open(ExchangeEnvelope(version = "1", payload = "anything"), "k")
+        }
+    }
+
+    @Test fun `open rejects malformed version strings`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            envelope.open(ExchangeEnvelope(version = "two", payload = "p"), "k")
+        }
+    }
+
+    @Test fun `open does not invoke jwe decrypt when version check fails`() {
+        runCatching { envelope.open(ExchangeEnvelope("3", "p"), "k") }
+        verify(jweCrypto, org.mockito.kotlin.never()).jweDecryptRsaOaep(any(), eq("k"))
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2QrCodeTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2QrCodeTest.kt
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import android.util.Base64
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RealExchangeV2QrCodeTest {
+
+    private val qrCode = RealExchangeV2QrCode()
+
+    // ---- parse: LinkingV2 ----
+
+    @Test fun `parse identifies a well-formed v2 linking URL`() {
+        val url = qrCode.buildLinkingCode(channelId = "abc", publicKeyBase64Url = "pubkey", version = "2")
+
+        val result = qrCode.parse(url)
+
+        assertTrue(result is ExchangeV2CodeParseResult.LinkingV2)
+        result as ExchangeV2CodeParseResult.LinkingV2
+        assertEquals("abc", result.channelId)
+        assertEquals("pubkey", result.publicKey)
+        assertEquals("2", result.version)
+    }
+
+    @Test fun `parse tolerates leading whitespace and prefix text before the URL`() {
+        val url = qrCode.buildLinkingCode("c", "k")
+        val noisy = "   Linking code: $url"
+
+        val result = qrCode.parse(noisy)
+
+        assertTrue(result is ExchangeV2CodeParseResult.LinkingV2)
+    }
+
+    @Test fun `parse accepts a bare base64url v2 payload (no URL wrapper)`() {
+        val bareB64 = encodeUrl("""{"version":"2","channel_id":"x","public_key":"k"}""")
+
+        val result = qrCode.parse(bareB64)
+
+        assertTrue(result is ExchangeV2CodeParseResult.LinkingV2)
+    }
+
+    // ---- parse: LinkingV1 ----
+
+    @Test fun `parse routes legacy connect-shape codes to LinkingV1`() {
+        val payload = """{"connect":{"device_id":"abc","secret_key":"sk"}}"""
+        val url = "https://duckduckgo.com/sync/pairing/#&code=${encodeUrl(payload)}"
+
+        val result = qrCode.parse(url)
+
+        assertEquals(ExchangeV2CodeParseResult.LinkingV1, result)
+    }
+
+    // ---- parse: RecoveryCode ----
+
+    @Test fun `parse detects v2 recovery codes by user_id+secret fields`() {
+        val payload = """{"recovery":{"user_id":"u","secret":"s","cid":"ddg","v":"2.0"}}"""
+        val bareB64 = encodeUrl(payload)
+
+        val result = qrCode.parse(bareB64)
+
+        assertTrue(result is ExchangeV2CodeParseResult.RecoveryCode)
+        result as ExchangeV2CodeParseResult.RecoveryCode
+        assertEquals("u", result.rawJson.getString("user_id"))
+        assertEquals("ddg", result.rawJson.getString("cid"))
+    }
+
+    @Test fun `parse rejects v1 recovery codes (primary_key) so they fall through to legacy stack`() {
+        val payload = """{"recovery":{"primary_key":"pk","user_id":"u"}}"""
+        val bareB64 = encodeUrl(payload)
+
+        val result = qrCode.parse(bareB64)
+
+        assertEquals(ExchangeV2CodeParseResult.Unknown, result)
+    }
+
+    // ---- parse: Unknown ----
+
+    @Test fun `parse returns Unknown for empty input`() {
+        assertEquals(ExchangeV2CodeParseResult.Unknown, qrCode.parse(""))
+    }
+
+    @Test fun `parse returns Unknown for non-base64 garbage`() {
+        assertEquals(ExchangeV2CodeParseResult.Unknown, qrCode.parse("not a code at all !!!"))
+    }
+
+    @Test fun `parse returns Unknown for URL with no code fragment`() {
+        assertEquals(ExchangeV2CodeParseResult.Unknown, qrCode.parse("https://example.com/no-fragment"))
+    }
+
+    @Test fun `parse returns Unknown when the base64 payload is not JSON`() {
+        val bareB64 = encodeUrl("not json at all")
+        assertEquals(ExchangeV2CodeParseResult.Unknown, qrCode.parse(bareB64))
+    }
+
+    @Test fun `parse returns Unknown for JSON with no recognised top-level keys`() {
+        val bareB64 = encodeUrl("""{"something":"else"}""")
+        assertEquals(ExchangeV2CodeParseResult.Unknown, qrCode.parse(bareB64))
+    }
+
+    @Test fun `parse requires version=2 (not just any version field)`() {
+        val bareB64 = encodeUrl("""{"version":"3","channel_id":"x","public_key":"k"}""")
+        assertEquals(ExchangeV2CodeParseResult.Unknown, qrCode.parse(bareB64))
+    }
+
+    @Test fun `parse accepts a 2_x minor version as LinkingV2`() {
+        val bareB64 = encodeUrl("""{"version":"2.1","channel_id":"chan","public_key":"pub"}""")
+
+        val parsed = qrCode.parse(bareB64)
+
+        assertTrue("expected LinkingV2 for a 2.x code, got $parsed", parsed is ExchangeV2CodeParseResult.LinkingV2)
+        parsed as ExchangeV2CodeParseResult.LinkingV2
+        assertEquals("chan", parsed.channelId)
+        assertEquals("pub", parsed.publicKey)
+        assertEquals("2.1", parsed.version)
+    }
+
+    @Test fun `parse rejects a v2 code with an empty public_key`() {
+        val bareB64 = encodeUrl("""{"version":"2","channel_id":"chan","public_key":""}""")
+        assertEquals(ExchangeV2CodeParseResult.Unknown, qrCode.parse(bareB64))
+    }
+
+    @Test fun `parse rejects a v2 code with an empty channel_id`() {
+        val bareB64 = encodeUrl("""{"version":"2","channel_id":"","public_key":"pub"}""")
+        assertEquals(ExchangeV2CodeParseResult.Unknown, qrCode.parse(bareB64))
+    }
+
+    // ---- buildLinkingCode round-trip ----
+
+    @Test fun `buildLinkingCode emits a URL parse can decode back to its inputs`() {
+        val built = qrCode.buildLinkingCode(channelId = "chan-123", publicKeyBase64Url = "pubkey-456")
+
+        val parsed = qrCode.parse(built) as ExchangeV2CodeParseResult.LinkingV2
+
+        assertEquals("chan-123", parsed.channelId)
+        assertEquals("pubkey-456", parsed.publicKey)
+    }
+
+    @Test fun `buildLinkingCode produces the documented URL shape`() {
+        val built = qrCode.buildLinkingCode(channelId = "c", publicKeyBase64Url = "k")
+        assertTrue("expected URL prefix, got: $built", built.startsWith("https://duckduckgo.com/sync/pairing/#&code2="))
+    }
+
+    @Test fun `buildLinkingCode emits the expected compact JSON shape`() {
+        // Field order is not contractual (codes are parse-only, never byte-compared); this pins the current serializer output.
+        val built = qrCode.buildLinkingCode(channelId = "c", publicKeyBase64Url = "k", version = "2")
+        val fragment = built.substringAfter("code2=")
+        val decoded = String(Base64.decode(fragment, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP))
+        assertEquals("""{"channel_id":"c","public_key":"k","version":"2"}""", decoded)
+    }
+
+    @Test fun `buildLinkingCode does not escape forward slashes (defense-in-depth)`() {
+        val built = qrCode.buildLinkingCode(channelId = "chan/123", publicKeyBase64Url = "pub/key+raw")
+        val fragment = built.substringAfter("code2=")
+        val decoded = String(Base64.decode(fragment, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP))
+        assertFalse("linking JSON must not contain escaped slashes (\\/): $decoded", decoded.contains("\\/"))
+        assertTrue(decoded.contains("chan/123"))
+        assertTrue(decoded.contains("pub/key+raw"))
+    }
+
+    @Test fun `buildLinkingCode honours custom version`() {
+        val built = qrCode.buildLinkingCode("c", "k", version = "2.1")
+        val fragment = built.substringAfter("code2=")
+        val decoded = Base64.decode(fragment, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
+        assertTrue(String(decoded).contains("\"version\":\"2.1\""))
+    }
+
+    private fun encodeUrl(s: String): String =
+        Base64.encodeToString(
+            s.toByteArray(Charsets.UTF_8),
+            Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP,
+        )
+
+    @Suppress("unused")
+    private fun ExchangeV2CodeParseResult.assertIs(): Unit = run {
+        assertNull(null)
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -1,0 +1,567 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import app.cash.turbine.test
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.sync.impl.Result
+import com.duckduckgo.sync.impl.SyncDeviceIds
+import com.duckduckgo.sync.impl.crypto.RsaKeyPair
+import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Hello
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeRequest
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse
+import com.duckduckgo.sync.store.SyncStore
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class RealExchangeV2RunnerTest {
+
+    @get:Rule val coroutineTestRule = CoroutineTestRule()
+
+    private val clock = ExchangeV2Clock { 42L }
+    private val parser = JsonExchangeV2MessageParser()
+    private val factory = ExchangeV2StateMachineFactory(clock)
+    private val syncStore: SyncStore = mock()
+    private val jweCrypto: SyncJweCrypto = mock()
+    private val channel: ExchangeV2Channel = mock()
+    private val qrCode: ExchangeV2QrCode = mock()
+    private val recoveryCodeProvider: RecoveryCodeProvider = mock()
+    private val syncDeviceIds: SyncDeviceIds = mock()
+
+    private fun newRunner(): RealExchangeV2Runner =
+        RealExchangeV2Runner(
+            smFactory = factory,
+            messageParser = parser,
+            clock = clock,
+            syncStore = syncStore,
+            jweCrypto = jweCrypto,
+            channel = channel,
+            qrCode = qrCode,
+            recoveryCodeProvider = recoveryCodeProvider,
+            syncDeviceIds = syncDeviceIds,
+            appScope = coroutineTestRule.testScope,
+            dispatchers = coroutineTestRule.testDispatcherProvider,
+        )
+
+    @Before fun stubWireDeps() {
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "peer-channel", publicKey = "peer-pubkey", version = "2"),
+        )
+        whenever(qrCode.buildLinkingCode(any(), any(), any())).thenReturn("https://duckduckgo.com/sync/pairing/#&code2=fake")
+        whenever(jweCrypto.generateRsaKeyPair()).thenReturn(RsaKeyPair(publicKeyBase64 = "own-pub", privateKeyBase64 = "own-priv"))
+        whenever(channel.createChannel(any())).thenReturn(Result.Success(Unit))
+        whenever(channel.poll(any(), any())).thenReturn(emptyFlow())
+        whenever(channel.sendMessage(any(), any(), any(), any())).thenReturn(Result.Success(Unit))
+        whenever(channel.deleteChannel(any())).thenReturn(Result.Success(Unit))
+        whenever(syncDeviceIds.deviceName()).thenReturn("This Device")
+    }
+
+    @Test fun `startScan creates a session in Negotiating (Scanner already knows the peer)`() {
+        val runner = newRunner()
+        runner.startScan(pastedUrl = "ignored")
+
+        assertSame(ExchangeV2State.Negotiating, runner.currentState)
+    }
+
+    @Test fun `cancel abandons the session`() = runTest {
+        val runner = newRunner()
+        runner.startScan("")
+        runner.cancel()
+
+        assertNull(runner.currentState)
+    }
+
+    @Test fun `startScan called twice replaces the existing session`() = runTest {
+        val runner = newRunner()
+        runner.startScan("")
+        runner.deliverIncomingMessage(
+            ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "peer", name = "Peer", kind = "3party"),
+        )
+
+        runner.startScan("")
+
+        assertSame(ExchangeV2State.Negotiating, runner.currentState)
+        assertSame(PairingRole.Scanner, runner.pairingRole)
+    }
+
+    @Test fun `deliverIncomingMessage forwards SM event to flow`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        val runner = newRunner()
+        runner.startPresent()
+
+        runner.events.filterIsInstance<ExchangeV2Event.Transition>().test {
+            runner.deliverIncomingMessage(Hello("""{"type":"hello"}"""))
+            val event = awaitItem()
+            assertSame(ExchangeV2State.Bootstrapped, event.from)
+            assertSame(ExchangeV2State.Negotiating, event.to)
+        }
+    }
+
+    @Test fun `deliverIncomingMessage without a session is a no-op`() = runTest {
+        val runner = newRunner()
+        runner.events.test {
+            runner.deliverIncomingMessage(Hello("{}"))
+            expectNoEvents()
+        }
+    }
+
+    @Test fun `deliverIncomingMessageJson parses and forwards`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        val runner = newRunner()
+        runner.startPresent()
+
+        runner.events.filterIsInstance<ExchangeV2Event.Transition>().test {
+            runner.deliverIncomingMessageJson("""{"type":"hello"}""")
+            val event = awaitItem()
+            assertSame(ExchangeV2State.Negotiating, event.to)
+            assertTrue(event.trigger is Hello)
+        }
+    }
+
+    @Test fun `deliverIncomingMessageJson with unknown type emits dropped`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        val runner = newRunner()
+        runner.startPresent()
+
+        runner.events.filterIsInstance<ExchangeV2Event.MessageRejected>().test {
+            runner.deliverIncomingMessageJson("""{"type":"future_msg"}""")
+            val event = awaitItem()
+            assertSame(RejectReason.UnknownMessageDropped, event.reason)
+        }
+    }
+
+    @Test fun `recordSentMessage emits MessageSent with given message`() = runTest {
+        val runner = newRunner()
+        val sent = RecoveryCodeRequest(rawJson = "{}", name = "me", kind = "3party")
+
+        runner.events.test {
+            runner.recordSentMessage(sent)
+            val event = awaitItem() as ExchangeV2Event.MessageSent
+            assertSame(sent, event.message)
+        }
+    }
+
+    @Test fun `localTrigger forwards SM event to flow`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        val runner = newRunner()
+        runner.startPresent()
+        runner.deliverIncomingMessage(Hello("{}"))
+
+        runner.events.filterIsInstance<ExchangeV2Event.Transition>().test {
+            awaitItem()
+            runner.localTrigger(LocalTrigger.RoleElected(Role.Host))
+            val event = awaitItem()
+            assertSame(ExchangeV2State.Host.Confirming, event.to)
+        }
+    }
+
+    @Test fun `terminal state abandons session`() = runTest {
+        whenever(syncStore.userId).thenReturn(null)
+        val runner = newRunner()
+        runner.startScan("")
+        runner.deliverIncomingMessage(ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "other", name = "Peer", kind = "3party"))
+        runner.localTrigger(LocalTrigger.RoleElected(Role.Joiner))
+        runner.localTrigger(LocalTrigger.UserConfirmedJoiner)
+        runner.deliverIncomingMessage(RecoveryCodeResponse("{}"))
+
+        assertNull(runner.currentState)
+    }
+
+    @Test fun `startScan passes local user_id from SyncStore so same-account abort fires`() = runTest {
+        whenever(syncStore.userId).thenReturn("shared-user")
+        val runner = newRunner()
+        runner.startScan("")
+
+        runner.events.filterIsInstance<ExchangeV2Event.Transition>().test {
+            runner.deliverIncomingMessage(
+                ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "shared-user", name = "Peer", kind = "3party"),
+            )
+            val event = awaitItem()
+            assertSame(ExchangeV2State.SameAccountAbort, event.to)
+        }
+    }
+
+    @Test fun `availability without an account carries this device's real name, not a hardcoded platform string`() = runTest {
+        whenever(syncStore.userId).thenReturn(null)
+        whenever(syncDeviceIds.deviceName()).thenReturn("google Pixel 7")
+        val runner = newRunner()
+
+        runner.startScan("")
+
+        // The peer shows this name on its security-confirmation screen, so it must be the real
+        // device name (e.g. "google Pixel 7"), never a generic "Android".
+        verify(channel).sendMessage(
+            argThat { contains("recovery_code_request") && contains("\"name\":\"google Pixel 7\"") },
+            any(),
+            any(),
+            any(),
+        )
+    }
+
+    @Test fun `availability with an account carries this device's real name, not a hardcoded platform string`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        whenever(syncDeviceIds.deviceName()).thenReturn("google Pixel 7")
+        val runner = newRunner()
+
+        runner.startScan("")
+
+        verify(channel).sendMessage(
+            argThat { contains("recovery_code_available") && contains("\"name\":\"google Pixel 7\"") },
+            any(),
+            any(),
+            any(),
+        )
+    }
+
+    // ---- Auto role election ----
+
+    @Test fun `startScan sets pairingRole to Scanner`() {
+        val runner = newRunner()
+        runner.startScan("")
+
+        assertSame(PairingRole.Scanner, runner.pairingRole)
+    }
+
+    @Test fun `startPresent sets pairingRole to Presenter and bootstraps session`() {
+        whenever(syncStore.userId).thenReturn("my-user")
+        val runner = newRunner()
+        runner.startPresent()
+
+        assertSame(PairingRole.Presenter, runner.pairingRole)
+        assertSame(ExchangeV2State.Bootstrapped, runner.currentState)
+    }
+
+    @Test fun `startPresent without an account still bootstraps (spec allows account creation during pairing)`() {
+        whenever(syncStore.userId).thenReturn(null)
+        val runner = newRunner()
+        runner.startPresent()
+
+        // Spec §"Exchange Share Recovery Code": Host may create its account during pairing.
+        assertSame(PairingRole.Presenter, runner.pairingRole)
+        assertSame(ExchangeV2State.Bootstrapped, runner.currentState)
+    }
+
+    @Test fun `canStartAsPresenter is true regardless of account state`() {
+        whenever(syncStore.userId).thenReturn(null)
+        assertTrue(newRunner().canStartAsPresenter)
+        whenever(syncStore.userId).thenReturn("my-user")
+        assertTrue(newRunner().canStartAsPresenter)
+    }
+
+    @Test fun `cancel clears pairingRole`() = runTest {
+        val runner = newRunner()
+        runner.startScan("")
+        runner.cancel()
+
+        assertNull(runner.pairingRole)
+    }
+
+    @Test fun `Scanner with no account auto-elects Joiner when peer (ddg) has account`() = runTest {
+        whenever(syncStore.userId).thenReturn(null)
+        val runner = newRunner()
+        runner.startScan("")
+
+        runner.deliverIncomingMessage(
+            ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "host-user", name = "Host", kind = "ddg"),
+        )
+
+        assertSame(ExchangeV2State.Joiner.Confirming, runner.currentState)
+    }
+
+    @Test fun `Presenter with account auto-elects Host when peer has no account`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        val runner = newRunner()
+        runner.startPresent()
+        runner.deliverIncomingMessage(Hello("{}"))
+
+        runner.deliverIncomingMessage(
+            ExchangeV2Message.RecoveryCodeRequest(rawJson = "{}", name = "Joiner", kind = "ddg"),
+        )
+
+        assertSame(ExchangeV2State.Host.Confirming, runner.currentState)
+    }
+
+    @Test fun `entering Host_Confirming sends recovery_code_awaiting_confirmation immediately (spec ordering)`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        val runner = newRunner()
+        runner.startPresent()
+        runner.deliverIncomingMessage(Hello("{}"))
+
+        runner.deliverIncomingMessage(
+            ExchangeV2Message.RecoveryCodeRequest(rawJson = "{}", name = "Joiner", kind = "ddg"),
+        )
+
+        // Spec §"Exchange Confirmations → Host": awaiting_confirmation is sent on entry to
+        // Confirming, before the user is prompted.
+        verify(channel).sendMessage(
+            argThat { contains("recovery_code_awaiting_confirmation") },
+            any(),
+            any(),
+            any(),
+        )
+        verify(channel, never()).sendMessage(
+            argThat { contains("recovery_code_confirmed") },
+            any(),
+            any(),
+            any(),
+        )
+    }
+
+    @Test fun `UserConfirmedHost sends recovery_code_confirmed but does NOT re-send awaiting_confirmation`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        whenever(recoveryCodeProvider.getDdgRecoveryCode()).thenReturn(com.duckduckgo.sync.impl.Result.Success("the-code"))
+        val runner = newRunner()
+        runner.startPresent()
+        runner.deliverIncomingMessage(Hello("{}"))
+        runner.deliverIncomingMessage(
+            ExchangeV2Message.RecoveryCodeRequest(rawJson = "{}", name = "Joiner", kind = "ddg"),
+        )
+        runner.localTrigger(LocalTrigger.UserConfirmedHost)
+
+        verify(channel).sendMessage(
+            argThat { contains("recovery_code_confirmed") && !contains("recovery_code_awaiting_confirmation") },
+            any(),
+            any(),
+            any(),
+        )
+        verify(channel, org.mockito.kotlin.times(1)).sendMessage(
+            argThat { contains("recovery_code_awaiting_confirmation") },
+            any(),
+            any(),
+            any(),
+        )
+    }
+
+    @Test fun `Host aborts (not Done) when the recovery_code_response send fails`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        whenever(recoveryCodeProvider.createDdgAccountIfNeeded()).thenReturn(Result.Success(Unit))
+        whenever(recoveryCodeProvider.getDdgRecoveryCode()).thenReturn(Result.Success("the-code"))
+        whenever(
+            channel.sendMessage(argThat { contains("recovery_code_response") }, any(), any(), any()),
+        ).thenReturn(Result.Error(reason = "relay unreachable"))
+
+        val runner = newRunner()
+        runner.startPresent()
+        runner.deliverIncomingMessage(Hello("{}"))
+        runner.deliverIncomingMessage(RecoveryCodeRequest(rawJson = "{}", name = "Joiner", kind = "ddg"))
+        runner.localTrigger(LocalTrigger.UserConfirmedHost)
+
+        val lastTransition = runner.events.replayCache.filterIsInstance<ExchangeV2Event.Transition>().last()
+        assertSame(ExchangeV2State.Host.Aborted, lastTransition.to)
+    }
+
+    @Test fun `Scanner ddg auto-elects Host when peer is 3party (both have accounts)`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        val runner = newRunner()
+        runner.startScan("")
+
+        runner.deliverIncomingMessage(
+            ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "peer-user", name = "Peer", kind = "3party"),
+        )
+
+        assertSame(ExchangeV2State.Host.Confirming, runner.currentState)
+    }
+
+    @Test fun `Scanner hello during negotiating aborts and tears down the session`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        val runner = newRunner()
+        runner.startScan("")
+
+        runner.events.filterIsInstance<ExchangeV2Event.Transition>().test {
+            runner.deliverIncomingMessage(Hello("{}"))
+            val event = awaitItem()
+            assertSame(ExchangeV2State.Aborted, event.to)
+        }
+        assertNull(runner.currentState)
+    }
+
+    @Test fun `same-account abort skips auto-election`() = runTest {
+        whenever(syncStore.userId).thenReturn("shared-user")
+        val runner = newRunner()
+        runner.startScan("")
+
+        runner.events.filterIsInstance<ExchangeV2Event.Transition>().test {
+            runner.deliverIncomingMessage(
+                ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "shared-user", name = "Peer", kind = "ddg"),
+            )
+            val event = awaitItem()
+            assertSame(ExchangeV2State.SameAccountAbort, event.to)
+        }
+        assertNull(runner.currentState)
+    }
+
+    @Test fun `Presenter auto-elects Host when both have accounts and peer is ddg (Presenter rule)`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        val runner = newRunner()
+        runner.startPresent()
+        runner.deliverIncomingMessage(Hello("{}"))
+
+        runner.deliverIncomingMessage(
+            ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "peer-user", name = "Peer", kind = "ddg"),
+        )
+
+        assertSame(ExchangeV2State.Host.Confirming, runner.currentState)
+    }
+
+    @Test fun `Scanner with both accounts and peer ddg auto-elects Joiner (catch-all)`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        val runner = newRunner()
+        runner.startScan("")
+
+        runner.deliverIncomingMessage(
+            ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "peer-user", name = "Peer", kind = "ddg"),
+        )
+
+        assertSame(ExchangeV2State.Joiner.Confirming, runner.currentState)
+    }
+
+    // ---- Session timeout ----
+
+    @Test fun `session times out and tears down after the deadline`() = coroutineTestRule.testScope.runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        val runner = newRunner()
+        runner.startPresent()
+        assertSame(ExchangeV2State.Bootstrapped, runner.currentState)
+
+        advanceTimeBy(6 * 60 * 1000L) // past the 5-min session deadline
+
+        val timedOut = runner.events.replayCache
+            .filterIsInstance<ExchangeV2Event.SessionError>()
+            .any { it.message.contains("timed out", ignoreCase = true) }
+        assertTrue("expected a 'timed out' SessionError", timedOut)
+        assertNull(runner.currentState)
+    }
+
+    @Test fun `no timeout fires after the session already reached a terminal state`() = coroutineTestRule.testScope.runTest {
+        whenever(syncStore.userId).thenReturn(null)
+        val runner = newRunner()
+        runner.startScan("")
+        runner.deliverIncomingMessage(
+            ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "other", name = "Peer", kind = "3party"),
+        )
+        runner.localTrigger(LocalTrigger.UserConfirmedJoiner)
+        runner.deliverIncomingMessage(RecoveryCodeResponse("{}"))
+        assertNull(runner.currentState)
+
+        advanceTimeBy(6 * 60 * 1000L)
+
+        val timedOut = runner.events.replayCache
+            .filterIsInstance<ExchangeV2Event.SessionError>()
+            .any { it.message.contains("timed out", ignoreCase = true) }
+        assertFalse("a completed session must not later emit a timeout", timedOut)
+    }
+
+    // ---- Poll-loop error handling ----
+
+    @Test fun `an unexpected poll error tears down the session with a SessionError`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        whenever(channel.poll(any(), any())).thenReturn(flow<ExchangeV2Message> { throw RuntimeException("boom") })
+        val runner = newRunner()
+        runner.startPresent()
+
+        val errored = runner.events.replayCache
+            .filterIsInstance<ExchangeV2Event.SessionError>()
+            .any { it.message.contains("boom") }
+        assertTrue("expected a SessionError from the failed poll loop", errored)
+        assertNull(runner.currentState)
+    }
+
+    @Test fun `polled messages are processed in wire order (hello before request reaches Host_Confirming)`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        whenever(channel.poll(any(), any())).thenReturn(
+            flowOf(
+                Hello("""{"type":"hello"}"""),
+                RecoveryCodeRequest(rawJson = "{}", name = "Joiner", kind = "ddg"),
+            ),
+        )
+
+        val runner = newRunner()
+        runner.startPresent()
+
+        assertSame(ExchangeV2State.Host.Confirming, runner.currentState)
+    }
+
+    @Test fun `a polled message that reaches a terminal state tears down without a spurious error`() = runTest {
+        whenever(syncStore.userId).thenReturn("shared")
+        whenever(channel.poll(any(), any())).thenReturn(
+            flowOf(
+                ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "shared", name = "Peer", kind = "ddg"),
+            ),
+        )
+
+        val runner = newRunner()
+        runner.startScan("")
+
+        assertNull(runner.currentState)
+        val spurious = runner.events.replayCache
+            .filterIsInstance<ExchangeV2Event.SessionError>()
+            .any { it.message.contains("Pairing failed") || it.message.contains("timed out", ignoreCase = true) }
+        assertFalse("terminal via poll must not surface a spurious error", spurious)
+    }
+
+    @Test fun `cancel during an open poll does not surface a spurious error`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        whenever(channel.poll(any(), any())).thenReturn(flow<ExchangeV2Message> { awaitCancellation() })
+        val runner = newRunner()
+        runner.startPresent()
+
+        runner.cancel()
+
+        val spurious = runner.events.replayCache
+            .filterIsInstance<ExchangeV2Event.SessionError>()
+            .any { it.message.contains("Pairing failed") }
+        assertFalse("cancellation must not surface as a 'Pairing failed' error", spurious)
+    }
+
+    @Test fun `startScan with a failed channel bootstrap aborts cleanly without the misleading reach-Presenter error`() = runTest {
+        whenever(channel.createChannel(any())).thenReturn(Result.Error(reason = "relay 500"))
+        val runner = newRunner()
+        runner.startScan("")
+
+        val errors = runner.events.replayCache.filterIsInstance<ExchangeV2Event.SessionError>().map { it.message }
+        assertTrue("expected the bootstrap error", errors.any { it.contains("Failed to create channel") })
+        assertFalse("must not emit the misleading reach-Presenter error on a bootstrap failure", errors.any { it.contains("reach the Presenter") })
+    }
+
+    @Test fun `a failed bootstrap clears the pairing role so no half-started session lingers`() = runTest {
+        whenever(channel.createChannel(any())).thenReturn(Result.Error(reason = "relay 500"))
+        val runner = newRunner()
+
+        runner.startScan("")
+
+        assertNull("pairingRole must be cleared after a failed bootstrap", runner.pairingRole)
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealRecoveryCodeProviderTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealRecoveryCodeProviderTest.kt
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.sync.impl.Result
+import com.duckduckgo.sync.impl.SyncAccountRepository
+import com.duckduckgo.sync.store.ScopedPassword
+import com.duckduckgo.sync.store.SyncStore
+import org.json.JSONObject
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.Base64
+
+@RunWith(AndroidJUnit4::class)
+class RealRecoveryCodeProviderTest {
+
+    private val syncAccountRepository: SyncAccountRepository = mock()
+    private val syncStore: SyncStore = mock()
+    private val provider = RealRecoveryCodeProvider(syncAccountRepository, syncStore)
+
+    // ---- getDdgRecoveryCode ----
+
+    @Test fun `getDdgRecoveryCode converts v1 shape to v2 with cid=ddg`() {
+        val v1Json = """{"recovery":{"primary_key":"pk-abc","user_id":"user-123"}}"""
+        val v1B64 = Base64.getUrlEncoder().withoutPadding().encodeToString(v1Json.toByteArray())
+        whenever(syncAccountRepository.getRecoveryCode()).thenReturn(
+            Result.Success(SyncAccountRepository.AuthCode(qrCode = v1B64, rawCode = v1B64)),
+        )
+
+        val result = provider.getDdgRecoveryCode()
+
+        assertTrue(result is Result.Success)
+        val v2 = decodeRecovery((result as Result.Success).data)
+        assertEquals("user-123", v2.getString("user_id"))
+        assertArrayEquals(Base64.getUrlDecoder().decode("pk-abc"), Base64.getUrlDecoder().decode(v2.getString("secret")))
+        assertEquals("ddg", v2.getString("cid"))
+        assertEquals("2.0", v2.getString("v"))
+    }
+
+    @Test fun `getDdgRecoveryCode encodes the secret as base64url per spec, not standard base64`() {
+        // Spec (Encryption Algorithms): the v2 account `secret` is base64url; Android stores primary_key as standard base64 internally.
+        val standardPrimaryKey = "apZ+7PAe89rDhuG4DRyi/M3zU2/D5DZNdRsR3RM6Ujw="
+        val v1Json = """{"recovery":{"primary_key":"$standardPrimaryKey","user_id":"user-123"}}"""
+        val v1B64 = Base64.getUrlEncoder().withoutPadding().encodeToString(v1Json.toByteArray())
+        whenever(syncAccountRepository.getRecoveryCode()).thenReturn(
+            Result.Success(SyncAccountRepository.AuthCode(qrCode = v1B64, rawCode = v1B64)),
+        )
+
+        val result = provider.getDdgRecoveryCode()
+
+        assertTrue(result is Result.Success)
+        val secret = decodeRecovery((result as Result.Success).data).getString("secret")
+        assertFalse("secret must be base64url (no '+'): $secret", secret.contains('+'))
+        assertFalse("secret must be base64url (no '/'): $secret", secret.contains('/'))
+        assertArrayEquals(
+            Base64.getDecoder().decode(standardPrimaryKey),
+            Base64.getUrlDecoder().decode(secret),
+        )
+    }
+
+    @Test fun `getDdgRecoveryCode bubbles up repository errors`() {
+        whenever(syncAccountRepository.getRecoveryCode()).thenReturn(Result.Error(reason = "Not signed in"))
+
+        val result = provider.getDdgRecoveryCode()
+
+        assertTrue(result is Result.Error)
+        assertEquals("Not signed in", (result as Result.Error).reason)
+    }
+
+    @Test fun `getDdgRecoveryCode reports a conversion error when v1 shape is malformed`() {
+        whenever(syncAccountRepository.getRecoveryCode()).thenReturn(
+            Result.Success(SyncAccountRepository.AuthCode(qrCode = "not-b64-or-json", rawCode = "not-b64-or-json")),
+        )
+
+        val result = provider.getDdgRecoveryCode()
+
+        assertTrue(result is Result.Error)
+        assertTrue(
+            "expected conversion error, got: ${(result as Result.Error).reason}",
+            result.reason.startsWith("Failed to convert ddg recovery code to v2.0"),
+        )
+    }
+
+    // ---- getThirdPartyRecoveryCode ----
+
+    @Test fun `getThirdPartyRecoveryCode returns raw rawCode untouched`() {
+        // The repo already emits v2.0 shape, so the provider must not re-wrap or re-encode.
+        val already3p = "already-v2-encoded-b64"
+        whenever(syncAccountRepository.getThirdPartyRecoveryCode()).thenReturn(
+            Result.Success(SyncAccountRepository.AuthCode(qrCode = "different-qr-form", rawCode = already3p)),
+        )
+
+        val result = provider.getThirdPartyRecoveryCode()
+
+        assertTrue(result is Result.Success)
+        assertEquals(already3p, (result as Result.Success).data)
+    }
+
+    @Test fun `getThirdPartyRecoveryCode bubbles up repository errors`() {
+        whenever(syncAccountRepository.getThirdPartyRecoveryCode()).thenReturn(
+            Result.Error(reason = "No 3party credential"),
+        )
+
+        val result = provider.getThirdPartyRecoveryCode()
+
+        assertTrue(result is Result.Error)
+        assertEquals("No 3party credential", (result as Result.Error).reason)
+    }
+
+    // ---- createDdgAccountIfNeeded ----
+
+    @Test fun `createDdgAccountIfNeeded is a no-op when already signed in`() {
+        whenever(syncStore.userId).thenReturn("existing-user")
+
+        val result = provider.createDdgAccountIfNeeded()
+
+        assertTrue(result is Result.Success)
+        verify(syncAccountRepository, org.mockito.kotlin.never()).createAccount()
+    }
+
+    @Test fun `createDdgAccountIfNeeded calls createAccount when no user id present`() {
+        whenever(syncStore.userId).thenReturn(null)
+        whenever(syncAccountRepository.createAccount()).thenReturn(Result.Success(true))
+
+        val result = provider.createDdgAccountIfNeeded()
+
+        assertTrue(result is Result.Success)
+        verify(syncAccountRepository).createAccount()
+    }
+
+    @Test fun `createDdgAccountIfNeeded propagates repository error so caller can abort`() {
+        whenever(syncStore.userId).thenReturn(null)
+        whenever(syncAccountRepository.createAccount()).thenReturn(Result.Error(reason = "BE down"))
+
+        val result = provider.createDdgAccountIfNeeded()
+
+        assertTrue(result is Result.Error)
+        assertEquals("BE down", (result as Result.Error).reason)
+    }
+
+    // ---- createThirdPartyCredentialIfNeeded ----
+
+    @Test fun `createThirdPartyCredentialIfNeeded is a no-op when scopedPassword already set locally`() {
+        // ScopedPassword is a `value class` so Mockito can't mock it — use a real instance.
+        whenever(syncStore.scopedPassword).thenReturn(ScopedPassword("existing"))
+
+        val result = provider.createThirdPartyCredentialIfNeeded()
+
+        assertTrue(result is Result.Success)
+        verify(syncAccountRepository, org.mockito.kotlin.never()).createThirdPartyCredential()
+    }
+
+    @Test fun `createThirdPartyCredentialIfNeeded extends the account when no scopedPassword locally`() {
+        whenever(syncStore.scopedPassword).thenReturn(null)
+        whenever(syncAccountRepository.createThirdPartyCredential()).thenReturn(Result.Success(true))
+
+        val result = provider.createThirdPartyCredentialIfNeeded()
+
+        assertTrue(result is Result.Success)
+        verify(syncAccountRepository).createThirdPartyCredential()
+    }
+
+    @Test fun `createThirdPartyCredentialIfNeeded propagates repository error`() {
+        whenever(syncStore.scopedPassword).thenReturn(null)
+        whenever(syncAccountRepository.createThirdPartyCredential())
+            .thenReturn(Result.Error(reason = "extend failed"))
+
+        val result = provider.createThirdPartyCredentialIfNeeded()
+
+        assertTrue(result is Result.Error)
+        assertEquals("extend failed", (result as Result.Error).reason)
+    }
+
+    private fun decodeRecovery(b64: String): JSONObject {
+        val bytes = Base64.getUrlDecoder().decode(b64)
+        return JSONObject(String(bytes, Charsets.UTF_8)).getJSONObject("recovery")
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
@@ -20,9 +20,22 @@ import android.content.SharedPreferences
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.api.InMemorySharedPreferences
 import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.sync.api.engine.SyncableType
 import com.duckduckgo.sync.impl.API_CODE
+import com.duckduckgo.sync.impl.AccountErrorCodes
+import com.duckduckgo.sync.impl.DispatchOutcome
 import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.SyncCodeType
+import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupFailureReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
 import com.duckduckgo.sync.impl.stats.DailyStats
 import com.duckduckgo.sync.impl.stats.SyncStatsRepository
 import com.duckduckgo.sync.store.SharedPrefsProvider
@@ -40,6 +53,7 @@ class RealSyncPixelsTest {
     private var pixel: Pixel = mock()
     private var syncStatsRepository: SyncStatsRepository = mock()
     private var sharedPrefsProv: SharedPrefsProvider = mock()
+    private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
 
     private lateinit var sharedPreferences: SharedPreferences
     private lateinit var testee: RealSyncPixels
@@ -55,6 +69,7 @@ class RealSyncPixelsTest {
             pixel,
             syncStatsRepository,
             sharedPrefsProv,
+            syncFeature,
         )
     }
 
@@ -118,6 +133,385 @@ class RealSyncPixelsTest {
     fun whenSignupConnectPixelCalledWithSourceThenPixelFiredIncludesSource() {
         testee.fireSignupConnectPixel(source = "foo")
         verify(pixel).fire(SyncPixelName.SYNC_SIGNUP_CONNECT, mapOf("source" to "foo"))
+    }
+
+    @Test
+    fun whenBarcodeScreenShownAndV2FlowEnabledThenPixelFiredWithV2AndDdg() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncBarcodeScreenShown(ScreenType.SYNC_CONNECT)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_BARCODE_SCREEN_SHOWN,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenBarcodeScreenShownAndV2FlowDisabledThenPixelFiredWithV1AndDdg() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireSyncBarcodeScreenShown(ScreenType.SYNC_EXCHANGE)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_BARCODE_SCREEN_SHOWN,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenManualCodeEntryScreenShownAndV2FlowEnabledThenPixelFiredWithV2AndDdg() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupManualCodeScreenShown(ScreenType.SYNC_EXCHANGE)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTRY_SCREEN_SHOWN,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenManualCodeEntryScreenShownAndV2FlowDisabledThenPixelFiredWithV1AndDdg() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireSyncSetupManualCodeScreenShown(ScreenType.SYNC_CONNECT)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTRY_SCREEN_SHOWN,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenBarcodeScannerParseSuccessOnLegacyPathThenPixelFiredWithV1AndNoCodeType() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireBarcodeScannerParseSuccess(ScreenType.SYNC_CONNECT, CodeVersion.V1)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_CODE_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenBarcodeScannerParseSuccessForV2RecoveryCodeThenPixelFiredWithCodeMetadata() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireBarcodeScannerParseSuccess(ScreenType.SYNC_EXCHANGE, CodeVersion.V2, SyncCodeType.RECOVERY)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_CODE_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_CODE_TYPE to "recovery",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenManualCodeEnteredSuccessForV2LinkingCodeThenPixelFiredWithCodeMetadata() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupCodePastedParseSuccess(ScreenType.SYNC_CONNECT, CodeVersion.V2, SyncCodeType.LINKING)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_CODE_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_CODE_TYPE to "linking",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenManualCodeEnteredSuccessOnLegacyPathThenPixelFiredWithV1AndNoCodeType() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireSyncSetupCodePastedParseSuccess(ScreenType.SYNC_EXCHANGE, CodeVersion.V1)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_CODE_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenBarcodeScannerParseErrorThenPixelFiredWithFlowMetadata() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireBarcodeScannerParseError(ScreenType.SYNC_CONNECT)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenManualCodeEnteredFailureThenPixelFiredWithFlowMetadata() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupCodePastedParseFailure(ScreenType.SYNC_EXCHANGE)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenSetupFinishedV1ThenPixelFiredWithFlowMetadataOnly() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireSyncSetupFinishedSuccessfully(ScreenType.SYNC_CONNECT)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenSetupFinishedV2RecoveryThenPixelFiredWithPathNoRoleOrPeer() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupFinishedSuccessfully(ScreenType.SYNC_EXCHANGE, SetupPath.RECOVERY)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_PATH to "recovery",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenSetupFinishedV2PairingThenPixelFiredWithPathRoleAndPeer() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupFinishedSuccessfully(
+            ScreenType.SYNC_CONNECT,
+            SetupPath.PAIRING,
+            SetupRole.HOST,
+            PeerKind.THIRD_PARTY,
+        )
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_PATH to "pairing",
+                SyncPixelParameters.SYNC_SETUP_MY_ROLE to "host",
+                SyncPixelParameters.SYNC_SETUP_PEER_KIND to "3party",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenSetupFailedWithAllDimsThenPixelFiredWithReasonPathRoleAndPeer() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupFailed(
+            SetupFailureReason.TRANSPORT_FAILURE,
+            SetupPath.PAIRING,
+            SetupRole.JOINER,
+            PeerKind.DDG,
+        )
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_REASON to "transport_failure",
+                SyncPixelParameters.SYNC_SETUP_PATH to "pairing",
+                SyncPixelParameters.SYNC_SETUP_MY_ROLE to "joiner",
+                SyncPixelParameters.SYNC_SETUP_PEER_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenSetupFailedWithReasonOnlyThenOptionalDimsOmitted() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupFailed(SetupFailureReason.UNEXPECTED_FAILURE)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_REASON to "unexpected_failure",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSetupFailedForUpgradeRequiredThenNeedsUpgrade() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSetupFailed(DispatchOutcome.UpgradeRequired(codeMajor = 3, path = SetupPath.PAIRING, myRole = SetupRole.HOST))
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_REASON to "needs_upgrade",
+                SyncPixelParameters.SYNC_SETUP_PATH to "pairing",
+                SyncPixelParameters.SYNC_SETUP_MY_ROLE to "host",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSetupFailedForFailedOutcomeThenReasonMappedFromCode() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSetupFailed(
+            DispatchOutcome.Failed(
+                reason = "boom",
+                code = AccountErrorCodes.INVALID_CODE.code,
+                path = SetupPath.RECOVERY,
+            ),
+        )
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_REASON to "invalid_credentials",
+                SyncPixelParameters.SYNC_SETUP_PATH to "recovery",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSetupFailedForCancellationCodesThenPixelNotFired() {
+        testee.fireSetupFailed(DispatchOutcome.Failed(reason = "user", code = AccountErrorCodes.PAIRING_CANCELLED.code))
+        testee.fireSetupFailed(DispatchOutcome.Failed(reason = "peer", code = AccountErrorCodes.PAIRING_REJECTED.code))
+
+        verifyNoInteractions(pixel)
+    }
+
+    @Test
+    fun whenSetupAbandonedWithReasonThenPixelFiredWithReasonAndFlowMetadata() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupAbandoned(ScreenType.SYNC_CONNECT, CancellationReason.CANCELLED_BEFORE_FINISHED)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_ABANDONED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_REASON to "cancelled_before_finished",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenSetupAbandonedWithoutReasonThenReasonOmitted() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireSyncSetupAbandoned(ScreenType.SYNC_EXCHANGE)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_ABANDONED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSetupCancelledIfDeniedForPairingCancelledThenAbandonedFired() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSetupCancelledIfDenied(
+            DispatchOutcome.Failed(reason = "user_denied", code = AccountErrorCodes.PAIRING_CANCELLED.code),
+            ScreenType.SYNC_CONNECT,
+        )
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_ABANDONED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_REASON to "sync_confirmation_denied",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSetupCancelledIfDeniedForPeerRejectionOrOtherThenNotFired() {
+        testee.fireSetupCancelledIfDenied(
+            DispatchOutcome.Failed(reason = "peer", code = AccountErrorCodes.PAIRING_REJECTED.code),
+            ScreenType.SYNC_CONNECT,
+        )
+        testee.fireSetupCancelledIfDenied(
+            DispatchOutcome.Failed(reason = "boom", code = AccountErrorCodes.PAIRING_FAILED.code),
+            ScreenType.SYNC_CONNECT,
+        )
+
+        verifyNoInteractions(pixel)
     }
 
     @Test

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
@@ -35,7 +35,10 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.CREATE_ACCOUNT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.GENERIC_ERROR
 import com.duckduckgo.sync.impl.AccountErrorCodes.INVALID_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED
 import com.duckduckgo.sync.impl.Clipboard
+import com.duckduckgo.sync.impl.RealSyncCodeDispatcher
 import com.duckduckgo.sync.impl.RecoveryCode
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
@@ -43,14 +46,23 @@ import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode.Recovery
 import com.duckduckgo.sync.impl.SyncAuthCode.Unknown
 import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState.Idle
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.AskToSwitchAccount
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.LoginSuccess
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.ShowError
+import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.ShowV2Error
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.SwitchAccountSuccess
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -73,6 +85,15 @@ internal class EnterCodeViewModelTest {
         this.seamlessAccountSwitching().setRawStoredState(State(true))
     }
     private val syncPixels: SyncPixels = mock()
+    private val qrCode: ExchangeV2QrCode = mock()
+    private val runner: ExchangeV2Runner = mock()
+
+    private val codeDispatcher = RealSyncCodeDispatcher(
+        syncFeature = syncFeature,
+        syncAccountRepository = syncAccountRepository,
+        qrCode = qrCode,
+        runner = runner,
+    )
 
     private val testee = EnterCodeViewModel(
         syncAccountRepository,
@@ -80,6 +101,7 @@ internal class EnterCodeViewModelTest {
         coroutineTestRule.testDispatcherProvider,
         syncFeature = syncFeature,
         syncPixels = syncPixels,
+        codeDispatcher = codeDispatcher,
     )
 
     @Test
@@ -104,6 +126,56 @@ internal class EnterCodeViewModelTest {
         testee.onPasteCodeClicked()
 
         verify(clipboard).pasteFromClipboard()
+    }
+
+    @Test
+    fun whenV2ThirdPartyRecoveryAlreadyUpgradedThenShowError() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
+        val pastedCode = "https://duckduckgo.com/sync/pairing/#&code2=3party-recovery"
+        whenever(clipboard.pasteFromClipboard()).thenReturn(pastedCode)
+        val recoveryJson = org.json.JSONObject().apply {
+            put("cid", "3party")
+            put("user_id", "u-1")
+            put("secret", "s-1")
+            put("v", "2.0")
+        }
+        whenever(qrCode.parse(pastedCode)).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson = recoveryJson))
+        whenever(syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(any())).thenReturn(
+            Error(code = THIRD_PARTY_ALREADY_UPGRADED.code, reason = "account already upgraded"),
+        )
+
+        testee.onPasteCodeClicked()
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(THIRD_PARTY_ALREADY_UPGRADED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2CodeRequiresNewerProtocolThenShowUpdateError() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
+        val pastedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(clipboard.pasteFromClipboard()).thenReturn(pastedCode)
+        whenever(qrCode.parse(pastedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(ExchangeV2Event.SessionError(timestampMs = 0L, message = "Peer requires protocol v3; please update this app")),
+        )
+
+        testee.onPasteCodeClicked()
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2UpgradeRequiredError, (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     @Test
@@ -319,6 +391,72 @@ internal class EnterCodeViewModelTest {
         testee.onPasteCodeClicked()
 
         testee.commands().test {
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2SameAccountThenShowAlreadyPaired() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
+        val pastedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(clipboard.pasteFromClipboard()).thenReturn(pastedCode)
+        whenever(qrCode.parse(pastedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(
+                ExchangeV2Event.Transition(
+                    timestampMs = 0L,
+                    from = ExchangeV2State.Negotiating,
+                    to = ExchangeV2State.SameAccountAbort,
+                    trigger = null,
+                    localTrigger = null,
+                ),
+            ),
+        )
+
+        testee.onPasteCodeClicked()
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2AlreadyPairedError, (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2PairingRejectedByPeerThenShowErrorAndClearLoading() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
+        val pastedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(clipboard.pasteFromClipboard()).thenReturn(pastedCode)
+        whenever(qrCode.parse(pastedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(
+                ExchangeV2Event.Transition(
+                    timestampMs = 0L,
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                    localTrigger = null,
+                ),
+            ),
+        )
+
+        testee.onPasteCodeClicked()
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_REJECTED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+        testee.viewState().test {
+            assertTrue(awaitItem().authState is Idle)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.sync.impl.ui
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.sync.TestSyncFixtures
 import com.duckduckgo.sync.TestSyncFixtures.jsonConnectKey
 import com.duckduckgo.sync.TestSyncFixtures.jsonConnectKeyEncoded
@@ -28,6 +29,10 @@ import com.duckduckgo.sync.TestSyncFixtures.primaryKey
 import com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN
 import com.duckduckgo.sync.impl.AccountErrorCodes.CONNECT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
+import com.duckduckgo.sync.impl.AccountInfo
 import com.duckduckgo.sync.impl.Clipboard
 import com.duckduckgo.sync.impl.ConnectCode
 import com.duckduckgo.sync.impl.QREncoder
@@ -37,19 +42,41 @@ import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAccountRepository.AuthCode
 import com.duckduckgo.sync.impl.SyncAuthCode.Connect
 import com.duckduckgo.sync.impl.SyncAuthCode.Recovery
+import com.duckduckgo.sync.impl.SyncCodeType
+import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
+import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
+import com.duckduckgo.sync.impl.exchange.v2.PairingRole
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_CONNECT
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupFailureReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command
+import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.AskHostConfirmation
+import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.AskJoinerConfirmation
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.LoginSuccess
+import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.ShowError
+import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.ShowV2Error
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -66,13 +93,38 @@ class SyncConnectViewModelTest {
     private val qrEncoder: QREncoder = mock()
     private val syncPixels: SyncPixels = mock()
 
+    private val syncFeature = com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory.create(SyncFeature::class.java)
+
+    private val runnerEventsFlow = kotlinx.coroutines.flow.MutableSharedFlow<com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event>(replay = 0)
+    private val qrCode: com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode = mock()
+    private val runner: com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner = mock<com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner>().also {
+        whenever(it.events).thenReturn(runnerEventsFlow)
+        whenever(it.eventsSince(any())).thenAnswer { invocation ->
+            val sinceMs = invocation.getArgument<Long>(0)
+            runnerEventsFlow.filter { event -> event.timestampMs >= sinceMs }
+        }
+    }
+    private val codeDispatcher = com.duckduckgo.sync.impl.RealSyncCodeDispatcher(
+        syncFeature = syncFeature,
+        syncAccountRepository = syncRepository,
+        qrCode = qrCode,
+        runner = runner,
+    )
+
     private val testee = SyncConnectViewModel(
         syncRepository,
         qrEncoder,
         clipboard,
         syncPixels,
         coroutineTestRule.testDispatcherProvider,
+        syncFeature,
+        codeDispatcher,
     )
+
+    @Before
+    fun setup() {
+        whenever(syncRepository.getAccountInfo()).thenReturn(AccountInfo())
+    }
 
     @Test
     fun whenScreenStartedThenShowQRCode() = runTest {
@@ -181,9 +233,9 @@ class SyncConnectViewModelTest {
             testee.onQRCodeScanned(jsonConnectKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.LoginSuccess)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_CONNECT))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_CONNECT), eq(CodeVersion.V1), isNull())
             verify(syncPixels).fireLoginPixel()
-            verify(syncPixels).fireSyncSetupFinishedSuccessfully(eq(SyncPixels.ScreenType.SYNC_CONNECT))
+            verify(syncPixels).fireSyncSetupFinishedSuccessfully(eq(SyncPixels.ScreenType.SYNC_CONNECT), isNull(), isNull(), isNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -196,9 +248,9 @@ class SyncConnectViewModelTest {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.ShowError)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_CONNECT))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_CONNECT), eq(CodeVersion.V1), isNull())
             verify(syncPixels, never()).fireLoginPixel()
-            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any())
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -212,9 +264,33 @@ class SyncConnectViewModelTest {
             testee.onQRCodeScanned(jsonConnectKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.ShowError)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_CONNECT))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_CONNECT), eq(CodeVersion.V1), isNull())
             verify(syncPixels, never()).fireLoginPixel()
-            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any())
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenUserScansV2RecoveryCodeThenBarcodeScannerParseSuccessFiredWithV2Recovery() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        val rawJson = org.json.JSONObject().apply {
+            put("user_id", "u-1")
+            put("secret", "s-1")
+            put("cid", "ddg")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
+
+        testee.commands().test {
+            testee.onQRCodeScanned("v2-recovery-code")
+            val command = awaitItem()
+            assertTrue("expected LoginSuccess, got $command", command is LoginSuccess)
+            verify(syncPixels).fireBarcodeScannerParseSuccess(
+                eq(SyncPixels.ScreenType.SYNC_CONNECT),
+                eq(CodeVersion.V2),
+                eq(SyncCodeType.RECOVERY),
+            )
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -226,7 +302,8 @@ class SyncConnectViewModelTest {
             val command = awaitItem()
             assertTrue(command is Command.LoginSuccess)
             verify(syncPixels).fireLoginPixel()
-            verify(syncPixels).fireSyncSetupFinishedSuccessfully(eq(SyncPixels.ScreenType.SYNC_CONNECT))
+            // Manual entry fires "Setup success" from EnterCodeViewModel, not here.
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -234,7 +311,7 @@ class SyncConnectViewModelTest {
     @Test
     fun whenUserCancelsThenAbandonedPixelFired() = runTest {
         testee.onUserCancelledWithoutSyncSetup()
-        verify(syncPixels).fireSyncSetupAbandoned(eq(SYNC_CONNECT))
+        verify(syncPixels).fireSyncSetupAbandoned(eq(SYNC_CONNECT), eq(CancellationReason.SCANNING_CANCELLED))
     }
 
     @Test
@@ -290,6 +367,530 @@ class SyncConnectViewModelTest {
             awaitItem()
             cancelAndIgnoreRemainingEvents()
             verify(syncRepository, times(2)).pollConnectionKeys()
+        }
+    }
+
+    private fun enableV2(displayOn: Boolean) {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        syncFeature.canShowV2ConnectCode().setRawStoredState(State(displayOn))
+    }
+
+    private fun presenterSessionStarted(linkingCode: String = "https://duckduckgo.com/sync/pairing/#&code2=xyz") =
+        ExchangeV2Event.SessionStarted(
+            timestampMs = System.currentTimeMillis(),
+            pairingRole = PairingRole.Presenter,
+            ownChannelId = "own-channel",
+            linkingCode = linkingCode,
+        )
+
+    private fun transition(
+        from: ExchangeV2State,
+        to: ExchangeV2State,
+        localTrigger: LocalTrigger? = null,
+        trigger: ExchangeV2Message? = null,
+    ) = ExchangeV2Event.Transition(
+        timestampMs = System.currentTimeMillis(),
+        from = from,
+        to = to,
+        trigger = trigger,
+        localTrigger = localTrigger,
+    )
+
+    @Test
+    fun whenBothV2FlagsOnThenRunnerStartPresentInvokedAndV1ConnectQRNotCalled() = runTest {
+        enableV2(displayOn = true)
+        val bitmap = TestSyncFixtures.qrBitmap()
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(bitmap)
+
+        testee.viewState(source = null).test {
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            val withQr = awaitItem()
+            Assert.assertEquals(bitmap, withQr.qrCodeBitmap)
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(runner).startPresent()
+        verify(syncRepository, never()).getConnectQR()
+    }
+
+    @Test
+    fun whenMasterFlagOnButCanShowV2OffThenV1PathTaken() = runTest {
+        enableV2(displayOn = false)
+        val bitmap = TestSyncFixtures.qrBitmap()
+        val authCode = AuthCode(qrCode = jsonConnectKeyEncoded, rawCode = "raw")
+        whenever(qrEncoder.encodeAsBitmap(eq(jsonConnectKeyEncoded), any(), any())).thenReturn(bitmap)
+        whenever(syncRepository.getConnectQR()).thenReturn(Result.Success(authCode))
+        whenever(syncRepository.pollConnectionKeys()).thenReturn(Result.Success(true))
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(runner, never()).startPresent()
+        verify(syncRepository).getConnectQR()
+    }
+
+    @Test
+    fun whenMasterFlagOffThenV1PathTakenRegardlessOfDisplayFlag() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+        syncFeature.canShowV2ConnectCode().setRawStoredState(State(true))
+        val bitmap = TestSyncFixtures.qrBitmap()
+        val authCode = AuthCode(qrCode = jsonConnectKeyEncoded, rawCode = "raw")
+        whenever(qrEncoder.encodeAsBitmap(eq(jsonConnectKeyEncoded), any(), any())).thenReturn(bitmap)
+        whenever(syncRepository.getConnectQR()).thenReturn(Result.Success(authCode))
+        whenever(syncRepository.pollConnectionKeys()).thenReturn(Result.Success(true))
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(runner, never()).startPresent()
+    }
+
+    @Test
+    fun whenLinkingCodeReadyThenCopyEmitsUrl() = runTest {
+        enableV2(displayOn = true)
+        val url = "https://duckduckgo.com/sync/pairing/#&code2=copy-me"
+        whenever(qrEncoder.encodeAsBitmap(eq(url), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState(source = null).test {
+            runnerEventsFlow.emit(presenterSessionStarted(linkingCode = url))
+            awaitItem()
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.onCopyCodeClicked()
+        verify(clipboard).copyToClipboard(url)
+        verify(syncRepository, never()).getConnectQR()
+    }
+
+    @Test
+    fun whenJoinerConfirmingDuringV2PresentThenAskJoinerConfirmationCommandEmitted() = runTest {
+        enableV2(displayOn = true)
+        whenever(runner.peerName).thenReturn("Peer Phone")
+        whenever(runner.peerKind).thenReturn("ddg")
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Joiner.Confirming),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected AskJoinerConfirmation, got $command", command is AskJoinerConfirmation)
+            Assert.assertEquals("Peer Phone", (command as AskJoinerConfirmation).peerName)
+            Assert.assertEquals(PeerKind.DDG, (command as AskJoinerConfirmation).peerKind)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenHostConfirmingDuringV2PresentThenAskHostConfirmationCommandEmitted() = runTest {
+        enableV2(displayOn = true)
+        whenever(runner.peerName).thenReturn("Peer Phone")
+        whenever(runner.peerKind).thenReturn("3party")
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Confirming),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected AskHostConfirmation, got $command", command is AskHostConfirmation)
+            Assert.assertEquals("Peer Phone", (command as AskHostConfirmation).peerName)
+            Assert.assertEquals(PeerKind.THIRD_PARTY, (command as AskHostConfirmation).peerKind)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenJoinerDoneWithCidDdgRecoveryCodeThenLoginSuccess() = runTest {
+        enableV2(displayOn = true)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+        val recoveryJson = org.json.JSONObject().apply {
+            put(
+                "recovery",
+                org.json.JSONObject().apply {
+                    put("user_id", "u-1")
+                    put("secret", "s-1")
+                    put("cid", "ddg")
+                    put("v", "2.0")
+                },
+            )
+        }.toString()
+        val b64 = android.util.Base64.encodeToString(
+            recoveryJson.toByteArray(Charsets.UTF_8),
+            android.util.Base64.URL_SAFE or android.util.Base64.NO_PADDING or android.util.Base64.NO_WRAP,
+        )
+        whenever(syncRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Waiting,
+                    to = ExchangeV2State.Joiner.Done,
+                    trigger = ExchangeV2Message.RecoveryCodeResponse(rawJson = "{}", recoveryCode = b64),
+                ),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected LoginSuccess, got $command", command is LoginSuccess)
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(syncRepository).processCode(any(), anyOrNull())
+    }
+
+    @Test
+    fun whenJoinerDoneViaCid3partyThenLoginSuccessAndUpgradeInvoked() = runTest {
+        enableV2(displayOn = true)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+        val recoveryJson = org.json.JSONObject().apply {
+            put(
+                "recovery",
+                org.json.JSONObject().apply {
+                    put("user_id", "u-3p")
+                    put("secret", "s-3p")
+                    put("cid", "3party")
+                    put("v", "2.0")
+                },
+            )
+        }.toString()
+        val b64 = android.util.Base64.encodeToString(
+            recoveryJson.toByteArray(Charsets.UTF_8),
+            android.util.Base64.URL_SAFE or android.util.Base64.NO_PADDING or android.util.Base64.NO_WRAP,
+        )
+        whenever(syncRepository.joinAccountFromThirdPartyRecoveryCode(any())).thenReturn(Result.Success(true))
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Waiting,
+                    to = ExchangeV2State.Joiner.Done,
+                    trigger = ExchangeV2Message.RecoveryCodeResponse(rawJson = "{}", recoveryCode = b64),
+                ),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected LoginSuccess, got $command", command is LoginSuccess)
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(syncRepository).joinAccountFromThirdPartyRecoveryCode(any())
+    }
+
+    @Test
+    fun whenV2LinkingCodeScannedThenRoutedThroughDispatcherAndLoginSuccess() = runTest {
+        enableV2(displayOn = true)
+        val scannedUrl = "https://duckduckgo.com/sync/pairing/#&code2=scan-me"
+        whenever(qrCode.parse(scannedUrl)).thenReturn(
+            com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult.LinkingV2(
+                channelId = "chan",
+                publicKey = "pk",
+                version = "2",
+            ),
+        )
+        val recoveryJson = org.json.JSONObject().apply {
+            put(
+                "recovery",
+                org.json.JSONObject().apply {
+                    put("user_id", "u-1")
+                    put("secret", "s-1")
+                    put("cid", "ddg")
+                    put("v", "2.0")
+                },
+            )
+        }.toString()
+        val recoveryB64 = android.util.Base64.encodeToString(
+            recoveryJson.toByteArray(Charsets.UTF_8),
+            android.util.Base64.URL_SAFE or android.util.Base64.NO_PADDING or android.util.Base64.NO_WRAP,
+        )
+        whenever(syncRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scannedUrl)
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Waiting,
+                    to = ExchangeV2State.Joiner.Done,
+                    trigger = ExchangeV2Message.RecoveryCodeResponse(rawJson = "{}", recoveryCode = recoveryB64),
+                ),
+            )
+            val command = awaitItem()
+            assertTrue("expected LoginSuccess, got $command", command is LoginSuccess)
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(runner).startScan(scannedUrl)
+    }
+
+    @Test
+    fun whenHostDoneDuringV2PresentThenLoginSuccess() = runTest {
+        enableV2(displayOn = true)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(from = ExchangeV2State.Host.Sending, to = ExchangeV2State.Host.Done),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected LoginSuccess, got $command", command is LoginSuccess)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenJoinerAbortedByHostThenShowError() = runTest {
+        enableV2(displayOn = true)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(from = ExchangeV2State.Joiner.Waiting, to = ExchangeV2State.Joiner.AbortedByHost),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_REJECTED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenJoinerAbortedLocalThenShowError() = runTest {
+        enableV2(displayOn = true)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedLocal,
+                    localTrigger = LocalTrigger.UserDeniedJoiner,
+                ),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_CANCELLED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenHostAbortedUserDeniedThenShowError() = runTest {
+        enableV2(displayOn = true)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Host.Confirming,
+                    to = ExchangeV2State.Host.Aborted,
+                    localTrigger = LocalTrigger.UserDeniedHost,
+                ),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_CANCELLED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        // Denying the confirmation (PAIRING_CANCELLED) fires the cancellation pixel, not the failed one.
+        verify(syncPixels).fireSyncSetupAbandoned(eq(SYNC_CONNECT), eq(CancellationReason.CONFIRMATION_DENIED))
+    }
+
+    @Test
+    fun whenUserCancelsMidExchangeThenAbandonedWithCancelledBeforeFinished() = runTest {
+        whenever(runner.currentState).thenReturn(ExchangeV2State.Negotiating)
+
+        testee.onUserCancelledWithoutSyncSetup()
+
+        verify(syncPixels).fireSyncSetupAbandoned(eq(SYNC_CONNECT), eq(CancellationReason.CANCELLED_BEFORE_FINISHED))
+    }
+
+    @Test
+    fun whenSessionErrorDuringV2PresentThenShowError() = runTest {
+        enableV2(displayOn = true)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                ExchangeV2Event.SessionError(timestampMs = System.currentTimeMillis(), message = "channel 5xx"),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_FAILED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        verify(syncPixels).fireSyncSetupFailed(
+            eq(SetupFailureReason.TRANSPORT_FAILURE),
+            eq(SetupPath.PAIRING),
+            isNull(),
+            isNull(),
+        )
+    }
+
+    @Test
+    fun whenViewStateReCollectedThenConnectQRGeneratedOnce() = runTest {
+        val authCodeToUse = AuthCode(qrCode = jsonConnectKeyEncoded, rawCode = "raw")
+        whenever(syncRepository.getConnectQR()).thenReturn(Result.Success(authCodeToUse))
+        whenever(qrEncoder.encodeAsBitmap(eq(jsonConnectKeyEncoded), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+        whenever(syncRepository.pollConnectionKeys()).thenReturn(Result.Success(true))
+        testee.viewState(source = null).test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        testee.viewState(source = null).test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(syncRepository, times(1)).getConnectQR()
+    }
+
+    @Test
+    fun whenViewStateReCollectedThenV2PresentStartedOnce() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        syncFeature.canShowV2ConnectCode().setRawStoredState(State(true))
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+        testee.viewState(source = null).test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        testee.viewState(source = null).test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(runner, times(1)).startPresent()
+    }
+
+    @Test
+    fun whenV2PairingRejectedByPeerThenShowError() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncRepository.getAccountInfo()).thenReturn(AccountInfo())
+        val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(qrCode.parse(scannedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(
+                ExchangeV2Event.Transition(
+                    timestampMs = 0L,
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                    localTrigger = null,
+                ),
+            ),
+        )
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scannedCode)
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_REJECTED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2PresentSameAccountThenShowAlreadyPaired() = runTest {
+        enableV2(displayOn = true)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.SameAccountAbort),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2AlreadyPairedError, (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2UpgradeRequiredThenShowUpdateError() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncRepository.getAccountInfo()).thenReturn(AccountInfo())
+        val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(qrCode.parse(scannedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(ExchangeV2Event.SessionError(timestampMs = 0L, message = "Peer requires protocol v3; please update this app")),
+        )
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scannedCode)
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2UpgradeRequiredError, (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
         }
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
@@ -19,16 +19,31 @@ package com.duckduckgo.sync.impl.ui
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.sync.TestSyncFixtures.jsonRecoveryKey
 import com.duckduckgo.sync.TestSyncFixtures.jsonRecoveryKeyEncoded
 import com.duckduckgo.sync.TestSyncFixtures.primaryKey
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
+import com.duckduckgo.sync.impl.RealSyncCodeDispatcher
 import com.duckduckgo.sync.impl.RecoveryCode
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode.Recovery
+import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command
+import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command.LoginSucess
+import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command.ShowV2Error
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -47,11 +62,21 @@ class SyncLoginViewModelTest {
 
     private val syncRepostitory: SyncAccountRepository = mock()
     private val syncPixels: SyncPixels = mock()
+    private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
+    private val qrCode: ExchangeV2QrCode = mock()
+    private val runner: ExchangeV2Runner = mock()
+    private val codeDispatcher = RealSyncCodeDispatcher(
+        syncFeature = syncFeature,
+        syncAccountRepository = syncRepostitory,
+        qrCode = qrCode,
+        runner = runner,
+    )
 
     private val testee = SyncLoginViewModel(
         syncRepostitory,
         syncPixels,
         coroutineTestRule.testDispatcherProvider,
+        codeDispatcher = codeDispatcher,
     )
 
     @Test
@@ -79,12 +104,88 @@ class SyncLoginViewModelTest {
     }
 
     @Test
+    fun whenV2CodeRequiresNewerProtocolThenShowUpdateError() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        val scanned = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(qrCode.parse(scanned)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(ExchangeV2Event.SessionError(timestampMs = 0L, message = "Peer requires protocol v3; please update this app")),
+        )
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scanned)
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2UpgradeRequiredError, (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2PairingRejectedByPeerThenShowError() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(qrCode.parse(scannedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(
+                ExchangeV2Event.Transition(
+                    timestampMs = 0L,
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                    localTrigger = null,
+                ),
+            ),
+        )
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scannedCode)
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_REJECTED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun whenOnLoginSuccessThenCommandIsLoginSuccess() = runTest {
         testee.commands().test {
             testee.onLoginSuccess()
             val command = awaitItem()
             assertTrue(command is Command.LoginSucess)
             verify(syncPixels).fireLoginPixel()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2SameAccountThenShowAlreadyPaired() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        val scanned = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(qrCode.parse(scanned)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(
+                ExchangeV2Event.Transition(
+                    timestampMs = 0L,
+                    from = ExchangeV2State.Negotiating,
+                    to = ExchangeV2State.SameAccountAbort,
+                    trigger = null,
+                    localTrigger = null,
+                ),
+            ),
+        )
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scanned)
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2AlreadyPairedError, (command as ShowV2Error).content)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncV2ConfirmationCopyTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncV2ConfirmationCopyTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui
+
+import com.duckduckgo.sync.impl.R
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SyncV2ConfirmationCopyTest {
+
+    @Test fun whenKnownDdgPeerThenFullDataList() {
+        assertEquals(
+            R.string.sync_v2_confirmation_message_ddg,
+            syncV2ConfirmationMessageRes(unknownPeer = false, peerKind = PeerKind.DDG),
+        )
+    }
+
+    @Test fun whenKnownThirdPartyPeerThenChatsOnly() {
+        assertEquals(
+            R.string.sync_v2_confirmation_message_3p,
+            syncV2ConfirmationMessageRes(unknownPeer = false, peerKind = PeerKind.THIRD_PARTY),
+        )
+    }
+
+    @Test fun whenUnknownDdgPeerThenFullDataListWithoutName() {
+        assertEquals(
+            R.string.sync_v2_confirmation_message_unknown_peer_ddg,
+            syncV2ConfirmationMessageRes(unknownPeer = true, peerKind = PeerKind.DDG),
+        )
+    }
+
+    @Test fun whenUnknownThirdPartyPeerThenChatsOnlyWithoutName() {
+        assertEquals(
+            R.string.sync_v2_confirmation_message_unknown_peer_3p,
+            syncV2ConfirmationMessageRes(unknownPeer = true, peerKind = PeerKind.THIRD_PARTY),
+        )
+    }
+
+    @Test fun whenKindNullThenFallsBackToFullDdgList() {
+        assertEquals(
+            R.string.sync_v2_confirmation_message_ddg,
+            syncV2ConfirmationMessageRes(unknownPeer = false, peerKind = null),
+        )
+        assertEquals(
+            R.string.sync_v2_confirmation_message_unknown_peer_ddg,
+            syncV2ConfirmationMessageRes(unknownPeer = true, peerKind = null),
+        )
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
@@ -36,11 +36,15 @@ import com.duckduckgo.sync.TestSyncFixtures.primaryKey
 import com.duckduckgo.sync.TestSyncFixtures.validLoginKeys
 import com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
 import com.duckduckgo.sync.impl.Clipboard
 import com.duckduckgo.sync.impl.ExchangeResult.AccountSwitchingRequired
 import com.duckduckgo.sync.impl.ExchangeResult.LoggedIn
 import com.duckduckgo.sync.impl.InvitationCode
 import com.duckduckgo.sync.impl.QREncoder
+import com.duckduckgo.sync.impl.RealSyncCodeDispatcher
 import com.duckduckgo.sync.impl.RecoveryCode
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.Result.Success
@@ -50,14 +54,31 @@ import com.duckduckgo.sync.impl.SyncAuthCode.Exchange
 import com.duckduckgo.sync.impl.SyncAuthCode.Recovery
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.encodeB64
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
+import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
+import com.duckduckgo.sync.impl.exchange.v2.PairingRole
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_EXCHANGE
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command
+import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.AskHostConfirmation
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.AskToSwitchAccount
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.LoginSuccess
+import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.ShowError
+import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.ShowV2Error
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.SwitchAccountSuccess
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -65,6 +86,7 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -85,6 +107,22 @@ class SyncWithAnotherDeviceViewModelTest {
         this.seamlessAccountSwitching().setRawStoredState(State(true))
         this.exchangeKeysToSyncWithAnotherDevice().setRawStoredState(State(false))
     }
+    private val qrCode: ExchangeV2QrCode = mock()
+
+    private val runnerEventsFlow = kotlinx.coroutines.flow.MutableSharedFlow<com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event>(replay = 0)
+    private val runner: ExchangeV2Runner = mock<ExchangeV2Runner>().also {
+        whenever(it.events).thenReturn(runnerEventsFlow)
+        whenever(it.eventsSince(any())).thenAnswer { invocation ->
+            val sinceMs = invocation.getArgument<Long>(0)
+            runnerEventsFlow.filter { event -> event.timestampMs >= sinceMs }
+        }
+    }
+    private val codeDispatcher = RealSyncCodeDispatcher(
+        syncFeature = syncFeature,
+        syncAccountRepository = syncRepository,
+        qrCode = qrCode,
+        runner = runner,
+    )
 
     private val testee = SyncWithAnotherActivityViewModel(
         syncRepository,
@@ -93,6 +131,7 @@ class SyncWithAnotherDeviceViewModelTest {
         syncPixels,
         coroutineTestRule.testDispatcherProvider,
         syncFeature,
+        codeDispatcher,
     )
 
     @Test
@@ -228,9 +267,9 @@ class SyncWithAnotherDeviceViewModelTest {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.ShowError)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE), eq(CodeVersion.V1), isNull())
             verify(syncPixels, never()).fireLoginPixel()
-            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any())
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -246,9 +285,9 @@ class SyncWithAnotherDeviceViewModelTest {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.ShowError)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE), eq(CodeVersion.V1), isNull())
             verify(syncPixels, never()).fireLoginPixel()
-            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any())
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -262,9 +301,9 @@ class SyncWithAnotherDeviceViewModelTest {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.AskToSwitchAccount)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE), eq(CodeVersion.V1), isNull())
             verify(syncPixels, never()).fireLoginPixel()
-            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any())
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -279,9 +318,9 @@ class SyncWithAnotherDeviceViewModelTest {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.AskToSwitchAccount)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE), eq(CodeVersion.V1), isNull())
             verify(syncPixels, never()).fireLoginPixel()
-            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any())
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -396,9 +435,9 @@ class SyncWithAnotherDeviceViewModelTest {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.ShowError)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE), eq(CodeVersion.V1), isNull())
             verify(syncPixels, never()).fireLoginPixel()
-            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any())
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -406,7 +445,7 @@ class SyncWithAnotherDeviceViewModelTest {
     @Test
     fun whenUserCancelsThenAbandonedPixelFired() = runTest {
         testee.onUserCancelledWithoutSyncSetup()
-        verify(syncPixels).fireSyncSetupAbandoned(eq(SYNC_EXCHANGE))
+        verify(syncPixels).fireSyncSetupAbandoned(eq(SYNC_EXCHANGE), eq(CancellationReason.SCANNING_CANCELLED))
     }
 
     @Test
@@ -427,5 +466,305 @@ class SyncWithAnotherDeviceViewModelTest {
         whenever(qrEncoder.encodeAsBitmap(eq(jsonExchangeKey), any(), any())).thenReturn(bitmap)
         whenever(syncRepository.processCode(any(), anyOrNull())).thenReturn(Success(true))
         return Pair(bitmap, authCodeToUse)
+    }
+
+    private fun enableV2(displayOn: Boolean) {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        syncFeature.canShowV2ConnectCode().setRawStoredState(State(displayOn))
+    }
+
+    private fun presenterSessionStarted(linkingCode: String = "https://duckduckgo.com/sync/pairing?code2=xyz") =
+        ExchangeV2Event.SessionStarted(
+            timestampMs = System.currentTimeMillis(),
+            pairingRole = PairingRole.Presenter,
+            ownChannelId = "own-channel",
+            linkingCode = linkingCode,
+        )
+
+    private fun transition(
+        from: ExchangeV2State,
+        to: ExchangeV2State,
+        localTrigger: LocalTrigger? = null,
+    ) = ExchangeV2Event.Transition(
+        timestampMs = System.currentTimeMillis(),
+        from = from,
+        to = to,
+        trigger = null,
+        localTrigger = localTrigger,
+    )
+
+    @Test
+    fun whenBothV2FlagsOnThenRunnerStartPresentInvokedAndV1RecoveryNotCalled() = runTest {
+        enableV2(displayOn = true)
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        val bitmap = TestSyncFixtures.qrBitmap()
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(bitmap)
+
+        testee.viewState().test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            val withQr = awaitItem()
+            Assert.assertEquals(bitmap, withQr.qrCodeBitmap)
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(runner).startPresent()
+        verify(syncRepository, never()).generateExchangeInvitationCode()
+        verify(syncRepository, never()).getRecoveryCode()
+    }
+
+    @Test
+    fun whenMasterFlagOnButCanShowV2OffThenV1PathTaken() = runTest {
+        enableV2(displayOn = false)
+        val bitmap = TestSyncFixtures.qrBitmap()
+        val authCode = AuthCode(qrCode = jsonRecoveryKeyEncoded, rawCode = "raw")
+        whenever(qrEncoder.encodeAsBitmap(eq(jsonRecoveryKeyEncoded), any(), any())).thenReturn(bitmap)
+        whenever(syncRepository.getRecoveryCode()).thenReturn(Result.Success(authCode))
+
+        testee.viewState().test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(runner, never()).startPresent()
+        verify(syncRepository).getRecoveryCode()
+    }
+
+    @Test
+    fun whenMasterFlagOffThenV1PathTakenRegardlessOfDisplayFlag() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+        syncFeature.canShowV2ConnectCode().setRawStoredState(State(true))
+        val bitmap = TestSyncFixtures.qrBitmap()
+        val authCode = AuthCode(qrCode = jsonRecoveryKeyEncoded, rawCode = "raw")
+        whenever(qrEncoder.encodeAsBitmap(eq(jsonRecoveryKeyEncoded), any(), any())).thenReturn(bitmap)
+        whenever(syncRepository.getRecoveryCode()).thenReturn(Result.Success(authCode))
+
+        testee.viewState().test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(runner, never()).startPresent()
+    }
+
+    @Test
+    fun whenLinkingCodeReadyThenBarcodeContentsPopulatedAndCopyEmitsUrl() = runTest {
+        enableV2(displayOn = true)
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        val url = "https://duckduckgo.com/sync/pairing?code2=copy-me"
+        val bitmap = TestSyncFixtures.qrBitmap()
+        whenever(qrEncoder.encodeAsBitmap(eq(url), any(), any())).thenReturn(bitmap)
+
+        testee.viewState().test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted(linkingCode = url))
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.onCopyCodeClicked()
+        verify(clipboard).copyToClipboard(url)
+    }
+
+    @Test
+    fun whenHostConfirmingDuringV2PresentThenAskHostConfirmationCommandEmitted() = runTest {
+        enableV2(displayOn = true)
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        whenever(runner.peerName).thenReturn("Peer Phone")
+        whenever(runner.peerKind).thenReturn("3party")
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState().test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Confirming),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected AskHostConfirmation, got $command", command is AskHostConfirmation)
+            Assert.assertEquals("Peer Phone", (command as AskHostConfirmation).peerName)
+            Assert.assertEquals(PeerKind.THIRD_PARTY, (command as AskHostConfirmation).peerKind)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenHostDoneDuringV2PresentThenLoginSuccessShowRecoveryFalse() = runTest {
+        enableV2(displayOn = true)
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState().test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(from = ExchangeV2State.Host.Sending, to = ExchangeV2State.Host.Done),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected LoginSuccess, got $command", command is LoginSuccess)
+            Assert.assertEquals(false, (command as LoginSuccess).showRecovery)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenSameAccountAbortDuringV2PresentThenShowAlreadyPaired() = runTest {
+        enableV2(displayOn = true)
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState().test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.SameAccountAbort),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2AlreadyPairedError, (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenHostAbortedUserDeniedDuringV2PresentThenShowErrorCommandEmitted() = runTest {
+        enableV2(displayOn = true)
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState().test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Host.Confirming,
+                    to = ExchangeV2State.Host.Aborted,
+                    localTrigger = LocalTrigger.UserDeniedHost,
+                ),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_CANCELLED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenSessionErrorDuringV2PresentThenShowErrorCommandEmitted() = runTest {
+        enableV2(displayOn = true)
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState().test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                ExchangeV2Event.SessionError(timestampMs = System.currentTimeMillis(), message = "channel 5xx"),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_FAILED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenViewStateReCollectedThenExchangeInvitationGeneratedOnce() = runTest {
+        configureExchangeKeysSupported()
+        testee.viewState().test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        testee.viewState().test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(syncRepository, times(1)).generateExchangeInvitationCode()
+    }
+
+    @Test
+    fun whenViewStateReCollectedThenV2PresentStartedOnce() = runTest {
+        enableV2(displayOn = true)
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+        testee.viewState().test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        testee.viewState().test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(runner, times(1)).startPresent()
+    }
+
+    @Test
+    fun whenV2PairingRejectedByPeerThenShowError() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(qrCode.parse(scannedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scannedCode)
+            runnerEventsFlow.emit(
+                ExchangeV2Event.Transition(
+                    timestampMs = System.currentTimeMillis(),
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                    localTrigger = null,
+                ),
+            )
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_REJECTED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2UpgradeRequiredThenShowUpdateError() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(qrCode.parse(scannedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(ExchangeV2Event.SessionError(timestampMs = 0L, message = "Peer requires protocol v3; please update this app")),
+        )
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scannedCode)
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2UpgradeRequiredError, (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/V2PairingErrorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/V2PairingErrorTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui
+
+import com.duckduckgo.sync.impl.AccountErrorCodes.GENERIC_ERROR
+import com.duckduckgo.sync.impl.AccountErrorCodes.NEGOTIATION_ABORTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.NO_RECOVERY_CODE
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_UNAVAILABLE
+import com.duckduckgo.sync.impl.AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED
+import com.duckduckgo.sync.impl.R
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class V2PairingErrorTest {
+
+    @Test
+    fun whenCodeIsPairingRejectedThenCanceledFromOtherDeviceTitleWithTryAgain() {
+        val content = PAIRING_REJECTED.code.toV2PairingError()
+        assertEquals(R.string.sync_v2_error_pairing_rejected, content.title)
+        assertEquals(R.string.sync_v2_error_try_again, content.message)
+    }
+
+    @Test
+    fun whenCodeIsPairingCancelledThenCanceledTitleOnly() {
+        val content = PAIRING_CANCELLED.code.toV2PairingError()
+        assertEquals(R.string.sync_v2_error_pairing_canceled, content.title)
+        assertNull(content.message)
+    }
+
+    @Test
+    fun whenCodeIsThirdPartyAlreadyUpgradedThenSyncFailedTitleWithUpgradeMessage() {
+        val content = THIRD_PARTY_ALREADY_UPGRADED.code.toV2PairingError()
+        assertEquals(R.string.sync_v2_error_pairing_failed, content.title)
+        assertEquals(R.string.sync_v2_error_third_party_already_upgraded, content.message)
+    }
+
+    @Test
+    fun whenCodeIsAnyOtherAbortThenSyncFailedTitleWithTryAgain() {
+        listOf(PAIRING_UNAVAILABLE, NEGOTIATION_ABORTED, NO_RECOVERY_CODE, PAIRING_FAILED).forEach { code ->
+            val content = code.code.toV2PairingError()
+            assertEquals("code $code title", R.string.sync_v2_error_pairing_failed, content.title)
+            assertEquals("code $code message", R.string.sync_v2_error_try_again, content.message)
+        }
+    }
+
+    @Test
+    fun whenCodeIsGenericOrUnknownThenSyncFailedTitleWithTryAgain() {
+        listOf(GENERIC_ERROR.code, 9999).forEach { code ->
+            val content = code.toV2PairingError()
+            assertEquals(R.string.sync_v2_error_pairing_failed, content.title)
+            assertEquals(R.string.sync_v2_error_try_again, content.message)
+        }
+    }
+
+    @Test
+    fun whenUpgradeRequiredThenUpdateBrowserTitleOnly() {
+        assertEquals(R.string.sync_v2_error_upgrade_required, v2UpgradeRequiredError.title)
+        assertNull(v2UpgradeRequiredError.message)
+    }
+
+    @Test
+    fun whenAlreadyPairedThenAlreadySyncedTitleWithMessage() {
+        assertEquals(R.string.sync_v2_already_paired_title, v2AlreadyPairedError.title)
+        assertEquals(R.string.sync_v2_already_paired_message, v2AlreadyPairedError.message)
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/qrcode/SyncBarcodeUrlTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/qrcode/SyncBarcodeUrlTest.kt
@@ -66,6 +66,44 @@ class SyncBarcodeUrlTest {
         assertEquals("${URL_BASE}code=ABC-123&deviceName=iPhone+16", url.asUrl())
     }
 
+    @Test
+    fun whenV2CodeParamProvidedThenIsSuccessfullyExtractedAsV2() {
+        val url = SyncBarcodeUrl.parseUrl("${URL_BASE}code2=ABC-V2")
+        assertNotNull(url)
+        assertEquals("ABC-V2", url!!.webSafeB64EncodedCode)
+        assertEquals(SyncBarcodeUrl.ProtocolVersion.V2, url.protocolVersion)
+    }
+
+    @Test
+    fun whenV1CodeParamProvidedThenProtocolVersionIsV1() {
+        val url = SyncBarcodeUrl.parseUrl("${URL_BASE}code=ABC-V1")
+        assertEquals(SyncBarcodeUrl.ProtocolVersion.V1, url!!.protocolVersion)
+    }
+
+    @Test
+    fun whenV2UrlBuiltThenUsesCode2Param() {
+        val url = SyncBarcodeUrl(
+            webSafeB64EncodedCode = "ABC-V2",
+            protocolVersion = SyncBarcodeUrl.ProtocolVersion.V2,
+        )
+        assertEquals("${URL_BASE}code2=ABC-V2", url.asUrl())
+    }
+
+    @Test
+    fun whenV2UrlHasDeviceNameThenIncludedInRebuiltUrl() {
+        val url = SyncBarcodeUrl.parseUrl("${URL_BASE}code2=ABC-V2&deviceName=Android")
+        assertEquals("Android", url!!.deviceName)
+        assertEquals("${URL_BASE}code2=ABC-V2&deviceName=Android", url.asUrl())
+    }
+
+    @Test
+    fun whenUrlContainsBothCodeAndCode2ThenV2Wins() {
+        // Malformed URL but defensible behavior — prefer v2 (the newer protocol).
+        val url = SyncBarcodeUrl.parseUrl("${URL_BASE}code=v1stale&code2=v2current")
+        assertEquals("v2current", url!!.webSafeB64EncodedCode)
+        assertEquals(SyncBarcodeUrl.ProtocolVersion.V2, url.protocolVersion)
+    }
+
     companion object {
         private const val URL_BASE = "https://duckduckgo.com/sync/pairing/#&"
     }

--- a/sync/sync-internal/build.gradle
+++ b/sync/sync-internal/build.gradle
@@ -60,4 +60,16 @@ dependencies {
     implementation "com.google.zxing:core:_"
 
     implementation "com.squareup.logcat:logcat:_"
+
+    // Testing dependencies
+    testImplementation "org.mockito.kotlin:mockito-kotlin:_"
+    testImplementation Testing.junit4
+    testImplementation AndroidX.test.ext.junit
+    testImplementation Testing.robolectric
+    testImplementation CashApp.turbine
+    testImplementation AndroidX.archCore.testing
+    testImplementation project(path: ':common-test')
+    testImplementation(KotlinX.coroutines.test) {
+        exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
+    }
 }

--- a/sync/sync-internal/src/main/AndroidManifest.xml
+++ b/sync/sync-internal/src/main/AndroidManifest.xml
@@ -23,5 +23,11 @@
             android:label="@string/sync_internal_activity_label"
             android:screenOrientation="portrait"
             android:parentActivityName="com.duckduckgo.app.settings.SettingsActivity" />
+        <activity
+            android:name=".ui.SyncV2PairingDebugActivity"
+            android:exported="false"
+            android:label="@string/sync_v2_pairing_debug_activity_label"
+            android:screenOrientation="portrait"
+            android:parentActivityName=".ui.SyncInternalSettingsActivity" />
     </application>
 </manifest>

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
@@ -110,6 +110,10 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         binding.launchSyncSettingsButton.setOnClickListener {
             startActivity(Intent(this, SyncActivity::class.java))
         }
+        binding.openV2PairingDebugButton.setOnClickListener {
+            startActivity(Intent(this, SyncV2PairingDebugActivity::class.java))
+        }
+        // this is temporary while testing
         binding.openDuckAiDevScreenButton.setOnClickListener {
             // Launch via class name so sync-internal doesn't need a direct dependency on duckchat-internal.
             val intent = Intent().setClassName(packageName, "com.duckduckgo.duckchat.internal.DuckAiDevActivity")

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncApi
+import com.duckduckgo.sync.impl.SyncAuthCode
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.autorestore.SyncAutoRestoreManager
 import com.duckduckgo.sync.impl.autorestore.SyncRecoveryPersistentStorageKey
@@ -396,7 +397,23 @@ constructor(
 
     fun useRecoveryCode(recoveryCode: String) {
         viewModelScope.launch(dispatchers.io()) {
-            authFlow(recoveryCode)
+            // 3party recovery codes are intentionally rejected by parseSyncAuthCode (production
+            // paste/scan paths must not accept them). For the dev-tool entrypoint we explicitly
+            // try the 3party→ddg upgrade path when the existing parser doesn't recognize the code.
+            val codeType = syncAccountRepository.parseSyncAuthCode(recoveryCode)
+            if (codeType is SyncAuthCode.Unknown) {
+                when (val joinResult = syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(recoveryCode)) {
+                    is Success -> {
+                        command.send(Command.LoginSuccess)
+                        updateViewState()
+                    }
+                    is Error -> {
+                        command.send(Command.ShowMessage("$joinResult"))
+                    }
+                }
+            } else {
+                authFlow(recoveryCode)
+            }
         }
     }
 
@@ -500,7 +517,6 @@ constructor(
     private fun buildV2StoreFieldsText(): String = buildString {
         appendLine("credentialId: ${syncStore.credentialId ?: "(not set)"}")
         appendLine("scopedPassword: ${syncStore.scopedPassword?.raw?.take(40)?.let { "$it..." } ?: "(not set)"}")
-        appendLine("protectedKeysJson: ${syncStore.protectedKeysJson?.take(60)?.let { "$it..." } ?: "(not set)"}")
     }.trim().also { logcat { "Sync-ScopedToken: v2 store fields:\n$it" } }
 
     fun onCreateThirdPartyCredentialClicked() {

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugActivity.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugActivity.kt
@@ -1,0 +1,327 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.internal.ui
+
+import android.annotation.SuppressLint
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.os.Bundle
+import android.view.View
+import android.widget.Toast
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.view.dialog.DaxAlertDialog
+import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
+import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.extensions.hideKeyboard
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.sync.impl.exchange.v2.Role
+import com.duckduckgo.sync.internal.databinding.ActivitySyncV2PairingDebugBinding
+import com.duckduckgo.sync.internal.databinding.ItemSyncV2PairingLogRowBinding
+import com.duckduckgo.sync.internal.ui.SyncV2PairingDebugViewModel.ConfirmationRequest
+import com.duckduckgo.sync.internal.ui.SyncV2PairingDebugViewModel.LogRow
+import com.duckduckgo.sync.internal.ui.SyncV2PairingDebugViewModel.TerminalReached
+import com.duckduckgo.sync.internal.ui.SyncV2PairingDebugViewModel.ViewState
+import com.google.zxing.BarcodeFormat.QR_CODE
+import com.journeyapps.barcodescanner.BarcodeEncoder
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.withContext
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import javax.inject.Inject
+
+@InjectWith(ActivityScope::class)
+class SyncV2PairingDebugActivity : DuckDuckGoActivity() {
+
+    @Inject
+    lateinit var dispatcherProvider: DispatcherProvider
+
+    private val binding: ActivitySyncV2PairingDebugBinding by viewBinding()
+    private val viewModel: SyncV2PairingDebugViewModel by bindViewModel()
+
+    private val timestampFormat = SimpleDateFormat("HH:mm:ss.SSS", Locale.US)
+    private val expandedRowIds = mutableSetOf<Long>()
+    private var renderedRows: List<LogRow> = emptyList()
+    private var activeConfirmationDialog: DaxAlertDialog? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(binding.root)
+        setupToolbar(binding.includeToolbar.toolbar)
+        configureListeners()
+        observeViewState()
+        observeConfirmations()
+        observeTerminals()
+        observeToasts()
+    }
+
+    private fun configureListeners() {
+        binding.runScanButton.setOnClickListener { startScanFromInput() }
+        binding.pasteAndGoButton.setOnClickListener { pasteAndStartScan() }
+        binding.runPresentButton.setOnClickListener {
+            if (!viewModel.canStartAsPresenter()) {
+                Toast.makeText(
+                    this,
+                    "Sign in to a sync account first — without one there's no recovery code to share. Set sync up in Sync Settings.",
+                    Toast.LENGTH_LONG,
+                ).show()
+                return@setOnClickListener
+            }
+            viewModel.onRunPresentClicked()
+        }
+        binding.clearPastedUrlButton.setOnClickListener { binding.pastedUrlInput.text = "" }
+        binding.cancelButton.setOnClickListener { viewModel.onCancelClicked() }
+        binding.clearLogButton.setOnClickListener {
+            expandedRowIds.clear()
+            viewModel.onClearLogClicked()
+        }
+        binding.autoApproveSetting.quietlySetIsChecked(newCheckedState = true) { _, enabled ->
+            viewModel.onAutoApproveToggled(enabled)
+        }
+
+        binding.signInOutButton.setOnClickListener { viewModel.onSignInOutClicked() }
+    }
+
+    private fun observeViewState() {
+        viewModel.viewState()
+            .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+            .onEach { render(it) }
+            .launchIn(lifecycleScope)
+    }
+
+    private fun observeConfirmations() {
+        viewModel.confirmations()
+            .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+            .onEach { showConfirmationDialog(it) }
+            .launchIn(lifecycleScope)
+    }
+
+    private fun observeTerminals() {
+        viewModel.terminals()
+            .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+            .onEach { showTerminalDialog(it) }
+            .launchIn(lifecycleScope)
+    }
+
+    private fun observeToasts() {
+        viewModel.toasts()
+            .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+            .onEach { Toast.makeText(this, it, Toast.LENGTH_LONG).show() }
+            .launchIn(lifecycleScope)
+    }
+
+    private fun showTerminalDialog(terminal: TerminalReached) {
+        // Auto-dismiss any open confirmation prompt — the session ended before the user
+        // could respond, so the prompt is no longer relevant.
+        activeConfirmationDialog?.dismiss()
+        activeConfirmationDialog = null
+        TextAlertDialogBuilder(this)
+            .setTitle(terminal.title)
+            .setMessage(terminal.message)
+            .setPositiveButton(android.R.string.ok)
+            .show()
+    }
+
+    private fun showConfirmationDialog(request: ConfirmationRequest) {
+        // Replace any prior confirmation dialog (shouldn't happen, but defensive).
+        activeConfirmationDialog?.dismiss()
+        val peer = request.peerName?.takeIf { it.isNotBlank() } ?: "the other device"
+        val (title, message) = when (request.role) {
+            Role.Host -> "Confirm pairing (Host)" to "Allow $peer to join your sync & backup?"
+            Role.Joiner -> "Confirm pairing (Joiner)" to "Sync your data with $peer?"
+        }
+        val dialog = TextAlertDialogBuilder(this)
+            .setTitle(title)
+            .setMessage(message)
+            .setPositiveButton(android.R.string.ok)
+            .setNegativeButton(android.R.string.cancel)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() {
+                        activeConfirmationDialog = null
+                        viewModel.onConfirmationApproved(request.role)
+                    }
+
+                    override fun onNegativeButtonClicked() {
+                        activeConfirmationDialog = null
+                        viewModel.onConfirmationDenied(request.role)
+                    }
+
+                    override fun onDialogDismissed() {
+                        activeConfirmationDialog = null
+                    }
+                },
+            )
+            .build()
+        activeConfirmationDialog = dialog
+        dialog.show()
+    }
+
+    private fun render(state: ViewState) {
+        renderAccountStatus(state.accountStatus)
+        binding.currentStateTextView.text = state.currentStateLabel
+        val code = state.linkingCode
+        if (code != null) {
+            binding.linkingCodeSectionHeader.visibility = View.VISIBLE
+            binding.linkingCodeTextView.visibility = View.VISIBLE
+            // Bare URL only — no "Linking code:" prefix — so long-press-select copies cleanly.
+            binding.linkingCodeTextView.text = code
+            binding.linkingCodeTextView.setOnClickListener { copyToClipboard("Linking code", code) }
+            binding.copyLinkingCodeButton.visibility = View.VISIBLE
+            binding.copyLinkingCodeButton.setOnClickListener { copyToClipboard("Linking code", code) }
+            renderQrFor(code)
+            // First time we see this code, push to clipboard automatically so the user can
+            // paste straight into the Scanner device without a manual Copy tap.
+            if (autoCopiedLinkingCode != code) {
+                autoCopiedLinkingCode = code
+                copyToClipboard("Linking code", code)
+            }
+        } else {
+            binding.linkingCodeSectionHeader.visibility = View.GONE
+            binding.linkingCodeTextView.visibility = View.GONE
+            binding.copyLinkingCodeButton.visibility = View.GONE
+            binding.linkingCodeQrImage.visibility = View.GONE
+            binding.linkingCodeQrImage.setImageBitmap(null)
+            renderedQrFor = null
+            autoCopiedLinkingCode = null
+        }
+        if (state.rows !== renderedRows) {
+            renderedRows = state.rows
+            renderRows(state.rows)
+        }
+    }
+
+    private var autoCopiedLinkingCode: String? = null
+
+    /**
+     * Encode [code] as a QR bitmap on a background thread (zxing is CPU-bound) and show it in
+     * [linkingCodeQrImage]. Skips work if we already rendered this exact code (render() runs
+     * on every event flow update — we don't want to regenerate the QR each time).
+     */
+    @SuppressLint("AvoidComputationUsage")
+    private fun renderQrFor(code: String) {
+        if (renderedQrFor == code) return
+        renderedQrFor = code
+        binding.linkingCodeQrImage.visibility = View.VISIBLE
+        lifecycleScope.launchWhenStarted {
+            val bitmap = withContext(dispatcherProvider.computation()) {
+                runCatching { BarcodeEncoder().encodeBitmap(code, QR_CODE, QR_SIZE_PX, QR_SIZE_PX) }
+                    .getOrNull()
+            }
+            if (renderedQrFor == code) binding.linkingCodeQrImage.setImageBitmap(bitmap)
+        }
+    }
+
+    private var renderedQrFor: String? = null
+
+    private fun renderRows(rows: List<LogRow>) {
+        binding.logContainer.removeAllViews()
+        rows.forEach { row ->
+            val rowBinding = ItemSyncV2PairingLogRowBinding.inflate(layoutInflater, binding.logContainer, true)
+            val timestamp = timestampFormat.format(Date(row.timestampMs))
+            rowBinding.summaryTextView.text = "[$timestamp] ${row.summary}"
+            rowBinding.rawJsonTextView.text = row.rawJson
+            applyExpansion(rowBinding, row.id in expandedRowIds)
+            rowBinding.summaryRow.setOnClickListener {
+                val newlyExpanded = row.id !in expandedRowIds
+                if (newlyExpanded) expandedRowIds.add(row.id) else expandedRowIds.remove(row.id)
+                applyExpansion(rowBinding, newlyExpanded)
+            }
+            rowBinding.copyRawButton.setOnClickListener {
+                copyToClipboard("Raw JSON", row.rawJson)
+            }
+        }
+    }
+
+    private fun applyExpansion(rowBinding: ItemSyncV2PairingLogRowBinding, expanded: Boolean) {
+        rowBinding.rawDetail.visibility = if (expanded) View.VISIBLE else View.GONE
+        rowBinding.chevronTextView.text = if (expanded) "▾" else "▸"
+    }
+
+    private fun copyToClipboard(label: String, value: String) {
+        val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        clipboard.setPrimaryClip(ClipData.newPlainText(label, value))
+        Toast.makeText(this, "$label copied", Toast.LENGTH_SHORT).show()
+    }
+
+    /** Shared handler for the "Start as Scanner" button — uses whatever is in the input field. */
+    private fun startScanFromInput() {
+        val pasted = binding.pastedUrlInput.text.trim()
+        if (pasted.isEmpty()) {
+            Toast.makeText(
+                this,
+                "Paste the Presenter's linking code into the V2 exchange URL field first.",
+                Toast.LENGTH_LONG,
+            ).show()
+            return
+        }
+        viewModel.onRunScanClicked(pasted)
+        // Clear the input now that we've handed it off — keeps the field tidy and avoids
+        // the user accidentally re-running with a stale code.
+        binding.pastedUrlInput.text = ""
+        // Dismiss the keyboard so the log + state are visible without scrolling.
+        hideKeyboard()
+    }
+
+    /**
+     * One-tap: read clipboard, fill the input (for visible feedback), then fire start-scan.
+     * Skips the keyboard / paste-menu round-trip entirely.
+     */
+    private fun pasteAndStartScan() {
+        val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        val text = clipboard.primaryClip
+            ?.takeIf { it.itemCount > 0 }
+            ?.getItemAt(0)
+            ?.coerceToText(this)
+            ?.toString()
+            ?.trim()
+            .orEmpty()
+        if (text.isEmpty()) {
+            Toast.makeText(this, "Clipboard is empty — copy the Presenter's linking code first.", Toast.LENGTH_LONG).show()
+            return
+        }
+        // Surface what was pasted so the user can see it before it disappears (input is then
+        // cleared by startScanFromInput).
+        binding.pastedUrlInput.text = text
+        startScanFromInput()
+    }
+
+    private fun renderAccountStatus(status: SyncV2PairingDebugViewModel.AccountStatus) {
+        binding.statusSignedIn.setSecondaryText(
+            if (status.signedIn) "Yes · user_id ${status.userId ?: "(unknown)"}" else "No",
+        )
+        binding.signInOutButton.text = if (status.signedIn) "Sign out" else "Sign in"
+        binding.statusThirdPartyCredential.setSecondaryText(
+            when {
+                !status.signedIn -> "(not signed in)"
+                status.thirdPartyCredentialCreated -> "Yes"
+                else -> "Not created; needed before pairing with 3party peers"
+            },
+        )
+    }
+
+    private companion object {
+        const val QR_SIZE_PX = 600
+    }
+}

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModel.kt
@@ -1,0 +1,617 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.internal.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.sync.impl.DispatchOutcome
+import com.duckduckgo.sync.impl.ExchangeResult.AccountSwitchingRequired
+import com.duckduckgo.sync.impl.ExchangeResult.LoggedIn
+import com.duckduckgo.sync.impl.ExchangeResult.Pending
+import com.duckduckgo.sync.impl.Result
+import com.duckduckgo.sync.impl.RouteDecision
+import com.duckduckgo.sync.impl.SyncAccountRepository
+import com.duckduckgo.sync.impl.SyncAuthCode
+import com.duckduckgo.sync.impl.SyncCodeDispatcher
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
+import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
+import com.duckduckgo.sync.impl.exchange.v2.RejectReason
+import com.duckduckgo.sync.impl.exchange.v2.Role
+import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Companion.POLLING_INTERVAL_EXCHANGE_FLOW
+import com.duckduckgo.sync.store.SyncStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import logcat.logcat
+import javax.inject.Inject
+
+@ContributesViewModel(ActivityScope::class)
+class SyncV2PairingDebugViewModel @Inject constructor(
+    private val runner: ExchangeV2Runner,
+    private val syncStore: SyncStore,
+    private val syncAccountRepository: SyncAccountRepository,
+    private val dispatcher: SyncCodeDispatcher,
+    private val dispatchers: DispatcherProvider,
+    @AppCoroutineScope private val appScope: CoroutineScope,
+) : ViewModel() {
+
+    data class LogRow(
+        val id: Long,
+        val timestampMs: Long,
+        val summary: String,
+        val rawJson: String,
+    )
+
+    /**
+     * Snapshot of the device's sync setup that's relevant to v2 pairing. Read from
+     * [SyncStore] at the points where it could have changed (init + after Cancel /
+     * terminal). Not reactive — this is a dev tool, the user can tap Cancel to refresh.
+     */
+    data class AccountStatus(
+        val signedIn: Boolean,
+        val userId: String?,
+        val thirdPartyCredentialCreated: Boolean,
+    )
+
+    data class ViewState(
+        val currentStateLabel: String = "(no session)",
+        val linkingCode: String? = null,
+        val rows: List<LogRow> = emptyList(),
+        val autoApproveConfirmation: Boolean = true,
+        val accountStatus: AccountStatus = AccountStatus(false, null, false),
+    )
+
+    /**
+     * One-shot prompt to show the user. The Activity renders this as an [AlertDialog] and
+     * dispatches the result back via [onConfirmationApproved] / [onConfirmationDenied].
+     */
+    data class ConfirmationRequest(
+        val role: Role,
+        val peerName: String?,
+    )
+
+    /**
+     * Emitted once when the session reaches a terminal state. The Activity shows a result
+     * alert summarising what happened.
+     */
+    data class TerminalReached(
+        val state: ExchangeV2State,
+        val title: String,
+        val message: String,
+        val isSuccess: Boolean,
+    )
+
+    private val viewState = MutableStateFlow(ViewState())
+    fun viewState(): Flow<ViewState> = viewState.asStateFlow()
+
+    /**
+     * Tear down any in-flight session when the Activity is finishing. ActivityScope VMs
+     * survive config changes but [onCleared] runs on real finish (back press, navigation away),
+     * which is when we want to dispose of a pairing session that the user has abandoned.
+     */
+    override fun onCleared() {
+        super.onCleared()
+        // cancel() suspends until teardown completes; onCleared can't await and viewModelScope is
+        // already cancelling, so fire-and-forget the teardown on the app scope (it outlives the VM).
+        appScope.launch { runner.cancel() }
+    }
+
+    private val confirmationRequests = Channel<ConfirmationRequest>(Channel.BUFFERED)
+    fun confirmations(): Flow<ConfirmationRequest> = confirmationRequests.receiveAsFlow()
+
+    private val terminalReached = Channel<TerminalReached>(Channel.BUFFERED)
+    fun terminals(): Flow<TerminalReached> = terminalReached.receiveAsFlow()
+
+    private val toasts = Channel<String>(Channel.BUFFERED)
+    fun toasts(): Flow<String> = toasts.receiveAsFlow()
+
+    private var nextRowId: Long = 0L
+
+    init {
+        viewState.update { it.copy(accountStatus = readAccountStatus()) }
+        viewModelScope.launch(dispatchers.io()) {
+            // Snapshot how many events the runner's SharedFlow will replay to us. Those events
+            // populate the log row history, but we skip side effects (terminal alerts,
+            // confirmation dialogs) for them — otherwise re-entering this Activity after a
+            // completed pairing would re-pop the "Pairing complete" dialog from a stale event.
+            val replayCount = runner.events.replayCache.size
+            var processed = 0
+            runner.events.collect { event ->
+                appendEvent(event, isReplay = processed < replayCount)
+                processed++
+            }
+        }
+    }
+
+    /**
+     * Delegate routing to [SyncCodeDispatcher] — the single source of truth for v1/v2 dispatch
+     * that the production VMs now share. The dispatcher's contract: FF off → byte-identical to
+     * direct [SyncAccountRepository.parseSyncAuthCode]; FF on → v2 shapes are taken into
+     * ownership and surfaced via a one-shot [DispatchOutcome] Flow.
+     *
+     * The VM still owns the v1 [SyncAuthCode.Exchange] two-stage polling locally (in
+     * [dispatchV1Exchange]) — the dispatcher only handles the routing decision, not the
+     * downstream v1 protocol details (preserved byte-for-byte from production).
+     */
+    fun onRunScanClicked(pastedUrl: String) {
+        viewModelScope.launch(dispatchers.io()) {
+            appendDevToolLog("Routing pasted code via SyncCodeDispatcher")
+            when (val decision = dispatcher.route(pastedUrl)) {
+                is RouteDecision.Legacy -> handleLegacyAuthCode(decision.authCode)
+                is RouteDecision.V2InProgress -> {
+                    appendDevToolLog("Dispatcher took v2 ownership — observing outcomes")
+                    decision.outcomes.collect { outcome -> handleV2Outcome(outcome) }
+                    refreshState()
+                }
+            }
+        }
+    }
+
+    /**
+     * Mirrors production v1 handling exactly: Recovery / Connect → [SyncAccountRepository.processCode];
+     * Exchange → two-stage post-then-poll loop; Unknown → user-facing error. Identical control
+     * flow to [com.duckduckgo.sync.impl.ui.EnterCodeViewModel.authFlow] but logging into the
+     * dev-tool log row stream instead of UI commands.
+     */
+    private suspend fun handleLegacyAuthCode(authCode: SyncAuthCode) {
+        appendDevToolLog("Legacy v1 auth code: ${authCode::class.simpleName}")
+        when (authCode) {
+            is SyncAuthCode.Recovery -> emitProcessCodeResult("v1 recovery", syncAccountRepository.processCode(authCode))
+            is SyncAuthCode.Connect -> emitProcessCodeResult("v1 connect", syncAccountRepository.processCode(authCode))
+            is SyncAuthCode.Exchange -> dispatchV1Exchange(authCode)
+            is SyncAuthCode.Unknown -> {
+                appendDevToolLog("Couldn't read the pasted code as v1 or v2")
+                toasts.send("Couldn't read the pasted code (no v1 or v2 shape matched)")
+            }
+        }
+        refreshState()
+    }
+
+    /**
+     * Translate one [DispatchOutcome] emitted by the v2 dispatcher into the dev tool's log +
+     * toast surface. Production VMs map these to their own command/error-dialog channels.
+     */
+    private suspend fun handleV2Outcome(outcome: DispatchOutcome) {
+        when (outcome) {
+            is DispatchOutcome.LoggedIn -> {
+                appendDevToolLog("v2 dispatch → LoggedIn")
+                toasts.send("Paired via v2 stack")
+            }
+            is DispatchOutcome.AlreadyConnected -> {
+                appendDevToolLog("v2 dispatch → AlreadyConnected (same-account, spec friendly finish)")
+                toasts.send("Already connected (same account)")
+            }
+            is DispatchOutcome.UpgradeRequired -> {
+                appendDevToolLog("v2 dispatch → UpgradeRequired (codeMajor=${outcome.codeMajor})")
+                toasts.send("This code requires a newer app version (v${outcome.codeMajor})")
+            }
+            is DispatchOutcome.Failed -> {
+                appendDevToolLog("v2 dispatch → Failed: ${outcome.reason}")
+                toasts.send("v2 dispatch failed: ${outcome.reason}")
+            }
+            is DispatchOutcome.JoinerConfirmationRequested,
+            is DispatchOutcome.HostConfirmationRequested,
+            -> {
+                // The dev tool already drives confirmation via its direct runner.events
+                // observation ([maybeHandleConfirmingTransition]). Ignoring the dispatcher's
+                // intermediate emission here avoids double-prompting.
+                appendDevToolLog("v2 dispatch → ${outcome::class.simpleName} (handled by dev tool's direct observation)")
+            }
+            is DispatchOutcome.LinkingCodeReady -> {
+                // No-op: the dev tool drives Presenter sessions directly via runner.startPresent()
+                // (onRunPresentClicked), not through dispatcher.presentV2(). This branch only exists
+                // to keep the when block exhaustive.
+                appendDevToolLog("v2 dispatch → LinkingCodeReady (handled by dev tool's direct observation)")
+            }
+        }
+    }
+
+    /**
+     * v1 Exchange is a two-stage scanner flow:
+     *   1. [SyncAccountRepository.processCode] (→ `onInvitationCodeReceived`) posts our
+     *      encrypted device details to the presenter's relay slot.
+     *   2. Poll [SyncAccountRepository.pollForRecoveryCodeAndLogin] until the presenter
+     *      replies with the encrypted recovery code, which the repo then uses to log us in.
+     *
+     * Mirrors [SyncLoginViewModel.pollForRecoveryKey] / [SyncWithAnotherActivityViewModel]
+     * — same polling cadence, same result handling. Without step 2 the device finishes step
+     * 1 with "OK" but never actually logs in (the original bug).
+     */
+    private suspend fun dispatchV1Exchange(code: SyncAuthCode.Exchange) {
+        when (val postResult = syncAccountRepository.processCode(code)) {
+            is Result.Error -> {
+                appendDevToolLog("v1 exchange step 1 (post device details) failed: ${postResult.reason}")
+                toasts.send("v1 exchange failed: ${postResult.reason}")
+                return
+            }
+            is Result.Success -> {
+                appendDevToolLog("v1 exchange step 1 (post device details) OK — polling for recovery code")
+            }
+        }
+        var polling = true
+        while (polling) {
+            delay(POLLING_INTERVAL_EXCHANGE_FLOW)
+            when (val pollResult = syncAccountRepository.pollForRecoveryCodeAndLogin()) {
+                is Result.Success -> when (pollResult.data) {
+                    is Pending -> Unit // keep polling
+                    is LoggedIn -> {
+                        polling = false
+                        appendDevToolLog("v1 exchange: logged in via received recovery code")
+                        toasts.send("Paired via v1 exchange stack")
+                    }
+                    is AccountSwitchingRequired -> {
+                        // Production prompts the user; dev tool stops short of destructive
+                        // account switching and just surfaces the situation.
+                        polling = false
+                        appendDevToolLog("v1 exchange: peer offered a different account (skipped — account switching not wired here)")
+                        toasts.send("v1 exchange: account switching required — not wired in dev tool")
+                    }
+                }
+                is Result.Error -> {
+                    polling = false
+                    appendDevToolLog("v1 exchange poll failed: ${pollResult.reason}")
+                    toasts.send("v1 exchange poll failed: ${pollResult.reason}")
+                }
+            }
+        }
+    }
+
+    private suspend fun emitProcessCodeResult(label: String, result: Result<Boolean>) {
+        when (result) {
+            is Result.Success -> {
+                appendDevToolLog("$label: OK")
+                toasts.send("Paired via $label stack")
+            }
+            is Result.Error -> {
+                appendDevToolLog("$label failed: ${result.reason}")
+                toasts.send("$label failed: ${result.reason}")
+            }
+        }
+    }
+
+    /**
+     * Push a synthetic row into the event log so v1-fallback progress is visible alongside
+     * native v2 [ExchangeV2Event]s. Reuses [LogRow] with the message in both summary and rawJson.
+     * Also tees to logcat with a `Sync-V2Debug:` prefix so the fallback path is traceable
+     * end-to-end (the in-screen log alone misses the eyes of anyone watching logcat).
+     */
+    private fun appendDevToolLog(message: String) {
+        logcat { "Sync-V2Debug: $message" }
+        viewState.update { current ->
+            current.copy(
+                rows = current.rows + LogRow(
+                    id = nextRowId++,
+                    timestampMs = System.currentTimeMillis(),
+                    summary = message,
+                    rawJson = message,
+                ),
+            )
+        }
+    }
+
+    fun onRunPresentClicked() {
+        viewModelScope.launch(dispatchers.io()) {
+            runner.startPresent()
+            refreshState()
+        }
+    }
+
+    /** True when this device has a sync account whose recovery code we could share with a Joiner. */
+    fun canStartAsPresenter(): Boolean = runner.canStartAsPresenter
+
+    /**
+     * Toggle account state: create a fresh sync account if signed out, or log out (and tear
+     * down the current session) if signed in. Status row refreshes either way.
+     */
+    fun onSignInOutClicked() {
+        viewModelScope.launch(dispatchers.io()) {
+            val signedIn = syncStore.userId != null
+            val result = if (signedIn) {
+                // If a pairing session was running on this device's old credentials, kill it
+                // before logout invalidates the recovery code under us.
+                runner.cancel()
+                val deviceId = syncStore.deviceId.orEmpty()
+                syncAccountRepository.logout(deviceId)
+            } else {
+                syncAccountRepository.createAccount()
+            }
+            val action = if (signedIn) "Sign out" else "Create account"
+            when (result) {
+                is Result.Success -> toasts.send("$action: OK")
+                is Result.Error -> toasts.send("$action failed: ${result.reason}")
+            }
+            refreshState()
+        }
+    }
+
+    fun onCancelClicked() {
+        viewModelScope.launch(dispatchers.io()) {
+            runner.cancel()
+            refreshState()
+        }
+    }
+
+    fun onClearLogClicked() {
+        viewState.update { it.copy(rows = emptyList()) }
+    }
+
+    fun onAutoApproveToggled(checked: Boolean) {
+        viewState.update { it.copy(autoApproveConfirmation = checked) }
+    }
+
+    fun onConfirmationApproved(role: Role) {
+        fireLocalTrigger(if (role == Role.Host) LocalTrigger.UserConfirmedHost else LocalTrigger.UserConfirmedJoiner)
+    }
+
+    fun onConfirmationDenied(role: Role) {
+        fireLocalTrigger(if (role == Role.Host) LocalTrigger.UserDeniedHost else LocalTrigger.UserDeniedJoiner)
+    }
+
+    private fun fireLocalTrigger(trigger: LocalTrigger) {
+        viewModelScope.launch(dispatchers.io()) {
+            runner.localTrigger(trigger)
+            refreshState()
+        }
+    }
+
+    private fun appendEvent(event: ExchangeV2Event, isReplay: Boolean = false) {
+        val row = LogRow(
+            id = nextRowId++,
+            timestampMs = event.timestampMs,
+            summary = summarise(event),
+            rawJson = rawJsonFor(event),
+        )
+        viewState.update { current ->
+            current.copy(
+                rows = current.rows + row,
+                currentStateLabel = buildStateLabel(),
+                linkingCode = runner.linkingCode,
+                // Refresh on every event so runner-driven account changes (e.g. on-demand
+                // account creation at Host.Sending per spec §"Exchange Share Recovery Code")
+                // surface immediately, not on next manual refresh.
+                accountStatus = readAccountStatus(),
+            )
+        }
+        if (!isReplay) {
+            maybeHandleConfirmingTransition(event)
+            maybeEmitTerminalAlert(event)
+            maybeToastSessionError(event)
+            maybeLoginAfterJoinerDone(event)
+        }
+    }
+
+    /**
+     * When the runner reaches [ExchangeV2State.Joiner.Done] from a session that was started
+     * via [onRunPresentClicked] (i.e. not routed through [SyncCodeDispatcher]), the dispatcher's
+     * own login Flow never runs and nothing else drives a login from the received recovery code.
+     * This handler closes that gap. Idempotent for dispatcher-routed sessions because
+     * [SyncCodeDispatcher.route] is only invoked from [onRunScanClicked] — the Presenter path
+     * never goes through it.
+     */
+    private fun maybeLoginAfterJoinerDone(event: ExchangeV2Event) {
+        if (event !is ExchangeV2Event.Transition) return
+        if (event.to != ExchangeV2State.Joiner.Done) return
+        val received = (event.trigger as? ExchangeV2Message.RecoveryCodeResponse)?.recoveryCode
+        if (received.isNullOrBlank()) return
+        viewModelScope.launch(dispatchers.io()) {
+            appendDevToolLog("Joiner.Done — driving login from received recovery code")
+            when (val decision = dispatcher.route(received)) {
+                is RouteDecision.V2InProgress -> decision.outcomes.collect { handleV2Outcome(it) }
+                is RouteDecision.Legacy -> when (decision.authCode) {
+                    is SyncAuthCode.Recovery -> emitProcessCodeResult(
+                        "Joiner.Done login",
+                        syncAccountRepository.processCode(decision.authCode),
+                    )
+                    else -> {
+                        appendDevToolLog("Joiner.Done: received code wasn't a Recovery shape, can't auto-login")
+                        toasts.send("Joiner.Done: unexpected code shape, manual login required")
+                    }
+                }
+            }
+            refreshState()
+        }
+    }
+
+    /** Surface transport-level errors (failed sends, version mismatches) so they don't just bury in the log. */
+    private fun maybeToastSessionError(event: ExchangeV2Event) {
+        if (event !is ExchangeV2Event.SessionError) return
+        viewModelScope.launch { toasts.send(event.message) }
+    }
+
+    private fun maybeEmitTerminalAlert(event: ExchangeV2Event) {
+        if (event !is ExchangeV2Event.Transition) return
+        val terminal = describeTerminal(event) ?: return
+        viewModelScope.launch { terminalReached.send(terminal) }
+    }
+
+    private fun describeTerminal(event: ExchangeV2Event.Transition): TerminalReached? = when (event.to) {
+        ExchangeV2State.Host.Done -> TerminalReached(
+            state = event.to,
+            title = "✓ Pairing complete (Host)",
+            message = "Sent recovery_code_response to peer. Session closed on this side.",
+            isSuccess = true,
+        )
+        ExchangeV2State.Joiner.Done -> {
+            val code = (event.trigger as? ExchangeV2Message.RecoveryCodeResponse)?.recoveryCode
+            TerminalReached(
+                state = event.to,
+                title = "✓ Pairing complete (Joiner)",
+                message = "Received recovery code from peer:\n\n${code ?: "(missing)"}",
+                isSuccess = true,
+            )
+        }
+        ExchangeV2State.Host.Aborted -> {
+            val (title, message) = when (event.localTrigger) {
+                LocalTrigger.HostUnavailable -> "✗ Pairing aborted (Host)" to (
+                    "Couldn't produce a recovery code on this device — sent recovery_code_unavailable to peer." +
+                        "\n\nIs this device signed in to a sync account?"
+                    )
+                else ->
+                    "✗ Pairing aborted (Host)" to
+                        "You denied the prompt on this device. Sent recovery_code_denied to peer."
+            }
+            TerminalReached(state = event.to, title = title, message = message, isSuccess = false)
+        }
+        ExchangeV2State.Joiner.AbortedLocal -> TerminalReached(
+            state = event.to,
+            title = "✗ Pairing aborted (Joiner)",
+            message = "You denied the prompt on this device. No message sent to peer (per spec).",
+            isSuccess = false,
+        )
+        ExchangeV2State.Joiner.AbortedByHost -> TerminalReached(
+            state = event.to,
+            title = "✗ Pairing aborted by peer",
+            message = "Peer sent ${event.trigger?.messageType ?: "an abort message"}.",
+            isSuccess = false,
+        )
+        ExchangeV2State.SameAccountAbort -> TerminalReached(
+            state = event.to,
+            title = "✗ Same-account abort",
+            message = "Peer reported the same user_id — devices are already paired. No action taken.",
+            isSuccess = false,
+        )
+        ExchangeV2State.Aborted -> TerminalReached(
+            state = event.to,
+            title = "✗ Negotiation aborted",
+            message = "Received an unexpected hello during negotiation (duplicate or double-scan). Channel closed.",
+            isSuccess = false,
+        )
+        else -> null
+    }
+
+    private fun maybeHandleConfirmingTransition(event: ExchangeV2Event) {
+        if (event !is ExchangeV2Event.Transition) return
+        val role = when (event.to) {
+            ExchangeV2State.Host.Confirming -> Role.Host
+            ExchangeV2State.Joiner.Confirming -> Role.Joiner
+            else -> return
+        }
+        if (viewState.value.autoApproveConfirmation) {
+            val trigger = if (role == Role.Host) LocalTrigger.UserConfirmedHost else LocalTrigger.UserConfirmedJoiner
+            viewModelScope.launch(dispatchers.io()) { runner.localTrigger(trigger) }
+        } else {
+            viewModelScope.launch {
+                confirmationRequests.send(ConfirmationRequest(role = role, peerName = runner.peerName))
+            }
+        }
+    }
+
+    private fun refreshState() {
+        viewState.update {
+            it.copy(
+                currentStateLabel = buildStateLabel(),
+                linkingCode = runner.linkingCode,
+                accountStatus = readAccountStatus(),
+            )
+        }
+    }
+
+    private fun readAccountStatus(): AccountStatus {
+        val userId = syncStore.userId
+        val signedIn = userId != null
+        val thirdParty = syncStore.scopedPassword != null
+        return AccountStatus(
+            signedIn = signedIn,
+            userId = userId,
+            thirdPartyCredentialCreated = signedIn && thirdParty,
+        )
+    }
+
+    private fun buildStateLabel(): String {
+        val state = labelFor(runner.currentState)
+        val role = runner.pairingRole ?: return state
+        return "$state · pairing as $role"
+    }
+
+    private fun summarise(event: ExchangeV2Event): String = when (event) {
+        is ExchangeV2Event.Transition -> {
+            val trigger = event.trigger?.let { "msg=${it.messageType}${peerSuffix(it)}" }
+                ?: event.localTrigger?.let { "local=${labelFor(it)}" }
+                ?: "(no trigger)"
+            "Transition ${labelFor(event.from)} → ${labelFor(event.to)} [$trigger]"
+        }
+        is ExchangeV2Event.MessageSent -> "Sent ${event.message.messageType}${peerSuffix(event.message)}"
+        is ExchangeV2Event.MessageRejected -> {
+            val verb = when (event.reason) {
+                RejectReason.ImplicitAbort -> "Aborted"
+                RejectReason.SameAccount -> "SameAccountAbort"
+                RejectReason.UnknownMessageDropped -> "Dropped (unknown)"
+            }
+            "$verb on ${event.message.messageType}${peerSuffix(event.message)} in ${labelFor(event.state)}"
+        }
+        is ExchangeV2Event.SessionStarted -> {
+            val codeLine = event.linkingCode?.let { " linkingCode=$it" } ?: ""
+            "Session started as ${event.pairingRole} ownChannelId=${event.ownChannelId}$codeLine"
+        }
+        is ExchangeV2Event.SessionError -> "Session error: ${event.message}"
+    }
+
+    private fun peerSuffix(message: ExchangeV2Message): String = when (message) {
+        is ExchangeV2Message.RecoveryCodeAvailable -> " name=${message.name} kind=${message.kind} user_id=${message.userId}"
+        is ExchangeV2Message.RecoveryCodeRequest -> " name=${message.name} kind=${message.kind}"
+        else -> ""
+    }
+
+    private fun rawJsonFor(event: ExchangeV2Event): String = when (event) {
+        is ExchangeV2Event.Transition -> event.trigger?.rawJson ?: "(local trigger: ${event.localTrigger?.let(::labelFor)})"
+        is ExchangeV2Event.MessageSent -> event.message.rawJson
+        is ExchangeV2Event.MessageRejected -> event.message.rawJson
+        is ExchangeV2Event.SessionStarted -> event.linkingCode ?: "(no linking code — Scanner side)"
+        is ExchangeV2Event.SessionError -> event.message
+    }
+
+    private fun labelFor(state: ExchangeV2State?): String = when (state) {
+        null -> "(no session)"
+        ExchangeV2State.Bootstrapped -> "Bootstrapped"
+        ExchangeV2State.Negotiating -> "Negotiating"
+        ExchangeV2State.SameAccountAbort -> "SameAccountAbort"
+        ExchangeV2State.Aborted -> "Aborted"
+        ExchangeV2State.Host.Confirming -> "Host.Confirming"
+        ExchangeV2State.Host.Sending -> "Host.Sending"
+        ExchangeV2State.Host.Aborted -> "Host.Aborted"
+        ExchangeV2State.Host.Done -> "Host.Done"
+        ExchangeV2State.Joiner.Confirming -> "Joiner.Confirming"
+        ExchangeV2State.Joiner.Waiting -> "Joiner.Waiting"
+        ExchangeV2State.Joiner.AbortedLocal -> "Joiner.AbortedLocal"
+        ExchangeV2State.Joiner.AbortedByHost -> "Joiner.AbortedByHost"
+        ExchangeV2State.Joiner.Done -> "Joiner.Done"
+    }
+
+    private fun labelFor(trigger: LocalTrigger): String = when (trigger) {
+        LocalTrigger.UserConfirmedHost -> "UserConfirmedHost"
+        LocalTrigger.UserDeniedHost -> "UserDeniedHost"
+        LocalTrigger.UserConfirmedJoiner -> "UserConfirmedJoiner"
+        LocalTrigger.UserDeniedJoiner -> "UserDeniedJoiner"
+        LocalTrigger.HostSendComplete -> "HostSendComplete"
+        LocalTrigger.HostUnavailable -> "HostUnavailable"
+        is LocalTrigger.RoleElected -> "RoleElected(${trigger.role})"
+    }
+}

--- a/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
+++ b/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
@@ -99,6 +99,13 @@
             app:primaryText="canShowV2ConnectCode (display, requires canUseV2ConnectFlow)" />
 
         <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+            android:id="@+id/openV2PairingDebugButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:text="V2 Pairing Debug" />
+
+        <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
             android:id="@+id/fetchAccessCredentialsButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/sync/sync-internal/src/main/res/layout/activity_sync_v2_pairing_debug.xml
+++ b/sync/sync-internal/src/main/res/layout/activity_sync_v2_pairing_debug.xml
@@ -1,0 +1,260 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <include
+        android:id="@+id/includeToolbar"
+        layout="@layout/include_default_toolbar" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fadeScrollbars="false"
+        android:scrollbarAlwaysDrawVerticalTrack="true"
+        android:scrollbars="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="Account status" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
+
+                <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                    android:id="@+id/statusSignedIn"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    app:primaryText="Signed in"
+                    tools:secondaryText="No" />
+
+                <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
+                    android:id="@+id/signInOutButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="@dimen/keyline_4"
+                    android:text="Sign in" />
+            </LinearLayout>
+
+            <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                android:id="@+id/statusThirdPartyCredential"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="3party credential"
+                tools:secondaryText="Not created" />
+
+            <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="Settings" />
+
+            <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                android:id="@+id/autoApproveSetting"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="Auto-approve confirmations"
+                app:secondaryText="When on, this device automatically confirms its own Host/Joiner prompt. Turn off to see the real alert dialog."
+                app:showSwitch="true" />
+
+            <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="Session" />
+
+            <!-- Presenter side: tap Start, get linking code, share it with the Scanner. -->
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_marginEnd="@dimen/keyline_4"
+                android:text="Presenter mode: tap Start to generate a v2 linking code for a Scanner to paste."
+                app:typography="caption" />
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+                android:id="@+id/runPresentButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_margin="10dp"
+                android:text="Start as Presenter" />
+
+            <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+                android:id="@+id/linkingCodeSectionHeader"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                app:primaryText="Linking code (give this to the Scanner)" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/linkingCodeTextView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_marginEnd="@dimen/keyline_4"
+                android:layout_marginBottom="@dimen/keyline_4"
+                android:visibility="gone"
+                app:typography="caption" />
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
+                android:id="@+id/copyLinkingCodeButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_marginBottom="@dimen/keyline_4"
+                android:text="Copy linking code"
+                android:visibility="gone" />
+
+            <ImageView
+                android:id="@+id/linkingCodeQrImage"
+                android:layout_width="280dp"
+                android:layout_height="280dp"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginBottom="@dimen/keyline_4"
+                android:contentDescription="QR for v2 linking code"
+                android:visibility="gone" />
+
+            <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <!-- Scanner side: paste a linking code, tap Start. -->
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_marginEnd="@dimen/keyline_4"
+                android:text="Scanner mode: paste the Presenter's linking code below, then tap Start as Scanner."
+                app:typography="caption" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextInput
+                android:id="@+id/pastedUrlInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_marginEnd="@dimen/keyline_4"
+                android:hint="Paste Presenter's https://duckduckgo.com/sync/pairing/#&amp;code2=… URL"
+                app:editable="true"
+                app:type="single_line" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+                    android:id="@+id/pasteAndGoButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="10dp"
+                    android:text="Paste &amp; Go" />
+
+                <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+                    android:id="@+id/runScanButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="10dp"
+                    android:text="Start as Scanner" />
+
+                <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
+                    android:id="@+id/clearPastedUrlButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="10dp"
+                    android:text="Clear URL" />
+            </LinearLayout>
+
+            <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
+                    android:id="@+id/cancelButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="10dp"
+                    android:text="Cancel" />
+
+                <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
+                    android:id="@+id/clearLogButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="10dp"
+                    android:text="Clear Log" />
+            </LinearLayout>
+
+            <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="State" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/currentStateTextView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_marginEnd="@dimen/keyline_4"
+                android:layout_marginBottom="@dimen/keyline_4"
+                app:typography="body2" />
+
+            <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="Log" />
+
+            <LinearLayout
+                android:id="@+id/logContainer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/keyline_4"
+                android:orientation="vertical" />
+
+        </LinearLayout>
+    </ScrollView>
+</LinearLayout>

--- a/sync/sync-internal/src/main/res/layout/item_sync_v2_pairing_log_row.xml
+++ b/sync/sync-internal/src/main/res/layout/item_sync_v2_pairing_log_row.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingStart="@dimen/keyline_4"
+    android:paddingEnd="@dimen/keyline_4"
+    android:paddingTop="6dp"
+    android:paddingBottom="6dp">
+
+    <LinearLayout
+        android:id="@+id/summaryRow"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:clickable="true"
+        android:focusable="true">
+
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/summaryTextView"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            app:typography="body2" />
+
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/chevronTextView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="8dp"
+            android:text="▸"
+            app:typography="body2" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/rawDetail"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/rawJsonTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:fontFamily="monospace"
+            android:textIsSelectable="true"
+            app:typography="caption" />
+
+        <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
+            android:id="@+id/copyRawButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="Copy JSON" />
+    </LinearLayout>
+</LinearLayout>

--- a/sync/sync-internal/src/main/res/values/donottranslate.xml
+++ b/sync/sync-internal/src/main/res/values/donottranslate.xml
@@ -21,6 +21,7 @@
 
     <!-- Internal Setting -->
     <string name="sync_internal_activity_label">Sync Setup Internal</string>
+    <string name="sync_v2_pairing_debug_activity_label">V2 Pairing Debug</string>
     <string name="sync_internal_environment_header">Environment Settings</string>
     <string name="sync_internal_environment_title">Use Dev Environment?</string>
     <string name="sync_internal_environment_subtitle_prod">https://sync.duckduckgo.com</string>

--- a/sync/sync-internal/src/test/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModelTest.kt
+++ b/sync/sync-internal/src/test/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModelTest.kt
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.internal.ui
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.sync.impl.DispatchOutcome
+import com.duckduckgo.sync.impl.Result
+import com.duckduckgo.sync.impl.RouteDecision
+import com.duckduckgo.sync.impl.SyncAccountRepository
+import com.duckduckgo.sync.impl.SyncAuthCode
+import com.duckduckgo.sync.impl.SyncCodeDispatcher
+import com.duckduckgo.sync.impl.SyncCodeType
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Hello
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
+import com.duckduckgo.sync.impl.exchange.v2.RejectReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.store.SyncStore
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class SyncV2PairingDebugViewModelTest {
+
+    @get:Rule val coroutineTestRule = CoroutineTestRule()
+
+    private val eventFlow = MutableSharedFlow<ExchangeV2Event>(replay = 0, extraBufferCapacity = 100)
+    private val runner: ExchangeV2Runner = mock<ExchangeV2Runner>().also {
+        whenever(it.events).thenReturn(eventFlow)
+        whenever(it.currentState).thenReturn(null)
+    }
+    private val syncStore: SyncStore = mock()
+    private val syncAccountRepository: SyncAccountRepository = mock()
+    private val dispatcher: SyncCodeDispatcher = mock()
+
+    private fun newViewModel() = SyncV2PairingDebugViewModel(
+        runner = runner,
+        syncStore = syncStore,
+        syncAccountRepository = syncAccountRepository,
+        dispatcher = dispatcher,
+        dispatchers = coroutineTestRule.testDispatcherProvider,
+        appScope = coroutineTestRule.testScope,
+    )
+
+    // ---- Event log ----
+
+    @Test fun `Transition event appended to rows with correct summary`() = runTest {
+        val viewModel = newViewModel()
+        viewModel.viewState().test {
+            assertEquals(emptyList<SyncV2PairingDebugViewModel.LogRow>(), awaitItem().rows)
+
+            whenever(runner.currentState).thenReturn(ExchangeV2State.Negotiating)
+            eventFlow.emit(
+                ExchangeV2Event.Transition(
+                    timestampMs = 100L,
+                    from = ExchangeV2State.Bootstrapped,
+                    to = ExchangeV2State.Negotiating,
+                    trigger = Hello("""{"type":"hello"}"""),
+                    localTrigger = null,
+                ),
+            )
+
+            val updated = awaitItem()
+            assertEquals(1, updated.rows.size)
+            assertTrue(updated.rows.single().summary.contains("Bootstrapped → Negotiating"))
+            assertEquals("Negotiating", updated.currentStateLabel)
+        }
+    }
+
+    @Test fun `MessageSent event labelled as Sent with type`() = runTest {
+        val viewModel = newViewModel()
+        viewModel.viewState().test {
+            awaitItem()
+            eventFlow.emit(
+                ExchangeV2Event.MessageSent(
+                    timestampMs = 0L,
+                    message = ExchangeV2Message.RecoveryCodeRequest(rawJson = "{}", name = "me", kind = "3party"),
+                ),
+            )
+            val state = awaitItem()
+            assertEquals(1, state.rows.size)
+            assertTrue(state.rows.single().summary.startsWith("Sent recovery_code_request"))
+        }
+    }
+
+    @Test fun `MessageRejected with SameAccount labelled SameAccountAbort`() = runTest {
+        val viewModel = newViewModel()
+        viewModel.viewState().test {
+            awaitItem()
+            eventFlow.emit(
+                ExchangeV2Event.MessageRejected(
+                    timestampMs = 0L,
+                    message = ExchangeV2Message.RecoveryCodeAvailable(
+                        rawJson = "{}",
+                        userId = "shared",
+                        name = "Peer",
+                        kind = "3party",
+                    ),
+                    state = ExchangeV2State.Negotiating,
+                    reason = RejectReason.SameAccount,
+                ),
+            )
+            val state = awaitItem()
+            assertTrue(state.rows.single().summary.startsWith("SameAccountAbort"))
+        }
+    }
+
+    @Test fun `onClearLogClicked empties rows`() = runTest {
+        val viewModel = newViewModel()
+        viewModel.viewState().test {
+            awaitItem()
+            eventFlow.emit(
+                ExchangeV2Event.Transition(
+                    timestampMs = 0L,
+                    from = ExchangeV2State.Bootstrapped,
+                    to = ExchangeV2State.Negotiating,
+                    trigger = Hello("{}"),
+                    localTrigger = null,
+                ),
+            )
+            assertEquals(1, awaitItem().rows.size)
+
+            viewModel.onClearLogClicked()
+            assertEquals(0, awaitItem().rows.size)
+        }
+    }
+
+    // ---- Lifecycle / control ----
+
+    @Test fun `onCancelClicked delegates to runner cancel`() = runTest {
+        val viewModel = newViewModel()
+        viewModel.onCancelClicked()
+        verify(runner).cancel()
+    }
+
+    // ---- Dispatch routing through SyncCodeDispatcher ----
+
+    @Test fun `onRunScanClicked delegates to dispatcher route`() {
+        val authCode = SyncAuthCode.Unknown("anything")
+        whenever(dispatcher.route(any())).thenReturn(RouteDecision.Legacy(authCode))
+        val viewModel = newViewModel()
+
+        viewModel.onRunScanClicked("the-url")
+
+        verify(dispatcher).route("the-url")
+    }
+
+    @Test fun `Legacy v1 Recovery — calls processCode and does NOT collect from a dispatcher Flow`() {
+        val recovery = SyncAuthCode.Recovery(mock())
+        whenever(dispatcher.route(any())).thenReturn(RouteDecision.Legacy(recovery))
+        whenever(syncAccountRepository.processCode(eq(recovery), anyOrNull())).thenReturn(Result.Success(true))
+        val viewModel = newViewModel()
+
+        viewModel.onRunScanClicked("v1-recovery-url")
+
+        verify(syncAccountRepository).processCode(eq(recovery), anyOrNull())
+    }
+
+    @Test fun `Legacy v1 Connect — calls processCode`() {
+        val connect = SyncAuthCode.Connect(mock())
+        whenever(dispatcher.route(any())).thenReturn(RouteDecision.Legacy(connect))
+        whenever(syncAccountRepository.processCode(eq(connect), anyOrNull())).thenReturn(Result.Success(true))
+        val viewModel = newViewModel()
+
+        viewModel.onRunScanClicked("v1-connect-url")
+
+        verify(syncAccountRepository).processCode(eq(connect), anyOrNull())
+    }
+
+    @Test fun `Legacy Unknown — does NOT call processCode (surfaces as user-facing toast)`() {
+        whenever(dispatcher.route(any())).thenReturn(RouteDecision.Legacy(SyncAuthCode.Unknown("garbage")))
+        val viewModel = newViewModel()
+
+        viewModel.onRunScanClicked("garbage")
+
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
+    }
+
+    @Test fun `V2InProgress — collects the outcomes Flow without calling parseSyncAuthCode`() {
+        whenever(dispatcher.route(any())).thenReturn(
+            RouteDecision.V2InProgress(
+                codeType = SyncCodeType.RECOVERY,
+                outcomes = flowOf(DispatchOutcome.LoggedIn(path = SetupPath.RECOVERY)),
+            ),
+        )
+        val viewModel = newViewModel()
+
+        viewModel.onRunScanClicked("v2-url")
+
+        verify(syncAccountRepository, never()).parseSyncAuthCode(any())
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
+    }
+
+    @Test fun `V2InProgress with Failed outcome — does NOT crash and does NOT fall back to legacy`() {
+        whenever(dispatcher.route(any())).thenReturn(
+            RouteDecision.V2InProgress(
+                codeType = SyncCodeType.RECOVERY,
+                outcomes = flowOf(DispatchOutcome.Failed("BE rejected")),
+            ),
+        )
+        val viewModel = newViewModel()
+
+        viewModel.onRunScanClicked("v2-url")
+
+        verify(syncAccountRepository, never()).parseSyncAuthCode(any())
+    }
+}

--- a/sync/sync-store/src/main/java/com/duckduckgo/sync/store/SyncStore.kt
+++ b/sync/sync-store/src/main/java/com/duckduckgo/sync/store/SyncStore.kt
@@ -30,9 +30,6 @@ interface SyncStore {
     /** Scoped password (SP primary key) for the 3party credential. Only present when a 3party credential exists. */
     var scopedPassword: ScopedPassword?
 
-    /** JSON array of protected keys with kid, purpose, encrypted_with, encrypted_private_key. */
-    var protectedKeysJson: String?
-
     fun isEncryptionSupported(): Boolean
     fun isSignedInFlow(): Flow<Boolean>
     fun isSignedIn(): Boolean
@@ -166,14 +163,6 @@ constructor(
             }
         }
 
-    override var protectedKeysJson: String?
-        get() = encryptedPreferences?.getString(KEY_PROTECTED_KEYS_JSON, null)
-        set(value) {
-            encryptedPreferences?.edit(commit = true) {
-                if (value == null) remove(KEY_PROTECTED_KEYS_JSON) else putString(KEY_PROTECTED_KEYS_JSON, value)
-            }
-        }
-
     override fun isEncryptionSupported(): Boolean = encryptedPreferences != null
 
     override fun isSignedInFlow(): Flow<Boolean> = isSignedInStateFlow
@@ -218,6 +207,5 @@ constructor(
         private const val KEY_SK = "KEY_SK"
         private const val KEY_CREDENTIAL_ID = "KEY_CREDENTIAL_ID"
         private const val KEY_SCOPED_PASSWORD = "KEY_SCOPED_PASSWORD"
-        private const val KEY_PROTECTED_KEYS_JSON = "KEY_PROTECTED_KEYS_JSON"
     }
 }

--- a/sync/sync-store/src/test/java/com/duckduckgo/sync/store/SyncSharedPrefsStoreTest.kt
+++ b/sync/sync-store/src/test/java/com/duckduckgo/sync/store/SyncSharedPrefsStoreTest.kt
@@ -134,25 +134,13 @@ class SyncSharedPrefsStoreTest {
     }
 
     @Test
-    fun whenProtectedKeysJsonStoredThenValueUpdatedInPrefsStore() {
-        assertNull(store.protectedKeysJson)
-        val keysJson = """[{"kid":"k1","purpose":"ai_chats","encrypted_with":"ddg","encrypted_private_key":"jwe_data"}]"""
-        store.protectedKeysJson = keysJson
-        assertEquals(keysJson, store.protectedKeysJson)
-        store.protectedKeysJson = null
-        assertNull(store.protectedKeysJson)
-    }
-
-    @Test
     fun whenClearAllThenV2FieldsAlsoCleared() {
         store.credentialId = "ddg"
         store.scopedPassword = ScopedPassword("encrypted_sp")
-        store.protectedKeysJson = """[{"kid":"k1"}]"""
 
         store.clearAll()
 
         assertNull(store.credentialId)
         assertNull(store.scopedPassword)
-        assertNull(store.protectedKeysJson)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1215473276390969?focus=true 

### Description
Introduces the pure-logic core of the v2 exchange: the ExchangeV2StateMachine (states, events, side-effects, transition results) and the JSON message model + parser. No I/O, no Android, no transport — just the protocol state machine and wire-message (de)serialisation. This is the heart of the v2 pairing handshake and is the most logic-dense branch.

Related specs: 
[Exchange V2 Message Sequence State Machine](https://app.asana.com/1/137249556945/project/1149059203486286/task/1215056232572322?focus=true)
[Exchange V2 Unified Algorithm](https://app.asana.com/1/137249556945/project/1149059203486286/task/1214739740392701?focus=true)

### Steps to test this PR
- E2E test will be done in future PRs
- QA-optional: tests must pass

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large changes to sync authentication, credential upgrade, and E2E key handling; incorrect crypto or store commits could lock users out or break ai_chats sync after upgrade.
> 
> **Overview**
> This PR extends sync setup beyond v1 when **`canUseV2ConnectFlow`** is on: a new **`SyncCodeDispatcher`** routes pasted/scanned codes to legacy v1 handling or to v2 **linking** / **recovery** flows, emitting **`DispatchOutcome`** (confirmations, login, failures) for UI to collect.
> 
> The v2 stack adds the **Exchange V2 state machine** (negotiation, host/joiner, side effects), **`ExchangeV2Runner`** (present/scan sessions, role election, 5‑min timeout, message buffering), plus **relay transport** (JWE envelopes, channel create/poll/send/delete) and **`code2`** QR parsing. **`RealSyncCodeDispatcher`** maps runner events to outcomes, including transparent logout+rejoin on **`ALREADY_SIGNED_IN`** during v2 recovery/pairing.
> 
> **Account/credential changes:** **`joinAccountFromThirdPartyRecoveryCode`** implements the native “join 3party account” upgrade (scoped login, re-wrap protected keys, POST `/access-credentials/ddg`, commit **`SyncStore`** atomically). Login API gains optional **`scope`**; **`protected_encryption_key`** is nullable for 3party logins; **`ProtectedKeyManager.create`** returns the server-authoritative **`ProtectedKeyEntry`** (race on set-if-absent). **`ThirdPartyCredentialManager`** ensures an **`ai_chats`** protected key exists before extending 3party credentials, with rate-limit retries.
> 
> **Telemetry:** new **`sync_setup.json5`** pixel definitions (v1/v2, connect/exchange, success/fail/abandon) and **`SYNC_SETUP_ENDED_FAILED`** ATB stripping in the pixel plugin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f070b91a2110d03719d998b15268a65924cd240b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->