### PR TITLE
Removes and unused breakage report pixel

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/brokensite/api/BrokenSiteSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/brokensite/api/BrokenSiteSender.kt
@@ -202,11 +202,6 @@ class BrokenSiteSubmitter @Inject constructor(
                     }
                 }
                 .onFailure { logcat(WARN) { "Feedback submission failed: ${it.asLog()}" } }
-
-            pixel.fire(
-                AppPixelName.BROKEN_SITE_REPORTED,
-                mapOf(Pixel.PixelParameter.URL to siteUrl),
-            )
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -37,7 +37,6 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     FORGET_ALL_AUTO_RESTART("m_f_r"),
     FORGET_ALL_AUTO_RESTART_WITH_INTENT("m_f_ri"),
 
-    BROKEN_SITE_REPORTED("m_bsr"),
     BROKEN_SITE_REPORT("epbf"),
     BROKEN_SITE_ALLOWLIST_ADD("m_broken_site_allowlist_add"),
     BROKEN_SITE_ALLOWLIST_REMOVE("m_broken_site_allowlist_remove"),

--- a/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/brokensite/api/BrokenSiteSubmitterTest.kt
@@ -3,7 +3,6 @@ package com.duckduckgo.app.brokensite.api
 import android.annotation.SuppressLint
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.pixels.AppPixelName.BROKEN_SITE_REPORT
-import com.duckduckgo.app.pixels.AppPixelName.BROKEN_SITE_REPORTED
 import com.duckduckgo.app.pixels.AppPixelName.PROTECTION_TOGGLE_BROKEN_SITE_REPORT
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.statistics.model.Atb
@@ -532,12 +531,6 @@ class BrokenSiteSubmitterTest {
         testee.submitBrokenSiteFeedback(brokenSite, toggle = false)
 
         verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), any(), any(), eq(Count))
-
-        val paramsCaptor = argumentCaptor<Map<String, String>>()
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORTED), parameters = paramsCaptor.capture(), any(), eq(Count))
-        val params = paramsCaptor.firstValue
-        assertEquals(brokenSite.siteUrl, params[Pixel.PixelParameter.URL])
-
         verify(mockPixel, never()).fire(eq(PROTECTION_TOGGLE_BROKEN_SITE_REPORT.pixelName), any(), any(), eq(Count))
     }
 
@@ -551,9 +544,6 @@ class BrokenSiteSubmitterTest {
         val paramsCaptor = argumentCaptor<Map<String, String>>()
         verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), parameters = paramsCaptor.capture(), any(), eq(Count))
         assertEquals(brokenSite.siteUrl, paramsCaptor.lastValue["siteUrl"])
-
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORTED), parameters = paramsCaptor.capture(), any(), eq(Count))
-        assertEquals(brokenSite.siteUrl, paramsCaptor.lastValue[Pixel.PixelParameter.URL])
     }
 
     @Test
@@ -566,9 +556,6 @@ class BrokenSiteSubmitterTest {
         val paramsCaptor = argumentCaptor<Map<String, String>>()
         verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), parameters = paramsCaptor.capture(), any(), eq(Count))
         assertEquals(brokenSite.siteUrl, paramsCaptor.lastValue["siteUrl"])
-
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORTED), parameters = paramsCaptor.capture(), any(), eq(Count))
-        assertEquals(brokenSite.siteUrl, paramsCaptor.lastValue[Pixel.PixelParameter.URL])
     }
 
     @Test
@@ -581,9 +568,6 @@ class BrokenSiteSubmitterTest {
         val paramsCaptor = argumentCaptor<Map<String, String>>()
         verify(mockPixel).fire(eq(BROKEN_SITE_REPORT.pixelName), parameters = paramsCaptor.capture(), any(), eq(Count))
         assertEquals(TRACKING_URL, paramsCaptor.lastValue["siteUrl"])
-
-        verify(mockPixel).fire(eq(BROKEN_SITE_REPORTED), parameters = paramsCaptor.capture(), any(), eq(Count))
-        assertEquals(TRACKING_URL, paramsCaptor.lastValue[Pixel.PixelParameter.URL])
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1215535613045871?focus=true 
Tech Design URL (if applicable): 

### Description
This PR removes an unused breakage report pixel

### Steps to test this PR

- [ ] Check code
- [ ] Tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only cleanup with no change to the primary breakage report pixel or submission flow.
> 
> **Overview**
> Stops firing the legacy **`BROKEN_SITE_REPORTED`** (`m_bsr`) count pixel when users submit broken-site feedback. **`BrokenSiteSubmitter`** now only sends the detailed **`BROKEN_SITE_REPORT`** (`epbf`) event (and the protection-toggle pixel when applicable); the extra fire with a URL-only parameter map is removed.
> 
> The **`BROKEN_SITE_REPORTED`** enum entry is deleted from **`AppPixelName`**, and **`BrokenSiteSubmitterTest`** no longer asserts that second pixel in the submit/AMP-link scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6712f8acffe6ccf8dfefdb0934715bb79701d9b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->