### PR TITLE
Hide return hatch when its tab leaves the repo

### DIFF
--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModel.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModel.kt
@@ -76,7 +76,6 @@ class NewTabReturnHatchViewModel @Inject constructor(
     val commands: Flow<Command> = commandChannel.receiveAsFlow()
 
     private val pendingClose = MutableStateFlow(false)
-    private val burnTargetTabId = MutableStateFlow<String?>(null)
 
     // The tab the hatch offers to return to, captured once when the app returns from idle. Driving
     // the hatch from this snapshot (instead of the live last-accessed flow) keeps the displayed tab
@@ -96,30 +95,19 @@ class NewTabReturnHatchViewModel @Inject constructor(
                 }
             }
         }
-        // When the user burns the hatch's tab via the FireDialog, hide the hatch as soon as that
-        // tab is gone from the repository. If the FireDialog is cancelled, the tab survives and the
-        // hatch stays visible.
-        viewModelScope.launch(dispatchers.io()) {
-            combine(burnTargetTabId, tabRepository.flowTabs) { targetId, tabs ->
-                targetId != null && tabs.none { it.tabId == targetId }
-            }.collect { targetGone ->
-                if (targetGone) {
-                    pendingClose.value = true
-                    burnTargetTabId.value = null
-                }
-            }
-        }
     }
 
     // Driven by the captured [snapshotTab] (not the live last-accessed flow) so the displayed tab is
