### PR TITLE
add onboarding module with LinearOnboardingOrchestrator

### DIFF
--- a/onboarding/onboarding-api/build.gradle
+++ b/onboarding/onboarding-api/build.gradle
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+}
+
+apply from: "$rootProject.projectDir/gradle/android-library.gradle"
+
+android {
+    namespace "com.duckduckgo.onboarding.api"
+}
+
+dependencies {
+    implementation KotlinX.coroutines.core
+}

--- a/onboarding/onboarding-api/src/main/java/com/duckduckgo/onboarding/api/LinearOnboardingOrchestrator.kt
+++ b/onboarding/onboarding-api/src/main/java/com/duckduckgo/onboarding/api/LinearOnboardingOrchestrator.kt
@@ -109,7 +109,20 @@ data class LinearOnboardingPlan(
     val onCompleted: suspend () -> Unit = {},
     val onSkipped: suspend () -> Unit = {},
     val result: suspend () -> LinearOnboardingResult? = { null },
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as LinearOnboardingPlan
+
+        return id == other.id
+    }
+
+    override fun hashCode(): Int {
+        return id.hashCode()
+    }
+}
 
 /** A stable, human-readable id for a plan, handy for filtering and telemetry. Not persisted. */
 typealias LinearOnboardingPlanId = String

--- a/onboarding/onboarding-api/src/main/java/com/duckduckgo/onboarding/api/LinearOnboardingOrchestrator.kt
+++ b/onboarding/onboarding-api/src/main/java/com/duckduckgo/onboarding/api/LinearOnboardingOrchestrator.kt
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.onboarding.api
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterIsInstance
+
+/**
+ * Drives one linear onboarding run at a time.
+ *
+ * A run is a [LinearOnboardingPlan] (ordered steps plus terminal callbacks). The orchestrator walks it,
+ * skipping steps whose [LinearOnboardingStep.precondition] is false, and exposes the current position as
+ * [state]. A step can branch by returning a [LinearOnboardingTransition]: [LinearOnboardingTransition.SwitchTo]
+ * pushes a side plan, [LinearOnboardingTransition.Return] pops back to its caller.
+ *
+ * It never touches UI: renderers observe [state] and report user actions via [onEvent].
+ *
+ * Implementations are thread-safe and serialise calls. Step and plan callbacks run inside that
+ * serialization, so they must not call back into [startPlan] / [onEvent] — a reentrant call throws
+ * IllegalStateException rather than deadlocking.
+ */
+interface LinearOnboardingOrchestrator {
+    /**
+     * Current position. [LinearOnboardingState.NotStarted] until the first [startPlan], then
+     * [LinearOnboardingState.InProgress] through to a terminal [LinearOnboardingState.Completed] /
+     * [LinearOnboardingState.Skipped]; restarting from a terminal state returns to InProgress. Never
+     * NotStarted again once started.
+     */
+    val state: StateFlow<LinearOnboardingState>
+
+    /**
+     * Begins a run with [plan] from its first eligible step; [state] is up to date by the time this returns
+     * (InProgress, or terminal if no step is eligible). Allowed from NotStarted or a terminal state; no-op
+     * while a run is in progress.
+     */
+    suspend fun startPlan(plan: LinearOnboardingPlan)
+
+    /**
+     * Forwards [event] to the current step's [LinearOnboardingStep.transition] and applies the result.
+     * No-op before start or after terminal.
+     */
+    suspend fun onEvent(event: LinearOnboardingEvent)
+}
+
+/** Where a run is: not yet started, mid-flow on a given step, or finished (completed / skipped). */
+sealed interface LinearOnboardingState {
+    /** No run has started. */
+    data object NotStarted : LinearOnboardingState
+
+    /**
+     * A run that has started (in progress or finished). [rootPlanId] is the root (bottom-of-stack) plan's id,
+     * the flow this run belongs to, so a consumer can scope to one flow regardless of the current step or
+     * side plan.
+     */
+    sealed interface Started : LinearOnboardingState {
+        val rootPlanId: LinearOnboardingPlanId
+    }
+
+    /**
+     * Paused on [currentStep] (the [currentStepIndex]-th step of [currentPlan]) awaiting the next event.
+     * [currentPlan] is the top-of-stack frame, which may be a side plan; [rootPlanId] is the root.
+     */
+    data class InProgress(
+        override val rootPlanId: LinearOnboardingPlanId,
+        val currentPlan: LinearOnboardingPlan,
+        val currentStepIndex: Int,
+    ) : Started {
+        val currentStep: LinearOnboardingStep
+            get() = currentPlan.steps[currentStepIndex]
+    }
+
+    /**
+     * Reached by walking off the end of the root plan. [result] is the root plan's outcome (e.g. a query to
+     * launch on handoff to the browser), or null. Terminal until a new run starts.
+     */
+    data class Completed(
+        override val rootPlanId: LinearOnboardingPlanId,
+        val result: LinearOnboardingResult? = null,
+    ) : Started
+
+    /** The run finished early via [LinearOnboardingTransition.AbortPlan]. Terminal until a new run is started. */
+    data class Skipped(override val rootPlanId: LinearOnboardingPlanId) : Started
+}
+
+/**
+ * Opaque marker for what a completed run produced (e.g. a pending query). The orchestrator only carries the
+ * root plan's [LinearOnboardingPlan.result] into [LinearOnboardingState.Completed.result]; concrete types
+ * live with the plan provider.
+ */
+interface LinearOnboardingResult
+
+/**
+ * Ordered [steps] plus terminal callbacks. [onCompleted] / [onSkipped] run before the matching terminal state
+ * is emitted, and on completion [result] is carried into [LinearOnboardingState.Completed.result].
+ * Only the root plan's callbacks and [result] fire.
+ * A side plan (pushed via [LinearOnboardingTransition.SwitchTo]) that aborts or exhausts surfaces through the root.
+ */
+data class LinearOnboardingPlan(
+    val id: LinearOnboardingPlanId,
+    val steps: List<LinearOnboardingStep>,
+    val onCompleted: suspend () -> Unit = {},
+    val onSkipped: suspend () -> Unit = {},
+    val result: suspend () -> LinearOnboardingResult? = { null },
+)
+
+/** Stable, human-readable identifier for a plan (e.g. for filtering/telemetry). Not persisted. */
+typealias LinearOnboardingPlanId = String
+
+/** Stable, human-readable identifier for a step (e.g. for logging/telemetry). Not persisted. */
+typealias LinearOnboardingStepId = String
+
+/**
+ * One step of a plan. Concrete steps live with the plan provider; this is the minimum the
+ * orchestrator needs to walk a plan. Renderer-specific data (which dialog to show, etc.) is added by
+ * host-specific subtypes the renderer downcasts to.
+ */
+interface LinearOnboardingStep {
+    /** Identifies the step within its plan. See [LinearOnboardingStepId]. */
+    val id: LinearOnboardingStepId
+
+    /** Which host renders this step. The orchestrator carries it so a renderer can route the handoff. */
+    val host: LinearOnboardingHost
+
+    /** Evaluated as the orchestrator advances; when false the step is skipped (not shown). */
+    val precondition: suspend () -> Boolean
+
+    /** Maps an incoming event to the next [LinearOnboardingTransition]. Returns [LinearOnboardingTransition.Stay] to ignore it. */
+    val transition: suspend (LinearOnboardingEvent) -> LinearOnboardingTransition
+}
+
+/** The screen that renders a step. The orchestrator only tags steps with it; routing is the caller's job. */
+enum class LinearOnboardingHost {
+    OnboardingActivity,
+    BrowserActivity,
+}
+
+/**
+ * Opaque marker; the orchestrator only routes events to [LinearOnboardingStep.transition]. Concrete event
+ * types live with the plan provider.
+ */
+interface LinearOnboardingEvent
+
+sealed interface LinearOnboardingTransition {
+    /** Move to the next eligible step in the current plan; with none left, the run completes via the root plan. */
+    data object Advance : LinearOnboardingTransition
+
+    /**
+     * Push a new frame and run [plan] from its first eligible step. The side plan resumes the caller only via
+     * [Return]; running off its end (no [Return]) completes the whole run via the root plan.
+     */
+    data class SwitchTo(val plan: LinearOnboardingPlan) : LinearOnboardingTransition
+
+    /** Pop the top frame; advance the caller past the step that pushed. */
+    data object Return : LinearOnboardingTransition
+
+    /** Terminate the entire flow as Skipped (clears the whole frame stack). */
+    data object AbortPlan : LinearOnboardingTransition
+
+    /** Explicit no-op. */
+    data object Stay : LinearOnboardingTransition
+}
+
+/**
+ * States of the run for [planId], in-progress and terminal; [LinearOnboardingState.NotStarted] and other
+ * plans' states never match. A new collector receives the current matching state on subscription.
+ */
+fun Flow<LinearOnboardingState>.forPlan(planId: LinearOnboardingPlanId): Flow<LinearOnboardingState.Started> =
+    filterIsInstance<LinearOnboardingState.Started>().filter { it.rootPlanId == planId }

