### PR TITLE
PIR: Fix dev data reset

### DIFF
--- a/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirDevScanActivity.kt
+++ b/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirDevScanActivity.kt
@@ -36,6 +36,7 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
+import com.duckduckgo.pir.impl.PirFeatureDataCleaner
 import com.duckduckgo.pir.impl.models.Address
 import com.duckduckgo.pir.impl.models.ExtractedProfile
 import com.duckduckgo.pir.impl.models.ProfileQuery
@@ -67,6 +68,9 @@ class PirDevScanActivity : DuckDuckGoActivity() {
 
     @Inject
     lateinit var pirSchedulingRepository: PirSchedulingRepository
+
+    @Inject
+    lateinit var pirFeatureDataCleaner: PirFeatureDataCleaner
 
     @Inject
     lateinit var dispatcherProvider: DispatcherProvider
@@ -200,12 +204,7 @@ class PirDevScanActivity : DuckDuckGoActivity() {
         binding.debugResetAll.setOnClickListener {
             killRunningWork()
             lifecycleScope.launch(dispatcherProvider.io()) {
-                eventsRepository.deleteAllScanResults()
-                repository.deleteAllUserProfilesQueries()
-                eventsRepository.deleteEventLogs()
-                eventsRepository.deleteAllOptOutData()
-                pirSchedulingRepository.clearAllData()
-                eventsRepository.deleteAllEmailConfirmationsLogs()
+                pirFeatureDataCleaner.removeUserData()
             }
         }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1210594645151737/task/1215500859391050?focus=true

### Description
See task description

### Steps to test this PR
QA-optional

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal dev-settings only; behavior change is to align reset with existing production data-cleaning logic.
> 
> **Overview**
> **Debug “Reset all”** in `PirDevScanActivity` no longer calls a hand-picked list of repository delete methods. It now invokes **`PirFeatureDataCleaner.removeUserData()`**, matching the path used when users delete their profile from the PIR dashboard.
> 
> That swap fixes incomplete dev resets: the cleaner also resets scan wide-event state and uses **`clearUserData()` / `clearAllData()`** on the PIR stores instead of the previous mix of granular deletes, which could leave PIR in an inconsistent state after a reset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8376cd7c20bddae9efbbd612199f152e9458aab5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->