### PR TITLE
Fix Duck.ai native input padding

### DIFF
--- a/duckchat/duckchat-impl/src/main/res/layout/view_native_input_mode_switch_widget.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_native_input_mode_switch_widget.xml
@@ -212,6 +212,7 @@
                             android:id="@id/optionsButtonContainer"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
+                            android:layout_marginStart="@dimen/nativeInputDuckAiControlSpacing"
                             android:visibility="gone"
                             tools:visibility="visible" />
 
@@ -237,7 +238,7 @@
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_gravity="center_vertical"
-                            android:layout_marginStart="@dimen/keyline_1"
+                            android:layout_marginStart="@dimen/nativeInputDuckAiModelPickerSpacing"
                             android:visibility="gone"
                             tools:visibility="visible" />
 

--- a/duckchat/duckchat-impl/src/main/res/layout/view_native_input_mode_switch_widget.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_native_input_mode_switch_widget.xml
@@ -108,9 +108,9 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="horizontal"
-                    android:paddingStart="@dimen/keyline_0"
+                    android:paddingStart="@dimen/nativeInputDuckAiCardContentPaddingHorizontal"
                     android:paddingTop="@dimen/keyline_empty"
-                    android:paddingEnd="@dimen/keyline_empty"
+                    android:paddingEnd="@dimen/nativeInputDuckAiCardContentPaddingHorizontal"
                     android:paddingBottom="@dimen/keyline_empty">
 
                     <EditText
@@ -189,6 +189,8 @@
                     android:layout_marginTop="8dp"
                     android:clipChildren="false"
                     android:clipToPadding="false"
+                    android:paddingStart="@dimen/nativeInputDuckAiBottomRowPaddingHorizontal"
+                    android:paddingEnd="@dimen/nativeInputDuckAiBottomRowPaddingHorizontal"
                     android:visibility="gone"
                     tools:visibility="visible">
 

--- a/duckchat/duckchat-impl/src/main/res/values/dimens.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/dimens.xml
@@ -20,6 +20,8 @@
     <dimen name="inputScreenOmnibarCardMarginHorizontal">4dp</dimen>
     <dimen name="inputScreenMarginHorizontal">0dp</dimen>
     <dimen name="nativeInputModeWidgetMarginHorizontal">4dp</dimen>
+    <dimen name="nativeInputDuckAiCardContentPaddingHorizontal">@dimen/keyline_2</dimen>
+    <dimen name="nativeInputDuckAiBottomRowPaddingHorizontal">@dimen/keyline_2</dimen>
     <dimen name="inputScreenAutocompleteListBottomSpace">64dp</dimen>
     <dimen name="inputScreenContentSeparatorHeight">0.5dp</dimen>
     <dimen name="contextualBottomSheetTopOffset">80dp</dimen>

--- a/duckchat/duckchat-impl/src/main/res/values/dimens.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/dimens.xml
@@ -22,6 +22,8 @@
     <dimen name="nativeInputModeWidgetMarginHorizontal">4dp</dimen>
     <dimen name="nativeInputDuckAiCardContentPaddingHorizontal">@dimen/keyline_2</dimen>
     <dimen name="nativeInputDuckAiBottomRowPaddingHorizontal">@dimen/keyline_2</dimen>
+    <dimen name="nativeInputDuckAiControlSpacing">6dp</dimen>
+    <dimen name="nativeInputDuckAiModelPickerSpacing">@dimen/keyline_1</dimen>
     <dimen name="inputScreenAutocompleteListBottomSpace">64dp</dimen>
     <dimen name="inputScreenContentSeparatorHeight">0.5dp</dimen>
     <dimen name="contextualBottomSheetTopOffset">80dp</dimen>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1215497088488464?focus=true

### Description
- Adds explicit Duck.ai native input spacing resources.
- Applies the missing horizontal inset to the Duck.ai native input text row.
- Aligns the focused Duck.ai bottom controls row to the annotated spacing, including control gaps and model picker spacing.

### Steps to test this PR

_Native Duck.ai input padding_
- [x] `JAVA_HOME=/tmp/jdk21 PATH=/tmp/jdk21/bin:$PATH ./gradlew :duckchat-impl:testDebugUnitTest -PuseProprietaryFont=false`
- [x] Captured before/after screenshots with Maestro on emulator densities 320 dpi and 440 dpi.
- [ ] Open Duck.ai with native input enabled on a device and confirm the input text row and bottom controls match the expected horizontal padding.

### UI changes
| 320 dpi comparison | 440 dpi comparison |
| ------ | ----- |
| <img alt="Before and after Duck.ai native input at 320 dpi" src="https://raw.githubusercontent.com/duckduckgo/Android/8a569d39e4a381db78bd59d4635f3c2d9a1bb115/pr-artifacts/native-input-padding/comparison-density-320.png" /> | <img alt="Before and after Duck.ai native input at 440 dpi" src="https://raw.githubusercontent.com/duckduckgo/Android/8a569d39e4a381db78bd59d4635f3c2d9a1bb115/pr-artifacts/native-input-padding/comparison-density-440.png" /> |

<details>
<summary>Individual screenshots</summary>

| Before  | After |
| ------ | ----- |
| <img alt="Before Duck.ai native input at 320 dpi" src="https://raw.githubusercontent.com/duckduckgo/Android/8a569d39e4a381db78bd59d4635f3c2d9a1bb115/pr-artifacts/native-input-padding/before-density-320.png" /> | <img alt="After Duck.ai native input at 320 dpi" src="https://raw.githubusercontent.com/duckduckgo/Android/8a569d39e4a381db78bd59d4635f3c2d9a1bb115/pr-artifacts/native-input-padding/after-density-320.png" /> |
| <img alt="Before Duck.ai native input at 440 dpi" src="https://raw.githubusercontent.com/duckduckgo/Android/8a569d39e4a381db78bd59d4635f3c2d9a1bb115/pr-artifacts/native-input-padding/before-density-440.png" /> | <img alt="After Duck.ai native input at 440 dpi" src="https://raw.githubusercontent.com/duckduckgo/Android/8a569d39e4a381db78bd59d4635f3c2d9a1bb115/pr-artifacts/native-input-padding/after-density-440.png" /> |

</details>