-    // stable across the close/undo toggle. Only the tabs count stays live, sourced from flowTabs.
+    // stable across the close/undo toggle. flowTabs both supplies the live tabs count and gates
+    // visibility: the hatch hides as soon as the snapshot tab leaves the repository (burned, closed,
+    // or purged), so every live ViewModel instance stays in sync without per-instance burn tracking.
     val viewState = combine(
         snapshotTab,
         pendingClose,
         tabRepository.flowTabs,
         duckChat.observeNativeInputFieldUserSettingEnabled(),
     ) { tab, closed, tabs, nativeInputEnabled ->
-        if (tab != null && !closed) {
+        if (tab != null && !closed && tabs.any { it.tabId == tab.tabId }) {
             val url = tab.url.orEmpty()
             ViewState(
                 tabTitle = tab.title.orEmpty(),
@@ -165,7 +153,6 @@ class NewTabReturnHatchViewModel @Inject constructor(
     fun onBurnTabPressed() {
         pixel.fire(NewTabReturnHatchPixelName.OPTION_SELECTED_BURN_TAB, type = Count)
         pixel.fire(NewTabReturnHatchPixelName.OPTION_SELECTED_BURN_TAB_DAILY, type = Daily())
-        burnTargetTabId.value = viewState.value.currentTabId.takeIf { it.isNotEmpty() }
     }
 
     fun onUndoCloseTab(tabId: String) {

--- a/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModelTest.kt
+++ b/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModelTest.kt
@@ -79,9 +79,11 @@ class NewTabReturnHatchViewModelTest {
         )
     }
 
-    // Simulates returning from idle: stub the one-time last-accessed read and trigger the rising
-    // edge that captures the snapshot.
+    // Simulates returning from idle: the last-accessed tab is present in the repository (so the
+    // hatch can show it), the one-time last-accessed read is stubbed, and the rising edge triggers
+    // the snapshot capture.
     private suspend fun returnFromIdleWith(tab: TabEntity?) {
+        tabsFlow.value = listOfNotNull(tab)
         whenever(mockTabRepository.getLastAccessedTab()).thenReturn(tab)
         afterIdleReturnFlow.value = false
         afterIdleReturnFlow.value = true
@@ -417,13 +419,9 @@ class NewTabReturnHatchViewModelTest {
             testee.onBurnTabPressed()
             tabsFlow.value = emptyList()
 
-            // The viewState combine and the burn-target observer both consume flowTabs, so the
-            // order of emissions is non-deterministic. Drain until we observe the hatch hidden.
-            var hidden = !awaitItem().shouldShow
-            while (!hidden) {
-                hidden = !awaitItem().shouldShow
-            }
-            cancelAndConsumeRemainingEvents()
+            // After the FireDialog burns the tab it leaves flowTabs, and visibility tracks
+            // membership, so the hatch hides.
+            assertFalse(expectMostRecentItem().shouldShow)
         }
     }
 
@@ -439,8 +437,26 @@ class NewTabReturnHatchViewModelTest {
             testee.onBurnTabPressed()
             advanceUntilIdle()
 
-            // Burn target still present, so the hatch state is unchanged (stays visible).
+            // The tab is still in flowTabs (FireDialog not confirmed), so the hatch stays visible.
             expectNoEvents()
+        }
+    }
+
+    @Test
+    fun whenSnapshotTabRemovedFromRepositoryThenHatchHides() = runTest {
+        val tab = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
+        tabsFlow.value = listOf(tab)
+
+        testee.viewState.test {
+            returnFromIdleWith(tab)
+            assertTrue(expectMostRecentItem().shouldShow)
+
+            // The snapshot tab leaves the repository without this instance closing or burning it
+            // (e.g. a second live hatch instance burned it, or an external close). Visibility must
+            // track flowTabs membership, so the hatch hides the moment its tab is gone.
+            tabsFlow.value = emptyList()
+
+            assertFalse(expectMostRecentItem().shouldShow)
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
@@ -425,6 +425,10 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
             .onEach { inputModeWidget.setBrowserMenuHighlightVisible(it) }
             .launchIn(viewLifecycleOwner.lifecycleScope)
 
+        viewModel.tabCount
+            .onEach { count -> inputModeWidget.tabSwitcherButton.count = count }
+            .launchIn(viewLifecycleOwner.lifecycleScope)
+
         if (duckChatFeature.chatTabAttachments().isEnabled()) {
             viewModel.tabAttachmentState
                 .onEach { state -> updateTabAttachmentPopup(state) }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -194,6 +194,13 @@ class InputScreenViewModel @AssistedInject constructor(
     private val chatInputTextState = MutableStateFlow("")
     val chatInputText: StateFlow<String> = chatInputTextState.asStateFlow()
 
+    // Live tab count for the input screen's tab switcher button. Driven off flowTabs so it tracks
+    // tab changes while the input screen is open (e.g. burning the hatch's tab); the launch-time
+    // snapshot passed in InputScreenActivityParams would otherwise go stale.
+    val tabCount: Flow<Int> = tabRepository.flowTabs
+        .map { it.size }
+        .distinctUntilChanged()
+
     private val _submitButtonIconState = MutableStateFlow(SubmitButtonIconState(SubmitButtonIcon.SEARCH))
     val submitButtonIconState: StateFlow<SubmitButtonIconState> = _submitButtonIconState.asStateFlow()
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
@@ -101,6 +101,7 @@ class InputScreenViewModelTest {
     private val omnibarRepository: OmnibarRepository = mock()
     private val queryUrlPredictor: QueryUrlPredictor = mock()
     private val tabRepository: TabRepository = mock()
+    private val tabsFlow = MutableStateFlow<List<TabEntity>>(emptyList())
     private val tabPageContextRepository: com.duckduckgo.app.tabs.model.TabPageContextRepository = mock()
     private val duckChatJSHelper: com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper = mock()
 
@@ -134,6 +135,7 @@ class InputScreenViewModelTest {
             whenever(inputScreenSessionStore.hasUsedSearchMode()).thenReturn(false)
             whenever(inputScreenSessionStore.hasUsedChatMode()).thenReturn(false)
             whenever(queryUrlPredictor.isReady()).thenReturn(true)
+            whenever(tabRepository.flowTabs).thenReturn(tabsFlow)
         }
 
     private fun createViewModel(currentOmnibarText: String = ""): InputScreenViewModel =
@@ -161,6 +163,26 @@ class InputScreenViewModelTest {
             tabPageContextRepository = tabPageContextRepository,
             duckChatJSHelper = duckChatJSHelper,
         )
+
+    private fun aTab(id: String) = TabEntity(tabId = id, url = null, title = null)
+
+    @Test
+    fun `when tabs are added or removed then tabCount emits the new size`() =
+        runTest {
+            val viewModel = createViewModel()
+
+            viewModel.tabCount.test {
+                assertEquals(0, awaitItem())
+
+                tabsFlow.value = listOf(aTab("1"), aTab("2"))
+                assertEquals(2, awaitItem())
+
+                tabsFlow.value = listOf(aTab("1"))
+                assertEquals(1, awaitItem())
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
 
     @Test
     fun `when initialized with web URL and autocomplete enabled then autocomplete suggestions should be hidden initially`() =


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1215607418826745?focus=true

### Description

Two related fixes for burning a tab from the NTP "return to tab" hatch.

**1. Hatch stayed visible after burn.** Two `NewTabReturnHatchViewModel` instances can be live at once (e.g. the current and an offscreen NTP fragment), and hiding was tracked per-instance via a `burnTargetTabId` observer — only the instance whose fire button was tapped learned its tab was gone. The other kept showing the burned tab because `shouldShow` never re-checked that the snapshot tab still existed in the repository. Now `shouldShow` also requires the snapshot tab to be present in `flowTabs`, so the hatch hides on **every** live instance the moment its tab leaves the repository (burn from any instance, external close, or purge). That makes the per-instance `burnTargetTabId` observer redundant, so it's removed. `pendingClose` stays — it remains the immediate-hide signal for the close/undo snackbar flow.

**2. Input-screen tab count was stale after burn.** The input screen's tab switcher count was set once from a snapshot captured at launch (`InputScreenActivityParams.browserButtonsConfig.tabs`) and never updated, so burning the hatch's tab (a single-tab delete) left the displayed count showing N instead of N−1. `InputScreenViewModel` now exposes a reactive `tabCount` derived from `tabRepository.flowTabs`, observed in `InputScreenFragment`, so the count tracks tab changes while the input screen is open. The launch-time snapshot is kept as the initial value to avoid a flash.

### Steps to test this PR

_Return hatch hides after burn_
- [ ] Settings → General → Show on App Launch → New Tab Page, with the **after-inactivity** option (shortest timeout)
- [ ] Open **≥2 tabs**, with a real site (e.g. reddit.com) as the last-accessed one
- [ ] Background the app (Home) and wait past the inactivity timeout
- [ ] Reopen → the NTP return hatch appears offering the last tab
- [ ] Tap the hatch's 🔥 fire button and confirm the FireDialog
- [ ] Verify the hatch is **gone** on the fresh NTP — and stays gone when switching/reselecting tabs

_Input-screen tab count stays correct_
- [ ] With the same setup, note the tab count shown in the input field before burning
- [ ] Burn the hatch's tab from the input screen
- [ ] Verify the tab count decrements to the correct value (N−1) and is not left stale

### UI changes

N/A — behavioral fixes, no visual or layout changes. The hatch hides correctly once its tab is burned, and the input field's tab count updates to reflect the burned tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes NTP hatch visibility and tab-count UI state across multiple ViewModel instances; behavior is well-covered by tests but affects post-idle return flows users see often.
> 
> **Overview**
> Fixes two tab-burn UX bugs on the NTP return hatch and the Duck Chat input screen.
> 
> **Return hatch:** `shouldShow` now also requires the snapshotted tab to still appear in `flowTabs`, so the hatch hides on every live `NewTabReturnHatchViewModel` when that tab is burned, closed, or purged—not only on the instance that tapped fire. The per-instance `burnTargetTabId` observer and the burn-target assignment in `onBurnTabPressed()` are removed; `pendingClose` still handles the close/undo snackbar path.
> 
> **Input screen:** Adds a reactive `tabCount` from `tabRepository.flowTabs` in `InputScreenViewModel` and wires it in `InputScreenFragment` to the tab switcher badge so the count updates while the screen is open (e.g. after burning from the hatch).
> 
> Tests cover undo-while-deletable, snapshot tab removal, and live tab count emissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da71c6f350b4c56efb16e01b2af731926370ee4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

