### PR TITLE
PIR: Fix missing last_step for UNKNOWN wide event status

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEvent.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEvent.kt
@@ -252,14 +252,11 @@ class PirScanWideEventImpl @Inject constructor(
             ),
         ).getOrNull() ?: return
 
-        wideEventClient.flowStep(wideEventId = flowId, stepName = STEP_STARTED, success = true)
+        recordStep(flowId, STEP_STARTED)
         wideEventClient.flowFinish(
             wideEventId = flowId,
             status = FlowStatus.Cancelled,
-            metadata = mapOf(
-                KEY_LAST_STEP to STEP_STARTED,
-                KEY_CANCELLATION_REASON to reason.value,
-            ),
+            metadata = mapOf(KEY_CANCELLATION_REASON to reason.value),
         )
     }
 
@@ -278,6 +275,22 @@ class PirScanWideEventImpl @Inject constructor(
     }
 
     /**
+     * Records a flow step and persists [stepName] as `last_step` metadata in the same write. Because
+     * flowStep metadata is merged into the event and persisted immediately, the furthest-reached step
+     * survives an abnormal termination — e.g. the `:pir` process being killed mid-scan and the flow
+     * finalized as [FlowStatus.Unknown] by the cleanup-on-timeout policy, which never calls
+     * flowFinish.
+     */
+    private suspend fun recordStep(flowId: Long, stepName: String) {
+        wideEventClient.flowStep(
+            wideEventId = flowId,
+            stepName = stepName,
+            success = true,
+            metadata = mapOf(KEY_LAST_STEP to stepName),
+        )
+    }
+
+    /**
      * Per-flow state. Two instances live in the singleton (manual and scheduled) so the two flows
      * never alias on `cachedFlowId`, decile counters, or the `getFlowIds(name)` lookup.
      */
