### PR TITLE
Speed up tab state update on return-card close

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -554,6 +554,38 @@ open class BrowserActivity : DuckDuckGoActivity() {
         }
     }
 
+    // Same parent + omnibar anchor as showSnackbar, but with an undo action. Used by the new-tab-page
+    // return hatch so its "tab closed" snackbar clears the keyboard and the floating native input,
+    // which it can't do when shown from inside the hatch view's own (lower) view subtree.
+    fun showUndoableSnackbar(
+        message: String,
+        actionLabel: String,
+        onAction: () -> Unit,
+        onDismiss: () -> Unit,
+    ) {
+        lifecycleScope.launch {
+            val omnibarType = withContext(dispatcherProvider.io()) {
+                settingsDataStore.omnibarType
+            }
+            val anchorView = when (omnibarType) {
+                OmnibarType.SINGLE_TOP -> null
+                OmnibarType.SINGLE_BOTTOM -> currentTab?.getOmnibar()?.omnibarView?.toolbar
+                    ?: binding.fragmentContainer
+
+                OmnibarType.SPLIT -> currentTab?.navigationBar ?: binding.fragmentContainer
+            }
+            DefaultSnackbar(
+                parentView = binding.fragmentContainer,
+                message = message,
+                anchor = anchorView,
+                action = actionLabel,
+                showAction = true,
+                onAction = onAction,
+                onDismiss = onDismiss,
+            ).show()
+        }
+    }
+
     override fun onStart() {
         super.onStart()
         duckAiAnimDelayJob =

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3738,6 +3738,19 @@ class BrowserTabFragment :
                     // no-op
                 }
 
