### PR TITLE
Pin Maestro e2e suites to API 35, ad-click to 30

### DIFF
--- a/.github/actions/maestro-cloud-asana-reporter/action.yml
+++ b/.github/actions/maestro-cloud-asana-reporter/action.yml
@@ -20,7 +20,7 @@ inputs:
   maestro_api_level:
     description: 'Android API level'
     required: false
-    default: '34'
+    default: '35'
   maestro_include_tags:
     description: 'Maestro tags to include'
     required: true

--- a/.github/workflows/e2e-maestro.yml
+++ b/.github/workflows/e2e-maestro.yml
@@ -28,7 +28,7 @@ on:
         description: 'Android API level to run tests on (e.g. 30, 33, 34)'
         required: false
         type: string
-        default: '30'
+        default: '35'
   workflow_dispatch:
     inputs:
       tags:
@@ -48,7 +48,7 @@ on:
         description: 'Android API level to run tests on (e.g. 30, 33, 34)'
         required: false
         type: string
-        default: '30'
+        default: '35'
 
 concurrency:
   group: ${{ github.workflow_ref }}-${{ github.ref }}

--- a/.github/workflows/e2e-nightly-full-suite.yml
+++ b/.github/workflows/e2e-nightly-full-suite.yml
@@ -84,7 +84,7 @@ jobs:
           maestro_test_name: binary_internal_upload${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_file: ${{ steps.assemble.outputs.internal_apk_path }}
-          maestro_api_level: 34
+          maestro_api_level: 35
           maestro_include_tags: binaryUpload
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -102,7 +102,7 @@ jobs:
           maestro_test_name: binary_release_upload${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_file: ${{ steps.assemble.outputs.play_apk_path }}
-          maestro_api_level: 34
+          maestro_api_level: 35
           maestro_include_tags: binaryUpload
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -120,7 +120,7 @@ jobs:
           maestro_test_name: customTabs${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-internal-binary.outputs.maestro_app_binary_id }}
-          maestro_api_level: 34
+          maestro_api_level: 35
           maestro_include_tags: customTabsTest
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -142,7 +142,7 @@ jobs:
           maestro_test_name: internalPrivacyTest${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-internal-binary.outputs.maestro_app_binary_id }}
-          maestro_api_level: 34
+          maestro_api_level: 35
           maestro_include_tags: privacyTestInternal
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -164,7 +164,7 @@ jobs:
           maestro_test_name: onboardingTest${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-release-binary.outputs.maestro_app_binary_id }}
-          maestro_api_level: 34
+          maestro_api_level: 35
           maestro_include_tags: onboardingTest
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -186,7 +186,7 @@ jobs:
           maestro_test_name: navigationTest${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-release-binary.outputs.maestro_app_binary_id }}
-          maestro_api_level: 34
+          maestro_api_level: 35
           maestro_include_tags: navigationTest
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -208,7 +208,7 @@ jobs:
           maestro_test_name: adClickTest${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-release-binary.outputs.maestro_app_binary_id }}
-          maestro_api_level: 34
+          maestro_api_level: 30
           maestro_include_tags: adClickTest
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -230,7 +230,7 @@ jobs:
           maestro_test_name: privacyTest${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-release-binary.outputs.maestro_app_binary_id }}
-          maestro_api_level: 34
+          maestro_api_level: 35
           maestro_include_tags: privacyTest
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -252,7 +252,7 @@ jobs:
           maestro_test_name: securityTest${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-release-binary.outputs.maestro_app_binary_id }}
-          maestro_api_level: 34
+          maestro_api_level: 35
           maestro_include_tags: securityTest
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -274,7 +274,7 @@ jobs:
           maestro_test_name: releaseTest${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-release-binary.outputs.maestro_app_binary_id }}
-          maestro_api_level: 34
+          maestro_api_level: 35
           maestro_include_tags: releaseTest
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -296,7 +296,7 @@ jobs:
           maestro_test_name: notificationPermissionTest${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-release-binary.outputs.maestro_app_binary_id }}
-          maestro_api_level: 33
+          maestro_api_level: 35
           maestro_include_tags: permissionsTest
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}

--- a/.github/workflows/e2e-nightly-non-blockers-suite.yml
+++ b/.github/workflows/e2e-nightly-non-blockers-suite.yml
@@ -46,7 +46,7 @@ jobs:
           maestro_test_name: binary_internal_upload_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_file: ${{ steps.assemble.outputs.internal_apk_path }}
-          maestro_api_level: 34
+          maestro_api_level: 35
           maestro_include_tags: binaryUpload
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -63,7 +63,7 @@ jobs:
           maestro_test_name: binary_release_upload_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_file: ${{ steps.assemble.outputs.play_apk_path }}
-          maestro_api_level: 34
+          maestro_api_level: 35
           maestro_include_tags: binaryUpload
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -81,7 +81,7 @@ jobs:
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-release-binary.outputs.maestro_app_binary_id }}
           maestro_include_tags: omnibarTest
