### PR TITLE
Add a tag to benchmark runs

### DIFF
--- a/build-benchmarks/build-benchmark.scenarios
+++ b/build-benchmarks/build-benchmark.scenarios
@@ -5,6 +5,10 @@ build-warm {
     tasks = ["app:buildInternalDebug"]
     warm-ups = 4
     iterations = 5
+    system-properties {
+        "scan.tag.benchmark" = "true"
+        "scan.value.benchmark.scenario" = "build-warm"
+    }
 }
 
 # Scenario 2: Clean Build
@@ -16,6 +20,10 @@ build-cold {
     cleanup-tasks = ["clean"]
     warm-ups = 2
     iterations = 4
+    system-properties {
+        "scan.tag.benchmark" = "true"
+        "scan.value.benchmark.scenario" = "build-cold"
+    }
 }
 
 # Scenario 3: ABI Change
@@ -30,6 +38,10 @@ build-abi-change-incremental {
 
     warm-ups = 4
     iterations = 5
+    system-properties {
+        "scan.tag.benchmark" = "true"
+        "scan.value.benchmark.scenario" = "build-abi-change-incremental"
+    }
 }
 
 # Scenario 4: Non-ABI Change
@@ -44,4 +56,8 @@ build-non-abi-change-incremental {
 
     warm-ups = 4
     iterations = 5
+    system-properties {
+        "scan.tag.benchmark" = "true"
+        "scan.value.benchmark.scenario" = "build-non-abi-change-incremental"
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1213622515470605?focus=true

### Description
Add a tag/custom value] to the benchmark scenarios so we can filter them out in performance analysis since they disable caching.

### Steps to test this PR
QA-optional, next nightly benchmark runs should be tagged correctly

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only changes to benchmark scenario definitions; no app or build logic changes.
> 
> **Overview**
> Adds **Gradle Build Scan** metadata to all four scenarios in `build-benchmark.scenarios` so nightly benchmark runs can be identified and filtered in performance tooling.
> 
> Each scenario now sets `system-properties` with `scan.tag.benchmark = "true"` and a scenario-specific `scan.value.benchmark.scenario` (`build-warm`, `build-cold`, `build-abi-change-incremental`, `build-non-abi-change-incremental`). Build tasks and warm-up/iteration settings are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 493c26181acda4ea77fbcc8dd0799bdc2d464f80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->