### PR TITLE
Theme DaxIconButton colors and add filled variant

### DIFF
--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/buttons/ComponentButtonsFragment.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/buttons/ComponentButtonsFragment.kt
@@ -23,6 +23,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
@@ -34,6 +35,7 @@ import com.duckduckgo.common.ui.compose.button.DaxDestructiveGhostSecondaryButto
 import com.duckduckgo.common.ui.compose.button.DaxDestructivePrimaryButton
 import com.duckduckgo.common.ui.compose.button.DaxGhostButton
 import com.duckduckgo.common.ui.compose.button.DaxIconButton
+import com.duckduckgo.common.ui.compose.button.DaxIconButtonDefaults
 import com.duckduckgo.common.ui.compose.button.DaxPrimaryButton
 import com.duckduckgo.common.ui.compose.button.DaxSecondaryButton
 import com.duckduckgo.common.ui.internal.databinding.ComponentButtonsBinding
@@ -288,11 +290,28 @@ class ComponentButtonsFragment : Fragment() {
             id = com.duckduckgo.common.ui.internal.R.id.compose_icon_button,
             isDarkTheme = isDarkTheme,
         ) {
-            DaxIconButton(
-                onClick = {},
-                iconPainter = painterResource(R.drawable.ic_union),
-                contentDescription = "Menu",
-            )
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                DaxIconButton(
+                    onClick = {},
+                    iconPainter = painterResource(R.drawable.ic_union),
+                    contentDescription = "Menu",
+                )
+                DaxIconButton(
+                    onClick = {},
+                    iconPainter = painterResource(R.drawable.ic_union),
+                    contentDescription = "Menu",
+                    colors = DaxIconButtonDefaults.filledColors,
+                )
+                DaxIconButton(
+                    onClick = {},
+                    iconPainter = painterResource(R.drawable.ic_union),
+                    contentDescription = "Menu",
+                    enabled = false,
+                )
+            }
         }
     }
 }

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/buttons/ComponentButtonsFragment.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/buttons/ComponentButtonsFragment.kt
@@ -303,7 +303,7 @@ class ComponentButtonsFragment : Fragment() {
                     onClick = {},
                     iconPainter = painterResource(R.drawable.ic_union),
                     contentDescription = "Menu",
-                    colors = DaxIconButtonDefaults.filledColors,
+                    colors = DaxIconButtonDefaults.filledIconButtonColors,
                 )
                 DaxIconButton(
                     onClick = {},

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxIconButton.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxIconButton.kt
@@ -24,6 +24,8 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.LocalMinimumInteractiveComponentSize
+import androidx.compose.material3.LocalRippleConfiguration
+import androidx.compose.material3.RippleConfiguration
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Immutable
@@ -35,7 +37,9 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.duckduckgo.common.ui.compose.theme.Black6
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+import com.duckduckgo.common.ui.compose.theme.White12
 import com.duckduckgo.common.ui.compose.tools.PreviewBox
 import com.duckduckgo.mobile.android.R
 
@@ -71,6 +75,7 @@ fun DaxIconButton(
 ) {
     CompositionLocalProvider(
         LocalMinimumInteractiveComponentSize provides Dp.Unspecified,
+        LocalRippleConfiguration provides DaxIconButtonDefaults.rippleConfiguration(),
     ) {
         IconButton(
             onClick = onClick,
@@ -110,6 +115,12 @@ object DaxIconButtonDefaults {
             disabledContainerColor = DuckDuckGoTheme.colors.backgrounds.containerDisabled,
             disabledContentColor = DuckDuckGoTheme.colors.icons.disabled,
         )
+
+    @Composable
+    fun rippleConfiguration(): RippleConfiguration {
+        val color = if (DuckDuckGoTheme.colors.isDark) White12 else Black6
+        return remember(color) { RippleConfiguration(color = color) }
+    }
 }
 
 @Immutable

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxIconButton.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxIconButton.kt
@@ -17,9 +17,12 @@
 package com.duckduckgo.common.ui.compose.button
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonColors
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -30,6 +33,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
 import com.duckduckgo.common.ui.compose.tools.PreviewBox
 import com.duckduckgo.mobile.android.R
 
@@ -38,15 +42,19 @@ import com.duckduckgo.mobile.android.R
  *
  * Wraps Material3 [IconButton] for icon-only actions (e.g. close, back, overflow).
  *
- * No tint is applied — the icon renders with its native colors, matching the
- * View-system [IconButton][com.duckduckgo.common.ui.view.button.IconButton] which
- * relies on the drawable's own `?attr/` theme colors (e.g. `?attr/daxColorPrimaryIcon`).
+ * The icon is tinted with [colors]'s content color so it follows the Compose
+ * [DuckDuckGoTheme] (light/dark) rather than the drawable's baked-in colors. Pass
+ * [DaxIconButtonDefaults.filledColors] for a filled container.
  *
  * @param onClick Called when the button is clicked.
  * @param iconPainter The icon to display.
  * @param contentDescription Accessibility description, or null if decorative.
  * @param modifier Modifier for this button.
+ * @param enabled Whether the button is enabled.
+ * @param colors Container and content colors; defaults to [DaxIconButtonDefaults.colors].
  * @param interactionSource The interaction source for this button.
+ *
+ * Asana task: https://app.asana.com/1/137249556945/project/1202857801505092/task/1215540472063931?focus=true
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -55,6 +63,8 @@ fun DaxIconButton(
     iconPainter: Painter,
     contentDescription: String?,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    colors: IconButtonColors = DaxIconButtonDefaults.colors,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
     CompositionLocalProvider(
@@ -63,25 +73,59 @@ fun DaxIconButton(
         IconButton(
             onClick = onClick,
             modifier = modifier,
+            colors = colors,
+            enabled = enabled,
             interactionSource = interactionSource,
         ) {
             Icon(
                 painter = iconPainter,
                 contentDescription = contentDescription,
-                tint = Color.Unspecified,
+                tint = if (enabled) {
+                    colors.contentColor
+                } else {
+                    colors.disabledContentColor
+                },
             )
         }
     }
+}
+
+object DaxIconButtonDefaults {
+    val colors: IconButtonColors
+        @Composable
+        get() = IconButtonDefaults.iconButtonColors(
+            containerColor = Color.Transparent,
+            contentColor = DuckDuckGoTheme.colors.icons.primary,
+            disabledContainerColor = Color.Transparent,
+            disabledContentColor = DuckDuckGoTheme.colors.icons.disabled,
+        )
+
+    val filledColors: IconButtonColors
+        @Composable
+        get() = IconButtonDefaults.iconButtonColors(
+            containerColor = DuckDuckGoTheme.colors.backgrounds.container,
+            contentColor = DuckDuckGoTheme.colors.icons.primary,
+            disabledContainerColor = DuckDuckGoTheme.colors.backgrounds.container,
+            disabledContentColor = DuckDuckGoTheme.colors.icons.disabled,
+        )
 }
 
 @PreviewLightDark
 @Composable
 private fun DaxIconButtonPreview() {
     PreviewBox {
-        DaxIconButton(
-            onClick = {},
-            iconPainter = painterResource(R.drawable.ic_settings_24),
-            contentDescription = "Settings",
-        )
+        Column {
+            DaxIconButton(
+                onClick = {},
+                iconPainter = painterResource(R.drawable.ic_settings_24),
+                contentDescription = "Settings",
+            )
+            DaxIconButton(
+                onClick = {},
+                iconPainter = painterResource(R.drawable.ic_settings_24),
+                contentDescription = "Settings",
+                colors = DaxIconButtonDefaults.filledColors,
+            )
+        }
     }
 }

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxIconButton.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxIconButton.kt
@@ -17,15 +17,16 @@
 package com.duckduckgo.common.ui.compose.button
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.IconButtonColors
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -33,6 +34,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
 import com.duckduckgo.common.ui.compose.tools.PreviewBox
 import com.duckduckgo.mobile.android.R
@@ -64,7 +66,7 @@ fun DaxIconButton(
     contentDescription: String?,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
-    colors: IconButtonColors = DaxIconButtonDefaults.colors,
+    colors: DaxIconButtonColors = DaxIconButtonDefaults.colors,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
     CompositionLocalProvider(
@@ -73,48 +75,56 @@ fun DaxIconButton(
         IconButton(
             onClick = onClick,
             modifier = modifier,
-            colors = colors,
+            colors = IconButtonDefaults.iconButtonColors(
+                containerColor = colors.containerColor,
+                contentColor = colors.contentColor,
+                disabledContainerColor = colors.disabledContainerColor,
+                disabledContentColor = colors.disabledContentColor,
+            ),
             enabled = enabled,
             interactionSource = interactionSource,
         ) {
             Icon(
                 painter = iconPainter,
                 contentDescription = contentDescription,
-                tint = if (enabled) {
-                    colors.contentColor
-                } else {
-                    colors.disabledContentColor
-                },
             )
         }
     }
 }
 
 object DaxIconButtonDefaults {
-    val colors: IconButtonColors
+    val colors: DaxIconButtonColors
         @Composable
-        get() = IconButtonDefaults.iconButtonColors(
-            containerColor = Color.Transparent,
+        get() = DaxIconButtonColors(
+            containerColor = Color.Unspecified,
             contentColor = DuckDuckGoTheme.colors.icons.primary,
-            disabledContainerColor = Color.Transparent,
+            disabledContainerColor = Color.Unspecified,
             disabledContentColor = DuckDuckGoTheme.colors.icons.disabled,
         )
 
-    val filledColors: IconButtonColors
+    val filledColors: DaxIconButtonColors
         @Composable
-        get() = IconButtonDefaults.iconButtonColors(
+        get() = DaxIconButtonColors(
             containerColor = DuckDuckGoTheme.colors.backgrounds.container,
             contentColor = DuckDuckGoTheme.colors.icons.primary,
-            disabledContainerColor = DuckDuckGoTheme.colors.backgrounds.container,
+            disabledContainerColor = DuckDuckGoTheme.colors.backgrounds.containerDisabled,
             disabledContentColor = DuckDuckGoTheme.colors.icons.disabled,
         )
 }
+
+@Immutable
+data class DaxIconButtonColors(
+    val containerColor: Color,
+    val contentColor: Color,
+    val disabledContainerColor: Color,
+    val disabledContentColor: Color,
+)
 
 @PreviewLightDark
 @Composable
 private fun DaxIconButtonPreview() {
     PreviewBox {
-        Column {
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
             DaxIconButton(
                 onClick = {},
                 iconPainter = painterResource(R.drawable.ic_settings_24),
@@ -124,6 +134,13 @@ private fun DaxIconButtonPreview() {
                 onClick = {},
                 iconPainter = painterResource(R.drawable.ic_settings_24),
                 contentDescription = "Settings",
+                colors = DaxIconButtonDefaults.filledColors,
+            )
+            DaxIconButton(
+                onClick = {},
+                iconPainter = painterResource(R.drawable.ic_settings_24),
+                contentDescription = "Settings",
+                enabled = false,
                 colors = DaxIconButtonDefaults.filledColors,
             )
         }

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxIconButton.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxIconButton.kt
@@ -46,14 +46,14 @@ import com.duckduckgo.mobile.android.R
  *
  * The icon is tinted with [colors]'s content color so it follows the Compose
  * [DuckDuckGoTheme] (light/dark) rather than the drawable's baked-in colors. Pass
- * [DaxIconButtonDefaults.filledColors] for a filled container.
+ * [DaxIconButtonDefaults.filledIconButtonColors] for a filled container.
  *
  * @param onClick Called when the button is clicked.
  * @param iconPainter The icon to display.
  * @param contentDescription Accessibility description, or null if decorative.
  * @param modifier Modifier for this button.
  * @param enabled Whether the button is enabled.
- * @param colors Container and content colors; defaults to [DaxIconButtonDefaults.colors].
+ * @param colors Container and content colors; defaults to [DaxIconButtonDefaults.iconButtonColors].
  * @param interactionSource The interaction source for this button.
  *
  * Asana task: https://app.asana.com/1/137249556945/project/1202857801505092/task/1215540472063931?focus=true
@@ -66,7 +66,7 @@ fun DaxIconButton(
     contentDescription: String?,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
-    colors: DaxIconButtonColors = DaxIconButtonDefaults.colors,
+    colors: DaxIconButtonColors = DaxIconButtonDefaults.iconButtonColors,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
     CompositionLocalProvider(
@@ -93,7 +93,7 @@ fun DaxIconButton(
 }
 
 object DaxIconButtonDefaults {
-    val colors: DaxIconButtonColors
+    val iconButtonColors: DaxIconButtonColors
         @Composable
         get() = DaxIconButtonColors(
             containerColor = Color.Unspecified,
@@ -102,7 +102,7 @@ object DaxIconButtonDefaults {
             disabledContentColor = DuckDuckGoTheme.colors.icons.disabled,
         )
 
-    val filledColors: DaxIconButtonColors
+    val filledIconButtonColors: DaxIconButtonColors
         @Composable
         get() = DaxIconButtonColors(
             containerColor = DuckDuckGoTheme.colors.backgrounds.container,
@@ -134,14 +134,14 @@ private fun DaxIconButtonPreview() {
                 onClick = {},
                 iconPainter = painterResource(R.drawable.ic_settings_24),
                 contentDescription = "Settings",
-                colors = DaxIconButtonDefaults.filledColors,
+                colors = DaxIconButtonDefaults.filledIconButtonColors,
             )
             DaxIconButton(
                 onClick = {},
                 iconPainter = painterResource(R.drawable.ic_settings_24),
                 contentDescription = "Settings",
                 enabled = false,
-                colors = DaxIconButtonDefaults.filledColors,
+                colors = DaxIconButtonDefaults.filledIconButtonColors,
             )
         }
     }

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/tools/PreviewBox.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/tools/PreviewBox.kt
@@ -16,15 +16,21 @@
 
 package com.duckduckgo.common.ui.compose.tools
 
+import android.view.ContextThemeWrapper
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+import com.duckduckgo.mobile.android.R
 
 @Composable
 fun PreviewBoxInverted(
@@ -43,12 +49,23 @@ fun PreviewBox(
     color: @Composable () -> Color = { DuckDuckGoTheme.colors.backgrounds.background },
     content: @Composable BoxScope.() -> Unit,
 ) {
-    DuckDuckGoTheme {
-        Box(
-            modifier = modifier
-                .background(color())
-                .padding(all = 16.dp),
-            content = content,
+    val isDarkTheme = isSystemInDarkTheme()
+    val baseContext = LocalContext.current
+    // Previews lack the View theme that painterResource uses to resolve drawable `?attr/daxColor*` fills, so without it icons render transparent.
+    val themedContext = remember(baseContext, isDarkTheme) {
+        ContextThemeWrapper(
+            baseContext,
+            if (isDarkTheme) R.style.Theme_DuckDuckGo_Dark else R.style.Theme_DuckDuckGo_Light,
         )
+    }
+    CompositionLocalProvider(LocalContext provides themedContext) {
+        DuckDuckGoTheme(isDarkTheme = isDarkTheme) {
+            Box(
+                modifier = modifier
+                    .background(color())
+                    .padding(all = 16.dp),
+                content = content,
+            )
+        }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1215496415658080/task/1215564036631797?focus=true

### Description

Makes the Compose `DaxIconButton` follow the Compose theme, and adds a filled variant.

- The icon is now tinted with the button's content color (`DuckDuckGoTheme.colors.icons.primary` by default) instead of `Color.Unspecified`. Previously, icons with hard-coded fills (e.g. `ic_ai_chat_24_solid_color`, which is `@color/black`) rendered the wrong color in dark mode because the drawable's baked-in color was used instead of the Compose theme.
- Adds `enabled` and `colors` parameters plus `DaxIconButtonDefaults` (`colors` = transparent container, `filledColors` = filled container).
- Showcases default, filled, and disabled states in the design system internal screen ("Icon Buttons" section).

### Steps to test this PR

_Design system screen_
- [x] Build & install the internal variant, open Design System → Components → Buttons.
- [x] Scroll to "Icon Buttons": confirm three Compose icon buttons render — default (transparent), filled, and disabled.
- [x] Toggle dark/light theme: confirm the icon color follows the theme in all three states.

### UI changes
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/627437dd-28df-4115-bef1-ce6a06680222" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default icon tinting changes behavior for every existing DaxIconButton call site; icons that relied on native drawable colors may look different until callers adjust assets or colors.
> 
> **Overview**
> **`DaxIconButton`** now drives icon appearance from Compose theme colors instead of leaving drawables untinted, fixing wrong colors in dark mode for icons with baked-in fills. It gains **`enabled`**, a **`colors`** parameter, **`DaxIconButtonDefaults`** (default transparent vs **filled** container), and themed ripple via **`LocalRippleConfiguration`**.
> 
> The internal **Buttons** design-system screen and Compose previews show default, filled, and disabled states. **`PreviewBox`** wraps previews in the app light/dark **`ContextThemeWrapper`** so **`painterResource`** icons resolve theme attrs correctly in Studio.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2190e86fd0b2ebd8621c285dd0702d9dba0c7e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->