### PR TITLE
Navigate URLs in Duck.ai mode outside a chat

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -431,9 +431,8 @@ class RealNativeInputManager @Inject constructor(
             },
             onChatSubmitted = { query ->
                 if (omnibarController.isDuckAiMode()) {
-                    // In Duck.ai context the user is actively chatting — a pasted URL is a chat
-                    // message, never a contextual-sheet trigger or a navigation. Fall through to
-                    // the standard chat-submit path so the message reaches the Duck.ai webview.
+                    // Already in a Duck.ai chat — every submission, URL or not, is a chat prompt
+                    // that reaches the Duck.ai webview.
                     widget.saveLastUsedTogglePosition(isChat = true)
                     val imagesJson = widget.getImageAttachmentsJson()
                     val filesJson = widget.getFileAttachmentsJson()
@@ -450,8 +449,11 @@ class RealNativeInputManager @Inject constructor(
                     )
                     widget.clearSelectedTool()
                 } else if (queryUrlPredictor.isUrl(query)) {
+                    // Not in a Duck.ai chat (e.g. on the NTP with the Duck.ai toggle selected): a
+                    // URL is an address, so navigate to it exactly like Search mode rather than
+                    // opening the Duck.ai contextual sheet.
                     hideNativeInput(isNavigation = true)
-                    callbacks.onContextualSheetRequested()
+                    callbacks.onSearchSubmitted(query)
                 } else {
                     widget.saveLastUsedTogglePosition(isChat = true)
                     widget.storePendingPrompt(query)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1213881875984009/task/1215558696611965

### Description

Typing a URL in the unified input while the Search/Duck.ai toggle is set to Duck.ai opened the Duck.ai contextual sheet instead of navigating to the URL.

In `NativeInputManager`'s chat-submit handler, a URL submitted while the omnibar is **not** in a Duck.ai chat (e.g. on the NTP — the omnibar isn't in Duck.ai mode there even with the Duck.ai toggle selected) hit a branch that opened the contextual sheet (`onContextualSheetRequested`). It now navigates via the same `onSearchSubmitted` path Search mode uses, so a URL behaves identically whichever toggle is selected.

An active Duck.ai chat (omnibar in Duck.ai mode) is unchanged — every submission, URL or not, is still sent as a chat prompt.

Note: `onContextualSheetRequested` / `BrowserTabViewModel.openDuckAIContextualMode()` are now unused; left in place to keep this fix focused — can be removed in a follow-up. The submit-handler branch isn't covered by a unit test (no harness exists for the widget callbacks); verified on device.

### Steps to test this PR

_URL in Duck.ai mode navigates_
- [ ] Internal build with the native input field enabled. On the NTP, tap the unified input and select Duck.ai
- [ ] Type `bbc.com` and submit → bbc.com opens (no contextual sheet)
- [ ] Type a non-URL prompt (e.g. `hello`) and submit → the Duck.ai chat opens with the prompt
- [ ] From within an existing Duck.ai chat, submit a URL → it stays a chat prompt (no navigation)

### UI changes

No UI changes (behaviour only).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single behavioral branch in native input submit handling; no auth, data, or security surface, and in-chat Duck.ai flow is unchanged.
> 
> **Overview**
> Fixes unified native input so **URLs submitted with the Duck.ai toggle on the NTP (or anywhere the omnibar is not in an active Duck.ai chat)** navigate like Search mode instead of opening the Duck.ai contextual sheet.
> 
> In `NativeInputManager`’s `onChatSubmitted` path, the `queryUrlPredictor.isUrl` branch now calls **`onSearchSubmitted`** (with `hideNativeInput(isNavigation = true)`) rather than **`onContextualSheetRequested`**. **Active Duck.ai chat** behavior is unchanged: submissions still go through **`onDuckAiChatSubmitted`** whether the text is a URL or not.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92f5f21e09575deb1f40ccbcffdfd8e0cf87797a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->