### PR TITLE
Add pixel interceptor to gate ad blocking pixels

### DIFF
--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/pixels/AdBlockingTelemetryPixelInterceptor.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/pixels/AdBlockingTelemetryPixelInterceptor.kt
@@ -82,6 +82,6 @@ class AdBlockingTelemetryPixelInterceptor @Inject constructor(
     override fun getInterceptor(): Interceptor = this
 
     companion object {
-        const val YOUTUBE_TELEMETRY_PIXEL_PREFIX = "webTelemetry_youTube"
+        const val YOUTUBE_TELEMETRY_PIXEL_PREFIX = "webTelemetry_youtube"
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/pixels/AdBlockingTelemetryPixelInterceptor.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/pixels/AdBlockingTelemetryPixelInterceptor.kt
@@ -54,14 +54,14 @@ class AdBlockingTelemetryPixelInterceptor @Inject constructor(
     override fun intercept(chain: Chain): Response {
         val pixelName = chain.request().url.pathSegments.last()
 
-        if (pixelName.startsWith(YOUTUBE_TELEMETRY_PIXEL_PREFIX, ignoreCase = true) &&
-            statusChecker.currentState() !is AdBlockingState.Enabled.UserEnabled
-        ) {
-            logcat(INFO) { "Ad blocking telemetry pixel dropped (no explicit consent): $pixelName" }
-            return dummyResponse(chain)
+        if (pixelName.startsWith(YOUTUBE_TELEMETRY_PIXEL_PREFIX, ignoreCase = true)) {
+            if (statusChecker.currentState() !is AdBlockingState.Enabled.UserEnabled) {
+                logcat(INFO) { "Ad blocking telemetry pixel dropped (no explicit consent): $pixelName" }
+                return dummyResponse(chain)
+            }
+            logcat(INFO) { "Ad blocking telemetry pixel sending: $pixelName" }
         }
 
-        logcat(INFO) { "Pixel proceeding: $pixelName" }
         return chain.proceed(chain.request())
     }
 

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/pixels/AdBlockingTelemetryPixelInterceptor.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/pixels/AdBlockingTelemetryPixelInterceptor.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.pixels
+
+import com.duckduckgo.adblocking.impl.domain.AdBlockingState
+import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
+import com.duckduckgo.common.utils.plugins.pixel.PixelInterceptorPlugin
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import logcat.LogPriority.INFO
+import logcat.logcat
+import okhttp3.Interceptor
+import okhttp3.Interceptor.Chain
+import okhttp3.Protocol
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import javax.inject.Inject
+
+/**
+ * Gates YouTube ad-blocking telemetry pixels behind explicit user consent.
+ *
+ * The EventHub pipeline fires `webTelemetry_youTube*` pixels for every user for whom the feature is
+ * remotely active, based on detection events sent by Content-Scope-Scripts.
+ * This interceptor only sends pixels for users who have explicitly opted in
+ * ([AdBlockingState.Enabled.UserEnabled]) — not for users enabled by the rollout
+ * default, nor users with the feature off.
+ *
+ * TODO: This native-side gate is a temporary workaround. Remove this interceptor once C-S-S honours
+ *  WebInterferenceDetectionContentScopeConfigPlugin.preferences() and gates the detection events at
+ *  the source. See TD task https://app.asana.com/1/137249556945/project/481882893211075/task/1215138970525763?focus=true.
+ */
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = PixelInterceptorPlugin::class,
+)
+class AdBlockingTelemetryPixelInterceptor @Inject constructor(
+    private val statusChecker: AdBlockingStatusChecker,
+) : Interceptor, PixelInterceptorPlugin {
+
+    override fun intercept(chain: Chain): Response {
+        val pixelName = chain.request().url.pathSegments.last()
+
+        if (pixelName.startsWith(YOUTUBE_TELEMETRY_PIXEL_PREFIX, ignoreCase = true) &&
+            statusChecker.currentState() !is AdBlockingState.Enabled.UserEnabled
+        ) {
+            logcat(INFO) { "Ad blocking telemetry pixel dropped (no explicit consent): $pixelName" }
+            return dummyResponse(chain)
+        }
+
+        logcat(INFO) { "Pixel proceeding: $pixelName" }
+        return chain.proceed(chain.request())
+    }
+
+    // Must return a 200, not an error. EventHub fires via Pixel.enqueueFire(), which stores the pixel
+    // in RxPixelSender's pending-pixel queue and only deletes it on a successful send. An error
+    // would leave the pixel queued and retried on every app start (and sent later if the user
+    // consents); a synthetic 200 makes it "sent" → deleted → never retried.
+    private fun dummyResponse(chain: Chain): Response {
+        return Response.Builder()
+            .code(200)
+            .protocol(Protocol.HTTP_2)
+            .body("Ad blocking telemetry pixel dropped".toResponseBody())
+            .message("Dropped ad blocking telemetry pixel")
+            .request(chain.request())
+            .build()
+    }
+
+    override fun getInterceptor(): Interceptor = this
+
+    companion object {
+        const val YOUTUBE_TELEMETRY_PIXEL_PREFIX = "webTelemetry_youTube"
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/domain/RealAdBlockingStatusCheckerTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/domain/RealAdBlockingStatusCheckerTest.kt
@@ -250,6 +250,37 @@ class RealAdBlockingStatusCheckerTest {
     }
 
     @Test
+    fun whenUserHasEnabledThenCurrentStateIsUserEnabled() {
+        userEnabledFlow.value = true
+
+        assertEquals(AdBlockingState.Enabled.UserEnabled, checker.currentState())
+    }
+
+    @Test
+    fun whenUserHasDisabledThenCurrentStateIsDisabled() {
+        userEnabledFlow.value = false
+
+        assertEquals(AdBlockingState.Disabled, checker.currentState())
+    }
+
+    @Test
+    fun whenNotSetAndEnabledByDefaultThenCurrentStateIsEnabledDefault() {
+        userEnabledFlow.value = null
+        enabledByDefaultFlow.value = true
+
+        assertEquals(AdBlockingState.Enabled.Default, checker.currentState())
+    }
+
+    @Test
+    fun whenStateChangesThenCurrentStateReflectsItSynchronously() {
+        userEnabledFlow.value = true
+        assertEquals(AdBlockingState.Enabled.UserEnabled, checker.currentState())
+
+        userEnabledFlow.value = false
+        assertEquals(AdBlockingState.Disabled, checker.currentState())
+    }
+
+    @Test
     fun whenUpstreamHasNotEmittedYetThenCurrentStateIsUninitialized() {
         val pendingRepository = object : AdBlockingSettingsRepository {
             override fun isEnabledFlow(): Flow<Boolean?> = emptyFlow()

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/pixels/AdBlockingTelemetryPixelInterceptorTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/pixels/AdBlockingTelemetryPixelInterceptorTest.kt
@@ -33,7 +33,17 @@ class AdBlockingTelemetryPixelInterceptorTest {
     fun whenUserEnabledAndPixelMatchesThenPixelProceeds() {
         whenever(statusChecker.currentState()).thenReturn(AdBlockingState.Enabled.UserEnabled)
 
-        val url = "$PIXEL_BASE/webTelemetry_youtubeBuffering_test_android_phone"
+        val url = "$PIXEL_BASE/webTelemetry_youtubeInterference_day.buffering_android_phone"
+        val response = interceptor.intercept(FakeChain(url))
+
+        assertEquals(url, response.request.url.toString())
+    }
+
+    @Test
+    fun whenUserEnabledAndPixelMatchesIgnoringCaseThenPixelProceeds() {
+        whenever(statusChecker.currentState()).thenReturn(AdBlockingState.Enabled.UserEnabled)
+
+        val url = "$PIXEL_BASE/webtelemetry_youtubetinterference_day.buffering_android_phone"
         val response = interceptor.intercept(FakeChain(url))
 
         assertEquals(url, response.request.url.toString())
@@ -43,7 +53,7 @@ class AdBlockingTelemetryPixelInterceptorTest {
     fun whenEnabledByDefaultAndPixelMatchesThenPixelIsDropped() {
         whenever(statusChecker.currentState()).thenReturn(AdBlockingState.Enabled.Default)
 
-        val url = "$PIXEL_BASE/webTelemetry_youtubeBuffering_test_android_phone"
+        val url = "$PIXEL_BASE/webTelemetry_youtubeInterference_day.buffering_android_phone"
         val response = interceptor.intercept(FakeChain(url))
 
         assertEquals(200, response.code)
@@ -55,7 +65,7 @@ class AdBlockingTelemetryPixelInterceptorTest {
     fun whenDisabledAndPixelMatchesThenPixelIsDropped() {
         whenever(statusChecker.currentState()).thenReturn(AdBlockingState.Disabled)
 
-        val url = "$PIXEL_BASE/webTelemetry_youtubeBuffering_test_android_phone"
+        val url = "$PIXEL_BASE/webTelemetry_youtubeInterference_day.buffering_android_phone"
         val response = interceptor.intercept(FakeChain(url))
 
         assertEquals(200, response.code)
@@ -63,10 +73,10 @@ class AdBlockingTelemetryPixelInterceptorTest {
     }
 
     @Test
-    fun whenNotConsentedAndPixelMatchesWithCamelCasePrefixThenPixelIsDropped() {
+    fun whenNotConsentedAndPixelMatchesThenPixelIsDropped() {
         whenever(statusChecker.currentState()).thenReturn(AdBlockingState.Enabled.Default)
 
-        val url = "$PIXEL_BASE/webTelemetry_youTubeBuffering_test_android_phone"
+        val url = "$PIXEL_BASE/webTelemetry_youtubeInterference_day.buffering_test_android_phone"
         val response = interceptor.intercept(FakeChain(url))
 
         assertEquals(200, response.code)

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/pixels/AdBlockingTelemetryPixelInterceptorTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/pixels/AdBlockingTelemetryPixelInterceptorTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.pixels
+
+import com.duckduckgo.adblocking.impl.domain.AdBlockingState
+import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
+import com.duckduckgo.common.test.api.FakeChain
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class AdBlockingTelemetryPixelInterceptorTest {
+
+    private val statusChecker = mock<AdBlockingStatusChecker>()
+    private val interceptor = AdBlockingTelemetryPixelInterceptor(statusChecker)
+
+    @Test
+    fun whenUserEnabledAndPixelMatchesThenPixelProceeds() {
+        whenever(statusChecker.currentState()).thenReturn(AdBlockingState.Enabled.UserEnabled)
+
+        val url = "$PIXEL_BASE/webTelemetry_youtubeBuffering_test_android_phone"
+        val response = interceptor.intercept(FakeChain(url))
+
+        assertEquals(url, response.request.url.toString())
+    }
+
+    @Test
+    fun whenEnabledByDefaultAndPixelMatchesThenPixelIsDropped() {
+        whenever(statusChecker.currentState()).thenReturn(AdBlockingState.Enabled.Default)
+
+        val url = "$PIXEL_BASE/webTelemetry_youtubeBuffering_test_android_phone"
+        val response = interceptor.intercept(FakeChain(url))
+
+        assertEquals(200, response.code)
+        assertEquals("Dropped ad blocking telemetry pixel", response.message)
+        assertEquals("Ad blocking telemetry pixel dropped", response.body?.string())
+    }
+
+    @Test
+    fun whenDisabledAndPixelMatchesThenPixelIsDropped() {
+        whenever(statusChecker.currentState()).thenReturn(AdBlockingState.Disabled)
+
+        val url = "$PIXEL_BASE/webTelemetry_youtubeBuffering_test_android_phone"
+        val response = interceptor.intercept(FakeChain(url))
+
+        assertEquals(200, response.code)
+        assertEquals("Dropped ad blocking telemetry pixel", response.message)
+    }
+
+    @Test
+    fun whenNotConsentedAndPixelMatchesWithCamelCasePrefixThenPixelIsDropped() {
+        whenever(statusChecker.currentState()).thenReturn(AdBlockingState.Enabled.Default)
+
+        val url = "$PIXEL_BASE/webTelemetry_youTubeBuffering_test_android_phone"
+        val response = interceptor.intercept(FakeChain(url))
+
+        assertEquals(200, response.code)
+        assertEquals("Dropped ad blocking telemetry pixel", response.message)
+    }
+
+    @Test
+    fun whenNotConsentedAndPixelDoesNotMatchThenPixelProceeds() {
+        whenever(statusChecker.currentState()).thenReturn(AdBlockingState.Disabled)
+
+        val url = "$PIXEL_BASE/m_unrelated_pixel_android_phone"
+        val response = interceptor.intercept(FakeChain(url))
+
+        assertEquals(url, response.request.url.toString())
+    }
+
+    @Test
+    fun whenUserEnabledAndPixelDoesNotMatchThenPixelProceeds() {
+        whenever(statusChecker.currentState()).thenReturn(AdBlockingState.Enabled.UserEnabled)
+
+        val url = "$PIXEL_BASE/m_unrelated_pixel_android_phone"
+        val response = interceptor.intercept(FakeChain(url))
+
+        assertEquals(url, response.request.url.toString())
+    }
+
+    companion object {
+        private const val PIXEL_BASE = "https://improving.duckduckgo.com/t"
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212227266948491/task/1214566871879495?focus=true

### Description
Only fire webEvent YouTube pixels if feature is enabled by user, not by default or disabled

### Steps to test this PR
> [!TIP]
> Set `package:mine tag~:"AdBlockingTelemetryPixelInterceptor" | message~:"Pixel url request: https://improving.duckduckgo.com/t/webTelemetry_youtube"` as a logcat filter

_Feature 1_
- [x] Apply _Patch 1: Support webEvents with ad blocking disabled_
- [x] Fresh install the app
- [x] Open YouTube ad blocking settings
- [x] Enable YouTube ad blocking
- [x] Open a video on YouTube
- [x] If the video doesn't buffer, find another video that displays buffering
- [x] Check logs for `Pixel proceeding:...`
- [x] Check logs for `Pixel url request: https://improving.duckduckgo.com/t/webTelemetry_youtube...`

_Feature 2_
- [x] Apply _Patch 2: Support webEvents with ad blocking enabled by default_
- [x] Fresh install the app
- [x] Load a video on YouTube
- [x] If the video doesn't buffer, find another video that displays buffering
- [x] Check logs for `Ad blocking telemetry pixel dropped (no explicit consent)...`
- [x] Check no logs for `Pixel url request: https://improving.duckduckgo.com/t/webTelemetry_youtube...`

### Patches

_Patch 1: Support webEvents with ad blocking disabled_
```
Subject: [PATCH] Set RC to support webTelemetry_youtubeBuffering_test pixel for youtube_buffering event type, with YouTube ad blocking disabled by default
---
Index: privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt	(revision 7bfb042b235a1d66237dec6145e3a39a43761c2f)
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt	(date 1781019513195)
@@ -29,4 +29,4 @@
     TrackingParametersFeatureName("trackingParameters"),
 }
 
-const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v5/android-config.json"
+const val PRIVACY_REMOTE_CONFIG_URL = "https://gist.githubusercontent.com/CrisBarreiro/c78b0362dbb8ae63e1e0f8af60361fdb/raw/d7cecc98f7ce7c2eef55dac337268edc08a1ba1f/eventhub-web-interference-detection-yt-android-config.json"
```


_Patch 2: Support webEvents with ad blocking enabled by default_ 
```
Subject: [PATCH] Set RC to support webTelemetry_youtubeBuffering_test pixel for youtube_buffering event type, with YouTube ad blocking enabled by default
---
Index: privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt	(revision 6f1f149b4678d4f6d24af06a6d269ac582bb777a)
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt	(date 1781019901322)
@@ -29,4 +29,4 @@
     TrackingParametersFeatureName("trackingParameters"),
 }
 
-const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v5/android-config.json"
+const val PRIVACY_REMOTE_CONFIG_URL = "https://gist.githubusercontent.com/CrisBarreiro/cc3a8f23300894f56d71a5d38a2173d2/raw/9441a22eddaff56ff260af87cac81111f3bcff63/eventhub-web-interference-detection-yt-enabled-by-default-android-config.json"
```

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which telemetry pixels leave the device based on consent state; dropped pixels use a synthetic 200 to avoid retry behavior, so incorrect gating could silently skew metrics.
> 
> **Overview**
> Adds a **temporary** OkHttp `PixelInterceptorPlugin` that blocks YouTube ad-blocking telemetry (`webTelemetry_youtube*`) unless the user has **explicitly** enabled ad blocking (`AdBlockingState.Enabled.UserEnabled`). Rollout-default and disabled users no longer send those pixels over the network.
> 
> When a pixel is dropped, the interceptor returns a **synthetic HTTP 200** so EventHub/RxPixelSender treats it as sent and does not keep retrying queued pixels if the user later opts in.
> 
> Unit tests cover proceed vs drop (including case-insensitive prefix matching and unrelated pixels), plus extra `currentState()` cases on `RealAdBlockingStatusChecker`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 775da0ec1f7d622a266ddb7128a8caa5f2a75dc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->