### PR TITLE
Use API 34 for custom tabs test

### DIFF
--- a/.github/workflows/e2e-nightly-full-suite.yml
+++ b/.github/workflows/e2e-nightly-full-suite.yml
@@ -120,7 +120,7 @@ jobs:
           maestro_test_name: customTabs${{ env.DI_UNDERSCORE_SUFFIX }}_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-internal-binary.outputs.maestro_app_binary_id }}
-          maestro_api_level: 35
+          maestro_api_level: 34
           maestro_include_tags: customTabsTest
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1215501013909790?focus=true 

### Description
Attempt to fix failing test

### Steps to test this PR
https://github.com/duckduckgo/Android/actions/runs/27147779281/job/80130246155 should pass


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI emulator API level tweak for one Maestro suite; no app or production code changes.
> 
> **Overview**
> The nightly full-suite E2E workflow now runs **Custom tabs** Maestro flows on **Android API 34** instead of **API 35**, by changing `maestro_api_level` on the `Custom tabs flows` step in `e2e-nightly-full-suite.yml`.
> 
> That matches how **Internal Privacy** tests in the same workflow already target API 34. Release-blocking behavior for the default Anvil path is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a822143f0fbbafc36e743a204e189d71f511f8a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->