--- a/onboarding/onboarding-api/src/main/java/com/duckduckgo/onboarding/api/LinearOnboardingOrchestrator.kt
+++ b/onboarding/onboarding-api/src/main/java/com/duckduckgo/onboarding/api/LinearOnboardingOrchestrator.kt
@@ -22,59 +22,55 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterIsInstance
 
 /**
- * Drives one linear onboarding run at a time.
+ * Drives one linear onboarding run at a time. It walks a [LinearOnboardingPlan]'s steps, skips any whose
+ * [LinearOnboardingStep.precondition] is false, and publishes the current position as [state]. A step can branch
+ * by returning a [LinearOnboardingTransition]. [LinearOnboardingTransition.SwitchTo] pushes a side plan, and
+ * [LinearOnboardingTransition.ReturnAndAdvance] pops back to its caller.
  *
- * A run is a [LinearOnboardingPlan] (ordered steps plus terminal callbacks). The orchestrator walks it,
- * skipping steps whose [LinearOnboardingStep.precondition] is false, and exposes the current position as
- * [state]. A step can branch by returning a [LinearOnboardingTransition]: [LinearOnboardingTransition.SwitchTo]
- * pushes a side plan, [LinearOnboardingTransition.Return] pops back to its caller.
+ * It never touches UI. Renderers observe [state] and report user actions through [onEvent].
  *
- * It never touches UI: renderers observe [state] and report user actions via [onEvent].
- *
- * Implementations are thread-safe and serialise calls. Step and plan callbacks run inside that
- * serialization, so they must not call back into [startPlan] / [onEvent] — a reentrant call throws
- * IllegalStateException rather than deadlocking.
+ * Implementations are thread-safe and run calls one at a time. Step and plan callbacks run inside that same
+ * serialization, so they must not call back into [startPlan] or [onEvent]. A reentrant call throws
+ * IllegalStateException instead of deadlocking.
  */
 interface LinearOnboardingOrchestrator {
     /**
-     * Current position. [LinearOnboardingState.NotStarted] until the first [startPlan], then
-     * [LinearOnboardingState.InProgress] through to a terminal [LinearOnboardingState.Completed] /
-     * [LinearOnboardingState.Skipped]; restarting from a terminal state returns to InProgress. Never
-     * NotStarted again once started.
+     * Where the run currently is. It starts as [LinearOnboardingState.NotStarted], becomes
+     * [LinearOnboardingState.InProgress] on the first [startPlan], and ends at [LinearOnboardingState.Completed]
+     * or [LinearOnboardingState.Skipped]. Starting again from a terminal state goes back to InProgress. Once a
+     * run has started it is never NotStarted again.
      */
     val state: StateFlow<LinearOnboardingState>
 
     /**
-     * Begins a run with [plan] from its first eligible step; [state] is up to date by the time this returns
-     * (InProgress, or terminal if no step is eligible). Allowed from NotStarted or a terminal state; no-op
-     * while a run is in progress.
+     * Starts a run with [plan] from its first eligible step. [state] is up to date by the time this returns.
+     * You can call it from NotStarted or a terminal state. It does nothing while a run is already in progress.
      */
     suspend fun startPlan(plan: LinearOnboardingPlan)
 
     /**
-     * Forwards [event] to the current step's [LinearOnboardingStep.transition] and applies the result.
-     * No-op before start or after terminal.
+     * Passes [event] to the current step's [LinearOnboardingStep.transition] and applies the result.
+     * Does nothing before the run starts or after it ends.
      */
     suspend fun onEvent(event: LinearOnboardingEvent)
 }
 
