### PR TITLE
Android: App missing pixels for voice chat service and notification

### DIFF
--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -681,5 +681,33 @@
         "triggers": ["other"],
         "suffixes": ["form_factor"],
         "parameters": ["appVersion"]
+    },
+    "m_aichat_voice_notification_open_chat_tapped": {
+        "description": "User tapped the Open Chat action on the Duck.ai voice session notification, returning to the chat",
+        "owners": ["karlenDimla"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_voice_notification_end_chat_tapped": {
+        "description": "User tapped the End Chat action on the Duck.ai voice session notification",
+        "owners": ["karlenDimla"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_voice_service_started": {
+        "description": "The Duck.ai voice microphone foreground service was created (voice session resources active)",
+        "owners": ["karlenDimla"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_voice_service_killed": {
+        "description": "The Duck.ai voice microphone foreground service was destroyed (voice session resources released)",
+        "owners": ["karlenDimla"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -626,6 +626,10 @@ open class BrowserActivity : DuckDuckGoActivity() {
 
         intent.sanitize()
 
+        intent.getStringExtra(LAUNCH_FROM_NOTIFICATION_PIXEL_NAME)?.let {
+            viewModel.onLaunchedFromNotification(it)
+        }
+
         dataClearerForegroundAppRestartPixel.registerIntent(intent)
 
         if (dataClearer.dataClearerState.value == ApplicationClearDataState.FINISHED) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -114,7 +114,11 @@ import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 interface DuckChatPixels {
-    fun sendReportMetricPixel(reportMetric: ReportMetric, modelTier: ModelTier? = null)
+    fun sendReportMetricPixel(
+        reportMetric: ReportMetric,
+        modelTier: ModelTier? = null,
+    )
+
     fun reportOpen()
     fun reportContextualSheetOpened()
     fun reportContextualSheetDismissed()
@@ -146,7 +150,7 @@ interface DuckChatPixels {
     fun reportNativeStorageDeletionUsed(native: Boolean)
     fun reportVoiceSessionStarted()
     fun reportVoiceNotificationOpenChatTapped()
-    fun reportVoiceNotificationEndSessionTapped()
+    fun reportVoiceNotificationEndChatTapped()
     fun reportVoiceServiceStarted()
     fun reportVoiceServiceKilled()
 }
@@ -162,7 +166,10 @@ class RealDuckChatPixels @Inject constructor(
     private val termsOfServiceHandler: DuckChatTermsOfServiceHandler,
 ) : DuckChatPixels {
 
-    override fun sendReportMetricPixel(reportMetric: ReportMetric, modelTier: ModelTier?) {
+    override fun sendReportMetricPixel(
+        reportMetric: ReportMetric,
+        modelTier: ModelTier?,
+    ) {
         appCoroutineScope.launch(dispatcherProvider.io()) {
             var refreshAtb = false
             val sessionParams = mapOf(
@@ -173,10 +180,12 @@ class RealDuckChatPixels @Inject constructor(
                     refreshAtb = true
                     DUCK_CHAT_SEND_PROMPT_ONGOING_CHAT to sessionParams
                 }
+
                 USER_DID_SUBMIT_FIRST_PROMPT -> {
                     refreshAtb = true
                     DUCK_CHAT_START_NEW_CONVERSATION to sessionParams
                 }
+
                 USER_DID_OPEN_HISTORY -> DUCK_CHAT_OPEN_HISTORY to sessionParams
                 USER_DID_SELECT_FIRST_HISTORY_ITEM -> DUCK_CHAT_OPEN_MOST_RECENT_HISTORY_CHAT to sessionParams
                 USER_DID_CREATE_NEW_CHAT -> DUCK_CHAT_START_NEW_CONVERSATION_BUTTON_CLICKED to sessionParams
@@ -405,11 +414,8 @@ class RealDuckChatPixels @Inject constructor(
         pixel.fire(DuckChatPixelName.DUCK_CHAT_VOICE_NOTIFICATION_OPEN_CHAT_TAPPED)
     }
 
-    override fun reportVoiceNotificationEndSessionTapped() {
-        pixel.fireCountAndDaily(
-            DuckChatPixelName.DUCK_CHAT_VOICE_NOTIFICATION_END_SESSION_TAPPED_COUNT,
-            DuckChatPixelName.DUCK_CHAT_VOICE_NOTIFICATION_END_SESSION_TAPPED_DAILY,
-        )
+    override fun reportVoiceNotificationEndChatTapped() {
+        pixel.fire(DuckChatPixelName.DUCK_CHAT_VOICE_NOTIFICATION_END_CHAT_TAPPED)
     }
 
     override fun reportVoiceServiceStarted() {
@@ -551,8 +557,7 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_CHAT_VOICE_ENTRY_TAPPED_DAILY("m_aichat_voice_entry_tapped_daily"),
     DUCK_CHAT_VOICE_SESSION_STARTED("m_aichat_voice_session_started"),
     DUCK_CHAT_VOICE_NOTIFICATION_OPEN_CHAT_TAPPED("m_aichat_voice_notification_open_chat_tapped"),
-    DUCK_CHAT_VOICE_NOTIFICATION_END_SESSION_TAPPED_COUNT("m_aichat_voice_notification_end_session_tapped_count"),
-    DUCK_CHAT_VOICE_NOTIFICATION_END_SESSION_TAPPED_DAILY("m_aichat_voice_notification_end_session_tapped_daily"),
+    DUCK_CHAT_VOICE_NOTIFICATION_END_CHAT_TAPPED("m_aichat_voice_notification_end_chat_tapped"),
     DUCK_CHAT_VOICE_SERVICE_STARTED("m_aichat_voice_service_started"),
     DUCK_CHAT_VOICE_SERVICE_KILLED("m_aichat_voice_service_killed"),
     DUCK_CHAT_CONTEXTUAL_FIRE_BUTTON_TAPPED_FIRST("m_aichat_contextual_fire_button_tapped_first"),
@@ -744,8 +749,7 @@ class DuckChatParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin
             DuckChatPixelName.DUCK_CHAT_VOICE_ENTRY_TAPPED_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_VOICE_SESSION_STARTED.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_VOICE_NOTIFICATION_OPEN_CHAT_TAPPED.pixelName to PixelParameter.removeAtb(),
-            DuckChatPixelName.DUCK_CHAT_VOICE_NOTIFICATION_END_SESSION_TAPPED_COUNT.pixelName to PixelParameter.removeAtb(),
-            DuckChatPixelName.DUCK_CHAT_VOICE_NOTIFICATION_END_SESSION_TAPPED_DAILY.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_VOICE_NOTIFICATION_END_CHAT_TAPPED.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_VOICE_SERVICE_STARTED.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_VOICE_SERVICE_KILLED.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_SETTINGS_DEFAULT_TOGGLE_POSITION_CHANGED_COUNT.pixelName to PixelParameter.removeAtb(),

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -149,7 +149,6 @@ interface DuckChatPixels {
     fun reportNativeStorageReaderUsed(native: Boolean)
     fun reportNativeStorageDeletionUsed(native: Boolean)
     fun reportVoiceSessionStarted()
-    fun reportVoiceNotificationOpenChatTapped()
     fun reportVoiceNotificationEndChatTapped()
     fun reportVoiceServiceStarted()
     fun reportVoiceServiceKilled()
@@ -408,10 +407,6 @@ class RealDuckChatPixels @Inject constructor(
 
     override fun reportVoiceSessionStarted() {
         pixel.fire(DuckChatPixelName.DUCK_CHAT_VOICE_SESSION_STARTED)
-    }
-
-    override fun reportVoiceNotificationOpenChatTapped() {
-        pixel.fire(DuckChatPixelName.DUCK_CHAT_VOICE_NOTIFICATION_OPEN_CHAT_TAPPED)
     }
 
     override fun reportVoiceNotificationEndChatTapped() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -145,6 +145,10 @@ interface DuckChatPixels {
     fun reportNativeStorageReaderUsed(native: Boolean)
     fun reportNativeStorageDeletionUsed(native: Boolean)
     fun reportVoiceSessionStarted()
+    fun reportVoiceNotificationOpenChatTapped()
+    fun reportVoiceNotificationEndSessionTapped()
+    fun reportVoiceServiceStarted()
+    fun reportVoiceServiceKilled()
 }
 
 @ContributesBinding(AppScope::class)
@@ -396,6 +400,25 @@ class RealDuckChatPixels @Inject constructor(
     override fun reportVoiceSessionStarted() {
         pixel.fire(DuckChatPixelName.DUCK_CHAT_VOICE_SESSION_STARTED)
     }
+
+    override fun reportVoiceNotificationOpenChatTapped() {
+        pixel.fire(DuckChatPixelName.DUCK_CHAT_VOICE_NOTIFICATION_OPEN_CHAT_TAPPED)
+    }
+
+    override fun reportVoiceNotificationEndSessionTapped() {
+        pixel.fireCountAndDaily(
+            DuckChatPixelName.DUCK_CHAT_VOICE_NOTIFICATION_END_SESSION_TAPPED_COUNT,
+            DuckChatPixelName.DUCK_CHAT_VOICE_NOTIFICATION_END_SESSION_TAPPED_DAILY,
+        )
+    }
+
+    override fun reportVoiceServiceStarted() {
+        pixel.fire(DuckChatPixelName.DUCK_CHAT_VOICE_SERVICE_STARTED)
+    }
+
+    override fun reportVoiceServiceKilled() {
+        pixel.fire(DuckChatPixelName.DUCK_CHAT_VOICE_SERVICE_KILLED)
+    }
 }
 
 enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
@@ -527,6 +550,11 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_CHAT_VOICE_ENTRY_TAPPED_COUNT("m_aichat_voice_entry_tapped_count"),
     DUCK_CHAT_VOICE_ENTRY_TAPPED_DAILY("m_aichat_voice_entry_tapped_daily"),
     DUCK_CHAT_VOICE_SESSION_STARTED("m_aichat_voice_session_started"),
+    DUCK_CHAT_VOICE_NOTIFICATION_OPEN_CHAT_TAPPED("m_aichat_voice_notification_open_chat_tapped"),
+    DUCK_CHAT_VOICE_NOTIFICATION_END_SESSION_TAPPED_COUNT("m_aichat_voice_notification_end_session_tapped_count"),
+    DUCK_CHAT_VOICE_NOTIFICATION_END_SESSION_TAPPED_DAILY("m_aichat_voice_notification_end_session_tapped_daily"),
+    DUCK_CHAT_VOICE_SERVICE_STARTED("m_aichat_voice_service_started"),
+    DUCK_CHAT_VOICE_SERVICE_KILLED("m_aichat_voice_service_killed"),
     DUCK_CHAT_CONTEXTUAL_FIRE_BUTTON_TAPPED_FIRST("m_aichat_contextual_fire_button_tapped_first"),
     DUCK_CHAT_CONTEXTUAL_FIRE_BUTTON_TAPPED_DAILY("m_aichat_contextual_fire_button_tapped_daily"),
     DUCK_CHAT_CONTEXTUAL_FIRE_BUTTON_TAPPED_COUNT("m_aichat_contextual_fire_button_tapped_count"),
@@ -715,6 +743,11 @@ class DuckChatParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin
             DuckChatPixelName.DUCK_CHAT_VOICE_ENTRY_TAPPED_COUNT.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_VOICE_ENTRY_TAPPED_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_VOICE_SESSION_STARTED.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_VOICE_NOTIFICATION_OPEN_CHAT_TAPPED.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_VOICE_NOTIFICATION_END_SESSION_TAPPED_COUNT.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_VOICE_NOTIFICATION_END_SESSION_TAPPED_DAILY.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_VOICE_SERVICE_STARTED.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_VOICE_SERVICE_KILLED.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_SETTINGS_DEFAULT_TOGGLE_POSITION_CHANGED_COUNT.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_SETTINGS_DEFAULT_TOGGLE_POSITION_CHANGED_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_FIRE_BUTTON_TAPPED_FIRST.pixelName to PixelParameter.removeAtb(),

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceMicrophoneService.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceMicrophoneService.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.ServiceScope
 import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import dagger.android.AndroidInjection
 import javax.inject.Inject
@@ -110,6 +111,8 @@ class DuckChatVoiceMicrophoneService : Service() {
     private fun openChatPendingIntent(tabId: String): PendingIntent {
         val intent = browserNav.openExistingTab(this, tabId).apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP
+            // Consumed by BrowserActivity to fire a pixel on cold/warm resume from a notification tap.
+            putExtra(LAUNCH_FROM_NOTIFICATION_PIXEL_NAME_EXTRA, DuckChatPixelName.DUCK_CHAT_VOICE_NOTIFICATION_OPEN_CHAT_TAPPED.pixelName)
         }
         return PendingIntent.getActivity(
             this,
@@ -152,6 +155,9 @@ class DuckChatVoiceMicrophoneService : Service() {
         private const val REQUEST_CODE_END_SESSION = 2
         private const val REQUEST_CODE_FALLBACK = 3
         private const val EXTRA_TAB_ID = "EXTRA_TAB_ID"
+
+        // Must match BrowserActivity.LAUNCH_FROM_NOTIFICATION_PIXEL_NAME — :app reads this extra to fire a pixel on resume.
+        private const val LAUNCH_FROM_NOTIFICATION_PIXEL_NAME_EXTRA = "LAUNCH_FROM_NOTIFICATION_PIXEL_NAME"
 
         fun start(context: Context, tabId: String) {
             val intent = Intent(context, DuckChatVoiceMicrophoneService::class.java).apply {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceMicrophoneService.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceMicrophoneService.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.di.scopes.ServiceScope
 import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import dagger.android.AndroidInjection
 import javax.inject.Inject
 
@@ -49,12 +50,21 @@ class DuckChatVoiceMicrophoneService : Service() {
     @Inject
     lateinit var browserNav: BrowserNav
 
+    @Inject
+    lateinit var duckChatPixels: DuckChatPixels
+
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onCreate() {
         super.onCreate()
         AndroidInjection.inject(this)
         createNotificationChannel()
+        duckChatPixels.reportVoiceServiceStarted()
+    }
+
+    override fun onDestroy() {
+        duckChatPixels.reportVoiceServiceKilled()
+        super.onDestroy()
     }
 
     override fun onStartCommand(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceNotificationActionReceiver.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceNotificationActionReceiver.kt
@@ -24,6 +24,7 @@ import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.common.utils.extensions.registerNotExportedReceiver
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.voice.VoiceSessionStateManager
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
@@ -37,6 +38,7 @@ import javax.inject.Inject
 class DuckChatVoiceNotificationActionReceiver @Inject constructor(
     private val context: Context,
     private val voiceSessionStateManager: VoiceSessionStateManager,
+    private val duckChatPixels: DuckChatPixels,
 ) : BroadcastReceiver(), MainProcessLifecycleObserver {
 
     override fun onCreate(owner: LifecycleOwner) {
@@ -56,6 +58,7 @@ class DuckChatVoiceNotificationActionReceiver @Inject constructor(
         if (intent.action != INTENT_VOICE_NOTIFICATION_ACTION) return
         val tabId = intent.getStringExtra(EXTRA_TAB_ID)?.takeIf { it.isNotBlank() } ?: return
 
+        duckChatPixels.reportVoiceNotificationEndSessionTapped()
         voiceSessionStateManager.triggerVoiceSessionEnd(tabId)
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceNotificationActionReceiver.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceNotificationActionReceiver.kt
@@ -58,7 +58,7 @@ class DuckChatVoiceNotificationActionReceiver @Inject constructor(
         if (intent.action != INTENT_VOICE_NOTIFICATION_ACTION) return
         val tabId = intent.getStringExtra(EXTRA_TAB_ID)?.takeIf { it.isNotBlank() } ?: return
 
-        duckChatPixels.reportVoiceNotificationEndSessionTapped()
+        duckChatPixels.reportVoiceNotificationEndChatTapped()
         voiceSessionStateManager.triggerVoiceSessionEnd(tabId)
     }
 

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceNotificationActionReceiverTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceNotificationActionReceiverTest.kt
@@ -20,12 +20,14 @@ import android.content.Context
 import android.content.Intent
 import androidx.lifecycle.LifecycleOwner
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.ui.DuckChatVoiceNotificationActionReceiver.Companion.endSessionIntent
 import com.duckduckgo.duckchat.impl.voice.VoiceSessionStateManager
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -36,21 +38,23 @@ class DuckChatVoiceNotificationActionReceiverTest {
 
     private val context: Context = mock()
     private val voiceSessionStateManager: VoiceSessionStateManager = mock()
+    private val duckChatPixels: DuckChatPixels = mock()
     private val lifecycleOwner: LifecycleOwner = mock()
 
     private lateinit var receiver: DuckChatVoiceNotificationActionReceiver
 
     @Before
     fun setUp() {
-        receiver = DuckChatVoiceNotificationActionReceiver(context, voiceSessionStateManager)
+        receiver = DuckChatVoiceNotificationActionReceiver(context, voiceSessionStateManager, duckChatPixels)
     }
 
     @Test
-    fun whenOnReceiveWithValidIntentThenTriggersVoiceSessionEnd() {
+    fun whenOnReceiveWithEndSessionIntentThenFiresPixelAndTriggersVoiceSessionEnd() {
         val intent = endSessionIntent(context, TAB_ID)
 
         receiver.onReceive(context, intent)
 
+        verify(duckChatPixels).reportVoiceNotificationEndSessionTapped()
         verify(voiceSessionStateManager).triggerVoiceSessionEnd(TAB_ID)
     }
 
@@ -63,6 +67,7 @@ class DuckChatVoiceNotificationActionReceiverTest {
         receiver.onReceive(context, intent)
 
         verifyNoInteractions(voiceSessionStateManager)
+        verifyNoInteractions(duckChatPixels)
     }
 
     @Test
@@ -72,7 +77,8 @@ class DuckChatVoiceNotificationActionReceiverTest {
 
         receiver.onReceive(context, intent)
 
-        verify(voiceSessionStateManager, never()).triggerVoiceSessionEnd(org.mockito.kotlin.any())
+        verify(voiceSessionStateManager, never()).triggerVoiceSessionEnd(any())
+        verifyNoInteractions(duckChatPixels)
     }
 
     @Test
@@ -81,7 +87,8 @@ class DuckChatVoiceNotificationActionReceiverTest {
 
         receiver.onReceive(context, intent)
 
-        verify(voiceSessionStateManager, never()).triggerVoiceSessionEnd(org.mockito.kotlin.any())
+        verify(voiceSessionStateManager, never()).triggerVoiceSessionEnd(any())
+        verifyNoInteractions(duckChatPixels)
     }
 
     @Test
@@ -90,7 +97,8 @@ class DuckChatVoiceNotificationActionReceiverTest {
 
         receiver.onReceive(context, intent)
 
-        verify(voiceSessionStateManager, never()).triggerVoiceSessionEnd(org.mockito.kotlin.any())
+        verify(voiceSessionStateManager, never()).triggerVoiceSessionEnd(any())
+        verifyNoInteractions(duckChatPixels)
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceNotificationActionReceiverTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/ui/DuckChatVoiceNotificationActionReceiverTest.kt
@@ -54,7 +54,7 @@ class DuckChatVoiceNotificationActionReceiverTest {
 
         receiver.onReceive(context, intent)
 
-        verify(duckChatPixels).reportVoiceNotificationEndSessionTapped()
+        verify(duckChatPixels).reportVoiceNotificationEndChatTapped()
         verify(voiceSessionStateManager).triggerVoiceSessionEnd(TAB_ID)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1215567316447344?focus=true
Tech Design URL (if applicable): 

### Description
Adds the missing pixels related to the voice chat service

### Steps to test this PR                                                                                                                                                                                  ### Setup                                                                                                                                                                                                          
  - [ ] Install an internal build with pixel logging visible (logcat filter `Pixel sent`)                                                                                                           
  - [ ] Open Duck.ai and start a Duck.ai voice chat session in a tab (so the microphone foreground service starts and the "Duck.ai voice mode active" notification appears in the shade)                             
  - [ ] Confirm the notification shows both **Open Chat** and **End Chat** actions                                                                                                                                   
  - [ ] Clear any prior pixel log entries before each scenario below                                                                                                                                                 
                                                                                                                                                                                                                     
### 1. Voice session start — service `onCreate`                                                                                                                                                                    
  - [ ] When the voice session begins, pixel `m_aichat_voice_service_started` IS fired exactly once        
  - [ ] The Duck.ai voice notification IS visible in the system notification shade                                                                                                                                   
                                                                                                                                                                                                                     
  ### 2. Tap "Open Chat" notification action — app already in foreground (warm path via `onNewIntent`)                                                                                                               
  - [ ] With the Duck.ai voice session active, switch to another app so Duck.ai goes to background but is NOT killed                                                                                               
  - [ ] Pull down the shade and tap the **Open Chat** action on the Duck.ai voice notification                                                                                                                       
  - [ ] The Duck.ai chat tab IS brought to the foreground (existing tab, not a new one)                                                                                                                              
  - [ ] Pixel `m_aichat_voice_notification_open_chat_tapped` IS fired exactly once                                                                                                                                   
  - [ ] Pixel `m_aichat_voice_service_killed` is **NOT** fired (the session is still active)   
  - [ ] Switch to another tab and background the app
  - [ ] Pull down the shade and tap the **Open Chat** action on the Duck.ai voice notification             
  - [ ]  The App with Duck.ai chat tab IS brought to the foreground           
  - [ ]  Pixel `m_aichat_voice_notification_open_chat_tapped` IS fired exactly once                                                                      
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
  ### 3. Tap "End Chat" notification action                                                                                                                                                                        
  - [ ] With the voice session active, pull down the shade and tap the **End Chat** action                                                                                                                           
  - [ ] Pixel `m_aichat_voice_notification_end_chat_tapped` IS fired exactly once                                                                                                                                    
  - [ ] The voice session ends (notification is dismissed; microphone indicator disappears)
  - [ ] Pixel `m_aichat_voice_service_killed` IS fired exactly once shortly after, as the foreground service is destroyed                                                                                            
                                                                                                                                                                                                                     
  ### 4. Voice session ended from the Duck.ai UI (not the notification)                                                                                                                                              
  - [ ] Start a voice session, then end it from inside the Duck.ai chat UI (not via the notification action)                                                                                                         
  - [ ] Pixel `m_aichat_voice_service_killed` IS fired exactly once                                                                                                                                                  
  - [ ] Pixel `m_aichat_voice_notification_end_chat_tapped` is **NOT** fired (this pixel is specific to the notification action)                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                                                                           

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only changes with no auth, data, or session logic changes beyond firing pixels at existing lifecycle and notification entry points.
> 
> **Overview**
> Adds **analytics pixels** for Duck.ai **voice** foreground service lifecycle and **notification** actions that were previously missing.
> 
> Four new metrics are registered in pixel definitions and wired through `DuckChatPixels`: **`m_aichat_voice_service_started`** / **`m_aichat_voice_service_killed`** fire when the microphone foreground service is created and destroyed; **`m_aichat_voice_notification_end_chat_tapped`** fires when the End Chat broadcast is handled; **`m_aichat_voice_notification_open_chat_tapped`** is passed on the Open Chat activity intent and fired via existing `BrowserActivity` / `onLaunchedFromNotification` handling (including the new **`onNewIntent`** path for warm resume).
> 
> Receiver unit tests now assert the end-chat pixel fires only on valid end-session intents.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbf8a0fb10b027d7b558189ebe10727e390bf80b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->