### PR TITLE
Trim volatile facts from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,12 @@ The following rule files contain detailed guidance for specific topics. Read the
 
 DuckDuckGo Android is a privacy-focused browser with 100+ Gradle modules. The app provides built-in search, tracker blocking, HTTPS enforcement, and other privacy features.
 
-**SDK targets:** minSdk 26, targetSdk 35, compileSdk 35
-**Language:** Kotlin (1.9.24), Java 17 (JVM toolchain)
-**Build:** Gradle 7.6, AGP via refreshVersions, Anvil (Dagger2)
+**Versions** (SDK levels, Kotlin, Gradle, libraries) live in the build files — don't restate them here:
+`min_sdk` / `target_sdk` / `compile_sdk` in `build.gradle`, `version.kotlin` in `versions.properties`,
+and the Gradle version in `gradle/wrapper/gradle-wrapper.properties`.
+**Build:** AGP via refreshVersions. DI is Anvil/Dagger2 today, with a migration to **Metro** in flight
+(dual-build selected by the `ddg.di` Gradle property; see `build.gradle`).
+**Toolchain:** Kotlin JVM target 17; building requires **JDK 21** (Metro compiler plugin).
 
 ---
 
@@ -159,8 +162,8 @@ These rules are enforced in the root `build.gradle`. Violations fail the build.
 
 ## Code Formatting
 
-- **Spotless** with ktlint (0.50.0) for Kotlin
-- Google Java Format (1.22.0) in AOSP style for Java
+- **Spotless** with ktlint for Kotlin
+- Google Java Format in AOSP style for Java
 - Max line length: 150 characters
 - Ratchet from `origin/develop` (only enforces formatting on changed code)
 
@@ -181,13 +184,6 @@ The `lint-rules` module enforces at compile time:
 
 ## Key Dependencies
 
-| Category | Library |
-|---|---|
-| DI | Dagger2 + Square Anvil |
-| Database | Room (with RxJava2 support) |
-| Network | Retrofit2 + OkHttp3 + Moshi |
-| Async | Kotlin Coroutines |
-| UI | Jetpack Compose (selective), Material Design |
-| Scheduling | WorkManager |
-| Logging | logcat (Square) |
-| Annotation Processing | KSP |
+Declared in `versions.properties` and module `build.gradle` files. Notable choices: DI via
+Anvil/Dagger2 (migrating to Metro), Room, Retrofit/OkHttp/Moshi, Coroutines, Jetpack Compose
+(selective), WorkManager, `logcat` (Square), and KSP for annotation processing.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214901934989258/task/1215497146488714

### Description
Conservatively trims `AGENTS.md` to remove volatile/inferable facts (hardcoded version numbers and the dependency-inventory table) and corrects the stale DI-framework claim (Anvil today, Metro migration in flight). Versions now point to their source of truth (`versions.properties`, `gradle-wrapper.properties`, `build.gradle`). Rule tables and non-obvious command aliases are kept.

Motivation: stated facts that duplicate the codebase drift silently (e.g. Kotlin was listed as 1.9.24, actually 2.2.21; Gradle 7.6, actually 8.14.4), and per Gloaguen et al. ([arXiv 2602.11988](https://arxiv.org/abs/2602.11988)) repository context files that carry superfluous/inferable requirements tend to *reduce* coding-agent success and add 20%+ cost. Keep only minimal, non-inferable guidance.

First of two PRs; PR 2 adds a drift-audit GitHub agentic workflow that guards the slimmed file and flags re-introduced volatile facts.

### Steps to test this PR
- [ ] Confirm `AGENTS.md` no longer states version numbers and the pointers resolve (`versions.properties`, `gradle/wrapper/gradle-wrapper.properties`, `build.gradle`)
- [ ] `./gradlew spotlessCheck`

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to AGENTS.md with no runtime or build logic impact.
> 
> **Overview**
> **Slims `AGENTS.md`** so agent guidance does not duplicate values that drift from the repo.
> 
> Hardcoded **SDK/Kotlin/Gradle/library versions** and the **Key Dependencies** table are removed; the doc now points readers to `build.gradle`, `versions.properties`, and `gradle/wrapper/gradle-wrapper.properties` for current numbers. **Spotless** wording drops pinned ktlint/Java format versions while keeping behavior (ktlint, AOSP Java, 150-char lines, ratchet from `origin/develop`).
> 
> The **build/DI** section is updated to match reality: **Anvil/Dagger2** as today’s stack, **Metro** migration and the `ddg.di` Gradle switch, and **JDK 21** for builds with JVM target 17. Rule tables, commands, and lint guidance are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ca26e30a5f50934e667c95c3d07fb354e4b0363. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->