### PR TITLE
Add Duck.AI settings menu item

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1857,7 +1857,7 @@ class BrowserTabFragment :
                 viewModel.openDuckChatHistory()
             }
             onMenuItemClicked(duckChatSettingsMenuItem) {
-                viewModel.openDuckChatSettings()
+                viewModel.openDuckChatSettings(omnibar.viewMode)
             }
             onMenuItemClicked(fireMenuItem) {
                 onFireButtonPressed()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -5384,11 +5384,15 @@ class BrowserTabViewModel @Inject constructor(
         }
     }
 
-    fun openDuckChatSettings() {
-        viewModelScope.launch {
-            pixel.fire(DuckChatPixelName.DUCK_CHAT_DUCK_AI_SETTINGS_TAPPED)
-            val subscriptionEvent = duckChatJSHelper.onNativeAction(NativeAction.DUCK_AI_SETTINGS)
-            _subscriptionEventDataChannel.send(subscriptionEvent)
+    fun openDuckChatSettings(viewMode: ViewMode) {
+        pixel.fire(DuckChatPixelName.DUCK_CHAT_DUCK_AI_SETTINGS_TAPPED)
+        if (viewMode == ViewMode.DuckAI) {
+            viewModelScope.launch {
+                val subscriptionEvent = duckChatJSHelper.onNativeAction(NativeAction.DUCK_AI_SETTINGS)
+                _subscriptionEventDataChannel.send(subscriptionEvent)
+            }
+        } else {
+            command.value = OpenInNewTab(duckChat.getDuckChatSettingsUrl(), tabId)
         }
     }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -10069,7 +10069,7 @@ class BrowserTabViewModelTest {
         )
         whenever(mockDuckChatJSHelper.onNativeAction(NativeAction.DUCK_AI_SETTINGS)).thenReturn(expectedEvent)
 
-        testee.openDuckChatSettings()
+        testee.openDuckChatSettings(ViewMode.DuckAI)
 
         testee.subscriptionEventDataFlow.test {
             val emittedEvent = awaitItem()
@@ -10079,6 +10079,19 @@ class BrowserTabViewModelTest {
             cancelAndIgnoreRemainingEvents()
         }
 
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_DUCK_AI_SETTINGS_TAPPED)
+    }
+
+    @Test
+    fun whenDuckChatSettingsRequestedOutsideDuckAiThenSettingsUrlOpenedInNewTab() = runTest {
+        val settingsUrl = "https://duck.ai?settings=open"
+        whenever(mockDuckChat.getDuckChatSettingsUrl()).thenReturn(settingsUrl)
+
+        testee.openDuckChatSettings(ViewMode.Browser("https://example.com"))
+
+        assertCommandIssued<Command.OpenInNewTab> {
+            assertEquals(settingsUrl, query)
+        }
         verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_DUCK_AI_SETTINGS_TAPPED)
     }
 

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/browsermenu/BrowserMenuBottomSheet.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/browsermenu/BrowserMenuBottomSheet.kt
@@ -267,7 +267,7 @@ class BrowserMenuBottomSheet(
             showShortcuts = viewState.showDuckAiSection,
             showVoiceChat = viewState.showDuckChatVoiceOption,
             showChatHistory = viewState.showDuckChatHistoryOption,
-            showChatSettings = false,
+            showChatSettings = viewState.showDuckAiSection,
         )
 
         createAliasMenuItem.isVisible = viewState.isEmailSignedIn
@@ -335,7 +335,7 @@ class BrowserMenuBottomSheet(
             showShortcuts = viewState.showDuckAiSection,
             showVoiceChat = viewState.showDuckChatVoiceOption,
             showChatHistory = viewState.showDuckChatHistoryOption,
-            showChatSettings = false,
+            showChatSettings = viewState.showDuckAiSection,
         )
         renderVpnMenu(viewState.vpnMenuState)
         createAliasMenuItem.isVisible = viewState.isEmailSignedIn

