### PR TITLE
Compose: Add DaxHorizontalDivider and DaxVerticalDivider

### DIFF
--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentViewHolder.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentViewHolder.kt
@@ -47,9 +47,12 @@ import com.airbnb.lottie.compose.LottieAnimation
 import com.airbnb.lottie.compose.LottieCompositionSpec
 import com.airbnb.lottie.compose.animateLottieCompositionAsState
 import com.airbnb.lottie.compose.rememberLottieComposition
+import com.duckduckgo.common.ui.compose.button.DaxIconButton
 import com.duckduckgo.common.ui.compose.cards.DaxCard
 import com.duckduckgo.common.ui.compose.cards.DaxSurface
 import com.duckduckgo.common.ui.compose.checkbox.DaxCheckbox
+import com.duckduckgo.common.ui.compose.divider.DaxHorizontalDivider
+import com.duckduckgo.common.ui.compose.divider.DaxVerticalDivider
 import com.duckduckgo.common.ui.compose.message.DaxAction
 import com.duckduckgo.common.ui.compose.message.remote.DaxBigSingleActionMessage
 import com.duckduckgo.common.ui.compose.message.remote.DaxBigTwoActionsMessage
@@ -605,7 +608,63 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
         }
     }
 
-    class DividerComponentViewHolder(parent: ViewGroup) : ComponentViewHolder(inflate(parent, R.layout.component_section_divider))
+    class DividerComponentViewHolder(
+        parent: ViewGroup,
+        private val isDarkTheme: Boolean,
+    ) : ComponentViewHolder(inflate(parent, R.layout.component_section_divider)) {
+        override fun bind(component: Component) {
+            view.setupThemedComposeView(
+                id = R.id.compose_dax_horizontal_divider_full_width,
+                isDarkTheme = isDarkTheme,
+            ) {
+                DaxHorizontalDivider(
+                    modifier = Modifier.padding(vertical = 8.dp),
+                )
+            }
+            view.setupThemedComposeView(
+                id = R.id.compose_dax_horizontal_divider_inset,
+                isDarkTheme = isDarkTheme,
+            ) {
+                DaxHorizontalDivider(
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                )
+            }
+            view.setupThemedComposeView(
+                id = R.id.compose_dax_horizontal_divider_custom_margin,
+                isDarkTheme = isDarkTheme,
+            ) {
+                DaxHorizontalDivider(
+                    modifier = Modifier.padding(56.dp),
+                )
+            }
+            view.setupThemedComposeView(
+                id = R.id.compose_dax_vertical_divider,
+                isDarkTheme = isDarkTheme,
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(100.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center,
+                ) {
+                    DaxIconButton(
+                        onClick = {},
+                        iconPainter = painterResource(CommonR.drawable.ic_union),
+                        contentDescription = "Menu",
+                    )
+
+                    DaxVerticalDivider()
+
+                    DaxIconButton(
+                        onClick = {},
+                        iconPainter = painterResource(CommonR.drawable.ic_union),
+                        contentDescription = "Menu",
+                    )
+                }
+            }
+        }
+    }
 
     class CardComponentViewHolder(
         parent: ViewGroup,
@@ -692,7 +751,7 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
                 Component.SECTION_HEADER_LIST_ITEM -> HeaderSectionComponentViewHolder(parent)
                 Component.SINGLE_LINE_LIST_ITEM -> OneLineListItemComponentViewHolder(parent)
                 Component.TWO_LINE_LIST_ITEM -> TwoLineItemComponentViewHolder(parent)
-                Component.SECTION_DIVIDER -> DividerComponentViewHolder(parent)
+                Component.SECTION_DIVIDER -> DividerComponentViewHolder(parent, isDarkTheme)
                 Component.CARD -> CardComponentViewHolder(parent, isDarkTheme)
                 Component.SETTINGS_LIST_ITEM -> SettingsListItemComponentViewHolder(parent)
                 else -> {

--- a/android-design-system/design-system-internal/src/main/res/layout/component_section_divider.xml
+++ b/android-design-system/design-system-internal/src/main/res/layout/component_section_divider.xml
@@ -14,79 +14,136 @@
   ~ limitations under the License.
   -->
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:app="http://schemas.android.com/apk/res-auto"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:orientation="vertical"
-              android:paddingTop="@dimen/keyline_5"
-              android:paddingEnd="@dimen/keyline_4">
-
-    <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
-        android:id="@+id/label"
-        android:layout_height="wrap_content"
-        android:layout_width="match_parent"
-        app:primaryText="Horizontal divider (Full Width)"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
-
-    <com.duckduckgo.common.ui.view.divider.HorizontalDivider
-        android:layout_height="wrap_content"
-        android:layout_width="match_parent"/>
-
-    <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
-        android:layout_height="wrap_content"
-        android:layout_width="match_parent"
-        app:primaryText="Horizontal divider (Not Full Width)"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
-
-    <com.duckduckgo.common.ui.view.divider.HorizontalDivider
-        android:layout_height="wrap_content"
-        android:layout_width="match_parent"
-        app:fullWidth="false"/>
-
-    <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
-        android:layout_height="wrap_content"
-        android:layout_width="match_parent"
-        app:primaryText="Horizontal divider (Custom margins)"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
-
-    <com.duckduckgo.common.ui.view.divider.HorizontalDivider
-        android:layout_height="wrap_content"
-        android:layout_width="match_parent"
-        android:layout_margin="@dimen/keyline_7"
-        app:defaultPadding="false"/>
-
-    <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
-        android:layout_height="wrap_content"
-        android:layout_width="match_parent"
-        android:paddingTop="@dimen/keyline_5"
-        app:primaryText="Vertical divider"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingTop="@dimen/keyline_5"
+    android:paddingEnd="@dimen/keyline_4"
+    android:paddingBottom="@dimen/keyline_5">
 
     <LinearLayout
-        android:layout_height="wrap_content"
         android:layout_width="match_parent"
-        android:orientation="horizontal"
-        android:gravity="center">
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
-        <com.duckduckgo.common.ui.view.button.IconButton
-            android:layout_width="48dp"
-            android:layout_height="48dp"
-            app:srcCompat="@drawable/ic_union"/>
-
-        <com.duckduckgo.common.ui.view.divider.VerticalDivider
+        <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+            android:id="@+id/label"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_width="wrap_content"/>
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:primaryText="Horizontal divider (Full Width)" />
 
-        <com.duckduckgo.common.ui.view.button.IconButton
-            android:layout_width="48dp"
-            android:layout_height="48dp"
-            app:srcCompat="@drawable/ic_union"/>
+        <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:primaryText="Horizontal divider (Not Full Width)" />
+
+        <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:fullWidth="false" />
+
+        <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:primaryText="Horizontal divider (Custom margins)" />
+
+        <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/keyline_7"
+            app:defaultPadding="false" />
+
+        <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="@dimen/keyline_5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:primaryText="Compose Horizontal divider (Full Width)" />
+
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/compose_dax_horizontal_divider_full_width"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:primaryText="Compose Horizontal divider (Not Full Width)" />
+
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/compose_dax_horizontal_divider_inset"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:primaryText="Compose Horizontal divider (Custom margins)" />
+
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/compose_dax_horizontal_divider_custom_margin"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="@dimen/keyline_5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:primaryText="Vertical divider" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="100dp"
+            android:gravity="center"
+            android:orientation="horizontal">
+
+            <com.duckduckgo.common.ui.view.button.IconButton
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                app:srcCompat="@drawable/ic_union" />
+
+            <com.duckduckgo.common.ui.view.divider.VerticalDivider
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+            <com.duckduckgo.common.ui.view.button.IconButton
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                app:srcCompat="@drawable/ic_union" />
+
+        </LinearLayout>
+
+        <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="@dimen/keyline_5"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:primaryText="Compose Vertical divider" />
+
+        <androidx.compose.ui.platform.ComposeView
+            android:id="@+id/compose_dax_vertical_divider"
+            android:layout_width="match_parent"
+            android:layout_height="100dp" />
 
     </LinearLayout>
 
-</LinearLayout>
+</androidx.core.widget.NestedScrollView>

--- a/android-design-system/design-system-internal/src/main/res/layout/component_section_divider.xml
+++ b/android-design-system/design-system-internal/src/main/res/layout/component_section_divider.xml
@@ -14,18 +14,14 @@
   ~ limitations under the License.
   -->
 
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:orientation="vertical"
     android:paddingTop="@dimen/keyline_5"
     android:paddingEnd="@dimen/keyline_4"
     android:paddingBottom="@dimen/keyline_5">
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
 
         <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
             android:id="@+id/label"
@@ -144,6 +140,4 @@
             android:layout_width="match_parent"
             android:layout_height="100dp" />
 
-    </LinearLayout>
-
-</androidx.core.widget.NestedScrollView>
+</LinearLayout>

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/divider/DaxHorizontalDivider.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/divider/DaxHorizontalDivider.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui.compose.divider
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+import com.duckduckgo.common.ui.compose.tools.PreviewBox
+
+/**
+ * DuckDuckGo design system composable horizontal divider.
+ *
+ * Wraps Material3 [HorizontalDivider] with DuckDuckGo theme colors matching the xml [com.duckduckgo.common.ui.view.divider.HorizontalDivider].
+ * Callers control surrounding spacing via [modifier].
+ *
+ * Common usages:
+ * - `DaxHorizontalDivider(modifier = Modifier.padding(vertical = 8.dp))` to
+ *   match the breathing room of the XML divider's default state.
+ * - `DaxHorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))`
+ *   for the inset variant (equivalent to XML `app:fullWidth="false"`).
+ *
+ * @param modifier the [Modifier] to apply
+ * @param thickness the thickness of the divider line
+ * @param color the color of the divider line
+ *
+ * Asana Task: https://app.asana.com/1/137249556945/project/1202857801505092/task/1215500875198339?focus=true
+ * Figma reference: https://www.figma.com/design/BOHDESHODUXK7wSRNBOHdu/%F0%9F%A4%96-Android-Components?m=dev&node-id=6036-11645
+ */
+@Composable
+fun DaxHorizontalDivider(
+    modifier: Modifier = Modifier,
+    thickness: Dp = DaxHorizontalDividerDefaults.Thickness,
+    color: Color = DaxHorizontalDividerDefaults.color,
+) {
+    HorizontalDivider(
+        modifier = modifier,
+        thickness = thickness,
+        color = color,
+    )
+}
+
+object DaxHorizontalDividerDefaults {
+    val Thickness: Dp = 1.dp
+
+    val color: Color
+        @Composable
+        @ReadOnlyComposable
+        get() = DuckDuckGoTheme.colors.system.lines
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxHorizontalDividerPreview() {
+    PreviewBox {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            DaxHorizontalDivider()
+            DaxHorizontalDivider(
+                modifier = Modifier.padding(horizontal = 16.dp),
+            )
+            DaxHorizontalDivider(
+                modifier = Modifier.padding(24.dp),
+            )
+        }
+    }
+}

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/divider/DaxVerticalDivider.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/divider/DaxVerticalDivider.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui.compose.divider
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+import com.duckduckgo.common.ui.compose.tools.PreviewBox
+
+/**
+ * DuckDuckGo design system composable vertical divider.
+ *
+ * Wraps Material3 [VerticalDivider] with DuckDuckGo theme colors matching the xml [com.duckduckgo.common.ui.view.divider.VerticalDivider].
+ * Callers control surrounding spacing via [modifier].
+ *
+ * The parent layout must impose a height (e.g. `Modifier.height(...)` or a
+ * `Row` with bounded height); the divider fills the available height.
+ *
+ * Common usages:
+ * - `DaxVerticalDivider(modifier = Modifier.padding(horizontal = 16.dp))` to
+ *   match the XML divider's `app:defaultPadding="true"` behavior.
+ *
+ * @param modifier the [Modifier] to apply
+ * @param thickness the thickness of the divider line
+ * @param color the color of the divider line
+ *
+ * Asana Task: https://app.asana.com/1/137249556945/project/1202857801505092/task/1215500875198340?focus=true
+ * Figma reference: https://www.figma.com/design/BOHDESHODUXK7wSRNBOHdu/%F0%9F%A4%96-Android-Components?m=dev&node-id=6036-11645
+ */
+@Composable
+fun DaxVerticalDivider(
+    modifier: Modifier = Modifier,
+    thickness: Dp = DaxVerticalDividerDefaults.Thickness,
+    color: Color = DaxVerticalDividerDefaults.color,
+) {
+    VerticalDivider(
+        modifier = modifier,
+        thickness = thickness,
+        color = color,
+    )
+}
+
+object DaxVerticalDividerDefaults {
+    val Thickness: Dp = 1.dp
+
+    val color: Color
+        @Composable
+        @ReadOnlyComposable
+        get() = DuckDuckGoTheme.colors.backgrounds.container
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxVerticalDividerPreview() {
+    PreviewBox {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(48.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            DaxVerticalDivider()
+            DaxVerticalDivider(
+                modifier = Modifier.padding(horizontal = 16.dp),
+            )
+            DaxVerticalDivider(
+                modifier = Modifier.padding(24.dp),
+            )
+        }
+    }
+}

--- a/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
@@ -46,6 +46,7 @@ import com.duckduckgo.lint.strings.MissingSmartlingRequiredDirectivesDetector.Co
 import com.duckduckgo.lint.strings.PlaceholderDetector.Companion.PLACEHOLDER_MISSING_POSITION
 import com.duckduckgo.lint.ui.ColorAttributeInXmlDetector.Companion.INVALID_COLOR_ATTRIBUTE
 import com.duckduckgo.lint.ui.DaxButtonStylingDetector.Companion.INVALID_DAX_BUTTON_PROPERTY
+import com.duckduckgo.lint.ui.DaxDividerColorUsageDetector.Companion.INVALID_DAX_DIVIDER_COLOR_USAGE
 import com.duckduckgo.lint.ui.DaxTextColorUsageDetector.Companion.INVALID_DAX_TEXT_COLOR_USAGE
 import com.duckduckgo.lint.ui.NoRawM3AlertDialogUsageDetector.Companion.NO_RAW_M3_ALERT_DIALOG_USAGE
 import com.duckduckgo.lint.ui.NoRawM3ButtonUsageDetector.Companion.NO_RAW_M3_BUTTON_USAGE
@@ -112,6 +113,7 @@ class DuckDuckGoIssueRegistry : IssueRegistry() {
             NO_COMPOSE_VIEW_USAGE,
             NO_SET_CONTENT_USAGE,
             INVALID_DAX_TEXT_COLOR_USAGE,
+            INVALID_DAX_DIVIDER_COLOR_USAGE,
             INVALID_DAX_TEXT_FIELD_TRAILING_ICON_USAGE,
             INVALID_DAX_SECURE_TEXT_FIELD_TRAILING_ICON_USAGE,
             NO_MATERIAL3_SWITCH_USAGE,

--- a/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
@@ -54,6 +54,8 @@ import com.duckduckgo.lint.ui.NoRawM3SurfaceUsageDetector.Companion.NO_RAW_M3_SU
 import com.duckduckgo.lint.ui.DaxTextFieldTrailingIconDetector.Companion.INVALID_DAX_TEXT_FIELD_TRAILING_ICON_USAGE
 import com.duckduckgo.lint.ui.DaxSecureTextFieldTrailingIconDetector.Companion.INVALID_DAX_SECURE_TEXT_FIELD_TRAILING_ICON_USAGE
 import com.duckduckgo.lint.ui.NoMaterial3CheckboxUsageDetector.Companion.NO_MATERIAL3_CHECKBOX_USAGE
+import com.duckduckgo.lint.ui.NoMaterial3DividerUsageDetector.Companion.NO_MATERIAL3_HORIZONTAL_DIVIDER_USAGE
+import com.duckduckgo.lint.ui.NoMaterial3DividerUsageDetector.Companion.NO_MATERIAL3_VERTICAL_DIVIDER_USAGE
 import com.duckduckgo.lint.ui.NoMaterial3RadioButtonUsageDetector.Companion.NO_MATERIAL3_RADIO_BUTTON_USAGE
 import com.duckduckgo.lint.ui.NoMaterial3SwitchUsageDetector.Companion.NO_MATERIAL3_SWITCH_USAGE
 import com.duckduckgo.lint.ui.DaxTextViewStylingDetector.Companion.INVALID_DAX_TEXT_VIEW_PROPERTY
@@ -119,6 +121,8 @@ class DuckDuckGoIssueRegistry : IssueRegistry() {
             NO_MATERIAL3_SWITCH_USAGE,
             NO_MATERIAL3_RADIO_BUTTON_USAGE,
             NO_MATERIAL3_CHECKBOX_USAGE,
+            NO_MATERIAL3_HORIZONTAL_DIVIDER_USAGE,
+            NO_MATERIAL3_VERTICAL_DIVIDER_USAGE,
             NO_RAW_M3_BUTTON_USAGE,
             NO_RAW_M3_ALERT_DIALOG_USAGE,
             NO_RAW_M3_SURFACE_USAGE,

--- a/lint-rules/src/main/java/com/duckduckgo/lint/ui/DaxDividerColorUsageDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/ui/DaxDividerColorUsageDetector.kt
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint.ui
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category.Companion.CUSTOM_LINT_CHECKS
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.TextFormat
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiField
+import com.intellij.psi.PsiMethod
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.UExpression
+import org.jetbrains.uast.UQualifiedReferenceExpression
+import org.jetbrains.uast.UReferenceExpression
+import org.jetbrains.uast.getParameterForArgument
+import java.util.EnumSet
+
+@Suppress("UnstableApiUsage")
+class DaxDividerColorUsageDetector : Detector(), SourceCodeScanner {
+
+    override fun getApplicableUastTypes() = listOf(UCallExpression::class.java)
+
+    override fun createUastHandler(context: JavaContext): UElementHandler = DaxDividerColorCallHandler(context)
+
+    internal class DaxDividerColorCallHandler(private val context: JavaContext) : UElementHandler() {
+        override fun visitCallExpression(node: UCallExpression) {
+            val methodName = node.methodName
+            if (methodName == "DaxHorizontalDivider" || methodName == "DaxVerticalDivider") {
+                checkColorParameter(node)
+            }
+        }
+
+        private fun checkColorParameter(node: UCallExpression) {
+            val colorArgument = node.valueArguments.find { arg ->
+                val parameterName = node.getParameterForArgument(arg)?.name
+                parameterName == "color"
+            } ?: return
+
+            if (!isFromValidDuckDuckGoColorSource(colorArgument)) {
+                reportInvalidColorUsage(colorArgument)
+            }
+        }
+
+        private fun isFromValidDuckDuckGoColorSource(argument: UExpression): Boolean {
+            val source = argument.sourcePsi?.text.orEmpty()
+
+            if (containsSemanticThemeColorPath(source)) return true
+
+            if (resolvesToThemePackageElement(argument)) return true
+
+            return resolvesToValidatedColorDeclaration(
+                expression = argument,
+                depth = 0,
+                visited = mutableSetOf(),
+            )
+        }
+
+        private fun containsSemanticThemeColorPath(source: String): Boolean {
+            return source.contains("DuckDuckGoTheme.colors.") || source.contains(".colors.")
+        }
+
+        private fun resolvesToThemePackageElement(expression: UExpression): Boolean {
+            val resolved = resolveExpression(expression) ?: return false
+            return isThemePackageElement(resolved)
+        }
+
+        private fun resolveExpression(expression: UExpression): PsiElement? {
+            return when (expression) {
+                is UQualifiedReferenceExpression -> expression.resolve()
+                is UReferenceExpression -> expression.resolve()
+                else -> null
+            }
+        }
+
+        private fun isThemePackageElement(element: PsiElement): Boolean {
+            val qualifiedName = when (element) {
+                is PsiMethod -> element.containingClass?.qualifiedName
+                is PsiField -> element.containingClass?.qualifiedName
+                else -> null
+            } ?: return false
+
+            return qualifiedName.startsWith(COLOR_THEME_PACKAGE)
+        }
+
+        private fun resolvesToValidatedColorDeclaration(
+            expression: UExpression,
+            depth: Int,
+            visited: MutableSet<PsiElement>,
+        ): Boolean {
+            if (depth > MAX_VALIDATION_DEPTH) return false
+
+            val resolved = resolveExpression(expression) ?: return false
+            if (!visited.add(resolved)) return false
+
+            if (isThemePackageElement(resolved)) return true
+
+            val declaration = resolved.navigationElement ?: resolved
+            val declarationText = declaration.text.orEmpty()
+            if (declarationText.isBlank()) return false
+
+            if (containsSemanticThemeColorPath(declarationText)) return true
+            if (declarationText.contains(COLOR_THEME_PACKAGE)) return true
+            if (containsArbitraryComposeColorLiteral(declarationText)) return false
+
+            val referencedIdentifier = extractSimpleReturnedIdentifier(declarationText) ?: return false
+            return isImportedFromThemePackage(
+                fileText = declaration.containingFile?.text.orEmpty(),
+                identifier = referencedIdentifier,
+            )
+        }
+
+        private fun containsArbitraryComposeColorLiteral(declarationText: String): Boolean {
+            return declarationText.contains(ARBITRARY_COLOR_ACCESS_REGEX) ||
+                declarationText.contains(ARBITRARY_COLOR_CONSTRUCTOR_REGEX)
+        }
+
+        private fun extractSimpleReturnedIdentifier(declarationText: String): String? {
+            val getterMatch = GETTER_IDENTIFIER_REGEX.find(declarationText)
+            if (getterMatch != null) return getterMatch.groupValues[1]
+
+            val initializerMatch = INITIALIZER_IDENTIFIER_REGEX.find(declarationText)
+            if (initializerMatch != null) return initializerMatch.groupValues[1]
+
+            val returnMatch = RETURN_IDENTIFIER_REGEX.find(declarationText)
+            if (returnMatch != null) return returnMatch.groupValues[1]
+
+            return null
+        }
+
+        private fun isImportedFromThemePackage(
+            fileText: String,
+            identifier: String,
+        ): Boolean {
+            if (fileText.isBlank()) return false
+            val escapedThemePackage = Regex.escape(COLOR_THEME_PACKAGE)
+            val escapedIdentifier = Regex.escape(identifier)
+            val importRegex = Regex("""import\s+$escapedThemePackage\.$escapedIdentifier(\s+as\s+\w+)?""")
+            return importRegex.containsMatchIn(fileText)
+        }
+
+        private fun reportInvalidColorUsage(colorArgument: UExpression) {
+            context.report(
+                issue = INVALID_DAX_DIVIDER_COLOR_USAGE,
+                location = context.getLocation(colorArgument),
+                message = INVALID_DAX_DIVIDER_COLOR_USAGE.getExplanation(TextFormat.RAW),
+            )
+        }
+    }
+
+    companion object {
+        private const val COLOR_THEME_PACKAGE = "com.duckduckgo.common.ui.compose.theme"
+        private const val MAX_VALIDATION_DEPTH = 4
+
+        private val ARBITRARY_COLOR_ACCESS_REGEX = Regex("""\bColor\.[A-Za-z_][A-Za-z0-9_]*""")
+        private val ARBITRARY_COLOR_CONSTRUCTOR_REGEX = Regex("""\bColor\s*\(""")
+
+        private val GETTER_IDENTIFIER_REGEX = Regex("""get\s*\(\s*\)\s*=\s*([A-Za-z_][A-Za-z0-9_]*)""")
+        private val INITIALIZER_IDENTIFIER_REGEX = Regex("""=\s*([A-Za-z_][A-Za-z0-9_]*)\s*${'$'}""")
+        private val RETURN_IDENTIFIER_REGEX = Regex("""return\s+([A-Za-z_][A-Za-z0-9_]*)""")
+
+        val INVALID_DAX_DIVIDER_COLOR_USAGE = Issue
+            .create(
+                id = "InvalidDaxDividerColorUsage",
+                briefDescription = "DaxHorizontalDivider/DaxVerticalDivider color parameter should use DuckDuckGoTheme semantic colors",
+                explanation = """
+                    Use a DuckDuckGoTheme semantic color (e.g. DuckDuckGoTheme.colors.system.lines for horizontal dividers, DuckDuckGoTheme.colors.backgrounds.container for vertical dividers) instead of arbitrary Color values.
+
+                    Defaults classes are allowed only when their implementation resolves to DuckDuckGoTheme semantic colors or theme-defined static colors.
+
+                    Examples:
+                    • DuckDuckGoTheme.colors.system.lines
+                    • DuckDuckGoTheme.colors.backgrounds.container
+                    • theme.colors.brand.accentBlue
+
+                    For one-off cases requiring custom colors, use good judgement or consider raising it in the Android Design System AOR.
+                """.trimIndent(),
+                moreInfo = "",
+                category = CUSTOM_LINT_CHECKS,
+                priority = 6,
+                severity = Severity.WARNING,
+                androidSpecific = true,
+                implementation = Implementation(
+                    DaxDividerColorUsageDetector::class.java,
+                    EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES),
+                ),
+            )
+    }
+}

--- a/lint-rules/src/main/java/com/duckduckgo/lint/ui/DaxDividerColorUsageDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/ui/DaxDividerColorUsageDetector.kt
@@ -77,7 +77,7 @@ class DaxDividerColorUsageDetector : Detector(), SourceCodeScanner {
         }
 
         private fun containsSemanticThemeColorPath(source: String): Boolean {
-            return source.contains("DuckDuckGoTheme.colors.") || source.contains(".colors.")
+            return SEMANTIC_THEME_COLOR_PATH_REGEX.containsMatchIn(source)
         }
 
         private fun resolvesToThemePackageElement(expression: UExpression): Boolean {
@@ -171,6 +171,9 @@ class DaxDividerColorUsageDetector : Detector(), SourceCodeScanner {
     companion object {
         private const val COLOR_THEME_PACKAGE = "com.duckduckgo.common.ui.compose.theme"
         private const val MAX_VALIDATION_DEPTH = 4
+
+        private val SEMANTIC_THEME_COLOR_PATH_REGEX =
+            Regex("""\.colors\.(backgrounds|text|brand|icons|infoPanel|textField|status|system)\.""")
 
         private val ARBITRARY_COLOR_ACCESS_REGEX = Regex("""\bColor\.[A-Za-z_][A-Za-z0-9_]*""")
         private val ARBITRARY_COLOR_CONSTRUCTOR_REGEX = Regex("""\bColor\s*\(""")

--- a/lint-rules/src/main/java/com/duckduckgo/lint/ui/DaxDividerColorUsageDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/ui/DaxDividerColorUsageDetector.kt
@@ -27,13 +27,15 @@ import com.android.tools.lint.detector.api.Severity
 import com.android.tools.lint.detector.api.SourceCodeScanner
 import com.android.tools.lint.detector.api.TextFormat
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiField
-import com.intellij.psi.PsiMethod
+import org.jetbrains.uast.UBlockExpression
 import org.jetbrains.uast.UCallExpression
 import org.jetbrains.uast.UExpression
-import org.jetbrains.uast.UQualifiedReferenceExpression
+import org.jetbrains.uast.UMethod
 import org.jetbrains.uast.UReferenceExpression
+import org.jetbrains.uast.UReturnExpression
+import org.jetbrains.uast.UVariable
 import org.jetbrains.uast.getParameterForArgument
+import org.jetbrains.uast.toUElement
 import java.util.EnumSet
 
 @Suppress("UnstableApiUsage")
@@ -44,66 +46,33 @@ class DaxDividerColorUsageDetector : Detector(), SourceCodeScanner {
     override fun createUastHandler(context: JavaContext): UElementHandler = DaxDividerColorCallHandler(context)
 
     internal class DaxDividerColorCallHandler(private val context: JavaContext) : UElementHandler() {
+
         override fun visitCallExpression(node: UCallExpression) {
             val methodName = node.methodName
-            if (methodName == "DaxHorizontalDivider" || methodName == "DaxVerticalDivider") {
-                checkColorParameter(node)
-            }
+            if (methodName != "DaxHorizontalDivider" && methodName != "DaxVerticalDivider") return
+
+            val resolvedMethod = node.resolve() ?: return
+            val pkg = context.evaluator.getPackage(resolvedMethod)?.qualifiedName
+            if (pkg != DAX_DIVIDER_PACKAGE) return
+
+            checkColorParameter(node)
         }
 
         private fun checkColorParameter(node: UCallExpression) {
             val colorArgument = node.valueArguments.find { arg ->
-                val parameterName = node.getParameterForArgument(arg)?.name
-                parameterName == "color"
+                node.getParameterForArgument(arg)?.name == "color"
             } ?: return
 
-            if (!isFromValidDuckDuckGoColorSource(colorArgument)) {
-                reportInvalidColorUsage(colorArgument)
+            if (!resolvesIntoThemePackage(colorArgument, depth = 0, visited = mutableSetOf())) {
+                context.report(
+                    issue = INVALID_DAX_DIVIDER_COLOR_USAGE,
+                    location = context.getLocation(colorArgument),
+                    message = INVALID_DAX_DIVIDER_COLOR_USAGE.getExplanation(TextFormat.RAW),
+                )
             }
         }
 
-        private fun isFromValidDuckDuckGoColorSource(argument: UExpression): Boolean {
-            val source = argument.sourcePsi?.text.orEmpty()
-
-            if (containsSemanticThemeColorPath(source)) return true
-
-            if (resolvesToThemePackageElement(argument)) return true
-
-            return resolvesToValidatedColorDeclaration(
-                expression = argument,
-                depth = 0,
-                visited = mutableSetOf(),
-            )
-        }
-
-        private fun containsSemanticThemeColorPath(source: String): Boolean {
-            return SEMANTIC_THEME_COLOR_PATH_REGEX.containsMatchIn(source)
-        }
-
-        private fun resolvesToThemePackageElement(expression: UExpression): Boolean {
-            val resolved = resolveExpression(expression) ?: return false
-            return isThemePackageElement(resolved)
-        }
-
-        private fun resolveExpression(expression: UExpression): PsiElement? {
-            return when (expression) {
-                is UQualifiedReferenceExpression -> expression.resolve()
-                is UReferenceExpression -> expression.resolve()
-                else -> null
-            }
-        }
-
-        private fun isThemePackageElement(element: PsiElement): Boolean {
-            val qualifiedName = when (element) {
-                is PsiMethod -> element.containingClass?.qualifiedName
-                is PsiField -> element.containingClass?.qualifiedName
-                else -> null
-            } ?: return false
-
-            return qualifiedName.startsWith(COLOR_THEME_PACKAGE)
-        }
-
-        private fun resolvesToValidatedColorDeclaration(
+        private fun resolvesIntoThemePackage(
             expression: UExpression,
             depth: Int,
             visited: MutableSet<PsiElement>,
@@ -115,72 +84,48 @@ class DaxDividerColorUsageDetector : Detector(), SourceCodeScanner {
 
             if (isThemePackageElement(resolved)) return true
 
-            val declaration = resolved.navigationElement ?: resolved
-            val declarationText = declaration.text.orEmpty()
-            if (declarationText.isBlank()) return false
-
-            if (containsSemanticThemeColorPath(declarationText)) return true
-            if (declarationText.contains(COLOR_THEME_PACKAGE)) return true
-            if (containsArbitraryComposeColorLiteral(declarationText)) return false
-
-            val referencedIdentifier = extractSimpleReturnedIdentifier(declarationText) ?: return false
-            return isImportedFromThemePackage(
-                fileText = declaration.containingFile?.text.orEmpty(),
-                identifier = referencedIdentifier,
-            )
+            val body = bodyExpressionOf(resolved) ?: return false
+            return resolvesIntoThemePackage(body, depth + 1, visited)
         }
 
-        private fun containsArbitraryComposeColorLiteral(declarationText: String): Boolean {
-            return declarationText.contains(ARBITRARY_COLOR_ACCESS_REGEX) ||
-                declarationText.contains(ARBITRARY_COLOR_CONSTRUCTOR_REGEX)
+        private fun resolveExpression(expression: UExpression): PsiElement? {
+            return when (expression) {
+                is UReferenceExpression -> expression.resolve()
+                is UCallExpression -> expression.resolve()
+                else -> null
+            }
         }
 
-        private fun extractSimpleReturnedIdentifier(declarationText: String): String? {
-            val getterMatch = GETTER_IDENTIFIER_REGEX.find(declarationText)
-            if (getterMatch != null) return getterMatch.groupValues[1]
-
-            val initializerMatch = INITIALIZER_IDENTIFIER_REGEX.find(declarationText)
-            if (initializerMatch != null) return initializerMatch.groupValues[1]
-
-            val returnMatch = RETURN_IDENTIFIER_REGEX.find(declarationText)
-            if (returnMatch != null) return returnMatch.groupValues[1]
-
-            return null
+        private fun isThemePackageElement(element: PsiElement): Boolean {
+            val packageName = context.evaluator.getPackage(element)?.qualifiedName ?: return false
+            return packageName == THEME_PACKAGE || packageName.startsWith("$THEME_PACKAGE.")
         }
 
-        private fun isImportedFromThemePackage(
-            fileText: String,
-            identifier: String,
-        ): Boolean {
-            if (fileText.isBlank()) return false
-            val escapedThemePackage = Regex.escape(COLOR_THEME_PACKAGE)
-            val escapedIdentifier = Regex.escape(identifier)
-            val importRegex = Regex("""import\s+$escapedThemePackage\.$escapedIdentifier(\s+as\s+\w+)?""")
-            return importRegex.containsMatchIn(fileText)
+        private fun bodyExpressionOf(element: PsiElement): UExpression? {
+            return when (val u = element.toUElement()) {
+                is UVariable -> u.uastInitializer
+                is UMethod -> singleExpressionBody(u.uastBody)
+                else -> null
+            }
         }
 
-        private fun reportInvalidColorUsage(colorArgument: UExpression) {
-            context.report(
-                issue = INVALID_DAX_DIVIDER_COLOR_USAGE,
-                location = context.getLocation(colorArgument),
-                message = INVALID_DAX_DIVIDER_COLOR_USAGE.getExplanation(TextFormat.RAW),
-            )
+        private fun singleExpressionBody(body: UExpression?): UExpression? {
+            return when (body) {
+                null -> null
+                is UReturnExpression -> body.returnExpression
+                is UBlockExpression -> {
+                    val single = body.expressions.singleOrNull() ?: return null
+                    if (single is UReturnExpression) single.returnExpression else single
+                }
+                else -> body
+            }
         }
     }
 
     companion object {
-        private const val COLOR_THEME_PACKAGE = "com.duckduckgo.common.ui.compose.theme"
+        private const val THEME_PACKAGE = "com.duckduckgo.common.ui.compose.theme"
+        private const val DAX_DIVIDER_PACKAGE = "com.duckduckgo.common.ui.compose.divider"
         private const val MAX_VALIDATION_DEPTH = 4
-
-        private val SEMANTIC_THEME_COLOR_PATH_REGEX =
-            Regex("""\.colors\.(backgrounds|text|brand|icons|infoPanel|textField|status|system)\.""")
-
-        private val ARBITRARY_COLOR_ACCESS_REGEX = Regex("""\bColor\.[A-Za-z_][A-Za-z0-9_]*""")
-        private val ARBITRARY_COLOR_CONSTRUCTOR_REGEX = Regex("""\bColor\s*\(""")
-
-        private val GETTER_IDENTIFIER_REGEX = Regex("""get\s*\(\s*\)\s*=\s*([A-Za-z_][A-Za-z0-9_]*)""")
-        private val INITIALIZER_IDENTIFIER_REGEX = Regex("""=\s*([A-Za-z_][A-Za-z0-9_]*)\s*${'$'}""")
-        private val RETURN_IDENTIFIER_REGEX = Regex("""return\s+([A-Za-z_][A-Za-z0-9_]*)""")
 
         val INVALID_DAX_DIVIDER_COLOR_USAGE = Issue
             .create(

--- a/lint-rules/src/main/java/com/duckduckgo/lint/ui/NoMaterial3DividerUsageDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/ui/NoMaterial3DividerUsageDetector.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint.ui
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category.Companion.CUSTOM_LINT_CHECKS
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.TextFormat
+import org.jetbrains.uast.UCallExpression
+import java.util.EnumSet
+
+@Suppress("UnstableApiUsage")
+class NoMaterial3DividerUsageDetector : Detector(), SourceCodeScanner {
+
+    override fun getApplicableUastTypes() = listOf(UCallExpression::class.java)
+
+    override fun createUastHandler(context: JavaContext): UElementHandler = DividerUsageHandler(context)
+
+    internal class DividerUsageHandler(private val context: JavaContext) : UElementHandler() {
+
+        override fun visitCallExpression(node: UCallExpression) {
+            if (isInDesignSystemModule()) return
+
+            val methodName = node.methodName ?: return
+            val issue = when (methodName) {
+                "HorizontalDivider" -> NO_MATERIAL3_HORIZONTAL_DIVIDER_USAGE
+                "VerticalDivider" -> NO_MATERIAL3_VERTICAL_DIVIDER_USAGE
+                else -> return
+            }
+
+            val resolved = node.resolve() ?: return
+            val qualifiedName = context.evaluator.getPackage(resolved)?.qualifiedName ?: return
+            if (qualifiedName == MATERIAL3_PACKAGE) {
+                context.report(
+                    issue = issue,
+                    location = context.getLocation(node),
+                    message = issue.getExplanation(TextFormat.RAW),
+                )
+            }
+        }
+
+        private fun isInDesignSystemModule(): Boolean {
+            return context.project.name in DESIGN_SYSTEM_MODULES
+        }
+    }
+
+    companion object {
+        private const val MATERIAL3_PACKAGE = "androidx.compose.material3"
+        private val DESIGN_SYSTEM_MODULES = setOf("design-system", "design-system-internal")
+
+        val NO_MATERIAL3_HORIZONTAL_DIVIDER_USAGE = Issue
+            .create(
+                id = "NoMaterial3HorizontalDividerUsage",
+                briefDescription = "Use DaxHorizontalDivider instead of Material3 HorizontalDivider",
+                explanation = "Use `DaxHorizontalDivider` from the design system instead of the Material3 `HorizontalDivider` " +
+                    "composable to ensure consistent styling across the app.",
+                moreInfo = "",
+                category = CUSTOM_LINT_CHECKS,
+                priority = 10,
+                severity = Severity.ERROR,
+                androidSpecific = true,
+                implementation = Implementation(
+                    NoMaterial3DividerUsageDetector::class.java,
+                    EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES),
+                ),
+            )
+
+        val NO_MATERIAL3_VERTICAL_DIVIDER_USAGE = Issue
+            .create(
+                id = "NoMaterial3VerticalDividerUsage",
+                briefDescription = "Use DaxVerticalDivider instead of Material3 VerticalDivider",
+                explanation = "Use `DaxVerticalDivider` from the design system instead of the Material3 `VerticalDivider` " +
+                    "composable to ensure consistent styling across the app.",
+                moreInfo = "",
+                category = CUSTOM_LINT_CHECKS,
+                priority = 10,
+                severity = Severity.ERROR,
+                androidSpecific = true,
+                implementation = Implementation(
+                    NoMaterial3DividerUsageDetector::class.java,
+                    EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES),
+                ),
+            )
+    }
+}

--- a/lint-rules/src/test/java/com/duckduckgo/lint/ui/DaxDividerColorUsageDetectorTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/ui/DaxDividerColorUsageDetectorTest.kt
@@ -306,7 +306,7 @@ class DaxDividerColorUsageDetectorTest {
             )
             .allowCompilationErrors()
             .issues(INVALID_DAX_DIVIDER_COLOR_USAGE)
-            .skipTestModes(TestMode.WHITESPACE, TestMode.IMPORT_ALIAS)
+            .skipTestModes(TestMode.WHITESPACE)
             .run()
             .expectClean()
     }
@@ -450,6 +450,144 @@ class DaxDividerColorUsageDetectorTest {
             .run()
             .expectContains("InvalidDaxDividerColorUsage")
             .expectContains("color = SomeOtherPalette.colors.danger")
+            .expectContains("0 errors, 1 warnings")
+    }
+
+    @Test
+    fun whenSameNamedFunctionInDifferentPackageThenNoWarning() {
+        // The rule only applies to the actual DDG composable.
+        // A user-defined function with the same name in another package must not trip it.
+        lint()
+            .files(
+                TestFiles.kt(
+                    """
+                    package com.example.othermodule
+
+                    import androidx.compose.runtime.Composable
+                    import androidx.compose.ui.graphics.Color
+
+                    @Composable
+                    fun DaxHorizontalDivider(color: Color = Color(0xFF111111)) {
+                        // Not the DDG composable
+                    }
+                    """.trimIndent(),
+                ).indented(),
+                TestFiles.kt(
+                    """
+                    package com.example.test
+
+                    import androidx.compose.runtime.Composable
+                    import androidx.compose.ui.graphics.Color
+                    import com.example.othermodule.DaxHorizontalDivider
+
+                    @Composable
+                    fun TestScreen() {
+                        DaxHorizontalDivider(color = Color.Red)
+                    }
+                    """.trimIndent(),
+                ).indented(),
+                composeStubs,
+                themeStubs,
+            )
+            .allowCompilationErrors()
+            .issues(INVALID_DAX_DIVIDER_COLOR_USAGE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenDefaultsBodyResolvesToFakeSemanticPathThenWarning() {
+        // Defaults class whose getter body uses a non-DDG receiver shaped like
+        // a DDG semantic color path. The PSI walk must follow the getter body
+        // and reject because the resolved property is not in the theme package.
+        lint()
+            .files(
+                TestFiles.kt(
+                    """
+                    package com.example.test
+
+                    import androidx.compose.runtime.Composable
+                    import androidx.compose.ui.graphics.Color
+                    import com.duckduckgo.common.ui.compose.divider.DaxHorizontalDivider
+
+                    data class FakeSystemColors(val lines: Color)
+                    data class FakeColors(val system: FakeSystemColors)
+
+                    object SomeOtherPalette {
+                        val colors: FakeColors = FakeColors(
+                            system = FakeSystemColors(lines = Color.Red),
+                        )
+                    }
+
+                    object FakeDefaults {
+                        val lineColor: Color
+                            @Composable
+                            get() = SomeOtherPalette.colors.system.lines
+                    }
+
+                    @Composable
+                    fun TestScreen() {
+                        DaxHorizontalDivider(
+                            color = FakeDefaults.lineColor,
+                        )
+                    }
+                    """.trimIndent(),
+                ).indented(),
+                composeStubs,
+                themeStubs,
+                daxDividerStubs,
+            )
+            .allowCompilationErrors()
+            .issues(INVALID_DAX_DIVIDER_COLOR_USAGE)
+            .skipTestModes(TestMode.WHITESPACE)
+            .run()
+            .expectContains("InvalidDaxDividerColorUsage")
+            .expectContains("color = FakeDefaults.lineColor")
+            .expectContains("0 errors, 1 warnings")
+    }
+
+    @Test
+    fun whenFakeSemanticPathFromNonDuckDuckGoColorsThenWarning() {
+        // Uses the exact DDG semantic path shape (.colors.system.lines) but with
+        // a non-theme receiver. A naive text-only check would accept this; the
+        // detector must require PSI resolution into the theme package.
+        lint()
+            .files(
+                TestFiles.kt(
+                    """
+                    package com.example.test
+
+                    import androidx.compose.runtime.Composable
+                    import androidx.compose.ui.graphics.Color
+                    import com.duckduckgo.common.ui.compose.divider.DaxHorizontalDivider
+
+                    data class FakeSystemColors(val lines: Color)
+                    data class FakeColors(val system: FakeSystemColors)
+
+                    object SomeOtherPalette {
+                        val colors: FakeColors = FakeColors(
+                            system = FakeSystemColors(lines = Color.Red),
+                        )
+                    }
+
+                    @Composable
+                    fun TestScreen() {
+                        DaxHorizontalDivider(
+                            color = SomeOtherPalette.colors.system.lines,
+                        )
+                    }
+                    """.trimIndent(),
+                ).indented(),
+                composeStubs,
+                themeStubs,
+                daxDividerStubs,
+            )
+            .allowCompilationErrors()
+            .issues(INVALID_DAX_DIVIDER_COLOR_USAGE)
+            .skipTestModes(TestMode.WHITESPACE)
+            .run()
+            .expectContains("InvalidDaxDividerColorUsage")
+            .expectContains("color = SomeOtherPalette.colors.system.lines")
             .expectContains("0 errors, 1 warnings")
     }
 

--- a/lint-rules/src/test/java/com/duckduckgo/lint/ui/DaxDividerColorUsageDetectorTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/ui/DaxDividerColorUsageDetectorTest.kt
@@ -1,0 +1,463 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint.ui
+
+import com.android.tools.lint.checks.infrastructure.TestFiles
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import com.android.tools.lint.checks.infrastructure.TestMode
+import com.duckduckgo.lint.ui.DaxDividerColorUsageDetector.Companion.INVALID_DAX_DIVIDER_COLOR_USAGE
+import org.junit.Test
+
+class DaxDividerColorUsageDetectorTest {
+
+    private val composeStubs = TestFiles.kotlin(
+        """
+        package androidx.compose.ui.graphics
+
+        data class Color(val value: Long) {
+            companion object {
+                val Red = Color(0xFFFF0000)
+                val Blue = Color(0xFF0000FF)
+            }
+        }
+
+        package androidx.compose.runtime
+
+        annotation class Composable
+
+        package androidx.compose.ui
+
+        class Modifier {
+            companion object : Modifier()
+        }
+        """.trimIndent(),
+    ).indented()
+
+    private val themeStubs = TestFiles.kotlin(
+        """
+        package com.duckduckgo.common.ui.compose.theme
+
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.graphics.Color
+
+        data class DuckDuckGoSystemColors(
+            val lines: Color,
+        )
+
+        data class DuckDuckGoBackgroundColors(
+            val container: Color,
+        )
+
+        data class DuckDuckGoBrandColors(
+            val accentBlue: Color,
+        )
+
+        data class DuckDuckGoColors(
+            val system: DuckDuckGoSystemColors,
+            val backgrounds: DuckDuckGoBackgroundColors,
+            val brand: DuckDuckGoBrandColors,
+        )
+
+        object DuckDuckGoTheme {
+            val colors: DuckDuckGoColors
+                @Composable
+                get() = DuckDuckGoColors(
+                    system = DuckDuckGoSystemColors(lines = Color(0xFFCCCCCC)),
+                    backgrounds = DuckDuckGoBackgroundColors(container = Color(0xFFEEEEEE)),
+                    brand = DuckDuckGoBrandColors(accentBlue = Color(0xFF1E90FF)),
+                )
+        }
+
+        val AlertGreen: Color
+            @Composable
+            get() = Color(0xFF21C000)
+        """.trimIndent(),
+    ).indented()
+
+    private val daxDividerStubs = TestFiles.kotlin(
+        """
+        package com.duckduckgo.common.ui.compose.divider
+
+        import androidx.compose.runtime.Composable
+        import androidx.compose.ui.Modifier
+        import androidx.compose.ui.graphics.Color
+        import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+
+        @Composable
+        fun DaxHorizontalDivider(
+            modifier: Modifier = Modifier,
+            color: Color = DuckDuckGoTheme.colors.system.lines,
+        ) {
+            // Implementation
+        }
+
+        @Composable
+        fun DaxVerticalDivider(
+            modifier: Modifier = Modifier,
+            color: Color = DuckDuckGoTheme.colors.backgrounds.container,
+        ) {
+            // Implementation
+        }
+        """.trimIndent(),
+    ).indented()
+
+    @Test
+    fun whenDaxHorizontalDividerWithoutColorThenNoWarning() {
+        lint()
+            .files(
+                TestFiles.kt(
+                    """
+                    package com.example.test
+
+                    import androidx.compose.runtime.Composable
+                    import com.duckduckgo.common.ui.compose.divider.DaxHorizontalDivider
+
+                    @Composable
+                    fun TestScreen() {
+                        DaxHorizontalDivider()
+                    }
+                    """.trimIndent(),
+                ).indented(),
+                composeStubs,
+                themeStubs,
+                daxDividerStubs,
+            )
+            .allowCompilationErrors()
+            .issues(INVALID_DAX_DIVIDER_COLOR_USAGE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenDaxHorizontalDividerWithSystemLinesThenNoWarning() {
+        lint()
+            .files(
+                TestFiles.kt(
+                    """
+                    package com.example.test
+
+                    import androidx.compose.runtime.Composable
+                    import com.duckduckgo.common.ui.compose.divider.DaxHorizontalDivider
+                    import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+
+                    @Composable
+                    fun TestScreen() {
+                        DaxHorizontalDivider(
+                            color = DuckDuckGoTheme.colors.system.lines,
+                        )
+                    }
+                    """.trimIndent(),
+                ).indented(),
+                composeStubs,
+                themeStubs,
+                daxDividerStubs,
+            )
+            .allowCompilationErrors()
+            .issues(INVALID_DAX_DIVIDER_COLOR_USAGE)
+            .skipTestModes(TestMode.WHITESPACE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenDaxVerticalDividerWithBackgroundsContainerThenNoWarning() {
+        lint()
+            .files(
+                TestFiles.kt(
+                    """
+                    package com.example.test
+
+                    import androidx.compose.runtime.Composable
+                    import com.duckduckgo.common.ui.compose.divider.DaxVerticalDivider
+                    import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+
+                    @Composable
+                    fun TestScreen() {
+                        DaxVerticalDivider(
+                            color = DuckDuckGoTheme.colors.backgrounds.container,
+                        )
+                    }
+                    """.trimIndent(),
+                ).indented(),
+                composeStubs,
+                themeStubs,
+                daxDividerStubs,
+            )
+            .allowCompilationErrors()
+            .issues(INVALID_DAX_DIVIDER_COLOR_USAGE)
+            .skipTestModes(TestMode.WHITESPACE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenDaxHorizontalDividerWithBrandAccentThenNoWarning() {
+        lint()
+            .files(
+                TestFiles.kt(
+                    """
+                    package com.example.test
+
+                    import androidx.compose.runtime.Composable
+                    import com.duckduckgo.common.ui.compose.divider.DaxHorizontalDivider
+                    import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+
+                    @Composable
+                    fun TestScreen() {
+                        DaxHorizontalDivider(
+                            color = DuckDuckGoTheme.colors.brand.accentBlue,
+                        )
+                    }
+                    """.trimIndent(),
+                ).indented(),
+                composeStubs,
+                themeStubs,
+                daxDividerStubs,
+            )
+            .allowCompilationErrors()
+            .issues(INVALID_DAX_DIVIDER_COLOR_USAGE)
+            .skipTestModes(TestMode.WHITESPACE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenDaxHorizontalDividerWithDefaultsObjectUsingThemeColorThenNoWarning() {
+        lint()
+            .files(
+                TestFiles.kt(
+                    """
+                    package com.example.test
+
+                    import androidx.compose.runtime.Composable
+                    import androidx.compose.ui.graphics.Color
+                    import com.duckduckgo.common.ui.compose.divider.DaxHorizontalDivider
+                    import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+
+                    object ExampleDividerDefaults {
+                        val lineColor: Color
+                            @Composable
+                            get() = DuckDuckGoTheme.colors.system.lines
+                    }
+
+                    @Composable
+                    fun TestScreen() {
+                        DaxHorizontalDivider(
+                            color = ExampleDividerDefaults.lineColor,
+                        )
+                    }
+                    """.trimIndent(),
+                ).indented(),
+                composeStubs,
+                themeStubs,
+                daxDividerStubs,
+            )
+            .allowCompilationErrors()
+            .issues(INVALID_DAX_DIVIDER_COLOR_USAGE)
+            .skipTestModes(TestMode.WHITESPACE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenDaxVerticalDividerWithDefaultsObjectUsingStaticThemeColorThenNoWarning() {
+        lint()
+            .files(
+                TestFiles.kt(
+                    """
+                    package com.example.test
+
+                    import androidx.compose.runtime.Composable
+                    import androidx.compose.ui.graphics.Color
+                    import com.duckduckgo.common.ui.compose.divider.DaxVerticalDivider
+                    import com.duckduckgo.common.ui.compose.theme.AlertGreen
+
+                    object ExampleDividerDefaults {
+                        val statusColor: Color
+                            @Composable
+                            get() = AlertGreen
+                    }
+
+                    @Composable
+                    fun TestScreen() {
+                        DaxVerticalDivider(
+                            color = ExampleDividerDefaults.statusColor,
+                        )
+                    }
+                    """.trimIndent(),
+                ).indented(),
+                composeStubs,
+                themeStubs,
+                daxDividerStubs,
+            )
+            .allowCompilationErrors()
+            .issues(INVALID_DAX_DIVIDER_COLOR_USAGE)
+            .skipTestModes(TestMode.WHITESPACE, TestMode.IMPORT_ALIAS)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenDaxHorizontalDividerWithDefaultsObjectUsingArbitraryColorThenWarning() {
+        lint()
+            .files(
+                TestFiles.kt(
+                    """
+                    package com.example.test
+
+                    import androidx.compose.runtime.Composable
+                    import androidx.compose.ui.graphics.Color
+                    import com.duckduckgo.common.ui.compose.divider.DaxHorizontalDivider
+
+                    object ExampleDividerDefaults {
+                        val invalidColor: Color
+                            @Composable
+                            get() = Color.Red
+                    }
+
+                    @Composable
+                    fun TestScreen() {
+                        DaxHorizontalDivider(
+                            color = ExampleDividerDefaults.invalidColor,
+                        )
+                    }
+                    """.trimIndent(),
+                ).indented(),
+                composeStubs,
+                themeStubs,
+                daxDividerStubs,
+            )
+            .allowCompilationErrors()
+            .issues(INVALID_DAX_DIVIDER_COLOR_USAGE)
+            .skipTestModes(TestMode.WHITESPACE)
+            .run()
+            .expectContains("InvalidDaxDividerColorUsage")
+            .expectContains("color = ExampleDividerDefaults.invalidColor")
+            .expectContains("0 errors, 1 warnings")
+    }
+
+    @Test
+    fun whenDaxHorizontalDividerWithArbitraryColorThenWarning() {
+        lint()
+            .files(
+                TestFiles.kt(
+                    """
+                    package com.example.test
+
+                    import androidx.compose.runtime.Composable
+                    import androidx.compose.ui.graphics.Color
+                    import com.duckduckgo.common.ui.compose.divider.DaxHorizontalDivider
+
+                    @Composable
+                    fun TestScreen() {
+                        DaxHorizontalDivider(
+                            color = Color.Red,
+                        )
+                    }
+                    """.trimIndent(),
+                ).indented(),
+                composeStubs,
+                themeStubs,
+                daxDividerStubs,
+            )
+            .allowCompilationErrors()
+            .issues(INVALID_DAX_DIVIDER_COLOR_USAGE)
+            .run()
+            .expectContains("InvalidDaxDividerColorUsage")
+            .expectContains("color = Color.Red")
+            .expectContains("0 errors, 1 warnings")
+    }
+
+    @Test
+    fun whenDaxVerticalDividerWithColorConstructorThenWarning() {
+        lint()
+            .files(
+                TestFiles.kt(
+                    """
+                    package com.example.test
+
+                    import androidx.compose.runtime.Composable
+                    import androidx.compose.ui.graphics.Color
+                    import com.duckduckgo.common.ui.compose.divider.DaxVerticalDivider
+
+                    @Composable
+                    fun TestScreen() {
+                        DaxVerticalDivider(
+                            color = Color(0xFF123456),
+                        )
+                    }
+                    """.trimIndent(),
+                ).indented(),
+                composeStubs,
+                themeStubs,
+                daxDividerStubs,
+            )
+            .allowCompilationErrors()
+            .issues(INVALID_DAX_DIVIDER_COLOR_USAGE)
+            .run()
+            .expectContains("InvalidDaxDividerColorUsage")
+            .expectContains("color = Color(0xFF123456)")
+            .expectContains("0 errors, 1 warnings")
+    }
+
+    @Test
+    fun whenMixedValidAndInvalidCallsThenWarningsForInvalidOnly() {
+        lint()
+            .files(
+                TestFiles.kt(
+                    """
+                    package com.example.test
+
+                    import androidx.compose.runtime.Composable
+                    import androidx.compose.ui.graphics.Color
+                    import com.duckduckgo.common.ui.compose.divider.DaxHorizontalDivider
+                    import com.duckduckgo.common.ui.compose.divider.DaxVerticalDivider
+                    import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+
+                    @Composable
+                    fun TestScreen() {
+                        DaxHorizontalDivider(
+                            color = DuckDuckGoTheme.colors.system.lines,
+                        )
+
+                        DaxHorizontalDivider(
+                            color = Color.Blue,
+                        )
+
+                        DaxVerticalDivider(
+                            color = DuckDuckGoTheme.colors.backgrounds.container,
+                        )
+
+                        DaxVerticalDivider(
+                            color = Color(0xFFFF0000),
+                        )
+                    }
+                    """.trimIndent(),
+                ).indented(),
+                composeStubs,
+                themeStubs,
+                daxDividerStubs,
+            )
+            .allowCompilationErrors()
+            .issues(INVALID_DAX_DIVIDER_COLOR_USAGE)
+            .skipTestModes(TestMode.WHITESPACE)
+            .run()
+            .expectContains("color = Color.Blue")
+            .expectContains("color = Color(0xFFFF0000)")
+            .expectContains("0 errors, 2 warnings")
+    }
+}

--- a/lint-rules/src/test/java/com/duckduckgo/lint/ui/DaxDividerColorUsageDetectorTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/ui/DaxDividerColorUsageDetectorTest.kt
@@ -415,6 +415,45 @@ class DaxDividerColorUsageDetectorTest {
     }
 
     @Test
+    fun whenNonDuckDuckGoColorsPathThenWarning() {
+        lint()
+            .files(
+                TestFiles.kt(
+                    """
+                    package com.example.test
+
+                    import androidx.compose.runtime.Composable
+                    import androidx.compose.ui.graphics.Color
+                    import com.duckduckgo.common.ui.compose.divider.DaxHorizontalDivider
+
+                    data class OtherColors(val danger: Color)
+
+                    object SomeOtherPalette {
+                        val colors: OtherColors = OtherColors(danger = Color.Red)
+                    }
+
+                    @Composable
+                    fun TestScreen() {
+                        DaxHorizontalDivider(
+                            color = SomeOtherPalette.colors.danger,
+                        )
+                    }
+                    """.trimIndent(),
+                ).indented(),
+                composeStubs,
+                themeStubs,
+                daxDividerStubs,
+            )
+            .allowCompilationErrors()
+            .issues(INVALID_DAX_DIVIDER_COLOR_USAGE)
+            .skipTestModes(TestMode.WHITESPACE)
+            .run()
+            .expectContains("InvalidDaxDividerColorUsage")
+            .expectContains("color = SomeOtherPalette.colors.danger")
+            .expectContains("0 errors, 1 warnings")
+    }
+
+    @Test
     fun whenMixedValidAndInvalidCallsThenWarningsForInvalidOnly() {
         lint()
             .files(

--- a/lint-rules/src/test/java/com/duckduckgo/lint/ui/NoMaterial3DividerUsageDetectorTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/ui/NoMaterial3DividerUsageDetectorTest.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint.ui
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.kotlin
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import com.duckduckgo.lint.ui.NoMaterial3DividerUsageDetector.Companion.NO_MATERIAL3_HORIZONTAL_DIVIDER_USAGE
+import com.duckduckgo.lint.ui.NoMaterial3DividerUsageDetector.Companion.NO_MATERIAL3_VERTICAL_DIVIDER_USAGE
+import org.junit.Test
+
+class NoMaterial3DividerUsageDetectorTest {
+
+    private val material3DividerStub = kotlin(
+        """
+        package androidx.compose.material3
+
+        fun HorizontalDivider() {}
+
+        fun VerticalDivider() {}
+        """.trimIndent(),
+    ).indented()
+
+    private val daxDividerStub = kotlin(
+        """
+        package com.duckduckgo.common.ui.compose.divider
+
+        fun DaxHorizontalDivider() {}
+
+        fun DaxVerticalDivider() {}
+        """.trimIndent(),
+    ).indented()
+
+    @Test
+    fun whenMaterial3HorizontalDividerUsedThenError() {
+        lint()
+            .files(
+                material3DividerStub,
+                kotlin(
+                    """
+                    package com.example.test
+
+                    import androidx.compose.material3.HorizontalDivider
+
+                    fun MyScreen() {
+                        HorizontalDivider()
+                    }
+                    """.trimIndent(),
+                ).indented(),
+            )
+            .issues(NO_MATERIAL3_HORIZONTAL_DIVIDER_USAGE)
+            .run()
+            .expect(
+                """
+                src/com/example/test/test.kt:6: Error: Use DaxHorizontalDivider from the design system instead of the Material3 HorizontalDivider composable to ensure consistent styling across the app. [NoMaterial3HorizontalDividerUsage]
+                    HorizontalDivider()
+                    ~~~~~~~~~~~~~~~~~~~
+                1 errors, 0 warnings
+                """.trimIndent(),
+            )
+    }
+
+    @Test
+    fun whenMaterial3VerticalDividerUsedThenError() {
+        lint()
+            .files(
+                material3DividerStub,
+                kotlin(
+                    """
+                    package com.example.test
+
+                    import androidx.compose.material3.VerticalDivider
+
+                    fun MyScreen() {
+                        VerticalDivider()
+                    }
+                    """.trimIndent(),
+                ).indented(),
+            )
+            .issues(NO_MATERIAL3_VERTICAL_DIVIDER_USAGE)
+            .run()
+            .expect(
+                """
+                src/com/example/test/test.kt:6: Error: Use DaxVerticalDivider from the design system instead of the Material3 VerticalDivider composable to ensure consistent styling across the app. [NoMaterial3VerticalDividerUsage]
+                    VerticalDivider()
+                    ~~~~~~~~~~~~~~~~~
+                1 errors, 0 warnings
+                """.trimIndent(),
+            )
+    }
+
+    @Test
+    fun whenDaxHorizontalDividerUsedThenNoError() {
+        lint()
+            .files(
+                daxDividerStub,
+                kotlin(
+                    """
+                    package com.example.test
+
+                    import com.duckduckgo.common.ui.compose.divider.DaxHorizontalDivider
+
+                    fun MyScreen() {
+                        DaxHorizontalDivider()
+                    }
+                    """.trimIndent(),
+                ).indented(),
+            )
+            .issues(NO_MATERIAL3_HORIZONTAL_DIVIDER_USAGE, NO_MATERIAL3_VERTICAL_DIVIDER_USAGE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenDaxVerticalDividerUsedThenNoError() {
+        lint()
+            .files(
+                daxDividerStub,
+                kotlin(
+                    """
+                    package com.example.test
+
+                    import com.duckduckgo.common.ui.compose.divider.DaxVerticalDivider
+
+                    fun MyScreen() {
+                        DaxVerticalDivider()
+                    }
+                    """.trimIndent(),
+                ).indented(),
+            )
+            .issues(NO_MATERIAL3_HORIZONTAL_DIVIDER_USAGE, NO_MATERIAL3_VERTICAL_DIVIDER_USAGE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenNoDividerUsedThenNoError() {
+        lint()
+            .files(
+                kotlin(
+                    """
+                    package com.example.test
+
+                    fun MyScreen() {
+                        val visible = true
+                    }
+                    """.trimIndent(),
+                ).indented(),
+            )
+            .issues(NO_MATERIAL3_HORIZONTAL_DIVIDER_USAGE, NO_MATERIAL3_VERTICAL_DIVIDER_USAGE)
+            .run()
+            .expectClean()
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1210594645151737/task/1211662779470299?focus=true

### Description
Adds `DaxHorizontalDivider` and `DaxVerticalDivider` components to the Compose Android Design System library.

### Steps to test this PR

_ADS_
- [x] Verify the new compose divider variants match the XML ones in the ADS screen (note there is a difference in the icon size used for divider example but this is how DaxIconButton renders icons so unrelated to this)

### UI changes
<img width="50%" height="50%" alt="Screenshot_20260608_091814" src="https://github.com/user-attachments/assets/5502098b-4107-412a-9576-9eab62cf8a7a" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to new design-system composables, internal ADS demos, and lint rules; no production feature or security paths are modified.
> 
> **Overview**
> Adds **Compose design-system dividers** `DaxHorizontalDivider` and `DaxVerticalDivider`, themed wrappers around Material3 with defaults aligned to the existing XML dividers (`system.lines` / `backgrounds.container`). Spacing is left to callers via `Modifier`, mirroring full-width, inset, and custom-margin XML patterns.
> 
> The **ADS divider showcase** keeps the XML examples and adds parallel Compose sections: `DividerComponentViewHolder` now binds themed `ComposeView`s for horizontal and vertical variants, and `component_section_divider.xml` gains the new headers and slots.
> 
> **Lint** enforces adoption: errors for raw Material3 `HorizontalDivider` / `VerticalDivider` outside design-system modules, and warnings when `color` on the Dax dividers does not resolve to `DuckDuckGoTheme` semantic colors. New detectors are registered with unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 004e182316fac417ecc59a2b11cc3cf6ed26b23f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->