### PR TITLE
Add Unified Input metrics & pixels

### DIFF
--- a/PixelDefinitions/pixels/definitions/autocomplete_displayed.json5
+++ b/PixelDefinitions/pixels/definitions/autocomplete_displayed.json5
@@ -41,5 +41,61 @@
         "triggers": ["other"],
         "suffixes": ["form_factor"],
         "parameters": ["appVersion"]
+    },
+    "m_autocomplete_duckai_click_website": {
+        "description": "User tapped a website autocomplete suggestion in the Duck.ai Unified Input.",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_autocomplete_duckai_click_bookmark": {
+        "description": "User tapped a bookmark autocomplete suggestion in the Duck.ai Unified Input.",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_autocomplete_duckai_click_favorite": {
+        "description": "User tapped a favorite autocomplete suggestion in the Duck.ai Unified Input.",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_autocomplete_duckai_click_history_search": {
+        "description": "User tapped a history search-query autocomplete suggestion in the Duck.ai Unified Input.",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_autocomplete_duckai_click_history_site": {
+        "description": "User tapped a history site autocomplete suggestion in the Duck.ai Unified Input.",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_autocomplete_duckai_click_switch_to_tab": {
+        "description": "User tapped a 'switch to tab' autocomplete suggestion in the Duck.ai Unified Input.",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_autocomplete_duckai_click_chat_history": {
+        "description": "User tapped a chat history autocomplete suggestion in the Duck.ai Unified Input.",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_autocomplete_duckai_click_search_duckduckgo": {
+        "description": "User tapped a 'search DuckDuckGo' autocomplete suggestion in the Duck.ai Unified Input.",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
     }
 }

--- a/PixelDefinitions/pixels/definitions/autocomplete_displayed.json5
+++ b/PixelDefinitions/pixels/definitions/autocomplete_displayed.json5
@@ -47,42 +47,102 @@
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": [
+            "appVersion",
+            { "key": "sb", "description": "A bookmark suggestion row was shown in the results", "type": "boolean" },
+            { "key": "sf", "description": "A favorite suggestion row was shown in the results", "type": "boolean" },
+            { "key": "sh", "description": "A history suggestion row was shown in the results", "type": "boolean" },
+            { "key": "showed_switch_to_tab", "description": "A switch-to-tab suggestion row was shown in the results", "type": "boolean" },
+            { "key": "bc", "description": "The user has bookmarks", "type": "boolean" },
+            { "key": "fc", "description": "The user has favorites", "type": "boolean" },
+            { "key": "hc", "description": "The user has history", "type": "boolean" },
+            { "key": "switch_to_tab_capable", "description": "More than one tab is open", "type": "boolean" }
+        ]
     },
     "m_autocomplete_duckai_click_bookmark": {
         "description": "User tapped a bookmark autocomplete suggestion in the Duck.ai Unified Input.",
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": [
+            "appVersion",
+            { "key": "sb", "description": "A bookmark suggestion row was shown in the results", "type": "boolean" },
+            { "key": "sf", "description": "A favorite suggestion row was shown in the results", "type": "boolean" },
+            { "key": "sh", "description": "A history suggestion row was shown in the results", "type": "boolean" },
+            { "key": "showed_switch_to_tab", "description": "A switch-to-tab suggestion row was shown in the results", "type": "boolean" },
+            { "key": "bc", "description": "The user has bookmarks", "type": "boolean" },
+            { "key": "fc", "description": "The user has favorites", "type": "boolean" },
+            { "key": "hc", "description": "The user has history", "type": "boolean" },
+            { "key": "switch_to_tab_capable", "description": "More than one tab is open", "type": "boolean" }
+        ]
     },
     "m_autocomplete_duckai_click_favorite": {
         "description": "User tapped a favorite autocomplete suggestion in the Duck.ai Unified Input.",
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": [
+            "appVersion",
+            { "key": "sb", "description": "A bookmark suggestion row was shown in the results", "type": "boolean" },
+            { "key": "sf", "description": "A favorite suggestion row was shown in the results", "type": "boolean" },
+            { "key": "sh", "description": "A history suggestion row was shown in the results", "type": "boolean" },
+            { "key": "showed_switch_to_tab", "description": "A switch-to-tab suggestion row was shown in the results", "type": "boolean" },
+            { "key": "bc", "description": "The user has bookmarks", "type": "boolean" },
+            { "key": "fc", "description": "The user has favorites", "type": "boolean" },
+            { "key": "hc", "description": "The user has history", "type": "boolean" },
+            { "key": "switch_to_tab_capable", "description": "More than one tab is open", "type": "boolean" }
+        ]
     },
     "m_autocomplete_duckai_click_history_search": {
         "description": "User tapped a history search-query autocomplete suggestion in the Duck.ai Unified Input.",
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": [
+            "appVersion",
+            { "key": "sb", "description": "A bookmark suggestion row was shown in the results", "type": "boolean" },
+            { "key": "sf", "description": "A favorite suggestion row was shown in the results", "type": "boolean" },
+            { "key": "sh", "description": "A history suggestion row was shown in the results", "type": "boolean" },
+            { "key": "showed_switch_to_tab", "description": "A switch-to-tab suggestion row was shown in the results", "type": "boolean" },
+            { "key": "bc", "description": "The user has bookmarks", "type": "boolean" },
+            { "key": "fc", "description": "The user has favorites", "type": "boolean" },
+            { "key": "hc", "description": "The user has history", "type": "boolean" },
+            { "key": "switch_to_tab_capable", "description": "More than one tab is open", "type": "boolean" }
+        ]
     },
     "m_autocomplete_duckai_click_history_site": {
         "description": "User tapped a history site autocomplete suggestion in the Duck.ai Unified Input.",
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": [
+            "appVersion",
+            { "key": "sb", "description": "A bookmark suggestion row was shown in the results", "type": "boolean" },
+            { "key": "sf", "description": "A favorite suggestion row was shown in the results", "type": "boolean" },
+            { "key": "sh", "description": "A history suggestion row was shown in the results", "type": "boolean" },
+            { "key": "showed_switch_to_tab", "description": "A switch-to-tab suggestion row was shown in the results", "type": "boolean" },
+            { "key": "bc", "description": "The user has bookmarks", "type": "boolean" },
+            { "key": "fc", "description": "The user has favorites", "type": "boolean" },
+            { "key": "hc", "description": "The user has history", "type": "boolean" },
+            { "key": "switch_to_tab_capable", "description": "More than one tab is open", "type": "boolean" }
+        ]
     },
     "m_autocomplete_duckai_click_switch_to_tab": {
         "description": "User tapped a 'switch to tab' autocomplete suggestion in the Duck.ai Unified Input.",
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": [
+            "appVersion",
+            { "key": "sb", "description": "A bookmark suggestion row was shown in the results", "type": "boolean" },
+            { "key": "sf", "description": "A favorite suggestion row was shown in the results", "type": "boolean" },
+            { "key": "sh", "description": "A history suggestion row was shown in the results", "type": "boolean" },
+            { "key": "showed_switch_to_tab", "description": "A switch-to-tab suggestion row was shown in the results", "type": "boolean" },
+            { "key": "bc", "description": "The user has bookmarks", "type": "boolean" },
+            { "key": "fc", "description": "The user has favorites", "type": "boolean" },
+            { "key": "hc", "description": "The user has history", "type": "boolean" },
+            { "key": "switch_to_tab_capable", "description": "More than one tab is open", "type": "boolean" }
+        ]
     },
     "m_autocomplete_duckai_click_chat_history": {
         "description": "User tapped a chat history autocomplete suggestion in the Duck.ai Unified Input.",

--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -709,5 +709,305 @@
         "triggers": ["other"],
         "suffixes": ["form_factor"],
         "parameters": ["appVersion"]
+    },
+    "m_aichat_unified_input_image_generation_selected_count": {
+        "description": "User selected the image generation tool in the Unified Input",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_unified_input_image_generation_selected_daily": {
+        "description": "(Daily Pixel) User selected the image generation tool in the Unified Input",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_unified_input_image_generation_deselected_count": {
+        "description": "User deselected the image generation tool in the Unified Input",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_unified_input_image_generation_deselected_daily": {
+        "description": "(Daily Pixel) User deselected the image generation tool in the Unified Input",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_unified_input_image_generation_submitted_count": {
+        "description": "User submitted a prompt with the image generation tool selected in the Unified Input",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_unified_input_image_generation_submitted_daily": {
+        "description": "(Daily Pixel) User submitted a prompt with the image generation tool selected in the Unified Input",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_unified_input_web_search_selected_count": {
+        "description": "User selected the web search tool in the Unified Input",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_unified_input_web_search_selected_daily": {
+        "description": "(Daily Pixel) User selected the web search tool in the Unified Input",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_unified_input_web_search_deselected_count": {
+        "description": "User deselected the web search tool in the Unified Input",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_unified_input_web_search_deselected_daily": {
+        "description": "(Daily Pixel) User deselected the web search tool in the Unified Input",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_unified_input_web_search_submitted_count": {
+        "description": "User submitted a prompt with the web search tool selected in the Unified Input",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_unified_input_web_search_submitted_daily": {
+        "description": "(Daily Pixel) User submitted a prompt with the web search tool selected in the Unified Input",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_unified_input_image_removed_count": {
+        "description": "User removed an attached image from the Unified Input",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_unified_input_image_removed_daily": {
+        "description": "(Daily Pixel) User removed an attached image from the Unified Input",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_unified_input_file_attached_count": {
+        "description": "User attached a file in the Unified Input",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_unified_input_file_attached_daily": {
+        "description": "(Daily Pixel) User attached a file in the Unified Input",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_unified_input_file_removed_count": {
+        "description": "User removed an attached file from the Unified Input",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_unified_input_file_removed_daily": {
+        "description": "(Daily Pixel) User removed an attached file from the Unified Input",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_unified_input_voice_tapped_count": {
+        "description": "User tapped the voice button in the Unified Input",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_unified_input_voice_tapped_daily": {
+        "description": "(Daily Pixel) User tapped the voice button in the Unified Input",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_unified_input_image_attached_count": {
+        "description": "User attached an image in the Unified Input",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Where the attached image came from",
+                "enum": ["camera", "photo_library"]
+            }
+        ]
+    },
+    "m_aichat_unified_input_image_attached_daily": {
+        "description": "(Daily Pixel) User attached an image in the Unified Input",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Where the attached image came from",
+                "enum": ["camera", "photo_library"]
+            }
+        ]
+    },
+    "m_aichat_unified_input_file_validation_failed_count": {
+        "description": "A file the user attempted to attach in the Unified Input failed validation",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Why the file validation failed",
+                "enum": ["size_exceeded", "count_exceeded", "unsupported_type", "other"]
+            }
+        ]
+    },
+    "m_aichat_unified_input_file_validation_failed_daily": {
+        "description": "(Daily Pixel) A file the user attempted to attach in the Unified Input failed validation",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Why the file validation failed",
+                "enum": ["size_exceeded", "count_exceeded", "unsupported_type", "other"]
+            }
+        ]
+    },
+    "m_aichat_unified_input_prompt_submitted_count": {
+        "description": "User submitted a prompt from the Unified Input",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "selected_tool",
+                "type": "string",
+                "description": "Which tool was selected when the prompt was submitted",
+                "enum": ["none", "image_generation", "web_search"]
+            },
+            { "key": "model_id", "type": "string", "description": "Identifier of the model used for the prompt" },
+            {
+                "key": "reasoning_effort",
+                "type": "string",
+                "description": "The reasoning effort level used for the prompt",
+                "enum": ["fast", "reasoning", "extended_reasoning"]
+            },
+            { "key": "has_image_attachment", "type": "boolean", "description": "Whether the prompt included an image attachment" },
+            { "key": "has_file_attachment", "type": "boolean", "description": "Whether the prompt included a file attachment" },
+            { "key": "has_text", "type": "boolean", "description": "Whether the prompt included text" }
+        ]
+    },
+    "m_aichat_unified_input_prompt_submitted_daily": {
+        "description": "(Daily Pixel) User submitted a prompt from the Unified Input",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "selected_tool",
+                "type": "string",
+                "description": "Which tool was selected when the prompt was submitted",
+                "enum": ["none", "image_generation", "web_search"]
+            },
+            { "key": "model_id", "type": "string", "description": "Identifier of the model used for the prompt" },
+            {
+                "key": "reasoning_effort",
+                "type": "string",
+                "description": "The reasoning effort level used for the prompt",
+                "enum": ["fast", "reasoning", "extended_reasoning"]
+            },
+            { "key": "has_image_attachment", "type": "boolean", "description": "Whether the prompt included an image attachment" },
+            { "key": "has_file_attachment", "type": "boolean", "description": "Whether the prompt included a file attachment" },
+            { "key": "has_text", "type": "boolean", "description": "Whether the prompt included text" }
+        ]
+    },
+    "m_aichat_unified_input_stop_generation_tapped": {
+        "description": "User tapped the stop generation button in the Unified Input",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_unified_input_model_selected": {
+        "description": "User selected a model in the Unified Input model picker",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            { "key": "model_id", "type": "string", "description": "Identifier of the selected model" }
+        ]
+    },
+    "m_aichat_unified_input_reasoning_effort_selected": {
+        "description": "User selected a reasoning effort level in the Unified Input",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "effort_level",
+                "type": "string",
+                "description": "The selected reasoning effort level",
+                "enum": ["fast", "reasoning", "extended_reasoning"]
+            }
+        ]
+    },
+    "m_aichat_unified_input_subscription_upsell_triggered": {
+        "description": "A subscription upsell was triggered from the Unified Input",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Where the upsell was triggered from",
+                "enum": ["model_picker", "reasoning_picker"]
+            },
+            { "key": "current_tier", "type": "string", "description": "The user's current subscription tier", "enum": ["free", "plus"] },
+            { "key": "required_tier", "type": "string", "description": "The subscription tier required to access the feature", "enum": ["plus", "pro"] },
+            { "key": "flow_type", "type": "string", "description": "The type of subscription flow offered", "enum": ["purchase", "upgrade"] }
+        ]
     }
 }

--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -921,7 +921,7 @@
                 "key": "reason",
                 "type": "string",
                 "description": "Why the file validation failed",
-                "enum": ["size_exceeded", "count_exceeded", "page_count_exceeded", "unsupported_type", "other"]
+                "enum": ["size_exceeded", "count_exceeded", "page_count_exceeded", "other"]
             }
         ]
     },
@@ -936,7 +936,7 @@
                 "key": "reason",
                 "type": "string",
                 "description": "Why the file validation failed",
-                "enum": ["size_exceeded", "count_exceeded", "page_count_exceeded", "unsupported_type", "other"]
+                "enum": ["size_exceeded", "count_exceeded", "page_count_exceeded", "other"]
             }
         ]
     },

--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -880,6 +880,36 @@
             }
         ]
     },
+    "m_aichat_unified_input_image_validation_failed_count": {
+        "description": "An image the user attempted to attach in the Unified Input failed validation",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Why the image validation failed",
+                "enum": ["count_exceeded", "other"]
+            }
+        ]
+    },
+    "m_aichat_unified_input_image_validation_failed_daily": {
+        "description": "(Daily Pixel) An image the user attempted to attach in the Unified Input failed validation",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Why the image validation failed",
+                "enum": ["count_exceeded", "other"]
+            }
+        ]
+    },
     "m_aichat_unified_input_file_validation_failed_count": {
         "description": "A file the user attempted to attach in the Unified Input failed validation",
         "owners": ["malmstein"],

--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -880,6 +880,21 @@
             }
         ]
     },
+    "m_aichat_unified_input_chat_header_upgrade_tapped": {
+        "description": "User tapped the Upgrade pill in the Duck.ai omnibar header (shown only while the subscription is inactive)",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "user_tier",
+                "type": "string",
+                "description": "The tapper's current tier",
+                "enum": ["free", "plus"]
+            }
+        ]
+    },
     "m_aichat_unified_input_image_validation_failed_count": {
         "description": "An image the user attempted to attach in the Unified Input failed validation",
         "owners": ["malmstein"],

--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -972,10 +972,7 @@
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": [
-            "appVersion",
-            { "key": "model_id", "type": "string", "description": "Identifier of the selected model" }
-        ]
+        "parameters": ["appVersion", { "key": "model_id", "type": "string", "description": "Identifier of the selected model" }]
     },
     "m_aichat_unified_input_reasoning_effort_selected": {
         "description": "User selected a reasoning effort level in the Unified Input",
@@ -1006,8 +1003,18 @@
                 "enum": ["model_picker", "reasoning_picker"]
             },
             { "key": "current_tier", "type": "string", "description": "The user's current subscription tier", "enum": ["free", "plus"] },
-            { "key": "required_tier", "type": "string", "description": "The subscription tier required to access the feature", "enum": ["plus", "pro"] },
-            { "key": "flow_type", "type": "string", "description": "The type of subscription flow offered", "enum": ["purchase", "upgrade"] }
+            {
+                "key": "required_tier",
+                "type": "string",
+                "description": "The subscription tier required to access the feature",
+                "enum": ["plus", "pro"]
+            },
+            {
+                "key": "flow_type",
+                "type": "string",
+                "description": "The type of subscription flow offered",
+                "enum": ["purchase", "upgrade"]
+            }
         ]
     }
 }

--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -921,7 +921,7 @@
                 "key": "reason",
                 "type": "string",
                 "description": "Why the file validation failed",
-                "enum": ["size_exceeded", "count_exceeded", "unsupported_type", "other"]
+                "enum": ["size_exceeded", "count_exceeded", "page_count_exceeded", "unsupported_type", "other"]
             }
         ]
     },