--- a/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/browsermenu/BrowserMenuBottomSheetTest.kt
+++ b/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/browsermenu/BrowserMenuBottomSheetTest.kt
@@ -290,7 +290,7 @@ class BrowserMenuBottomSheetTest {
         assertTrue(dialog.duckAiNewChatMenuItem.isVisible)
         assertTrue(dialog.duckAiNewVoiceChatMenuItem.isVisible)
         assertTrue(dialog.duckChatHistoryMenuItem.isVisible)
-        assertFalse(dialog.duckChatSettingsMenuItem.isVisible)
+        assertTrue(dialog.duckChatSettingsMenuItem.isVisible)
     }
 
     @Test
@@ -300,6 +300,7 @@ class BrowserMenuBottomSheetTest {
         dialog.render(BrowserMenuViewState.Browser(showDuckAiSection = false))
 
         assertFalse(duckAiSection.isVisible)
+        assertFalse(dialog.duckChatSettingsMenuItem.isVisible)
     }
 
     @Test

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
@@ -53,6 +53,12 @@ interface DuckChat {
     fun getDuckChatUrl(query: String, autoPrompt: Boolean, sidebar: Boolean = false): String
 
     /**
+     * Returns the Duck.ai URL that opens with the settings panel open (e.g. https://duck.ai?settings=open),
+     * using the configured Duck.ai host. Used to reach Duck.ai settings from outside the Duck.ai web view.
+     */
+    fun getDuckChatSettingsUrl(): String
+
+    /**
      * Determines whether a given [Uri] is a DuckChat URL.
      * There are two Duck Chat URLs
      * Legacy: https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=5

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -627,6 +627,8 @@ class RealDuckChat @Inject constructor(
         return appendParameters(parameters, getDuckChatLink())
     }
 
+    override fun getDuckChatSettingsUrl(): String = resolveDuckAiUrl(DUCK_CHAT_SETTINGS_WEB_LINK)
+
     private fun addChatParameters(
         query: String,
         autoPrompt: Boolean,
@@ -698,9 +700,11 @@ class RealDuckChat @Inject constructor(
             }
     }
 
-    private fun getDuckChatLink(): String {
-        return duckChatLink.toUri().buildUpon().authority(duckAiHostProvider.getHost()).build().toString()
-    }
+    private fun getDuckChatLink(): String = resolveDuckAiUrl(duckChatLink)
+
+    /** Resolves [link] against the configured Duck.ai host by swapping its authority (e.g. for internal/staging overrides). */
+    private fun resolveDuckAiUrl(link: String): String =
+        link.toUri().buildUpon().authority(duckAiHostProvider.getHost()).build().toString()
 
     private fun nativeInputParameters(): Map<String, String> =
         if (isNativeInputFieldEnabled) mapOf(NATIVE_INPUT_QUERY_NAME to NATIVE_INPUT_QUERY_VALUE) else emptyMap()
@@ -973,6 +977,7 @@ class RealDuckChat @Inject constructor(
 
     companion object {
         private const val DUCK_CHAT_WEB_LINK = "https://duck.ai/chat?duckai=5"
+        private const val DUCK_CHAT_SETTINGS_WEB_LINK = "https://duck.ai?settings=open"
         private const val DUCKDUCKGO_HOST = "duckduckgo.com"
         private const val CHAT_QUERY_NAME = "ia"
         private const val CHAT_QUERY_VALUE = "chat"

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -1433,6 +1433,22 @@ class RealDuckChatTest {
     }
 
     @Test
+    fun `when get duck chat settings url then return settings url with configured host`() = runTest {
+        val url = testee.getDuckChatSettingsUrl()
+
+        assertTrue(url == "https://duck.ai?settings=open")
+    }
+
+    @Test
+    fun `when get duck chat settings url with custom host then use that host`() = runTest {
+        whenever(mockDuckAiHostProvider.getHost()).thenReturn("staging.duck.ai")
+
+        val url = testee.getDuckChatSettingsUrl()
+
+        assertTrue(url == "https://staging.duck.ai?settings=open")
+    }
+
+    @Test
     fun `when get duck chat url with empty query and autoprompt then return correct url`() = runTest {
         val url = testee.getDuckChatUrl(query = "", autoPrompt = true, sidebar = false)
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -1593,6 +1593,8 @@ class DuckChatContextualViewModelTest {
             sidebar: Boolean,
         ): String = nextUrl
 
+        override fun getDuckChatSettingsUrl(): String = "https://duck.ai?settings=open"
+
         override fun isDuckChatUrl(uri: android.net.Uri): Boolean =
             uri.host == "duck.ai" || uri.host == "duckduckgo.com"
         override suspend fun wasOpenedBefore(): Boolean = false

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
@@ -62,6 +62,8 @@ class FakeDuckChat(
         return "https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=5"
     }
 
+    override fun getDuckChatSettingsUrl(): String = "https://duck.ai?settings=open"
+
     override fun isDuckChatUrl(uri: Uri): Boolean {
         return uri.toString().contains("duckchat")
     }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -71,6 +71,8 @@ class FakeDuckChatInternal(
         return "https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=5"
     }
 
+    override fun getDuckChatSettingsUrl(): String = "https://duck.ai?settings=open"
+
     override fun isDuckChatUrl(uri: Uri): Boolean = false
 
     override suspend fun wasOpenedBefore(): Boolean = false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1215516325566396?focus=true 

### Description

Surfaces the **Duck.ai Settings** item in the **Browser** and **New Tab Page** overflow menus too. Previously it appeared only in Duck.ai mode. It sits at the bottom of the existing Duck.ai menu section and follows the **Browser Menu** Duck.ai Shortcut toggle (shows only when that section shows). Duck.ai mode is unchanged (Settings stays always-visible there).

### Steps to test this PR

_Prerequisites_
- [ ] Duck.ai enabled; Settings → Duck.ai → Duck.ai Shortcuts → **Browser Menu** toggle ON.

_Browser / NTP_
- [ ] Open a web page (and the New Tab Page) → overflow menu → **Duck.ai Settings** appears at the bottom of the Duck.ai section.
- [ ] Tapping it opens a **new Duck.ai tab with settings panel open.
- [ ] Close (X or back button) should return you to where you were

_Duck.ai_
- [ ] Open Duck.ai → menu → **Duck.ai Settings** opens settings **in same page** (not a new tab).
- [ ] It remains visible even with the **Browser Menu** toggle off.

_Toggle gating_
- [ ] Turn **Browser Menu** OFF → Duck.ai Settings is hidden in Browser/NTP (the section is hidden), but still shown in Duck.ai.

### UI changes
| Before  | After |
| ------ | ----- |
|<img width="396" height="168" alt="Screenshot 2026-06-08 at 6 57 17 PM" src="https://github.com/user-attachments/assets/1c994e42-d1c7-4460-b621-eed19038beea" />|<img width="398" height="217" alt="Screenshot 2026-06-08 at 6 57 32 PM" src="https://github.com/user-attachments/assets/d03a9fac-1f5a-4961-bf76-3718a4645f7e" />|






<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Menu visibility and navigation branching only; Duck.ai in-page settings path is unchanged, with new-tab fallback using an existing open-tab command.
> 
> **Overview**
> Surfaces **Duck.ai Settings** in the browser and NTP overflow menus when the Duck.ai menu section is shown (`showChatSettings` now follows `showDuckAiSection` instead of staying hidden).
> 
> **Settings** behavior is split by omnibar view mode: in **Duck.ai** mode it still triggers the native `DUCK_AI_SETTINGS` subscription event in the current web view; elsewhere it opens `getDuckChatSettingsUrl()` (`https://duck.ai?settings=open`, host-aware) in a **new tab** via `OpenInNewTab`. The fragment passes `omnibar.viewMode` into `openDuckChatSettings`.
> 
> Adds `DuckChat.getDuckChatSettingsUrl()` and implements it in `RealDuckChat`, with `resolveDuckAiUrl` shared for chat and settings links. Tests cover the new-tab path and settings URL host override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f9b3cdb9a32129e63895dce2e7acb25e5fe1880. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->