+                override fun onTabClosed(
+                    tabId: String,
+                    onUndo: () -> Unit,
+                    onCommit: () -> Unit,
+                ) {
+                    browserActivity?.showUndoableSnackbar(
+                        message = getString(com.duckduckgo.browser.ui.R.string.newTabReturnHatchTabClosed),
+                        actionLabel = getString(com.duckduckgo.browser.ui.R.string.newTabReturnHatchUndo),
+                        onAction = onUndo,
+                        onDismiss = onCommit,
+                    )
+                }
+
                 override fun onBurnTabPressed() {
                     viewLifecycleOwner.lifecycleScope.launch {
                         val dialog = fireDialogProvider.createFireDialog(FireDialogOrigin.Hatch(newTabReturnHatchView.tabId))

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -20,6 +20,7 @@ import android.animation.LayoutTransition
 import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
+import android.view.ViewTreeObserver
 import android.widget.FrameLayout
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.updateLayoutParams
@@ -273,6 +274,19 @@ class NativeInputLayoutCoordinator(
             }
         widgetView.addOnLayoutChangeListener(layoutListener)
         rootView.addOnLayoutChangeListener(layoutListener)
+
+        // NTP content can change visibility/size asynchronously without moving rootView/widgetView
+        // — e.g. the return hatch re-appearing on undo. Those passes never re-fire the layout
+        // listeners above, leaving a stale offset that overlaps the floating input. Observe the NTP
+        // subtree and re-apply the offset on its layout passes. Guarded by isWidgetAnimating like
+        // layoutListener, and idempotent via applyPadding's no-op-when-unchanged check.
+        val ntpContentView = newTabContent?.takeIf { !isBottom }
+        val globalLayoutListener =
+            ViewTreeObserver.OnGlobalLayoutListener {
+                if (isWidgetAnimating) return@OnGlobalLayoutListener
+                applyOffset()
+            }
+        ntpContentView?.viewTreeObserver?.addOnGlobalLayoutListener(globalLayoutListener)
         widgetView.addOnAttachStateChangeListener(
             object : View.OnAttachStateChangeListener {
                 override fun onViewAttachedToWindow(v: View) = Unit
@@ -287,6 +301,7 @@ class NativeInputLayoutCoordinator(
                     }
                     v.removeOnLayoutChangeListener(layoutListener)
                     rootView.removeOnLayoutChangeListener(layoutListener)
+                    ntpContentView?.viewTreeObserver?.takeIf { it.isAlive }?.removeOnGlobalLayoutListener(globalLayoutListener)
                     v.removeOnAttachStateChangeListener(this)
                 }
             },

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -177,6 +177,13 @@ class NativeInputLayoutCoordinator(
         if (targets.isEmpty()) return
         val anchor = widgetView.findViewById(R.id.inputModeWidgetCard) ?: widgetView
 
+        // Resolved once here instead of per call inside isLogoOnlyContent: that runs from the global
+        // layout listener below on every window layout pass, and findViewById walks the tree each
+        // time. These views inflate alongside newTabContent, so caching the references is safe;
+        // their live visibility/height are still read on each pass.
+        val ddgLogoView = rootView.findViewById<View?>(R.id.ddgLogo)
+        val returnHatchView = rootView.findViewById<View?>(R.id.newTabReturnHatchView)
+
         // Animate child reflows when the widget toggles Search ↔ DuckAI changes our padding.
         // The transition is staged here but only assigned to the parent once the enter animation
         // completes (see enableContentLayoutTransition). Otherwise the per-frame setPadding
@@ -210,8 +217,8 @@ class NativeInputLayoutCoordinator(
 
         fun isLogoOnlyContent(view: View): Boolean {
             if (view != newTabContent) return false
-            val logoVisible = rootView.findViewById<View?>(R.id.ddgLogo)?.visibility == View.VISIBLE
-            val hatchHeightPx = rootView.findViewById<View?>(R.id.newTabReturnHatchView)?.height ?: 0
+            val logoVisible = ddgLogoView?.visibility == View.VISIBLE
+            val hatchHeightPx = returnHatchView?.height ?: 0
             return isLogoOnly(logoVisible, hatchHeightPx)
         }
 
@@ -275,11 +282,15 @@ class NativeInputLayoutCoordinator(
         widgetView.addOnLayoutChangeListener(layoutListener)
         rootView.addOnLayoutChangeListener(layoutListener)
 
-        // NTP content can change visibility/size asynchronously without moving rootView/widgetView
-        // — e.g. the return hatch re-appearing on undo. Those passes never re-fire the layout
-        // listeners above, leaving a stale offset that overlaps the floating input. Observe the NTP
-        // subtree and re-apply the offset on its layout passes. Guarded by isWidgetAnimating like
-        // layoutListener, and idempotent via applyPadding's no-op-when-unchanged check.
+        // Several inputs to the offset change asynchronously without moving rootView/widgetView —
+        // the return hatch showing/hiding (its height feeds isLogoOnlyContent), the logo's
+        // visibility, and NTP content reflow shifting the content's window position. The per-view
+        // OnLayoutChange listeners above don't fire for those, so we need a post-layout signal that
+        // covers the whole NTP. viewTreeObserver is the window-shared one, so this fires on every
+        // global layout pass (keyboard, scroll, etc.); that breadth is deliberate — a listener
+        // scoped to just the hatch misses the logo/content cases and fires mid-layout with stale
+        // sibling positions. Kept cheap: skipped while animating (isWidgetAnimating), a no-op when
+        // padding is unchanged (applyPadding), and the lookups it needs are cached above.
         val ntpContentView = newTabContent?.takeIf { !isBottom }
         val globalLayoutListener =
             ViewTreeObserver.OnGlobalLayoutListener {

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchView.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchView.kt
@@ -38,7 +38,6 @@ import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.ViewViewModelFactory
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
-import com.google.android.material.snackbar.Snackbar
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -58,6 +57,11 @@ class NewTabReturnHatchView @JvmOverloads constructor(
         fun onHatchRendered(visible: Boolean)
         fun onBurnTabPressed()
         fun onAfterInactivityPressed()
+
+        // The host shows the "tab closed" snackbar so it can parent it to the activity content
+        // (above the floating native input) and anchor it to the omnibar, matching the burn-tab
+        // snackbar. onUndo restores the tab; onCommit commits the deletion.
+        fun onTabClosed(tabId: String, onUndo: () -> Unit, onCommit: () -> Unit)
     }
 
     @Inject
@@ -106,19 +110,12 @@ class NewTabReturnHatchView @JvmOverloads constructor(
             NewTabReturnHatchViewModel.Command.LaunchTabSwitcher ->
                 globalActivityStarter.start(context, TabSwitcherScreenNoParams)
             is NewTabReturnHatchViewModel.Command.ShowTabClosedSnackbar ->
-                showTabClosedSnackbar(command.tabId)
+                hatchHatchListener?.onTabClosed(
+                    command.tabId,
+                    onUndo = { viewModel.onUndoCloseTab(command.tabId) },
+                    onCommit = { viewModel.onTabClosedSnackbarDismissed(command.tabId) },
+                )
         }
-    }
-
-    private fun showTabClosedSnackbar(tabId: String) {
-        Snackbar.make(rootView, R.string.newTabReturnHatchTabClosed, Snackbar.LENGTH_LONG)
-            .setAction(R.string.newTabReturnHatchUndo) { viewModel.onUndoCloseTab(tabId) }
-            .addCallback(object : Snackbar.Callback() {
-                override fun onDismissed(snackbar: Snackbar, event: Int) {
-                    if (event != DISMISS_EVENT_ACTION) viewModel.onTabClosedSnackbarDismissed(tabId)
-                }
-            })
-            .show()
     }
 
     override fun onDetachedFromWindow() {

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModel.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModel.kt
@@ -26,20 +26,18 @@ import com.duckduckgo.app.browser.DuckDuckGoUrlDetector
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
+import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
@@ -80,7 +78,24 @@ class NewTabReturnHatchViewModel @Inject constructor(
     private val pendingClose = MutableStateFlow(false)
     private val burnTargetTabId = MutableStateFlow<String?>(null)
 
+    // The tab the hatch offers to return to, captured once when the app returns from idle. Driving
+    // the hatch from this snapshot (instead of the live last-accessed flow) keeps the displayed tab
+    // stable: it never switches to another tab while up, and survives the close/undo toggle.
+    private val snapshotTab = MutableStateFlow<TabEntity?>(null)
+
     init {
+        // Capture the last-accessed tab once per idle-return; reset on a fresh return so the hatch
+        // can re-appear for the next one.
+        viewModelScope.launch(dispatchers.io()) {
+            ntpAfterIdleManager.isAfterIdleReturn.collect { afterIdle ->
+                if (afterIdle) {
+                    snapshotTab.value = tabRepository.getLastAccessedTab()
+                    pendingClose.value = false
+                } else {
+                    snapshotTab.value = null
+                }
+            }
+        }
         // When the user burns the hatch's tab via the FireDialog, hide the hatch as soon as that
         // tab is gone from the repository. If the FireDialog is cancelled, the tab survives and the
         // hatch stays visible.
@@ -96,36 +111,33 @@ class NewTabReturnHatchViewModel @Inject constructor(
         }
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
-    val viewState = pendingClose.flatMapLatest { isClosed ->
-        if (isClosed) {
-            // Once the user closes the hatch, freeze it: stop observing upstream flows so the
-            // post-deletion re-emission from flowLastAccessedTab doesn't trigger another render.
-            flowOf(ViewState(shouldShow = false))
+    // Driven by the captured [snapshotTab] (not the live last-accessed flow) so the displayed tab is
+    // stable across the close/undo toggle. Only the tabs count stays live, sourced from flowTabs.
+    val viewState = combine(
+        snapshotTab,
+        pendingClose,
+        tabRepository.flowTabs,
+        duckChat.observeNativeInputFieldUserSettingEnabled(),
+    ) { tab, closed, tabs, nativeInputEnabled ->
+        if (tab != null && !closed) {
+            val url = tab.url.orEmpty()
+            ViewState(
+                tabTitle = tab.title.orEmpty(),
+                url = url,
+                tabId = tab.tabId,
+                currentTabId = tab.tabId,
+                shouldShow = true,
+                isDuckChat = url.isNotEmpty() && duckChat.isDuckChatUrl(Uri.parse(url)),
+                isSerp = url.isNotEmpty() && duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(url),
+                tabs = tabs.size,
+                showTabsButton = nativeInputEnabled,
+            )
         } else {
-            combine(
-                tabRepository.flowLastAccessedTab,
-                tabRepository.flowTabs,
-                ntpAfterIdleManager.isAfterIdleReturn,
-                duckChat.observeNativeInputFieldUserSettingEnabled(),
-            ) { lastTab, tabs, afterIdle, nativeInputEnabled ->
-                if (lastTab != null && afterIdle) {
-                    val url = lastTab.url.orEmpty()
-                    ViewState(
-                        tabTitle = lastTab.title.orEmpty(),
-                        url = url,
-                        tabId = lastTab.tabId,
-                        currentTabId = lastTab.tabId,
-                        shouldShow = true,
-                        isDuckChat = url.isNotEmpty() && duckChat.isDuckChatUrl(Uri.parse(url)),
-                        isSerp = url.isNotEmpty() && duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(url),
-                        tabs = tabs.size,
-                        showTabsButton = nativeInputEnabled,
-                    )
-                } else {
-                    ViewState(shouldShow = false)
-                }
-            }
+            ViewState(
+                shouldShow = false,
+                tabs = tabs.size,
+                showTabsButton = nativeInputEnabled,
+            )
         }
     }
         .flowOn(dispatchers.io())
@@ -141,6 +153,11 @@ class NewTabReturnHatchViewModel @Inject constructor(
         pixel.fire(NewTabReturnHatchPixelName.OPTION_SELECTED_CLOSE_TAB_DAILY, type = Daily())
         val tabId = viewState.value.currentTabId
         if (tabId.isEmpty()) return
+        // Mark the tab deletable now so it disappears from the tab list/switcher immediately
+        // (recoverable via undo); the actual delete is committed when the snackbar is dismissed.
+        viewModelScope.launch(dispatchers.io()) {
+            tabRepository.markDeletable(listOf(tabId))
+        }
         pendingClose.value = true
         commandChannel.trySend(Command.ShowTabClosedSnackbar(tabId))
     }
@@ -152,15 +169,21 @@ class NewTabReturnHatchViewModel @Inject constructor(
     }
 
     fun onUndoCloseTab(tabId: String) {
+        // Restore the tab that was marked deletable on close, and re-show the hatch with the same
+        // snapshot (no recompute, so it doesn't jump to a different tab).
+        viewModelScope.launch(dispatchers.io()) {
+            tabRepository.undoDeletable(listOf(tabId))
+        }
         pendingClose.value = false
     }
 
     fun onTabClosedSnackbarDismissed(tabId: String) {
+        // The tab was already marked deletable on close; commit the deletion now.
         viewModelScope.launch(dispatchers.io()) {
-            tabRepository.deleteTabs(listOf(tabId))
+            tabRepository.purgeDeletableTabs()
         }
         // pendingClose intentionally not reset: once the user commits to closing the hatch's tab,
-        // the hatch should not reappear with a different last-accessed tab.
+        // the hatch should not reappear until a fresh idle-return.
     }
 
     fun onTabManagerPressed() {

--- a/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModelTest.kt
+++ b/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModelTest.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -54,16 +55,16 @@ class NewTabReturnHatchViewModelTest {
     private val mockDuckDuckGoUrlDetector: DuckDuckGoUrlDetector = mock()
     private val mockNtpAfterIdleManager: NtpAfterIdleManager = mock()
     private val mockPixel: Pixel = mock()
-    private val lastAccessedTabFlow = MutableStateFlow<TabEntity?>(null)
     private val tabsFlow = MutableStateFlow<List<TabEntity>>(emptyList())
-    private val afterIdleReturnFlow = MutableStateFlow(true)
+
+    // Starts false so each test controls the idle-return rising edge that captures the snapshot.
+    private val afterIdleReturnFlow = MutableStateFlow(false)
     private val nativeInputEnabledFlow = MutableStateFlow(true)
 
     private lateinit var testee: NewTabReturnHatchViewModel
 
     @Before
     fun setup() {
-        whenever(mockTabRepository.flowLastAccessedTab).thenReturn(lastAccessedTabFlow)
         whenever(mockTabRepository.flowTabs).thenReturn(tabsFlow)
         whenever(mockNtpAfterIdleManager.isAfterIdleReturn).thenReturn(afterIdleReturnFlow)
         whenever(mockDuckChat.observeNativeInputFieldUserSettingEnabled()).thenReturn(nativeInputEnabledFlow)
@@ -78,14 +79,22 @@ class NewTabReturnHatchViewModelTest {
         )
     }
 
+    // Simulates returning from idle: stub the one-time last-accessed read and trigger the rising
+    // edge that captures the snapshot.
+    private suspend fun returnFromIdleWith(tab: TabEntity?) {
+        whenever(mockTabRepository.getLastAccessedTab()).thenReturn(tab)
+        afterIdleReturnFlow.value = false
+        afterIdleReturnFlow.value = true
+    }
+
     @Test
-    fun whenLastAccessedTabExistsThenViewStateShowsTab() = runTest {
+    fun whenReturnFromIdleWithTabThenViewStateShowsTab() = runTest {
         val tab = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
 
-        lastAccessedTabFlow.emit(tab)
-
         testee.viewState.test {
-            val state = awaitItem()
+            returnFromIdleWith(tab)
+
+            val state = expectMostRecentItem()
             assertTrue(state.shouldShow)
             assertEquals("Example", state.tabTitle)
             assertEquals("https://example.com", state.url)
@@ -95,45 +104,64 @@ class NewTabReturnHatchViewModelTest {
     }
 
     @Test
-    fun whenNoLastAccessedTabThenViewStateHidesHatch() = runTest {
-        lastAccessedTabFlow.emit(null)
-
+    fun whenReturnFromIdleWithNoTabThenViewStateHidesHatch() = runTest {
         testee.viewState.test {
-            val state = awaitItem()
+            returnFromIdleWith(null)
+
+            assertFalse(expectMostRecentItem().shouldShow)
+        }
+    }
+
+    @Test
+    fun whenInitialStateThenTabIdIsEmptyAndHatchHidden() = runTest {
+        testee.viewState.test {
+            val state = expectMostRecentItem()
+            assertEquals("", state.tabId)
             assertFalse(state.shouldShow)
         }
     }
 
     @Test
-    fun whenLastAccessedTabChangesThenViewStateUpdates() = runTest {
+    fun whenSnapshotCapturedThenHatchDoesNotChangeWhenLastAccessedTabChanges() = runTest {
         val tab1 = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
         val tab2 = TabEntity(tabId = "tab2", url = "https://other.com", title = "Other")
 
         testee.viewState.test {
-            skipItems(1) // initial state
+            returnFromIdleWith(tab1)
+            assertEquals("tab1", expectMostRecentItem().tabId)
 
-            lastAccessedTabFlow.emit(tab1)
-            assertEquals("tab1", awaitItem().tabId)
+            // A new last-accessed tab without a fresh idle-return must NOT re-emit / switch tabs.
+            whenever(mockTabRepository.getLastAccessedTab()).thenReturn(tab2)
+            advanceUntilIdle()
 
-            lastAccessedTabFlow.emit(tab2)
-            assertEquals("tab2", awaitItem().tabId)
+            expectNoEvents()
         }
     }
 
     @Test
-    fun whenOnHatchPressedThenFiresReturnTabCountAndDailyPixels() = runTest {
-        testee.onHatchPressed()
+    fun whenFreshIdleReturnThenRecapturesSnapshot() = runTest {
+        val tab1 = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
+        val tab2 = TabEntity(tabId = "tab2", url = "https://other.com", title = "Other")
 
-        verify(mockPixel).fire(NewTabReturnHatchPixelName.OPTION_SELECTED_RETURN_TAB, type = Count)
-        verify(mockPixel).fire(NewTabReturnHatchPixelName.OPTION_SELECTED_RETURN_TAB_DAILY, type = Daily())
+        testee.viewState.test {
+            returnFromIdleWith(tab1)
+            assertEquals("tab1", expectMostRecentItem().tabId)
+
+            returnFromIdleWith(tab2)
+            assertEquals("tab2", expectMostRecentItem().tabId)
+        }
     }
 
     @Test
-    fun whenInitialStateThenTabIdIsEmpty() = runTest {
+    fun whenNotAfterIdleReturnThenViewStateHidesHatch() = runTest {
+        val tab = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
+
         testee.viewState.test {
-            val state = awaitItem()
-            assertEquals("", state.tabId)
-            assertFalse(state.shouldShow)
+            returnFromIdleWith(tab)
+            assertTrue(expectMostRecentItem().shouldShow)
+
+            afterIdleReturnFlow.value = false
+            assertFalse(expectMostRecentItem().shouldShow)
         }
     }
 
@@ -141,10 +169,10 @@ class NewTabReturnHatchViewModelTest {
     fun whenLastAccessedTabHasNullTitleAndUrlThenViewStateUsesEmptyStrings() = runTest {
         val tab = TabEntity(tabId = "tab1", url = null, title = null)
 
-        lastAccessedTabFlow.emit(tab)
-
         testee.viewState.test {
-            val state = awaitItem()
+            returnFromIdleWith(tab)
+
+            val state = expectMostRecentItem()
             assertTrue(state.shouldShow)
             assertEquals("", state.tabTitle)
             assertEquals("", state.url)
@@ -158,11 +186,9 @@ class NewTabReturnHatchViewModelTest {
         val tab = TabEntity(tabId = "tab1", url = url, title = "Duck.ai")
         whenever(mockDuckChat.isDuckChatUrl(Uri.parse(url))).thenReturn(true)
 
-        lastAccessedTabFlow.emit(tab)
-
         testee.viewState.test {
-            val state = awaitItem()
-            assertTrue(state.isDuckChat)
+            returnFromIdleWith(tab)
+            assertTrue(expectMostRecentItem().isDuckChat)
         }
     }
 
@@ -172,11 +198,9 @@ class NewTabReturnHatchViewModelTest {
         val tab = TabEntity(tabId = "tab1", url = url, title = "Example")
         whenever(mockDuckChat.isDuckChatUrl(Uri.parse(url))).thenReturn(false)
 
-        lastAccessedTabFlow.emit(tab)
-
         testee.viewState.test {
-            val state = awaitItem()
-            assertFalse(state.isDuckChat)
+            returnFromIdleWith(tab)
+            assertFalse(expectMostRecentItem().isDuckChat)
         }
     }
 
@@ -184,11 +208,9 @@ class NewTabReturnHatchViewModelTest {
     fun whenLastAccessedTabHasNullUrlThenIsDuckChatIsFalse() = runTest {
         val tab = TabEntity(tabId = "tab1", url = null, title = null)
 
-        lastAccessedTabFlow.emit(tab)
-
         testee.viewState.test {
-            val state = awaitItem()
-            assertFalse(state.isDuckChat)
+            returnFromIdleWith(tab)
+            assertFalse(expectMostRecentItem().isDuckChat)
         }
     }
 
@@ -198,11 +220,9 @@ class NewTabReturnHatchViewModelTest {
         val tab = TabEntity(tabId = "tab1", url = url, title = "test at DuckDuckGo")
         whenever(mockDuckDuckGoUrlDetector.isDuckDuckGoQueryUrl(url)).thenReturn(true)
 
-        lastAccessedTabFlow.emit(tab)
-
         testee.viewState.test {
-            val state = awaitItem()
-            assertTrue(state.isSerp)
+            returnFromIdleWith(tab)
+            assertTrue(expectMostRecentItem().isSerp)
         }
     }
 
@@ -212,83 +232,18 @@ class NewTabReturnHatchViewModelTest {
         val tab = TabEntity(tabId = "tab1", url = url, title = "Example")
         whenever(mockDuckDuckGoUrlDetector.isDuckDuckGoQueryUrl(url)).thenReturn(false)
 
-        lastAccessedTabFlow.emit(tab)
-
         testee.viewState.test {
-            val state = awaitItem()
-            assertFalse(state.isSerp)
+            returnFromIdleWith(tab)
+            assertFalse(expectMostRecentItem().isSerp)
         }
     }
 
     @Test
-    fun whenLastAccessedTabIsDuckChatWithEmptyTitleThenViewStateHasEmptyTitle() = runTest {
-        val url = "https://duck.ai/chat"
-        val tab = TabEntity(tabId = "tab1", url = url, title = "")
-        whenever(mockDuckChat.isDuckChatUrl(Uri.parse(url))).thenReturn(true)
+    fun whenOnHatchPressedThenFiresReturnTabCountAndDailyPixels() = runTest {
+        testee.onHatchPressed()
 
-        lastAccessedTabFlow.emit(tab)
-
-        testee.viewState.test {
-            val state = awaitItem()
-            assertTrue(state.isDuckChat)
-            assertEquals("", state.tabTitle)
-        }
-    }
-
-    @Test
-    fun whenLastAccessedTabIsSerpWithEmptyTitleThenViewStateHasEmptyTitle() = runTest {
-        val url = "https://duckduckgo.com/?q=test"
-        val tab = TabEntity(tabId = "tab1", url = url, title = "")
-        whenever(mockDuckDuckGoUrlDetector.isDuckDuckGoQueryUrl(url)).thenReturn(true)
-
-        lastAccessedTabFlow.emit(tab)
-
-        testee.viewState.test {
-            val state = awaitItem()
-            assertTrue(state.isSerp)
-            assertEquals("", state.tabTitle)
-        }
-    }
-
-    @Test
-    fun whenLastAccessedTabExistsButNotAfterIdleReturnThenViewStateHidesHatch() = runTest {
-        afterIdleReturnFlow.value = false
-        val tab = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
-
-        lastAccessedTabFlow.emit(tab)
-
-        testee.viewState.test {
-            val state = awaitItem()
-            assertFalse(state.shouldShow)
-        }
-    }
-
-    @Test
-    fun whenAfterIdleReturnChangesToFalseThenViewStateHidesHatch() = runTest {
-        val tab = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
-        lastAccessedTabFlow.emit(tab)
-
-        testee.viewState.test {
-            assertTrue(awaitItem().shouldShow)
-
-            afterIdleReturnFlow.value = false
-            assertFalse(awaitItem().shouldShow)
-        }
-    }
-
-    @Test
-    fun whenLastAccessedTabClearedThenViewStateHidesHatch() = runTest {
-        val tab = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
-
-        testee.viewState.test {
-            skipItems(1) // initial state
-
-            lastAccessedTabFlow.emit(tab)
-            assertTrue(awaitItem().shouldShow)
-
-            lastAccessedTabFlow.emit(null)
-            assertFalse(awaitItem().shouldShow)
-        }
+        verify(mockPixel).fire(NewTabReturnHatchPixelName.OPTION_SELECTED_RETURN_TAB, type = Count)
+        verify(mockPixel).fire(NewTabReturnHatchPixelName.OPTION_SELECTED_RETURN_TAB_DAILY, type = Daily())
     }
 
     @Test
@@ -296,11 +251,9 @@ class NewTabReturnHatchViewModelTest {
         nativeInputEnabledFlow.value = true
         val tab = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
 
-        lastAccessedTabFlow.emit(tab)
-
         testee.viewState.test {
-            val state = awaitItem()
-            assertTrue(state.showTabsButton)
+            returnFromIdleWith(tab)
+            assertTrue(expectMostRecentItem().showTabsButton)
         }
     }
 
@@ -309,27 +262,23 @@ class NewTabReturnHatchViewModelTest {
         nativeInputEnabledFlow.value = false
         val tab = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
 
-        lastAccessedTabFlow.emit(tab)
-
         testee.viewState.test {
-            val state = awaitItem()
-            assertFalse(state.showTabsButton)
+            returnFromIdleWith(tab)
+            assertFalse(expectMostRecentItem().showTabsButton)
         }
     }
 
     @Test
-    fun whenNativeInputToggledThenShowTabsButtonUpdates() = runTest {
+    fun whenTabsCountChangesThenViewStateCountStaysLive() = runTest {
         val tab = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
-        lastAccessedTabFlow.emit(tab)
+        tabsFlow.value = listOf(tab)
 
         testee.viewState.test {
-            assertTrue(awaitItem().showTabsButton)
+            returnFromIdleWith(tab)
+            assertEquals(1, expectMostRecentItem().tabs)
 
-            nativeInputEnabledFlow.value = false
-            assertFalse(awaitItem().showTabsButton)
-
-            nativeInputEnabledFlow.value = true
-            assertTrue(awaitItem().showTabsButton)
+            tabsFlow.value = listOf(tab, TabEntity(tabId = "tab2", url = "https://other.com", title = "Other"))
+            assertEquals(2, expectMostRecentItem().tabs)
         }
     }
 
@@ -343,28 +292,31 @@ class NewTabReturnHatchViewModelTest {
     }
 
     @Test
-    fun whenCloseTabThenHidesHatchWithoutDeletingTab() = runTest {
+    fun whenCloseTabThenMarksTabDeletableAndHidesHatch() = runTest {
         val tab = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
-        lastAccessedTabFlow.emit(tab)
 
         testee.viewState.test {
-            assertTrue(awaitItem().shouldShow)
+            returnFromIdleWith(tab)
+            assertTrue(expectMostRecentItem().shouldShow)
 
             testee.closeTab()
+            advanceUntilIdle()
 
-            assertFalse(awaitItem().shouldShow)
+            assertFalse(expectMostRecentItem().shouldShow)
         }
 
+        verify(mockTabRepository).markDeletable(listOf("tab1"))
+        verify(mockTabRepository, never()).purgeDeletableTabs()
         verify(mockTabRepository, never()).deleteTabs(any())
     }
 
     @Test
     fun whenCloseTabThenShowTabClosedSnackbarCommandEmittedWithTabId() = runTest {
         val tab = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
-        lastAccessedTabFlow.emit(tab)
 
         testee.viewState.test {
-            awaitItem() // wait for state to settle with the emitted tab
+            returnFromIdleWith(tab)
+            expectMostRecentItem()
         }
 
         testee.commands.test {
@@ -375,71 +327,92 @@ class NewTabReturnHatchViewModelTest {
     }
 
     @Test
-    fun whenCloseTabWithEmptyCurrentTabIdThenNoSnackbarAndNoStateChange() = runTest {
+    fun whenCloseTabWithEmptyCurrentTabIdThenNoSnackbarAndDoesNotMarkDeletable() = runTest {
         testee.viewState.test {
-            assertFalse(awaitItem().shouldShow)
+            assertFalse(expectMostRecentItem().shouldShow)
 
             testee.commands.test {
                 testee.closeTab()
                 expectNoEvents()
             }
-
-            expectNoEvents()
         }
+
+        advanceUntilIdle()
+        verify(mockTabRepository, never()).markDeletable(any<List<String>>())
     }
 
     @Test
-    fun whenOnUndoCloseTabThenRestoresHatchWithoutDeletingTab() = runTest {
+    fun whenOnUndoCloseTabThenUndoesDeletableAndReshowsSameTab() = runTest {
         val tab = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
-        lastAccessedTabFlow.emit(tab)
 
         testee.viewState.test {
-            assertTrue(awaitItem().shouldShow)
+            returnFromIdleWith(tab)
+            assertTrue(expectMostRecentItem().shouldShow)
 
             testee.closeTab()
-            assertFalse(awaitItem().shouldShow)
+            advanceUntilIdle()
+            assertFalse(expectMostRecentItem().shouldShow)
 
             testee.onUndoCloseTab("tab1")
-            assertTrue(awaitItem().shouldShow)
+            advanceUntilIdle()
+            val restored = expectMostRecentItem()
+            assertTrue(restored.shouldShow)
+            assertEquals("tab1", restored.tabId)
         }
 
+        verify(mockTabRepository).undoDeletable(listOf("tab1"))
+        verify(mockTabRepository, never()).purgeDeletableTabs()
+    }
+
+    @Test
+    fun whenOnTabClosedSnackbarDismissedThenPurgesDeletableTabs() = runTest {
+        testee.onTabClosedSnackbarDismissed("tab1")
+        advanceUntilIdle()
+
+        verify(mockTabRepository).purgeDeletableTabs()
         verify(mockTabRepository, never()).deleteTabs(any())
     }
 
     @Test
-    fun whenOnTabClosedSnackbarDismissedThenDeletesTab() = runTest {
-        testee.onTabClosedSnackbarDismissed("tab1")
+    fun whenSnackbarDismissedThenHatchStaysHiddenUntilFreshIdleReturn() = runTest {
+        val tab1 = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
 
-        verify(mockTabRepository).deleteTabs(listOf("tab1"))
+        testee.viewState.test {
+            returnFromIdleWith(tab1)
+            assertTrue(expectMostRecentItem().shouldShow)
+
+            testee.closeTab()
+            advanceUntilIdle()
+            testee.onTabClosedSnackbarDismissed("tab1")
+            advanceUntilIdle()
+
+            assertFalse(expectMostRecentItem().shouldShow)
+        }
     }
 
     @Test
-    fun whenSnackbarDismissedThenHatchStaysHiddenEvenIfAnotherTabBecomesLastAccessed() = runTest {
-        val tab1 = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
-        val tab2 = TabEntity(tabId = "tab2", url = "https://other.com", title = "Other")
-        lastAccessedTabFlow.emit(tab1)
+    fun whenCloseTabThenFiresCloseTabCountAndDailyPixels() = runTest {
+        val tab = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
 
         testee.viewState.test {
-            assertTrue(awaitItem().shouldShow)
-
-            testee.closeTab()
-            assertFalse(awaitItem().shouldShow)
-
-            testee.onTabClosedSnackbarDismissed("tab1")
-            lastAccessedTabFlow.emit(tab2)
-
-            expectNoEvents()
+            returnFromIdleWith(tab)
+            expectMostRecentItem()
         }
+
+        testee.closeTab()
+
+        verify(mockPixel).fire(NewTabReturnHatchPixelName.OPTION_SELECTED_CLOSE_TAB, type = Count)
+        verify(mockPixel).fire(NewTabReturnHatchPixelName.OPTION_SELECTED_CLOSE_TAB_DAILY, type = Daily())
     }
 
     @Test
     fun whenBurnTabPressedAndTabRemovedFromRepositoryThenHatchHides() = runTest {
         val tab = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
-        lastAccessedTabFlow.emit(tab)
         tabsFlow.value = listOf(tab)
 
         testee.viewState.test {
-            assertTrue(awaitItem().shouldShow)
+            returnFromIdleWith(tab)
+            assertTrue(expectMostRecentItem().shouldShow)
 
             testee.onBurnTabPressed()
             tabsFlow.value = emptyList()
@@ -457,72 +430,18 @@ class NewTabReturnHatchViewModelTest {
     @Test
     fun whenBurnTabPressedButTabStillInRepositoryThenHatchStaysVisible() = runTest {
         val tab = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
-        lastAccessedTabFlow.emit(tab)
         tabsFlow.value = listOf(tab)
 
         testee.viewState.test {
-            assertTrue(awaitItem().shouldShow)
+            returnFromIdleWith(tab)
+            assertTrue(expectMostRecentItem().shouldShow)
 
             testee.onBurnTabPressed()
+            advanceUntilIdle()
 
+            // Burn target still present, so the hatch state is unchanged (stays visible).
             expectNoEvents()
         }
-    }
-
-    @Test
-    fun whenBurnTabPressedAndOnlyAnotherTabRemovedThenHatchStaysVisible() = runTest {
-        val burnTarget = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
-        val otherTab = TabEntity(tabId = "tab2", url = "https://other.com", title = "Other")
-        lastAccessedTabFlow.emit(burnTarget)
-        tabsFlow.value = listOf(burnTarget, otherTab)
-
-        testee.viewState.test {
-            assertTrue(awaitItem().shouldShow)
-
-            testee.onBurnTabPressed()
-            tabsFlow.value = listOf(burnTarget)
-
-            // tabs count drops from 2 to 1 so viewState re-emits, but shouldShow stays true
-            // because the burn target is still present in the repository.
-            assertTrue(awaitItem().shouldShow)
-        }
-    }
-
-    @Test
-    fun whenBurnTabPressedWithEmptyCurrentTabIdThenHatchUnaffectedByTabsChanges() = runTest {
-        lastAccessedTabFlow.emit(null)
-
-        testee.viewState.test {
-            assertFalse(awaitItem().shouldShow)
-
-            testee.onBurnTabPressed()
-            tabsFlow.value = emptyList()
-
-            expectNoEvents()
-        }
-    }
-
-    @Test
-    fun whenCloseTabThenFiresCloseTabCountAndDailyPixels() = runTest {
-        val tab = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
-        lastAccessedTabFlow.emit(tab)
-
-        testee.viewState.test {
-            awaitItem() // wait for state to settle so currentTabId is populated
-        }
-
-        testee.closeTab()
-
-        verify(mockPixel).fire(NewTabReturnHatchPixelName.OPTION_SELECTED_CLOSE_TAB, type = Count)
-        verify(mockPixel).fire(NewTabReturnHatchPixelName.OPTION_SELECTED_CLOSE_TAB_DAILY, type = Daily())
-    }
-
-    @Test
-    fun whenCloseTabWithEmptyCurrentTabIdThenStillFiresCloseTabPixels() = runTest {
-        testee.closeTab()
-
-        verify(mockPixel).fire(NewTabReturnHatchPixelName.OPTION_SELECTED_CLOSE_TAB, type = Count)
-        verify(mockPixel).fire(NewTabReturnHatchPixelName.OPTION_SELECTED_CLOSE_TAB_DAILY, type = Daily())
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
@@ -105,6 +105,8 @@ import com.duckduckgo.voice.api.VoiceSearchLauncher.Event.VoiceRecognitionSucces
 import com.duckduckgo.voice.api.VoiceSearchLauncher.Event.VoiceSearchDisabled
 import com.duckduckgo.voice.api.VoiceSearchLauncher.Source.BROWSER
 import com.duckduckgo.voice.api.VoiceSearchLauncher.VoiceSearchMode
+import com.google.android.material.snackbar.BaseTransientBottomBar
+import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -112,6 +114,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import logcat.logcat
 import javax.inject.Inject
+import com.duckduckgo.browser.ui.R as BrowserUiR
 import com.duckduckgo.mobile.android.R as CommonR
 
 @InjectWith(FragmentScope::class)
@@ -616,6 +619,25 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
                             restoreLogoTopMargin(visible)
                         }
                     }
+                }
+
+                override fun onTabClosed(
+                    tabId: String,
+                    onUndo: () -> Unit,
+                    onCommit: () -> Unit,
+                ) {
+                    // Parent to the screen root (resolves to the resizing activity content, so it
+                    // clears the keyboard) and anchor above the input widget when it's at the bottom.
+                    val anchor = if (useTopBar) null else binding.inputModeWidgetContainerBottom
+                    Snackbar.make(binding.root, BrowserUiR.string.newTabReturnHatchTabClosed, Snackbar.LENGTH_LONG)
+                        .apply { anchor?.let { setAnchorView(it) } }
+                        .setAction(BrowserUiR.string.newTabReturnHatchUndo) { onUndo() }
+                        .addCallback(object : Snackbar.Callback() {
+                            override fun onDismissed(snackbar: Snackbar, event: Int) {
+                                if (event != BaseTransientBottomBar.BaseCallback.DISMISS_EVENT_ACTION) onCommit()
+                            }
+                        })
+                        .show()
                 }
 
                 override fun onBurnTabPressed() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1157893581871903/task/1214802869599812

### Description

Closing a tab from the new-tab-page "return to" card used to defer the actual deletion until the "tab closed" snackbar timed out, so the tab count and the tab switcher only reflected the close several seconds later.

This makes the close take effect immediately while keeping it undoable:

- On close the tab is marked deletable, so it leaves the tab list / switcher right away; the delete is committed only when the snackbar is dismissed, and undo restores it.
- The card is now driven by a snapshot of the last-accessed tab, captured once per idle-return, instead of the live last-accessed flow. This keeps the shown tab stable across the close/undo toggle and stops it jumping to a different tab while the card is up.
- The floating native-input content offset is re-applied on new-tab-page layout passes so the card re-appearing on undo no longer overlaps the input.

### Steps to test this PR

_Return-card close updates state immediately_
- [x] Enable the native input field (internal build), open a few tabs, then background the app and return so the NTP "return to" card appears
- [x] Close the tab from the card → the tab count drops immediately and the tab is gone from the tab switcher straight away (no multi-second delay)
- [ ] Tap Undo on the snackbar → the tab is restored and the card re-appears showing the same tab, without overlapping the input
- [x] Let the snackbar time out instead → the tab is permanently closed

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tab lifecycle (mark deletable vs delete) and NTP/native-input layout timing; behavior is covered by updated ViewModel tests but touches user-visible tab state.
> 
> **Overview**
> Closing a tab from the new-tab **return** card now **marks it deletable immediately** (same pattern as tab switcher undo), so tab count and the switcher update right away; **permanent removal** happens on snackbar dismiss via `purgeDeletableTabs`, and **undo** calls `undoDeletable`.
> 
> The hatch no longer follows the **live last-accessed tab** flow—it **snapshots** `getLastAccessedTab()` once per idle return so the offered tab stays fixed through close/undo and doesn’t jump to another tab while the card is visible.
> 
> The **“tab closed” snackbar** is delegated to the host: `BrowserActivity.showUndoableSnackbar` (and Duck.ai input screen with activity-root parent + anchor) instead of a snackbar inside the hatch view, so it sits above the floating native input and can dismiss the keyboard.
> 
> **Native input layout** on NTP re-applies content padding on global layout passes (with cached hatch/logo lookups) so when the card reappears after undo it doesn’t overlap the input widget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebec70eec884b876a2975545dd13421a372bd726. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->