### PR TITLE
Reload page when settings change

### DIFF
--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingRefreshTriggerPlugin.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingRefreshTriggerPlugin.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl
+
+import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
+import com.duckduckgo.browser.api.BrowserRefreshTriggerPlugin
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class AdBlockingRefreshTriggerPlugin @Inject constructor(
+    private val statusChecker: AdBlockingStatusChecker,
+) : BrowserRefreshTriggerPlugin {
+
+    override fun observeRefreshRequests(): Flow<Unit> =
+        statusChecker.observeState()
+            .distinctUntilChanged()
+            .drop(1)
+            .map { }
+}

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingRefreshTriggerPluginTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingRefreshTriggerPluginTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl
+
+import app.cash.turbine.test
+import com.duckduckgo.adblocking.impl.domain.AdBlockingState
+import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AdBlockingRefreshTriggerPluginTest {
+
+    private val stateFlow = MutableStateFlow<AdBlockingState>(AdBlockingState.Enabled.UserEnabled)
+    private val statusChecker: AdBlockingStatusChecker = mock {
+        on { observeState() } doReturn stateFlow
+    }
+    private val plugin = AdBlockingRefreshTriggerPlugin(statusChecker)
+
+    @Test
+    fun whenSubscribedAndNoChangeThenDoesNotEmitForCurrentState() = runTest {
+        plugin.observeRefreshRequests().test {
+            expectNoEvents()
+            cancel()
+        }
+    }
+
+    @Test
+    fun whenStateChangesThenEmits() = runTest {
+        plugin.observeRefreshRequests().test {
+            stateFlow.value = AdBlockingState.Disabled
+
+            awaitItem()
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenStateChangesMultipleTimesThenEmitsForEachChange() = runTest {
+        plugin.observeRefreshRequests().test {
+            stateFlow.value = AdBlockingState.Disabled
+            awaitItem()
+
+            stateFlow.value = AdBlockingState.Enabled.UserEnabled
+            awaitItem()
+
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenStateRepeatsSameValueThenDoesNotEmit() = runTest {
+        plugin.observeRefreshRequests().test {
+            stateFlow.value = AdBlockingState.Enabled.UserEnabled
+
+            expectNoEvents()
+            cancel()
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -313,6 +313,7 @@ import com.duckduckgo.autofill.api.passwordgeneration.AutomaticSavedLoginsMonito
 import com.duckduckgo.autofill.impl.AutofillFireproofDialogSuppressor
 import com.duckduckgo.brokensite.api.BrokenSitePrompt
 import com.duckduckgo.brokensite.api.RefreshPattern
+import com.duckduckgo.browser.api.BrowserRefreshTriggerPlugin
 import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.browser.api.autocomplete.AutoComplete
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteResult
@@ -432,9 +433,11 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import logcat.LogPriority.ERROR
@@ -554,6 +557,7 @@ class BrowserTabViewModel @Inject constructor(
     private val faviconFetchingFixFeature: FaviconFetchingFixFeature,
     private val ntpAfterIdleManager: NtpAfterIdleManager,
     private val browserInteractionsPlugins: PluginPoint<BrowserInteractionsPlugin>,
+    private val browserRefreshTriggerPlugins: PluginPoint<BrowserRefreshTriggerPlugin>,
     private val inlinePdfHandler: InlinePdfHandler,
     private val pdfDownloadTooltipDataStore: PdfDownloadTooltipDataStore,
     private val cachedFileDownloader: CachedFileDownloader,
@@ -731,6 +735,7 @@ class BrowserTabViewModel @Inject constructor(
     private var hasCompletedPageLoad = false
 
     private var allowlistRefreshTriggerJob: Job? = null
+    private var refreshTriggerJob: Job? = null
     private var isCustomTabScreen: Boolean = false
     private var alreadyShownKeyboard: Boolean = false
     private var pendingDuckChatAuthUpdate: Boolean = false
@@ -845,6 +850,7 @@ class BrowserTabViewModel @Inject constructor(
             }.launchIn(viewModelScope)
 
         observeAccessibilitySettings()
+        observeRefreshTriggers()
 
         savedSitesRepository
             .getFavorites()
@@ -1003,6 +1009,7 @@ class BrowserTabViewModel @Inject constructor(
 
     fun onViewRecreated() {
         observeAccessibilitySettings()
+        observeRefreshTriggers()
     }
 
     fun observeSelectedTab(isRestored: Boolean) {
@@ -1071,6 +1078,20 @@ class BrowserTabViewModel @Inject constructor(
                             refreshWebView = shouldRefreshWebview,
                         )
                 }.launchIn(viewModelScope)
+    }
+
+    fun observeRefreshTriggers() {
+        refreshTriggerJob?.cancel()
+        refreshTriggerJob = browserRefreshTriggerPlugins.getPlugins()
+            .map { plugin ->
+                plugin.observeRefreshRequests()
+                    .catch { logcat(WARN) { "Refresh trigger failed: ${it.asLog()}" } }
+            }
+            .merge()
+            .debounce(REFRESH_TRIGGER_DEBOUNCE_MILLIS)
+            .flatMapLatest { refreshOnViewVisible.asStateFlow().filter { it }.take(1) }
+            .onEach { command.value = NavigationCommand.Refresh }
+            .launchIn(viewModelScope)
     }
 
     private fun observeSyncStatusChangesForDuckChat() {
@@ -5566,6 +5587,8 @@ class BrowserTabViewModel @Inject constructor(
     companion object {
         private const val FIXED_PROGRESS = 50
         private const val UPGRADED_PROGRESS_THRESHOLD = 95
+
+        private const val REFRESH_TRIGGER_DEBOUNCE_MILLIS = 200L
 
         // Minimum progress to show web content again after decided to hide web content (possible spoofing attack).
         // We think that progress is enough to assume next site has already loaded new content.

--- a/app/src/main/java/com/duckduckgo/app/plugins/BrowserRefreshTriggerPluginPoint.kt
+++ b/app/src/main/java/com/duckduckgo/app/plugins/BrowserRefreshTriggerPluginPoint.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.plugins
+
+import com.duckduckgo.anvil.annotations.ContributesPluginPoint
+import com.duckduckgo.browser.api.BrowserRefreshTriggerPlugin
+import com.duckduckgo.di.scopes.AppScope
+
+@ContributesPluginPoint(
+    scope = AppScope::class,
+    boundType = BrowserRefreshTriggerPlugin::class,
+)
+@Suppress("unused")
+interface UnusedBrowserRefreshTriggerPluginPoint

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -251,6 +251,7 @@ import com.duckduckgo.autofill.api.passwordgeneration.AutomaticSavedLoginsMonito
 import com.duckduckgo.autofill.impl.AutofillFireproofDialogSuppressor
 import com.duckduckgo.brokensite.api.BrokenSitePrompt
 import com.duckduckgo.brokensite.api.RefreshPattern
+import com.duckduckgo.browser.api.BrowserRefreshTriggerPlugin
 import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.browser.api.autocomplete.AutoComplete
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteResult
@@ -609,6 +610,13 @@ class BrowserTabViewModelTest {
     private val mockTabStatsBucketing: TabStatsBucketing = mock()
     private val mockNtpAfterIdleManager: NtpAfterIdleManager = mock()
     private val mockBrowserInteractionsPlugins: PluginPoint<BrowserInteractionsPlugin> = mock()
+    private val browserRefreshTriggerFlow = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    private val browserRefreshTriggerPlugin: BrowserRefreshTriggerPlugin = mock {
+        on { observeRefreshRequests() } doReturn browserRefreshTriggerFlow
+    }
+    private val mockBrowserRefreshTriggerPlugins: PluginPoint<BrowserRefreshTriggerPlugin> = mock {
+        on { getPlugins() } doReturn listOf(browserRefreshTriggerPlugin)
+    }
     private val mockDuckChatJSHelper: DuckChatJSHelper = mock()
     private val swipingTabsFeature = FakeFeatureToggleFactory.create(SwipingTabsFeature::class.java)
     private val swipingTabsFeatureProvider = SwipingTabsFeatureProvider(swipingTabsFeature)
@@ -992,6 +1000,7 @@ class BrowserTabViewModelTest {
                 faviconFetchingFixFeature = fakeFaviconFetchingFixFeature,
                 ntpAfterIdleManager = mockNtpAfterIdleManager,
                 browserInteractionsPlugins = mockBrowserInteractionsPlugins,
+                browserRefreshTriggerPlugins = mockBrowserRefreshTriggerPlugins,
                 inlinePdfHandler = mockInlinePdfHandler,
                 pdfDownloadTooltipDataStore = mockPdfDownloadTooltipDataStore,
                 cachedFileDownloader = mockCachedFileDownloader,
@@ -7874,6 +7883,30 @@ class BrowserTabViewModelTest {
         testee.openDuckAiChatById("https://duck.ai/chat?chatId=abc")
 
         verify(plugin).onChatSelected()
+    }
+
+    @Test
+    fun whenBrowserRefreshTriggerPluginEmitsThenNavigationRefreshCommandIssued() = runTest {
+        browserRefreshTriggerFlow.emit(Unit)
+        advanceUntilIdle()
+
+        assertCommandIssued<NavigationCommand.Refresh>()
+    }
+
+    @Test
+    fun whenBrowserRefreshTriggerPluginEmitsWhileTabHiddenThenNoRefreshUntilVisible() = runTest {
+        testee.onViewHidden()
+        advanceUntilIdle()
+
+        browserRefreshTriggerFlow.emit(Unit)
+        advanceUntilIdle()
+
+        assertCommandNotIssued<NavigationCommand.Refresh>()
+
+        testee.onViewVisible()
+        advanceUntilIdle()
+
+        assertCommandIssued<NavigationCommand.Refresh>()
     }
 
     @Test

--- a/browser-api/src/main/java/com/duckduckgo/browser/api/BrowserRefreshTriggerPlugin.kt
+++ b/browser-api/src/main/java/com/duckduckgo/browser/api/BrowserRefreshTriggerPlugin.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.browser.api
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Plugin contributed by features that need to request the active browser tab to reload when
+ * their state changes in a way that invalidates the currently loaded page (e.g. a global
+ * setting toggled by the user).
+ */
+interface BrowserRefreshTriggerPlugin {
+    /**
+     * Emits when something changed that requires reloading the active tab.
+     */
+    fun observeRefreshRequests(): Flow<Unit>
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1215100641316002?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/481882893211075/task/1215495992379744?focus=true

### Description

### Steps to test this PR

_Feature 1_
- [ ] Apply _Patch 1: Enable YouTube ad blocking_ 
- [ ] Fresh start
- [ ] Open 2 tabs, and open a video in YouTube on each one
- [ ] Go to YouTube Ad Blocking settings
- [ ] Enable the feature
- [ ] Go back
- [ ] Notice the current tab reloads (you'll now see the Duck Player overlay)
- [ ] Go to the other tab
- [ ] Notice the tab reloads immediately as well

### Patches
_Patch 1: Enable YouTube ad blocking_ 
```
Subject: [PATCH] Set RC to support webTelemetry_youtubeBuffering_test pixel for youtube_buffering event type, with YouTube ad blocking disabled by default
---
Index: privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt	(revision 7bfb042b235a1d66237dec6145e3a39a43761c2f)
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt	(date 1781019513195)
@@ -29,4 +29,4 @@
     TrackingParametersFeatureName("trackingParameters"),
 }
 
-const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v5/android-config.json"
+const val PRIVACY_REMOTE_CONFIG_URL = "https://gist.githubusercontent.com/CrisBarreiro/c78b0362dbb8ae63e1e0f8af60361fdb/raw/d7cecc98f7ce7c2eef55dac337268edc08a1ba1f/eventhub-web-interference-detection-yt-android-config.json"
```

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when tabs auto-reload across the browser; behavior is debounced and visibility-gated but could surprise users or reload at awkward times if plugins emit too broadly.
> 
> **Overview**
> Adds a **`BrowserRefreshTriggerPlugin`** extension point so features can ask the active tab to reload when a global setting changes, without baking feature logic into the browser module.
> 
> **`BrowserTabViewModel`** merges all contributed plugins, debounces triggers (200ms), and issues **`NavigationCommand.Refresh`** only when the tab is visible—pending refreshes run when the user returns to a background tab. **`AdBlockingRefreshTriggerPlugin`** is the first consumer: it emits when **`AdBlockingStatusChecker`** state changes (e.g. toggling YouTube ad blocking), so open pages pick up the new behavior without a manual reload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74463a5eccc5b285279a264361e90f57807aad1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->