-          maestro_api_level: 34
+          maestro_api_level: 35
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
@@ -115,7 +115,7 @@ jobs:
           maestro_app_binary_id: ${{ steps.maestro-upload-internal-binary.outputs.maestro_app_binary_id }}
           maestro_include_tags: androidDesignSystemTest
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          maestro_api_level: 34
+          maestro_api_level: 35
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
           test_suite_name: Android Design System (Nightly)
@@ -132,7 +132,7 @@ jobs:
           maestro_app_binary_id: ${{ steps.maestro-upload-internal-binary.outputs.maestro_app_binary_id }}
           maestro_include_tags: unifiedInputTest
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          maestro_api_level: 34
+          maestro_api_level: 35
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
           test_suite_name: Unified Input Field
@@ -148,7 +148,7 @@ jobs:
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-internal-binary.outputs.maestro_app_binary_id }}
           maestro_include_tags: preonboardingTest
-          maestro_api_level: 34
+          maestro_api_level: 35
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}

--- a/.github/workflows/e2e-nightly-sync-critical-path.yml
+++ b/.github/workflows/e2e-nightly-sync-critical-path.yml
@@ -52,7 +52,7 @@ jobs:
           maestro_app_file: ${{ steps.assemble.outputs.internal_apk_path }}
           maestro_include_tags: syncCriticalPathTest
           test_suite_name: Sync Critical Path
-          maestro_api_level: 34
+          maestro_api_level: 35
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}

--- a/.github/workflows/e2e-privacy-dashboard.yml
+++ b/.github/workflows/e2e-privacy-dashboard.yml
@@ -63,7 +63,7 @@ jobs:
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_file: ${{ steps.assemble.outputs.play_apk_path }}
           maestro_include_tags: privacyTest
-          maestro_api_level: 30
+          maestro_api_level: 35
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1215475035341566?focus=true

### Description

Standardises the Maestro e2e suites on **Android 15 (API 35)** — every `maestro_api_level` pin plus the generic `e2e-maestro.yml` workflow defaults and the `maestro-cloud-asana-reporter` action default move off the old mix of 30/33/34 to 35 — **except the two ad-click steps, which stay on API 30.**

**What changed (6 files):**
- `e2e-nightly-full-suite.yml` — all suite pins → 35, **except "Ad click detection flows" → 30**
- `e2e-privacy-dashboard.yml` — privacy step → 35, **ad-click step → 30**
- `e2e-nightly-non-blockers-suite.yml`, `e2e-nightly-sync-critical-path.yml` — pins → 35
- `e2e-maestro.yml` — `workflow_call` + `workflow_dispatch` `maestro_api_level` defaults → 35
- `maestro-cloud-asana-reporter/action.yml` — default → 35

### Background / why ad-click is split out

The original goal was a straight bump to API 36 (`feature/david/maestro_api36_trial`). That trial failed on the **"Ad click detection flows"** step, so we investigated:

- **Maestro Cloud / Robin caps at API 36.** `maestro list-cloud-devices` → `29, 30, 31, 33, 34, 35, 36` (default 33). API 37 isn't offered, so "just go to 37" isn't possible in CI (even though it passes on a local API 37 image).
- The ad-click suite behaves differently per Robin image (all verified via the generic `e2e-maestro.yml` workflow with `tags=adClickTest`):

| Robin API | Ad-click result |
| --- | --- |
| **30** | ✅ 14/14 pass (incl. flow 11) — [run 27123664136](https://github.com/duckduckgo/Android/actions/runs/27123664136) |
| 34 | ✅ green (current CI pin) |
| **35** | ❌ 14/14 fail at the first `assertVisible id: ad-id-N` — the `search-company.site` ad elements are never exposed to the accessibility tree — [run 27106186442](https://github.com/duckduckgo/Android/actions/runs/27106186442) |
| **36** | ❌ flow 11 only, at `Publisher site` — its `y.js` SERP redirect never reaches the publisher page (m.js twin flow 12 passes) — [trial run 27010030066](https://github.com/duckduckgo/Android/actions/runs/27010030066) |
| 37 | n/a (not offered by Robin) |

- The same flows **pass locally** on both API 34 (`Pixel_8_Pro`) and API 37 (`Pixel_10_Pro_XL`), and on Robin API 30/34. So the API 35/36 failures are a **Robin image WebView/accessibility issue, not an app or test bug**.

Conclusion: pin the ad-click steps to **API 30** (the highest level that's fully green for them) and move everything else to **35**. This unblocks the migration without touching the ad-click flows or the app.

### Steps to test this PR

_CI verification (generic `e2e-maestro.yml` on this branch)_
- [x] Ad-click @ API 30 → 14/14 green incl. flow 11 (run 27123664136)
- [x] Ad-click @ API 35 → 14/14 fail (run 27106186442), confirming the 30 pin is required
- [ ] Recommended before merge: a full nightly on this branch to confirm the **non-ad-click** suites are green on API 35 (the API 36 trial had every non-ad-click suite passing, which is reassuring but not a guarantee for 35)

### UI changes
No UI changes — CI configuration only.
