### PR TITLE
fix unit tests skip checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,12 @@ jobs:
   unit_tests:
     name: ${{ matrix.di == 'AnvilDagger' && 'Unit tests' || format('Unit tests ({0})', matrix.di) }}
     needs: [check_changes]
-    if: needs.check_changes.outputs.should_run == 'true'
+    # NOTE: no job-level `if` here on purpose. This is a matrix job whose check name
+    # depends on `matrix.di`. If we skipped the whole job, GitHub wouldn't expand the
+    # matrix and the required checks ("Unit tests" / "Unit tests (Metro)") would never
+    # be reported, blocking the PR. Instead, we always run the job (so the matrix expands
+    # and both check names report) and gate each step on should_run — a job with all
+    # steps skipped reports success and satisfies the required check.
     runs-on: android-large-runner
     strategy:
       matrix:
@@ -90,30 +95,34 @@ jobs:
 
     steps:
       - name: Checkout repository
+        if: needs.check_changes.outputs.should_run == 'true'
         uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Set up JDK version
+        if: needs.check_changes.outputs.should_run == 'true'
         uses: actions/setup-java@v4
         with:
           java-version-file: .github/.java-version
           distribution: 'adopt'
 
       - name: Setup Gradle
+        if: needs.check_changes.outputs.should_run == 'true'
         uses: gradle/actions/setup-gradle@v5
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: JVM tests
+        if: needs.check_changes.outputs.should_run == 'true'
         run: ./gradlew jvm_tests -Pddg.di=${{ matrix.di }} ${{ github.event_name != 'pull_request' && '-Dpts.enabled=false' || '' }}
 
       - name: Bundle the JVM checks report
-        if: always()
+        if: always() && needs.check_changes.outputs.should_run == 'true'
         run: find . -type d -name 'reports' | zip -@ -r unit-tests-report-${{ matrix.di }}.zip
 
       - name: Upload the JVM checks report
-        if: always()
+        if: always() && needs.check_changes.outputs.should_run == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: unit-tests-report-${{ matrix.di }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1215529545916182?focus=true

### Description
Do not skip the whole `unit_tests` job but instead let it start so that the matrix of check names is generated, and then skip each step.

An alternative would be to create an aggregator gate for expected jobs, and make only that required by branch protection rules, but I don't think we need it just yet. Something to consider in the future if this becomes an issues again.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to when steps run; no application or test logic changes.
> 
> **Overview**
> Fixes PRs getting stuck when `check_changes` sets `should_run=false` (e.g. docs-only changes) because branch protection still expects the matrix check names **Unit tests** and **Unit tests (Metro)**.
> 
> The `unit_tests` job **no longer** uses a job-level `if` on `should_run`. The job always starts so GitHub expands the `AnvilDagger` / `Metro` matrix and both required statuses are reported. Each step (checkout, JDK, Gradle, JVM tests, and report bundle/upload) is gated with `if: needs.check_changes.outputs.should_run == 'true'` instead, so skipped runs do no work but the job still completes successfully. Report steps keep `always()` but also require `should_run == 'true'`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cbf54c172b98b8c8688b844048a7389301544eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->