### PR TITLE
Add pixel for direct navigation to Duck.ai

### DIFF
--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -446,6 +446,36 @@
             }
         ]
     },
+    "m_aichat_duck_ai_direct_navigation_count": {
+        "description": "User navigated directly to the Duck.ai URL by typing it in the omnibar",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "duck_ai_enabled",
+                "type": "string",
+                "description": "Whether the Duck.ai global setting is enabled",
+                "enum": ["true", "false"]
+            }
+        ]
+    },
+    "m_aichat_duck_ai_direct_navigation_daily": {
+        "description": "(Daily Pixel) User navigated directly to the Duck.ai URL by typing it in the omnibar",
+        "owners": ["malmstein"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "duck_ai_enabled",
+                "type": "string",
+                "description": "Whether the Duck.ai global setting is enabled",
+                "enum": ["true", "false"]
+            }
+        ]
+    },
     "m_aichat_experimental_omnibar_mode_switched": {
         "description": "User switched between Search and Duck.ai toggle in the input screen",
         "owners": ["YoussefKeyrouz"],

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -355,6 +355,7 @@ import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
 import com.duckduckgo.downloads.api.model.DownloadItem
 import com.duckduckgo.downloads.store.DownloadStatus
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
+import com.duckduckgo.duckchat.api.DuckAiHostProvider
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.contextual.PageContextJSHelper
 import com.duckduckgo.duckchat.impl.contextual.RealPageContextJSHelper.Companion.PAGE_CONTEXT_FEATURE_NAME
@@ -513,6 +514,7 @@ class BrowserTabViewModel @Inject constructor(
     private val httpErrorPixels: Lazy<HttpErrorPixels>,
     private val duckPlayer: DuckPlayer,
     private val duckChat: DuckChat,
+    private val duckAiHostProvider: DuckAiHostProvider,
     private val duckAiFeatureState: DuckAiFeatureState,
     private val duckPlayerJSHelper: DuckPlayerJSHelper,
     private val refreshPixelSender: RefreshPixelSender,
@@ -1457,6 +1459,10 @@ class BrowserTabViewModel @Inject constructor(
         val verticalParameter = extractVerticalParameter(url)
         var urlToNavigate = queryUrlConverter.convertQueryToUrl(trimmedInput, verticalParameter, queryOrigin)
 
+        if (queryOrigin is QueryOrigin.FromUser && isTypedDuckAiUrl(urlToNavigate)) {
+            fireDuckAiDirectNavigationPixel()
+        }
+
         when (val type = specialUrlDetector.determineType(trimmedInput)) {
             is ShouldLaunchDuckChatLink -> {
                 runCatching {
@@ -1542,6 +1548,18 @@ class BrowserTabViewModel @Inject constructor(
             )
         autoCompleteViewState.value =
             currentAutoCompleteViewState().copy(showSuggestions = false, showFocusedView = false, searchResults = AutoCompleteResult("", emptyList()))
+    }
+
+    private fun isTypedDuckAiUrl(url: String): Boolean {
+        val host = runCatching { url.toUri().host }.getOrNull() ?: return false
+        val duckAiHost = duckAiHostProvider.getHost()
+        return host == duckAiHost || host == "www.$duckAiHost"
+    }
+
+    private fun fireDuckAiDirectNavigationPixel() {
+        val params = mapOf("duck_ai_enabled" to duckChat.isEnabled().toString())
+        pixel.fire(AppPixelName.AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_COUNT, parameters = params)
+        pixel.fire(AppPixelName.AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_DAILY, parameters = params, type = Daily())
     }
 
     private fun getUrlHeaders(url: String?): Map<String, String> = url?.let { customHeadersProvider.getCustomHeaders(it) } ?: emptyMap()

--- a/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/AppPixelName.kt
@@ -60,6 +60,8 @@ enum class AppPixelName(override val pixelName: String) : Pixel.PixelName {
     NEW_ADDRESS_BAR_PICKER_V2_DISPLAYED_DAILY("m_aichat_new_address_bar_picker_v2_displayed_daily"),
     NEW_ADDRESS_BAR_PICKER_V2_CONFIRMED_COUNT("m_aichat_new_address_bar_picker_v2_confirmed_count"),
     NEW_ADDRESS_BAR_PICKER_V2_CONFIRMED_DAILY("m_aichat_new_address_bar_picker_v2_confirmed_daily"),
+    AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_COUNT("m_aichat_duck_ai_direct_navigation_count"),
+    AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_DAILY("m_aichat_duck_ai_direct_navigation_daily"),
     PREONBOARDING_SKIP_ONBOARDING_PRESSED("m_preonboarding_skip-onboarding-pressed"),
     PREONBOARDING_CONFIRM_SKIP_ONBOARDING_PRESSED("m_preonboarding_confirm-skip-onboarding-pressed"),
     PREONBOARDING_RESUME_ONBOARDING_PRESSED("m_preonboarding_resume-onboarding-pressed"),

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -285,6 +285,7 @@ import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
 import com.duckduckgo.downloads.api.model.DownloadItem
 import com.duckduckgo.downloads.store.DownloadStatus
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
+import com.duckduckgo.duckchat.api.DuckAiHostProvider
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.contextual.PageContextJSHelper
 import com.duckduckgo.duckchat.impl.contextual.RealPageContextJSHelper.Companion.PAGE_CONTEXT_FEATURE_NAME
@@ -616,6 +617,7 @@ class BrowserTabViewModelTest {
     private val mockDuckChat: DuckChat = mock {
         on { observeTriggerVoiceChatSessionEnd() } doReturn voiceSessionEndTriggerFlow
     }
+    private val mockDuckAiHostProvider: DuckAiHostProvider = mock()
     private val mockSyncStatusChangedObserver: SyncStatusChangedObserver = mock()
     private val syncStatusChangedEventsFlow = MutableSharedFlow<JSONObject>()
     private val subscriptionStatusFlow = MutableSharedFlow<SubscriptionStatus>()
@@ -845,6 +847,7 @@ class BrowserTabViewModelTest {
 
             fakeContentScopeScriptsSubscriptionEventPluginPoint = FakeContentScopeScriptsSubscriptionEventPluginPoint()
 
+            whenever(mockDuckAiHostProvider.getHost()).thenReturn("duck.ai")
             whenever(mockDuckChat.getDuckChatUrl(any(), any(), any())).thenReturn(duckChatURL)
             whenever(mockDuckChat.isChatHistoryAvailable()).thenReturn(false)
             whenever(mockDuckChat.observeNativeInputFieldUserSettingEnabled()).thenReturn(nativeInputUserSettingFlow)
@@ -941,6 +944,7 @@ class BrowserTabViewModelTest {
                 httpErrorPixels = { mockHttpErrorPixels },
                 duckPlayer = mockDuckPlayer,
                 duckChat = mockDuckChat,
+                duckAiHostProvider = mockDuckAiHostProvider,
                 duckAiFeatureState = mockDuckAiFeatureState,
                 duckPlayerJSHelper =
                 DuckPlayerJSHelper(
@@ -7234,6 +7238,62 @@ class BrowserTabViewModelTest {
         testee.onUserSubmittedQuery("foo")
 
         assertEquals(testee.browserViewState.value?.lastQueryOrigin, FromUser)
+    }
+
+    @Test
+    fun whenTypedDuckAiUrlSubmittedFromUserAndDuckAiEnabledThenDirectNavigationPixelsFireWithEnabledTrue() {
+        whenever(mockOmnibarConverter.convertQueryToUrl("duck.ai", null, FromUser)).thenReturn("https://duck.ai/")
+        whenever(mockDuckChat.isEnabled()).thenReturn(true)
+
+        testee.onUserSubmittedQuery("duck.ai", queryOrigin = FromUser)
+
+        verify(mockPixel).fire(
+            AppPixelName.AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_COUNT,
+            parameters = mapOf("duck_ai_enabled" to "true"),
+        )
+        verify(mockPixel).fire(
+            AppPixelName.AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_DAILY,
+            parameters = mapOf("duck_ai_enabled" to "true"),
+            type = Daily(),
+        )
+    }
+
+    @Test
+    fun whenTypedDuckAiUrlSubmittedFromUserAndDuckAiDisabledThenDirectNavigationPixelsFireWithEnabledFalse() {
+        whenever(mockOmnibarConverter.convertQueryToUrl("duck.ai", null, FromUser)).thenReturn("https://duck.ai/")
+        whenever(mockDuckChat.isEnabled()).thenReturn(false)
+
+        testee.onUserSubmittedQuery("duck.ai", queryOrigin = FromUser)
+
+        verify(mockPixel).fire(
+            AppPixelName.AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_COUNT,
+            parameters = mapOf("duck_ai_enabled" to "false"),
+        )
+        verify(mockPixel).fire(
+            AppPixelName.AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_DAILY,
+            parameters = mapOf("duck_ai_enabled" to "false"),
+            type = Daily(),
+        )
+    }
+
+    @Test
+    fun whenTypedNonDuckAiUrlSubmittedFromUserThenDirectNavigationPixelsDoNotFire() {
+        whenever(mockOmnibarConverter.convertQueryToUrl("example.com", null, FromUser)).thenReturn("https://example.com/")
+
+        testee.onUserSubmittedQuery("example.com", queryOrigin = FromUser)
+
+        verify(mockPixel, never()).fire(eq(AppPixelName.AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_COUNT), any(), any(), any())
+        verify(mockPixel, never()).fire(eq(AppPixelName.AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_DAILY), any(), any(), any())
+    }
+
+    @Test
+    fun whenDuckAiUrlSubmittedFromBookmarkThenDirectNavigationPixelsDoNotFire() {
+        whenever(mockOmnibarConverter.convertQueryToUrl("duck.ai", null, FromBookmark)).thenReturn("https://duck.ai/")
+
+        testee.onUserSubmittedQuery("duck.ai", queryOrigin = FromBookmark)
+
+        verify(mockPixel, never()).fire(eq(AppPixelName.AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_COUNT), any(), any(), any())
+        verify(mockPixel, never()).fire(eq(AppPixelName.AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_DAILY), any(), any(), any())
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215321415119180
Tech Design URL (if applicable):

### Description

Adds a pixel to measure how many users navigate to the Duck.ai URL **directly** — i.e. by typing `duck.ai` in the omnibar and submitting it. This informs whether we should ever surface the unified-input UX to users who have the global Duck.ai setting **disabled**.

- Fires `m_aichat_duck_ai_direct_navigation_count` / `_daily` from `BrowserTabViewModel.onUserSubmittedQuery`, immediately after the typed query is resolved to a URL and before the special-URL `when` (so it catches both cohorts: enabled users early-return via `ShouldLaunchDuckChatLink`; disabled users fall through to a normal navigation).
- Gated on `queryOrigin is QueryOrigin.FromUser` (the user typed it — not a bookmark or autocomplete selection).
- Duck.ai URL detection uses `DuckAiHostProvider.getHost()` (host == `duck.ai` / `www.duck.ai`), which is **independent of the Duck.ai feature flag** — `duckChat.isDuckChatUrl()` returns false when the setting is off, so it can't be used for the disabled cohort we care about.
- Param `duck_ai_enabled: "true" | "false"` (`duckChat.isEnabled()`) so the disabled-setting cohort can be isolated in analytics.

Note: for the enabled cohort, typing `duck.ai` also fires the existing `aichat_open` (via `openDuckChat()`); the two are separate metrics — filter this one on `duck_ai_enabled=false` for the target cohort.

### Steps to test this PR

- [x] With Duck.ai **disabled**, type `duck.ai` in the omnibar and submit → `m_aichat_duck_ai_direct_navigation_count` + `_daily` fire with `duck_ai_enabled=false` (pixel debug viewer).
- [x] With Duck.ai **enabled**, type `duck.ai` and submit → both fire with `duck_ai_enabled=true`.
- [x] Type a non-duck.ai URL → neither fires.
- [x] Open Duck.ai via a bookmark/autocomplete suggestion (not typed) → neither fires.

### UI changes
No UI changes (analytics only).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only change on omnibar submit with no navigation or settings behavior changes beyond firing pixels.
> 
> **Overview**
> Adds analytics for users who **type the Duck.ai URL in the omnibar** (not bookmarks or suggestions), including when the global Duck.ai setting is off.
> 
> `BrowserTabViewModel.onUserSubmittedQuery` now fires `m_aichat_duck_ai_direct_navigation_count` and `_daily` right after the query becomes a URL and **before** special-url handling, so both enabled (Duck Chat launch) and disabled (normal navigation) paths are counted. Firing is limited to `QueryOrigin.FromUser`. Host matching uses `DuckAiHostProvider` (`duck.ai` / `www.duck.ai`) instead of flag-gated Duck Chat URL helpers, with parameter `duck_ai_enabled` from `duckChat.isEnabled()`.
> 
> Pixel definitions and `AppPixelName` entries were added; unit tests cover enabled/disabled, non-Duck.ai URLs, and non-user origins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a10b77f581e08f89e9b10af707575683892f874. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->