### PR TITLE
Fix Duck.ai direct-navigation pixel: host casing + ATB

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1551,8 +1551,8 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     private fun isTypedDuckAiUrl(url: String): Boolean {
-        val host = runCatching { url.toUri().host }.getOrNull() ?: return false
-        val duckAiHost = duckAiHostProvider.getHost()
+        val host = runCatching { url.toUri().host }.getOrNull()?.lowercase() ?: return false
+        val duckAiHost = duckAiHostProvider.getHost().lowercase()
         return host == duckAiHost || host == "www.$duckAiHost"
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/EngagementPixelsParamRemovalPlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/EngagementPixelsParamRemovalPlugin.kt
@@ -26,6 +26,8 @@ import com.duckduckgo.app.pixels.AppPixelName.ADDRESS_BAR_WEBSITE_CANCELLED
 import com.duckduckgo.app.pixels.AppPixelName.ADDRESS_BAR_WEBSITE_CLICKED
 import com.duckduckgo.app.pixels.AppPixelName.ADDRESS_BAR_WEBSITE_ENTRY_CLEARED
 import com.duckduckgo.app.pixels.AppPixelName.ADD_BOOKMARK_CONFIRM_EDITED
+import com.duckduckgo.app.pixels.AppPixelName.AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_COUNT
+import com.duckduckgo.app.pixels.AppPixelName.AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_DAILY
 import com.duckduckgo.app.pixels.AppPixelName.KEYBOARD_GO_NEW_TAB_CLICKED
 import com.duckduckgo.app.pixels.AppPixelName.KEYBOARD_GO_SERP_CLICKED
 import com.duckduckgo.app.pixels.AppPixelName.KEYBOARD_GO_WEBSITE_CLICKED
@@ -83,6 +85,8 @@ class EngagementPixelsParamRemovalPlugin @Inject constructor() : PixelParamRemov
             TAB_MANAGER_MENU_SETTINGS_PRESSED.pixelName to PixelParameter.removeAtb(),
             ADD_BOOKMARK_CONFIRM_EDITED.pixelName to PixelParameter.removeAtb(),
             LONG_PRESS_COPY_LINK_TEXT.pixelName to PixelParameter.removeAtb(),
+            AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_COUNT.pixelName to PixelParameter.removeAtb(),
+            AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_DAILY.pixelName to PixelParameter.removeAtb(),
         )
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -7259,6 +7259,19 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenTypedDuckAiUrlWithUppercaseHostThenDirectNavigationPixelsFire() {
+        whenever(mockOmnibarConverter.convertQueryToUrl("Duck.ai", null, FromUser)).thenReturn("https://Duck.ai/")
+        whenever(mockDuckChat.isEnabled()).thenReturn(true)
+
+        testee.onUserSubmittedQuery("Duck.ai", queryOrigin = FromUser)
+
+        verify(mockPixel).fire(
+            AppPixelName.AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_COUNT,
+            parameters = mapOf("duck_ai_enabled" to "true"),
+        )
+    }
+
+    @Test
     fun whenTypedDuckAiUrlSubmittedFromUserAndDuckAiDisabledThenDirectNavigationPixelsFireWithEnabledFalse() {
         whenever(mockOmnibarConverter.convertQueryToUrl("duck.ai", null, FromUser)).thenReturn("https://duck.ai/")
         whenever(mockDuckChat.isEnabled()).thenReturn(false)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -760,6 +760,10 @@ class DuckChatParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin
             DuckChatPixelName.DUCK_CHAT_HISTORY_DOWNLOAD_SELECTED_COUNT.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_HISTORY_DOWNLOAD_SELECTED_DAILY.pixelName to PixelParameter.removeAtb(),
             "m_duck-ai_native-storage_" to PixelParameter.removeAtb(),
+            // Duck.ai telemetry: strip ATB from the direct-navigation pixels (fired from :app's
+            // BrowserTabViewModel). The interceptor matches outgoing names with startsWith across
+            // all plugins, so this prefix covers both _count and _daily.
+            "m_aichat_duck_ai_direct_navigation_" to PixelParameter.removeAtb(),
         )
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -760,10 +760,6 @@ class DuckChatParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin
             DuckChatPixelName.DUCK_CHAT_HISTORY_DOWNLOAD_SELECTED_COUNT.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_HISTORY_DOWNLOAD_SELECTED_DAILY.pixelName to PixelParameter.removeAtb(),
             "m_duck-ai_native-storage_" to PixelParameter.removeAtb(),
-            // Duck.ai telemetry: strip ATB from the direct-navigation pixels (fired from :app's
-            // BrowserTabViewModel). The interceptor matches outgoing names with startsWith across
-            // all plugins, so this prefix covers both _count and _daily.
-            "m_aichat_duck_ai_direct_navigation_" to PixelParameter.removeAtb(),
         )
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215321415119180
Tech Design URL (if applicable):

### Description

Follow-up to #8833 (merged), addressing two review comments:

- **Host comparison is now case-insensitive.** Typing `Duck.ai` (or any casing) previously didn't fire `m_aichat_duck_ai_direct_navigation_*` because `isTypedDuckAiUrl` compared the raw host against `duck.ai`. Both sides are now lowercased.
- **ATB is stripped from the direct-navigation pixels.** `m_aichat_duck_ai_direct_navigation_count` / `_daily` weren't registered for ATB removal, so the runtime `atb` param didn't match the JSON5 definitions (triage could reject the measurements). Registered the `m_aichat_duck_ai_direct_navigation_` prefix in `DuckChatParamRemovalPlugin` (the interceptor matches outgoing names with `startsWith` across all plugins, covering both count and daily).

### Steps to test this PR

- [ ] Type `Duck.ai` (capitalised) in the omnibar and submit → `m_aichat_duck_ai_direct_navigation_count` + `_daily` fire (pixel debug viewer).
- [ ] Confirm the fired pixels carry no `atb` param.
- [ ] Lowercase `duck.ai` still fires as before.

### UI changes
No UI changes (analytics only).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes to pixel firing conditions and param stripping; no user-facing or security behavior.
> 
> **Overview**
> Follow-up analytics fixes for **Duck.ai direct-navigation** pixels (`m_aichat_duck_ai_direct_navigation_count` / `_daily`).
> 
> **`isTypedDuckAiUrl`** now compares hosts case-insensitively by lowercasing the parsed URL host and `duckAiHostProvider.getHost()`, so omnibar submits like `Duck.ai` fire the direct-navigation pixels the same as `duck.ai`.
> 
> **ATB stripping:** both pixel names are registered in `EngagementPixelsParamRemovalPlugin` with `removeAtb()`, aligning outgoing events with pixel definitions so triage is not rejected for an unexpected `atb` param.
> 
> A unit test covers uppercase-host submission firing `AI_CHAT_DUCK_AI_DIRECT_NAVIGATION_COUNT`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 530a5a54bc4e459d42754a48e07cfc9a0f374ac4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->