### PR TITLE
Pin internal privacy e2e suite to API 34

### DIFF
--- a/.github/workflows/e2e-nightly-full-suite.yml
+++ b/.github/workflows/e2e-nightly-full-suite.yml
@@ -142,7 +142,7 @@ jobs:
           maestro_test_name: internalPrivacyTest${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-internal-binary.outputs.maestro_app_binary_id }}
-          maestro_api_level: 35
+          maestro_api_level: 34
           maestro_include_tags: privacyTestInternal
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1215492537717186?focus=true 

### Description
Set API version to 34 for internal privacy test

### Steps to test this PR
https://github.com/duckduckgo/Android/actions/runs/27132429975/job/80076450399 should pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI workflow input change with no application or production runtime impact.
> 
> **Overview**
> The **Internal Privacy** Maestro step in the nightly full-suite workflow now runs on **Android API 34** instead of **API 35**. All other Maestro jobs in that workflow keep their existing API levels (mostly 35).
> 
> This only affects which emulator/API level Maestro Cloud uses for the `privacyTestInternal` tagged suite; release-blocker and Asana reporting behavior for that step are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d09b5b0a35fb65e68d6580fd55fef6a46b1ad15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->