### PR TITLE
Speed up the single tab burning

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/global/view/ClearPersonalDataActionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/view/ClearPersonalDataActionTest.kt
@@ -43,6 +43,7 @@ import com.duckduckgo.history.api.NavigationHistory
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.site.permissions.api.SitePermissionsManager
 import com.duckduckgo.sync.api.DeviceSyncState
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -85,7 +86,7 @@ class ClearPersonalDataActionTest {
     @Before
     fun setup() {
         whenever(mockDuckAiHostProvider.getHost()).thenReturn("duck.ai")
-        fakeAndroidBrowserConfigFeature.concurrentSingleTabDataClearing().setRawStoredState(State(enable = true))
+        fakeAndroidBrowserConfigFeature.backgroundSingleTabDataClearing().setRawStoredState(State(enable = true))
         testee = createTestee()
         whenever(mockFireproofWebsiteRepository.getFireproofWebsites()).thenReturn(fireproofWebsites)
         whenever(mockDeviceSyncState.isUserSignedInOnDevice()).thenReturn(true)
@@ -387,7 +388,7 @@ class ClearPersonalDataActionTest {
     }
 
     @Test
-    fun whenClearDataForSpecificDomainsCalledWithMixedDomainsThenOnlyNonFireproofDomainsAreCleared() = runTest {
+    fun whenClearDataForSpecificDomainsCalledWithMixedDomainsThenOnlyNonFireproofDomainsAreCleared() = runBlocking {
         whenever(mockWebViewCapabilityChecker.isSupported(DeleteBrowsingData)).thenReturn(true)
         whenever(mockFireproofWebsiteRepository.fireproofWebsitesSync()).thenReturn(
             listOf(FireproofWebsiteEntity("fireproof.com")),
@@ -402,7 +403,7 @@ class ClearPersonalDataActionTest {
     }
 
     @Test
-    fun whenClearDataForSpecificDomainsCalledWithMixedDuckDuckGoDomainsThenOnlyNonDdgDomainsAreCleared() = runTest {
+    fun whenClearDataForSpecificDomainsCalledWithMixedDuckDuckGoDomainsThenOnlyNonDdgDomainsAreCleared() = runBlocking {
         whenever(mockWebViewCapabilityChecker.isSupported(DeleteBrowsingData)).thenReturn(true)
         whenever(mockFireproofWebsiteRepository.fireproofWebsitesSync()).thenReturn(emptyList())
         val clearedDomains = mutableListOf<String>()
@@ -415,7 +416,7 @@ class ClearPersonalDataActionTest {
     }
 
     @Test
-    fun whenClearDataForSpecificDomainsCalledAndCleanerThrowsThenReturnsError() = runTest {
+    fun whenClearDataForSpecificDomainsCalledAndCleanerThrowsThenReturnsError() = runBlocking {
         whenever(mockWebViewCapabilityChecker.isSupported(DeleteBrowsingData)).thenReturn(true)
         whenever(mockFireproofWebsiteRepository.fireproofWebsitesSync()).thenReturn(emptyList())
         val testeeWithError = createTestee(
@@ -426,7 +427,7 @@ class ClearPersonalDataActionTest {
     }
 
     @Test
-    fun whenClearDataForSpecificDomainsCalledWithManyDomainsThenAllNonFilteredDomainsAreCleared() = runTest {
+    fun whenClearDataForSpecificDomainsCalledWithManyDomainsThenAllNonFilteredDomainsAreCleared() = runBlocking {
         whenever(mockWebViewCapabilityChecker.isSupported(DeleteBrowsingData)).thenReturn(true)
         whenever(mockFireproofWebsiteRepository.fireproofWebsitesSync()).thenReturn(emptyList())
         val domains = (1..25).map { "site$it.com" }.toSet()
@@ -444,7 +445,7 @@ class ClearPersonalDataActionTest {
     }
 
     @Test
-    fun whenClearDataForSpecificDomainsCalledAndOneDomainStallsThenOthersAreClearedAndReturnsSuccess() = runTest {
+    fun whenClearDataForSpecificDomainsCalledAndOneDomainStallsThenOthersAreClearedAndReturnsSuccess() = runBlocking {
         whenever(mockWebViewCapabilityChecker.isSupported(DeleteBrowsingData)).thenReturn(true)
         whenever(mockFireproofWebsiteRepository.fireproofWebsitesSync()).thenReturn(emptyList())
         val clearedDomains = java.util.Collections.synchronizedList(mutableListOf<String>())
@@ -470,7 +471,7 @@ class ClearPersonalDataActionTest {
     fun whenClearDataForSpecificDomainsCalledAndConcurrentClearingDisabledThenDomainsAreStillCleared() = runTest {
         whenever(mockWebViewCapabilityChecker.isSupported(DeleteBrowsingData)).thenReturn(true)
         whenever(mockFireproofWebsiteRepository.fireproofWebsitesSync()).thenReturn(emptyList())
-        fakeAndroidBrowserConfigFeature.concurrentSingleTabDataClearing().setRawStoredState(State(enable = false))
+        fakeAndroidBrowserConfigFeature.backgroundSingleTabDataClearing().setRawStoredState(State(enable = false))
         val clearedDomains = java.util.Collections.synchronizedList(mutableListOf<String>())
         val testeeWithCapture = createTestee(
             siteDataCleaner = { _, domain -> clearedDomains.add(domain) },

--- a/app/src/androidTest/java/com/duckduckgo/app/global/view/ClearPersonalDataActionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/view/ClearPersonalDataActionTest.kt
@@ -29,11 +29,14 @@ import com.duckduckgo.app.fire.UnsentForgetAllPixelStore
 import com.duckduckgo.app.fire.fireproofwebsite.data.FireproofWebsiteEntity
 import com.duckduckgo.app.fire.fireproofwebsite.data.FireproofWebsiteRepository
 import com.duckduckgo.app.fire.store.TabVisitedSitesRepository
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.trackerdetection.api.WebTrackersBlockedRepository
 import com.duckduckgo.cookies.api.DuckDuckGoCookieManager
 import com.duckduckgo.duckchat.api.DuckAiHostProvider
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.history.api.NavigationHistory
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.site.permissions.api.SitePermissionsManager
@@ -70,6 +73,7 @@ class ClearPersonalDataActionTest {
     private val mockTabVisitedSitesRepository: TabVisitedSitesRepository = mock()
     private val mockWebViewCapabilityChecker: WebViewCapabilityChecker = mock()
     private val mockDuckAiHostProvider: DuckAiHostProvider = mock()
+    private val fakeAndroidBrowserConfigFeature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
 
     private val fireproofWebsites: LiveData<List<FireproofWebsiteEntity>> = MutableLiveData()
 
@@ -78,6 +82,7 @@ class ClearPersonalDataActionTest {
     @Before
     fun setup() {
         whenever(mockDuckAiHostProvider.getHost()).thenReturn("duck.ai")
+        fakeAndroidBrowserConfigFeature.concurrentSingleTabDataClearing().setRawStoredState(State(enable = true))
         testee = createTestee()
         whenever(mockFireproofWebsiteRepository.getFireproofWebsites()).thenReturn(fireproofWebsites)
         whenever(mockDeviceSyncState.isUserSignedInOnDevice()).thenReturn(true)
@@ -104,6 +109,7 @@ class ClearPersonalDataActionTest {
         webViewCapabilityChecker = mockWebViewCapabilityChecker,
         duckAiHostProvider = mockDuckAiHostProvider,
         siteDataCleaner = siteDataCleaner,
+        androidBrowserConfigFeature = fakeAndroidBrowserConfigFeature,
     )
 
     @Test
@@ -452,6 +458,22 @@ class ClearPersonalDataActionTest {
 
         assertTrue(result is ClearDataResult.Success)
         assertEquals(setOf("a.com", "b.com"), clearedDomains.toSet())
+    }
+
+    @Test
+    fun whenClearDataForSpecificDomainsCalledAndConcurrentClearingDisabledThenDomainsAreStillCleared() = runTest {
+        whenever(mockWebViewCapabilityChecker.isSupported(DeleteBrowsingData)).thenReturn(true)
+        whenever(mockFireproofWebsiteRepository.fireproofWebsitesSync()).thenReturn(emptyList())
+        fakeAndroidBrowserConfigFeature.concurrentSingleTabDataClearing().setRawStoredState(State(enable = false))
+        val clearedDomains = java.util.Collections.synchronizedList(mutableListOf<String>())
+        val testeeWithCapture = createTestee(
+            siteDataCleaner = { _, domain -> clearedDomains.add(domain) },
+        )
+
+        val result = testeeWithCapture.clearDataForSpecificDomains(domains = setOf("a.com", "b.com", "c.com"))
+
+        assertTrue(result is ClearDataResult.Success)
+        assertEquals(setOf("a.com", "b.com", "c.com"), clearedDomains.toSet())
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/global/view/ClearPersonalDataActionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/view/ClearPersonalDataActionTest.kt
@@ -38,6 +38,7 @@ import com.duckduckgo.history.api.NavigationHistory
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.site.permissions.api.SitePermissionsManager
 import com.duckduckgo.sync.api.DeviceSyncState
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -387,7 +388,7 @@ class ClearPersonalDataActionTest {
         )
         val result = testeeWithCapture.clearDataForSpecificDomains(domains = setOf("fireproof.com", "clearable.com"))
         assertTrue(result is ClearDataResult.Success)
-        assertEquals(listOf("clearable.com"), clearedDomains)
+        assertEquals(setOf("clearable.com"), clearedDomains.toSet())
     }
 
     @Test
@@ -400,7 +401,7 @@ class ClearPersonalDataActionTest {
         )
         val result = testeeWithCapture.clearDataForSpecificDomains(domains = setOf("duckduckgo.com", "duck.ai", "clearable.com"))
         assertTrue(result is ClearDataResult.Success)
-        assertEquals(listOf("clearable.com"), clearedDomains)
+        assertEquals(setOf("clearable.com"), clearedDomains.toSet())
     }
 
     @Test
@@ -412,6 +413,45 @@ class ClearPersonalDataActionTest {
         )
         val result = testeeWithError.clearDataForSpecificDomains(domains = setOf("example.com"))
         assertTrue(result is ClearDataResult.Error)
+    }
+
+    @Test
+    fun whenClearDataForSpecificDomainsCalledWithManyDomainsThenAllNonFilteredDomainsAreCleared() = runTest {
+        whenever(mockWebViewCapabilityChecker.isSupported(DeleteBrowsingData)).thenReturn(true)
+        whenever(mockFireproofWebsiteRepository.fireproofWebsitesSync()).thenReturn(emptyList())
+        val domains = (1..25).map { "site$it.com" }.toSet()
+        // Synchronised because the bounded-concurrency clear may invoke the cleaner from multiple coroutines.
+        val clearedDomains = java.util.Collections.synchronizedList(mutableListOf<String>())
+        val testeeWithCapture = createTestee(
+            siteDataCleaner = { _, domain -> clearedDomains.add(domain) },
+        )
+
+        val result = testeeWithCapture.clearDataForSpecificDomains(domains = domains)
+
+        assertTrue(result is ClearDataResult.Success)
+        assertEquals(domains, clearedDomains.toSet())
+    }
+
+    @Test
+    fun whenClearDataForSpecificDomainsCalledAndOneDomainStallsThenOthersAreClearedAndReturnsSuccess() = runTest {
+        whenever(mockWebViewCapabilityChecker.isSupported(DeleteBrowsingData)).thenReturn(true)
+        whenever(mockFireproofWebsiteRepository.fireproofWebsitesSync()).thenReturn(emptyList())
+        val clearedDomains = java.util.Collections.synchronizedList(mutableListOf<String>())
+        val testeeWithStall = createTestee(
+            siteDataCleaner = { _, domain ->
+                if (domain == "stall.com") {
+                    // Simulate a WebView callback that never fires; the overall timeout must recover.
+                    suspendCancellableCoroutine<Unit> { }
+                } else {
+                    clearedDomains.add(domain)
+                }
+            },
+        )
+
+        val result = testeeWithStall.clearDataForSpecificDomains(domains = setOf("stall.com", "a.com", "b.com"))
+
+        assertTrue(result is ClearDataResult.Success)
+        assertEquals(setOf("a.com", "b.com"), clearedDomains.toSet())
     }
 
     @Test

--- a/app/src/androidTest/java/com/duckduckgo/app/global/view/ClearPersonalDataActionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/global/view/ClearPersonalDataActionTest.kt
@@ -29,6 +29,8 @@ import com.duckduckgo.app.fire.UnsentForgetAllPixelStore
 import com.duckduckgo.app.fire.fireproofwebsite.data.FireproofWebsiteEntity
 import com.duckduckgo.app.fire.fireproofwebsite.data.FireproofWebsiteRepository
 import com.duckduckgo.app.fire.store.TabVisitedSitesRepository
+import com.duckduckgo.app.fire.wideevents.DataClearingFlowStep
+import com.duckduckgo.app.fire.wideevents.DataClearingWideEvent
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.tabs.model.TabRepository
@@ -73,6 +75,7 @@ class ClearPersonalDataActionTest {
     private val mockTabVisitedSitesRepository: TabVisitedSitesRepository = mock()
     private val mockWebViewCapabilityChecker: WebViewCapabilityChecker = mock()
     private val mockDuckAiHostProvider: DuckAiHostProvider = mock()
+    private val mockDataClearingWideEvent: DataClearingWideEvent = mock()
     private val fakeAndroidBrowserConfigFeature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
 
     private val fireproofWebsites: LiveData<List<FireproofWebsiteEntity>> = MutableLiveData()
@@ -110,6 +113,7 @@ class ClearPersonalDataActionTest {
         duckAiHostProvider = mockDuckAiHostProvider,
         siteDataCleaner = siteDataCleaner,
         androidBrowserConfigFeature = fakeAndroidBrowserConfigFeature,
+        dataClearingWideEvent = mockDataClearingWideEvent,
     )
 
     @Test
@@ -436,6 +440,7 @@ class ClearPersonalDataActionTest {
 
         assertTrue(result is ClearDataResult.Success)
         assertEquals(domains, clearedDomains.toSet())
+        verify(mockDataClearingWideEvent).stepSuccess(DataClearingFlowStep.WEB_STORAGE_CLEAR_SELECTIVE)
     }
 
     @Test
@@ -458,6 +463,7 @@ class ClearPersonalDataActionTest {
 
         assertTrue(result is ClearDataResult.Success)
         assertEquals(setOf("a.com", "b.com"), clearedDomains.toSet())
+        verify(mockDataClearingWideEvent).stepFailure(eq(DataClearingFlowStep.WEB_STORAGE_CLEAR_SELECTIVE), any())
     }
 
     @Test

--- a/app/src/main/java/com/duckduckgo/app/di/PrivacyModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/PrivacyModule.kt
@@ -86,6 +86,7 @@ object PrivacyModule {
         duckAiHostProvider: DuckAiHostProvider,
         siteDataCleaner: SiteDataCleaner,
         androidBrowserConfigFeature: AndroidBrowserConfigFeature,
+        dataClearingWideEvent: DataClearingWideEvent,
     ): ClearDataAction {
         // TODO: Burns currently only clear @RegularMode tabs. Cross-mode tab clearing will be
         // handled as part of the data-clearing fire-mode work.
@@ -110,6 +111,7 @@ object PrivacyModule {
             duckAiHostProvider,
             siteDataCleaner,
             androidBrowserConfigFeature,
+            dataClearingWideEvent,
         )
     }
 

--- a/app/src/main/java/com/duckduckgo/app/di/PrivacyModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/PrivacyModule.kt
@@ -39,6 +39,7 @@ import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.location.data.LocationPermissionsDao
 import com.duckduckgo.app.location.data.LocationPermissionsRepository
 import com.duckduckgo.app.location.data.LocationPermissionsRepositoryImpl
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.trackerdetection.api.WebTrackersBlockedRepository
@@ -84,6 +85,7 @@ object PrivacyModule {
         webViewCapabilityChecker: WebViewCapabilityChecker,
         duckAiHostProvider: DuckAiHostProvider,
         siteDataCleaner: SiteDataCleaner,
+        androidBrowserConfigFeature: AndroidBrowserConfigFeature,
     ): ClearDataAction {
         // TODO: Burns currently only clear @RegularMode tabs. Cross-mode tab clearing will be
         // handled as part of the data-clearing fire-mode work.
@@ -107,6 +109,7 @@ object PrivacyModule {
             webViewCapabilityChecker,
             duckAiHostProvider,
             siteDataCleaner,
+            androidBrowserConfigFeature,
         )
     }
 

--- a/app/src/main/java/com/duckduckgo/app/fire/DataClearing.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/DataClearing.kt
@@ -46,6 +46,7 @@ import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import logcat.LogPriority.WARN
@@ -125,11 +126,23 @@ class DataClearing @Inject constructor(
             }
         }
 
+        suspend fun clearSiteDataWithRetry(): ClearDataResult {
+            var result = clearDataAction.clearDataForSpecificDomains(visitedSites)
+            var attempt = 1
+            while (result is ClearDataResult.Error && attempt < MAX_BACKGROUND_CLEAR_ATTEMPTS) {
+                logcat(WARN) { "Background site data clear attempt $attempt failed for tab $tabId; retrying" }
+                delay(BACKGROUND_CLEAR_RETRY_DELAY_MS * attempt)
+                result = clearDataAction.clearDataForSpecificDomains(visitedSites)
+                attempt++
+            }
+            return result
+        }
+
         return if (androidBrowserConfigFeature.backgroundSingleTabDataClearing().isEnabled()) {
             tearDownTab()
             appCoroutineScope.launch {
                 try {
-                    val result = clearDataAction.clearDataForSpecificDomains(visitedSites)
+                    val result = clearSiteDataWithRetry()
                     clearChatsAndHistory()
                     completeWideEvent(result)
                     logcat { "Single tab clear completed (background) for tab: $tabId" }
@@ -309,5 +322,13 @@ class DataClearing @Inject constructor(
         }
 
         logcat { "Granular clear completed" }
+    }
+
+    private companion object {
+        // Total attempts (1 initial + retries) for the background single-tab site-data clear.
+        private const val MAX_BACKGROUND_CLEAR_ATTEMPTS = 3
+
+        // Base backoff between background clear retries; multiplied by the attempt number.
+        private const val BACKGROUND_CLEAR_RETRY_DELAY_MS = 1_000L
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/fire/DataClearing.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/DataClearing.kt
@@ -20,6 +20,7 @@ package com.duckduckgo.app.fire
 
 import android.annotation.SuppressLint
 import androidx.core.net.toUri
+import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.fire.store.FireDataStore
 import com.duckduckgo.app.fire.store.TabVisitedSitesRepository
 import com.duckduckgo.app.fire.wideevents.DataClearingWideEvent
@@ -27,6 +28,7 @@ import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchO
 import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore
 import com.duckduckgo.app.global.view.ClearDataAction
 import com.duckduckgo.app.global.view.ClearDataResult
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.clear.ClearWhenOption
 import com.duckduckgo.app.settings.clear.FireClearOption
 import com.duckduckgo.app.settings.db.SettingsDataStore
@@ -42,7 +44,9 @@ import com.duckduckgo.duckchat.impl.store.DuckChatContextualDataStore
 import com.duckduckgo.history.api.NavigationHistory
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
 import logcat.LogPriority.WARN
 import logcat.logcat
 import javax.inject.Inject
@@ -75,6 +79,8 @@ class DataClearing @Inject constructor(
     private val contextualDataStore: DuckChatContextualDataStore,
     private val showOnAppLaunchOptionDataStore: ShowOnAppLaunchOptionDataStore,
     private val dataClearingTrigger: DataClearingTrigger,
+    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) : ManualDataClearing, AutomaticDataClearing {
 
     override suspend fun clearSingleTabData(tabId: String, replaceCurrentTab: Boolean): ClearDataResult {
@@ -93,25 +99,53 @@ class DataClearing @Inject constructor(
         logcat { "Performing single tab clear for tab: $tabId" }
 
         val visitedSites = tabVisitedSitesRepository.getVisitedSites(tabId)
-        val clearDataResult = clearDataAction.clearDataForSpecificDomains(visitedSites)
         val tabUrl = tabRepository.getTab(tabId)?.url
 
-        // Reset this tab's URL before dispatching the chat clear: the tabs-cleanup plugin matches
-        // tabs by chatID, and we don't want this tab caught by that match — it stays open with a
-        // new chat URL. Other tabs at the same chatID (duplicates) do get closed, which is desired.
-        if (replaceCurrentTab) {
-            val url = getNewTabUrl(tabUrl)
-            tabOperations.replaceTabWithNewTab(tabId, url)
-        } else {
-            tabRepository.deleteTabs(listOf(tabId))
+        suspend fun tearDownTab() {
+            if (replaceCurrentTab) {
+                tabOperations.replaceTabWithNewTab(tabId, getNewTabUrl(tabUrl))
+            } else {
+                tabRepository.deleteTabs(listOf(tabId))
+            }
         }
 
-        clearDuckAiChatIfNeeded(tabUrl)
-        clearContextualChatDataIfNeeded(tabId)
-        navigationHistory.removeHistoryForTab(tabId)
+        suspend fun clearChatsAndHistory() {
+            clearDuckAiChatIfNeeded(tabUrl)
+            clearContextualChatDataIfNeeded(tabId)
+            navigationHistory.removeHistoryForTab(tabId)
+        }
 
-        logcat { "Single tab clear completed for tab: $tabId" }
-        return clearDataResult
+        suspend fun completeWideEvent(result: ClearDataResult) {
+            when (result) {
+                is ClearDataResult.Success -> dataClearingWideEvent.finishSuccess()
+                is ClearDataResult.Error -> dataClearingWideEvent.finishFailure(result.exception)
+                is ClearDataResult.FeatureNotSupported ->
+                    dataClearingWideEvent.finishFailure(UnsupportedOperationException("DeleteBrowsingData not supported"))
+            }
+        }
+
+        return if (androidBrowserConfigFeature.backgroundSingleTabDataClearing().isEnabled()) {
+            tearDownTab()
+            appCoroutineScope.launch {
+                try {
+                    val result = clearDataAction.clearDataForSpecificDomains(visitedSites)
+                    clearChatsAndHistory()
+                    completeWideEvent(result)
+                    logcat { "Single tab clear completed (background) for tab: $tabId" }
+                } catch (e: Exception) {
+                    dataClearingWideEvent.finishFailure(e)
+                    logcat(WARN) { "Background single tab clear failed for tab $tabId: ${e.message}" }
+                }
+            }
+            ClearDataResult.Success
+        } else {
+            val result = clearDataAction.clearDataForSpecificDomains(visitedSites)
+            tearDownTab()
+            clearChatsAndHistory()
+            completeWideEvent(result)
+            logcat { "Single tab clear completed for tab: $tabId" }
+            result
+        }
     }
 
     override suspend fun clearTabContextualChat(tabId: String): ClearDataResult {

--- a/app/src/main/java/com/duckduckgo/app/fire/DataClearing.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/DataClearing.kt
@@ -44,6 +44,7 @@ import com.duckduckgo.duckchat.impl.store.DuckChatContextualDataStore
 import com.duckduckgo.history.api.NavigationHistory
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
@@ -132,6 +133,8 @@ class DataClearing @Inject constructor(
                     clearChatsAndHistory()
                     completeWideEvent(result)
                     logcat { "Single tab clear completed (background) for tab: $tabId" }
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     dataClearingWideEvent.finishFailure(e)
                     logcat(WARN) { "Background single tab clear failed for tab $tabId: ${e.message}" }

--- a/app/src/main/java/com/duckduckgo/app/fire/SiteDataCleaner.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/SiteDataCleaner.kt
@@ -22,8 +22,10 @@ import androidx.webkit.WebStorageCompat
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 import kotlin.coroutines.resume
+import kotlin.time.Duration.Companion.milliseconds
 
 fun interface SiteDataCleaner {
     suspend fun deleteSiteData(webStorage: WebStorage, domain: String)
@@ -33,10 +35,16 @@ fun interface SiteDataCleaner {
 @SuppressLint("RequiresFeature")
 class RealSiteDataCleaner @Inject constructor() : SiteDataCleaner {
     override suspend fun deleteSiteData(webStorage: WebStorage, domain: String) {
-        suspendCancellableCoroutine { continuation ->
-            WebStorageCompat.deleteBrowsingDataForSite(webStorage, domain) {
-                continuation.resume(Unit)
+        withTimeoutOrNull(SITE_DELETION_TIMEOUT_MS.milliseconds) {
+            suspendCancellableCoroutine { continuation ->
+                WebStorageCompat.deleteBrowsingDataForSite(webStorage, domain) {
+                    continuation.resume(Unit)
+                }
             }
         }
+    }
+
+    private companion object {
+        private const val SITE_DELETION_TIMEOUT_MS = 5_000L
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/fire/SiteDataCleaner.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/SiteDataCleaner.kt
@@ -35,7 +35,11 @@ class RealSiteDataCleaner @Inject constructor() : SiteDataCleaner {
     override suspend fun deleteSiteData(webStorage: WebStorage, domain: String) {
         suspendCancellableCoroutine { continuation ->
             WebStorageCompat.deleteBrowsingDataForSite(webStorage, domain) {
-                continuation.resume(Unit)
+                // The caller times out each deletion, so the continuation may already be cancelled by the
+                // time this callback fires — only resume while it's still active (see InlinePdfHandler).
+                if (continuation.isActive) {
+                    continuation.resume(Unit)
+                }
             }
         }
     }

--- a/app/src/main/java/com/duckduckgo/app/fire/SiteDataCleaner.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/SiteDataCleaner.kt
@@ -22,10 +22,8 @@ import androidx.webkit.WebStorageCompat
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 import kotlin.coroutines.resume
-import kotlin.time.Duration.Companion.milliseconds
 
 fun interface SiteDataCleaner {
     suspend fun deleteSiteData(webStorage: WebStorage, domain: String)
@@ -35,16 +33,10 @@ fun interface SiteDataCleaner {
 @SuppressLint("RequiresFeature")
 class RealSiteDataCleaner @Inject constructor() : SiteDataCleaner {
     override suspend fun deleteSiteData(webStorage: WebStorage, domain: String) {
-        withTimeoutOrNull(SITE_DELETION_TIMEOUT_MS.milliseconds) {
-            suspendCancellableCoroutine { continuation ->
-                WebStorageCompat.deleteBrowsingDataForSite(webStorage, domain) {
-                    continuation.resume(Unit)
-                }
+        suspendCancellableCoroutine { continuation ->
+            WebStorageCompat.deleteBrowsingDataForSite(webStorage, domain) {
+                continuation.resume(Unit)
             }
         }
-    }
-
-    private companion object {
-        private const val SITE_DELETION_TIMEOUT_MS = 5_000L
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/fire/wideevents/DataClearingWideEvent.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/wideevents/DataClearingWideEvent.kt
@@ -58,6 +58,7 @@ interface DataClearingWideEvent {
 
 enum class DataClearingFlowStep(val stepName: String) {
     WEB_STORAGE_CLEAR("web_storage_clear"),
+    WEB_STORAGE_CLEAR_SELECTIVE("web_storage_clear_selective"),
     WEBVIEW_APP_WEBVIEW_CLEAR("webview_app_webview_clear"),
     WEBVIEW_DEFAULT_CLEAR("webview_default_clear"),
     INDEXEDDB_CLEAR_SELECTIVE("indexeddb_clear_selective"),

--- a/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
@@ -29,6 +29,8 @@ import com.duckduckgo.app.fire.SiteDataCleaner
 import com.duckduckgo.app.fire.UnsentForgetAllPixelStore
 import com.duckduckgo.app.fire.fireproofwebsite.data.FireproofWebsiteRepository
 import com.duckduckgo.app.fire.store.TabVisitedSitesRepository
+import com.duckduckgo.app.fire.wideevents.DataClearingFlowStep
+import com.duckduckgo.app.fire.wideevents.DataClearingWideEvent
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.tabs.model.TabRepository
@@ -145,6 +147,7 @@ class ClearPersonalDataAction(
     duckAiHostProvider: DuckAiHostProvider,
     private val siteDataCleaner: SiteDataCleaner,
     private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
+    private val dataClearingWideEvent: DataClearingWideEvent,
 ) : ClearDataAction {
 
     override fun killAndRestartProcess(notifyDataCleared: Boolean, enableTransitionAnimation: Boolean, deletedTabCount: Int) {
@@ -247,23 +250,32 @@ class ClearPersonalDataAction(
         }
 
         return try {
-            val fireproofDomains = withContext(dispatchers.io()) {
-                fireproofWebsiteRepository.fireproofWebsitesSync()
+            val fireproofDomains: Set<String>
+            val isConcurrentClearEnabled: Boolean
+            withContext(dispatchers.io()) {
+                fireproofDomains = fireproofWebsiteRepository.fireproofWebsitesSync()
                     .mapNotNull { it.domain.toTldPlusOne() }
                     .toSet()
+                isConcurrentClearEnabled = androidBrowserConfigFeature
+                    .concurrentSingleTabDataClearing().isEnabled()
             }
 
             val domainsToClear = domains
                 .filter { !duckDuckGoDomains.contains(it) && !fireproofDomains.contains(it) }
 
-            val concurrentClearEnabled = withContext(dispatchers.io()) {
-                androidBrowserConfigFeature.concurrentSingleTabDataClearing().isEnabled()
-            }
-
-            if (concurrentClearEnabled) {
+            val fullyCleared = if (isConcurrentClearEnabled) {
                 clearDomainsConcurrently(domainsToClear)
             } else {
                 clearDomainsSequentially(domainsToClear)
+                true
+            }
+
+            // Record the selective clear as a wide-event step so a partial clear (a domain — or the whole
+            // batch — hitting its timeout) is observable
+            if (fullyCleared) {
+                dataClearingWideEvent.stepSuccess(DataClearingFlowStep.WEB_STORAGE_CLEAR_SELECTIVE)
+            } else {
+                dataClearingWideEvent.stepFailure(DataClearingFlowStep.WEB_STORAGE_CLEAR_SELECTIVE, SiteDataClearTimeoutException())
             }
             ClearDataResult.Success
         } catch (e: CancellationException) {
@@ -275,11 +287,14 @@ class ClearPersonalDataAction(
     }
 
     /**
-     * Each deleteBrowsingDataForSite is async/callback-based. The per-domain timeout skip a stalled
-     * WebView callback; the overall timeout is a backstop so the burn can block the dialog.
+     * Each deleteBrowsingDataForSite is async-based. The per-domain timeout skips a stalled
+     * WebView callback; the overall timeout is a backstop so the burn can never wedge the dialog
+     * indefinitely.
+     *
+     * @return true if every domain cleared within the deadlines, false if the timeout fired.
      */
-    private suspend fun clearDomainsConcurrently(domainsToClear: List<String>) {
-        val completedWithinDeadline = withTimeoutOrNull(OVERALL_CLEAR_TIMEOUT_MS.milliseconds) {
+    private suspend fun clearDomainsConcurrently(domainsToClear: List<String>): Boolean {
+        val perDomainResults = withTimeoutOrNull(OVERALL_CLEAR_TIMEOUT_MS.milliseconds) {
             withContext(dispatchers.main()) {
                 val webStorage = createWebStorage()
                 val semaphore = Semaphore(MAX_CONCURRENT_SITE_DELETIONS)
@@ -295,13 +310,22 @@ class ClearPersonalDataAction(
                     }.awaitAll()
                 }
             }
-            true
-        } ?: false
+        }
 
-        if (completedWithinDeadline) {
-            logcat(INFO) { "Cleared site data for ${domainsToClear.size} domains" }
-        } else {
-            logcat(WARN) { "Clearing site data timed out after ${OVERALL_CLEAR_TIMEOUT_MS}ms" }
+        return when {
+            perDomainResults == null -> {
+                logcat(WARN) { "Clearing site data timed out after ${OVERALL_CLEAR_TIMEOUT_MS}ms" }
+                false
+            }
+            perDomainResults.any { it == null } -> {
+                val timedOut = perDomainResults.count { it == null }
+                logcat(WARN) { "Cleared site data for ${domainsToClear.size - timedOut} of ${domainsToClear.size} domains ($timedOut timed out)" }
+                false
+            }
+            else -> {
+                logcat(INFO) { "Cleared site data for ${domainsToClear.size} domains" }
+                true
+            }
         }
     }
 
@@ -383,3 +407,5 @@ class ClearPersonalDataAction(
         private const val OVERALL_CLEAR_TIMEOUT_MS = 15_000L
     }
 }
+
+private class SiteDataClearTimeoutException : Exception("Timed out clearing per-site web storage")

--- a/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
@@ -257,7 +257,7 @@ class ClearPersonalDataAction(
                     .mapNotNull { it.domain.toTldPlusOne() }
                     .toSet()
                 isConcurrentClearEnabled = androidBrowserConfigFeature
-                    .concurrentSingleTabDataClearing().isEnabled()
+                    .backgroundSingleTabDataClearing().isEnabled()
             }
 
             val domainsToClear = domains

--- a/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.app.fire.SiteDataCleaner
 import com.duckduckgo.app.fire.UnsentForgetAllPixelStore
 import com.duckduckgo.app.fire.fireproofwebsite.data.FireproofWebsiteRepository
 import com.duckduckgo.app.fire.store.TabVisitedSitesRepository
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.app.trackerdetection.api.WebTrackersBlockedRepository
@@ -143,6 +144,7 @@ class ClearPersonalDataAction(
     private val webViewCapabilityChecker: WebViewCapabilityChecker,
     duckAiHostProvider: DuckAiHostProvider,
     private val siteDataCleaner: SiteDataCleaner,
+    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
 ) : ClearDataAction {
 
     override fun killAndRestartProcess(notifyDataCleared: Boolean, enableTransitionAnimation: Boolean, deletedTabCount: Int) {
@@ -254,27 +256,14 @@ class ClearPersonalDataAction(
             val domainsToClear = domains
                 .filter { !duckDuckGoDomains.contains(it) && !fireproofDomains.contains(it) }
 
-            val completedWithinDeadline = withTimeoutOrNull(OVERALL_CLEAR_TIMEOUT_MS.milliseconds) {
-                withContext(dispatchers.main()) {
-                    val webStorage = createWebStorage()
-                    val semaphore = Semaphore(MAX_CONCURRENT_SITE_DELETIONS)
-                    coroutineScope {
-                        domainsToClear.map { domain ->
-                            async {
-                                semaphore.withPermit {
-                                    siteDataCleaner.deleteSiteData(webStorage, domain)
-                                }
-                            }
-                        }.awaitAll()
-                    }
-                }
-                true
-            } ?: false
+            val concurrentClearEnabled = withContext(dispatchers.io()) {
+                androidBrowserConfigFeature.concurrentSingleTabDataClearing().isEnabled()
+            }
 
-            if (completedWithinDeadline) {
-                logcat(INFO) { "Cleared site data for ${domainsToClear.size} domains" }
+            if (concurrentClearEnabled) {
+                clearDomainsConcurrently(domainsToClear)
             } else {
-                logcat(WARN) { "Clearing site data timed out after ${OVERALL_CLEAR_TIMEOUT_MS}ms" }
+                clearDomainsSequentially(domainsToClear)
             }
             ClearDataResult.Success
         } catch (e: CancellationException) {
@@ -282,6 +271,47 @@ class ClearPersonalDataAction(
         } catch (e: Exception) {
             logcat(WARN) { "Failed to clear site data: ${e.message}" }
             ClearDataResult.Error(e)
+        }
+    }
+
+    /**
+     * Each deleteBrowsingDataForSite is async/callback-based. The per-domain timeout skip a stalled
+     * WebView callback; the overall timeout is a backstop so the burn can block the dialog.
+     */
+    private suspend fun clearDomainsConcurrently(domainsToClear: List<String>) {
+        val completedWithinDeadline = withTimeoutOrNull(OVERALL_CLEAR_TIMEOUT_MS.milliseconds) {
+            withContext(dispatchers.main()) {
+                val webStorage = createWebStorage()
+                val semaphore = Semaphore(MAX_CONCURRENT_SITE_DELETIONS)
+                coroutineScope {
+                    domainsToClear.map { domain ->
+                        async {
+                            semaphore.withPermit {
+                                withTimeoutOrNull(SITE_DELETION_TIMEOUT_MS.milliseconds) {
+                                    siteDataCleaner.deleteSiteData(webStorage, domain)
+                                }
+                            }
+                        }
+                    }.awaitAll()
+                }
+            }
+            true
+        } ?: false
+
+        if (completedWithinDeadline) {
+            logcat(INFO) { "Cleared site data for ${domainsToClear.size} domains" }
+        } else {
+            logcat(WARN) { "Clearing site data timed out after ${OVERALL_CLEAR_TIMEOUT_MS}ms" }
+        }
+    }
+
+    private suspend fun clearDomainsSequentially(domainsToClear: List<String>) {
+        withContext(dispatchers.main()) {
+            val webStorage = createWebStorage()
+            domainsToClear.forEach { domain ->
+                siteDataCleaner.deleteSiteData(webStorage, domain)
+            }
+            logcat(INFO) { "Cleared site data for ${domainsToClear.size} domains" }
         }
     }
 
@@ -345,6 +375,9 @@ class ClearPersonalDataAction(
     private companion object {
         // Max number of per-site web-storage deletions in flight at once
         private const val MAX_CONCURRENT_SITE_DELETIONS = 10
+
+        // Per-domain timeout, so a single stalled WebView callback skips that domain instead of hanging the burn
+        private const val SITE_DELETION_TIMEOUT_MS = 5_000L
 
         // Hard ceiling for the whole per-domain clear, so a stalled WebView can never hang the burn
         private const val OVERALL_CLEAR_TIMEOUT_MS = 15_000L

--- a/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/ClearPersonalDataAction.kt
@@ -41,12 +41,19 @@ import com.duckduckgo.history.api.NavigationHistory
 import com.duckduckgo.savedsites.api.SavedSitesRepository
 import com.duckduckgo.site.permissions.api.SitePermissionsManager
 import com.duckduckgo.sync.api.DeviceSyncState
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import logcat.LogPriority.INFO
 import logcat.LogPriority.WARN
 import logcat.logcat
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Duration.Companion.milliseconds
 
 sealed class ClearDataResult {
     data object Success : ClearDataResult()
@@ -244,14 +251,30 @@ class ClearPersonalDataAction(
                     .toSet()
             }
 
-            withContext(dispatchers.main()) {
-                val webStorage = createWebStorage()
-                domains
-                    .filter { !duckDuckGoDomains.contains(it) && !fireproofDomains.contains(it) }
-                    .forEach { domain ->
-                        siteDataCleaner.deleteSiteData(webStorage, domain)
+            val domainsToClear = domains
+                .filter { !duckDuckGoDomains.contains(it) && !fireproofDomains.contains(it) }
+
+            val completedWithinDeadline = withTimeoutOrNull(OVERALL_CLEAR_TIMEOUT_MS.milliseconds) {
+                withContext(dispatchers.main()) {
+                    val webStorage = createWebStorage()
+                    val semaphore = Semaphore(MAX_CONCURRENT_SITE_DELETIONS)
+                    coroutineScope {
+                        domainsToClear.map { domain ->
+                            async {
+                                semaphore.withPermit {
+                                    siteDataCleaner.deleteSiteData(webStorage, domain)
+                                }
+                            }
+                        }.awaitAll()
                     }
-                logcat(INFO) { "Cleared site data for ${domains.size} domains" }
+                }
+                true
+            } ?: false
+
+            if (completedWithinDeadline) {
+                logcat(INFO) { "Cleared site data for ${domainsToClear.size} domains" }
+            } else {
+                logcat(WARN) { "Clearing site data timed out after ${OVERALL_CLEAR_TIMEOUT_MS}ms" }
             }
             ClearDataResult.Success
         } catch (e: CancellationException) {
@@ -317,5 +340,13 @@ class ClearPersonalDataAction(
         setOf("duckduckgo.com", duckAiHostProvider.getHost())
             .map { host -> "https://$host".toHttpUrlOrNull()?.topPrivateDomain() ?: host }
             .toSet()
+    }
+
+    private companion object {
+        // Max number of per-site web-storage deletions in flight at once
+        private const val MAX_CONCURRENT_SITE_DELETIONS = 10
+
+        // Hard ceiling for the whole per-domain clear, so a stalled WebView can never hang the burn
+        private const val OVERALL_CLEAR_TIMEOUT_MS = 15_000L
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/global/view/SingleTabFireDialogViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/SingleTabFireDialogViewModel.kt
@@ -71,6 +71,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
+import kotlin.time.Duration.Companion.milliseconds
 
 @ContributesViewModel(FragmentScope::class)
 class SingleTabFireDialogViewModel @Inject constructor(
@@ -220,22 +221,22 @@ class SingleTabFireDialogViewModel @Inject constructor(
                         clearOptions = clearOptions,
                     )
                     try {
-                        val clearResult = if (origin.value == DuckAiContextualChat) {
-                            dataClearing.clearTabContextualChat(originalTabId)
+                        if (origin.value == DuckAiContextualChat) {
+                            val contextualResult = dataClearing.clearTabContextualChat(originalTabId)
+                            // Contextual-chat clear is synchronous, so finish the wide event here.
+                            when (contextualResult) {
+                                is ClearDataResult.Success -> dataClearingWideEvent.finishSuccess()
+                                is ClearDataResult.Error -> dataClearingWideEvent.finishFailure(contextualResult.exception)
+                                is ClearDataResult.FeatureNotSupported ->
+                                    dataClearingWideEvent.finishFailure(UnsupportedOperationException("DeleteBrowsingData not supported"))
+                            }
+                            contextualResult
                         } else {
                             dataClearing.clearSingleTabData(
                                 tabId = originalTabId,
                                 replaceCurrentTab = origin.value !is Hatch,
                             )
                         }
-
-                        when (clearResult) {
-                            is ClearDataResult.Success -> dataClearingWideEvent.finishSuccess()
-                            is ClearDataResult.Error -> dataClearingWideEvent.finishFailure(clearResult.exception)
-                            is ClearDataResult.FeatureNotSupported ->
-                                dataClearingWideEvent.finishFailure(UnsupportedOperationException("DeleteBrowsingData not supported"))
-                        }
-                        clearResult
                     } catch (e: CancellationException) {
                         throw e
                     } catch (e: Exception) {
@@ -335,10 +336,10 @@ class SingleTabFireDialogViewModel @Inject constructor(
 
     private suspend fun waitForTabsToUpdate(originalTabId: String?) {
         // wait for the tab selection to change before signaling completion
-        withTimeoutOrNull(TAB_UPDATE_TIMEOUT_MS) {
+        withTimeoutOrNull(TAB_UPDATE_TIMEOUT_MS.milliseconds) {
             tabRepository.flowSelectedTab.firstOrNull { it?.tabId != originalTabId }
         }
-        delay(500)
+        delay(500.milliseconds)
     }
 
     private suspend fun trySendDailyDeleteClicked() {

--- a/app/src/main/java/com/duckduckgo/app/global/view/SingleTabFireDialogViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/SingleTabFireDialogViewModel.kt
@@ -51,6 +51,7 @@ import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.downloads.api.DownloadsRepository
 import com.duckduckgo.downloads.store.DownloadStatus
 import com.duckduckgo.duckchat.api.DuckChat
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
@@ -227,11 +228,16 @@ class SingleTabFireDialogViewModel @Inject constructor(
                                 replaceCurrentTab = origin.value !is Hatch,
                             )
                         }
+
                         when (clearResult) {
+                            is ClearDataResult.Success -> dataClearingWideEvent.finishSuccess()
                             is ClearDataResult.Error -> dataClearingWideEvent.finishFailure(clearResult.exception)
-                            else -> dataClearingWideEvent.finishSuccess()
+                            is ClearDataResult.FeatureNotSupported ->
+                                dataClearingWideEvent.finishFailure(UnsupportedOperationException("DeleteBrowsingData not supported"))
                         }
                         clearResult
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
                         dataClearingWideEvent.finishFailure(e)
                         throw e

--- a/app/src/main/java/com/duckduckgo/app/global/view/SingleTabFireDialogViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/SingleTabFireDialogViewModel.kt
@@ -213,13 +213,28 @@ class SingleTabFireDialogViewModel @Inject constructor(
 
             val result = withContext(dispatcherProvider.io()) {
                 if (originalTabId != null) {
-                    if (origin.value == DuckAiContextualChat) {
-                        dataClearing.clearTabContextualChat(originalTabId)
-                    } else {
-                        dataClearing.clearSingleTabData(
-                            tabId = originalTabId,
-                            replaceCurrentTab = origin.value !is Hatch,
-                        )
+                    val clearOptions = fireDataStore.getManualClearOptions()
+                    dataClearingWideEvent.start(
+                        entryPoint = DataClearingWideEvent.EntryPoint.SINGLE_TAB_FIRE_DIALOG,
+                        clearOptions = clearOptions,
+                    )
+                    try {
+                        val clearResult = if (origin.value == DuckAiContextualChat) {
+                            dataClearing.clearTabContextualChat(originalTabId)
+                        } else {
+                            dataClearing.clearSingleTabData(
+                                tabId = originalTabId,
+                                replaceCurrentTab = origin.value !is Hatch,
+                            )
+                        }
+                        when (clearResult) {
+                            is ClearDataResult.Error -> dataClearingWideEvent.finishFailure(clearResult.exception)
+                            else -> dataClearingWideEvent.finishSuccess()
+                        }
+                        clearResult
+                    } catch (e: Exception) {
+                        dataClearingWideEvent.finishFailure(e)
+                        throw e
                     }
                 } else {
                     null

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -324,6 +324,15 @@ interface AndroidBrowserConfigFeature {
     fun singleTabFireDialog(): Toggle
 
     /**
+     * Kill switch for the bounded-concurrency, time-bounded single-tab data clearing
+     * (fixes slow/stuck fire-button burns). When enabled, per-domain web-storage deletions run
+     * concurrently (bounded) with per-domain and overall timeouts.
+     * If the remote feature is not present defaults to `true`.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun concurrentSingleTabDataClearing(): Toggle
+
+    /**
      * Controls whether the state saving for some of the views inside the BrowserTabFragment is disabled or not
      */
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -324,13 +324,15 @@ interface AndroidBrowserConfigFeature {
     fun singleTabFireDialog(): Toggle
 
     /**
-     * Kill switch for the bounded-concurrency, time-bounded single-tab data clearing
-     * (fixes slow/stuck fire-button burns). When enabled, per-domain web-storage deletions run
-     * concurrently (bounded) with per-domain and overall timeouts.
+     * Kill switch for the non-blocking single-tab data clearing (fixes slow/stuck fire-button burns).
+     * When enabled, the fire dialog returns to browsing immediately while the per-domain web-storage
+     * clear runs on the app scope (bounded concurrency, per-domain and overall timeouts).
+     * When disabled, the clear runs synchronously and sequentially — the UI waits until the data is
+     * fully cleared before the dialog dismisses (original behaviour).
      * If the remote feature is not present defaults to `true`.
      */
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
-    fun concurrentSingleTabDataClearing(): Toggle
+    fun backgroundSingleTabDataClearing(): Toggle
 
     /**
      * Controls whether the state saving for some of the views inside the BrowserTabFragment is disabled or not

--- a/app/src/test/java/com/duckduckgo/app/fire/DataClearingTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/fire/DataClearingTest.kt
@@ -45,6 +45,7 @@ import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.history.api.NavigationHistory
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -60,6 +61,7 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.isNull
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -797,6 +799,36 @@ class DataClearingTest {
 
         testee.clearSingleTabData("tab1")
 
+        verify(mockDataClearingWideEvent).finishFailure(exception)
+    }
+
+    @Test
+    fun whenBackgroundClearFailsThenSucceedsOnRetry_thenWideEventFinishedWithSuccess() = runTest {
+        fakeAndroidBrowserConfigFeature.backgroundSingleTabDataClearing().setRawStoredState(State(enable = true))
+        whenever(mockTabVisitedSitesRepository.getVisitedSites("tab1")).thenReturn(emptySet())
+        whenever(mockClearDataAction.clearDataForSpecificDomains(any()))
+            .thenReturn(ClearDataResult.Error(RuntimeException("transient")))
+            .thenReturn(ClearDataResult.Success)
+
+        testee.clearSingleTabData("tab1")
+        coroutineTestRule.testScope.advanceUntilIdle()
+
+        verify(mockClearDataAction, times(2)).clearDataForSpecificDomains(any())
+        verify(mockDataClearingWideEvent).finishSuccess()
+        verify(mockDataClearingWideEvent, never()).finishFailure(any())
+    }
+
+    @Test
+    fun whenBackgroundClearKeepsFailing_thenRetriesUpToMaxAndWideEventFinishedWithFailure() = runTest {
+        fakeAndroidBrowserConfigFeature.backgroundSingleTabDataClearing().setRawStoredState(State(enable = true))
+        whenever(mockTabVisitedSitesRepository.getVisitedSites("tab1")).thenReturn(emptySet())
+        val exception = RuntimeException("persistent")
+        whenever(mockClearDataAction.clearDataForSpecificDomains(any())).thenReturn(ClearDataResult.Error(exception))
+
+        testee.clearSingleTabData("tab1")
+        coroutineTestRule.testScope.advanceUntilIdle()
+
+        verify(mockClearDataAction, times(3)).clearDataForSpecificDomains(any())
         verify(mockDataClearingWideEvent).finishFailure(exception)
     }
 

--- a/app/src/test/java/com/duckduckgo/app/fire/DataClearingTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/fire/DataClearingTest.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchO
 import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore
 import com.duckduckgo.app.global.view.ClearDataAction
 import com.duckduckgo.app.global.view.ClearDataResult
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.clear.ClearWhenOption
 import com.duckduckgo.app.settings.clear.FireClearOption
 import com.duckduckgo.app.settings.db.SettingsDataStore
@@ -39,6 +40,8 @@ import com.duckduckgo.dataclearing.api.plugin.DataClearingTrigger
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.impl.store.DuckChatContextualDataStore
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.history.api.NavigationHistory
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
@@ -110,12 +113,17 @@ class DataClearingTest {
     @Mock
     private lateinit var mockDataClearingTrigger: DataClearingTrigger
 
+    private val fakeAndroidBrowserConfigFeature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
+
     private val showClearDuckAIChatHistoryFlow = MutableStateFlow(true)
     private val showOnAppLaunchOptionFlow = MutableStateFlow<ShowOnAppLaunchOption>(ShowOnAppLaunchOption.LastOpenedTab)
 
     @Before
     fun setup() {
         MockitoAnnotations.openMocks(this)
+        // Exercise the synchronous clear path so these tests can assert the returned result and the
+        // clear/teardown ordering directly. The background (default) path is covered on-device.
+        fakeAndroidBrowserConfigFeature.backgroundSingleTabDataClearing().setRawStoredState(State(enable = false))
         showClearDuckAIChatHistoryFlow.value = true
         showOnAppLaunchOptionFlow.value = ShowOnAppLaunchOption.LastOpenedTab
         whenever(mockDuckAiFeatureState.showClearDuckAIChatHistory).thenReturn(showClearDuckAIChatHistoryFlow)
@@ -140,6 +148,8 @@ class DataClearingTest {
             contextualDataStore = mockContextualDataStore,
             showOnAppLaunchOptionDataStore = mockShowOnAppLaunchOptionDataStore,
             dataClearingTrigger = mockDataClearingTrigger,
+            androidBrowserConfigFeature = fakeAndroidBrowserConfigFeature,
+            appCoroutineScope = coroutineTestRule.testScope,
         )
     }
 
@@ -768,6 +778,26 @@ class DataClearingTest {
         val result = testee.clearSingleTabData("tab1")
 
         assertEquals(ClearDataResult.Error(exception), result)
+    }
+
+    @Test
+    fun whenClearSingleTabDataSucceeds_thenWideEventFinishedWithSuccess() = runTest {
+        whenever(mockTabVisitedSitesRepository.getVisitedSites("tab1")).thenReturn(emptySet())
+
+        testee.clearSingleTabData("tab1")
+
+        verify(mockDataClearingWideEvent).finishSuccess()
+    }
+
+    @Test
+    fun whenClearSingleTabDataError_thenWideEventFinishedWithFailure() = runTest {
+        whenever(mockTabVisitedSitesRepository.getVisitedSites("tab1")).thenReturn(emptySet())
+        val exception = RuntimeException("test error")
+        whenever(mockClearDataAction.clearDataForSpecificDomains(any())).thenReturn(ClearDataResult.Error(exception))
+
+        testee.clearSingleTabData("tab1")
+
+        verify(mockDataClearingWideEvent).finishFailure(exception)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/global/view/SingleTabFireDialogViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/global/view/SingleTabFireDialogViewModelTest.kt
@@ -1460,6 +1460,22 @@ class SingleTabFireDialogViewModelTest {
     }
 
     @Test
+    fun `when delete this tab returns feature not supported then wide event finishes with failure`() = runTest {
+        whenever(mockTabRepository.getSelectedTab()).thenReturn(
+            TabEntity(tabId = "tab1", url = "https://example.com", title = "Example"),
+        )
+        whenever(mockDataClearing.clearSingleTabData(any(), any())).thenReturn(ClearDataResult.FeatureNotSupported)
+        testee = createViewModel()
+
+        testee.onDeleteThisTabClicked()
+
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(mockDataClearingWideEvent).finishFailure(any())
+        verify(mockDataClearingWideEvent, never()).finishSuccess()
+    }
+
+    @Test
     fun `when delete this tab clicked without selected tab then wide event is not started`() = runTest {
         whenever(mockTabRepository.getSelectedTab()).thenReturn(null)
         testee = createViewModel()

--- a/app/src/test/java/com/duckduckgo/app/global/view/SingleTabFireDialogViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/global/view/SingleTabFireDialogViewModelTest.kt
@@ -1425,7 +1425,7 @@ class SingleTabFireDialogViewModelTest {
     }
 
     @Test
-    fun `when delete this tab clicked then wide event is started with single tab entry point and finished`() = runTest {
+    fun `when delete this tab clicked then wide event is started with single tab entry point and completion delegated to data clearing`() = runTest {
         whenever(mockTabRepository.getSelectedTab()).thenReturn(
             TabEntity(tabId = "tab1", url = "https://example.com", title = "Example"),
         )
@@ -1439,28 +1439,30 @@ class SingleTabFireDialogViewModelTest {
             entryPoint = eq(DataClearingWideEvent.EntryPoint.SINGLE_TAB_FIRE_DIALOG),
             clearOptions = any(),
         )
-        verify(mockDataClearingWideEvent).finishSuccess()
+        // The single-tab clear may run in the background, so DataClearing (not the view model)
+        // completes the wide event once the clear actually finishes.
+        verify(mockDataClearingWideEvent, never()).finishSuccess()
     }
 
     @Test
-    fun `when delete this tab returns error then wide event finishes with failure`() = runTest {
+    fun `when delete this tab returns error then view model does not complete the wide event`() = runTest {
         whenever(mockTabRepository.getSelectedTab()).thenReturn(
             TabEntity(tabId = "tab1", url = "https://example.com", title = "Example"),
         )
-        val exception = RuntimeException("test")
-        whenever(mockDataClearing.clearSingleTabData(any(), any())).thenReturn(ClearDataResult.Error(exception))
+        whenever(mockDataClearing.clearSingleTabData(any(), any())).thenReturn(ClearDataResult.Error(RuntimeException("test")))
         testee = createViewModel()
 
         testee.onDeleteThisTabClicked()
 
         coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
 
-        verify(mockDataClearingWideEvent).finishFailure(exception)
+        // Wide-event completion for the single-tab clear is owned by DataClearing.
+        verify(mockDataClearingWideEvent, never()).finishFailure(any())
         verify(mockDataClearingWideEvent, never()).finishSuccess()
     }
 
     @Test
-    fun `when delete this tab returns feature not supported then wide event finishes with failure`() = runTest {
+    fun `when delete this tab returns feature not supported then view model does not complete the wide event`() = runTest {
         whenever(mockTabRepository.getSelectedTab()).thenReturn(
             TabEntity(tabId = "tab1", url = "https://example.com", title = "Example"),
         )
@@ -1471,7 +1473,8 @@ class SingleTabFireDialogViewModelTest {
 
         coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
 
-        verify(mockDataClearingWideEvent).finishFailure(any())
+        // Wide-event completion for the single-tab clear is owned by DataClearing.
+        verify(mockDataClearingWideEvent, never()).finishFailure(any())
         verify(mockDataClearingWideEvent, never()).finishSuccess()
     }
 

--- a/app/src/test/java/com/duckduckgo/app/global/view/SingleTabFireDialogViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/global/view/SingleTabFireDialogViewModelTest.kt
@@ -1424,6 +1424,53 @@ class SingleTabFireDialogViewModelTest {
         }
     }
 
+    @Test
+    fun `when delete this tab clicked then wide event is started with single tab entry point and finished`() = runTest {
+        whenever(mockTabRepository.getSelectedTab()).thenReturn(
+            TabEntity(tabId = "tab1", url = "https://example.com", title = "Example"),
+        )
+        testee = createViewModel()
+
+        testee.onDeleteThisTabClicked()
+
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(mockDataClearingWideEvent).start(
+            entryPoint = eq(DataClearingWideEvent.EntryPoint.SINGLE_TAB_FIRE_DIALOG),
+            clearOptions = any(),
+        )
+        verify(mockDataClearingWideEvent).finishSuccess()
+    }
+
+    @Test
+    fun `when delete this tab returns error then wide event finishes with failure`() = runTest {
+        whenever(mockTabRepository.getSelectedTab()).thenReturn(
+            TabEntity(tabId = "tab1", url = "https://example.com", title = "Example"),
+        )
+        val exception = RuntimeException("test")
+        whenever(mockDataClearing.clearSingleTabData(any(), any())).thenReturn(ClearDataResult.Error(exception))
+        testee = createViewModel()
+
+        testee.onDeleteThisTabClicked()
+
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(mockDataClearingWideEvent).finishFailure(exception)
+        verify(mockDataClearingWideEvent, never()).finishSuccess()
+    }
+
+    @Test
+    fun `when delete this tab clicked without selected tab then wide event is not started`() = runTest {
+        whenever(mockTabRepository.getSelectedTab()).thenReturn(null)
+        testee = createViewModel()
+
+        testee.onDeleteThisTabClicked()
+
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(mockDataClearingWideEvent, never()).start(any(), any())
+    }
+
     // endregion
 
     // region DUCK_AI_CONTEXTUAL_CHAT origin


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1215536646273752?focus=true

### Description

This PR attempts to speed up the single tab burning using 2 things:

- Parallelize the site data clearing (up 10 coroutines)
- Add timeouts so that a failure can't block the data clearing forever
- Run the single tab data-clearing completely in the background (UI doesn't wait until it's done)

### Steps to test this PR

There are not clear steps to reproduce the original issue. Smoke test the data clearing using single tab burning.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when browsing data is actually removed relative to UI dismissal; timeouts can leave some site storage uncleared while still reporting success, though telemetry and a remote kill switch mitigate rollout risk.
> 
> **Overview**
> Makes **single-tab fire** feel faster by not blocking the dialog on per-site WebView storage deletion, while adding bounded parallelism and timeouts so a stuck callback cannot hang the burn forever.
> 
> When remote flag **`backgroundSingleTabDataClearing`** is on (default), **`DataClearing`** tears down/replaces the tab first, returns success immediately, and finishes site-data clearing (with up to 3 retries), Duck AI/history cleanup, and **wide-event** completion on the app coroutine scope. With the flag off, behavior stays synchronous (clear → teardown → finish event).
> 
> **`clearDataForSpecificDomains`** uses the same flag to choose **up to 10 concurrent** per-domain deletes with **5s per domain** and **15s overall** caps; partial/timeouts still return success but emit **`WEB_STORAGE_CLEAR_SELECTIVE`** step failure for telemetry. **`SiteDataCleaner`** only resumes its continuation if still active after a timeout.
> 
> The single-tab fire dialog **starts** the wide event; completion for normal tab burns is owned by **`DataClearing`**, not the view model (contextual chat still finishes synchronously in the VM).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0df28b372f203121b499aba7a9c877f190c8a867. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->