### PR TITLE
Remove temporary default browser page shown pixel

### DIFF
--- a/PixelDefinitions/pixels/definitions/onboarding.json5
+++ b/PixelDefinitions/pixels/definitions/onboarding.json5
@@ -1,12 +1,4 @@
 {
-    "m_preonboarding_default_browser_page_shown_unique": {
-        "description": "Fires when the the default browser page is shown during onboarding",
-        "owners": ["mikescamell"],
-        "triggers": ["other"],
-        "suffixes": ["form_factor"],
-        "parameters": ["appVersion"],
-        "expires": "2026-04-05"
-    },
     "m_preonboarding_choose_search_experience_impressions_unique": {
         "description": "Fires during onboarding when the Search Experience view appears",
         "owners": ["joshliebe"],

--- a/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
@@ -156,7 +156,6 @@ object PixelInterceptorPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
             AppPixelName.PREONBOARDING_SKIP_ONBOARDING_PRESSED.pixelName to PixelParameter.removeAtb(),
             AppPixelName.PREONBOARDING_CONFIRM_SKIP_ONBOARDING_PRESSED.pixelName to PixelParameter.removeAtb(),
             AppPixelName.PREONBOARDING_RESUME_ONBOARDING_PRESSED.pixelName to PixelParameter.removeAtb(),
-            AppPixelName.PREONBOARDING_DEFAULT_BROWSER_PAGE_SHOWN_UNIQUE.pixelName to PixelParameter.removeAtb(),
             AppPixelName.PREONBOARDING_CHOOSE_SEARCH_EXPERIENCE_IMPRESSIONS_UNIQUE.pixelName to PixelParameter.removeAtb(),
             AppPixelName.PREONBOARDING_AICHAT_SELECTED.pixelName to PixelParameter.removeAtb(),
             AppPixelName.PREONBOARDING_SEARCH_ONLY_SELECTED.pixelName to PixelParameter.removeAtb(),

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateDefaultBrowserPage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateDefaultBrowserPage.kt
@@ -140,23 +140,9 @@ class BrandDesignUpdateDefaultBrowserPage :
         setButtonsBehaviour()
     }
 
-    @Suppress("DEPRECATION")
-    override fun setUserVisibleHint(isVisibleToUser: Boolean) {
-        super.setUserVisibleHint(isVisibleToUser)
-        maybeReportPageShown()
-    }
-
     override fun onResume() {
         super.onResume()
-        maybeReportPageShown()
         viewModel.loadUI()
-    }
-
-    @Suppress("DEPRECATION")
-    private fun maybeReportPageShown() {
-        if (userVisibleHint && isResumed && view != null) {
-            viewModel.onPageShown()
-        }
     }
 
     override fun onStop() {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPage.kt
@@ -92,23 +92,9 @@ class DefaultBrowserPage : OnboardingPageFragment(R.layout.content_onboarding_de
         setButtonsBehaviour()
     }
 
-    @Suppress("DEPRECATION")
-    override fun setUserVisibleHint(isVisibleToUser: Boolean) {
-        super.setUserVisibleHint(isVisibleToUser)
-        maybeReportPageShown()
-    }
-
     override fun onResume() {
         super.onResume()
-        maybeReportPageShown()
         viewModel.loadUI()
-    }
-
-    @Suppress("DEPRECATION")
-    private fun maybeReportPageShown() {
-        if (userVisibleHint && isResumed && view != null) {
-            viewModel.onPageShown()
-        }
     }
 
     override fun onStop() {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModel.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
 import com.duckduckgo.common.utils.SingleLiveEvent
 import com.duckduckgo.di.scopes.FragmentScope
 import javax.inject.Inject
@@ -60,10 +59,6 @@ class DefaultBrowserPageViewModel @Inject constructor(
 
     init {
         viewState.value = newViewState()
-    }
-
-    fun onPageShown() {
-        pixel.fire(pixel = AppPixelName.PREONBOARDING_DEFAULT_BROWSER_PAGE_SHOWN_UNIQUE, type = Unique())
     }
 
     fun loadUI() {

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -46,7 +46,6 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     PREONBOARDING_INTRO_SHOWN_UNIQUE("m_preonboarding_intro_shown_unique"),
     PREONBOARDING_INTRO_REINSTALL_USER_SHOWN_UNIQUE("m_preonboarding_intro_reinstall_user_shown_unique"),
     PREONBOARDING_COMPARISON_CHART_SHOWN_UNIQUE("m_preonboarding_comparison_chart_shown_unique"),
-    PREONBOARDING_DEFAULT_BROWSER_PAGE_SHOWN_UNIQUE("m_preonboarding_default_browser_page_shown_unique"),
     PREONBOARDING_CHOOSE_BROWSER_PRESSED("m_preonboarding_choose_browser_pressed"),
     PREONBOARDING_ADDRESS_BAR_POSITION_SHOWN_UNIQUE("m_preonboarding_address_bar_position_dialog_shown_unique"),
     PREONBOARDING_BOTTOM_ADDRESS_BAR_SELECTED_UNIQUE("m_preonboarding_bottom_address_bar_selected_unique"),

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/DefaultBrowserPageViewModelTest.kt
@@ -26,7 +26,6 @@ import com.duckduckgo.app.onboarding.ui.page.DefaultBrowserPageViewModel.Origin
 import com.duckduckgo.app.onboarding.ui.page.DefaultBrowserPageViewModel.ViewState.*
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelValues.DEFAULT_BROWSER_DIALOG
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelValues.DEFAULT_BROWSER_SETTINGS
 import org.junit.After
@@ -361,20 +360,6 @@ class DefaultBrowserPageViewModelTest {
         testee.handleResult(Origin.InternalBrowser)
 
         assertEquals(0, testee.timesPressedJustOnce)
-    }
-
-    @Test
-    fun whenViewModelInitializedThenPageShownPixelIsNotFired() {
-        testee = DefaultBrowserPageViewModel(mockDefaultBrowserDetector, mockPixel, mockInstallStore)
-
-        verify(mockPixel, never()).fire(AppPixelName.PREONBOARDING_DEFAULT_BROWSER_PAGE_SHOWN_UNIQUE, type = Unique())
-    }
-
-    @Test
-    fun whenOnPageShownCalledThenPageShownPixelIsFired() {
-        testee.onPageShown()
-
-        verify(mockPixel).fire(AppPixelName.PREONBOARDING_DEFAULT_BROWSER_PAGE_SHOWN_UNIQUE, type = Unique())
     }
 
     private fun captureCommands(): KArgumentCaptor<Command> {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207908166761516/task/1213393365036875?focus=true

### Description

Removes the temporary pixel `m_preonboarding_default_browser_page_shown_unique`, which was added to gauge whether users reach the default browser page during onboarding. It has served its purpose and expired, so this removes the pixel and all the plumbing that fired it.

### Steps to test this PR

- [ ] On a device/emulator running API 28 or below, clean install and launch the app
- [ ] Proceed through onboarding to the "Choose Default Browser" screen
- [ ] Check the logs and confirm `m_preonboarding_default_browser_page_shown_unique` is no longer fired

### UI changes
N/A