-/** Where a run is: not yet started, mid-flow on a given step, or finished (completed / skipped). */
+/** Where a run is. Either not yet started, paused on a step, or finished (completed or skipped). */
 sealed interface LinearOnboardingState {
-    /** No run has started. */
     data object NotStarted : LinearOnboardingState
 
     /**
-     * A run that has started (in progress or finished). [rootPlanId] is the root (bottom-of-stack) plan's id,
-     * the flow this run belongs to, so a consumer can scope to one flow regardless of the current step or
-     * side plan.
+     * A run that has started, whether in progress or finished. [rootPlanId] is the id of the root plan, the one
+     * at the bottom of the stack. It stays the same across side plans, so a consumer can scope to a single flow
+     * no matter which step is current.
      */
     sealed interface Started : LinearOnboardingState {
         val rootPlanId: LinearOnboardingPlanId
     }
 
     /**
-     * Paused on [currentStep] (the [currentStepIndex]-th step of [currentPlan]) awaiting the next event.
-     * [currentPlan] is the top-of-stack frame, which may be a side plan; [rootPlanId] is the root.
+     * Paused on [currentStep], the [currentStepIndex]-th step of [currentPlan], waiting for the next event.
+     * [currentPlan] is the frame on top of the stack and may be a side plan. [rootPlanId] is the root plan.
      */
     data class InProgress(
         override val rootPlanId: LinearOnboardingPlanId,
@@ -86,30 +82,26 @@ sealed interface LinearOnboardingState {
     }
 
     /**
-     * Reached by walking off the end of the root plan. [result] is the root plan's outcome (e.g. a query to
-     * launch on handoff to the browser), or null. Terminal until a new run starts.
+     * Reached by running past the last step of the top plan. [result] is the root plan's outcome, such as a
+     * query to launch when handing off to the browser, or null. This state is terminal.
      */
     data class Completed(
         override val rootPlanId: LinearOnboardingPlanId,
         val result: LinearOnboardingResult? = null,
     ) : Started
 
-    /** The run finished early via [LinearOnboardingTransition.AbortPlan]. Terminal until a new run is started. */
+    /** Reached through [LinearOnboardingTransition.AbortPlan], which clears the whole frame stack. This state is terminal. */
     data class Skipped(override val rootPlanId: LinearOnboardingPlanId) : Started
 }
 
-/**
- * Opaque marker for what a completed run produced (e.g. a pending query). The orchestrator only carries the
- * root plan's [LinearOnboardingPlan.result] into [LinearOnboardingState.Completed.result]; concrete types
- * live with the plan provider.
- */
+/** A marker for whatever a completed run produced, such as a pending query. Concrete types live with the plan provider. */
 interface LinearOnboardingResult
 
 /**
- * Ordered [steps] plus terminal callbacks. [onCompleted] / [onSkipped] run before the matching terminal state
- * is emitted, and on completion [result] is carried into [LinearOnboardingState.Completed.result].
- * Only the root plan's callbacks and [result] fire.
- * A side plan (pushed via [LinearOnboardingTransition.SwitchTo]) that aborts or exhausts surfaces through the root.
+ * An ordered list of [steps] with callbacks for the end of the run. [onCompleted] and [onSkipped] run just
+ * before the matching terminal state, and on completion [result] is passed into
+ * [LinearOnboardingState.Completed.result]. Only the root plan's callbacks and [result] run. When a side plan
+ * aborts or runs out of steps, that outcome surfaces through the root.
  */
 data class LinearOnboardingPlan(
     val id: LinearOnboardingPlanId,
@@ -119,66 +111,60 @@ data class LinearOnboardingPlan(
     val result: suspend () -> LinearOnboardingResult? = { null },
 )
 
-/** Stable, human-readable identifier for a plan (e.g. for filtering/telemetry). Not persisted. */
+/** A stable, human-readable id for a plan, handy for filtering and telemetry. Not persisted. */
 typealias LinearOnboardingPlanId = String
 
-/** Stable, human-readable identifier for a step (e.g. for logging/telemetry). Not persisted. */
+/** A stable, human-readable id for a step, handy for logging and telemetry. Not persisted. */
 typealias LinearOnboardingStepId = String
 
 /**
- * One step of a plan. Concrete steps live with the plan provider; this is the minimum the
- * orchestrator needs to walk a plan. Renderer-specific data (which dialog to show, etc.) is added by
- * host-specific subtypes the renderer downcasts to.
+ * The least the orchestrator needs to walk a plan. Concrete steps live with the plan provider. Anything a
+ * renderer needs, like which dialog to show, goes on host-specific subtypes that the renderer downcasts to.
  */
 interface LinearOnboardingStep {
-    /** Identifies the step within its plan. See [LinearOnboardingStepId]. */
     val id: LinearOnboardingStepId
 
-    /** Which host renders this step. The orchestrator carries it so a renderer can route the handoff. */
     val host: LinearOnboardingHost
 
-    /** Evaluated as the orchestrator advances; when false the step is skipped (not shown). */
+    /** Checked as the orchestrator advances. When it returns false the step is skipped and not shown. */
     val precondition: suspend () -> Boolean
 
-    /** Maps an incoming event to the next [LinearOnboardingTransition]. Returns [LinearOnboardingTransition.Stay] to ignore it. */
+    /** Turns an incoming event into the next [LinearOnboardingTransition]. Return [LinearOnboardingTransition.Stay] to ignore the event. */
     val transition: suspend (LinearOnboardingEvent) -> LinearOnboardingTransition
 }
 
-/** The screen that renders a step. The orchestrator only tags steps with it; routing is the caller's job. */
+/** The screen that renders a step. The orchestrator only tags steps with it. Routing is up to the caller. */
 enum class LinearOnboardingHost {
     OnboardingActivity,
     BrowserActivity,
 }
 
-/**
- * Opaque marker; the orchestrator only routes events to [LinearOnboardingStep.transition]. Concrete event
- * types live with the plan provider.
- */
+/** A marker for events. Concrete event types live with the plan provider. The orchestrator only routes them to [LinearOnboardingStep.transition]. */
 interface LinearOnboardingEvent
 
 sealed interface LinearOnboardingTransition {
-    /** Move to the next eligible step in the current plan; with none left, the run completes via the root plan. */
+    /** Move to the next eligible step in the current plan. If none are left, the run completes through the root plan. */
     data object Advance : LinearOnboardingTransition
 
     /**
-     * Push a new frame and run [plan] from its first eligible step. The side plan resumes the caller only via
-     * [Return]; running off its end (no [Return]) completes the whole run via the root plan.
+     * Push a new frame and run [plan] from its first eligible step. The caller only resumes if the side plan
+     * ends with [ReturnAndAdvance]. If the side plan runs past its last step without a [ReturnAndAdvance], the whole run completes
+     * through the root plan.
      */
     data class SwitchTo(val plan: LinearOnboardingPlan) : LinearOnboardingTransition
 
-    /** Pop the top frame; advance the caller past the step that pushed. */
-    data object Return : LinearOnboardingTransition
+    /** Pop the top frame and advance the caller past the step that pushed it. */
+    data object ReturnAndAdvance : LinearOnboardingTransition
 
-    /** Terminate the entire flow as Skipped (clears the whole frame stack). */
+    /** End the entire flow as Skipped and clear the whole frame stack. */
     data object AbortPlan : LinearOnboardingTransition
 
-    /** Explicit no-op. */
     data object Stay : LinearOnboardingTransition
 }
 
 /**
- * States of the run for [planId], in-progress and terminal; [LinearOnboardingState.NotStarted] and other
- * plans' states never match. A new collector receives the current matching state on subscription.
+ * The states of the run for [planId], both in-progress and terminal. [LinearOnboardingState.NotStarted] and
+ * states from other plans never match. A new collector gets the current matching state as soon as it subscribes.
  */
 fun Flow<LinearOnboardingState>.forPlan(planId: LinearOnboardingPlanId): Flow<LinearOnboardingState.Started> =
     filterIsInstance<LinearOnboardingState.Started>().filter { it.rootPlanId == planId }

--- a/onboarding/onboarding-impl/build.gradle
+++ b/onboarding/onboarding-impl/build.gradle
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'com.android.library'
+    id 'kotlin-android'
+    id 'com.squareup.anvil'
+    id 'com.google.devtools.ksp'
+}
+
+apply from: "$rootProject.projectDir/gradle/android-library.gradle"
+
+android {
+    namespace "com.duckduckgo.onboarding.impl"
+    anvil {
+        generateDaggerFactories = true // default is false
+    }
+}
+
+dependencies {
+    ksp project(':anvil-ksp')
+    implementation project(':anvil-annotations')
+    implementation project(':onboarding-api')
+    implementation project(':di')
+
+    implementation KotlinX.coroutines.core
+    implementation Google.dagger
+    implementation "com.squareup.logcat:logcat:_"
+
+    testImplementation Testing.junit4
+    testImplementation(KotlinX.coroutines.test) {
+        // conflicts with mockito due to direct inclusion of byte buddy
+        exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
+    }
+}

--- a/onboarding/onboarding-impl/src/main/java/com/duckduckgo/onboarding/impl/LinearOnboardingOrchestratorImpl.kt
+++ b/onboarding/onboarding-impl/src/main/java/com/duckduckgo/onboarding/impl/LinearOnboardingOrchestratorImpl.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.onboarding.impl
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.onboarding.api.LinearOnboardingEvent
+import com.duckduckgo.onboarding.api.LinearOnboardingOrchestrator
+import com.duckduckgo.onboarding.api.LinearOnboardingPlan
+import com.duckduckgo.onboarding.api.LinearOnboardingResult
+import com.duckduckgo.onboarding.api.LinearOnboardingState
+import com.duckduckgo.onboarding.api.LinearOnboardingTransition
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import logcat.logcat
+import javax.inject.Inject
+
+/**
+ * Implementation of [LinearOnboardingOrchestrator].
+ *
+ * A run is a stack of plan frames ([backStack], bottom = root plan); [onEvent] applies the transition the top
+ * step returns, pushing a side plan on [LinearOnboardingTransition.SwitchTo] and popping on
+ * [LinearOnboardingTransition.Return]. Running off the end of a frame completes the whole run via the root
+ * plan; only an explicit Return resumes a caller.
+ *
+ * [backStack] and [_state] are always written together (stack reassigned wholesale, never mutated in place),
+ * so they never drift. A non-reentrant mutex serialises events; step and plan callbacks run while it is held,
+ * so they must not call back into [startPlan] / [onEvent] (a reentrant call throws IllegalStateException
+ * instead of deadlocking). Root-plan terminal callbacks run before the terminal state is emitted, so anything
+ * they write (e.g. AppStage) is visible to listeners routing off Completed / Skipped.
+ */
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class LinearOnboardingOrchestratorImpl @Inject constructor() : LinearOnboardingOrchestrator {
+
+    private val _state = MutableStateFlow<LinearOnboardingState>(LinearOnboardingState.NotStarted)
+    override val state: StateFlow<LinearOnboardingState> = _state.asStateFlow()
+
+    private val mutex = Mutex()
+
+    // Frame stack (bottom = root plan, top = current).
+    // Always reassigned wholesale and together with [_state], so the two can't drift.
+    private var backStack: List<Frame> = emptyList()
+
+    override suspend fun startPlan(plan: LinearOnboardingPlan) {
+        // owner = current Job makes the mutex throw on a reentrant call instead of deadlocking; a genuinely
+        // concurrent caller has a different Job and waits as usual.
+        mutex.withLock(owner = currentCoroutineContext()[Job]) {
+            // No-op while a run is in progress (safe to call from more than one place at app start); a new run
+            // may begin before any run or from a terminal state.
+            if (backStack.isNotEmpty()) {
+                logcat { "startPlan ignored: a run is already in progress" }
+                return@withLock
+            }
+            advance(listOf(Frame(plan, index = 0)), fromIndex = 0)
+        }
+    }
+
+    override suspend fun onEvent(event: LinearOnboardingEvent) {
+        mutex.withLock(owner = currentCoroutineContext()[Job]) {
+            // No-op before start / after terminal.
+            val frames = backStack
+            if (frames.isEmpty()) return
+            val top = frames.last()
+            when (val transition = top.plan.steps[top.index].transition(event)) {
+                LinearOnboardingTransition.Advance ->
+                    advance(frames, fromIndex = top.index + 1)
+
+                is LinearOnboardingTransition.SwitchTo ->
+                    advance(frames + Frame(transition.plan, index = 0), fromIndex = 0)
+
+                LinearOnboardingTransition.Return -> {
+                    // Returning from the root frame is a programming error; treat as no-op.
+                    if (frames.size <= 1) return
+                    val caller = frames.dropLast(1)
+                    advance(caller, fromIndex = caller.last().index + 1)
+                }
+
+                LinearOnboardingTransition.AbortPlan -> terminateSkipped(frames.first().plan)
+
+                LinearOnboardingTransition.Stay -> Unit
+            }
+        }
+    }
+
+    // Advances the top frame from [fromIndex] past ineligible steps, then publishes the new position. Running
+    // off the end of a frame completes the whole run via the root plan, whether that frame is the root or a
+    // side plan; resuming a caller only happens on an explicit Return. [frames] is local, so a throwing
+    // precondition leaves [backStack] / [_state] untouched.
+    private suspend fun advance(frames: List<Frame>, fromIndex: Int) {
+        val top = frames.last()
+        var index = fromIndex
+        while (index < top.plan.steps.size && !top.plan.steps[index].precondition()) {
+            index++
+        }
+        if (index < top.plan.steps.size) {
+            // Set backStack and _state together (no suspension between) so they can't diverge.
+            backStack = frames.dropLast(1) + top.copy(index = index)
+            _state.value = LinearOnboardingState.InProgress(
+                rootPlanId = frames.first().plan.id,
+                currentPlan = top.plan,
+                currentStepIndex = index,
+            )
+        } else {
+            terminateCompleted(frames.first().plan)
+        }
+    }
+
+    // Clears the stack and emits the terminal state from a finally, so a throwing or cancelled callback still
+    // ends the run consistently and the callback runs at most once. On success it runs before the state is
+    // emitted, so its writes (e.g. AppStage) are visible to Completed / Skipped listeners.
+    private suspend fun terminateCompleted(rootPlan: LinearOnboardingPlan) {
+        var result: LinearOnboardingResult? = null
+        try {
+            rootPlan.onCompleted()
+            result = rootPlan.result()
+        } finally {
+            backStack = emptyList()
+            _state.value = LinearOnboardingState.Completed(rootPlanId = rootPlan.id, result = result)
+        }
+    }
+
+    private suspend fun terminateSkipped(rootPlan: LinearOnboardingPlan) {
+        try {
+            rootPlan.onSkipped()
+        } finally {
+            backStack = emptyList()
+            _state.value = LinearOnboardingState.Skipped(rootPlanId = rootPlan.id)
+        }
+    }
+
+    private data class Frame(val plan: LinearOnboardingPlan, val index: Int)
+}

--- a/onboarding/onboarding-impl/src/main/java/com/duckduckgo/onboarding/impl/LinearOnboardingOrchestratorImpl.kt
+++ b/onboarding/onboarding-impl/src/main/java/com/duckduckgo/onboarding/impl/LinearOnboardingOrchestratorImpl.kt
@@ -40,7 +40,7 @@ import javax.inject.Inject
  *
  * A run is a stack of plan frames ([backStack], bottom = root plan); [onEvent] applies the transition the top
  * step returns, pushing a side plan on [LinearOnboardingTransition.SwitchTo] and popping on
- * [LinearOnboardingTransition.Return]. Running off the end of a frame completes the whole run via the root
+ * [LinearOnboardingTransition.ReturnAndAdvance]. Running off the end of a frame completes the whole run via the root
  * plan; only an explicit Return resumes a caller.
  *
  * [backStack] and [_state] are always written together (stack reassigned wholesale, never mutated in place),
@@ -89,7 +89,7 @@ class LinearOnboardingOrchestratorImpl @Inject constructor() : LinearOnboardingO
                 is LinearOnboardingTransition.SwitchTo ->
                     advance(frames + Frame(transition.plan, index = 0), fromIndex = 0)
 
-                LinearOnboardingTransition.Return -> {
+                LinearOnboardingTransition.ReturnAndAdvance -> {
                     // Returning from the root frame is a programming error; treat as no-op.
                     if (frames.size <= 1) return
                     val caller = frames.dropLast(1)

--- a/onboarding/onboarding-impl/src/test/java/com/duckduckgo/onboarding/impl/LinearOnboardingOrchestratorImplTest.kt
+++ b/onboarding/onboarding-impl/src/test/java/com/duckduckgo/onboarding/impl/LinearOnboardingOrchestratorImplTest.kt
@@ -30,7 +30,7 @@ import com.duckduckgo.onboarding.api.LinearOnboardingStepId
 import com.duckduckgo.onboarding.api.LinearOnboardingTransition
 import com.duckduckgo.onboarding.api.LinearOnboardingTransition.AbortPlan
 import com.duckduckgo.onboarding.api.LinearOnboardingTransition.Advance
-import com.duckduckgo.onboarding.api.LinearOnboardingTransition.Return
+import com.duckduckgo.onboarding.api.LinearOnboardingTransition.ReturnAndAdvance
 import com.duckduckgo.onboarding.api.LinearOnboardingTransition.Stay
 import com.duckduckgo.onboarding.api.LinearOnboardingTransition.SwitchTo
 import kotlinx.coroutines.test.runTest
@@ -360,7 +360,7 @@ class LinearOnboardingOrchestratorImplTest {
 
     @Test
     fun `when return from side plan then resumes caller past switching step`() = runTest {
-        val sidePlan = LinearOnboardingPlan(id = SIDE_PLAN_ID, steps = listOf(step("side", transition = { Return })))
+        val sidePlan = LinearOnboardingPlan(id = SIDE_PLAN_ID, steps = listOf(step("side", transition = { ReturnAndAdvance })))
         testee.startPlan(
             LinearOnboardingPlan(
                 id = PLAN_ID,

--- a/onboarding/onboarding-impl/src/test/java/com/duckduckgo/onboarding/impl/LinearOnboardingOrchestratorImplTest.kt
+++ b/onboarding/onboarding-impl/src/test/java/com/duckduckgo/onboarding/impl/LinearOnboardingOrchestratorImplTest.kt
@@ -1,0 +1,425 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.onboarding.impl
+
+import com.duckduckgo.onboarding.api.LinearOnboardingEvent
+import com.duckduckgo.onboarding.api.LinearOnboardingHost
+import com.duckduckgo.onboarding.api.LinearOnboardingPlan
+import com.duckduckgo.onboarding.api.LinearOnboardingResult
+import com.duckduckgo.onboarding.api.LinearOnboardingState
+import com.duckduckgo.onboarding.api.LinearOnboardingState.Completed
+import com.duckduckgo.onboarding.api.LinearOnboardingState.InProgress
+import com.duckduckgo.onboarding.api.LinearOnboardingState.NotStarted
+import com.duckduckgo.onboarding.api.LinearOnboardingState.Skipped
+import com.duckduckgo.onboarding.api.LinearOnboardingStep
+import com.duckduckgo.onboarding.api.LinearOnboardingStepId
+import com.duckduckgo.onboarding.api.LinearOnboardingTransition
+import com.duckduckgo.onboarding.api.LinearOnboardingTransition.AbortPlan
+import com.duckduckgo.onboarding.api.LinearOnboardingTransition.Advance
+import com.duckduckgo.onboarding.api.LinearOnboardingTransition.Return
+import com.duckduckgo.onboarding.api.LinearOnboardingTransition.Stay
+import com.duckduckgo.onboarding.api.LinearOnboardingTransition.SwitchTo
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LinearOnboardingOrchestratorImplTest {
+
+    private val testee = LinearOnboardingOrchestratorImpl()
+
+    companion object {
+        private const val PLAN_ID = "test_plan"
+        private const val SIDE_PLAN_ID = "side_plan"
+    }
+
+    private object Next : LinearOnboardingEvent
+
+    private fun step(
+        id: String,
+        precondition: suspend () -> Boolean = { true },
+        host: LinearOnboardingHost = LinearOnboardingHost.OnboardingActivity,
+        transition: suspend (LinearOnboardingEvent) -> LinearOnboardingTransition = { Advance },
+    ): LinearOnboardingStep = object : LinearOnboardingStep {
+        override val id: LinearOnboardingStepId = id
+        override val host: LinearOnboardingHost = host
+        override val precondition: suspend () -> Boolean = precondition
+        override val transition: suspend (LinearOnboardingEvent) -> LinearOnboardingTransition = transition
+    }
+
+    @Test
+    fun `when start plan then advances to first eligible step`() = runTest {
+        testee.startPlan(LinearOnboardingPlan(id = PLAN_ID, steps = listOf(step("a"), step("b"))))
+
+        val state = testee.state.value
+        assertTrue(state is InProgress)
+        assertEquals("a", (state as InProgress).currentStep.id)
+    }
+
+    @Test
+    fun `when start plan then skips steps with false precondition`() = runTest {
+        testee.startPlan(
+            LinearOnboardingPlan(id = PLAN_ID, steps = listOf(step("a", precondition = { false }), step("b"))),
+        )
+
+        assertEquals("b", (testee.state.value as InProgress).currentStep.id)
+    }
+
+    @Test
+    fun `when all preconditions false then completes immediately`() = runTest {
+        testee.startPlan(
+            LinearOnboardingPlan(id = PLAN_ID, steps = listOf(step("a", precondition = { false }))),
+        )
+
+        assertEquals(Completed(rootPlanId = PLAN_ID), testee.state.value)
+    }
+
+    @Test
+    fun `when start plan called while in progress then second call is no op and state unchanged`() = runTest {
+        testee.startPlan(LinearOnboardingPlan(id = PLAN_ID, steps = listOf(step("a"))))
+
+        testee.startPlan(LinearOnboardingPlan(id = "other_plan", steps = listOf(step("z"))))
+
+        assertEquals("a", (testee.state.value as InProgress).currentStep.id)
+    }
+
+    @Test
+    fun `when start plan returns then state is already up to date`() = runTest {
+        testee.startPlan(LinearOnboardingPlan(id = PLAN_ID, steps = listOf(step("a"))))
+
+        // No onEvent/advance between startPlan returning and this read: startPlan must have
+        // published the started state before it returned, as its contract promises.
+        val state = testee.state.value
+        assertTrue(state is InProgress)
+        assertEquals("a", (state as InProgress).currentStep.id)
+    }
+
+    @Test
+    fun `when start plan with no eligible steps then state is already completed on return`() = runTest {
+        testee.startPlan(LinearOnboardingPlan(id = PLAN_ID, steps = listOf(step("a", precondition = { false }))))
+
+        // An immediate-terminal outcome is also visible by the time startPlan returns.
+        assertEquals(Completed(rootPlanId = PLAN_ID), testee.state.value)
+    }
+
+    @Test
+    fun `when plan has a result then completed carries it`() = runTest {
+        val planResult = object : LinearOnboardingResult {}
+        testee.startPlan(LinearOnboardingPlan(id = PLAN_ID, steps = listOf(step("a")), result = { planResult }))
+
+        testee.onEvent(Next) // advance past "a" -> Completed
+
+        assertEquals(Completed(rootPlanId = PLAN_ID, result = planResult), testee.state.value)
+    }
+
+    @Test
+    fun `when plan has no result then completed result is null`() = runTest {
+        testee.startPlan(LinearOnboardingPlan(id = PLAN_ID, steps = listOf(step("a"))))
+
+        testee.onEvent(Next)
+
+        val state = testee.state.value
+        assertEquals(Completed(rootPlanId = PLAN_ID, result = null), state)
+        assertEquals(PLAN_ID, (state as Completed).rootPlanId)
+    }
+
+    @Test
+    fun `when start plan from completed then starts a new run`() = runTest {
+        testee.startPlan(LinearOnboardingPlan(id = PLAN_ID, steps = listOf(step("a"))))
+        testee.onEvent(Next) // advance past "a" -> Completed
+        assertEquals(Completed(rootPlanId = PLAN_ID), testee.state.value)
+
+        testee.startPlan(LinearOnboardingPlan(id = PLAN_ID, steps = listOf(step("b"))))
+
+        assertEquals("b", (testee.state.value as InProgress).currentStep.id)
+    }
+
+    @Test
+    fun `when start plan from skipped then starts a new run`() = runTest {
+        testee.startPlan(LinearOnboardingPlan(id = PLAN_ID, steps = listOf(step("a", transition = { AbortPlan }))))
+        testee.onEvent(Next) // -> Skipped
+        assertEquals(Skipped(rootPlanId = PLAN_ID), testee.state.value)
+
+        testee.startPlan(LinearOnboardingPlan(id = PLAN_ID, steps = listOf(step("b"))))
+
+        assertEquals("b", (testee.state.value as InProgress).currentStep.id)
+    }
+
+    @Test
+    fun `when restart same plan after completion then runs again from first step`() = runTest {
+        val plan = LinearOnboardingPlan(id = PLAN_ID, steps = listOf(step("a"), step("b")))
+        testee.startPlan(plan)
+        testee.onEvent(Next) // a -> b
+        testee.onEvent(Next) // b -> Completed
+        assertEquals(Completed(rootPlanId = PLAN_ID), testee.state.value)
+
+        testee.startPlan(plan)
+
+        assertEquals("a", (testee.state.value as InProgress).currentStep.id)
+    }
+
+    @Test
+    fun `when advance then moves to next eligible step`() = runTest {
+        testee.startPlan(
+            LinearOnboardingPlan(id = PLAN_ID, steps = listOf(step("a"), step("b", precondition = { false }), step("c"))),
+        )
+
+        testee.onEvent(Next) // step "a" returns Advance by default
+
+        assertEquals("c", (testee.state.value as InProgress).currentStep.id)
+    }
+
+    @Test
+    fun `when advance past last step then completes`() = runTest {
+        testee.startPlan(LinearOnboardingPlan(id = PLAN_ID, steps = listOf(step("a"))))
+
+        testee.onEvent(Next)
+
+        val state = testee.state.value
+        assertEquals(Completed(rootPlanId = PLAN_ID), state)
+        assertEquals(PLAN_ID, (state as Completed).rootPlanId)
+    }
+
+    @Test
+    fun `when step returns abort plan then skipped`() = runTest {
+        testee.startPlan(
+            LinearOnboardingPlan(id = PLAN_ID, steps = listOf(step("a", transition = { AbortPlan }))),
+        )
+
+        testee.onEvent(Next)
+
+        val state = testee.state.value
+        assertEquals(Skipped(rootPlanId = PLAN_ID), state)
+        assertEquals(PLAN_ID, (state as Skipped).rootPlanId)
+    }
+
+    @Test
+    fun `when step returns stay then state unchanged`() = runTest {
+        testee.startPlan(
+            LinearOnboardingPlan(id = PLAN_ID, steps = listOf(step("a", transition = { Stay }), step("b"))),
+        )
+
+        testee.onEvent(Next)
+
+        assertEquals("a", (testee.state.value as InProgress).currentStep.id)
+    }
+
+    @Test
+    fun `when on event before start then no op`() = runTest {
+        testee.onEvent(Next)
+
+        assertEquals(NotStarted, testee.state.value)
+    }
+
+    @Test
+    fun `when on completed then runs before completed emitted`() = runTest {
+        var stateInsideCallback: LinearOnboardingState? = null
+        testee.startPlan(
+            LinearOnboardingPlan(
+                id = PLAN_ID,
+                steps = listOf(step("a")),
+                onCompleted = { stateInsideCallback = testee.state.value },
+            ),
+        )
+
+        testee.onEvent(Next)
+
+        // The callback observed a non-terminal state, proving it ran before Completed was emitted.
+        assertTrue(stateInsideCallback is InProgress)
+        assertEquals(Completed(rootPlanId = PLAN_ID), testee.state.value)
+    }
+
+    @Test
+    fun `when on completed throws then run still terminates as completed and side effect runs once`() = runTest {
+        var completedCount = 0
+        testee.startPlan(
+            LinearOnboardingPlan(
+                id = PLAN_ID,
+                steps = listOf(step("a")),
+                onCompleted = {
+                    completedCount++
+                    error("completion failed")
+                },
+            ),
+        )
+
+        runCatching { testee.onEvent(Next) } // advance past "a" -> terminate; onCompleted throws
+
+        // The run commits a terminal state (not wedged on InProgress) and is not retried.
+        assertEquals(Completed(rootPlanId = PLAN_ID), testee.state.value)
+        runCatching { testee.onEvent(Next) } // no-op; must not re-run onCompleted
+        assertEquals(1, completedCount)
+    }
+
+    @Test
+    fun `when immediate completion onCompleted throws then no orphan frame corrupts a later start`() = runTest {
+        runCatching {
+            testee.startPlan(
+                LinearOnboardingPlan(
+                    id = "first",
+                    steps = listOf(step("a", precondition = { false })), // completes immediately
+                    onCompleted = { error("completion failed") },
+                ),
+            )
+        }
+
+        // A later start must not be blocked by, nor inherit the rootPlanId of, an orphan frame.
+        testee.startPlan(LinearOnboardingPlan(id = "second", steps = listOf(step("b"))))
+
+        val state = testee.state.value as InProgress
+        assertEquals("b", state.currentStep.id)
+        assertEquals("second", state.rootPlanId)
+    }
+
+    @Test
+    fun `when start fails on immediate completion then onEvent does not dispatch into a stale frame`() = runTest {
+        runCatching {
+            testee.startPlan(
+                LinearOnboardingPlan(id = PLAN_ID, steps = emptyList(), onCompleted = { error("completion failed") }),
+            )
+        }
+
+        testee.onEvent(Next) // must be a no-op, not an index crash into steps[0] of an orphan frame
+
+        assertTrue(testee.state.value is Completed)
+    }
+
+    @Test
+    fun `when start fails on a throwing precondition then onEvent is a no-op`() = runTest {
+        runCatching {
+            testee.startPlan(
+                LinearOnboardingPlan(id = PLAN_ID, steps = listOf(step("a", precondition = { error("precondition failed") }))),
+            )
+        }
+
+        testee.onEvent(Next) // no run in progress -> must not dispatch into the abandoned frame
+
+        assertEquals(NotStarted, testee.state.value)
+    }
+
+    @Test
+    fun `when a callback reenters the orchestrator then it throws instead of deadlocking`() = runTest {
+        testee.startPlan(
+            LinearOnboardingPlan(
+                id = PLAN_ID,
+                steps = listOf(step("a")),
+                onCompleted = { testee.onEvent(Next) }, // illegal reentry from a terminal callback
+            ),
+        )
+
+        val error = runCatching { testee.onEvent(Next) }.exceptionOrNull() // advance past "a" -> terminate -> reentry
+
+        assertTrue("expected IllegalStateException but was $error", error is IllegalStateException)
+    }
+
+    @Test
+    fun `when on skipped then runs before skipped emitted`() = runTest {
+        var stateInsideCallback: LinearOnboardingState? = null
+        testee.startPlan(
+            LinearOnboardingPlan(
+                id = PLAN_ID,
+                steps = listOf(step("a", transition = { AbortPlan })),
+                onSkipped = { stateInsideCallback = testee.state.value },
+            ),
+        )
+
+        testee.onEvent(Next)
+
+        assertTrue(stateInsideCallback is InProgress)
+        assertEquals(Skipped(rootPlanId = PLAN_ID), testee.state.value)
+    }
+
+    @Test
+    fun `when switch to then runs side plan from first step`() = runTest {
+        val sidePlan = LinearOnboardingPlan(id = SIDE_PLAN_ID, steps = listOf(step("side")))
+        testee.startPlan(
+            LinearOnboardingPlan(id = PLAN_ID, steps = listOf(step("a", transition = { SwitchTo(sidePlan) }), step("b"))),
+        )
+
+        testee.onEvent(Next)
+
+        val state = testee.state.value as InProgress
+        assertEquals("side", state.currentStep.id)
+        // rootPlanId must remain the ROOT plan's id, not the side plan's id.
+        assertEquals(PLAN_ID, state.rootPlanId)
+    }
+
+    @Test
+    fun `when return from side plan then resumes caller past switching step`() = runTest {
+        val sidePlan = LinearOnboardingPlan(id = SIDE_PLAN_ID, steps = listOf(step("side", transition = { Return })))
+        testee.startPlan(
+            LinearOnboardingPlan(
+                id = PLAN_ID,
+                steps = listOf(
+                    step("a", transition = { SwitchTo(sidePlan) }),
+                    step("b"),
+                ),
+            ),
+        )
+
+        testee.onEvent(Next) // a -> SwitchTo(side); now on "side"
+        testee.onEvent(Next) // side -> Return; pop, advance caller past "a" -> "b"
+
+        val state = testee.state.value as InProgress
+        assertEquals("b", state.currentStep.id)
+        assertEquals(PLAN_ID, state.rootPlanId)
+    }
+
+    @Test
+    fun `when side plan aborts then whole flow skipped via main on skipped`() = runTest {
+        var mainSkippedRan = false
+        val sidePlan = LinearOnboardingPlan(id = SIDE_PLAN_ID, steps = listOf(step("side", transition = { AbortPlan })))
+        testee.startPlan(
+            LinearOnboardingPlan(
+                id = PLAN_ID,
+                steps = listOf(step("a", transition = { SwitchTo(sidePlan) })),
+                onSkipped = { mainSkippedRan = true },
+            ),
+        )
+
+        testee.onEvent(Next) // a -> SwitchTo(side)
+        testee.onEvent(Next) // side -> AbortPlan
+
+        assertTrue(mainSkippedRan)
+        val state = testee.state.value
+        assertEquals(Skipped(rootPlanId = PLAN_ID), state)
+        assertEquals(PLAN_ID, (state as Skipped).rootPlanId)
+    }
+
+    @Test
+    fun `when side plan exhausts then completes via main without resuming the caller`() = runTest {
+        var mainCompletedRan = false
+        val sidePlan = LinearOnboardingPlan(id = SIDE_PLAN_ID, steps = listOf(step("side"))) // default transition Advance
+        testee.startPlan(
+            LinearOnboardingPlan(
+                id = PLAN_ID,
+                // "b" follows the switching step: running off the end of the side plan must complete the run,
+                // not resume the main plan into "b". Only an explicit Return would resume the caller.
+                steps = listOf(step("a", transition = { SwitchTo(sidePlan) }), step("b")),
+                onCompleted = { mainCompletedRan = true },
+            ),
+        )
+
+        testee.onEvent(Next) // a -> SwitchTo(side)
+        testee.onEvent(Next) // side runs off its end -> whole run completes via main, does not resume "b"
+
+        assertTrue(mainCompletedRan)
+        val state = testee.state.value
+        assertEquals(Completed(rootPlanId = PLAN_ID), state)
+        assertEquals(PLAN_ID, (state as Completed).rootPlanId)
+    }
+}

--- a/onboarding/onboarding-impl/src/test/java/com/duckduckgo/onboarding/impl/LinearOnboardingStateForPlanTest.kt
+++ b/onboarding/onboarding-impl/src/test/java/com/duckduckgo/onboarding/impl/LinearOnboardingStateForPlanTest.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.onboarding.impl
+
+import com.duckduckgo.onboarding.api.LinearOnboardingState
+import com.duckduckgo.onboarding.api.LinearOnboardingState.Completed
+import com.duckduckgo.onboarding.api.LinearOnboardingState.InProgress
+import com.duckduckgo.onboarding.api.LinearOnboardingState.NotStarted
+import com.duckduckgo.onboarding.api.LinearOnboardingState.Skipped
+import com.duckduckgo.onboarding.api.forPlan
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Tests for the [forPlan] extension on [Flow<LinearOnboardingState>].
+ *
+ * The key property under test: because the source is a [StateFlow], a late subscriber
+ * collecting [forPlan] already receives the current terminal state immediately on subscription
+ * (StateFlow replay-on-subscribe semantics).
+ */
+class LinearOnboardingStateForPlanTest {
+
+    // --- forPlan scoping ---
+
+    @Test
+    fun `forPlan emits matching InProgress immediately on subscription`() = runTest {
+        val planId = "plan_a"
+        // No steps needed; we are testing the extension directly, not the orchestrator.
+        val stateFlow = MutableStateFlow<LinearOnboardingState>(
+            InProgress(rootPlanId = planId, currentPlan = planStub(planId), currentStepIndex = 0),
+        )
+
+        val emitted = stateFlow.forPlan(planId).first()
+
+        assertEquals(planId, emitted.rootPlanId)
+    }
+
+    @Test
+    fun `forPlan emits Completed immediately for a late subscriber when state is already terminal`() = runTest {
+        val planId = "plan_a"
+        // Arrange: state is already Completed before any subscriber arrives.
+        val stateFlow = MutableStateFlow<LinearOnboardingState>(Completed(rootPlanId = planId))
+
+        // Act: subscribe after the fact.
+        val emitted = stateFlow.forPlan(planId).first()
+
+        // Assert: the late subscriber still receives the current Completed state.
+        assertEquals(Completed(rootPlanId = planId), emitted)
+        assertEquals(planId, emitted.rootPlanId)
+    }
+
+    @Test
+    fun `forPlan emits Skipped immediately for a late subscriber when state is already terminal`() = runTest {
+        val planId = "plan_a"
+        val stateFlow = MutableStateFlow<LinearOnboardingState>(Skipped(rootPlanId = planId))
+
+        val emitted = stateFlow.forPlan(planId).first()
+
+        assertEquals(Skipped(rootPlanId = planId), emitted)
+        assertEquals(planId, emitted.rootPlanId)
+    }
+
+    @Test
+    fun `forPlan does not emit for a different plan id when state is Completed`() = runTest {
+        val stateFlow = MutableStateFlow<LinearOnboardingState>(Completed(rootPlanId = "plan_a"))
+
+        // forPlan("plan_b") should not emit the Completed(rootPlanId = "plan_a") state.
+        val emitted = withTimeoutOrNull(100) {
+            stateFlow.forPlan("plan_b").first()
+        }
+
+        assertNull("forPlan(\"plan_b\") should not emit Completed for \"plan_a\"", emitted)
+    }
+
+    @Test
+    fun `forPlan does not emit NotStarted`() = runTest {
+        val stateFlow = MutableStateFlow<LinearOnboardingState>(NotStarted)
+
+        val emitted = withTimeoutOrNull(100) {
+            stateFlow.forPlan("any_plan").first()
+        }
+
+        assertNull("forPlan should not emit NotStarted", emitted)
+    }
+
+    @Test
+    fun `forPlan filters out states from a different plan id`() = runTest {
+        val planA = "plan_a"
+        val planB = "plan_b"
+        // Arrange: state is planB's terminal — forPlan(planA) should yield nothing.
+        val stateFlow = MutableStateFlow<LinearOnboardingState>(Completed(rootPlanId = planB))
+
+        val emitted = withTimeoutOrNull(100) {
+            stateFlow.forPlan(planA).first()
+        }
+
+        assertNull("forPlan(planA) must not emit a state whose rootPlanId is planB", emitted)
+    }
+
+    @Test
+    fun `forPlan emits planA Completed even when state previously held planB Completed`() = runTest {
+        val planA = "plan_a"
+        val planB = "plan_b"
+        val stateFlow = MutableStateFlow<LinearOnboardingState>(Completed(rootPlanId = planB))
+
+        // Transition to planA's terminal state and then subscribe.
+        stateFlow.value = Completed(rootPlanId = planA)
+
+        val emitted = stateFlow.forPlan(planA).first()
+
+        assertEquals(Completed(rootPlanId = planA), emitted)
+    }
+
+    // Minimal plan stub — the forPlan extension only inspects rootPlanId on LinearOnboardingState.Started,
+    // so the plan itself is irrelevant here; we just need a valid LinearOnboardingPlan.
+    private fun planStub(id: String) = com.duckduckgo.onboarding.api.LinearOnboardingPlan(
+        id = id,
+        steps = emptyList(),
+    )
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1215361206566537?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/481882893211075/task/1214772963645835

### Description

This is the first slice of the Linear Onboarding Orchestrator work. It adds a new `:onboarding` module and nothing else, with no `:app` wiring yet. The orchestrator is introduced as a standalone, fully tested unit so it can be reviewed on its own. Integration into `BrandDesignUpdatePageViewModel`, the host activities, the plan provider, the AppStage bootstrapper, and the kill-switch toggle land in a follow-up stacked PR.

**Divergences from the tech design**

The public surface follows the tech design's architecture but extends it in two places, both around plan identity and carrying an outcome on completion:

1. **Plan identity.** Added `LinearOnboardingPlan.id`, a `Started` sealed supertype exposing `rootPlanId`, and a `Flow<LinearOnboardingState>.forPlan(planId)` operator. This lets a consumer scope to one onboarding flow and ignore another flow's terminal state, which is a low-cost groundwork for allowing other (non-new-user) flows to reuse this architecture. `rootPlanId` is the bottom-of-stack plan, so a `SwitchTo` side plan does not change the flow identity a consumer is scoped to.
2. **Completion result.** The design's `Completed` carried nothing. Added an opaque `LinearOnboardingResult`, a `plan.result` supplier, and `Completed.result`, so a run can hand a payload (for example a query to launch when onboarding hands off to the browser) across the terminal boundary. It stays opaque and defined in `:app`, the same way `LinearOnboardingEvent` does.

Everything else matches the design.

### Steps to test this PR

This PR adds no user-visible behavior and is not yet wired into the app, so verification is the unit suite plus an API review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New isolated libraries with no production wiring; behavior is covered by unit tests and does not change existing app flows.
> 
> **Overview**
> Introduces a new **`:onboarding`** slice (`onboarding-api` + `onboarding-impl`) with a UI-agnostic **linear onboarding orchestrator**—no `:app` wiring in this PR.
> 
> The **`onboarding-api`** module defines `LinearOnboardingOrchestrator`, plan/step/event/transition models, `StateFlow`-based `LinearOnboardingState` (including `rootPlanId` on started states), opaque `LinearOnboardingResult` on `Completed`, and `Flow.forPlan(planId)` for scoping observers to one flow.
> 
> **`onboarding-impl`** provides `LinearOnboardingOrchestratorImpl` (Dagger/Anvil app-scoped binding): a mutex-serialized frame stack for `SwitchTo` / `ReturnAndAdvance`, precondition skipping, root-plan terminal callbacks before state emission, and reentrancy guards on `startPlan`/`onEvent`. Broad unit tests cover side plans, abort/complete paths, and failure/restart edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a93c402612375570ce356244247b2bef1487d3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->