@@ -289,7 +302,6 @@ class PirScanWideEventImpl @Inject constructor(
         private var lastReportedDecile: Int = 0
         private var currentDecileIntervalKey: String? = null
         private var optOutIntervalOpen: Boolean = false
-        private var lastStep: String = STEP_STARTED
 
         suspend fun onRunStarted(
             executionType: PirExecutionType,
@@ -317,10 +329,7 @@ class PirScanWideEventImpl @Inject constructor(
                     wideEventClient.flowFinish(
                         wideEventId = staleId,
                         status = FlowStatus.Cancelled,
-                        metadata = mapOf(
-                            KEY_LAST_STEP to lastStep,
-                            KEY_CANCELLATION_REASON to supersededReason.value,
-                        ),
+                        metadata = mapOf(KEY_CANCELLATION_REASON to supersededReason.value),
                     )
                     clearStateLocked()
                 }
@@ -329,7 +338,6 @@ class PirScanWideEventImpl @Inject constructor(
                 this.completedScanJobs = 0
                 this.lastReportedDecile = 0
                 this.currentDecileIntervalKey = null
-                this.lastStep = STEP_STARTED
 
                 val newFlowId = wideEventClient.flowStart(
                     name = wideEventName,
@@ -353,7 +361,7 @@ class PirScanWideEventImpl @Inject constructor(
                 ).getOrNull() ?: return@withLock
 
                 cachedFlowId = newFlowId
-                wideEventClient.flowStep(wideEventId = newFlowId, stepName = STEP_STARTED, success = true)
+                recordStep(newFlowId, STEP_STARTED)
 
                 if (totalScanJobs > 0) {
                     val key = decileIntervalKey(0, 10)
@@ -396,8 +404,7 @@ class PirScanWideEventImpl @Inject constructor(
                     }
 
                     val stepName = "$STEP_PROGRESS_PREFIX${currentDecile * 10}"
-                    wideEventClient.flowStep(wideEventId = flowId, stepName = stepName, success = true)
-                    lastStep = stepName
+                    recordStep(flowId, stepName)
 
                     if (currentDecile < 9) {
                         val nextKey = decileIntervalKey(currentDecile * 10, (currentDecile + 1) * 10)
@@ -421,18 +428,16 @@ class PirScanWideEventImpl @Inject constructor(
                     currentDecileIntervalKey = null
                 }
 
-                wideEventClient.flowStep(wideEventId = flowId, stepName = STEP_SCAN_COMPLETED, success = true)
-                lastStep = STEP_SCAN_COMPLETED
+                recordStep(flowId, STEP_SCAN_COMPLETED)
             }
         }
 
         suspend fun onOptOutStarted() {
             mutex.withLock {
                 val flowId = cachedFlowId ?: return@withLock
-                wideEventClient.flowStep(wideEventId = flowId, stepName = STEP_OPT_OUT_STARTED, success = true)
+                recordStep(flowId, STEP_OPT_OUT_STARTED)
                 wideEventClient.intervalStart(wideEventId = flowId, key = INTERVAL_OPT_OUT_DURATION)
                 optOutIntervalOpen = true
-                lastStep = STEP_OPT_OUT_STARTED
             }
         }
 
@@ -441,14 +446,11 @@ class PirScanWideEventImpl @Inject constructor(
                 val flowId = cachedFlowId ?: return@withLock
                 wideEventClient.intervalEnd(wideEventId = flowId, key = INTERVAL_OPT_OUT_DURATION)
                 optOutIntervalOpen = false
-                wideEventClient.flowStep(wideEventId = flowId, stepName = STEP_OPT_OUT_COMPLETED, success = true)
+                recordStep(flowId, STEP_OPT_OUT_COMPLETED)
                 wideEventClient.flowFinish(
                     wideEventId = flowId,
                     status = FlowStatus.Success,
-                    metadata = mapOf(
-                        KEY_LAST_STEP to STEP_OPT_OUT_COMPLETED,
-                        KEY_TOTAL_OPT_OUT_JOBS to totalOptOutJobs.toString(),
-                    ),
+                    metadata = mapOf(KEY_TOTAL_OPT_OUT_JOBS to totalOptOutJobs.toString()),
                 )
                 clearStateLocked()
             }
@@ -457,14 +459,11 @@ class PirScanWideEventImpl @Inject constructor(
         suspend fun onOptOutSkipped() {
             mutex.withLock {
                 val flowId = cachedFlowId ?: return@withLock
-                wideEventClient.flowStep(wideEventId = flowId, stepName = STEP_OPT_OUT_SKIPPED, success = true)
+                recordStep(flowId, STEP_OPT_OUT_SKIPPED)
                 wideEventClient.flowFinish(
                     wideEventId = flowId,
                     status = FlowStatus.Success,
-                    metadata = mapOf(
-                        KEY_LAST_STEP to STEP_OPT_OUT_SKIPPED,
-                        KEY_TOTAL_OPT_OUT_JOBS to "0",
-                    ),
+                    metadata = mapOf(KEY_TOTAL_OPT_OUT_JOBS to "0"),
                 )
                 clearStateLocked()
             }
@@ -474,11 +473,11 @@ class PirScanWideEventImpl @Inject constructor(
             mutex.withLock {
                 val flowId = cachedFlowId ?: return@withLock
                 closeOpenIntervalsLocked(flowId)
-                val finalStep = lastStep
+                // last_step is already persisted per-step via recordStep, so it stays on the flow
+                // even when this finish is never reached (Unknown timeout cleanup).
                 wideEventClient.flowFinish(
                     wideEventId = flowId,
                     status = FlowStatus.Failure(reason = reason.value),
-                    metadata = mapOf(KEY_LAST_STEP to finalStep),
                 )
                 clearStateLocked()
             }
@@ -495,19 +494,15 @@ class PirScanWideEventImpl @Inject constructor(
                 // the one handling the cancellation (the main process, for profile deletion or
                 // eligibility loss). cachedFlowId is per-process in-memory state, so fall back to the
                 // shared wide-events DB to resolve the still-open flow by name.
-                val ownFlowId = cachedFlowId
-                val flowId = ownFlowId
+                val flowId = cachedFlowId
                     ?: wideEventClient.getFlowIds(wideEventName).getOrNull()?.lastOrNull()
                     ?: return@withLock false
                 closeOpenIntervalsLocked(flowId)
+                // last_step is persisted incrementally via recordStep, so it is already stored
                 wideEventClient.flowFinish(
                     wideEventId = flowId,
                     status = FlowStatus.Cancelled,
-                    metadata = buildMap {
-                        // last_step is in-memory state, authoritative only when this process owns the flow.
-                        ownFlowId?.let { put(KEY_LAST_STEP, lastStep) }
-                        put(KEY_CANCELLATION_REASON, reason.value)
-                    },
+                    metadata = mapOf(KEY_CANCELLATION_REASON to reason.value),
                 )
                 clearStateLocked()
                 true
@@ -544,7 +539,6 @@ class PirScanWideEventImpl @Inject constructor(
             lastReportedDecile = 0
             currentDecileIntervalKey = null
             optOutIntervalOpen = false
-            lastStep = STEP_STARTED
         }
     }
 

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEventTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEventTest.kt
@@ -238,7 +238,12 @@ class PirScanWideEventTest {
             ),
             cleanupPolicy = CleanupPolicy.OnTimeout(duration = 8.hours, flowStatus = FlowStatus.Unknown),
         )
-        verify(wideEventClient).flowStep(wideEventId = 123L, stepName = STEP_STARTED, success = true)
+        verify(wideEventClient).flowStep(
+            wideEventId = 123L,
+            stepName = STEP_STARTED,
+            success = true,
+            metadata = mapOf(KEY_LAST_STEP to STEP_STARTED),
+        )
         verify(wideEventClient).intervalStart(
             wideEventId = 123L,
             key = "decile_0_10_duration_ms_bucketed",
@@ -291,16 +296,28 @@ class PirScanWideEventTest {
 
         // Then - manual flow remains open, scheduled flow finishes successfully without
         // touching the manual flow's id.
-        verify(wideEventClient).flowStep(wideEventId = 11L, stepName = "progress_50", success = true)
-        verify(wideEventClient).flowStep(wideEventId = 22L, stepName = "progress_30", success = true)
-        verify(wideEventClient).flowStep(wideEventId = 22L, stepName = STEP_SCAN_COMPLETED, success = true)
+        verify(wideEventClient).flowStep(
+            wideEventId = 11L,
+            stepName = "progress_50",
+            success = true,
+            metadata = mapOf(KEY_LAST_STEP to "progress_50"),
+        )
+        verify(wideEventClient).flowStep(
+            wideEventId = 22L,
+            stepName = "progress_30",
+            success = true,
+            metadata = mapOf(KEY_LAST_STEP to "progress_30"),
+        )
+        verify(wideEventClient).flowStep(
+            wideEventId = 22L,
+            stepName = STEP_SCAN_COMPLETED,
+            success = true,
+            metadata = mapOf(KEY_LAST_STEP to STEP_SCAN_COMPLETED),
+        )
         verify(wideEventClient).flowFinish(
             wideEventId = 22L,
             status = FlowStatus.Success,
-            metadata = mapOf(
-                KEY_LAST_STEP to STEP_OPT_OUT_SKIPPED,
-                KEY_TOTAL_OPT_OUT_JOBS to "0",
-            ),
+            metadata = mapOf(KEY_TOTAL_OPT_OUT_JOBS to "0"),
         )
         verify(wideEventClient, never()).flowFinish(eq(11L), any(), any())
     }
@@ -318,7 +335,12 @@ class PirScanWideEventTest {
         // Then - decile math uses the actual count (5), so progress_90 fires on the last job
         // (5/5 = 100% → clamped to 90). Without the resolved-count update, completedScanJobs/100
         // would only reach 5%, and no progress step would fire — that's the bug being fixed.
-        verify(wideEventClient).flowStep(wideEventId = 42L, stepName = "progress_90", success = true)
+        verify(wideEventClient).flowStep(
+            wideEventId = 42L,
+            stepName = "progress_90",
+            success = true,
+            metadata = mapOf(KEY_LAST_STEP to "progress_90"),
+        )
     }
 
     @Test
@@ -353,6 +375,7 @@ class PirScanWideEventTest {
                 wideEventId = 44L,
                 stepName = "progress_${decile * 10}",
                 success = true,
+                metadata = mapOf(KEY_LAST_STEP to "progress_${decile * 10}"),
             )
         }
     }
@@ -366,7 +389,12 @@ class PirScanWideEventTest {
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 0, 0)
 
         // Then
-        verify(wideEventClient).flowStep(wideEventId = 789L, stepName = STEP_STARTED, success = true)
+        verify(wideEventClient).flowStep(
+            wideEventId = 789L,
+            stepName = STEP_STARTED,
+            success = true,
+            metadata = mapOf(KEY_LAST_STEP to STEP_STARTED),
+        )
         verify(wideEventClient, never()).intervalStart(any(), any(), any(), any())
     }
 
@@ -388,10 +416,7 @@ class PirScanWideEventTest {
         order.verify(wideEventClient).flowFinish(
             wideEventId = 100L,
             status = FlowStatus.Cancelled,
-            metadata = mapOf(
-                KEY_LAST_STEP to STEP_STARTED,
-                KEY_CANCELLATION_REASON to "superseded_by_new_run",
-            ),
+            metadata = mapOf(KEY_CANCELLATION_REASON to "superseded_by_new_run"),
         )
     }
 
@@ -412,10 +437,34 @@ class PirScanWideEventTest {
         order.verify(wideEventClient).flowFinish(
             wideEventId = 101L,
             status = FlowStatus.Cancelled,
-            metadata = mapOf(
-                KEY_LAST_STEP to STEP_STARTED,
-                KEY_CANCELLATION_REASON to "superseded_by_profile_edit",
-            ),
+            metadata = mapOf(KEY_CANCELLATION_REASON to "superseded_by_profile_edit"),
+        )
+    }
+
+    @Test
+    fun whenStepsRecordedThenEachCarriesLastStepMetadataSoUnknownEventsRetainProgress() = runTest {
+        // The :pir process can be killed mid-scan and the flow finalized as FlowStatus.Unknown by the
+        // 8h cleanup-on-timeout policy, which never calls flowFinish. Attaching last_step as metadata on
+        // every step persists it incrementally (flowStep metadata is merged + stored immediately), so an
+        // Unknown event still reports how far the scan got.
+        whenever(wideEventClient.flowStart(any(), any(), any(), any())).thenReturn(Result.success(70L))
+        runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 10)
+
+        // When - complete 5 of 10 jobs (crosses 50%)
+        repeat(5) { testee.onScanJobCompleted(PirExecutionType.MANUAL_INITIAL) }
+
+        // Then - the initial step and the latest progress step each persist last_step = their own name
+        verify(wideEventClient).flowStep(
+            wideEventId = 70L,
+            stepName = STEP_STARTED,
+            success = true,
+            metadata = mapOf(KEY_LAST_STEP to STEP_STARTED),
+        )
+        verify(wideEventClient).flowStep(
+            wideEventId = 70L,
+            stepName = "progress_50",
+            success = true,
+            metadata = mapOf(KEY_LAST_STEP to "progress_50"),
         )
     }
 
@@ -434,6 +483,7 @@ class PirScanWideEventTest {
                 wideEventId = 1L,
                 stepName = "progress_${decile * 10}",
                 success = true,
+                metadata = mapOf(KEY_LAST_STEP to "progress_${decile * 10}"),
             )
         }
     }
@@ -448,11 +498,36 @@ class PirScanWideEventTest {
         repeat(5) { testee.onScanJobCompleted(PirExecutionType.MANUAL_INITIAL) }
 
         // Then - progress_20/40/60/80/90 fire (the 5th completion clamps to 90), no progress_10/30/50/70/100
-        verify(wideEventClient).flowStep(wideEventId = 1L, stepName = "progress_20", success = true)
-        verify(wideEventClient).flowStep(wideEventId = 1L, stepName = "progress_40", success = true)
-        verify(wideEventClient).flowStep(wideEventId = 1L, stepName = "progress_60", success = true)
-        verify(wideEventClient).flowStep(wideEventId = 1L, stepName = "progress_80", success = true)
-        verify(wideEventClient).flowStep(wideEventId = 1L, stepName = "progress_90", success = true)
+        verify(wideEventClient).flowStep(
+            wideEventId = 1L,
+            stepName = "progress_20",
+            success = true,
+            metadata = mapOf(KEY_LAST_STEP to "progress_20"),
+        )
+        verify(wideEventClient).flowStep(
+            wideEventId = 1L,
+            stepName = "progress_40",
+            success = true,
+            metadata = mapOf(KEY_LAST_STEP to "progress_40"),
+        )
+        verify(wideEventClient).flowStep(
+            wideEventId = 1L,
+            stepName = "progress_60",
+            success = true,
+            metadata = mapOf(KEY_LAST_STEP to "progress_60"),
+        )
+        verify(wideEventClient).flowStep(
+            wideEventId = 1L,
+            stepName = "progress_80",
+            success = true,
+            metadata = mapOf(KEY_LAST_STEP to "progress_80"),
+        )
+        verify(wideEventClient).flowStep(
+            wideEventId = 1L,
+            stepName = "progress_90",
+            success = true,
+            metadata = mapOf(KEY_LAST_STEP to "progress_90"),
+        )
         verify(wideEventClient, never()).flowStep(any(), eq("progress_10"), any(), any())
         verify(wideEventClient, never()).flowStep(any(), eq("progress_30"), any(), any())
         verify(wideEventClient, never()).flowStep(any(), eq("progress_50"), any(), any())
@@ -471,9 +546,19 @@ class PirScanWideEventTest {
         testee.onScanCompleted(PirExecutionType.MANUAL_INITIAL)
 
         // Then
-        verify(wideEventClient).flowStep(wideEventId = 7L, stepName = "progress_90", success = true)
+        verify(wideEventClient).flowStep(
+            wideEventId = 7L,
+            stepName = "progress_90",
+            success = true,
+            metadata = mapOf(KEY_LAST_STEP to "progress_90"),
+        )
         verify(wideEventClient).intervalEnd(wideEventId = 7L, key = "decile_0_10_duration_ms_bucketed")
-        verify(wideEventClient).flowStep(wideEventId = 7L, stepName = STEP_SCAN_COMPLETED, success = true)
+        verify(wideEventClient).flowStep(
+            wideEventId = 7L,
+            stepName = STEP_SCAN_COMPLETED,
+            success = true,
+            metadata = mapOf(KEY_LAST_STEP to STEP_SCAN_COMPLETED),
+        )
     }
 
     @Test
@@ -520,7 +605,12 @@ class PirScanWideEventTest {
         testee.onScanCompleted(PirExecutionType.MANUAL_INITIAL)
 
         // Then
-        verify(wideEventClient).flowStep(wideEventId = 2L, stepName = STEP_SCAN_COMPLETED, success = true)
+        verify(wideEventClient).flowStep(
+            wideEventId = 2L,
+            stepName = STEP_SCAN_COMPLETED,
+            success = true,
+            metadata = mapOf(KEY_LAST_STEP to STEP_SCAN_COMPLETED),
+        )
     }
 
     @Test
@@ -534,7 +624,12 @@ class PirScanWideEventTest {
 
         // Then
         val order = inOrder(wideEventClient)
-        order.verify(wideEventClient).flowStep(wideEventId = 3L, stepName = STEP_OPT_OUT_STARTED, success = true)
+        order.verify(wideEventClient).flowStep(
+            wideEventId = 3L,
+            stepName = STEP_OPT_OUT_STARTED,
+            success = true,
+            metadata = mapOf(KEY_LAST_STEP to STEP_OPT_OUT_STARTED),
+        )
         order.verify(wideEventClient).intervalStart(
             wideEventId = 3L,
             key = INTERVAL_OPT_OUT_DURATION,
@@ -553,14 +648,16 @@ class PirScanWideEventTest {
 
         // Then
         verify(wideEventClient).intervalEnd(wideEventId = 4L, key = INTERVAL_OPT_OUT_DURATION)
-        verify(wideEventClient).flowStep(wideEventId = 4L, stepName = STEP_OPT_OUT_COMPLETED, success = true)
+        verify(wideEventClient).flowStep(
+            wideEventId = 4L,
+            stepName = STEP_OPT_OUT_COMPLETED,
+            success = true,
+            metadata = mapOf(KEY_LAST_STEP to STEP_OPT_OUT_COMPLETED),
+        )
         verify(wideEventClient).flowFinish(
             wideEventId = 4L,
             status = FlowStatus.Success,
-            metadata = mapOf(
-                KEY_LAST_STEP to STEP_OPT_OUT_COMPLETED,
-                KEY_TOTAL_OPT_OUT_JOBS to "7",
-            ),
+            metadata = mapOf(KEY_TOTAL_OPT_OUT_JOBS to "7"),
         )
     }
 
@@ -574,14 +671,16 @@ class PirScanWideEventTest {
         testee.onOptOutSkipped(PirExecutionType.MANUAL_INITIAL)
 
         // Then
-        verify(wideEventClient).flowStep(wideEventId = 5L, stepName = STEP_OPT_OUT_SKIPPED, success = true)
+        verify(wideEventClient).flowStep(
+            wideEventId = 5L,
+            stepName = STEP_OPT_OUT_SKIPPED,
+            success = true,
+            metadata = mapOf(KEY_LAST_STEP to STEP_OPT_OUT_SKIPPED),
+        )
         verify(wideEventClient).flowFinish(
             wideEventId = 5L,
             status = FlowStatus.Success,
-            metadata = mapOf(
-                KEY_LAST_STEP to STEP_OPT_OUT_SKIPPED,
-                KEY_TOTAL_OPT_OUT_JOBS to "0",
-            ),
+            metadata = mapOf(KEY_TOTAL_OPT_OUT_JOBS to "0"),
         )
         verify(wideEventClient, never()).intervalEnd(
             wideEventId = 5L,
@@ -590,7 +689,7 @@ class PirScanWideEventTest {
     }
 
     @Test
-    fun whenRunFailedThenFlowFinishedWithFailureAndLastStep() = runTest {
+    fun whenRunFailedThenFlowFinishedWithFailure() = runTest {
         // Given
         whenever(wideEventClient.flowStart(any(), any(), any(), any())).thenReturn(Result.success(6L))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 0, 0)
@@ -598,11 +697,10 @@ class PirScanWideEventTest {
         // When
         testee.onRunFailed(PirExecutionType.MANUAL_INITIAL, FailureReason.NO_ACTIVE_BROKERS)
 
-        // Then
+        // Then - last_step is not attached here; it is persisted per-step via recordStep.
         verify(wideEventClient).flowFinish(
             wideEventId = 6L,
             status = FlowStatus.Failure(reason = "no_active_brokers"),
-            metadata = mapOf(KEY_LAST_STEP to STEP_STARTED),
         )
     }
 
@@ -611,19 +709,16 @@ class PirScanWideEventTest {
         // Given
         whenever(wideEventClient.flowStart(any(), any(), any(), any())).thenReturn(Result.success(8L))
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 1)
-        testee.onScanJobCompleted(PirExecutionType.MANUAL_INITIAL) // emits progress_90 -> last_step = progress_90
+        testee.onScanJobCompleted(PirExecutionType.MANUAL_INITIAL) // emits progress_90 (which persists last_step = progress_90)
 
         // When
         testee.onRunCancelled(PirExecutionType.MANUAL_INITIAL, CancellationReason.WORK_STOPPED)
 
-        // Then
+        // Then - only the cancellation reason is attached at finish; last_step was persisted per-step.
         verify(wideEventClient).flowFinish(
             wideEventId = 8L,
             status = FlowStatus.Cancelled,
-            metadata = mapOf(
-                KEY_LAST_STEP to "progress_90",
-                KEY_CANCELLATION_REASON to "work_stopped",
-            ),
+            metadata = mapOf(KEY_CANCELLATION_REASON to "work_stopped"),
         )
     }
 
@@ -643,7 +738,6 @@ class PirScanWideEventTest {
         order.verify(wideEventClient).flowFinish(
             wideEventId = 60L,
             status = FlowStatus.Failure(reason = "unknown_error"),
-            metadata = mapOf(KEY_LAST_STEP to "progress_20"),
         )
     }
 
@@ -664,7 +758,6 @@ class PirScanWideEventTest {
         order.verify(wideEventClient).flowFinish(
             wideEventId = 61L,
             status = FlowStatus.Failure(reason = "unknown_error"),
-            metadata = mapOf(KEY_LAST_STEP to STEP_OPT_OUT_STARTED),
         )
     }
 
@@ -683,10 +776,7 @@ class PirScanWideEventTest {
         order.verify(wideEventClient).flowFinish(
             wideEventId = 62L,
             status = FlowStatus.Cancelled,
-            metadata = mapOf(
-                KEY_LAST_STEP to STEP_STARTED,
-                KEY_CANCELLATION_REASON to "work_stopped",
-            ),
+            metadata = mapOf(KEY_CANCELLATION_REASON to "work_stopped"),
         )
     }
 
@@ -707,10 +797,7 @@ class PirScanWideEventTest {
         order.verify(wideEventClient).flowFinish(
             wideEventId = 63L,
             status = FlowStatus.Cancelled,
-            metadata = mapOf(
-                KEY_LAST_STEP to STEP_OPT_OUT_STARTED,
-                KEY_CANCELLATION_REASON to "work_stopped",
-            ),
+            metadata = mapOf(KEY_CANCELLATION_REASON to "work_stopped"),
         )
     }
 
@@ -727,10 +814,7 @@ class PirScanWideEventTest {
         verify(wideEventClient).flowFinish(
             wideEventId = 80L,
             status = FlowStatus.Cancelled,
-            metadata = mapOf(
-                KEY_LAST_STEP to STEP_STARTED,
-                KEY_CANCELLATION_REASON to "profile_deleted",
-            ),
+            metadata = mapOf(KEY_CANCELLATION_REASON to "profile_deleted"),
         )
     }
 
@@ -751,7 +835,8 @@ class PirScanWideEventTest {
 
         testee.onWorkCancelled(CancellationReason.PROFILE_DELETED)
 
-        // last_step is omitted: it is per-process in-memory state we don't own here.
+        // last_step is not attached at finish: it was persisted per-step (via recordStep) by the
+        // process that ran the scan, so it is already stored on the flow we resolved from the DB.
         verify(wideEventClient).flowFinish(
             wideEventId = 555L,
             status = FlowStatus.Cancelled,
@@ -778,14 +863,16 @@ class PirScanWideEventTest {
             ),
             cleanupPolicy = CleanupPolicy.OnTimeout(duration = 8.hours, flowStatus = FlowStatus.Unknown),
         )
-        order.verify(wideEventClient).flowStep(wideEventId = 90L, stepName = STEP_STARTED, success = true)
+        order.verify(wideEventClient).flowStep(
+            wideEventId = 90L,
+            stepName = STEP_STARTED,
+            success = true,
+            metadata = mapOf(KEY_LAST_STEP to STEP_STARTED),
+        )
         order.verify(wideEventClient).flowFinish(
             wideEventId = 90L,
             status = FlowStatus.Cancelled,
-            metadata = mapOf(
-                KEY_LAST_STEP to STEP_STARTED,
-                KEY_CANCELLATION_REASON to "foreground_start_failed",
-            ),
+            metadata = mapOf(KEY_CANCELLATION_REASON to "foreground_start_failed"),
         )
     }
 
@@ -811,10 +898,7 @@ class PirScanWideEventTest {
         verify(wideEventClient).flowFinish(
             wideEventId = 300L,
             status = FlowStatus.Cancelled,
-            metadata = mapOf(
-                KEY_LAST_STEP to STEP_STARTED,
-                KEY_CANCELLATION_REASON to "subscription_expired",
-            ),
+            metadata = mapOf(KEY_CANCELLATION_REASON to "subscription_expired"),
         )
     }
 
@@ -884,7 +968,6 @@ class PirScanWideEventTest {
         verify(wideEventClient).flowFinish(
             wideEventId = 99L,
             status = FlowStatus.Failure(reason = "io_exception"),
-            metadata = mapOf(KEY_LAST_STEP to STEP_STARTED),
         )
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1210594645151737/task/1215426452088650?focus=true

### Description
Fixes missing `last_step` for UNKNOWN wide event status by recording it for every step instead of attaching it at the end as metadata.

### Steps to test this PR

_PIR scan_
- [x] Smoke test - run a new scan and verify the wide event `pir-initial-scan` is fired at the end with correct `last_step`
- [x] Apply the patch below and rebuild
- [x] Start a new scan and wait for 30 seconds - 1 minute (so that it moves from started to 10%)
- [x] Force close the app (not just swipe it away, but go to app info and click force close)
- [x] Wait for roughly more 2 minutes so that the 3 minute timeout is reached before re-opening the app
- [x] Verify that the wide event `pir-initial-scan` is fired at app open with correct `last_step` (either `started` or 10%)

```
Index: pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEvent.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEvent.kt b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEvent.kt
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEvent.kt	(revision f824cb66b53483658af5eaef039d2456c69e3793)
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEvent.kt	(date 1780985020007)
@@ -35,6 +35,7 @@
 import javax.inject.Inject
 import kotlin.random.Random
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
 
 interface PirScanWideEvent {
     suspend fun onRunStarted(
@@ -566,7 +567,7 @@
     private fun Boolean.toTrackerBlockingState(): String = if (this) "enabled" else "disabled"
 
     companion object {
-        private val TIMEOUT_DURATION = 8.hours
+        private val TIMEOUT_DURATION = 3.minutes
 
         const val WIDE_EVENT_NAME_MANUAL = "pir-initial-scan"
         const val WIDE_EVENT_NAME_SCHEDULED = "pir-scheduled-scan"

```

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only change in PIR wide-event wiring; no user-facing scan behavior or auth/data paths affected.
> 
> **Overview**
> Fixes **missing `last_step` on PIR scan wide events** that end as **`FlowStatus.Unknown`** (e.g. `:pir` killed mid-scan and the 8h cleanup-on-timeout finalizes without `flowFinish`).
> 
> **`recordStep`** now wraps every progress/opt-out step so each `flowStep` writes **`last_step`** metadata immediately (merged into the stored event). The in-memory **`lastStep`** field is removed, and **`flowFinish`** no longer attaches `last_step`—only fields like cancellation reason or opt-out job counts where relevant. Cross-process cancellation paths no longer try to supply `last_step` from the cancelling process.
> 
> Tests assert `last_step` on each `flowStep` and add coverage for incremental persistence when a flow would become Unknown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f824cb66b53483658af5eaef039d2456c69e3793. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->