### PR TITLE
Extend drift audit to .cursor/rules

### DIFF
--- a/.cursor/rules/dependency-updates.mdc
+++ b/.cursor/rules/dependency-updates.mdc
@@ -33,8 +33,9 @@ It is required by the refreshVersions plugin at build time. If missing, the buil
 
 This is the most important rule when evaluating a library update.
 
-**The project currently uses Kotlin 1.9.24.** Many libraries have silently started publishing
-releases compiled with Kotlin 2.x. These cause a build failure at KSP/kapt time:
+**The project's Kotlin version is pinned in `versions.properties` (`version.kotlin`).** Many libraries
+may publish releases compiled with a newer Kotlin than the one we are pinned to. These cause a build
+failure at KSP/kapt time:
 
 ```
 Module was compiled with an incompatible version of Kotlin.
@@ -45,7 +46,7 @@ The binary version of its metadata is 2.x.x, expected version is 1.9.0.
 
 **Do not auto-revert.** Instead, **ask the engineer**:
 
-> "Library X update from A → B requires Kotlin 2.x (currently on 1.9.24).
+> "Library X update from A → B requires a newer Kotlin than our pinned `version.kotlin`.
 > Do you want to:
 > 1. Skip this update for now
 > 2. Include it as a separate task to upgrade Kotlin first"

--- a/.github/workflows/drift-audit.lock.yml
+++ b/.github/workflows/drift-audit.lock.yml
@@ -20,13 +20,13 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# Detects drift between AGENTS.md and the codebase. Runs a deterministic checker over a
-# claim registry, surveys recent develop activity for new or uncovered claims, and opens a
-# draft PR correcting AGENTS.md when it finds drift or a re-introduced volatile fact.
+# Detects drift between the AI-docs files (AGENTS.md and registered .cursor/rules/*.mdc) and the
+# codebase. Runs a deterministic checker over a claim registry, surveys recent develop activity for
+# new or uncovered claims, and opens a draft PR correcting the affected doc when it finds drift.
 #
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f044d9d3d54e20792c838dbf673ae74e6b1a333d4b132226d4b58dc928813107","compiler_version":"v0.64.4","strict":true,"agent_id":"claude"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"48630e14ce8d43a6ddf5b057e89f214edc24f22ac0c53c2b9bda880103e6321c","compiler_version":"v0.64.4","strict":true,"agent_id":"claude"}
 
-name: "AGENTS.md Drift Audit"
+name: "AI-docs Drift Audit"
 "on":
   schedule:
   - cron: "0 5 */3 * *"
@@ -44,7 +44,7 @@ concurrency:
   cancel-in-progress: false
   group: drift-audit
 
-run-name: "AGENTS.md Drift Audit"
+run-name: "AI-docs Drift Audit"
 
 jobs:
   activation:
@@ -71,7 +71,7 @@ jobs:
           GH_AW_INFO_VERSION: "latest"
           GH_AW_INFO_AGENT_VERSION: "latest"
           GH_AW_INFO_CLI_VERSION: "v0.64.4"
-          GH_AW_INFO_WORKFLOW_NAME: "AGENTS.md Drift Audit"
+          GH_AW_INFO_WORKFLOW_NAME: "AI-docs Drift Audit"
           GH_AW_INFO_EXPERIMENTAL: "false"
           GH_AW_INFO_SUPPORTS_TOOLS_ALLOWLIST: "true"
           GH_AW_INFO_STAGED: "false"
@@ -128,19 +128,19 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_f9d49b0f4a1ada01_EOF'
+          cat << 'GH_AW_PROMPT_48eaa40a1d7e3fd4_EOF'
           <system>
-          GH_AW_PROMPT_f9d49b0f4a1ada01_EOF
+          GH_AW_PROMPT_48eaa40a1d7e3fd4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_f9d49b0f4a1ada01_EOF'
+          cat << 'GH_AW_PROMPT_48eaa40a1d7e3fd4_EOF'
           <safe-output-tools>
           Tools: create_pull_request, missing_tool, missing_data, noop
-          GH_AW_PROMPT_f9d49b0f4a1ada01_EOF
+          GH_AW_PROMPT_48eaa40a1d7e3fd4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_f9d49b0f4a1ada01_EOF'
+          cat << 'GH_AW_PROMPT_48eaa40a1d7e3fd4_EOF'
           </safe-output-tools>
           <github-context>
           The following GitHub context information is available for this workflow:
@@ -170,14 +170,14 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_f9d49b0f4a1ada01_EOF
+          GH_AW_PROMPT_48eaa40a1d7e3fd4_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_f9d49b0f4a1ada01_EOF'
+          cat << 'GH_AW_PROMPT_48eaa40a1d7e3fd4_EOF'
           </system>
-          GH_AW_PROMPT_f9d49b0f4a1ada01_EOF
-          cat << 'GH_AW_PROMPT_f9d49b0f4a1ada01_EOF'
+          GH_AW_PROMPT_48eaa40a1d7e3fd4_EOF
+          cat << 'GH_AW_PROMPT_48eaa40a1d7e3fd4_EOF'
           {{#runtime-import .github/workflows/drift-audit.md}}
-          GH_AW_PROMPT_f9d49b0f4a1ada01_EOF
+          GH_AW_PROMPT_48eaa40a1d7e3fd4_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -337,12 +337,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_9daa7fe95c822b32_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_70d525327f2d7203_EOF'
           {"create_pull_request":{"base_branch":"develop","draft":true,"github-token":"${{ secrets.GT_DAXMOBILE }}","labels":["drift-audit"],"max":1,"max_patch_size":1024,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS"],"protected_path_prefixes":[".github/",".agents/"],"title_prefix":"[Drift Audit] "},"mentions":{"enabled":false},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_9daa7fe95c822b32_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_70d525327f2d7203_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_a60d873c21b0e4ef_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_2e15dc062e24dc25_EOF'
           {
             "description_suffixes": {
               "create_pull_request": " CONSTRAINTS: Maximum 1 pull request(s) can be created. Title will be prefixed with \"[Drift Audit] \". Labels [\"drift-audit\"] will be automatically added. PRs will be created as drafts."
@@ -350,8 +350,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_a60d873c21b0e4ef_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_96108735efdef8ae_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_2e15dc062e24dc25_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_f43351c71dd674ea_EOF'
           {
             "create_pull_request": {
               "defaultMax": 1,
@@ -447,7 +447,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_96108735efdef8ae_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_f43351c71dd674ea_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -514,7 +514,7 @@ jobs:
           export GH_AW_ENGINE="claude"
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.9'
           
-          cat << GH_AW_MCP_CONFIG_cd0974cef50312c5_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_f2c8f2e490ef1a88_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -554,7 +554,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_cd0974cef50312c5_EOF
+          GH_AW_MCP_CONFIG_f2c8f2e490ef1a88_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -837,7 +837,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_NOOP_MAX: "1"
-          GH_AW_WORKFLOW_NAME: "AGENTS.md Drift Audit"
+          GH_AW_WORKFLOW_NAME: "AI-docs Drift Audit"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -851,7 +851,7 @@ jobs:
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
           GH_AW_MISSING_TOOL_CREATE_ISSUE: "true"
-          GH_AW_WORKFLOW_NAME: "AGENTS.md Drift Audit"
+          GH_AW_WORKFLOW_NAME: "AI-docs Drift Audit"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |
@@ -865,7 +865,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "AGENTS.md Drift Audit"
+          GH_AW_WORKFLOW_NAME: "AI-docs Drift Audit"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_WORKFLOW_ID: "drift-audit"
@@ -889,7 +889,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "AGENTS.md Drift Audit"
+          GH_AW_WORKFLOW_NAME: "AI-docs Drift Audit"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GH_AW_AGENT_CONCLUSION: ${{ needs.agent.result }}
           GH_AW_NOOP_MESSAGE: ${{ steps.noop.outputs.noop_message }}
@@ -906,7 +906,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           GH_AW_AGENT_OUTPUT: ${{ steps.setup-agent-output-env.outputs.GH_AW_AGENT_OUTPUT }}
-          GH_AW_WORKFLOW_NAME: "AGENTS.md Drift Audit"
+          GH_AW_WORKFLOW_NAME: "AI-docs Drift Audit"
           GH_AW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
@@ -984,8 +984,8 @@ jobs:
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
-          WORKFLOW_NAME: "AGENTS.md Drift Audit"
-          WORKFLOW_DESCRIPTION: "Detects drift between AGENTS.md and the codebase. Runs a deterministic checker over a\nclaim registry, surveys recent develop activity for new or uncovered claims, and opens a\ndraft PR correcting AGENTS.md when it finds drift or a re-introduced volatile fact."
+          WORKFLOW_NAME: "AI-docs Drift Audit"
+          WORKFLOW_DESCRIPTION: "Detects drift between the AI-docs files (AGENTS.md and registered .cursor/rules/*.mdc) and the\ncodebase. Runs a deterministic checker over a claim registry, surveys recent develop activity for\nnew or uncovered claims, and opens a draft PR correcting the affected doc when it finds drift."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |
@@ -1086,7 +1086,7 @@ jobs:
       GH_AW_ENGINE_ID: "claude"
       GH_AW_ENGINE_MODEL: ${{ needs.agent.outputs.model }}
       GH_AW_WORKFLOW_ID: "drift-audit"
-      GH_AW_WORKFLOW_NAME: "AGENTS.md Drift Audit"
+      GH_AW_WORKFLOW_NAME: "AI-docs Drift Audit"
     outputs:
       code_push_failure_count: ${{ steps.process_safe_outputs.outputs.code_push_failure_count }}
       code_push_failure_errors: ${{ steps.process_safe_outputs.outputs.code_push_failure_errors }}

--- a/.github/workflows/drift-audit.md
+++ b/.github/workflows/drift-audit.md
@@ -1,8 +1,8 @@
 ---
 description: |
-  Detects drift between AGENTS.md and the codebase. Runs a deterministic checker over a
-  claim registry, surveys recent develop activity for new or uncovered claims, and opens a
-  draft PR correcting AGENTS.md when it finds drift or a re-introduced volatile fact.
+  Detects drift between the AI-docs files (AGENTS.md and registered .cursor/rules/*.mdc) and the
+  codebase. Runs a deterministic checker over a claim registry, surveys recent develop activity for
+  new or uncovered claims, and opens a draft PR correcting the affected doc when it finds drift.
 
 on:
   workflow_dispatch:
@@ -39,17 +39,20 @@ safe-outputs:
 engine: claude
 ---
 
-# AGENTS.md Drift Audit
+# AI-docs Drift Audit
 
-You are the AGENTS.md Drift Auditor for the DuckDuckGo Android repository. Your job is to keep
-`AGENTS.md` honest: it must not state facts that disagree with the codebase, and it must not
-re-introduce volatile version numbers that were deliberately removed. When you find drift, you
-open ONE draft PR with the fix. You never merge PRs yourself.
+You are the AI-docs Drift Auditor for the DuckDuckGo Android repository. Your job is to keep the
+registered AI-docs files honest — `AGENTS.md` and the `.cursor/rules/*.mdc` files listed in the
+registry. They must not state facts that disagree with the codebase, and must not re-introduce
+volatile version numbers that were deliberately removed. When you find drift, you open ONE draft PR
+with the fix. You never merge PRs yourself.
 
 Always be:
 - Deterministic first: trust `scripts/drift-audit/check.py` for the registered facts; do not
   eyeball version numbers yourself.
-- Focused: only touch `AGENTS.md` and `scripts/drift-audit/registry.json`. Never change code.
+- Focused: only touch the registered doc files (`AGENTS.md` and `.cursor/rules/*.mdc`) and
+  `scripts/drift-audit/registry.json`. Never change code or other docs. Edit the `.cursor/rules/*.mdc`
+  canonical files, never the `.claude/rules/*.md` symlinks.
 - Honest: if nothing drifted, open no PR and say so.
 - Transparent: every PR you open identifies you as Drift Auditor (🤖).
 - Restrained: when a fix needs human judgement, describe it in the PR rather than guessing.
@@ -65,18 +68,19 @@ python3 scripts/drift-audit/check.py
 ```
 
 It prints JSON: `{"clean": <bool>, "findings": [...]}` and exits 0 when clean, 1 when there are
-findings. Each finding has an `id` and `status`:
+findings. Each finding names the offending `file` and has an `id` and `status`:
 - `volatile-fact-guard` (`status: drift`) — a tool name followed by a version number reappeared
-  in `AGENTS.md`. The fix is to remove the version and point to the source of truth.
+  in that file. The fix is to remove the version and point to the source of truth.
 - A registry claim with `status: review` (e.g. `di-framework`) — a source signal changed; read
-  the finding's `message` and update the relevant `AGENTS.md` wording.
-- A registry claim with `status: drift` — the stated value disagrees with the codebase value.
+  the finding's `message` and update the relevant wording in the named file.
+- A registry claim with `status: drift` — a stated value or a referenced file path disagrees with
+  the codebase (e.g. a `path-exists` target was moved or renamed). Fix the named file per the message.
 
 ### Step 2: Survey what landed recently (judgement layer)
 
 Using the GitHub tools, list pull requests merged to `develop` since roughly the last
 `[Drift Audit]` PR (or the last few days if there is none). Skim their changes and re-read
-`AGENTS.md` for:
+the registered docs for:
 - New non-inferable claims worth adding to `scripts/drift-audit/registry.json`.
 - Conventions the doc states that recent changes have invalidated but the registry does not yet cover.
 
@@ -91,8 +95,9 @@ not register illustrative examples or anything an agent could discover by readin
 
 ### Step 4: Open the draft PR
 
-Fix `AGENTS.md` for every finding, and update `scripts/drift-audit/registry.json` if Step 2 found
-a gap. Re-run `python3 scripts/drift-audit/check.py` and confirm it is clean before opening the PR.
+Fix the affected file (each finding's `file`) for every finding, and update
+`scripts/drift-audit/registry.json` if Step 2 found a gap. Re-run `python3 scripts/drift-audit/check.py`
+and confirm it is clean before opening the PR.
 
 Use the repo's PR template (`.github/PULL_REQUEST_TEMPLATE.md`) exactly. Do not add any content
 above the first line of the template.
@@ -104,10 +109,10 @@ Body (follow the template exactly — replace the placeholder sections):
     Task/Issue URL: https://app.asana.com/1/137249556945/project/1214901934989258/task/1214933126123976
 
     ### Description
-    <For each finding: what AGENTS.md said, what the codebase actually is, and the source file.
-    Note any registry additions from the recent-activity survey.>
+    <For each finding: which file drifted, what it said, what the codebase actually is, and the
+    source. Note any registry additions from the recent-activity survey.>
 
-    🤖 AGENTS.md Drift Auditor
+    🤖 AI-docs Drift Auditor
 
     ### Steps to test this PR
     - [ ] python3 scripts/drift-audit/check.py   (exits 0 / "clean": true)
@@ -128,7 +133,8 @@ are unsure about):
 
 ## Guidelines
 
-- Scope: only `AGENTS.md` and `scripts/drift-audit/registry.json`. Never modify code or other docs.
-- Trust the checker: the registered version/signal facts come from `check.py`, not your own memory.
+- Scope: only the registered doc files (`AGENTS.md`, `.cursor/rules/*.mdc`) and
+  `scripts/drift-audit/registry.json`. Never modify code or other docs.
+- Trust the checker: the registered version/signal/path facts come from `check.py`, not your own memory.
 - One PR per run: never open more than one `[Drift Audit]` PR in a single run.
-- AI transparency: every PR description includes the 🤖 AGENTS.md Drift Auditor disclosure.
+- AI transparency: every PR description includes the 🤖 AI-docs Drift Auditor disclosure.

--- a/scripts/drift-audit/check.py
+++ b/scripts/drift-audit/check.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
-"""Deterministic drift checker for AGENTS.md.
+"""Deterministic drift checker for AI-docs files.
 
-Reads `.github/drift-audit/registry.json` and verifies two things:
+Reads `scripts/drift-audit/registry.json` and, for each registered doc
+(`AGENTS.md` and selected `.cursor/rules/*.mdc`), verifies:
 
-  1. AGENTS.md has not re-introduced volatile version numbers (the inverse
-     guard — see the spec). A trimmed AGENTS.md points to the build files for
+  1. The doc has not re-introduced volatile version numbers (the inverse
+     guard — see the spec). Trimmed docs point to the build files for
      versions; if a tool name reappears followed by a semver, that's drift.
-  2. Each registered claim still agrees with the codebase.
+  2. Each registered claim still agrees with the codebase (source signals,
+     value equality, referenced file paths).
 
 Prints a JSON report to stdout. Exit code 0 = clean, 1 = findings found.
 
@@ -28,15 +30,13 @@ def load_registry(path):
         return json.load(fh)
 
 
-def run_guard(agents_text, guard):
+def run_guard(text, pattern, allow):
     """Flag a known tool name immediately followed by a semver-like version."""
     findings = []
-    if not guard:
-        return findings
-    pattern = re.compile(guard["pattern"])
-    allow = set(guard.get("allow", []))
-    for line_no, line in enumerate(agents_text.splitlines(), start=1):
-        for match in pattern.finditer(line):
+    compiled = re.compile(pattern)
+    allow = set(allow or [])
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        for match in compiled.finditer(line):
             snippet = match.group(0)
             if snippet in allow:
                 continue
@@ -45,7 +45,7 @@ def run_guard(agents_text, guard):
                 "status": "drift",
                 "line": line_no,
                 "match": snippet,
-                "message": "AGENTS.md restates a tool version number; remove it and point to the source of truth.",
+                "message": "Restates a tool version number; remove it and point to the source of truth.",
             })
     return findings
 
@@ -56,7 +56,7 @@ def _shell(cmd, root):
     ).stdout.strip()
 
 
-def run_claim(claim, agents_text, root):
+def run_claim(claim, doc_text, root):
     ctype = claim.get("type")
     if ctype == "source_signal":
         actual = _shell(claim["extract"], root)
@@ -71,7 +71,7 @@ def run_claim(claim, agents_text, root):
         return None
     if ctype == "equals":
         actual = _shell(claim["extract"], root)
-        match = re.search(claim["doc_pattern"], agents_text)
+        match = re.search(claim["doc_pattern"], doc_text)
         doc_value = match.group(1) if match else None
         if doc_value != actual:
             return {
@@ -79,7 +79,17 @@ def run_claim(claim, agents_text, root):
                 "status": "drift",
                 "doc_value": doc_value,
                 "actual": actual,
-                "message": claim.get("on_mismatch", "AGENTS.md value disagrees with the codebase."),
+                "message": claim.get("on_mismatch", "Doc value disagrees with the codebase."),
+            }
+        return None
+    if ctype == "path-exists":
+        target = os.path.join(root, claim["target"])
+        if not os.path.exists(target):
+            return {
+                "id": claim["id"],
+                "status": "drift",
+                "target": claim["target"],
+                "message": claim.get("on_missing", "Referenced file no longer exists."),
             }
         return None
     return {
@@ -89,20 +99,35 @@ def run_claim(claim, agents_text, root):
     }
 
 
-def audit(registry, root):
-    agents_path = os.path.join(root, registry["agents_md"])
-    with open(agents_path) as fh:
-        agents_text = fh.read()
-    findings = list(run_guard(agents_text, registry.get("volatile_fact_guard")))
-    for claim in registry.get("claims", []):
-        finding = run_claim(claim, agents_text, root)
+def audit_doc(doc, registry, root):
+    """Run the guard and claims for a single registered doc. Returns findings,
+    each tagged with the doc's path."""
+    findings = []
+    doc_path = doc["path"]
+    with open(os.path.join(root, doc_path)) as fh:
+        text = fh.read()
+
+    if doc.get("guard"):
+        findings += run_guard(text, registry["guard_pattern"], doc.get("guard_allow", []))
+    for claim in doc.get("claims", []):
+        finding = run_claim(claim, text, root)
         if finding:
             findings.append(finding)
+
+    for finding in findings:
+        finding["file"] = doc_path
+    return findings
+
+
+def audit(registry, root):
+    findings = []
+    for doc in registry.get("docs", []):
+        findings += audit_doc(doc, registry, root)
     return findings
 
 
 def main(argv=None):
-    parser = argparse.ArgumentParser(description="AGENTS.md drift checker")
+    parser = argparse.ArgumentParser(description="AI-docs drift checker")
     parser.add_argument(
         "--registry",
         default=os.path.join(os.path.dirname(__file__), "registry.json"),

--- a/scripts/drift-audit/registry.json
+++ b/scripts/drift-audit/registry.json
@@ -1,18 +1,46 @@
 {
-  "agents_md": "AGENTS.md",
-  "volatile_fact_guard": {
-    "description": "AGENTS.md must not restate tool version numbers — they drift and are inferable from the build files. Flag a known tool name immediately followed by a semver-like version (x.y or x.y.z). Single integers (e.g. 'JDK 21', 'JVM target 17') are intentionally allowed.",
-    "pattern": "(?i)\\b(kotlin|gradle|ktlint|google java format|agp)\\b\\s*\\(?\\s*v?\\d+\\.\\d+(?:\\.\\d+)?\\)?",
-    "allow": []
-  },
-  "claims": [
+  "guard_description": "Guarded docs must not restate tool version numbers — they drift and are inferable from the build files. The guard flags a known tool name immediately followed by a semver-like version (x.y or x.y.z). Single integers (e.g. 'JDK 21', 'JVM target 17') are intentionally allowed. Use a doc's guard_allow to whitelist intentional example snippets.",
+  "guard_pattern": "(?i)\\b(kotlin|gradle|ktlint|google java format|agp)\\b\\s*\\(?\\s*v?\\d+\\.\\d+(?:\\.\\d+)?\\)?",
+  "docs": [
     {
-      "id": "di-framework",
-      "type": "source_signal",
-      "extract": "grep -q 'dev.zacsweers.metro' build.gradle && echo present || echo absent",
-      "expected": "present",
-      "doc_note": "AGENTS.md states DI is Anvil/Dagger2 today with a Metro migration in flight (the 'dev.zacsweers.metro' plugin in build.gradle).",
-      "on_mismatch": "build.gradle no longer shows the 'dev.zacsweers.metro' plugin; the Metro migration may be complete or reverted. Review the DI wording in AGENTS.md (Project Overview > Build) and update the claim accordingly."
+      "path": "AGENTS.md",
+      "guard": true,
+      "guard_allow": [],
+      "claims": [
+        {
+          "id": "di-framework",
+          "type": "source_signal",
+          "extract": "grep -q 'dev.zacsweers.metro' build.gradle && echo present || echo absent",
+          "expected": "present",
+          "doc_note": "AGENTS.md states DI is Anvil/Dagger2 today with a Metro migration in flight (the 'dev.zacsweers.metro' plugin in build.gradle).",
+          "on_mismatch": "build.gradle no longer shows the 'dev.zacsweers.metro' plugin; the Metro migration may be complete or reverted. Review the DI wording in AGENTS.md (Project Overview > Build) and update the claim accordingly."
+        }
+      ]
+    },
+    {
+      "path": ".cursor/rules/dependency-updates.mdc",
+      "guard": true,
+      "guard_allow": [],
+      "claims": []
+    },
+    {
+      "path": ".cursor/rules/wide-events.mdc",
+      "guard": false,
+      "guard_allow": [],
+      "claims": [
+        {
+          "id": "wide-events-pageload-ref",
+          "type": "path-exists",
+          "target": "app/src/main/java/com/duckduckgo/app/browser/pageload/PageLoadWideEvent.kt",
+          "on_missing": "wide-events.mdc cites this reference implementation; the file was moved or renamed. Update the path in the 'Reference implementations' list."
+        },
+        {
+          "id": "wide-events-subscription-ref",
+          "type": "path-exists",
+          "target": "subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/wideevents/SubscriptionPurchaseWideEvent.kt",
+          "on_missing": "wide-events.mdc cites this reference implementation (abbreviated as '.../SubscriptionPurchaseWideEvent.kt'); the file was moved or renamed. Update the reference."
+        }
+      ]
     }
   ]
 }

--- a/scripts/drift-audit/test_check.py
+++ b/scripts/drift-audit/test_check.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""Tests for the AGENTS.md drift checker. stdlib unittest only."""
-import json
+"""Tests for the AI-docs drift checker. stdlib unittest only."""
 import os
 import tempfile
 import unittest
@@ -8,10 +7,7 @@ import unittest
 import check
 
 
-GUARD = {
-    "pattern": r"(?i)\b(kotlin|gradle|ktlint|google java format|agp)\b\s*\(?\s*v?\d+\.\d+(?:\.\d+)?\)?",
-    "allow": [],
-}
+PATTERN = r"(?i)\b(kotlin|gradle|ktlint|google java format|agp)\b\s*\(?\s*v?\d+\.\d+(?:\.\d+)?\)?"
 
 
 class GuardTests(unittest.TestCase):
@@ -24,75 +20,70 @@ class GuardTests(unittest.TestCase):
             "- Max line length: 150 characters\n"
             "**Toolchain:** Kotlin JVM target 17; building requires JDK 21.\n"
         )
-        self.assertEqual(check.run_guard(text, GUARD), [])
+        self.assertEqual(check.run_guard(text, PATTERN, []), [])
 
     def test_flags_reintroduced_kotlin_version(self):
-        findings = check.run_guard("**Language:** Kotlin (1.9.24)\n", GUARD)
+        findings = check.run_guard("**Language:** Kotlin (1.9.24)\n", PATTERN, [])
         self.assertEqual(len(findings), 1)
         self.assertEqual(findings[0]["id"], "volatile-fact-guard")
         self.assertEqual(findings[0]["line"], 1)
-        self.assertIn("1.9.24", findings[0]["match"])
+        self.assertEqual(findings[0]["match"], "Kotlin (1.9.24)")
 
     def test_flags_reintroduced_gradle_version(self):
-        findings = check.run_guard("Build: Gradle 7.6, AGP via refreshVersions\n", GUARD)
+        findings = check.run_guard("Build: Gradle 7.6, AGP via refreshVersions\n", PATTERN, [])
         self.assertTrue(any("7.6" in f["match"] for f in findings))
 
     def test_single_integers_are_allowed(self):
         # "JDK 21" and "JVM target 17" must NOT be flagged (kept on purpose).
-        findings = check.run_guard("Kotlin JVM target 17; building requires JDK 21.\n", GUARD)
+        findings = check.run_guard("Kotlin JVM target 17; building requires JDK 21.\n", PATTERN, [])
         self.assertEqual(findings, [])
 
     def test_allowlist_suppresses_a_match(self):
-        guard = dict(GUARD, allow=["ktlint (0.50.0)"])
-        findings = check.run_guard("- Spotless with ktlint (0.50.0)\n", guard)
+        findings = check.run_guard("- Spotless with ktlint (0.50.0)\n", PATTERN, ["ktlint (0.50.0)"])
         self.assertEqual(findings, [])
+
+    def test_non_guarded_tool_names_are_not_flagged(self):
+        # The example bump table in dependency-updates.mdc uses tools that are
+        # NOT in the guard list (turbine, harmony) — they must not be flagged.
+        text = "| `app.cash.turbine` | 1.1.0 | 1.2.1 |\n| `com.frybits.harmony` | 1.2.6 | 1.2.7 |\n"
+        self.assertEqual(check.run_guard(text, PATTERN, []), [])
 
 
 class ClaimTests(unittest.TestCase):
     def test_source_signal_present_passes(self):
-        claim = {
-            "id": "di-framework",
-            "type": "source_signal",
-            "extract": "echo present",
-            "expected": "present",
-            "on_mismatch": "review the DI wording",
-        }
+        claim = {"id": "di", "type": "source_signal", "extract": "echo present", "expected": "present", "on_mismatch": "x"}
         self.assertIsNone(check.run_claim(claim, "", "."))
 
     def test_source_signal_absent_flags_review(self):
-        claim = {
-            "id": "di-framework",
-            "type": "source_signal",
-            "extract": "echo absent",
-            "expected": "present",
-            "on_mismatch": "review the DI wording",
-        }
+        claim = {"id": "di", "type": "source_signal", "extract": "echo absent", "expected": "present", "on_mismatch": "review"}
         finding = check.run_claim(claim, "", ".")
-        self.assertIsNotNone(finding)
         self.assertEqual(finding["status"], "review")
         self.assertEqual(finding["actual"], "absent")
 
     def test_equals_match_passes(self):
-        claim = {
-            "id": "example",
-            "type": "equals",
-            "doc_pattern": r"value is (\S+)",
-            "extract": "echo 1.2.3",
-        }
+        claim = {"id": "e", "type": "equals", "doc_pattern": r"value is (\S+)", "extract": "echo 1.2.3"}
         self.assertIsNone(check.run_claim(claim, "the value is 1.2.3 here", "."))
 
     def test_equals_mismatch_flags_drift(self):
-        claim = {
-            "id": "example",
-            "type": "equals",
-            "doc_pattern": r"value is (\S+)",
-            "extract": "echo 9.9.9",
-            "on_mismatch": "stale",
-        }
+        claim = {"id": "e", "type": "equals", "doc_pattern": r"value is (\S+)", "extract": "echo 9.9.9", "on_mismatch": "stale"}
         finding = check.run_claim(claim, "the value is 1.2.3 here", ".")
         self.assertEqual(finding["status"], "drift")
         self.assertEqual(finding["doc_value"], "1.2.3")
         self.assertEqual(finding["actual"], "9.9.9")
+
+    def test_path_exists_passes_for_present_file(self):
+        with tempfile.TemporaryDirectory() as root:
+            os.makedirs(os.path.join(root, "src"))
+            open(os.path.join(root, "src", "Foo.kt"), "w").close()
+            claim = {"id": "p", "type": "path-exists", "target": "src/Foo.kt"}
+            self.assertIsNone(check.run_claim(claim, "", root))
+
+    def test_path_exists_flags_missing_file(self):
+        with tempfile.TemporaryDirectory() as root:
+            claim = {"id": "p", "type": "path-exists", "target": "src/Gone.kt", "on_missing": "moved"}
+            finding = check.run_claim(claim, "", root)
+            self.assertEqual(finding["status"], "drift")
+            self.assertEqual(finding["target"], "src/Gone.kt")
 
     def test_unknown_type_is_error(self):
         finding = check.run_claim({"id": "x", "type": "bogus"}, "", ".")
@@ -100,18 +91,42 @@ class ClaimTests(unittest.TestCase):
 
 
 class AuditTests(unittest.TestCase):
-    def test_audit_clean_then_dirty(self):
-        with tempfile.TemporaryDirectory() as root:
-            agents = os.path.join(root, "AGENTS.md")
-            with open(agents, "w") as fh:
-                fh.write("Versions live in the build files.\n")
-            registry = {"agents_md": "AGENTS.md", "volatile_fact_guard": GUARD, "claims": []}
-            self.assertEqual(check.audit(registry, root), [])
+    def _registry(self, docs):
+        return {"guard_pattern": PATTERN, "docs": docs}
 
-            with open(agents, "w") as fh:
-                fh.write("Kotlin (1.9.24) and Gradle 7.6\n")
+    def test_audit_tags_findings_with_file(self):
+        with tempfile.TemporaryDirectory() as root:
+            with open(os.path.join(root, "DOC.md"), "w") as fh:
+                fh.write("Kotlin (1.9.24)\n")
+            registry = self._registry([{"path": "DOC.md", "guard": True, "guard_allow": [], "claims": []}])
             findings = check.audit(registry, root)
-            self.assertEqual(len(findings), 2)
+            self.assertEqual(len(findings), 1)
+            self.assertEqual(findings[0]["file"], "DOC.md")
+
+    def test_audit_runs_multiple_docs(self):
+        with tempfile.TemporaryDirectory() as root:
+            with open(os.path.join(root, "A.md"), "w") as fh:
+                fh.write("Versions live in the build files.\n")
+            with open(os.path.join(root, "B.md"), "w") as fh:
+                fh.write("Gradle 7.6\n")
+            registry = self._registry([
+                {"path": "A.md", "guard": True, "guard_allow": [], "claims": []},
+                {"path": "B.md", "guard": True, "guard_allow": [], "claims": []},
+            ])
+            findings = check.audit(registry, root)
+            self.assertEqual([f["file"] for f in findings], ["B.md"])
+
+    def test_audit_path_exists_claim_on_doc(self):
+        with tempfile.TemporaryDirectory() as root:
+            with open(os.path.join(root, "C.md"), "w") as fh:
+                fh.write("see Ref.kt\n")
+            registry = self._registry([{
+                "path": "C.md", "guard": False, "guard_allow": [],
+                "claims": [{"id": "ref", "type": "path-exists", "target": "Ref.kt", "on_missing": "gone"}],
+            }])
+            findings = check.audit(registry, root)
+            self.assertEqual(findings[0]["id"], "ref")
+            self.assertEqual(findings[0]["file"], "C.md")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214901934989258/task/1214933126123976

### Description
Extends the AGENTS.md drift audit to the `.cursor/rules/*.mdc` files (PR 3 of the effort; stacked on #8809).

- Generalizes `scripts/drift-audit/check.py` from a single doc to a list of registered docs, and adds a `path-exists` check type.
- Registers the two rule files with machine-checkable facts: `dependency-updates.mdc` (version guard) and `wide-events.mdc` (its two reference-implementation `.kt` paths).
- Fixes the stale "Kotlin 1.9.24" hardcoded in `dependency-updates.mdc` — it now points to `versions.properties`.
- Extends the drift-audit workflow to correct any registered doc.

The other 5 rule files have no machine-checkable facts (conventions, design philosophy, pixel/Maestro guidance), so they are left to the workflow's judgement-layer survey rather than the deterministic checker. A surgical content trim of the rule prose is deferred to a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Steps to test this PR
- [ ] `python3 scripts/drift-audit/check.py` exits 0 with `"clean": true` (AGENTS.md + both rule files)
- [ ] `cd scripts/drift-audit && python3 -m unittest test_check` passes (16 tests)
- [ ] `gh aw compile drift-audit` reports 0 errors / 0 warnings

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |