### PR TITLE
Move nightly non-blocker Maestro tests to API 34

### DIFF
--- a/.github/workflows/e2e-nightly-non-blockers-suite.yml
+++ b/.github/workflows/e2e-nightly-non-blockers-suite.yml
@@ -98,6 +98,7 @@ jobs:
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-internal-binary.outputs.maestro_app_binary_id }}
           maestro_include_tags: duckplayer
+          maestro_api_level: 34
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}

--- a/.github/workflows/e2e-nightly-non-blockers-suite.yml
+++ b/.github/workflows/e2e-nightly-non-blockers-suite.yml
@@ -46,7 +46,7 @@ jobs:
           maestro_test_name: binary_internal_upload_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_file: ${{ steps.assemble.outputs.internal_apk_path }}
-          maestro_api_level: 35
+          maestro_api_level: 34
           maestro_include_tags: binaryUpload
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -63,7 +63,7 @@ jobs:
           maestro_test_name: binary_release_upload_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_file: ${{ steps.assemble.outputs.play_apk_path }}
-          maestro_api_level: 35
+          maestro_api_level: 34
           maestro_include_tags: binaryUpload
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -81,7 +81,7 @@ jobs:
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-release-binary.outputs.maestro_app_binary_id }}
           maestro_include_tags: omnibarTest
-          maestro_api_level: 35
+          maestro_api_level: 34
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
@@ -115,7 +115,7 @@ jobs:
           maestro_app_binary_id: ${{ steps.maestro-upload-internal-binary.outputs.maestro_app_binary_id }}
           maestro_include_tags: androidDesignSystemTest
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          maestro_api_level: 35
+          maestro_api_level: 34
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
           test_suite_name: Android Design System (Nightly)
@@ -132,7 +132,7 @@ jobs:
           maestro_app_binary_id: ${{ steps.maestro-upload-internal-binary.outputs.maestro_app_binary_id }}
           maestro_include_tags: unifiedInputTest
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          maestro_api_level: 35
+          maestro_api_level: 34
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
           test_suite_name: Unified Input Field
@@ -148,7 +148,7 @@ jobs:
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-internal-binary.outputs.maestro_app_binary_id }}
           maestro_include_tags: preonboardingTest
-          maestro_api_level: 35
+          maestro_api_level: 34
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1215532977297689?focus=true

### Description

Moves all Maestro test suites in the nightly non-release-blocker workflow (`e2e-nightly-non-blockers-suite.yml`) from API level 35 to 34. This updates the `maestro_api_level` for the internal/release binary uploads, Omnibar, Android Design System, Unified Input Field, and Preonboarding suites.

### Steps to test this PR

_Nightly non-blocker suite_
- [ ] Trigger the workflow via `workflow_dispatch` and confirm the Maestro Cloud runs use API level 34

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only emulator API level change in one workflow; no app, auth, or production runtime impact.
> 
> **Overview**
> Pins the **nightly non-release-blocker** Maestro workflow (`e2e-nightly-non-blockers-suite.yml`) to **Android API 34** instead of **35** for every `maestro-cloud-asana-reporter` step: internal/release binary uploads, Omnibar, Duck Player, Android Design System, Unified Input Field, and Preonboarding.
> 
> The Duck Player step now sets `maestro_api_level` explicitly (34) alongside the other suites that were updated from 35.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0d9f2caa2f5436f369e0c5aa334d79c7aae0eaa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->