### PR TITLE
Fix local build scan DI tag

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -30,7 +30,7 @@ develocity {
         }
         // Tag scans with the active DI framework so cache hits are queryable per-variant
         // and Anvil/Metro builds remain visibly distinct on Develocity.
-        def diFrameworkTag = settings.startParameter.projectProperties.get('ddg.di') ?: 'AnvilDagger'
+        def diFrameworkTag = providers.gradleProperty('ddg.di').getOrElse('AnvilDagger')
         tag(diFrameworkTag)
         value('ddg.di', diFrameworkTag)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1215427136993683?focus=true

### Description
Fixes 

### Steps to test this PR

_QA-optional_
- [ ] Checkout this branch and do a local build  - verify published build scan is tagged with `AnvilDagger`
- [ ] Set override to `ddg.di=Metro` in `gradle.properties` and build - verify published build scan is tagged with `Metro`

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line Develocity build scan configuration change with no runtime or app behavior impact.
> 
> **Overview**
> Fixes **Develocity build scan** tagging for the active DI framework on **local builds** by reading `ddg.di` via `providers.gradleProperty('ddg.di').getOrElse('AnvilDagger')` instead of `settings.startParameter.projectProperties`.
> 
> Local overrides in `gradle.properties` (e.g. `ddg.di=Metro`) now show up as scan tags/values; the default remains **`AnvilDagger`** when the property is unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bda0ae9d71dc9bc39ea24010b5c130ea34d584c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->