### PR TITLE
Add consent logic to settings

### DIFF
--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/AdBlockingStatusChecker.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/AdBlockingStatusChecker.kt
@@ -52,6 +52,7 @@ interface AdBlockingStatusChecker {
 }
 
 sealed interface AdBlockingState {
+    data object Uninitialized : AdBlockingState
     data object Disabled : AdBlockingState
     sealed interface Enabled : AdBlockingState {
         data object UserEnabled : Enabled
@@ -109,8 +110,8 @@ class RealAdBlockingStatusChecker @Inject constructor(
                 }
             }
         }
-    private val isUserEnabled: StateFlow<AdBlockingState> = observeState()
-        .stateIn(appScope, SharingStarted.Eagerly, AdBlockingState.Disabled)
+    private val state: StateFlow<AdBlockingState> = observeState()
+        .stateIn(appScope, SharingStarted.Eagerly, AdBlockingState.Uninitialized)
 
-    override fun currentState(): AdBlockingState = isUserEnabled.value
+    override fun currentState(): AdBlockingState = state.value
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/AdBlockingStatusChecker.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/AdBlockingStatusChecker.kt
@@ -41,9 +41,22 @@ interface AdBlockingStatusChecker {
      */
     fun isShownInSettingsFlow(): Flow<Boolean>
 
-    fun isUserEnabledFlow(): Flow<Boolean>
+    /**
+     * Emits the current [AdBlockingState], distinguishing whether ad blocking is enabled because
+     * the user turned it on ([AdBlockingState.Enabled.UserEnabled]) or because of the remote
+     * default ([AdBlockingState.Enabled.Default]).
+     */
+    fun observeState(): Flow<AdBlockingState>
 
-    fun isUserEnabled(): Boolean
+    fun currentState(): AdBlockingState
+}
+
+sealed interface AdBlockingState {
+    data object Disabled : AdBlockingState
+    sealed interface Enabled : AdBlockingState {
+        data object UserEnabled : Enabled
+        data object Default : Enabled
+    }
 }
 
 @SingleInstanceIn(AppScope::class)
@@ -81,10 +94,23 @@ class RealAdBlockingStatusChecker @Inject constructor(
 
     override fun isShownInSettingsFlow(): Flow<Boolean> = feature.self().enabled()
 
-    private val isUserEnabled: StateFlow<Boolean> = isUserEnabledFlow()
-        .stateIn(appScope, SharingStarted.Eagerly, false)
+    override fun observeState(): Flow<AdBlockingState> =
+        combine(
+            settingsRepository.isEnabledFlow(),
+            feature.enabledByDefault().enabled(),
+        ) { userSetting, enabledByDefault ->
+            when (userSetting) {
+                true -> AdBlockingState.Enabled.UserEnabled
+                false -> AdBlockingState.Disabled
+                null -> if (enabledByDefault) {
+                    AdBlockingState.Enabled.Default
+                } else {
+                    AdBlockingState.Disabled
+                }
+            }
+        }
+    private val isUserEnabled: StateFlow<AdBlockingState> = observeState()
+        .stateIn(appScope, SharingStarted.Eagerly, AdBlockingState.Disabled)
 
-    override fun isUserEnabledFlow(): Flow<Boolean> = userEnabled
-
-    override fun isUserEnabled(): Boolean = isUserEnabled.value
+    override fun currentState(): AdBlockingState = isUserEnabled.value
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/duckplayer/RealDuckPlayer.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/duckplayer/RealDuckPlayer.kt
@@ -181,11 +181,12 @@ class RealDuckPlayer @Inject constructor(
     }
 
     override fun getUserPreferences(): UserPreferences {
-        val defaultPlayerMode = if (adBlockingStatusChecker.isShownInSettings() && adBlockingStatusChecker.currentState() is AdBlockingState.Enabled) {
-            Disabled
-        } else {
-            AlwaysAsk
-        }
+        val defaultPlayerMode =
+            if (adBlockingStatusChecker.isShownInSettings() && adBlockingStatusChecker.currentState() is AdBlockingState.Enabled) {
+                Disabled
+            } else {
+                AlwaysAsk
+            }
         val stored = duckPlayerFeatureRepository.getUserPreferences()
         return UserPreferences(
             overlayInteracted = stored.overlayInteracted,

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/duckplayer/RealDuckPlayer.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/duckplayer/RealDuckPlayer.kt
@@ -42,6 +42,7 @@ import com.duckduckgo.adblocking.api.duckplayer.PrivatePlayerMode.Disabled
 import com.duckduckgo.adblocking.api.duckplayer.PrivatePlayerMode.Enabled
 import com.duckduckgo.adblocking.api.duckplayer.YOUTUBE_HOST
 import com.duckduckgo.adblocking.api.duckplayer.YOUTUBE_MOBILE_HOST
+import com.duckduckgo.adblocking.impl.domain.AdBlockingState
 import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
 import com.duckduckgo.adblocking.impl.duckplayer.DuckPlayerPixelName.DUCK_PLAYER_DAILY_UNIQUE_VIEW
 import com.duckduckgo.adblocking.impl.duckplayer.DuckPlayerPixelName.DUCK_PLAYER_NEWTAB_SETTING_OFF
@@ -180,7 +181,7 @@ class RealDuckPlayer @Inject constructor(
     }
 
     override fun getUserPreferences(): UserPreferences {
-        val defaultPlayerMode = if (adBlockingStatusChecker.isShownInSettings() && adBlockingStatusChecker.isUserEnabled()) {
+        val defaultPlayerMode = if (adBlockingStatusChecker.isShownInSettings() && adBlockingStatusChecker.currentState() is AdBlockingState.Enabled) {
             Disabled
         } else {
             AlwaysAsk
@@ -214,9 +215,9 @@ class RealDuckPlayer @Inject constructor(
     override fun observeUserPreferences(): Flow<UserPreferences> {
         return combine(
             adBlockingStatusChecker.isShownInSettingsFlow(),
-            adBlockingStatusChecker.isUserEnabledFlow(),
-        ) { isShownInSettings, isUserEnabled ->
-            isShownInSettings && isUserEnabled
+            adBlockingStatusChecker.observeState(),
+        ) { isShownInSettings, currentState ->
+            isShownInSettings && currentState is AdBlockingState.Enabled
         }
             .flatMapLatest { consentGated ->
                 val defaultPlayerMode = if (consentGated) Disabled else AlwaysAsk

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsActivity.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsActivity.kt
@@ -31,6 +31,8 @@ import com.duckduckgo.browser.api.ui.BrowserScreens
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.spans.DuckDuckGoClickableSpan
 import com.duckduckgo.common.ui.view.addClickableSpan
+import com.duckduckgo.common.ui.view.gone
+import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
@@ -58,17 +60,6 @@ class AdBlockingSettingsActivity : DuckDuckGoActivity() {
         setContentView(binding.root)
         setupToolbar(binding.includeToolbar.toolbar)
 
-        binding.adBlockingDescription.addClickableSpan(
-            textSequence = getText(R.string.ad_blocking_settings_description),
-            spans = listOf(
-                "learn_more_link" to object : DuckDuckGoClickableSpan() {
-                    override fun onClick(widget: View) {
-                        viewModel.onLearnMoreClicked()
-                    }
-                },
-            ),
-        )
-
         binding.blockAdsToggle.setOnCheckedChangeListener(blockAdsToggleListener)
 
         val openDuckPlayerSettings = View.OnClickListener { viewModel.onDuckPlayerClicked() }
@@ -78,10 +69,36 @@ class AdBlockingSettingsActivity : DuckDuckGoActivity() {
         observeViewModel()
     }
 
+    private fun renderDescription(showConsentDescription: Boolean?) {
+        if (showConsentDescription == null) {
+            binding.adBlockingDescription.gone()
+            return
+        }
+        val descriptionRes = if (showConsentDescription) {
+            R.string.ad_blocking_settings_description_with_consent
+        } else {
+            R.string.ad_blocking_settings_description
+        }
+        binding.adBlockingDescription.addClickableSpan(
+            textSequence = getText(descriptionRes),
+            spans = listOf(
+                "learn_more_link" to object : DuckDuckGoClickableSpan() {
+                    override fun onClick(widget: View) {
+                        viewModel.onLearnMoreClicked()
+                    }
+                },
+            ),
+        )
+        binding.adBlockingDescription.show()
+    }
+
     private fun observeViewModel() {
         viewModel.viewState
             .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
-            .onEach { state -> binding.blockAdsToggle.quietlySetIsChecked(state.isEnabled, blockAdsToggleListener) }
+            .onEach { state ->
+                binding.blockAdsToggle.quietlySetIsChecked(state.isEnabled, blockAdsToggleListener)
+                renderDescription(state.showConsentDescription)
+            }
             .launchIn(lifecycleScope)
 
         viewModel.commands

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsViewModel.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsViewModel.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.adblocking.impl.ui
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.adblocking.impl.AdBlockingSettingsRepository
+import com.duckduckgo.adblocking.impl.domain.AdBlockingState
 import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
 import com.duckduckgo.adblocking.impl.ui.AdBlockingSettingsViewModel.Command.OpenDuckPlayerSettings
 import com.duckduckgo.adblocking.impl.ui.AdBlockingSettingsViewModel.Command.OpenLearnMore
@@ -41,15 +42,23 @@ class AdBlockingSettingsViewModel @Inject constructor(
     private val repository: AdBlockingSettingsRepository,
 ) : ViewModel() {
 
-    data class ViewState(val isEnabled: Boolean = false)
+    data class ViewState(
+        val isEnabled: Boolean = false,
+        val showConsentDescription: Boolean? = null,
+    )
 
     sealed class Command {
         data class OpenLearnMore(val url: String) : Command()
         data object OpenDuckPlayerSettings : Command()
     }
 
-    val viewState: StateFlow<ViewState> = statusChecker.isUserEnabledFlow()
-        .map { ViewState(isEnabled = it) }
+    val viewState: StateFlow<ViewState> = statusChecker.observeState()
+        .map { state ->
+            ViewState(
+                isEnabled = state is AdBlockingState.Enabled,
+                showConsentDescription = state !is AdBlockingState.Enabled.Default,
+            )
+        }
         .stateIn(
             viewModelScope,
             started = WhileSubscribed(),

--- a/ad-blocking/ad-blocking-impl/src/main/res/layout/activity_ad_blocking_settings.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/layout/activity_ad_blocking_settings.xml
@@ -74,7 +74,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="@dimen/keyline_4"
                 android:layout_marginTop="@dimen/keyline_2"
-                android:text="@string/ad_blocking_settings_description"
+                android:visibility="gone"
                 app:textType="secondary"
                 app:typography="body2" />
 

--- a/ad-blocking/ad-blocking-impl/src/main/res/values/donottranslate.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values/donottranslate.xml
@@ -16,7 +16,8 @@
 <resources>
     <string name="ad_blocking_settings_title">YouTube Ad Blocking</string>
     <string name="ad_blocking_settings_toggle_title">Block Ads on YouTube</string>
-    <string name="ad_blocking_settings_description">DuckDuckGo removes video ads on YouTube, so you can watch videos without interruption.\n\nWhen this is on, DuckDuckGo will anonymously detect ad blocking interference or YouTube errors, to improve the experience for everyone. DuckDuckGo never sees which videos you view or any personally identifiable information. <annotation type="learn_more_link">Learn more</annotation></string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo removes video ads on YouTube, so you can watch videos without interruption.\n\nWhen this is on, DuckDuckGo will anonymously detect ad blocking interference or YouTube errors, to improve the experience for everyone. DuckDuckGo never sees which videos you view or any personally identifiable information. <annotation type="learn_more_link">Learn more</annotation></string>
+    <string name="ad_blocking_settings_description">DuckDuckGo removes video ads on YouTube, so you can watch videos without interruption. <annotation type="learn_more_link">Learn more</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Opens videos in a distraction-free theater mode that prevents what you watch from influencing your YouTube feed.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/domain/RealAdBlockingStatusCheckerTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/domain/RealAdBlockingStatusCheckerTest.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -246,5 +247,17 @@ class RealAdBlockingStatusCheckerTest {
 
         enabledByDefaultFlow.value = true
         assertEquals(AdBlockingState.Enabled.Default, checker.observeState().first())
+    }
+
+    @Test
+    fun whenUpstreamHasNotEmittedYetThenCurrentStateIsUninitialized() {
+        val pendingRepository = object : AdBlockingSettingsRepository {
+            override fun isEnabledFlow(): Flow<Boolean?> = emptyFlow()
+            override suspend fun setEnabled(enabled: Boolean) = Unit
+        }
+
+        val checker = RealAdBlockingStatusChecker(feature, pendingRepository, testScope)
+
+        assertEquals(AdBlockingState.Uninitialized, checker.currentState())
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/domain/RealAdBlockingStatusCheckerTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/domain/RealAdBlockingStatusCheckerTest.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -122,69 +123,46 @@ class RealAdBlockingStatusCheckerTest {
     }
 
     @Test
-    fun whenUserHasSetTrueThenIsUserEnabledFlowEmitsTrue() = runTest {
-        userEnabledFlow.value = true
+    fun whenUserHasNoPreferenceAndDefaultFlowChangesThenCanInjectReflectsIt() {
+        userEnabledFlow.value = null
+        enabledByDefaultFlow.value = false
+        assertFalse(checker.canInject())
 
-        assertTrue(checker.isUserEnabledFlow().first())
+        enabledByDefaultFlow.value = true
+        assertTrue(checker.canInject())
     }
 
     @Test
-    fun whenUserHasSetFalseThenIsUserEnabledFlowEmitsFalseEvenIfDefaultIsTrue() = runTest {
+    fun whenUserHasSetTrueThenCurrentStateIsUserEnabled() {
+        userEnabledFlow.value = true
+
+        assertEquals(AdBlockingState.Enabled.UserEnabled, checker.currentState())
+    }
+
+    @Test
+    fun whenUserHasSetFalseThenCurrentStateIsDisabledEvenIfDefaultIsTrue() {
         userEnabledFlow.value = false
         enabledByDefaultFlow.value = true
 
-        assertFalse(checker.isUserEnabledFlow().first())
+        assertEquals(AdBlockingState.Disabled, checker.currentState())
     }
 
     @Test
-    fun whenUserHasNoPreferenceThenIsUserEnabledFlowEmitsDefault() = runTest {
+    fun whenUserHasNoPreferenceAndEnabledByDefaultThenCurrentStateIsEnabledDefault() {
         userEnabledFlow.value = null
         enabledByDefaultFlow.value = true
 
-        assertTrue(checker.isUserEnabledFlow().first())
+        assertEquals(AdBlockingState.Enabled.Default, checker.currentState())
     }
 
     @Test
-    fun whenUserHasNoPreferenceAndDefaultFlowChangesThenIsUserEnabledFlowReflectsIt() = runTest {
-        userEnabledFlow.value = null
-        enabledByDefaultFlow.value = false
-        assertFalse(checker.isUserEnabledFlow().first())
-
-        enabledByDefaultFlow.value = true
-        assertTrue(checker.isUserEnabledFlow().first())
-    }
-
-    @Test
-    fun whenUserHasSetTrueThenIsUserEnabledReturnsTrue() {
-        userEnabledFlow.value = true
-
-        assertTrue(checker.isUserEnabled())
-    }
-
-    @Test
-    fun whenUserHasSetFalseThenIsUserEnabledReturnsFalseEvenIfDefaultIsTrue() {
-        userEnabledFlow.value = false
-        enabledByDefaultFlow.value = true
-
-        assertFalse(checker.isUserEnabled())
-    }
-
-    @Test
-    fun whenUserHasNoPreferenceThenIsUserEnabledReturnsDefault() {
-        userEnabledFlow.value = null
-        enabledByDefaultFlow.value = true
-
-        assertTrue(checker.isUserEnabled())
-    }
-
-    @Test
-    fun whenUserHasNoPreferenceAndDefaultChangesThenIsUserEnabledReflectsIt() {
+    fun whenUserHasNoPreferenceAndDefaultChangesThenCurrentStateReflectsIt() {
         userEnabledFlow.value = null
         enabledByDefaultFlow.value = false
-        assertFalse(checker.isUserEnabled())
+        assertEquals(AdBlockingState.Disabled, checker.currentState())
 
         enabledByDefaultFlow.value = true
-        assertTrue(checker.isUserEnabled())
+        assertEquals(AdBlockingState.Enabled.Default, checker.currentState())
     }
 
     @Test
@@ -220,5 +198,53 @@ class RealAdBlockingStatusCheckerTest {
 
         killSwitchEnabledFlow.value = false
         assertFalse(checker.isShownInSettingsFlow().first())
+    }
+
+    @Test
+    fun whenUserHasEnabledThenObserveStateEmitsUserEnabled() = runTest {
+        userEnabledFlow.value = true
+
+        assertEquals(AdBlockingState.Enabled.UserEnabled, checker.observeState().first())
+    }
+
+    @Test
+    fun whenUserHasDisabledThenObserveStateEmitsDisabled() = runTest {
+        userEnabledFlow.value = false
+
+        assertEquals(AdBlockingState.Disabled, checker.observeState().first())
+    }
+
+    @Test
+    fun whenUserHasDisabledThenObserveStateEmitsDisabledEvenIfDefaultIsTrue() = runTest {
+        userEnabledFlow.value = false
+        enabledByDefaultFlow.value = true
+
+        assertEquals(AdBlockingState.Disabled, checker.observeState().first())
+    }
+
+    @Test
+    fun whenNotSetAndEnabledByDefaultThenObserveStateEmitsEnabledDefault() = runTest {
+        userEnabledFlow.value = null
+        enabledByDefaultFlow.value = true
+
+        assertEquals(AdBlockingState.Enabled.Default, checker.observeState().first())
+    }
+
+    @Test
+    fun whenNotSetAndDisabledByDefaultThenObserveStateEmitsDisabled() = runTest {
+        userEnabledFlow.value = null
+        enabledByDefaultFlow.value = false
+
+        assertEquals(AdBlockingState.Disabled, checker.observeState().first())
+    }
+
+    @Test
+    fun whenNotSetAndDefaultFlowChangesThenObserveStateReflectsIt() = runTest {
+        userEnabledFlow.value = null
+        enabledByDefaultFlow.value = false
+        assertEquals(AdBlockingState.Disabled, checker.observeState().first())
+
+        enabledByDefaultFlow.value = true
+        assertEquals(AdBlockingState.Enabled.Default, checker.observeState().first())
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/duckplayer/RealDuckPlayerTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/duckplayer/RealDuckPlayerTest.kt
@@ -281,6 +281,17 @@ class RealDuckPlayerTest {
         assertEquals(AlwaysAsk, result.privatePlayerMode)
     }
 
+    @Test
+    fun whenAdBlockingStateUninitializedAndNoStoredModeThenGetUserPreferencesDefaultsToAlwaysAsk() = runTest {
+        whenever(mockAdBlockingStatusChecker.isShownInSettings()).thenReturn(true)
+        whenever(mockAdBlockingStatusChecker.currentState()).thenReturn(AdBlockingState.Uninitialized)
+        whenever(mockDuckPlayerFeatureRepository.getUserPreferences()).thenReturn(StoredUserPreferences(false, null))
+
+        val result = testee.getUserPreferences()
+
+        assertEquals(AlwaysAsk, result.privatePlayerMode)
+    }
+
     // endregion
 
     // region shouldHideDuckPlayerOverlay

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/duckplayer/RealDuckPlayerTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/duckplayer/RealDuckPlayerTest.kt
@@ -33,6 +33,8 @@ import com.duckduckgo.adblocking.api.duckplayer.DuckPlayer.UserPreferences
 import com.duckduckgo.adblocking.api.duckplayer.PrivatePlayerMode.AlwaysAsk
 import com.duckduckgo.adblocking.api.duckplayer.PrivatePlayerMode.Disabled
 import com.duckduckgo.adblocking.api.duckplayer.PrivatePlayerMode.Enabled
+import com.duckduckgo.adblocking.impl.domain.AdBlockingState
+import com.duckduckgo.adblocking.impl.domain.AdBlockingState.Enabled.UserEnabled
 import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
 import com.duckduckgo.adblocking.impl.duckplayer.DuckPlayerPixelName.DUCK_PLAYER_DAILY_UNIQUE_VIEW
 import com.duckduckgo.adblocking.impl.duckplayer.DuckPlayerPixelName.DUCK_PLAYER_NEWTAB_SETTING_OFF
@@ -103,8 +105,8 @@ class RealDuckPlayerTest {
         setFeatureToggle(true)
         whenever(mockAdBlockingStatusChecker.isShownInSettings()).thenReturn(false)
         whenever(mockAdBlockingStatusChecker.isShownInSettingsFlow()).thenReturn(flowOf(false))
-        whenever(mockAdBlockingStatusChecker.isUserEnabled()).thenReturn(false)
-        whenever(mockAdBlockingStatusChecker.isUserEnabledFlow()).thenReturn(flowOf(false))
+        whenever(mockAdBlockingStatusChecker.currentState()).thenReturn(AdBlockingState.Disabled)
+        whenever(mockAdBlockingStatusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled))
         whenever(mockDuckPlayerFeatureRepository.getDuckPlayerDisabledHelpPageLink())
             .thenReturn(null)
         whenever(mockDuckPlayerFeatureRepository.getVideoIDQueryParam()).thenReturn("v")
@@ -238,7 +240,7 @@ class RealDuckPlayerTest {
     @Test
     fun whenStoredPlayerModeSetThenGetUserPreferencesKeepsItOverDefault() = runTest {
         whenever(mockAdBlockingStatusChecker.isShownInSettings()).thenReturn(true)
-        whenever(mockAdBlockingStatusChecker.isUserEnabled()).thenReturn(true)
+        whenever(mockAdBlockingStatusChecker.currentState()).thenReturn(UserEnabled)
         whenever(mockDuckPlayerFeatureRepository.getUserPreferences()).thenReturn(StoredUserPreferences(false, Enabled))
 
         val result = testee.getUserPreferences()
@@ -249,7 +251,7 @@ class RealDuckPlayerTest {
     @Test
     fun whenAdBlockingShownInSettingsAndUserEnabledAndNoStoredModeThenGetUserPreferencesDefaultsToDisabled() = runTest {
         whenever(mockAdBlockingStatusChecker.isShownInSettings()).thenReturn(true)
-        whenever(mockAdBlockingStatusChecker.isUserEnabled()).thenReturn(true)
+        whenever(mockAdBlockingStatusChecker.currentState()).thenReturn(UserEnabled)
         whenever(mockDuckPlayerFeatureRepository.getUserPreferences()).thenReturn(StoredUserPreferences(false, null))
 
         val result = testee.getUserPreferences()
@@ -260,7 +262,7 @@ class RealDuckPlayerTest {
     @Test
     fun whenAdBlockingShownInSettingsButUserNotEnabledAndNoStoredModeThenGetUserPreferencesDefaultsToAlwaysAsk() = runTest {
         whenever(mockAdBlockingStatusChecker.isShownInSettings()).thenReturn(true)
-        whenever(mockAdBlockingStatusChecker.isUserEnabled()).thenReturn(false)
+        whenever(mockAdBlockingStatusChecker.currentState()).thenReturn(AdBlockingState.Disabled)
         whenever(mockDuckPlayerFeatureRepository.getUserPreferences()).thenReturn(StoredUserPreferences(false, null))
 
         val result = testee.getUserPreferences()
@@ -271,7 +273,7 @@ class RealDuckPlayerTest {
     @Test
     fun whenAdBlockingNotShownInSettingsAndNoStoredModeThenGetUserPreferencesDefaultsToAlwaysAsk() = runTest {
         whenever(mockAdBlockingStatusChecker.isShownInSettings()).thenReturn(false)
-        whenever(mockAdBlockingStatusChecker.isUserEnabled()).thenReturn(true)
+        whenever(mockAdBlockingStatusChecker.currentState()).thenReturn(UserEnabled)
         whenever(mockDuckPlayerFeatureRepository.getUserPreferences()).thenReturn(StoredUserPreferences(false, null))
 
         val result = testee.getUserPreferences()
@@ -322,7 +324,7 @@ class RealDuckPlayerTest {
     @Test
     fun whenStoredPlayerModeSetThenObserveUserPreferencesKeepsItOverDefault() = runTest {
         whenever(mockAdBlockingStatusChecker.isShownInSettingsFlow()).thenReturn(flowOf(true))
-        whenever(mockAdBlockingStatusChecker.isUserEnabledFlow()).thenReturn(flowOf(true))
+        whenever(mockAdBlockingStatusChecker.observeState()).thenReturn(flowOf(UserEnabled))
         whenever(mockDuckPlayerFeatureRepository.observeUserPreferences()).thenReturn(flowOf(StoredUserPreferences(false, Enabled)))
 
         val result = testee.observeUserPreferences().first()
@@ -333,7 +335,7 @@ class RealDuckPlayerTest {
     @Test
     fun whenAdBlockingShownInSettingsAndUserEnabledAndNoStoredModeThenObserveUserPreferencesDefaultsToDisabled() = runTest {
         whenever(mockAdBlockingStatusChecker.isShownInSettingsFlow()).thenReturn(flowOf(true))
-        whenever(mockAdBlockingStatusChecker.isUserEnabledFlow()).thenReturn(flowOf(true))
+        whenever(mockAdBlockingStatusChecker.observeState()).thenReturn(flowOf(UserEnabled))
         whenever(mockDuckPlayerFeatureRepository.observeUserPreferences()).thenReturn(flowOf(StoredUserPreferences(false, null)))
 
         val result = testee.observeUserPreferences().first()
@@ -344,7 +346,7 @@ class RealDuckPlayerTest {
     @Test
     fun whenAdBlockingShownInSettingsButUserNotEnabledAndNoStoredModeThenObserveUserPreferencesDefaultsToAlwaysAsk() = runTest {
         whenever(mockAdBlockingStatusChecker.isShownInSettingsFlow()).thenReturn(flowOf(true))
-        whenever(mockAdBlockingStatusChecker.isUserEnabledFlow()).thenReturn(flowOf(false))
+        whenever(mockAdBlockingStatusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled))
         whenever(mockDuckPlayerFeatureRepository.observeUserPreferences()).thenReturn(flowOf(StoredUserPreferences(false, null)))
 
         val result = testee.observeUserPreferences().first()
@@ -355,7 +357,7 @@ class RealDuckPlayerTest {
     @Test
     fun whenAdBlockingNotShownInSettingsButUserEnabledAndNoStoredModeThenObserveUserPreferencesDefaultsToAlwaysAsk() = runTest {
         whenever(mockAdBlockingStatusChecker.isShownInSettingsFlow()).thenReturn(flowOf(false))
-        whenever(mockAdBlockingStatusChecker.isUserEnabledFlow()).thenReturn(flowOf(true))
+        whenever(mockAdBlockingStatusChecker.observeState()).thenReturn(flowOf(UserEnabled))
         whenever(mockDuckPlayerFeatureRepository.observeUserPreferences()).thenReturn(flowOf(StoredUserPreferences(false, null)))
 
         val result = testee.observeUserPreferences().first()
@@ -366,7 +368,7 @@ class RealDuckPlayerTest {
     @Test
     fun whenAdBlockingNotShownInSettingsAndNoStoredModeThenObserveUserPreferencesDefaultsToAlwaysAsk() = runTest {
         whenever(mockAdBlockingStatusChecker.isShownInSettingsFlow()).thenReturn(flowOf(false))
-        whenever(mockAdBlockingStatusChecker.isUserEnabledFlow()).thenReturn(flowOf(false))
+        whenever(mockAdBlockingStatusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled))
         whenever(mockDuckPlayerFeatureRepository.observeUserPreferences()).thenReturn(flowOf(StoredUserPreferences(false, null)))
 
         val result = testee.observeUserPreferences().first()

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsViewModelTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsViewModelTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.ui
+
+import app.cash.turbine.test
+import com.duckduckgo.adblocking.impl.AdBlockingSettingsRepository
+import com.duckduckgo.adblocking.impl.domain.AdBlockingState
+import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class AdBlockingSettingsViewModelTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val statusChecker: AdBlockingStatusChecker = mock()
+    private val repository: AdBlockingSettingsRepository = mock()
+
+    private fun createViewModel() = AdBlockingSettingsViewModel(statusChecker, repository)
+
+    @Test
+    fun whenEnabledByDefaultThenDoesNotShowConsentDescription() = runTest {
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Enabled.Default))
+
+        createViewModel().viewState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state.isEnabled)
+            assertEquals(false, state.showConsentDescription)
+        }
+    }
+
+    @Test
+    fun whenUserEnabledThenShowsConsentDescription() = runTest {
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Enabled.UserEnabled))
+
+        createViewModel().viewState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state.isEnabled)
+            assertEquals(true, state.showConsentDescription)
+        }
+    }
+
+    @Test
+    fun whenDisabledThenShowsConsentDescription() = runTest {
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled))
+
+        createViewModel().viewState.test {
+            val state = expectMostRecentItem()
+            assertFalse(state.isEnabled)
+            assertEquals(true, state.showConsentDescription)
+        }
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/481882893211075/task/1215138970525759?focus=true

### Description
Don't show consent messaging if enabled by default. This will be taken into account when firing pixels

### Steps to test this PR

_Default off shows disclaimer_
- [x] Apply _Patch 1: Feature enabled with settings_
- [x] Clean install the app
- [x] Open YT ad blocking settings 
- [x] Check toggle is disabled and description is "DuckDuckGo removes video ads on YouTube, so you can watch videos without interruption.\n\nWhen this is on, DuckDuckGo will anonymously detect ad blocking interference or YouTube errors, to improve the experience for everyone. DuckDuckGo never sees which videos you view or any personally identifiable information. Learn More"
- [x] Toggle YT ad blocking on and check description doesn't change

_Default on doesn't show disclaimer_
- [x] Apply _Patch 2: Feature enabled with settings and enabledByDefault_
- [x] Clean install the app
- [x] Open YT ad blocking settings 
- [x] Check toggle is enabled and description is only "DuckDuckGo removes video ads on YouTube, so you can watch videos without interruption."
- [x] Toggle YT ad blocking off
- [x] Check description changes to "DuckDuckGo removes video ads on YouTube, so you can watch videos without interruption.\n\nWhen this is on, DuckDuckGo will anonymously detect ad blocking interference or YouTube errors, to improve the experience for everyone. DuckDuckGo never sees which videos you view or any personally identifiable information. Learn More"
- [x] Toggle on again and check description doesn't change

_Patch 1: Feature enabled with settings_
```
Subject: [PATCH] Update privacy-config URL - Feature enabled with settings
---
Index: privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt	(revision 61e308ef7401f17000e20c67f6a150f7d424badc)
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt	(date 1779712348322)
@@ -29,4 +29,4 @@
     TrackingParametersFeatureName("trackingParameters"),
 }
 
-const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v5/android-config.json"
+const val PRIVACY_REMOTE_CONFIG_URL = "https://gist.githubusercontent.com/CrisBarreiro/bf9e0dd845db24899fbac8d4450f1d93/raw/3f7244595442e3d6fd3d27631ebe826458318985/android-config.json"
```

_Patch 2: Feature enabled with settings and enabledByDefault_
```
Subject: [PATCH] Update privacy-config URL - Feature enabled with settings and enabledByDefault
---
Index: privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt	(revision d931e4a72dc1165517cb7c04a92c4cae354281d2)
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt	(date 1779722673717)
@@ -29,4 +29,4 @@
     TrackingParametersFeatureName("trackingParameters"),
 }
 
-const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v5/android-config.json"
+const val PRIVACY_REMOTE_CONFIG_URL = "https://gist.githubusercontent.com/CrisBarreiro/7f27eaa4178f0d232e0282ce7f765213/raw/6642049d9080d3657c641dbe44ff0d9d69c201ce/android-config%2520for%2520testing%2520ad%2520blocking%2520feature%2520(enabled)"
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-facing consent copy and refactors how enabled state is observed for Duck Player defaults; injection behavior via canInject is unchanged but pixel/consent semantics now depend on Default vs UserEnabled.
> 
> **Overview**
> Introduces **`AdBlockingState`** so ad blocking can be distinguished when it is on because the user opted in (`UserEnabled`) versus remote **`enabledByDefault`** (`Default`), replacing the old boolean **`isUserEnabled`** / **`isUserEnabledFlow`** APIs with **`observeState()`** and **`currentState()`**.
> 
> **YouTube ad blocking settings** now pick between two description strings: the shorter copy when blocking is **`Enabled.Default`**, and the longer consent/anonymous-detection disclaimer in all other states (off, user-enabled, etc.). The description view starts hidden until state is known.
> 
> **Duck Player** preference defaults still treat any **`AdBlockingState.Enabled`** (user or default) as consent-gated for default private-player mode when settings are shown; **`Uninitialized`** is handled like not enabled for defaults.
> 
> Tests cover the new state model, view-model consent flag, and Duck Player behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0065eb2e8df5c2d0bed943d399b21a76b20cbabf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->