@@ -936,7 +936,7 @@
                 "key": "reason",
                 "type": "string",
                 "description": "Why the file validation failed",
-                "enum": ["size_exceeded", "count_exceeded", "unsupported_type", "other"]
+                "enum": ["size_exceeded", "count_exceeded", "page_count_exceeded", "unsupported_type", "other"]
             }
         ]
     },

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
@@ -264,6 +264,7 @@ class AutoCompleteApi constructor(
         suggestions: List<AutoCompleteSuggestion>,
         suggestion: AutoCompleteSuggestion,
         experimentalInputScreen: Boolean,
+        duckAiSurface: Boolean,
     ) {
         val hasBookmarks = withContext(dispatchers.io()) {
             savedSitesRepository.hasBookmarks()
@@ -295,21 +296,45 @@ class AutoCompleteApi constructor(
         val pixelName = when (suggestion) {
             is AutoCompleteBookmarkSuggestion -> {
                 if (suggestion.isFavorite) {
-                    AutoCompletePixelNames.AUTOCOMPLETE_FAVORITE_SELECTION
+                    if (duckAiSurface) {
+                        AutoCompletePixelNames.AUTOCOMPLETE_DUCKAI_FAVORITE_SELECTION
+                    } else {
+                        AutoCompletePixelNames.AUTOCOMPLETE_FAVORITE_SELECTION
+                    }
                 } else {
-                    AutoCompletePixelNames.AUTOCOMPLETE_BOOKMARK_SELECTION
+                    if (duckAiSurface) {
+                        AutoCompletePixelNames.AUTOCOMPLETE_DUCKAI_BOOKMARK_SELECTION
+                    } else {
+                        AutoCompletePixelNames.AUTOCOMPLETE_BOOKMARK_SELECTION
+                    }
                 }
             }
 
             is AutoCompleteSearchSuggestion -> if (suggestion.isUrl) {
-                AutoCompletePixelNames.AUTOCOMPLETE_SEARCH_WEBSITE_SELECTION
+                if (duckAiSurface) {
+                    AutoCompletePixelNames.AUTOCOMPLETE_DUCKAI_WEBSITE_SELECTION
+                } else {
+                    AutoCompletePixelNames.AUTOCOMPLETE_SEARCH_WEBSITE_SELECTION
+                }
             } else {
                 AutoCompletePixelNames.AUTOCOMPLETE_SEARCH_PHRASE_SELECTION
             }
 
-            is AutoCompleteHistorySuggestion -> AutoCompletePixelNames.AUTOCOMPLETE_HISTORY_SITE_SELECTION
-            is AutoCompleteHistorySearchSuggestion -> AutoCompletePixelNames.AUTOCOMPLETE_HISTORY_SEARCH_SELECTION
-            is AutoCompleteSwitchToTabSuggestion -> AutoCompletePixelNames.AUTOCOMPLETE_SWITCH_TO_TAB_SELECTION
+            is AutoCompleteHistorySuggestion -> if (duckAiSurface) {
+                AutoCompletePixelNames.AUTOCOMPLETE_DUCKAI_HISTORY_SITE_SELECTION
+            } else {
+                AutoCompletePixelNames.AUTOCOMPLETE_HISTORY_SITE_SELECTION
+            }
+            is AutoCompleteHistorySearchSuggestion -> if (duckAiSurface) {
+                AutoCompletePixelNames.AUTOCOMPLETE_DUCKAI_HISTORY_SEARCH_SELECTION
+            } else {
+                AutoCompletePixelNames.AUTOCOMPLETE_HISTORY_SEARCH_SELECTION
+            }
+            is AutoCompleteSwitchToTabSuggestion -> if (duckAiSurface) {
+                AutoCompletePixelNames.AUTOCOMPLETE_DUCKAI_SWITCH_TO_TAB_SELECTION
+            } else {
+                AutoCompletePixelNames.AUTOCOMPLETE_SWITCH_TO_TAB_SELECTION
+            }
             is AutoCompleteSuggestion.AutoCompleteDuckAIPrompt -> if (experimentalInputScreen) {
                 AutoCompletePixelNames.AUTOCOMPLETE_DUCKAI_PROMPT_EXPERIMENTAL_SELECTION
             } else {

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/api/AutoComplete.kt
@@ -294,47 +294,21 @@ class AutoCompleteApi constructor(
             PixelParameter.SHOWED_SWITCH_TO_TAB to hasSwitchToTabResults.toString(),
         )
         val pixelName = when (suggestion) {
-            is AutoCompleteBookmarkSuggestion -> {
-                if (suggestion.isFavorite) {
-                    if (duckAiSurface) {
-                        AutoCompletePixelNames.AUTOCOMPLETE_DUCKAI_FAVORITE_SELECTION
-                    } else {
-                        AutoCompletePixelNames.AUTOCOMPLETE_FAVORITE_SELECTION
-                    }
-                } else {
-                    if (duckAiSurface) {
-                        AutoCompletePixelNames.AUTOCOMPLETE_DUCKAI_BOOKMARK_SELECTION
-                    } else {
-                        AutoCompletePixelNames.AUTOCOMPLETE_BOOKMARK_SELECTION
-                    }
-                }
+            is AutoCompleteBookmarkSuggestion -> if (suggestion.isFavorite) {
+                AutoCompletePixelNames.AUTOCOMPLETE_FAVORITE_SELECTION
+            } else {
+                AutoCompletePixelNames.AUTOCOMPLETE_BOOKMARK_SELECTION
             }
 
             is AutoCompleteSearchSuggestion -> if (suggestion.isUrl) {
-                if (duckAiSurface) {
-                    AutoCompletePixelNames.AUTOCOMPLETE_DUCKAI_WEBSITE_SELECTION
-                } else {
-                    AutoCompletePixelNames.AUTOCOMPLETE_SEARCH_WEBSITE_SELECTION
-                }
+                AutoCompletePixelNames.AUTOCOMPLETE_SEARCH_WEBSITE_SELECTION
             } else {
                 AutoCompletePixelNames.AUTOCOMPLETE_SEARCH_PHRASE_SELECTION
             }
 
-            is AutoCompleteHistorySuggestion -> if (duckAiSurface) {
-                AutoCompletePixelNames.AUTOCOMPLETE_DUCKAI_HISTORY_SITE_SELECTION
-            } else {
-                AutoCompletePixelNames.AUTOCOMPLETE_HISTORY_SITE_SELECTION
-            }
-            is AutoCompleteHistorySearchSuggestion -> if (duckAiSurface) {
-                AutoCompletePixelNames.AUTOCOMPLETE_DUCKAI_HISTORY_SEARCH_SELECTION
-            } else {
-                AutoCompletePixelNames.AUTOCOMPLETE_HISTORY_SEARCH_SELECTION
-            }
-            is AutoCompleteSwitchToTabSuggestion -> if (duckAiSurface) {
-                AutoCompletePixelNames.AUTOCOMPLETE_DUCKAI_SWITCH_TO_TAB_SELECTION
-            } else {
-                AutoCompletePixelNames.AUTOCOMPLETE_SWITCH_TO_TAB_SELECTION
-            }
+            is AutoCompleteHistorySuggestion -> AutoCompletePixelNames.AUTOCOMPLETE_HISTORY_SITE_SELECTION
+            is AutoCompleteHistorySearchSuggestion -> AutoCompletePixelNames.AUTOCOMPLETE_HISTORY_SEARCH_SELECTION
+            is AutoCompleteSwitchToTabSuggestion -> AutoCompletePixelNames.AUTOCOMPLETE_SWITCH_TO_TAB_SELECTION
             is AutoCompleteSuggestion.AutoCompleteDuckAIPrompt -> if (experimentalInputScreen) {
                 AutoCompletePixelNames.AUTOCOMPLETE_DUCKAI_PROMPT_EXPERIMENTAL_SELECTION
             } else {
@@ -348,7 +322,19 @@ class AutoCompleteApi constructor(
             else -> return
         }
 
-        pixel.fire(pixelName, params)
+        // On the Duck.ai tab the same suggestion taps are attributed to a separate
+        // m_autocomplete_duckai_click_* family so they aren't conflated with search-mode taps.
+        pixel.fire(if (duckAiSurface) pixelName.toDuckAiSurface() else pixelName, params)
+    }
+
+    private fun AutoCompletePixelNames.toDuckAiSurface(): AutoCompletePixelNames = when (this) {
+        AutoCompletePixelNames.AUTOCOMPLETE_FAVORITE_SELECTION -> AutoCompletePixelNames.AUTOCOMPLETE_DUCKAI_FAVORITE_SELECTION
+        AutoCompletePixelNames.AUTOCOMPLETE_BOOKMARK_SELECTION -> AutoCompletePixelNames.AUTOCOMPLETE_DUCKAI_BOOKMARK_SELECTION
+        AutoCompletePixelNames.AUTOCOMPLETE_SEARCH_WEBSITE_SELECTION -> AutoCompletePixelNames.AUTOCOMPLETE_DUCKAI_WEBSITE_SELECTION
+        AutoCompletePixelNames.AUTOCOMPLETE_HISTORY_SITE_SELECTION -> AutoCompletePixelNames.AUTOCOMPLETE_DUCKAI_HISTORY_SITE_SELECTION
+        AutoCompletePixelNames.AUTOCOMPLETE_HISTORY_SEARCH_SELECTION -> AutoCompletePixelNames.AUTOCOMPLETE_DUCKAI_HISTORY_SEARCH_SELECTION
+        AutoCompletePixelNames.AUTOCOMPLETE_SWITCH_TO_TAB_SELECTION -> AutoCompletePixelNames.AUTOCOMPLETE_DUCKAI_SWITCH_TO_TAB_SELECTION
+        else -> this
     }
 
     private fun isAllowedInTopHits(entry: HistoryEntry): Boolean {

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/impl/AutoCompletePixelNames.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/impl/AutoCompletePixelNames.kt
@@ -52,6 +52,10 @@ class AutocompleteParamRemovalPlugin @Inject constructor() : PixelParamRemovalPl
     override fun names(): List<Pair<String, Set<PixelParameter>>> {
         return listOf(
             AutoCompletePixelNames.AUTOCOMPLETE_INSTALLED_APP_SELECTION.pixelName to PixelParameter.removeAtb(),
+            // Prefix: the Duck.ai-surface autocomplete family is Duck.ai telemetry, so it drops ATB.
+            // Covers the 6 names above and the 2 Duck.ai-unique ones (chat_history, search_duckduckgo)
+            // declared in DuckChatPixelName — the interceptor matches outgoing names with startsWith.
+            "m_autocomplete_duckai_click_" to PixelParameter.removeAtb(),
         )
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/autocomplete/impl/AutoCompletePixelNames.kt
+++ b/app/src/main/java/com/duckduckgo/app/autocomplete/impl/AutoCompletePixelNames.kt
@@ -38,6 +38,13 @@ enum class AutoCompletePixelNames(override val pixelName: String) : Pixel.PixelN
     AUTOCOMPLETE_DUCKAI_PROMPT_EXPERIMENTAL_SELECTION("m_autocomplete_click_duckai_experimental"),
     AUTOCOMPLETE_DUCKAI_PROMPT_LEGACY_SELECTION("m_autocomplete_click_duckai_legacy"),
     AUTOCOMPLETE_INSTALLED_APP_SELECTION("m_autocomplete_click_installed-app"),
+
+    AUTOCOMPLETE_DUCKAI_WEBSITE_SELECTION("m_autocomplete_duckai_click_website"),
+    AUTOCOMPLETE_DUCKAI_BOOKMARK_SELECTION("m_autocomplete_duckai_click_bookmark"),
+    AUTOCOMPLETE_DUCKAI_FAVORITE_SELECTION("m_autocomplete_duckai_click_favorite"),
+    AUTOCOMPLETE_DUCKAI_HISTORY_SEARCH_SELECTION("m_autocomplete_duckai_click_history_search"),
+    AUTOCOMPLETE_DUCKAI_HISTORY_SITE_SELECTION("m_autocomplete_duckai_click_history_site"),
+    AUTOCOMPLETE_DUCKAI_SWITCH_TO_TAB_SELECTION("m_autocomplete_duckai_click_switch_to_tab"),
 }
 
 @ContributesMultibinding(AppScope::class)

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -36,6 +36,8 @@ import androidx.recyclerview.widget.RecyclerView
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.omnibar.Omnibar
 import com.duckduckgo.app.browser.omnibar.QueryUrlPredictor
+import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion
 import com.duckduckgo.common.ui.view.getColorFromAttr
@@ -126,6 +128,7 @@ class RealNativeInputManager @Inject constructor(
     private val globalActivityStarter: GlobalActivityStarter,
     private val queryUrlPredictor: QueryUrlPredictor,
     private val duckAiFeatureState: DuckAiFeatureState,
+    private val pixel: Pixel,
 ) : NativeInputManager {
     private lateinit var omnibarController: NativeInputOmnibarController
     private lateinit var rootView: ViewGroup
@@ -557,7 +560,10 @@ class RealNativeInputManager @Inject constructor(
             )
             onPaidTierChanged = { isPaid ->
                 val tier = if (isPaid) DuckAiTier.Paid else DuckAiTier.Free
-                omnibarController.updateTierTitle(tier) { launchPurchase() }
+                omnibarController.updateTierTitle(tier) {
+                    fireChatHeaderUpgradeTapped(tier)
+                    launchPurchase()
+                }
             }
             if (!isBottom) {
                 setFloatingSubmitContainer(createFloatingSubmitContainer())
@@ -837,6 +843,15 @@ class RealNativeInputManager @Inject constructor(
 
     private fun launchPurchase() {
         globalActivityStarter.start(rootView.context, SubscriptionPurchase(featurePage = DUCK_AI_FEATURE_PAGE))
+    }
+
+    /**
+     * Fired when the user taps the "Upgrade" pill in the Duck.ai omnibar header. The pill is only shown
+     * for [DuckAiTier.Free] (subscription inactive), so this is the chat-header upgrade entry point.
+     */
+    internal fun fireChatHeaderUpgradeTapped(tier: DuckAiTier) {
+        val userTier = if (tier is DuckAiTier.Paid) "plus" else "free"
+        pixel.fire(AppPixelName.AI_CHAT_UNIFIED_INPUT_CHAT_HEADER_UPGRADE_TAPPED, mapOf("user_tier" to userTier))
     }
 
     /** True if [rawUrl] points at an in-progress Duck.ai chat (Duck.ai URL with a non-blank `chatID`). */

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -62,6 +62,7 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     NEW_ADDRESS_BAR_PICKER_V2_CONFIRMED_DAILY("m_aichat_new_address_bar_picker_v2_confirmed_daily"),
     AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_COUNT("m_aichat_duck_ai_direct_navigation_count"),
     AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_DAILY("m_aichat_duck_ai_direct_navigation_daily"),
+    AI_CHAT_UNIFIED_INPUT_CHAT_HEADER_UPGRADE_TAPPED("m_aichat_unified_input_chat_header_upgrade_tapped"),
     PREONBOARDING_SKIP_ONBOARDING_PRESSED("m_preonboarding_skip-onboarding-pressed"),
     PREONBOARDING_CONFIRM_SKIP_ONBOARDING_PRESSED("m_preonboarding_confirm-skip-onboarding-pressed"),
     PREONBOARDING_RESUME_ONBOARDING_PRESSED("m_preonboarding_resume-onboarding-pressed"),

--- a/app/src/test/java/com/duckduckgo/app/autocomplete/api/AutoCompleteApiTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/autocomplete/api/AutoCompleteApiTest.kt
@@ -1726,6 +1726,104 @@ class AutoCompleteApiTest {
     }
 
     @Test
+    fun whenBookmarkSubmittedFromDuckAiSurfaceThenDuckAiBookmarkPixelSentAndSearchFamilyNotSent() = runTest {
+        whenever(mockSavedSitesRepository.hasBookmarks()).thenReturn(true)
+        whenever(mockSavedSitesRepository.hasFavorites()).thenReturn(false)
+        whenever(mockHistory.hasHistory()).thenReturn(false)
+        tabsLiveData.value = listOf(TabEntity("1", "https://example.com", position = 0), TabEntity("2", "https://example.com", position = 1))
+
+        val suggestion = AutoCompleteBookmarkSuggestion("example", "Example", "https://example.com")
+        testee.fireAutocompletePixel(listOf(suggestion), suggestion, duckAiSurface = true)
+
+        verify(mockPixel).fire(eq(AutoCompletePixelNames.AUTOCOMPLETE_DUCKAI_BOOKMARK_SELECTION), any(), any(), any())
+        verify(mockPixel, never()).fire(eq(AutoCompletePixelNames.AUTOCOMPLETE_BOOKMARK_SELECTION), any(), any(), any())
+    }
+
+    @Test
+    fun whenFavoriteSubmittedFromDuckAiSurfaceThenDuckAiFavoritePixelSentAndSearchFamilyNotSent() = runTest {
+        whenever(mockSavedSitesRepository.hasBookmarks()).thenReturn(true)
+        whenever(mockSavedSitesRepository.hasFavorites()).thenReturn(true)
+        whenever(mockHistory.hasHistory()).thenReturn(false)
+        tabsLiveData.value = listOf(TabEntity("1", "https://example.com", position = 0), TabEntity("2", "https://example.com", position = 1))
+
+        val suggestion = AutoCompleteBookmarkSuggestion("example", "Example", "https://example.com", isFavorite = true)
+        testee.fireAutocompletePixel(listOf(suggestion), suggestion, duckAiSurface = true)
+
+        verify(mockPixel).fire(eq(AutoCompletePixelNames.AUTOCOMPLETE_DUCKAI_FAVORITE_SELECTION), any(), any(), any())
+        verify(mockPixel, never()).fire(eq(AutoCompletePixelNames.AUTOCOMPLETE_FAVORITE_SELECTION), any(), any(), any())
+    }
+
+    @Test
+    fun whenUrlSearchSuggestionSubmittedFromDuckAiSurfaceThenDuckAiWebsitePixelSentAndSearchFamilyNotSent() = runTest {
+        whenever(mockSavedSitesRepository.hasBookmarks()).thenReturn(false)
+        whenever(mockNavigationHistory.hasHistory()).thenReturn(false)
+        whenever(mockHistory.hasHistory()).thenReturn(false)
+        tabsLiveData.value = listOf(TabEntity("1", "https://example.com", position = 0), TabEntity("2", "https://example.com", position = 1))
+
+        val suggestion = AutoCompleteSearchSuggestion("example", isUrl = true, isAllowedInTopHits = true)
+        testee.fireAutocompletePixel(listOf(suggestion), suggestion, duckAiSurface = true)
+
+        verify(mockPixel).fire(eq(AutoCompletePixelNames.AUTOCOMPLETE_DUCKAI_WEBSITE_SELECTION), any(), any(), any())
+        verify(mockPixel, never()).fire(eq(AutoCompletePixelNames.AUTOCOMPLETE_SEARCH_WEBSITE_SELECTION), any(), any(), any())
+    }
+
+    @Test
+    fun whenHistorySiteSubmittedFromDuckAiSurfaceThenDuckAiHistorySitePixelSentAndSearchFamilyNotSent() = runTest {
+        whenever(mockSavedSitesRepository.hasBookmarks()).thenReturn(false)
+        whenever(mockNavigationHistory.hasHistory()).thenReturn(true)
+        whenever(mockHistory.hasHistory()).thenReturn(true)
+        tabsLiveData.value = listOf(TabEntity("1", "https://example.com", position = 0), TabEntity("2", "https://example.com", position = 1))
+
+        val suggestion = AutoCompleteHistorySuggestion("example", "Example", "https://example.com", isAllowedInTopHits = true)
+        testee.fireAutocompletePixel(listOf(suggestion), suggestion, duckAiSurface = true)
+
+        verify(mockPixel).fire(eq(AutoCompletePixelNames.AUTOCOMPLETE_DUCKAI_HISTORY_SITE_SELECTION), any(), any(), any())
+        verify(mockPixel, never()).fire(eq(AutoCompletePixelNames.AUTOCOMPLETE_HISTORY_SITE_SELECTION), any(), any(), any())
+    }
+
+    @Test
+    fun whenHistorySearchSubmittedFromDuckAiSurfaceThenDuckAiHistorySearchPixelSentAndSearchFamilyNotSent() = runTest {
+        whenever(mockSavedSitesRepository.hasBookmarks()).thenReturn(false)
+        whenever(mockNavigationHistory.hasHistory()).thenReturn(true)
+        whenever(mockHistory.hasHistory()).thenReturn(true)
+        tabsLiveData.value = listOf(TabEntity("1", "https://example.com", position = 0), TabEntity("2", "https://example.com", position = 1))
+
+        val suggestion = AutoCompleteHistorySearchSuggestion("example", true)
+        testee.fireAutocompletePixel(listOf(suggestion), suggestion, duckAiSurface = true)
+
+        verify(mockPixel).fire(eq(AutoCompletePixelNames.AUTOCOMPLETE_DUCKAI_HISTORY_SEARCH_SELECTION), any(), any(), any())
+        verify(mockPixel, never()).fire(eq(AutoCompletePixelNames.AUTOCOMPLETE_HISTORY_SEARCH_SELECTION), any(), any(), any())
+    }
+
+    @Test
+    fun whenSwitchToTabSubmittedFromDuckAiSurfaceThenDuckAiSwitchToTabPixelSentAndSearchFamilyNotSent() = runTest {
+        whenever(mockSavedSitesRepository.hasBookmarks()).thenReturn(false)
+        whenever(mockNavigationHistory.hasHistory()).thenReturn(false)
+        whenever(mockHistory.hasHistory()).thenReturn(false)
+        tabsLiveData.value = listOf(TabEntity("1", "https://example.com", position = 0), TabEntity("2", "https://example.com", position = 1))
+
+        val suggestion = AutoCompleteSwitchToTabSuggestion("example", "", "", "")
+        testee.fireAutocompletePixel(listOf(suggestion), suggestion, duckAiSurface = true)
+
+        verify(mockPixel).fire(eq(AutoCompletePixelNames.AUTOCOMPLETE_DUCKAI_SWITCH_TO_TAB_SELECTION), any(), any(), any())
+        verify(mockPixel, never()).fire(eq(AutoCompletePixelNames.AUTOCOMPLETE_SWITCH_TO_TAB_SELECTION), any(), any(), any())
+    }
+
+    @Test
+    fun whenBookmarkSubmittedWithDefaultDuckAiSurfaceThenSearchFamilyBookmarkPixelStillSent() = runTest {
+        whenever(mockSavedSitesRepository.hasBookmarks()).thenReturn(true)
+        whenever(mockSavedSitesRepository.hasFavorites()).thenReturn(false)
+        whenever(mockHistory.hasHistory()).thenReturn(false)
+        tabsLiveData.value = listOf(TabEntity("1", "https://example.com", position = 0), TabEntity("2", "https://example.com", position = 1))
+
+        val suggestion = AutoCompleteBookmarkSuggestion("example", "Example", "https://example.com")
+        testee.fireAutocompletePixel(listOf(suggestion), suggestion)
+
+        verify(mockPixel).fire(eq(AutoCompletePixelNames.AUTOCOMPLETE_BOOKMARK_SELECTION), any(), any(), any())
+        verify(mockPixel, never()).fire(eq(AutoCompletePixelNames.AUTOCOMPLETE_DUCKAI_BOOKMARK_SELECTION), any(), any(), any())
+    }
+
+    @Test
     fun whenShowInstalledAppsDisabledThenNoDeviceAppResultsReturned() = runTest {
         val testee = createTestee(AutoComplete.Config(showInstalledApps = false))
         val mockIntent = Intent()

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
@@ -19,6 +19,8 @@ package com.duckduckgo.app.browser.nativeinput
 import android.net.Uri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.browser.omnibar.QueryUrlPredictor
+import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.navigation.api.GlobalActivityStarter
@@ -44,6 +46,7 @@ class RealNativeInputManagerTest {
     private val globalActivityStarter: GlobalActivityStarter = mock()
     private val queryUrlPredictor: QueryUrlPredictor = mock()
     private val duckAiFeatureState: DuckAiFeatureState = mock()
+    private val pixel: Pixel = mock()
 
     private lateinit var testee: RealNativeInputManager
 
@@ -56,6 +59,27 @@ class RealNativeInputManagerTest {
             globalActivityStarter,
             queryUrlPredictor,
             duckAiFeatureState,
+            pixel,
+        )
+    }
+
+    @Test
+    fun whenChatHeaderUpgradeTappedByFreeUserThenPixelFiredWithFreeTier() {
+        testee.fireChatHeaderUpgradeTapped(DuckAiTier.Free)
+
+        verify(pixel).fire(
+            AppPixelName.AI_CHAT_UNIFIED_INPUT_CHAT_HEADER_UPGRADE_TAPPED,
+            mapOf("user_tier" to "free"),
+        )
+    }
+
+    @Test
+    fun whenChatHeaderUpgradeTappedByPaidUserThenPixelFiredWithPlusTier() {
+        testee.fireChatHeaderUpgradeTapped(DuckAiTier.Paid)
+
+        verify(pixel).fire(
+            AppPixelName.AI_CHAT_UNIFIED_INPUT_CHAT_HEADER_UPGRADE_TAPPED,
+            mapOf("user_tier" to "plus"),
         )
     }
 

--- a/browser-api/src/main/java/com/duckduckgo/browser/api/autocomplete/AutoComplete.kt
+++ b/browser-api/src/main/java/com/duckduckgo/browser/api/autocomplete/AutoComplete.kt
@@ -27,6 +27,7 @@ interface AutoComplete {
         suggestions: List<AutoCompleteSuggestion>,
         suggestion: AutoCompleteSuggestion,
         experimentalInputScreen: Boolean = false,
+        duckAiSurface: Boolean = false,
     )
 
     data class Config(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -606,6 +606,20 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_CHAT_HISTORY_NEW_CHAT_TAPPED_DAILY("m_aichat_history_new_chat_tapped_daily"),
     DUCK_CHAT_HISTORY_DOWNLOAD_SELECTED_COUNT("m_aichat_history_download_selected_count"),
     DUCK_CHAT_HISTORY_DOWNLOAD_SELECTED_DAILY("m_aichat_history_download_selected_daily"),
+    DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_SELECTED_COUNT("m_aichat_unified_input_image_generation_selected_count"),
+    DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_SELECTED_DAILY("m_aichat_unified_input_image_generation_selected_daily"),
+    DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_DESELECTED_COUNT("m_aichat_unified_input_image_generation_deselected_count"),
+    DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_DESELECTED_DAILY("m_aichat_unified_input_image_generation_deselected_daily"),
+    DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_SUBMITTED_COUNT("m_aichat_unified_input_image_generation_submitted_count"),
+    DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_SUBMITTED_DAILY("m_aichat_unified_input_image_generation_submitted_daily"),
+    DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_SELECTED_COUNT("m_aichat_unified_input_web_search_selected_count"),
+    DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_SELECTED_DAILY("m_aichat_unified_input_web_search_selected_daily"),
+    DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_DESELECTED_COUNT("m_aichat_unified_input_web_search_deselected_count"),
+    DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_DESELECTED_DAILY("m_aichat_unified_input_web_search_deselected_daily"),
+    DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_SUBMITTED_COUNT("m_aichat_unified_input_web_search_submitted_count"),
+    DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_SUBMITTED_DAILY("m_aichat_unified_input_web_search_submitted_daily"),
+    DUCK_CHAT_UNIFIED_INPUT_PROMPT_SUBMITTED_COUNT("m_aichat_unified_input_prompt_submitted_count"),
+    DUCK_CHAT_UNIFIED_INPUT_PROMPT_SUBMITTED_DAILY("m_aichat_unified_input_prompt_submitted_daily"),
 }
 
 object DuckChatPixelParameters {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -166,6 +166,13 @@ interface DuckChatPixels {
     fun fireModelSelected(modelId: String)
     fun fireReasoningEffortSelected(effortLevel: String)
     fun fireSubscriptionUpsellTriggered(source: String, currentTier: String, requiredTier: String, flowType: String)
+    fun fireImageAttached(source: String)
+    fun fireImageRemoved()
+    fun fireFileAttached()
+    fun fireFileRemoved()
+    fun fireFileValidationFailed(reason: String)
+    fun fireVoiceTapped()
+    fun fireStopGenerationTapped()
 }
 
 @ContributesBinding(AppScope::class)
@@ -524,6 +531,44 @@ class RealDuckChatPixels @Inject constructor(
             )
         }
     }
+
+    override fun fireImageAttached(source: String) = fireCountAndDaily(
+        DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_ATTACHED_COUNT,
+        DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_ATTACHED_DAILY,
+        mapOf(DuckChatPixelParameters.ATTACHMENT_SOURCE to source),
+    )
+
+    override fun fireImageRemoved() = fireCountAndDaily(
+        DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_REMOVED_COUNT,
+        DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_REMOVED_DAILY,
+    )
+
+    override fun fireFileAttached() = fireCountAndDaily(
+        DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_ATTACHED_COUNT,
+        DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_ATTACHED_DAILY,
+    )
+
+    override fun fireFileRemoved() = fireCountAndDaily(
+        DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_REMOVED_COUNT,
+        DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_REMOVED_DAILY,
+    )
+
+    override fun fireFileValidationFailed(reason: String) = fireCountAndDaily(
+        DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_VALIDATION_FAILED_COUNT,
+        DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_VALIDATION_FAILED_DAILY,
+        mapOf(DuckChatPixelParameters.FILE_VALIDATION_REASON to reason),
+    )
+
+    override fun fireVoiceTapped() = fireCountAndDaily(
+        DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_VOICE_TAPPED_COUNT,
+        DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_VOICE_TAPPED_DAILY,
+    )
+
+    override fun fireStopGenerationTapped() {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_STOP_GENERATION_TAPPED)
+        }
+    }
 }
 
 enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
@@ -727,6 +772,19 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_CHAT_UNIFIED_INPUT_MODEL_SELECTED("m_aichat_unified_input_model_selected"),
     DUCK_CHAT_UNIFIED_INPUT_REASONING_EFFORT_SELECTED("m_aichat_unified_input_reasoning_effort_selected"),
     DUCK_CHAT_UNIFIED_INPUT_SUBSCRIPTION_UPSELL_TRIGGERED("m_aichat_unified_input_subscription_upsell_triggered"),
+    DUCK_CHAT_UNIFIED_INPUT_IMAGE_ATTACHED_COUNT("m_aichat_unified_input_image_attached_count"),
+    DUCK_CHAT_UNIFIED_INPUT_IMAGE_ATTACHED_DAILY("m_aichat_unified_input_image_attached_daily"),
+    DUCK_CHAT_UNIFIED_INPUT_IMAGE_REMOVED_COUNT("m_aichat_unified_input_image_removed_count"),
+    DUCK_CHAT_UNIFIED_INPUT_IMAGE_REMOVED_DAILY("m_aichat_unified_input_image_removed_daily"),
+    DUCK_CHAT_UNIFIED_INPUT_FILE_ATTACHED_COUNT("m_aichat_unified_input_file_attached_count"),
+    DUCK_CHAT_UNIFIED_INPUT_FILE_ATTACHED_DAILY("m_aichat_unified_input_file_attached_daily"),
+    DUCK_CHAT_UNIFIED_INPUT_FILE_REMOVED_COUNT("m_aichat_unified_input_file_removed_count"),
+    DUCK_CHAT_UNIFIED_INPUT_FILE_REMOVED_DAILY("m_aichat_unified_input_file_removed_daily"),
+    DUCK_CHAT_UNIFIED_INPUT_FILE_VALIDATION_FAILED_COUNT("m_aichat_unified_input_file_validation_failed_count"),
+    DUCK_CHAT_UNIFIED_INPUT_FILE_VALIDATION_FAILED_DAILY("m_aichat_unified_input_file_validation_failed_daily"),
+    DUCK_CHAT_UNIFIED_INPUT_VOICE_TAPPED_COUNT("m_aichat_unified_input_voice_tapped_count"),
+    DUCK_CHAT_UNIFIED_INPUT_VOICE_TAPPED_DAILY("m_aichat_unified_input_voice_tapped_daily"),
+    DUCK_CHAT_UNIFIED_INPUT_STOP_GENERATION_TAPPED("m_aichat_unified_input_stop_generation_tapped"),
 }
 
 object DuckChatPixelParameters {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -616,6 +616,21 @@ object DuckChatPixelParameters {
     const val NEW_ADDRESS_BAR_SELECTION = "selection"
     const val DEFAULT_TOGGLE_POSITION = "default_position"
     const val DEFAULT_TOGGLE_POSITION_VALUE = "value"
+
+    // Unified Input pixels
+    const val SELECTED_TOOL = "selected_tool"
+    const val MODEL_ID = "model_id"
+    const val REASONING_EFFORT = "reasoning_effort"
+    const val EFFORT_LEVEL = "effort_level"
+    const val HAS_IMAGE_ATTACHMENT = "has_image_attachment"
+    const val HAS_FILE_ATTACHMENT = "has_file_attachment"
+    const val HAS_TEXT = "has_text"
+    const val ATTACHMENT_SOURCE = "source"
+    const val FILE_VALIDATION_REASON = "reason"
+    const val UPSELL_SOURCE = "source"
+    const val UPSELL_CURRENT_TIER = "current_tier"
+    const val UPSELL_REQUIRED_TIER = "required_tier"
+    const val UPSELL_FLOW_TYPE = "flow_type"
 }
 
 @ContributesMultibinding(AppScope::class)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -1011,6 +1011,10 @@ class DuckChatParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin
             DuckChatPixelName.DUCK_CHAT_HISTORY_DOWNLOAD_SELECTED_COUNT.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_HISTORY_DOWNLOAD_SELECTED_DAILY.pixelName to PixelParameter.removeAtb(),
             "m_duck-ai_native-storage_" to PixelParameter.removeAtb(),
+            // Prefix: covers every m_aichat_unified_input_* pixel (tools, submit, model/reasoning,
+            // upsell, attachments, voice, stop) AND the app-side chat_header_upgrade_tapped, which
+            // shares the prefix — the interceptor matches outgoing pixel names with startsWith.
+            "m_aichat_unified_input_" to PixelParameter.removeAtb(),
         )
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -167,6 +167,7 @@ interface DuckChatPixels {
     fun fireReasoningEffortSelected(effortLevel: String)
     fun fireSubscriptionUpsellTriggered(source: String, currentTier: String, requiredTier: String, flowType: String)
     fun fireImageAttached(source: String)
+    fun fireImageValidationFailed(reason: String)
     fun fireImageRemoved()
     fun fireFileAttached()
     fun fireFileRemoved()
@@ -545,6 +546,12 @@ class RealDuckChatPixels @Inject constructor(
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_REMOVED_DAILY,
     )
 
+    override fun fireImageValidationFailed(reason: String) = fireCountAndDaily(
+        DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_VALIDATION_FAILED_COUNT,
+        DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_VALIDATION_FAILED_DAILY,
+        mapOf(DuckChatPixelParameters.FILE_VALIDATION_REASON to reason),
+    )
+
     override fun fireFileAttached() = fireCountAndDaily(
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_ATTACHED_COUNT,
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_ATTACHED_DAILY,
@@ -792,6 +799,8 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_CHAT_UNIFIED_INPUT_IMAGE_ATTACHED_DAILY("m_aichat_unified_input_image_attached_daily"),
     DUCK_CHAT_UNIFIED_INPUT_IMAGE_REMOVED_COUNT("m_aichat_unified_input_image_removed_count"),
     DUCK_CHAT_UNIFIED_INPUT_IMAGE_REMOVED_DAILY("m_aichat_unified_input_image_removed_daily"),
+    DUCK_CHAT_UNIFIED_INPUT_IMAGE_VALIDATION_FAILED_COUNT("m_aichat_unified_input_image_validation_failed_count"),
+    DUCK_CHAT_UNIFIED_INPUT_IMAGE_VALIDATION_FAILED_DAILY("m_aichat_unified_input_image_validation_failed_daily"),
     DUCK_CHAT_UNIFIED_INPUT_FILE_ATTACHED_COUNT("m_aichat_unified_input_file_attached_count"),
     DUCK_CHAT_UNIFIED_INPUT_FILE_ATTACHED_DAILY("m_aichat_unified_input_file_attached_daily"),
     DUCK_CHAT_UNIFIED_INPUT_FILE_REMOVED_COUNT("m_aichat_unified_input_file_removed_count"),

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -114,11 +114,7 @@ import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 interface DuckChatPixels {
-    fun sendReportMetricPixel(
-        reportMetric: ReportMetric,
-        modelTier: ModelTier? = null,
-    )
-
+    fun sendReportMetricPixel(reportMetric: ReportMetric, modelTier: ModelTier? = null)
     fun reportOpen()
     fun reportContextualSheetOpened()
     fun reportContextualSheetDismissed()
@@ -152,6 +148,21 @@ interface DuckChatPixels {
     fun reportVoiceNotificationEndChatTapped()
     fun reportVoiceServiceStarted()
     fun reportVoiceServiceKilled()
+
+    fun fireImageGenerationSelected()
+    fun fireImageGenerationDeselected()
+    fun fireImageGenerationSubmitted()
+    fun fireWebSearchSelected()
+    fun fireWebSearchDeselected()
+    fun fireWebSearchSubmitted()
+    fun firePromptSubmitted(
+        selectedTool: String,
+        modelId: String?,
+        reasoningEffort: String?,
+        hasImageAttachment: Boolean,
+        hasFileAttachment: Boolean,
+        hasText: Boolean,
+    )
 }
 
 @ContributesBinding(AppScope::class)
@@ -165,10 +176,18 @@ class RealDuckChatPixels @Inject constructor(
     private val termsOfServiceHandler: DuckChatTermsOfServiceHandler,
 ) : DuckChatPixels {
 
-    override fun sendReportMetricPixel(
-        reportMetric: ReportMetric,
-        modelTier: ModelTier?,
+    private fun fireCountAndDaily(
+        count: DuckChatPixelName,
+        daily: DuckChatPixelName,
+        parameters: Map<String, String> = emptyMap(),
     ) {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            pixel.fire(count, parameters = parameters)
+            pixel.fire(daily, parameters = parameters, type = Pixel.PixelType.Daily())
+        }
+    }
+
+    override fun sendReportMetricPixel(reportMetric: ReportMetric, modelTier: ModelTier?) {
         appCoroutineScope.launch(dispatcherProvider.io()) {
             var refreshAtb = false
             val sessionParams = mapOf(
@@ -419,6 +438,59 @@ class RealDuckChatPixels @Inject constructor(
 
     override fun reportVoiceServiceKilled() {
         pixel.fire(DuckChatPixelName.DUCK_CHAT_VOICE_SERVICE_KILLED)
+    }
+
+    override fun fireImageGenerationSelected() = fireCountAndDaily(
+        DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_SELECTED_COUNT,
+        DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_SELECTED_DAILY,
+    )
+
+    override fun fireImageGenerationDeselected() = fireCountAndDaily(
+        DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_DESELECTED_COUNT,
+        DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_DESELECTED_DAILY,
+    )
+
+    override fun fireImageGenerationSubmitted() = fireCountAndDaily(
+        DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_SUBMITTED_COUNT,
+        DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_SUBMITTED_DAILY,
+    )
+
+    override fun fireWebSearchSelected() = fireCountAndDaily(
+        DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_SELECTED_COUNT,
+        DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_SELECTED_DAILY,
+    )
+
+    override fun fireWebSearchDeselected() = fireCountAndDaily(
+        DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_DESELECTED_COUNT,
+        DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_DESELECTED_DAILY,
+    )
+
+    override fun fireWebSearchSubmitted() = fireCountAndDaily(
+        DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_SUBMITTED_COUNT,
+        DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_SUBMITTED_DAILY,
+    )
+
+    override fun firePromptSubmitted(
+        selectedTool: String,
+        modelId: String?,
+        reasoningEffort: String?,
+        hasImageAttachment: Boolean,
+        hasFileAttachment: Boolean,
+        hasText: Boolean,
+    ) {
+        val params = buildMap {
+            put(DuckChatPixelParameters.SELECTED_TOOL, selectedTool)
+            modelId?.let { put(DuckChatPixelParameters.MODEL_ID, it) }
+            reasoningEffort?.let { put(DuckChatPixelParameters.REASONING_EFFORT, it) }
+            put(DuckChatPixelParameters.HAS_IMAGE_ATTACHMENT, hasImageAttachment.toString())
+            put(DuckChatPixelParameters.HAS_FILE_ATTACHMENT, hasFileAttachment.toString())
+            put(DuckChatPixelParameters.HAS_TEXT, hasText.toString())
+        }
+        fireCountAndDaily(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_PROMPT_SUBMITTED_COUNT,
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_PROMPT_SUBMITTED_DAILY,
+            params,
+        )
     }
 }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -173,6 +173,8 @@ interface DuckChatPixels {
     fun fireFileValidationFailed(reason: String)
     fun fireVoiceTapped()
     fun fireStopGenerationTapped()
+    fun fireDuckAiChatHistorySuggestionClicked()
+    fun fireDuckAiSearchDuckDuckGoSuggestionClicked()
 }
 
 @ContributesBinding(AppScope::class)
@@ -569,6 +571,18 @@ class RealDuckChatPixels @Inject constructor(
             pixel.fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_STOP_GENERATION_TAPPED)
         }
     }
+
+    override fun fireDuckAiChatHistorySuggestionClicked() {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            pixel.fire(DuckChatPixelName.AUTOCOMPLETE_DUCKAI_CLICK_CHAT_HISTORY)
+        }
+    }
+
+    override fun fireDuckAiSearchDuckDuckGoSuggestionClicked() {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            pixel.fire(DuckChatPixelName.AUTOCOMPLETE_DUCKAI_CLICK_SEARCH_DUCKDUCKGO)
+        }
+    }
 }
 
 enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
@@ -697,6 +711,8 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_CHAT_RECENT_CHAT_SELECTED_DAILY("m_aichat_recent_chat_selected_daily"),
     DUCK_CHAT_RECENT_CHAT_SELECTED_PINNED_COUNT("m_aichat_recent_chat_selected_pinned_count"),
     DUCK_CHAT_RECENT_CHAT_SELECTED_PINNED_DAILY("m_aichat_recent_chat_selected_pinned_daily"),
+    AUTOCOMPLETE_DUCKAI_CLICK_CHAT_HISTORY("m_autocomplete_duckai_click_chat_history"),
+    AUTOCOMPLETE_DUCKAI_CLICK_SEARCH_DUCKDUCKGO("m_autocomplete_duckai_click_search_duckduckgo"),
     DUCK_CHAT_VOICE_ENTRY_TAPPED_COUNT("m_aichat_voice_entry_tapped_count"),
     DUCK_CHAT_VOICE_ENTRY_TAPPED_DAILY("m_aichat_voice_entry_tapped_daily"),
     DUCK_CHAT_VOICE_SESSION_STARTED("m_aichat_voice_session_started"),

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -163,6 +163,9 @@ interface DuckChatPixels {
         hasFileAttachment: Boolean,
         hasText: Boolean,
     )
+    fun fireModelSelected(modelId: String)
+    fun fireReasoningEffortSelected(effortLevel: String)
+    fun fireSubscriptionUpsellTriggered(source: String, currentTier: String, requiredTier: String, flowType: String)
 }
 
 @ContributesBinding(AppScope::class)
@@ -492,6 +495,35 @@ class RealDuckChatPixels @Inject constructor(
             params,
         )
     }
+
+    override fun fireModelSelected(modelId: String) {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_MODEL_SELECTED, parameters = mapOf(DuckChatPixelParameters.MODEL_ID to modelId))
+        }
+    }
+
+    override fun fireReasoningEffortSelected(effortLevel: String) {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            pixel.fire(
+                DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_REASONING_EFFORT_SELECTED,
+                parameters = mapOf(DuckChatPixelParameters.EFFORT_LEVEL to effortLevel),
+            )
+        }
+    }
+
+    override fun fireSubscriptionUpsellTriggered(source: String, currentTier: String, requiredTier: String, flowType: String) {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            pixel.fire(
+                DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SUBSCRIPTION_UPSELL_TRIGGERED,
+                parameters = mapOf(
+                    DuckChatPixelParameters.UPSELL_SOURCE to source,
+                    DuckChatPixelParameters.UPSELL_CURRENT_TIER to currentTier,
+                    DuckChatPixelParameters.UPSELL_REQUIRED_TIER to requiredTier,
+                    DuckChatPixelParameters.UPSELL_FLOW_TYPE to flowType,
+                ),
+            )
+        }
+    }
 }
 
 enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
@@ -692,6 +724,9 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_SUBMITTED_DAILY("m_aichat_unified_input_web_search_submitted_daily"),
     DUCK_CHAT_UNIFIED_INPUT_PROMPT_SUBMITTED_COUNT("m_aichat_unified_input_prompt_submitted_count"),
     DUCK_CHAT_UNIFIED_INPUT_PROMPT_SUBMITTED_DAILY("m_aichat_unified_input_prompt_submitted_daily"),
+    DUCK_CHAT_UNIFIED_INPUT_MODEL_SELECTED("m_aichat_unified_input_model_selected"),
+    DUCK_CHAT_UNIFIED_INPUT_REASONING_EFFORT_SELECTED("m_aichat_unified_input_reasoning_effort_selected"),
+    DUCK_CHAT_UNIFIED_INPUT_SUBSCRIPTION_UPSELL_TRIGGERED("m_aichat_unified_input_subscription_upsell_triggered"),
 }
 
 object DuckChatPixelParameters {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/AttachmentViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/AttachmentViewModel.kt
@@ -243,7 +243,7 @@ class AttachmentViewModel @Inject constructor(
             added.sizeBytes > fileLimits.maxFileSizeBytes -> FILE_VALIDATION_SIZE_EXCEEDED
             totalFileSizeBytes > fileLimits.maxTotalFileSizeBytes -> FILE_VALIDATION_SIZE_EXCEEDED
             totalFiles > fileLimits.maxPerConversation -> FILE_VALIDATION_COUNT_EXCEEDED
-            (added.pageCount ?: 0) > fileLimits.maxPagesPerFile -> FILE_VALIDATION_OTHER
+            (added.pageCount ?: 0) > fileLimits.maxPagesPerFile -> FILE_VALIDATION_PAGE_COUNT_EXCEEDED
             else -> null
         }
     }
@@ -409,6 +409,7 @@ class AttachmentViewModel @Inject constructor(
         private const val MAX_DIMENSION_PX = 512
         private const val FILE_VALIDATION_SIZE_EXCEEDED = "size_exceeded"
         private const val FILE_VALIDATION_COUNT_EXCEEDED = "count_exceeded"
+        private const val FILE_VALIDATION_PAGE_COUNT_EXCEEDED = "page_count_exceeded"
         private const val FILE_VALIDATION_OTHER = "other"
         private const val IMAGE_VALIDATION_COUNT_EXCEEDED = "count_exceeded"
         private const val IMAGE_VALIDATION_OTHER = "other"

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/AttachmentViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/AttachmentViewModel.kt
@@ -36,6 +36,7 @@ import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.impl.models.ImageLimits
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.ImageAttachment
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.LimitsHandler
 import com.duckduckgo.duckchat.impl.ui.nativeinput.file.FileAttachment
@@ -61,13 +62,19 @@ import kotlin.math.max
 class AttachmentViewModel @Inject constructor(
     private val duckChatInternal: DuckChatInternal,
     private val dispatchers: DispatcherProvider,
-    modelManager: DuckAiModelManager,
+    private val modelManager: DuckAiModelManager,
     private val limitsHandler: LimitsHandler,
     private val fileAttachmentProcessor: FileAttachmentProcessor,
     private val context: Context,
     private val appBuildConfig: AppBuildConfig,
     nativeInputStateProvider: NativeInputStateProvider,
+    private val duckChatPixels: DuckChatPixels,
 ) : ViewModel() {
+
+    enum class ImageSource(val pixelValue: String) {
+        CAMERA("camera"),
+        PHOTO_LIBRARY("photo_library"),
+    }
 
     data class AttachmentState(
         val images: List<ImageAttachment> = emptyList(),
@@ -130,11 +137,12 @@ class AttachmentViewModel @Inject constructor(
         )
     }.stateIn(scope = viewModelScope, started = SharingStarted.Eagerly, initialValue = AttachmentState())
 
-    fun onImagesPicked(uris: List<Uri>) {
+    fun onImagesPicked(uris: List<Uri>, source: ImageSource) {
         viewModelScope.launch {
             uris.forEach { uri ->
                 val attachment = withContext(dispatchers.io()) { processImage(uri) } ?: return@forEach
                 imageAttachments.update { it + attachment }
+                duckChatPixels.fireImageAttached(source.pixelValue)
             }
         }
     }
@@ -142,8 +150,13 @@ class AttachmentViewModel @Inject constructor(
     fun onFilesPicked(uris: List<Uri>) {
         viewModelScope.launch {
             for (uri in uris) {
-                val attachment = fileAttachmentProcessor.processFile(context, uri) ?: continue
+                val attachment = fileAttachmentProcessor.processFile(context, uri)
+                if (attachment == null) {
+                    duckChatPixels.fireFileValidationFailed(FILE_VALIDATION_OTHER)
+                    continue
+                }
                 _fileAttachments.update { it + attachment }
+                fireFileAcceptedOrRejectedPixel(attachment)
             }
         }
     }
@@ -157,25 +170,70 @@ class AttachmentViewModel @Inject constructor(
             imageUris.forEach { uri ->
                 val attachment = withContext(dispatchers.io()) { processImage(uri) } ?: return@forEach
                 imageAttachments.update { it + attachment }
+                duckChatPixels.fireImageAttached(ImageSource.PHOTO_LIBRARY.pixelValue)
             }
             for (uri in fileUris) {
-                val attachment = fileAttachmentProcessor.processFile(context, uri) ?: continue
+                val attachment = fileAttachmentProcessor.processFile(context, uri)
+                if (attachment == null) {
+                    duckChatPixels.fireFileValidationFailed(FILE_VALIDATION_OTHER)
+                    continue
+                }
                 _fileAttachments.update { it + attachment }
+                fireFileAcceptedOrRejectedPixel(attachment)
             }
+        }
+    }
+
+    /**
+     * Fired once per picked file, after it has been added to the list. Files are always added; limit
+     * violations are reflected as derived error state rather than an explicit rejection, so this is the
+     * single transition point where we can attribute a reason to a freshly-picked file exactly once.
+     */
+    private fun fireFileAcceptedOrRejectedPixel(added: FileAttachment) {
+        val reason = resolveFileValidationReason(added)
+        if (reason != null) {
+            duckChatPixels.fireFileValidationFailed(reason)
+        } else {
+            duckChatPixels.fireFileAttached()
+        }
+    }
+
+    private fun resolveFileValidationReason(added: FileAttachment): String? {
+        val fileLimits = modelManager.modelState.value.attachmentLimits.files
+        val isDuckAiMode = isDuckAiModeFlow.value
+        val files = _fileAttachments.value
+        val conversationFilesUsed = limitsHandler.conversationFilesUsed.value
+        val totalFiles = files.size + if (isDuckAiMode) conversationFilesUsed.count else 0
+        val totalFileSizeBytes = files.sumOf { it.sizeBytes } + if (isDuckAiMode) conversationFilesUsed.sizeBytes else 0L
+        return when {
+            added.sizeBytes > fileLimits.maxFileSizeBytes -> FILE_VALIDATION_SIZE_EXCEEDED
+            totalFileSizeBytes > fileLimits.maxTotalFileSizeBytes -> FILE_VALIDATION_SIZE_EXCEEDED
+            totalFiles > fileLimits.maxPerConversation -> FILE_VALIDATION_COUNT_EXCEEDED
+            (added.pageCount ?: 0) > fileLimits.maxPagesPerFile -> FILE_VALIDATION_OTHER
+            else -> null
         }
     }
 
     fun removeImageAttachment(id: String) {
         var toRecycle: Bitmap? = null
+        var removed = false
         imageAttachments.update { list ->
-            toRecycle = list.find { it.id == id }?.bitmap
+            val match = list.find { it.id == id }
+            toRecycle = match?.bitmap
+            removed = match != null
             list.filter { it.id != id }
         }
+        if (removed) duckChatPixels.fireImageRemoved()
         viewModelScope.launch { toRecycle?.recycle() }
     }
 
     fun removeFileAttachment(id: String) {
-        _fileAttachments.update { list -> list.filter { it.id != id } }
+        var removed = false
+        _fileAttachments.update { list ->
+            removed = list.any { it.id == id }
+            list.filter { it.id != id }
+        }
+        if (removed) duckChatPixels.fireFileRemoved()
     }
 
     fun clearAttachments() {
@@ -315,5 +373,8 @@ class AttachmentViewModel @Inject constructor(
     companion object {
         private const val COMPRESSION_QUALITY = 85
         private const val MAX_DIMENSION_PX = 512
+        private const val FILE_VALIDATION_SIZE_EXCEEDED = "size_exceeded"
+        private const val FILE_VALIDATION_COUNT_EXCEEDED = "count_exceeded"
+        private const val FILE_VALIDATION_OTHER = "other"
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/AttachmentViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/AttachmentViewModel.kt
@@ -140,9 +140,13 @@ class AttachmentViewModel @Inject constructor(
     fun onImagesPicked(uris: List<Uri>, source: ImageSource) {
         viewModelScope.launch {
             uris.forEach { uri ->
-                val attachment = withContext(dispatchers.io()) { processImage(uri) } ?: return@forEach
+                val attachment = withContext(dispatchers.io()) { processImage(uri) }
+                if (attachment == null) {
+                    duckChatPixels.fireImageValidationFailed(IMAGE_VALIDATION_OTHER)
+                    return@forEach
+                }
                 imageAttachments.update { it + attachment }
-                duckChatPixels.fireImageAttached(source.pixelValue)
+                fireImageAcceptedOrRejectedPixel(source)
             }
         }
     }
@@ -168,9 +172,13 @@ class AttachmentViewModel @Inject constructor(
             }
             val fileUris = uris - imageUris.toSet()
             imageUris.forEach { uri ->
-                val attachment = withContext(dispatchers.io()) { processImage(uri) } ?: return@forEach
+                val attachment = withContext(dispatchers.io()) { processImage(uri) }
+                if (attachment == null) {
+                    duckChatPixels.fireImageValidationFailed(IMAGE_VALIDATION_OTHER)
+                    return@forEach
+                }
                 imageAttachments.update { it + attachment }
-                duckChatPixels.fireImageAttached(ImageSource.PHOTO_LIBRARY.pixelValue)
+                fireImageAcceptedOrRejectedPixel(ImageSource.PHOTO_LIBRARY)
             }
             for (uri in fileUris) {
                 val attachment = fileAttachmentProcessor.processFile(context, uri)
@@ -195,6 +203,32 @@ class AttachmentViewModel @Inject constructor(
             duckChatPixels.fireFileValidationFailed(reason)
         } else {
             duckChatPixels.fireFileAttached()
+        }
+    }
+
+    /**
+     * Fired once per picked image, after it has been added to the list. Mirrors the file flow: images are
+     * always added and limit violations surface as derived error state, so this is the single transition
+     * point where a freshly-picked image is attributed as attached or as a validation failure exactly once.
+     */
+    private fun fireImageAcceptedOrRejectedPixel(source: ImageSource) {
+        val reason = resolveImageValidationReason()
+        if (reason != null) {
+            duckChatPixels.fireImageValidationFailed(reason)
+        } else {
+            duckChatPixels.fireImageAttached(source.pixelValue)
+        }
+    }
+
+    private fun resolveImageValidationReason(): String? {
+        val imageLimits = modelManager.modelState.value.attachmentLimits.images
+        val isDuckAiMode = isDuckAiModeFlow.value
+        val currentImageCount = imageAttachments.value.size
+        val totalImages = currentImageCount + if (isDuckAiMode) limitsHandler.conversationImagesSent.value else 0
+        return when {
+            currentImageCount > imageLimits.maxPerTurn -> IMAGE_VALIDATION_COUNT_EXCEEDED
+            totalImages > imageLimits.maxPerConversation -> IMAGE_VALIDATION_COUNT_EXCEEDED
+            else -> null
         }
     }
 
@@ -376,5 +410,7 @@ class AttachmentViewModel @Inject constructor(
         private const val FILE_VALIDATION_SIZE_EXCEEDED = "size_exceeded"
         private const val FILE_VALIDATION_COUNT_EXCEEDED = "count_exceeded"
         private const val FILE_VALIDATION_OTHER = "other"
+        private const val IMAGE_VALIDATION_COUNT_EXCEEDED = "count_exceeded"
+        private const val IMAGE_VALIDATION_OTHER = "other"
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -447,7 +447,7 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         val suggestionsShown = lastChatUrlSuggestions
         // Use appCoroutineScope so the pixel fire survives the widget detach
         appCoroutineScope.launch(dispatchers.io()) {
-            autoComplete.fireAutocompletePixel(suggestionsShown, suggestion, experimentalInputScreen = true)
+            autoComplete.fireAutocompletePixel(suggestionsShown, suggestion, experimentalInputScreen = true, duckAiSurface = true)
         }
     }
 
@@ -459,6 +459,13 @@ class NativeInputModeWidgetViewModel @Inject constructor(
             pixel.fire(DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_SELECTED_COUNT)
             pixel.fire(DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_SELECTED_DAILY, type = Daily())
         }
+        // The autocomplete-family pixel sits alongside the RECENT_CHAT_SELECTED metrics above: those
+        // measure recent-chat re-entry, this one credits the Duck.ai-tab autocomplete surface.
+        duckChatPixels.fireDuckAiChatHistorySuggestionClicked()
+    }
+
+    fun fireDuckAiSearchForQuerySubmittedPixel() {
+        duckChatPixels.fireDuckAiSearchDuckDuckGoSuggestionClicked()
     }
 
     fun buildChatSuggestionUrl(suggestion: ChatSuggestion): String =

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -221,6 +221,10 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         }
     }
 
+    fun fireVoiceTapped() = duckChatPixels.fireVoiceTapped()
+
+    fun fireStopGenerationTapped() = duckChatPixels.fireStopGenerationTapped()
+
     private data class WidgetConfig(
         val inputContext: NativeInputState.InputContext = NativeInputState.InputContext.BROWSER,
         val inputPosition: NativeInputState.InputPosition = NativeInputState.InputPosition.TOP,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -50,8 +50,10 @@ import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestion
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsReader
 import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.impl.models.ReasoningResolver
+import com.duckduckgo.duckchat.impl.models.Tool
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import com.duckduckgo.duckchat.store.impl.DuckAiChat
 import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
@@ -98,6 +100,7 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val inputScreenConfigResolver: InputScreenConfigResolver,
     private val pixel: Pixel,
+    private val duckChatPixels: DuckChatPixels,
     private val nativeInputStatePublisher: NativeInputStatePublisher,
     private val nativeInputStateProvider: NativeInputStateProvider,
     private val modelManager: DuckAiModelManager,
@@ -185,6 +188,37 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     fun getSelectedTool(): String? {
         val tabId = activeTabId.value ?: return null
         return nativeInputStateProvider.stateForTab(tabId).value.selectedTool
+    }
+
+    /**
+     * Fires the unified prompt-submitted pixel plus, when a tool is selected, the matching per-tool
+     * submitted pixel. Called exactly once per Duck.ai (AI-chat) submission by the widget. Attachment
+     * presence is passed in because the attachment lists live in the widget's AttachmentView, not here.
+     */
+    fun fireSubmissionPixels(
+        hasText: Boolean,
+        hasImageAttachment: Boolean,
+        hasFileAttachment: Boolean,
+    ) {
+        val tool = getSelectedTool()?.let { Tool.from(it) }
+        val selectedToolParam = when (tool) {
+            Tool.IMAGE_GENERATION -> "image_generation"
+            Tool.WEB_SEARCH -> "web_search"
+            null -> "none"
+        }
+        duckChatPixels.firePromptSubmitted(
+            selectedTool = selectedToolParam,
+            modelId = getSelectedModelId(),
+            reasoningEffort = getResolvedReasoningEffort(),
+            hasImageAttachment = hasImageAttachment,
+            hasFileAttachment = hasFileAttachment,
+            hasText = hasText,
+        )
+        when (tool) {
+            Tool.IMAGE_GENERATION -> duckChatPixels.fireImageGenerationSubmitted()
+            Tool.WEB_SEARCH -> duckChatPixels.fireWebSearchSubmitted()
+            null -> {}
+        }
     }
 
     private data class WidgetConfig(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
@@ -280,7 +280,7 @@ class AttachmentView(
             ) {
                 popup.dismiss()
                 host?.showAttachmentChooser(true)
-                onCameraCaptureRequested?.invoke(buildImagePickerCallback())
+                onCameraCaptureRequested?.invoke(buildImagePickerCallback(AttachmentViewModel.ImageSource.CAMERA))
             }
 
             addMenuItem(
@@ -290,7 +290,7 @@ class AttachmentView(
             ) {
                 popup.dismiss()
                 host?.showAttachmentChooser(true)
-                onFilePickerRequested?.invoke(buildImagePickerCallback(), listOf("image/*"))
+                onFilePickerRequested?.invoke(buildImagePickerCallback(AttachmentViewModel.ImageSource.PHOTO_LIBRARY), listOf("image/*"))
             }
         }
 
@@ -335,9 +335,9 @@ class AttachmentView(
         popupWindow = null
     }
 
-    private fun buildImagePickerCallback(): ValueCallback<Array<Uri>> = ValueCallback { uris ->
+    private fun buildImagePickerCallback(source: AttachmentViewModel.ImageSource): ValueCallback<Array<Uri>> = ValueCallback { uris ->
         val list = uris?.toList()
-        if (!list.isNullOrEmpty()) viewModel?.onImagesPicked(list)
+        if (!list.isNullOrEmpty()) viewModel?.onImagesPicked(list, source)
     }
 
     private fun buildFilePickerCallback(): ValueCallback<Array<Uri>> = ValueCallback { uris ->

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.duckchat.impl.models.ModelProvider
 import com.duckduckgo.duckchat.impl.models.ModelState
 import com.duckduckgo.duckchat.impl.models.Tool
 import com.duckduckgo.duckchat.impl.models.UserTier
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -43,6 +44,7 @@ data class ModelSection(@StringRes val headerRes: Int?, val models: List<AIChatM
 @ContributesViewModel(ViewScope::class)
 class ModelPickerViewModel @Inject constructor(
     private val modelManager: DuckAiModelManager,
+    private val duckChatPixels: DuckChatPixels,
 ) : ViewModel() {
 
     val state: StateFlow<ModelState> = modelManager.modelState
@@ -68,6 +70,9 @@ class ModelPickerViewModel @Inject constructor(
 
     fun onModelTapped(model: AIChatModel, surface: PickerSurface) {
         if (model.isAccessible) {
+            if (model.id != modelManager.getSelectedModelId()) {
+                duckChatPixels.fireModelSelected(model.id)
+            }
             viewModelScope.launch { modelManager.selectModel(model) }
             return
         }
@@ -76,7 +81,15 @@ class ModelPickerViewModel @Inject constructor(
             logcat { "Duck.ai picker: tapped model has no public required tier (id=${model.id}, accessTier=${model.accessTier}), ignoring." }
             return
         }
-        routeUpsell(userTier, requiredTier, surface.origin)?.let { command.trySend(it) }
+        routeUpsell(userTier, requiredTier, surface.origin)?.let { upsell ->
+            duckChatPixels.fireSubscriptionUpsellTriggered(
+                source = "model_picker",
+                currentTier = userTier.toParam(),
+                requiredTier = requiredTier.toParam(),
+                flowType = upsell.toFlowTypeParam(),
+            )
+            command.trySend(upsell)
+        }
     }
 
     fun buildSections(state: ModelState): List<ModelSection> {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -1073,7 +1073,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
                     viewModel.fireChatUrlSuggestionPixel(suggestion)
                     onChatUrlSuggestionClicked(suggestion)
                 },
-                onSearchForQuerySubmitted = onSearchForQuerySubmitted,
+                onSearchForQuerySubmitted = { query ->
+                    viewModel.fireDuckAiSearchForQuerySubmittedPixel()
+                    onSearchForQuerySubmitted(query)
+                },
                 onChatHistoryShortcutClicked = onChatHistoryShortcutClicked,
             ).also { chatSuggestionsBinding = it }
         }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -237,8 +237,16 @@ class NativeInputModeWidget @JvmOverloads constructor(
     override var onVoiceChatClick: (() -> Unit)? = null
         set(value) {
             field = value
-            voiceHostButtons()?.onVoiceChatClick = value
+            voiceHostButtons()?.onVoiceChatClick = voiceChatClickWithPixel
         }
+
+    // Wrapper installed on the host buttons so the unified-input voice pixel fires exactly once per
+    // tap, before delegating to whatever external [onVoiceChatClick] is currently set. Reads the
+    // field at invocation time so re-assigning the external callback keeps working.
+    private val voiceChatClickWithPixel: () -> Unit = {
+        viewModel.fireVoiceTapped()
+        onVoiceChatClick?.invoke()
+    }
     override var onPaidTierChanged: ((Boolean) -> Unit)? = null
         set(value) {
             field = value
@@ -1260,8 +1268,11 @@ class NativeInputModeWidget @JvmOverloads constructor(
                 layoutResId = R.layout.view_native_input_screen_buttons,
             ).apply {
                 onSendClick = { submitMessage() }
-                onStopClick = { this@NativeInputModeWidget.onStopTapped?.invoke() }
-                onVoiceChatClick = this@NativeInputModeWidget.onVoiceChatClick
+                onStopClick = {
+                    viewModel.fireStopGenerationTapped()
+                    this@NativeInputModeWidget.onStopTapped?.invoke()
+                }
+                onVoiceChatClick = voiceChatClickWithPixel
                 setSendButtonVisible(false)
                 setNewLineButtonVisible(false)
             }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -231,8 +231,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
     override var onVoiceSearchClick: (() -> Unit)? = null
         set(value) {
             field = value
-            voiceHostButtons()?.onVoiceSearchClick = value
-            onVoiceClick = value
+            voiceHostButtons()?.onVoiceSearchClick = voiceSearchClickWithPixel
+            onVoiceClick = voiceSearchClickWithPixel
         }
     override var onVoiceChatClick: (() -> Unit)? = null
         set(value) {
@@ -246,6 +246,17 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private val voiceChatClickWithPixel: () -> Unit = {
         viewModel.fireVoiceTapped()
         onVoiceChatClick?.invoke()
+    }
+
+    // The in-field microphone doubles as the Duck.ai voice entry whenever the Duck.ai tab is selected
+    // — including an active Duck.ai chat page, where configure(isDuckAiMode = true) selects the chat
+    // tab and the bottom-row voice-chat chip is hidden, leaving the mic as the only voice affordance.
+    // Count those as a unified voice tap; a search-tab mic tap is plain voice search, not Duck.ai.
+    private val voiceSearchClickWithPixel: () -> Unit = {
+        if (isChatTabSelected()) {
+            viewModel.fireVoiceTapped()
+        }
+        onVoiceSearchClick?.invoke()
     }
     override var onPaidTierChanged: ((Boolean) -> Unit)? = null
         set(value) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -746,12 +746,31 @@ class NativeInputModeWidget @JvmOverloads constructor(
             logcat { "submitMessage: suppressed - attachment limit exceeded" }
             return
         }
+        // Capture text presence before any clearFocus / submission mutates the field.
+        val hasText = !(message ?: inputField.text?.toString()).isNullOrBlank()
         if (message == null && inputField.text.isNullOrBlank() && hasAttachments && isChatTabSelected()) {
+            fireSubmissionPixels(hasText = hasText)
             onChatSent?.invoke("")
             inputField.clearFocus()
         } else {
+            // super routes to onChatSent (chat tab) or onSearchSent (search tab) only when there is
+            // non-blank text. Fire the chat-submission pixels only for the chat-tab + has-text case so
+            // we never fire for a search submit nor for a no-op blank submit.
+            if (isChatTabSelected() && hasText) {
+                fireSubmissionPixels(hasText = true)
+            }
             super.submitMessage(message)
         }
+    }
+
+    private fun fireSubmissionPixels(hasText: Boolean) {
+        val hasImageAttachment = attachmentView?.getImageAttachments()?.isNotEmpty() == true
+        val hasFileAttachment = attachmentView?.getFileAttachments()?.isNotEmpty() == true
+        viewModel.fireSubmissionPixels(
+            hasText = hasText,
+            hasImageAttachment = hasImageAttachment,
+            hasFileAttachment = hasFileAttachment,
+        )
     }
 
     override fun focusInput(activity: Activity?) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -1228,6 +1228,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     override fun stop() {
+        // Single chokepoint for every stop affordance (the streaming-plugin button routes here via
+        // host.stop(), and the input-screen stop button calls stop() too), so the pixel fires once.
+        viewModel.fireStopGenerationTapped()
         onStopTapped?.invoke()
     }
 
@@ -1271,10 +1274,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
                 layoutResId = R.layout.view_native_input_screen_buttons,
             ).apply {
                 onSendClick = { submitMessage() }
-                onStopClick = {
-                    viewModel.fireStopGenerationTapped()
-                    this@NativeInputModeWidget.onStopTapped?.invoke()
-                }
+                onStopClick = { this@NativeInputModeWidget.stop() }
                 onVoiceChatClick = voiceChatClickWithPixel
                 setSendButtonVisible(false)
                 setNewLineButtonVisible(false)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -1207,7 +1207,13 @@ class NativeInputModeWidget @JvmOverloads constructor(
     override fun submit() {
         // in Duck.ai mode we treat this as submitting prompts.
         // In non-Duck.ai mode we treat this as starting a chat with or without a prompt.
-        if (!submitAsChat()) viewModel.openNewChat()
+        // submitAsChat() returns true only when there is text to submit (a real prompt
+        // submission), so an empty start-new-chat does not fire the submission pixels.
+        if (submitAsChat()) {
+            fireSubmissionPixels(hasText = true)
+        } else {
+            viewModel.openNewChat()
+        }
     }
 
     override fun stop() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
@@ -237,6 +237,7 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
 
     private fun onOptionTapped(item: MenuItem) {
         val nowSelected = item.tool != viewModel.selectedTool.value
+        if (nowSelected) viewModel.onToolSelectedByUser(item.tool) else viewModel.onToolDeselectedByUser(item.tool)
         host.toolSelected(if (nowSelected) item.tool.rawValue else null)
     }
 
@@ -249,6 +250,7 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
         view.findViewById<ImageView>(R.id.optionsChipIcon).setImageResource(item.iconRes)
         view.contentDescription = context.getString(R.string.duckChatOptionsChipDismissContentDescription, context.getString(item.titleRes))
         view.setOnClickListener {
+            viewModel.selectedTool.value?.let { viewModel.onToolDeselectedByUser(it) }
             host.toolSelected(null)
         }
         return view

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
@@ -250,7 +250,7 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
         view.findViewById<ImageView>(R.id.optionsChipIcon).setImageResource(item.iconRes)
         view.contentDescription = context.getString(R.string.duckChatOptionsChipDismissContentDescription, context.getString(item.titleRes))
         view.setOnClickListener {
-            viewModel.selectedTool.value?.let { viewModel.onToolDeselectedByUser(it) }
+            viewModel.onToolDeselectedByUser(item.tool)
             host.toolSelected(null)
         }
         return view

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsViewModel.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.impl.models.Tool
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -33,6 +34,7 @@ import javax.inject.Inject
 @ContributesViewModel(ViewScope::class)
 class OptionsViewModel @Inject constructor(
     nativeInputStateProvider: NativeInputStateProvider,
+    private val duckChatPixels: DuckChatPixels,
 ) : ViewModel() {
 
     val selectedTool: StateFlow<Tool?> = nativeInputStateProvider.state
@@ -53,5 +55,19 @@ class OptionsViewModel @Inject constructor(
         _visibleTools.value = tools
         val current = selectedTool.value
         return current != null && current !in tools
+    }
+
+    fun onToolSelectedByUser(tool: Tool) {
+        when (tool) {
+            Tool.IMAGE_GENERATION -> duckChatPixels.fireImageGenerationSelected()
+            Tool.WEB_SEARCH -> duckChatPixels.fireWebSearchSelected()
+        }
+    }
+
+    fun onToolDeselectedByUser(tool: Tool) {
+        when (tool) {
+            Tool.IMAGE_GENERATION -> duckChatPixels.fireImageGenerationDeselected()
+            Tool.WEB_SEARCH -> duckChatPixels.fireWebSearchDeselected()
+        }
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/PickerUpsell.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/PickerUpsell.kt
@@ -31,6 +31,17 @@ sealed class UpsellCommand {
     data class LaunchUpgrade(val origin: String) : UpsellCommand()
 }
 
+internal fun UserTier.toParam(): String = when (this) {
+    UserTier.FREE -> "free"
+    UserTier.PLUS -> "plus"
+    UserTier.PRO -> "pro"
+}
+
+internal fun UpsellCommand.toFlowTypeParam(): String = when (this) {
+    is UpsellCommand.LaunchPurchase -> "purchase"
+    is UpsellCommand.LaunchUpgrade -> "upgrade"
+}
+
 /**
  * Maps a (userTier, requiredTier) pair to the upsell flow that should fire, or `null` when no
  * native subscription flow applies (FREE-required gating, or a tier transition we don't route).

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerViewModel.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.impl.models.ModelState
 import com.duckduckgo.duckchat.impl.models.ReasoningMode
 import com.duckduckgo.duckchat.impl.models.ReasoningResolver
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.store.impl.DuckAiChat
 import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
 import kotlinx.coroutines.channels.BufferOverflow
@@ -68,6 +69,7 @@ class ReasoningModePickerViewModel @Inject constructor(
     private val modelManager: DuckAiModelManager,
     private val nativeInputStateProvider: NativeInputStateProvider,
     private val duckAiChatStore: DuckAiChatStore,
+    private val duckChatPixels: DuckChatPixels,
 ) : ViewModel() {
 
     private val currentChat = MutableStateFlow<DuckAiChat?>(null)
@@ -132,6 +134,7 @@ class ReasoningModePickerViewModel @Inject constructor(
             return
         }
         if (match.isAccessible) {
+            duckChatPixels.fireReasoningEffortSelected(mode.toEffortParam())
             if (chatResolution != null) {
                 viewModelScope.launch { modelManager.setChatScopedReasoningMode(mode) }
             } else {
@@ -144,7 +147,21 @@ class ReasoningModePickerViewModel @Inject constructor(
             logcat { "Duck.ai reasoning picker: gated mode $mode has no public required tier, ignoring." }
             return
         }
-        routeUpsell(userTier, requiredTier, surface.origin)?.let { command.trySend(it) }
+        routeUpsell(userTier, requiredTier, surface.origin)?.let { upsell ->
+            duckChatPixels.fireSubscriptionUpsellTriggered(
+                source = "reasoning_picker",
+                currentTier = userTier.toParam(),
+                requiredTier = requiredTier.toParam(),
+                flowType = upsell.toFlowTypeParam(),
+            )
+            command.trySend(upsell)
+        }
+    }
+
+    private fun ReasoningMode.toEffortParam(): String = when (this) {
+        ReasoningMode.FAST -> "fast"
+        ReasoningMode.REASONING -> "reasoning"
+        ReasoningMode.EXTENDED_REASONING -> "extended_reasoning"
     }
 
     @DrawableRes

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerViewModel.kt
@@ -134,7 +134,11 @@ class ReasoningModePickerViewModel @Inject constructor(
             return
         }
         if (match.isAccessible) {
-            duckChatPixels.fireReasoningEffortSelected(mode.toEffortParam())
+            // Mirror the model picker: only report a selection when it actually changes, not on
+            // re-tapping the already-selected effort. The persisted selection still updates below.
+            if (mode != state.value.displayedMode) {
+                duckChatPixels.fireReasoningEffortSelected(mode.toEffortParam())
+            }
             if (chatResolution != null) {
                 viewModelScope.launch { modelManager.setChatScopedReasoningMode(mode) }
             } else {

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsAttachmentsTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsAttachmentsTest.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.pixel
+
+import com.duckduckgo.app.statistics.api.StatisticsUpdater
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.impl.helper.DuckChatTermsOfServiceHandler
+import com.duckduckgo.duckchat.impl.metric.DuckAiMetricCollector
+import com.duckduckgo.duckchat.impl.repository.DuckChatFeatureRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class RealDuckChatPixelsAttachmentsTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    private val pixel: Pixel = mock()
+    private val duckChatFeatureRepository: DuckChatFeatureRepository = mock()
+    private val statisticsUpdater: StatisticsUpdater = mock()
+    private val duckAiMetricCollector: DuckAiMetricCollector = mock()
+    private val termsOfServiceHandler: DuckChatTermsOfServiceHandler = mock()
+
+    private val testee = RealDuckChatPixels(
+        pixel = pixel,
+        duckChatFeatureRepository = duckChatFeatureRepository,
+        appCoroutineScope = coroutineTestRule.testScope,
+        dispatcherProvider = coroutineTestRule.testDispatcherProvider,
+        statisticsUpdater = statisticsUpdater,
+        duckAiMetricCollector = duckAiMetricCollector,
+        termsOfServiceHandler = termsOfServiceHandler,
+    )
+
+    @Test
+    fun whenImageAttachedFromCameraThenSourceParam() = runTest {
+        testee.fireImageAttached(source = "camera")
+
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_ATTACHED_COUNT,
+            parameters = mapOf(DuckChatPixelParameters.ATTACHMENT_SOURCE to "camera"),
+        )
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_ATTACHED_DAILY,
+            parameters = mapOf(DuckChatPixelParameters.ATTACHMENT_SOURCE to "camera"),
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+
+    @Test
+    fun whenImageRemovedThenCountAndDaily() = runTest {
+        testee.fireImageRemoved()
+
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_REMOVED_COUNT, parameters = emptyMap())
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_REMOVED_DAILY,
+            parameters = emptyMap(),
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+
+    @Test
+    fun whenFileAttachedThenCountAndDaily() = runTest {
+        testee.fireFileAttached()
+
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_ATTACHED_COUNT, parameters = emptyMap())
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_ATTACHED_DAILY,
+            parameters = emptyMap(),
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+
+    @Test
+    fun whenFileRemovedThenCountAndDaily() = runTest {
+        testee.fireFileRemoved()
+
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_REMOVED_COUNT, parameters = emptyMap())
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_REMOVED_DAILY,
+            parameters = emptyMap(),
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+
+    @Test
+    fun whenFileValidationFailedThenReasonParam() = runTest {
+        testee.fireFileValidationFailed(reason = "size_exceeded")
+
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_VALIDATION_FAILED_COUNT,
+            parameters = mapOf(DuckChatPixelParameters.FILE_VALIDATION_REASON to "size_exceeded"),
+        )
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_VALIDATION_FAILED_DAILY,
+            parameters = mapOf(DuckChatPixelParameters.FILE_VALIDATION_REASON to "size_exceeded"),
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+
+    @Test
+    fun whenVoiceTappedThenCountAndDaily() = runTest {
+        testee.fireVoiceTapped()
+
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_VOICE_TAPPED_COUNT, parameters = emptyMap())
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_VOICE_TAPPED_DAILY,
+            parameters = emptyMap(),
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+
+    @Test
+    fun whenStopTappedThenSingleCount() = runTest {
+        testee.fireStopGenerationTapped()
+
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_STOP_GENERATION_TAPPED)
+    }
+}

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsAttachmentsTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsAttachmentsTest.kt
@@ -77,6 +77,21 @@ class RealDuckChatPixelsAttachmentsTest {
     }
 
     @Test
+    fun whenImageValidationFailedThenReasonParam() = runTest {
+        testee.fireImageValidationFailed(reason = "count_exceeded")
+
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_VALIDATION_FAILED_COUNT,
+            parameters = mapOf(DuckChatPixelParameters.FILE_VALIDATION_REASON to "count_exceeded"),
+        )
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_VALIDATION_FAILED_DAILY,
+            parameters = mapOf(DuckChatPixelParameters.FILE_VALIDATION_REASON to "count_exceeded"),
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+
+    @Test
     fun whenFileAttachedThenCountAndDaily() = runTest {
         testee.fireFileAttached()
 

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsPickerTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsPickerTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.pixel
+
+import com.duckduckgo.app.statistics.api.StatisticsUpdater
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.impl.helper.DuckChatTermsOfServiceHandler
+import com.duckduckgo.duckchat.impl.metric.DuckAiMetricCollector
+import com.duckduckgo.duckchat.impl.repository.DuckChatFeatureRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class RealDuckChatPixelsPickerTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    private val pixel: Pixel = mock()
+    private val duckChatFeatureRepository: DuckChatFeatureRepository = mock()
+    private val statisticsUpdater: StatisticsUpdater = mock()
+    private val duckAiMetricCollector: DuckAiMetricCollector = mock()
+    private val termsOfServiceHandler: DuckChatTermsOfServiceHandler = mock()
+
+    private val testee = RealDuckChatPixels(
+        pixel = pixel,
+        duckChatFeatureRepository = duckChatFeatureRepository,
+        appCoroutineScope = coroutineTestRule.testScope,
+        dispatcherProvider = coroutineTestRule.testDispatcherProvider,
+        statisticsUpdater = statisticsUpdater,
+        duckAiMetricCollector = duckAiMetricCollector,
+        termsOfServiceHandler = termsOfServiceHandler,
+    )
+
+    @Test
+    fun whenModelSelectedThenSingleCountWithModelId() = runTest {
+        testee.fireModelSelected(modelId = "gpt-5")
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_MODEL_SELECTED,
+            parameters = mapOf(DuckChatPixelParameters.MODEL_ID to "gpt-5"),
+        )
+    }
+
+    @Test
+    fun whenReasoningSelectedThenSingleCountWithEffort() = runTest {
+        testee.fireReasoningEffortSelected(effortLevel = "extended_reasoning")
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_REASONING_EFFORT_SELECTED,
+            parameters = mapOf(DuckChatPixelParameters.EFFORT_LEVEL to "extended_reasoning"),
+        )
+    }
+
+    @Test
+    fun whenUpsellTriggeredThenSingleCountWithAllParams() = runTest {
+        testee.fireSubscriptionUpsellTriggered(source = "model_picker", currentTier = "free", requiredTier = "plus", flowType = "purchase")
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SUBSCRIPTION_UPSELL_TRIGGERED,
+            parameters = mapOf(
+                DuckChatPixelParameters.UPSELL_SOURCE to "model_picker",
+                DuckChatPixelParameters.UPSELL_CURRENT_TIER to "free",
+                DuckChatPixelParameters.UPSELL_REQUIRED_TIER to "plus",
+                DuckChatPixelParameters.UPSELL_FLOW_TYPE to "purchase",
+            ),
+        )
+    }
+}

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsToolsTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsToolsTest.kt
@@ -172,4 +172,18 @@ class RealDuckChatPixelsToolsTest {
             type = Pixel.PixelType.Daily(),
         )
     }
+
+    @Test
+    fun whenDuckAiChatHistorySuggestionClickedThenFiresSingleCountPixel() = runTest {
+        testee.fireDuckAiChatHistorySuggestionClicked()
+
+        verify(pixel).fire(DuckChatPixelName.AUTOCOMPLETE_DUCKAI_CLICK_CHAT_HISTORY)
+    }
+
+    @Test
+    fun whenDuckAiSearchDuckDuckGoSuggestionClickedThenFiresSingleCountPixel() = runTest {
+        testee.fireDuckAiSearchDuckDuckGoSuggestionClicked()
+
+        verify(pixel).fire(DuckChatPixelName.AUTOCOMPLETE_DUCKAI_CLICK_SEARCH_DUCKDUCKGO)
+    }
 }

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsToolsTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsToolsTest.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.pixel
+
+import com.duckduckgo.app.statistics.api.StatisticsUpdater
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.impl.helper.DuckChatTermsOfServiceHandler
+import com.duckduckgo.duckchat.impl.metric.DuckAiMetricCollector
+import com.duckduckgo.duckchat.impl.repository.DuckChatFeatureRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+class RealDuckChatPixelsToolsTest {
+
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    private val pixel: Pixel = mock()
+    private val duckChatFeatureRepository: DuckChatFeatureRepository = mock()
+    private val statisticsUpdater: StatisticsUpdater = mock()
+    private val duckAiMetricCollector: DuckAiMetricCollector = mock()
+    private val termsOfServiceHandler: DuckChatTermsOfServiceHandler = mock()
+
+    private val testee = RealDuckChatPixels(
+        pixel = pixel,
+        duckChatFeatureRepository = duckChatFeatureRepository,
+        appCoroutineScope = coroutineTestRule.testScope,
+        dispatcherProvider = coroutineTestRule.testDispatcherProvider,
+        statisticsUpdater = statisticsUpdater,
+        duckAiMetricCollector = duckAiMetricCollector,
+        termsOfServiceHandler = termsOfServiceHandler,
+    )
+
+    @Test
+    fun whenImageGenerationSelectedThenFiresCountAndDaily() = runTest {
+        testee.fireImageGenerationSelected()
+
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_SELECTED_COUNT, parameters = emptyMap())
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_SELECTED_DAILY,
+            parameters = emptyMap(),
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+
+    @Test
+    fun whenImageGenerationDeselectedThenFiresCountAndDaily() = runTest {
+        testee.fireImageGenerationDeselected()
+
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_DESELECTED_COUNT, parameters = emptyMap())
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_DESELECTED_DAILY,
+            parameters = emptyMap(),
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+
+    @Test
+    fun whenImageGenerationSubmittedThenFiresCountAndDaily() = runTest {
+        testee.fireImageGenerationSubmitted()
+
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_SUBMITTED_COUNT, parameters = emptyMap())
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_SUBMITTED_DAILY,
+            parameters = emptyMap(),
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+
+    @Test
+    fun whenWebSearchSelectedThenFiresCountAndDaily() = runTest {
+        testee.fireWebSearchSelected()
+
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_SELECTED_COUNT, parameters = emptyMap())
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_SELECTED_DAILY,
+            parameters = emptyMap(),
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+
+    @Test
+    fun whenWebSearchDeselectedThenFiresCountAndDaily() = runTest {
+        testee.fireWebSearchDeselected()
+
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_DESELECTED_COUNT, parameters = emptyMap())
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_DESELECTED_DAILY,
+            parameters = emptyMap(),
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+
+    @Test
+    fun whenWebSearchSubmittedThenFiresCountAndDaily() = runTest {
+        testee.fireWebSearchSubmitted()
+
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_SUBMITTED_COUNT, parameters = emptyMap())
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_SUBMITTED_DAILY,
+            parameters = emptyMap(),
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+
+    @Test
+    fun whenPromptSubmittedThenFiresWithFullState() = runTest {
+        testee.firePromptSubmitted(
+            selectedTool = "image_generation",
+            modelId = "gpt-5",
+            reasoningEffort = "fast",
+            hasImageAttachment = true,
+            hasFileAttachment = false,
+            hasText = true,
+        )
+
+        val params = mapOf(
+            DuckChatPixelParameters.SELECTED_TOOL to "image_generation",
+            DuckChatPixelParameters.MODEL_ID to "gpt-5",
+            DuckChatPixelParameters.REASONING_EFFORT to "fast",
+            DuckChatPixelParameters.HAS_IMAGE_ATTACHMENT to "true",
+            DuckChatPixelParameters.HAS_FILE_ATTACHMENT to "false",
+            DuckChatPixelParameters.HAS_TEXT to "true",
+        )
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_PROMPT_SUBMITTED_COUNT, parameters = params)
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_PROMPT_SUBMITTED_DAILY,
+            parameters = params,
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+
+    @Test
+    fun whenPromptSubmittedWithNullModelAndReasoningThenOmitsThoseParams() = runTest {
+        testee.firePromptSubmitted(
+            selectedTool = "none",
+            modelId = null,
+            reasoningEffort = null,
+            hasImageAttachment = false,
+            hasFileAttachment = false,
+            hasText = true,
+        )
+
+        val params = mapOf(
+            DuckChatPixelParameters.SELECTED_TOOL to "none",
+            DuckChatPixelParameters.HAS_IMAGE_ATTACHMENT to "false",
+            DuckChatPixelParameters.HAS_FILE_ATTACHMENT to "false",
+            DuckChatPixelParameters.HAS_TEXT to "true",
+        )
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_PROMPT_SUBMITTED_COUNT, parameters = params)
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_PROMPT_SUBMITTED_DAILY,
+            parameters = params,
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+}

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/AttachmentViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/AttachmentViewModelTest.kt
@@ -743,6 +743,33 @@ class AttachmentViewModelTest {
     }
 
     @Test
+    fun whenImageExceedsPerTurnLimitThenImageValidationFailedCountExceeded() = runTest {
+        modelStateFlow.value = ModelState(attachmentLimits = AttachmentLimits(images = ImageLimits(maxPerTurn = 1, maxPerConversation = 10)))
+        addImages(1)
+        val uri = givenImageDecodes()
+
+        viewModel.onImagesPicked(listOf(uri), AttachmentViewModel.ImageSource.PHOTO_LIBRARY)
+        advanceUntilIdle()
+
+        verify(duckChatPixels).fireImageValidationFailed("count_exceeded")
+        verify(duckChatPixels, never()).fireImageAttached(any())
+    }
+
+    @Test
+    fun whenImageDecodeFailsThenImageValidationFailedOther() = runTest {
+        val contentResolver: android.content.ContentResolver = mock()
+        whenever(context.contentResolver).thenReturn(contentResolver)
+        whenever(contentResolver.openInputStream(any())).thenReturn(null)
+        val uri: Uri = mock()
+
+        viewModel.onImagesPicked(listOf(uri), AttachmentViewModel.ImageSource.PHOTO_LIBRARY)
+        advanceUntilIdle()
+
+        verify(duckChatPixels).fireImageValidationFailed("other")
+        verify(duckChatPixels, never()).fireImageAttached(any())
+    }
+
+    @Test
     fun whenImageRemovedThenImageRemovedPixelFired() = runTest {
         addImages(1)
         val id = viewModel.attachmentState.value.images[0].id

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/AttachmentViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/AttachmentViewModelTest.kt
@@ -832,13 +832,13 @@ class AttachmentViewModelTest {
     }
 
     @Test
-    fun whenFileExceedsPageCountThenValidationFailedPixelFiredWithOther() = runTest {
+    fun whenFileExceedsPageCountThenValidationFailedPixelFiredWithPageCountExceeded() = runTest {
         val limits = FileLimits(maxPagesPerFile = 10)
         modelStateFlow.value = ModelState(attachmentLimits = AttachmentLimits(files = limits))
         addFiles(aFileAttachment(pageCount = 11))
         advanceUntilIdle()
 
-        verify(duckChatPixels).fireFileValidationFailed("other")
+        verify(duckChatPixels).fireFileValidationFailed("page_count_exceeded")
         verify(duckChatPixels, never()).fireFileAttached()
     }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/AttachmentViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/AttachmentViewModelTest.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.duckchat.impl.models.FileLimits
 import com.duckduckgo.duckchat.impl.models.ImageLimits
 import com.duckduckgo.duckchat.impl.models.ModelState
 import com.duckduckgo.duckchat.impl.nativeinput.RealNativeInputStateStore
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.ConversationFileUsage
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.ImageAttachment
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.LimitsHandler
@@ -54,6 +55,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.util.UUID
 
@@ -93,6 +96,8 @@ class AttachmentViewModelTest {
             .thenReturn("Total file size limit exceeded")
     }
 
+    private val duckChatPixels: DuckChatPixels = mock()
+
     private val selectedTabFlow = MutableStateFlow<TabEntity?>(null)
     private val tabRepository: TabRepository = mock<TabRepository>().also {
         whenever(it.flowSelectedTab).thenReturn(selectedTabFlow)
@@ -112,6 +117,7 @@ class AttachmentViewModelTest {
             context = context,
             appBuildConfig = appBuildConfig,
             nativeInputStateProvider = nativeInputStateStore,
+            duckChatPixels = duckChatPixels,
         )
     }
 
@@ -622,7 +628,7 @@ class AttachmentViewModelTest {
         whenever(contentResolver.openInputStream(any())).thenReturn(null)
         val uri: Uri = mock()
 
-        viewModel.onImagesPicked(listOf(uri))
+        viewModel.onImagesPicked(listOf(uri), AttachmentViewModel.ImageSource.PHOTO_LIBRARY)
         advanceUntilIdle()
 
         assertTrue(viewModel.attachmentState.value.images.isEmpty())
@@ -701,6 +707,133 @@ class AttachmentViewModelTest {
         advanceUntilIdle()
 
         assertEquals(1, viewModel.attachmentState.value.files.size)
+    }
+
+    @Test
+    fun whenImagePickedFromPhotoLibraryThenImageAttachedPixelFiredWithPhotoLibrarySource() = runTest {
+        val uri = givenImageDecodes()
+
+        viewModel.onImagesPicked(listOf(uri), AttachmentViewModel.ImageSource.PHOTO_LIBRARY)
+        advanceUntilIdle()
+
+        verify(duckChatPixels).fireImageAttached("photo_library")
+    }
+
+    @Test
+    fun whenImageCapturedFromCameraThenImageAttachedPixelFiredWithCameraSource() = runTest {
+        val uri = givenImageDecodes()
+
+        viewModel.onImagesPicked(listOf(uri), AttachmentViewModel.ImageSource.CAMERA)
+        advanceUntilIdle()
+
+        verify(duckChatPixels).fireImageAttached("camera")
+    }
+
+    @Test
+    fun whenImageDecodeFailsThenImageAttachedPixelNotFired() = runTest {
+        val contentResolver: android.content.ContentResolver = mock()
+        whenever(context.contentResolver).thenReturn(contentResolver)
+        whenever(contentResolver.openInputStream(any())).thenReturn(null)
+        val uri: Uri = mock()
+
+        viewModel.onImagesPicked(listOf(uri), AttachmentViewModel.ImageSource.PHOTO_LIBRARY)
+        advanceUntilIdle()
+
+        verify(duckChatPixels, never()).fireImageAttached(any())
+    }
+
+    @Test
+    fun whenImageRemovedThenImageRemovedPixelFired() = runTest {
+        addImages(1)
+        val id = viewModel.attachmentState.value.images[0].id
+
+        viewModel.removeImageAttachment(id)
+
+        verify(duckChatPixels).fireImageRemoved()
+    }
+
+    @Test
+    fun whenFileRemovedThenFileRemovedPixelFired() = runTest {
+        addFiles(aFileAttachment(id = "file-1"))
+
+        viewModel.removeFileAttachment("file-1")
+
+        verify(duckChatPixels).fireFileRemoved()
+    }
+
+    @Test
+    fun whenFileAddedWithinLimitsThenFileAttachedPixelFired() = runTest {
+        addFiles(aFileAttachment())
+        advanceUntilIdle()
+
+        verify(duckChatPixels).fireFileAttached()
+    }
+
+    @Test
+    fun whenFileAddedWithinLimitsThenValidationFailedPixelNotFired() = runTest {
+        addFiles(aFileAttachment())
+        advanceUntilIdle()
+
+        verify(duckChatPixels, never()).fireFileValidationFailed(any())
+    }
+
+    @Test
+    fun whenFileExceedsSizeLimitThenValidationFailedPixelFiredWithSizeExceeded() = runTest {
+        val maxBytes = 5L * 1024 * 1024
+        val limits = FileLimits(maxFileSizeBytes = maxBytes, maxTotalFileSizeBytes = 100L * 1024 * 1024)
+        modelStateFlow.value = ModelState(attachmentLimits = AttachmentLimits(files = limits))
+        addFiles(aFileAttachment(sizeBytes = maxBytes + 1))
+        advanceUntilIdle()
+
+        verify(duckChatPixels).fireFileValidationFailed("size_exceeded")
+        verify(duckChatPixels, never()).fireFileAttached()
+    }
+
+    @Test
+    fun whenFileExceedsConversationLimitThenValidationFailedPixelFiredWithCountExceeded() = runTest {
+        val limits = FileLimits(maxPerConversation = 2)
+        modelStateFlow.value = ModelState(attachmentLimits = AttachmentLimits(files = limits))
+        selectDuckAiTab()
+        advanceUntilIdle()
+        limitsHandler.addConversationFilesSent(2)
+
+        addFiles(aFileAttachment())
+        advanceUntilIdle()
+
+        verify(duckChatPixels).fireFileValidationFailed("count_exceeded")
+        verify(duckChatPixels, never()).fireFileAttached()
+    }
+
+    @Test
+    fun whenFileExceedsPageCountThenValidationFailedPixelFiredWithOther() = runTest {
+        val limits = FileLimits(maxPagesPerFile = 10)
+        modelStateFlow.value = ModelState(attachmentLimits = AttachmentLimits(files = limits))
+        addFiles(aFileAttachment(pageCount = 11))
+        advanceUntilIdle()
+
+        verify(duckChatPixels).fireFileValidationFailed("other")
+        verify(duckChatPixels, never()).fireFileAttached()
+    }
+
+    @Test
+    fun whenProcessFileReturnsNullThenValidationFailedPixelFiredWithOther() = runTest {
+        val uri: Uri = mock()
+
+        viewModel.onFilesPicked(listOf(uri))
+        advanceUntilIdle()
+
+        verify(duckChatPixels).fireFileValidationFailed("other")
+        verify(duckChatPixels, never()).fireFileAttached()
+    }
+
+    private fun givenImageDecodes(): Uri {
+        val contentResolver: android.content.ContentResolver = mock()
+        whenever(context.contentResolver).thenReturn(contentResolver)
+        val uri: Uri = mock()
+        whenever(contentResolver.openInputStream(uri))
+            .thenReturn(java.io.ByteArrayInputStream(ByteArray(8)))
+        whenever(contentResolver.getType(uri)).thenReturn("image/png")
+        return uri
     }
 
     private fun addImages(

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.duckchat.impl.models.ModelProvider
 import com.duckduckgo.duckchat.impl.models.ModelState
 import com.duckduckgo.duckchat.impl.models.Tool
 import com.duckduckgo.duckchat.impl.models.UserTier
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ModelPickerViewModel
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.PickerSurface
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.UpsellCommand
@@ -39,7 +40,9 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -51,6 +54,7 @@ class ModelPickerViewModelTest {
     val coroutineRule = CoroutineTestRule()
 
     private val modelManager: DuckAiModelManager = mock()
+    private val duckChatPixels: DuckChatPixels = mock()
     private val stateFlow = MutableStateFlow(ModelState())
 
     private lateinit var testee: ModelPickerViewModel
@@ -58,7 +62,7 @@ class ModelPickerViewModelTest {
     @Before
     fun setUp() {
         whenever(modelManager.modelState).thenReturn(stateFlow)
-        testee = ModelPickerViewModel(modelManager)
+        testee = ModelPickerViewModel(modelManager, duckChatPixels)
     }
 
     @Test
@@ -213,6 +217,45 @@ class ModelPickerViewModelTest {
             expectNoEvents()
             cancelAndConsumeRemainingEvents()
         }
+    }
+
+    @Test
+    fun whenAccessibleModelTappedWithDifferentIdThenModelSelectedPixelFired() = runTest {
+        whenever(modelManager.getSelectedModelId()).thenReturn("current")
+        val model = freeModel("new")
+
+        testee.onModelTapped(model, PickerSurface.MODEL_PICKER_ADDRESS_BAR)
+        runCurrent()
+
+        verify(duckChatPixels).fireModelSelected("new")
+    }
+
+    @Test
+    fun whenAccessibleModelTappedWithSameIdThenModelSelectedPixelNotFired() = runTest {
+        whenever(modelManager.getSelectedModelId()).thenReturn("same")
+        val model = freeModel("same")
+
+        testee.onModelTapped(model, PickerSurface.MODEL_PICKER_ADDRESS_BAR)
+        runCurrent()
+
+        verify(duckChatPixels, never()).fireModelSelected(any())
+    }
+
+    @Test
+    fun whenFreeUserTapsGatedPlusModelThenUpsellPixelFiredAndModelSelectedNotFired() = runTest {
+        stateFlow.value = ModelState(userTier = UserTier.FREE)
+        val model = plusModel("p")
+
+        testee.onModelTapped(model, PickerSurface.MODEL_PICKER_ADDRESS_BAR)
+        runCurrent()
+
+        verify(duckChatPixels).fireSubscriptionUpsellTriggered(
+            source = "model_picker",
+            currentTier = "free",
+            requiredTier = "plus",
+            flowType = "purchase",
+        )
+        verify(duckChatPixels, never()).fireModelSelected(any())
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -1106,7 +1106,7 @@ class NativeInputModeWidgetViewModelTest {
 
         testee.fireChatUrlSuggestionPixel(url)
 
-        verify(autoComplete).fireAutocompletePixel(eq(listOf(url)), eq(url), eq(true))
+        verify(autoComplete).fireAutocompletePixel(eq(listOf(url)), eq(url), experimentalInputScreen = eq(true), duckAiSurface = eq(true))
     }
 
     @Test
@@ -1115,7 +1115,7 @@ class NativeInputModeWidgetViewModelTest {
 
         testee.fireChatUrlSuggestionPixel(url)
 
-        verify(autoComplete).fireAutocompletePixel(eq(emptyList()), eq(url), eq(true))
+        verify(autoComplete).fireAutocompletePixel(eq(emptyList()), eq(url), experimentalInputScreen = eq(true), duckAiSurface = eq(true))
     }
 
     @Test
@@ -1129,7 +1129,7 @@ class NativeInputModeWidgetViewModelTest {
         testee.cancelChatSuggestions()
         testee.fireChatUrlSuggestionPixel(url)
 
-        verify(autoComplete).fireAutocompletePixel(eq(emptyList()), eq(url), eq(true))
+        verify(autoComplete).fireAutocompletePixel(eq(emptyList()), eq(url), experimentalInputScreen = eq(true), duckAiSurface = eq(true))
     }
 
     // endregion
@@ -1282,6 +1282,18 @@ class NativeInputModeWidgetViewModelTest {
         verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_SELECTED_DAILY, type = Daily())
         verify(pixel, never()).fire(DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_SELECTED_PINNED_COUNT)
         verify(pixel, never()).fire(DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_SELECTED_PINNED_DAILY, type = Daily())
+        verify(duckChatPixels).fireDuckAiChatHistorySuggestionClicked()
+    }
+
+    // endregion
+
+    // region duckai autocomplete-family pixels
+
+    @Test
+    fun whenFireDuckAiSearchForQuerySubmittedPixelThenFiresSearchDuckDuckGoPixel() {
+        testee.fireDuckAiSearchForQuerySubmittedPixel()
+
+        verify(duckChatPixels).fireDuckAiSearchDuckDuckGoSuggestionClicked()
     }
 
     // endregion

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -1384,4 +1384,20 @@ class NativeInputModeWidgetViewModelTest {
     }
 
     // endregion
+
+    // region voice / stop pixels
+
+    @Test
+    fun whenVoiceTappedThenVoicePixel() {
+        testee.fireVoiceTapped()
+        verify(duckChatPixels).fireVoiceTapped()
+    }
+
+    @Test
+    fun whenStopGenerationTappedThenStopPixel() {
+        testee.fireStopGenerationTapped()
+        verify(duckChatPixels).fireStopGenerationTapped()
+    }
+
+    // endregion
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -51,10 +51,12 @@ import com.duckduckgo.duckchat.impl.models.ModelState
 import com.duckduckgo.duckchat.impl.models.ReasoningEffort
 import com.duckduckgo.duckchat.impl.models.ReasoningEffortAccess
 import com.duckduckgo.duckchat.impl.models.ReasoningMode
+import com.duckduckgo.duckchat.impl.models.Tool
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
 import com.duckduckgo.duckchat.impl.nativeinput.RealNativeInputStateStore
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.store.impl.DuckAiChat
 import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
 import com.duckduckgo.subscriptions.api.Product
@@ -107,6 +109,7 @@ class NativeInputModeWidgetViewModelTest {
     private val duckAiChatHistoryFeature: DuckAiChatHistoryFeature = mock()
     private val inputScreenConfigResolver: InputScreenConfigResolver = mock()
     private val pixel: Pixel = mock()
+    private val duckChatPixels: DuckChatPixels = mock()
     private val modelManager: DuckAiModelManager = mock()
     private val duckAiChatStore: DuckAiChatStore = mock()
 
@@ -163,6 +166,7 @@ class NativeInputModeWidgetViewModelTest {
             dispatchers = coroutineRule.testDispatcherProvider,
             inputScreenConfigResolver = inputScreenConfigResolver,
             pixel = pixel,
+            duckChatPixels = duckChatPixels,
             nativeInputStatePublisher = nativeInputStatePublisher,
             nativeInputStateProvider = nativeInputStateProvider,
             modelManager = modelManager,
@@ -1302,6 +1306,81 @@ class NativeInputModeWidgetViewModelTest {
 
         val emitted = testee.state.first()
         assertEquals(NativeInputState.ToggleSelection.SEARCH, emitted.toggleSelection)
+    }
+
+    // endregion
+
+    // region fireSubmissionPixels
+
+    @Test
+    fun whenImageGenerationToolSelectedThenFiresPromptSubmittedAndImageGenerationSubmitted() = runTest {
+        val tabId = "tab-A"
+        whenever(modelManager.getSelectedModelId()).thenReturn("model-1")
+        whenever(modelManager.getResolvedReasoningEffort()).thenReturn("fast")
+        val viewModel = createViewModel()
+        viewModel.configure(tabId = tabId, isDuckAiMode = true, isBottom = false)
+        advanceUntilIdle()
+        viewModel.setSelectedTool(Tool.IMAGE_GENERATION.rawValue)
+
+        viewModel.fireSubmissionPixels(hasText = true, hasImageAttachment = true, hasFileAttachment = false)
+
+        verify(duckChatPixels).firePromptSubmitted(
+            selectedTool = "image_generation",
+            modelId = "model-1",
+            reasoningEffort = "fast",
+            hasImageAttachment = true,
+            hasFileAttachment = false,
+            hasText = true,
+        )
+        verify(duckChatPixels).fireImageGenerationSubmitted()
+        verify(duckChatPixels, never()).fireWebSearchSubmitted()
+    }
+
+    @Test
+    fun whenNoToolSelectedThenFiresPromptSubmittedWithNoneAndNoPerToolPixel() = runTest {
+        val tabId = "tab-A"
+        whenever(modelManager.getSelectedModelId()).thenReturn("model-1")
+        whenever(modelManager.getResolvedReasoningEffort()).thenReturn("fast")
+        val viewModel = createViewModel()
+        viewModel.configure(tabId = tabId, isDuckAiMode = true, isBottom = false)
+        advanceUntilIdle()
+
+        viewModel.fireSubmissionPixels(hasText = true, hasImageAttachment = false, hasFileAttachment = false)
+
+        verify(duckChatPixels).firePromptSubmitted(
+            selectedTool = "none",
+            modelId = "model-1",
+            reasoningEffort = "fast",
+            hasImageAttachment = false,
+            hasFileAttachment = false,
+            hasText = true,
+        )
+        verify(duckChatPixels, never()).fireImageGenerationSubmitted()
+        verify(duckChatPixels, never()).fireWebSearchSubmitted()
+    }
+
+    @Test
+    fun whenWebSearchToolSelectedThenFiresPromptSubmittedAndWebSearchSubmitted() = runTest {
+        val tabId = "tab-A"
+        whenever(modelManager.getSelectedModelId()).thenReturn("model-1")
+        whenever(modelManager.getResolvedReasoningEffort()).thenReturn("fast")
+        val viewModel = createViewModel()
+        viewModel.configure(tabId = tabId, isDuckAiMode = true, isBottom = false)
+        advanceUntilIdle()
+        viewModel.setSelectedTool(Tool.WEB_SEARCH.rawValue)
+
+        viewModel.fireSubmissionPixels(hasText = true, hasImageAttachment = false, hasFileAttachment = false)
+
+        verify(duckChatPixels).firePromptSubmitted(
+            selectedTool = "web_search",
+            modelId = "model-1",
+            reasoningEffort = "fast",
+            hasImageAttachment = false,
+            hasFileAttachment = false,
+            hasText = true,
+        )
+        verify(duckChatPixels).fireWebSearchSubmitted()
+        verify(duckChatPixels, never()).fireImageGenerationSubmitted()
     }
 
     // endregion

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ReasoningModePickerViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ReasoningModePickerViewModelTest.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.duckchat.impl.models.ReasoningEffort
 import com.duckduckgo.duckchat.impl.models.ReasoningEffortAccess
 import com.duckduckgo.duckchat.impl.models.ReasoningMode
 import com.duckduckgo.duckchat.impl.models.UserTier
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.PickerSurface
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ReasoningModePickerViewModel
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.UpsellCommand
@@ -69,6 +70,7 @@ class ReasoningModePickerViewModelTest {
         whenever(it.state).thenReturn(nativeInputState)
     }
     private val duckAiChatStore: DuckAiChatStore = mock()
+    private val duckChatPixels: DuckChatPixels = mock()
 
     private lateinit var testee: ReasoningModePickerViewModel
 
@@ -78,6 +80,7 @@ class ReasoningModePickerViewModelTest {
             modelManager = modelManager,
             nativeInputStateProvider = nativeInputStateProvider,
             duckAiChatStore = duckAiChatStore,
+            duckChatPixels = duckChatPixels,
         )
     }
 
@@ -168,6 +171,45 @@ class ReasoningModePickerViewModelTest {
             expectNoEvents()
             cancelAndConsumeRemainingEvents()
         }
+    }
+
+    @Test
+    fun whenAccessibleModeTappedThenReasoningEffortSelectedPixelFired() = runTest {
+        modelState.value = ModelState(
+            availableReasoningModes = listOf(
+                AvailableReasoningMode(ReasoningMode.FAST, ReasoningEffort.NONE),
+                AvailableReasoningMode(ReasoningMode.REASONING, ReasoningEffort.LOW),
+            ),
+        )
+        runCurrent()
+
+        testee.onModeTapped(ReasoningMode.REASONING, PickerSurface.REASONING_PICKER_ADDRESS_BAR)
+        runCurrent()
+
+        verify(duckChatPixels).fireReasoningEffortSelected("reasoning")
+    }
+
+    @Test
+    fun whenPlusUserTapsGatedModeRequiringProThenUpsellPixelFiredAndNoEffortPixel() = runTest {
+        modelState.value = ModelState(
+            userTier = UserTier.PLUS,
+            availableReasoningModes = listOf(
+                AvailableReasoningMode(ReasoningMode.FAST, ReasoningEffort.NONE),
+                gatedExtended(requires = listOf("pro")),
+            ),
+        )
+        runCurrent()
+
+        testee.onModeTapped(ReasoningMode.EXTENDED_REASONING, PickerSurface.REASONING_PICKER_ADDRESS_BAR)
+        runCurrent()
+
+        verify(duckChatPixels).fireSubscriptionUpsellTriggered(
+            source = "reasoning_picker",
+            currentTier = "plus",
+            requiredTier = "pro",
+            flowType = "upgrade",
+        )
+        verify(duckChatPixels, never()).fireReasoningEffortSelected(any())
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ReasoningModePickerViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ReasoningModePickerViewModelTest.kt
@@ -190,6 +190,24 @@ class ReasoningModePickerViewModelTest {
     }
 
     @Test
+    fun whenAccessibleModeTappedMatchingCurrentThenNoEffortPixel() = runTest {
+        modelState.value = ModelState(
+            selectedReasoningMode = ReasoningMode.FAST,
+            availableReasoningModes = listOf(
+                AvailableReasoningMode(ReasoningMode.FAST, ReasoningEffort.NONE),
+                AvailableReasoningMode(ReasoningMode.REASONING, ReasoningEffort.LOW),
+            ),
+        )
+        runCurrent()
+        assertEquals(ReasoningMode.FAST, testee.state.value.displayedMode)
+
+        testee.onModeTapped(ReasoningMode.FAST, PickerSurface.REASONING_PICKER_ADDRESS_BAR)
+        runCurrent()
+
+        verify(duckChatPixels, never()).fireReasoningEffortSelected(any())
+    }
+
+    @Test
     fun whenPlusUserTapsGatedModeRequiringProThenUpsellPixelFiredAndNoEffortPixel() = runTest {
         modelState.value = ModelState(
             userTier = UserTier.PLUS,

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
@@ -1181,7 +1181,7 @@ class InputScreenViewModelTest {
             assertEquals(SubmitChat(query), viewModel.command.value)
 
             verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_OPEN_AUTOCOMPLETE_EXPERIMENTAL, params)
-            verify(autoComplete).fireAutocompletePixel(any(), any(), any())
+            verify(autoComplete).fireAutocompletePixel(any(), any(), any(), any())
         }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsViewModelTest.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -125,8 +126,18 @@ class OptionsViewModelTest {
     }
 
     @Test
-    fun whenVisibleToolsClearsSelectionThenNoPixel() {
-        testee.updateVisibleTools(emptySet())
+    fun whenVisibleToolsAutoClearsSelectedToolThenNoPixel() = runTest {
+        val tabId = "tab-E"
+        store.publish(tabId, NativeInputState.zero().copy(selectedTool = Tool.WEB_SEARCH.rawValue))
+        selectedTabFlow.value = tabEntity(tabId)
+        advanceUntilIdle()
+        assertEquals(Tool.WEB_SEARCH, testee.selectedTool.value)
+
+        // A model-capability change that removes the selected tool must auto-clear it
+        // (updateVisibleTools returns true) WITHOUT firing a deselect pixel.
+        val selectionCleared = testee.updateVisibleTools(emptySet())
+
+        assertTrue(selectionCleared)
         verifyNoInteractions(duckChatPixels)
     }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsViewModelTest.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.impl.models.Tool
 import com.duckduckgo.duckchat.impl.nativeinput.RealNativeInputStateStore
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -33,6 +34,8 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -46,11 +49,12 @@ class OptionsViewModelTest {
         whenever(it.flowSelectedTab).thenReturn(selectedTabFlow)
     }
     private val store = RealNativeInputStateStore { tabRepository }
+    private val duckChatPixels: DuckChatPixels = mock()
     private lateinit var testee: OptionsViewModel
 
     @Before
     fun setUp() {
-        testee = OptionsViewModel(store)
+        testee = OptionsViewModel(store, duckChatPixels)
     }
 
     @Test
@@ -94,6 +98,36 @@ class OptionsViewModelTest {
         advanceUntilIdle()
 
         assertEquals(Tool.IMAGE_GENERATION, testee.selectedTool.value)
+    }
+
+    @Test
+    fun whenImageGenSelectedByUserThenSelectedPixel() {
+        testee.onToolSelectedByUser(Tool.IMAGE_GENERATION)
+        verify(duckChatPixels).fireImageGenerationSelected()
+    }
+
+    @Test
+    fun whenWebSearchDeselectedByUserThenDeselectedPixel() {
+        testee.onToolDeselectedByUser(Tool.WEB_SEARCH)
+        verify(duckChatPixels).fireWebSearchDeselected()
+    }
+
+    @Test
+    fun whenWebSearchSelectedByUserThenSelectedPixel() {
+        testee.onToolSelectedByUser(Tool.WEB_SEARCH)
+        verify(duckChatPixels).fireWebSearchSelected()
+    }
+
+    @Test
+    fun whenImageGenDeselectedByUserThenDeselectedPixel() {
+        testee.onToolDeselectedByUser(Tool.IMAGE_GENERATION)
+        verify(duckChatPixels).fireImageGenerationDeselected()
+    }
+
+    @Test
+    fun whenVisibleToolsClearsSelectionThenNoPixel() {
+        testee.updateVisibleTools(emptySet())
+        verifyNoInteractions(duckChatPixels)
     }
 
     private fun tabEntity(tabId: String): TabEntity = TabEntity(tabId = tabId, position = 0)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1214229837647255?focus=true
Tech Design URL (if applicable):

### Description

Ports the iOS "Unified Input — Metrics & Pixels" set to Android for the native Unified Input (Duck.ai). All firing goes through the existing `DuckChatPixels` facade + `DuckChatPixelName` enum; the Duck.ai suggestion family is routed through `AutoComplete.fireAutocompletePixel` via a new `duckAiSurface` flag so a Duck.ai-tab tap fires the `m_autocomplete_duckai_click_*` family instead of the search-mode `m_autocomplete_click_*` (no double-counting). iOS `DailyPixel.fireDailyAndCount` maps to two Android pixels (`_count` + `_daily`); per-event pixels are a single `_count`.

Pixels added:
- Tools: `image_generation` / `web_search` selected / deselected / submitted (daily+count). Deselect fires only on user action, not on auto-clear when switching to a model that doesn't support the tool.
- `prompt_submitted` (daily+count) with `selected_tool`, `model_id`, `reasoning_effort`, `has_image_attachment`, `has_file_attachment`, `has_text`. Fires once per Duck.ai submit (send button, IME, and the start-chat icon), never for search.
- `model_selected` and `reasoning_effort_selected` (each fired only when the selection actually changes — re-tapping the current one is a no-op), `subscription_upsell_triggered` (model/reasoning pickers; gated-tap routing).
- `chat_header_upgrade_tapped` — fired when a free-tier user taps the Upgrade pill in the Duck.ai omnibar header (param `user_tier`).
- Attachments: image/file attached, removed, and `image_validation_failed` / `file_validation_failed` (all daily+count); image attach carries `source` (camera/photo_library). `*_attached` fires only when the attachment passes its limits; an over-limit or undecodable attachment fires the matching `*_validation_failed` instead (mutually exclusive per item).
- `voice_tapped` (daily+count), `stop_generation_tapped` (count).
- Duck.ai autocomplete family `m_autocomplete_duckai_click_*` (website, bookmark, favorite, history_search, history_site, switch_to_tab, chat_history, search_duckduckgo).

All new pixels have JSON definitions (`duck_chat.json5`, `autocomplete_displayed.json5`); definition validation + prettier pass.

**Decisions to confirm (pixel owner):**
- **`chat_history` overlap (intentional — keep both):** on the native Duck.ai tab a chat-history suggestion tap emits both `m_aichat_recent_chat_selected[_pinned]_*` and the new `m_autocomplete_duckai_click_chat_history`. They measure different things: `recent_chat_selected` is the cross-surface usage metric (legacy Input Screen + native widget, with a pinned/unpinned split, count+daily, feeds the existing CDS dashboard); `duckai_click_chat_history` is one member of the Duck.ai suggestions-engagement family so the 8 row types can be compared like-for-like. **Action for analytics: do not sum across the two families** (no O-J/CDS chart should add `recent_chat_selected` and the `duckai_click_*` family together), otherwise chat-history is over-counted.
- An over-limit / undecodable attachment fires `*_validation_failed` (not `*_attached`) — Android adds-then-warns rather than hard-rejecting, so `*_attached` means "passed validation". Applies to both images and files. Image reasons are `count_exceeded` | `other`; file reasons are `size_exceeded` | `count_exceeded` | `page_count_exceeded` | `other`.
- `file_validation_failed` reasons: `size_exceeded`, `count_exceeded`, `page_count_exceeded` (PDF over the per-file page limit), `other` (genuine processing failure). iOS's `unsupported_type` is intentionally NOT declared on Android — the picker pre-filters MIME and we never reject by type, so the enum only lists reasons Android actually emits. Images only emit `count_exceeded` / `other`.
- New `m_aichat_unified_input_voice_tapped` is distinct from the legacy `m_aichat_voice_entry_tapped` (which fires only on the old Input Screen surface).
- iOS §11 (chat-header "Upgrade" tap) IS implemented: the Duck.ai omnibar header shows an Upgrade pill for free-tier users (subscription inactive), wired in `RealNativeInputManager`. Tapping it fires `m_aichat_unified_input_chat_header_upgrade_tapped` with `user_tier`. The pill only renders for free tier, so `user_tier` is `free` in practice (the `plus` value is supported for parity).

`has_reference_image` was intentionally dropped (Android UTI has no reference-image support).

### Steps to test this PR

_Pixels fire from the Duck.ai Unified Input (internal build, pixel debug viewer)_
- [x] Select / deselect Image Generation and Web Search tools → `*_selected` / `*_deselected` (count + daily); switching models that drop the tool does NOT fire a deselect.
- [x] Submit a Duck.ai prompt (send button, keyboard, and start-chat icon) → `prompt_submitted` once + per-tool `*_submitted` when a tool is active; search submits fire neither.
- [x] Change model → `model_selected` (only on change); tap a gated model/reasoning → `subscription_upsell_triggered`; change reasoning effort → `reasoning_effort_selected` (re-tapping the current effort fires nothing).
- [x] Attach/remove image (camera vs library `source`) and file → `*_attached` / `*_removed`; exceed an image or file limit → matching `*_validation_failed` (and no `*_attached` for that item).
- [x] Tap voice → `voice_tapped`; tap stop during streaming → `stop_generation_tapped`.
- [x] Tap each Duck.ai-tab suggestion type → the matching `m_autocomplete_duckai_click_*` only (no search-family pixel).

### UI changes
No UI changes (analytics only).



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes with no auth, payment, or data-handling logic; main risk is mis-attributed or double-fired pixels if call sites drift.
> 
> **Overview**
> Adds **Duck.ai Unified Input** analytics on Android: new pixel definitions in `duck_chat.json5` and `autocomplete_displayed.json5`, wiring through `DuckChatPixels` / `RealDuckChatPixels`, and UI hooks in the native input stack.
> 
> **Autocomplete:** `fireAutocompletePixel` gains `duckAiSurface`; on the Duck.ai tab, suggestion taps map to `m_autocomplete_duckai_click_*` instead of search-mode `m_autocomplete_click_*`, with ATB stripped via prefix rules in `AutoCompletePixelNames`.
> 
> **Unified input events:** Tools (image gen / web search select-deselect-submit), `prompt_submitted` with model/reasoning/attachment flags, model and reasoning pickers (including subscription upsell), attachments (attach/remove/validation with reasons and image `source`), voice and stop generation, chat-header upgrade tap, and Duck.ai-only suggestion types (chat history, search DuckDuckGo).
> 
> **Instrumentation chokepoints:** `NativeInputModeWidget`, `AttachmentViewModel`, `OptionsViewModel`, model/reasoning pickers, and `RealNativeInputManager` fire pixels at single user-action boundaries; tests cover pixel routing and parameters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aea1760f643d4bf8f0217bb772461ffee105bdd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->