### PR TITLE
Add DaxScaffold and lint rule enforcing it over Material Scaffold

### DIFF
--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/Component.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/Component.kt
@@ -20,6 +20,7 @@ enum class Component {
     BUTTON,
     FAB,
     CARD,
+    SCAFFOLD,
     TOP_APP_BAR,
     CHIP,
     DRAWER,

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentViewHolder.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentViewHolder.kt
@@ -25,14 +25,17 @@ import android.widget.FrameLayout
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -65,6 +68,7 @@ import com.duckduckgo.common.ui.compose.cards.DaxSurface
 import com.duckduckgo.common.ui.compose.checkbox.DaxCheckbox
 import com.duckduckgo.common.ui.compose.divider.DaxHorizontalDivider
 import com.duckduckgo.common.ui.compose.divider.DaxVerticalDivider
+import com.duckduckgo.common.ui.compose.layout.DaxScaffold
 import com.duckduckgo.common.ui.compose.message.remote.DaxBigSingleActionMessage
 import com.duckduckgo.common.ui.compose.message.remote.DaxBigTwoActionsMessage
 import com.duckduckgo.common.ui.compose.message.remote.DaxMediumMessage
@@ -867,6 +871,47 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
         }
     }
 
+    class ScaffoldComponentViewHolder(
+        parent: ViewGroup,
+        private val isDarkTheme: Boolean,
+    ) : ComponentViewHolder(inflate(parent, R.layout.component_scaffold)) {
+        @OptIn(ExperimentalMaterial3Api::class)
+        override fun bind(component: Component) {
+            view.setupThemedComposeView(R.id.composeScaffold, isDarkTheme) {
+                val searchState = rememberTextFieldState()
+                var searchActive by remember { mutableStateOf(false) }
+                DaxScaffold(
+                    modifier = Modifier.height(400.dp),
+                    topBar = {
+                        DaxSearchTopAppBar(
+                            title = "Bookmarks",
+                            navigationIcon = DaxTopAppBarNavigationIcon.Back { },
+                            shadow = true,
+                            searchActive = searchActive,
+                            searchState = searchState,
+                            searchPlaceholder = "Search…",
+                            onSearchBack = { searchActive = false },
+                            actions = {
+                                DaxIconButton(
+                                    onClick = { searchActive = true },
+                                    iconPainter = painterResource(CommonR.drawable.ic_find_search_24),
+                                    contentDescription = "Search",
+                                )
+                            },
+                        )
+                    },
+                ) { paddingValues ->
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        DaxText(text = "Content goes here")
+                    }
+                }
+            }
+        }
+    }
+
     class SettingsListItemComponentViewHolder(parent: ViewGroup) :
         ComponentViewHolder(inflate(parent, R.layout.component_settings)) {
         override fun bind(component: Component) {
@@ -901,6 +946,7 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
                 Component.SECTION_DIVIDER -> DividerComponentViewHolder(parent, isDarkTheme)
                 Component.PROGRESS_SPINNER -> ProgressSpinnerComponentViewHolder(parent, isDarkTheme)
                 Component.CARD -> CardComponentViewHolder(parent, isDarkTheme)
+                Component.SCAFFOLD -> ScaffoldComponentViewHolder(parent, isDarkTheme)
                 Component.SETTINGS_LIST_ITEM -> SettingsListItemComponentViewHolder(parent)
                 else -> {
                     TODO()

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentViewHolder.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentViewHolder.kt
@@ -35,7 +35,6 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.input.rememberTextFieldState
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -875,7 +874,6 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
         parent: ViewGroup,
         private val isDarkTheme: Boolean,
     ) : ComponentViewHolder(inflate(parent, R.layout.component_scaffold)) {
-        @OptIn(ExperimentalMaterial3Api::class)
         override fun bind(component: Component) {
             view.setupThemedComposeView(R.id.composeScaffold, isDarkTheme) {
                 val searchState = rememberTextFieldState()

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/cards/ComponentLayoutsFragment.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/cards/ComponentLayoutsFragment.kt
@@ -21,6 +21,6 @@ import com.duckduckgo.common.ui.internal.ui.component.ComponentFragment
 
 class ComponentLayoutsFragment : ComponentFragment() {
     override fun getComponents(): List<Component> {
-        return listOf(Component.CARD)
+        return listOf(Component.CARD, Component.SCAFFOLD)
     }
 }

--- a/android-design-system/design-system-internal/src/main/res/layout/component_scaffold.xml
+++ b/android-design-system/design-system-internal/src/main/res/layout/component_scaffold.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+~ Copyright (C) 2019 The Android Open Source Project
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~      http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingTop="@dimen/keyline_5"
+    android:paddingBottom="@dimen/keyline_5"
+    android:clipChildren="false"
+    android:orientation="vertical">
+
+    <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+        android:id="@+id/daxBubbleLabel"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        app:primaryText="Dax Scaffold"/>
+
+    <com.duckduckgo.common.ui.internal.ui.PlatformLabelView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/keyline_1"
+        android:layout_marginBottom="@dimen/keyline_1"
+        app:platformType="compose"/>
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/composeScaffold"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/keyline_1"
+        android:layout_marginBottom="@dimen/keyline_2" />
+
+</LinearLayout>

--- a/android-design-system/design-system-internal/src/main/res/layout/component_scaffold.xml
+++ b/android-design-system/design-system-internal/src/main/res/layout/component_scaffold.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-~ Copyright (C) 2019 The Android Open Source Project
-~
-~ Licensed under the Apache License, Version 2.0 (the "License");
-~ you may not use this file except in compliance with the License.
-~ You may obtain a copy of the License at
-~
-~      http://www.apache.org/licenses/LICENSE-2.0
-~
-~ Unless required by applicable law or agreed to in writing, software
-~ distributed under the License is distributed on an "AS IS" BASIS,
-~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-~ See the License for the specific language governing permissions and
-~ limitations under the License.
--->
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
 
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
@@ -25,7 +25,7 @@
     android:orientation="vertical">
 
     <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
-        android:id="@+id/daxBubbleLabel"
+        android:id="@+id/scaffoldLabel"
         android:layout_height="wrap_content"
         android:layout_width="match_parent"
         app:primaryText="Dax Scaffold"/>

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/layout/DaxScaffold.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/layout/DaxScaffold.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui.compose.layout
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScaffoldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import com.duckduckgo.common.ui.compose.appbars.DaxTopAppBar
+import com.duckduckgo.common.ui.compose.appbars.DaxTopAppBarNavigationIcon
+import com.duckduckgo.common.ui.compose.button.DaxIconButton
+import com.duckduckgo.common.ui.compose.text.DaxText
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+import com.duckduckgo.mobile.android.R
+
+/**
+ * DuckDuckGo themed Scaffold layout.
+ * Wraps Material3 [Scaffold] with DuckDuckGo's default colors and styling.
+ *
+ * @param modifier Modifier for this Scaffold.
+ * @param topBar Composable for the top app bar.
+ * @param bottomBar Composable for the bottom bar.
+ * @param snackbarHost Composable for the snackbar host.
+ * @param contentWindowInsets Window insets for the content area.
+ * @param content Composable for the main content, with padding values provided by Scaffold.
+ *
+ * Asana Task: https://app.asana.com/1/137249556945/project/1202857801505092/task/1215519019861192?focus=true
+ */
+@Composable
+fun DaxScaffold(
+    modifier: Modifier = Modifier,
+    topBar: @Composable () -> Unit = {},
+    bottomBar: @Composable () -> Unit = {},
+    snackbarHost: @Composable () -> Unit = {},
+    contentWindowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
+    content: @Composable (PaddingValues) -> Unit,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = topBar,
+        bottomBar = bottomBar,
+        snackbarHost = snackbarHost,
+        containerColor = DaxScaffoldDefaults.containerColor,
+        contentColor = DaxScaffoldDefaults.contentColor,
+        contentWindowInsets = contentWindowInsets,
+        content = content,
+    )
+}
+
+object DaxScaffoldDefaults {
+    val containerColor: Color
+        @Composable
+        get() = DuckDuckGoTheme.colors.backgrounds.background
+
+    val contentColor: Color
+        @Composable
+        get() = DuckDuckGoTheme.colors.text.primary
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@PreviewLightDark
+@Composable
+private fun DaxScaffoldPreview() {
+    DuckDuckGoTheme {
+        DaxScaffold(
+            topBar = {
+                DaxTopAppBar(
+                    title = "Bookmarks",
+                    navigationIcon = DaxTopAppBarNavigationIcon.Back { },
+                    actions = {
+                        DaxIconButton(
+                            iconPainter = painterResource(R.drawable.ic_ai_chat_24_solid_color),
+                            contentDescription = "Duck.ai",
+                            onClick = { },
+                        )
+                    },
+                )
+            },
+        ) { paddingValues ->
+            DaxText(
+                text = "Content goes here",
+                modifier = Modifier.padding(paddingValues),
+            )
+        }
+    }
+}

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/layout/DaxScaffold.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/layout/DaxScaffold.kt
@@ -19,14 +19,16 @@ package com.duckduckgo.common.ui.compose.layout
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.ScaffoldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.PreviewFontScale
 import androidx.compose.ui.tooling.preview.PreviewLightDark
+import com.duckduckgo.common.ui.compose.appbars.DaxSearchTopAppBar
 import com.duckduckgo.common.ui.compose.appbars.DaxTopAppBar
 import com.duckduckgo.common.ui.compose.appbars.DaxTopAppBarNavigationIcon
 import com.duckduckgo.common.ui.compose.button.DaxIconButton
@@ -68,7 +70,7 @@ fun DaxScaffold(
     )
 }
 
-object DaxScaffoldDefaults {
+internal object DaxScaffoldDefaults {
     val containerColor: Color
         @Composable
         get() = DuckDuckGoTheme.colors.backgrounds.background
@@ -78,7 +80,6 @@ object DaxScaffoldDefaults {
         get() = DuckDuckGoTheme.colors.text.primary
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @PreviewLightDark
 @Composable
 private fun DaxScaffoldPreview() {
@@ -95,6 +96,49 @@ private fun DaxScaffoldPreview() {
                             onClick = { },
                         )
                     },
+                )
+            },
+        ) { paddingValues ->
+            DaxText(
+                text = "Content goes here",
+                modifier = Modifier.padding(paddingValues),
+            )
+        }
+    }
+}
+
+@PreviewFontScale
+@Composable
+private fun DaxScaffoldFontScalePreview() {
+    DuckDuckGoTheme {
+        DaxScaffold(
+            topBar = {
+                DaxTopAppBar(
+                    title = "Bookmarks",
+                    navigationIcon = DaxTopAppBarNavigationIcon.Back { },
+                )
+            },
+        ) { paddingValues ->
+            DaxText(
+                text = "Content goes here",
+                modifier = Modifier.padding(paddingValues),
+            )
+        }
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxScaffoldSearchTopAppBarPreview() {
+    DuckDuckGoTheme {
+        DaxScaffold(
+            topBar = {
+                DaxSearchTopAppBar(
+                    title = "Bookmarks",
+                    searchActive = true,
+                    searchState = rememberTextFieldState("query"),
+                    searchPlaceholder = "Search…",
+                    navigationIcon = DaxTopAppBarNavigationIcon.Back { },
                 )
             },
         ) { paddingValues ->

--- a/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
@@ -59,6 +59,7 @@ import com.duckduckgo.lint.ui.NoMaterial3CircularProgressIndicatorUsageDetector.
 import com.duckduckgo.lint.ui.NoMaterial3DividerUsageDetector.Companion.NO_MATERIAL3_HORIZONTAL_DIVIDER_USAGE
 import com.duckduckgo.lint.ui.NoMaterial3DividerUsageDetector.Companion.NO_MATERIAL3_VERTICAL_DIVIDER_USAGE
 import com.duckduckgo.lint.ui.NoMaterial3RadioButtonUsageDetector.Companion.NO_MATERIAL3_RADIO_BUTTON_USAGE
+import com.duckduckgo.lint.ui.NoMaterial3ScaffoldUsageDetector.Companion.NO_MATERIAL3_SCAFFOLD_USAGE
 import com.duckduckgo.lint.ui.NoMaterial3SwitchUsageDetector.Companion.NO_MATERIAL3_SWITCH_USAGE
 import com.duckduckgo.lint.ui.NoMaterial3TopAppBarUsageDetector.Companion.NO_MATERIAL3_TOP_APP_BAR_USAGE
 import com.duckduckgo.lint.ui.DaxTextViewStylingDetector.Companion.INVALID_DAX_TEXT_VIEW_PROPERTY
@@ -128,6 +129,7 @@ class DuckDuckGoIssueRegistry : IssueRegistry() {
             NO_MATERIAL3_CIRCULAR_PROGRESS_INDICATOR_USAGE,
             NO_MATERIAL3_HORIZONTAL_DIVIDER_USAGE,
             NO_MATERIAL3_VERTICAL_DIVIDER_USAGE,
+            NO_MATERIAL3_SCAFFOLD_USAGE,
             NO_RAW_M3_BUTTON_USAGE,
             NO_RAW_M3_ALERT_DIALOG_USAGE,
             NO_RAW_M3_SURFACE_USAGE,

--- a/lint-rules/src/main/java/com/duckduckgo/lint/ui/NoMaterial3ScaffoldUsageDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/ui/NoMaterial3ScaffoldUsageDetector.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint.ui
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category.Companion.CUSTOM_LINT_CHECKS
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.TextFormat
+import org.jetbrains.uast.UCallExpression
+import java.util.EnumSet
+
+@Suppress("UnstableApiUsage")
+class NoMaterial3ScaffoldUsageDetector : Detector(), SourceCodeScanner {
+
+    override fun getApplicableUastTypes() = listOf(UCallExpression::class.java)
+
+    override fun createUastHandler(context: JavaContext): UElementHandler = ScaffoldUsageHandler(context)
+
+    internal class ScaffoldUsageHandler(private val context: JavaContext) : UElementHandler() {
+
+        override fun visitCallExpression(node: UCallExpression) {
+            if (isInDesignSystemModule()) return
+
+            val methodName = node.methodName ?: return
+            if (methodName == "Scaffold") {
+                val resolved = node.resolve() ?: return
+                val qualifiedName = context.evaluator.getPackage(resolved)?.qualifiedName ?: return
+                if (qualifiedName == MATERIAL3_PACKAGE) {
+                    context.report(
+                        issue = NO_MATERIAL3_SCAFFOLD_USAGE,
+                        location = context.getLocation(node),
+                        message = NO_MATERIAL3_SCAFFOLD_USAGE.getExplanation(TextFormat.RAW),
+                    )
+                }
+            }
+        }
+
+        private fun isInDesignSystemModule(): Boolean {
+            return context.project.name in DESIGN_SYSTEM_MODULES
+        }
+    }
+
+    companion object {
+        private const val MATERIAL3_PACKAGE = "androidx.compose.material3"
+        private val DESIGN_SYSTEM_MODULES = setOf("design-system", "design-system-internal")
+
+        val NO_MATERIAL3_SCAFFOLD_USAGE = Issue
+            .create(
+                id = "NoMaterial3ScaffoldUsage",
+                briefDescription = "Use DaxScaffold instead of Material3 Scaffold",
+                explanation = "Use `DaxScaffold` from the design system instead of the Material3 `Scaffold` composable " +
+                    "to ensure consistent styling across the app.",
+                moreInfo = "",
+                category = CUSTOM_LINT_CHECKS,
+                priority = 10,
+                severity = Severity.ERROR,
+                androidSpecific = true,
+                implementation = Implementation(
+                    NoMaterial3ScaffoldUsageDetector::class.java,
+                    EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES),
+                ),
+            )
+    }
+}

--- a/lint-rules/src/test/java/com/duckduckgo/lint/ui/NoMaterial3ScaffoldUsageDetectorTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/ui/NoMaterial3ScaffoldUsageDetectorTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint.ui
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.kotlin
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import com.duckduckgo.lint.ui.NoMaterial3ScaffoldUsageDetector.Companion.NO_MATERIAL3_SCAFFOLD_USAGE
+import org.junit.Test
+
+class NoMaterial3ScaffoldUsageDetectorTest {
+
+    private val scaffoldStub = kotlin(
+        """
+        package androidx.compose.material3
+
+        fun Scaffold(
+            content: () -> Unit,
+        ) {}
+        """.trimIndent(),
+    ).indented()
+
+    private val daxScaffoldStub = kotlin(
+        """
+        package com.duckduckgo.common.ui.compose.layout
+
+        fun DaxScaffold(
+            content: () -> Unit,
+        ) {}
+        """.trimIndent(),
+    ).indented()
+
+    @Test
+    fun whenMaterial3ScaffoldUsedThenError() {
+        lint()
+            .files(
+                scaffoldStub,
+                kotlin(
+                    """
+                    package com.example.test
+
+                    import androidx.compose.material3.Scaffold
+
+                    fun MyScreen() {
+                        Scaffold(content = {})
+                    }
+                    """.trimIndent(),
+                ).indented(),
+            )
+            .issues(NO_MATERIAL3_SCAFFOLD_USAGE)
+            .run()
+            .expect(
+                """
+                src/com/example/test/test.kt:6: Error: Use DaxScaffold from the design system instead of the Material3 Scaffold composable to ensure consistent styling across the app. [NoMaterial3ScaffoldUsage]
+                    Scaffold(content = {})
+                    ~~~~~~~~~~~~~~~~~~~~~~
+                1 errors, 0 warnings
+                """.trimIndent(),
+            )
+    }
+
+    @Test
+    fun whenDaxScaffoldUsedThenNoError() {
+        lint()
+            .files(
+                daxScaffoldStub,
+                kotlin(
+                    """
+                    package com.example.test
+
+                    import com.duckduckgo.common.ui.compose.layout.DaxScaffold
+
+                    fun MyScreen() {
+                        DaxScaffold(content = {})
+                    }
+                    """.trimIndent(),
+                ).indented(),
+            )
+            .issues(NO_MATERIAL3_SCAFFOLD_USAGE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenNoScaffoldUsedThenNoError() {
+        lint()
+            .files(
+                kotlin(
+                    """
+                    package com.example.test
+
+                    fun MyScreen() {
+                        val visible = true
+                    }
+                    """.trimIndent(),
+                ).indented(),
+            )
+            .issues(NO_MATERIAL3_SCAFFOLD_USAGE)
+            .run()
+            .expectClean()
+    }
+}

--- a/lint-rules/src/test/java/com/duckduckgo/lint/ui/NoMaterial3ScaffoldUsageDetectorTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/ui/NoMaterial3ScaffoldUsageDetectorTest.kt
@@ -95,6 +95,36 @@ class NoMaterial3ScaffoldUsageDetectorTest {
     }
 
     @Test
+    fun whenNonMaterial3ScaffoldUsedThenNoError() {
+        lint()
+            .files(
+                kotlin(
+                    """
+                    package com.example.widgets
+
+                    fun Scaffold(
+                        content: () -> Unit,
+                    ) {}
+                    """.trimIndent(),
+                ).indented(),
+                kotlin(
+                    """
+                    package com.example.test
+
+                    import com.example.widgets.Scaffold
+
+                    fun MyScreen() {
+                        Scaffold(content = {})
+                    }
+                    """.trimIndent(),
+                ).indented(),
+            )
+            .issues(NO_MATERIAL3_SCAFFOLD_USAGE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
     fun whenNoScaffoldUsedThenNoError() {
         lint()
             .files(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1215496415658080/task/1215518884361562

### Description

Adds a DuckDuckGo-themed Compose scaffold and a lint rule that enforces its use.

- `DaxScaffold` wraps Material3 `Scaffold` with DuckDuckGo default container/content colors and content window insets.
- Showcased with a top app bar (back + AI chat icon buttons) in the design system internal screen as a new "Scaffold" component.
- Adds the `NoMaterial3ScaffoldUsage` lint rule (error severity) that directs usage to `DaxScaffold` everywhere except the design system modules, mirroring the existing Material3 switch/checkbox/radio rules.

> Stacked on top of #8823 — the scaffold's top bar uses `DaxIconButton`, which only themes correctly (dark mode) with that PR's color fix.

### Steps to test this PR

_Design system screen_
- [ ] Build & install the internal variant, open the Design System → Layout.
- [ ] Scroll to "Scaffold" component: confirm the top app bar (title + back + AI chat icons) and content render.
- [ ] Toggle dark/light theme: confirm the scaffold background, top bar, and icons follow the theme.

### UI changes
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/ed736254-44d1-4735-b811-a1678b7707fe" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New design-system composable and lint-only enforcement; no changes to production app screens or security-sensitive paths. Existing Material3 Scaffold usage outside design-system modules may need migration when lint runs.
> 
> **Overview**
> Introduces **`DaxScaffold`**, a design-system wrapper around Material3 `Scaffold` that applies DuckDuckGo theme **background** and **text** colors (and default content window insets) for consistent screen chrome.
> 
> The internal Design System **Layout** screen now includes a **Scaffold** demo (`Component.SCAFFOLD`) with a `DaxSearchTopAppBar` sample and placeholder content.
> 
> Adds **`NoMaterial3ScaffoldUsage`** lint (error), registered in `DuckDuckGoIssueRegistry`, which flags `androidx.compose.material3.Scaffold` outside `design-system` / `design-system-internal` modules—aligned with existing Material3 component lint rules. Unit tests cover Material3 vs `DaxScaffold` vs unrelated `Scaffold` calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4093ce2f04f148b905df1d6b4669b7cb23dcda07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->