### PR TITLE
Add standard pixels for ad blocking

### DIFF
--- a/PixelDefinitions/pixels/definitions/ad_blocking.json5
+++ b/PixelDefinitions/pixels/definitions/ad_blocking.json5
@@ -1,0 +1,136 @@
+// YouTube ad blocking pixels: https://app.asana.com/1/137249556945/project/72649045549333/task/1214489455564221?focus=true.
+{
+    "adBlocking_settings_opened_daily": {
+        "description": "(Daily) User opened the YouTube ad blocking settings screen.",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "adBlocking_settings_opened_count": {
+        "description": "User opened the YouTube ad blocking settings screen.",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "adBlocking_state_daily": {
+        "description": "(Daily) Reports the client-side ad blocking state. Fired once daily on app foreground.",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "is_enabled",
+                "type": "boolean",
+                "description": "Whether ad blocking is currently active (requires the feature enabled in remote config — kill-switch on and not in contingency mode — in addition to the user/default setting being on)"
+            },
+            {
+                "key": "analytics_enabled",
+                "type": "boolean",
+                "description": "Whether the user has explicitly opted in (turned the ad blocking setting on)"
+            }
+        ]
+    },
+    "adBlocking_enabled_daily": {
+        "description": "(Daily) User enabled YouTube ad blocking in settings.",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "adBlocking_enabled_count": {
+        "description": "User enabled YouTube ad blocking in settings.",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "adBlocking_disabled_daily": {
+        "description": "(Daily) User disabled YouTube ad blocking in settings.",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "adBlocking_disabled_count": {
+        "description": "User disabled YouTube ad blocking in settings.",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "adBlocking_scriptlets_fetch_error_daily": {
+        "description": "(Daily) Downloading an ad blocking scriptlet failed; the update will be retried.",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["exception"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "adBlocking_scriptlets_fetch_error_count": {
+        "description": "Downloading an ad blocking scriptlet failed; the update will be retried.",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["exception"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "adBlocking_scriptlets_validation_error_daily": {
+        "description": "(Daily) Signature validation of a downloaded ad blocking scriptlet failed, blocking the update.",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["exception"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "The validation failure reason",
+                "enum": ["Encoding", "SignatureFormat", "SignatureVerificationFailed", "Unknown"]
+            }
+        ]
+    },
+    "adBlocking_scriptlets_validation_error_count": {
+        "description": "Signature validation of a downloaded ad blocking scriptlet failed, blocking the update.",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["exception"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "The validation failure reason",
+                "enum": ["Encoding", "SignatureFormat", "SignatureVerificationFailed", "Unknown"]
+            }
+        ]
+    },
+    "adBlocking_scriptlets_installed_daily": {
+        "description": "(Daily) Ad blocking scriptlets were downloaded and stored.",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion", { "key": "version", "type": "string", "description": "The newly stored scriptlets version" }]
+    },
+    "adBlocking_scriptlets_installed_count": {
+        "description": "Ad blocking scriptlets were downloaded and stored.",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion", { "key": "version", "type": "string", "description": "The newly stored scriptlets version" }]
+    },
+    "adBlocking_scriptlets_install_error_daily": {
+        "description": "(Daily) Storing ad blocking scriptlets into the local cache failed; the update will be retried.",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["exception"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "adBlocking_scriptlets_install_error_count": {
+        "description": "Storing ad blocking scriptlets into the local cache failed; the update will be retried.",
+        "owners": ["CrisBarreiro"],
+        "triggers": ["exception"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    }
+}

--- a/PixelDefinitions/pixels/definitions/ad_blocking.json5
+++ b/PixelDefinitions/pixels/definitions/ad_blocking.json5
@@ -27,7 +27,7 @@
                 "description": "Whether ad blocking is currently active (requires the feature enabled in remote config — kill-switch on and not in contingency mode — in addition to the user/default setting being on)"
             },
             {
-                "key": "analytics_enabled",
+                "key": "user_opted_in",
                 "type": "boolean",
                 "description": "Whether the user has explicitly opted in (turned the ad blocking setting on)"
             }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingPixelNames.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingPixelNames.kt
@@ -16,4 +16,28 @@
 
 package com.duckduckgo.adblocking.impl
 
-object AdBlockingPixelNames
+import com.duckduckgo.app.statistics.pixels.Pixel
+
+enum class AdBlockingPixelNames(override val pixelName: String) : Pixel.PixelName {
+    AD_BLOCKING_SETTINGS_OPENED_DAILY("adBlocking_settings_opened_daily"),
+    AD_BLOCKING_SETTINGS_OPENED_COUNT("adBlocking_settings_opened_count"),
+
+    // Daily report of the current ad blocking state, fired at app launch.
+    AD_BLOCKING_STATE_DAILY("adBlocking_state_daily"),
+
+    // User enabled/disabled YouTube ad blocking in settings.
+    AD_BLOCKING_ENABLED_DAILY("adBlocking_enabled_daily"),
+    AD_BLOCKING_ENABLED_COUNT("adBlocking_enabled_count"),
+    AD_BLOCKING_DISABLED_DAILY("adBlocking_disabled_daily"),
+    AD_BLOCKING_DISABLED_COUNT("adBlocking_disabled_count"),
+
+    // Scriptlet update lifecycle: fetch -> validation -> install.
+    AD_BLOCKING_SCRIPTLETS_FETCH_ERROR_DAILY("adBlocking_scriptlets_fetch_error_daily"),
+    AD_BLOCKING_SCRIPTLETS_FETCH_ERROR_COUNT("adBlocking_scriptlets_fetch_error_count"),
+    AD_BLOCKING_SCRIPTLETS_VALIDATION_ERROR_DAILY("adBlocking_scriptlets_validation_error_daily"),
+    AD_BLOCKING_SCRIPTLETS_VALIDATION_ERROR_COUNT("adBlocking_scriptlets_validation_error_count"),
+    AD_BLOCKING_SCRIPTLETS_INSTALLED_DAILY("adBlocking_scriptlets_installed_daily"),
+    AD_BLOCKING_SCRIPTLETS_INSTALLED_COUNT("adBlocking_scriptlets_installed_count"),
+    AD_BLOCKING_SCRIPTLETS_INSTALL_ERROR_DAILY("adBlocking_scriptlets_install_error_daily"),
+    AD_BLOCKING_SCRIPTLETS_INSTALL_ERROR_COUNT("adBlocking_scriptlets_install_error_count"),
+}

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/AdBlockingStatusChecker.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/AdBlockingStatusChecker.kt
@@ -33,6 +33,16 @@ import javax.inject.Inject
 
 interface AdBlockingStatusChecker {
     fun canInject(): Boolean
+
+    /**
+     * Reactive equivalent of [canInject]: emits whether ad blocking is currently active (remote
+     * config kill-switch on, not in contingency mode, and the user/default setting on). Unlike
+     * [canInject] — whose snapshot is seeded `false` until the DataStore-backed user setting
+     * resolves — collecting this waits for a real value, so it is safe for one-shot reads at app
+     * start.
+     */
+    fun observeCanInject(): Flow<Boolean>
+
     fun isShownInSettings(): Boolean
 
     /**
@@ -68,12 +78,8 @@ class RealAdBlockingStatusChecker @Inject constructor(
     @AppCoroutineScope appScope: CoroutineScope,
 ) : AdBlockingStatusChecker {
 
-    private val userEnabled: StateFlow<Boolean> = combine(
-        settingsRepository.isEnabledFlow(),
-        feature.enabledByDefault().enabled(),
-    ) { stored, enabledByDefault ->
-        stored ?: enabledByDefault
-    }.stateIn(appScope, SharingStarted.Eagerly, initialValue = false)
+    private val state: StateFlow<AdBlockingState> = observeState()
+        .stateIn(appScope, SharingStarted.Eagerly, AdBlockingState.Uninitialized)
 
     override fun canInject(): Boolean {
         if (!feature.self().isEnabled()) {
@@ -84,12 +90,22 @@ class RealAdBlockingStatusChecker @Inject constructor(
             logcat { "Contingency mode is on" }
             return false
         }
-        if (!userEnabled.value) {
+        if (state.value !is AdBlockingState.Enabled) {
             logcat { "User disabled ad blocking" }
             return false
         }
         return true
     }
+
+    override fun observeCanInject(): Flow<Boolean> =
+        combine(
+            feature.self().enabled(),
+            feature.enableContingencyMode().enabled(),
+            settingsRepository.isEnabledFlow(),
+            feature.enabledByDefault().enabled(),
+        ) { killSwitchOn, contingencyModeOn, stored, enabledByDefault ->
+            killSwitchOn && !contingencyModeOn && (stored ?: enabledByDefault)
+        }
 
     override fun isShownInSettings(): Boolean = feature.self().isEnabled()
 
@@ -110,8 +126,6 @@ class RealAdBlockingStatusChecker @Inject constructor(
                 }
             }
         }
-    private val state: StateFlow<AdBlockingState> = observeState()
-        .stateIn(appScope, SharingStarted.Eagerly, AdBlockingState.Uninitialized)
 
     override fun currentState(): AdBlockingState = state.value
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/ScriptletUpdater.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/ScriptletUpdater.kt
@@ -17,14 +17,25 @@
 package com.duckduckgo.adblocking.impl.domain
 
 import com.duckduckgo.adblocking.impl.AdBlockingExtensionRepository
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_SCRIPTLETS_FETCH_ERROR_COUNT
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_SCRIPTLETS_FETCH_ERROR_DAILY
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_SCRIPTLETS_INSTALLED_COUNT
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_SCRIPTLETS_INSTALLED_DAILY
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_SCRIPTLETS_INSTALL_ERROR_COUNT
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_SCRIPTLETS_INSTALL_ERROR_DAILY
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_SCRIPTLETS_VALIDATION_ERROR_COUNT
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_SCRIPTLETS_VALIDATION_ERROR_DAILY
 import com.duckduckgo.adblocking.impl.ScriptletDownloader
 import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionSettings
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import logcat.LogPriority.WARN
 import logcat.logcat
 import javax.inject.Inject
@@ -44,10 +55,12 @@ class RealScriptletUpdater @Inject constructor(
     private val repository: AdBlockingExtensionRepository,
     private val downloader: ScriptletDownloader,
     private val validator: ScriptletSignatureValidator,
+    private val pixel: Pixel,
 ) : ScriptletUpdater {
 
     override suspend fun update(settings: AdBlockingExtensionSettings): ScriptletUpdateResult {
-        if (settings.version == repository.getStoredVersion()) {
+        val storedVersion = repository.getStoredVersion()
+        if (settings.version == storedVersion) {
             logcat { "Version matches stored. Skipping" }
             return ScriptletUpdateResult.Success
         }
@@ -59,7 +72,7 @@ class RealScriptletUpdater @Inject constructor(
                         logcat { "Downloading ${entry.url}" }
                         val bytes = downloader.download(entry.url).getOrElse {
                             logcat(WARN) { "ScriptletUpdater: download failed for $name: ${it.message}" }
-                            throw ScriptletFailure()
+                            throw ScriptletFailure.Fetch()
                         }
 
                         when (val validationResult = validator.validate(bytes, entry.signature)) {
@@ -71,20 +84,53 @@ class RealScriptletUpdater @Inject constructor(
                             }
                             is ScriptletValidationResult.Invalid -> {
                                 logcat(WARN) { "ScriptletUpdater: validation failed for $name: $validationResult" }
-                                throw ScriptletFailure()
+                                throw ScriptletFailure.Validation(validationResult::class.simpleName ?: "Unknown")
                             }
                         }
                     }
                 }.awaitAll().filterNotNull().toMap()
             }
-        } catch (_: ScriptletFailure) {
+        } catch (failure: ScriptletFailure) {
+            // Multiple scriptlets download/validate in parallel, but coroutineScope + awaitAll
+            // propagate only the first failure (siblings are cancelled), so this fires exactly once.
+            when (failure) {
+                is ScriptletFailure.Fetch -> {
+                    pixel.enqueueFire(AD_BLOCKING_SCRIPTLETS_FETCH_ERROR_DAILY, type = Pixel.PixelType.Daily())
+                    pixel.enqueueFire(AD_BLOCKING_SCRIPTLETS_FETCH_ERROR_COUNT)
+                }
+                is ScriptletFailure.Validation -> {
+                    val params = mapOf(PARAM_REASON to failure.reason)
+                    pixel.enqueueFire(AD_BLOCKING_SCRIPTLETS_VALIDATION_ERROR_DAILY, parameters = params, type = Pixel.PixelType.Daily())
+                    pixel.enqueueFire(AD_BLOCKING_SCRIPTLETS_VALIDATION_ERROR_COUNT, parameters = params)
+                }
+            }
             return ScriptletUpdateResult.Retry
         }
 
         logcat { "Storing scriptlets" }
-        repository.storeScriptlets(settings.version, downloaded)
+        try {
+            repository.storeScriptlets(settings.version, downloaded)
+        } catch (e: Exception) {
+            currentCoroutineContext().ensureActive()
+            logcat(WARN) { "ScriptletUpdater: storing scriptlets failed: ${e.message}" }
+            pixel.enqueueFire(AD_BLOCKING_SCRIPTLETS_INSTALL_ERROR_DAILY, type = Pixel.PixelType.Daily())
+            pixel.enqueueFire(AD_BLOCKING_SCRIPTLETS_INSTALL_ERROR_COUNT)
+            return ScriptletUpdateResult.Retry
+        }
+
+        val installedParams = mapOf(PARAM_VERSION to settings.version)
+        pixel.enqueueFire(AD_BLOCKING_SCRIPTLETS_INSTALLED_DAILY, parameters = installedParams, type = Pixel.PixelType.Daily())
+        pixel.enqueueFire(AD_BLOCKING_SCRIPTLETS_INSTALLED_COUNT, parameters = installedParams)
         return ScriptletUpdateResult.Success
     }
 
-    private class ScriptletFailure : RuntimeException()
+    private sealed class ScriptletFailure : RuntimeException() {
+        class Fetch : ScriptletFailure()
+        data class Validation(val reason: String) : ScriptletFailure()
+    }
+
+    companion object {
+        private const val PARAM_VERSION = "version"
+        private const val PARAM_REASON = "reason"
+    }
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/pixels/AdBlockingPixelParamRemovalPlugin.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/pixels/AdBlockingPixelParamRemovalPlugin.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.pixels
+
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames
+import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin
+import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class AdBlockingPixelParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin {
+    override fun names(): List<Pair<String, Set<PixelParameter>>> {
+        return AdBlockingPixelNames.entries.map { it.pixelName to PixelParameter.removeAtb() }
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/pixels/AdBlockingStateReporter.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/pixels/AdBlockingStateReporter.kt
@@ -54,7 +54,7 @@ class AdBlockingStateReporter @Inject constructor(
                 AD_BLOCKING_STATE_DAILY,
                 parameters = mapOf(
                     PARAM_IS_ENABLED to isActive.toString(),
-                    PARAM_ANALYTICS_ENABLED to (userState is AdBlockingState.Enabled.UserEnabled).toString(),
+                    PARAM_USER_OPTED_IN to (userState is AdBlockingState.Enabled.UserEnabled).toString(),
                 ),
                 type = Pixel.PixelType.Daily(),
             )
@@ -63,6 +63,6 @@ class AdBlockingStateReporter @Inject constructor(
 
     private companion object {
         private const val PARAM_IS_ENABLED = "is_enabled"
-        private const val PARAM_ANALYTICS_ENABLED = "analytics_enabled"
+        private const val PARAM_USER_OPTED_IN = "user_opted_in"
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/pixels/AdBlockingStateReporter.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/pixels/AdBlockingStateReporter.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.pixels
+
+import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_STATE_DAILY
+import com.duckduckgo.adblocking.impl.domain.AdBlockingState
+import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Reports the client-side ad blocking state once per day, on app foreground.
+ * The [Pixel.PixelType.Daily] dedup guarantees at most one report per UTC day.
+ */
+@ContributesMultibinding(scope = AppScope::class, boundType = MainProcessLifecycleObserver::class)
+@SingleInstanceIn(AppScope::class)
+class AdBlockingStateReporter @Inject constructor(
+    private val statusChecker: AdBlockingStatusChecker,
+    private val pixel: Pixel,
+    @AppCoroutineScope private val appScope: CoroutineScope,
+) : MainProcessLifecycleObserver {
+
+    override fun onResume(owner: LifecycleOwner) {
+        appScope.launch {
+            val (isActive, userState) = combine(
+                statusChecker.observeCanInject(),
+                statusChecker.observeState(),
+            ) { isActive, userState -> isActive to userState }.firstOrNull() ?: return@launch
+            pixel.fire(
+                AD_BLOCKING_STATE_DAILY,
+                parameters = mapOf(
+                    PARAM_IS_ENABLED to isActive.toString(),
+                    PARAM_ANALYTICS_ENABLED to (userState is AdBlockingState.Enabled.UserEnabled).toString(),
+                ),
+                type = Pixel.PixelType.Daily(),
+            )
+        }
+    }
+
+    private companion object {
+        private const val PARAM_IS_ENABLED = "is_enabled"
+        private const val PARAM_ANALYTICS_ENABLED = "analytics_enabled"
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsViewModel.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsViewModel.kt
@@ -18,12 +18,19 @@ package com.duckduckgo.adblocking.impl.ui
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_DISABLED_COUNT
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_DISABLED_DAILY
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_ENABLED_COUNT
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_ENABLED_DAILY
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_SETTINGS_OPENED_COUNT
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_SETTINGS_OPENED_DAILY
 import com.duckduckgo.adblocking.impl.AdBlockingSettingsRepository
 import com.duckduckgo.adblocking.impl.domain.AdBlockingState
 import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
 import com.duckduckgo.adblocking.impl.ui.AdBlockingSettingsViewModel.Command.OpenDuckPlayerSettings
 import com.duckduckgo.adblocking.impl.ui.AdBlockingSettingsViewModel.Command.OpenLearnMore
 import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.di.scopes.ActivityScope
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
@@ -40,7 +47,13 @@ import javax.inject.Inject
 class AdBlockingSettingsViewModel @Inject constructor(
     statusChecker: AdBlockingStatusChecker,
     private val repository: AdBlockingSettingsRepository,
+    private val pixel: Pixel,
 ) : ViewModel() {
+
+    init {
+        pixel.fire(AD_BLOCKING_SETTINGS_OPENED_DAILY, type = Pixel.PixelType.Daily())
+        pixel.fire(AD_BLOCKING_SETTINGS_OPENED_COUNT)
+    }
 
     data class ViewState(
         val isEnabled: Boolean = false,
@@ -72,6 +85,13 @@ class AdBlockingSettingsViewModel @Inject constructor(
     fun onBlockAdsToggled(enabled: Boolean) {
         viewModelScope.launch {
             repository.setEnabled(enabled)
+            if (enabled) {
+                pixel.fire(AD_BLOCKING_ENABLED_DAILY, type = Pixel.PixelType.Daily())
+                pixel.fire(AD_BLOCKING_ENABLED_COUNT)
+            } else {
+                pixel.fire(AD_BLOCKING_DISABLED_DAILY, type = Pixel.PixelType.Daily())
+                pixel.fire(AD_BLOCKING_DISABLED_COUNT)
+            }
         }
     }
 

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/RealScriptletUpdaterTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/RealScriptletUpdaterTest.kt
@@ -16,12 +16,21 @@
 
 package com.duckduckgo.adblocking.impl
 
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_SCRIPTLETS_FETCH_ERROR_COUNT
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_SCRIPTLETS_FETCH_ERROR_DAILY
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_SCRIPTLETS_INSTALLED_COUNT
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_SCRIPTLETS_INSTALLED_DAILY
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_SCRIPTLETS_INSTALL_ERROR_COUNT
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_SCRIPTLETS_INSTALL_ERROR_DAILY
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_SCRIPTLETS_VALIDATION_ERROR_COUNT
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_SCRIPTLETS_VALIDATION_ERROR_DAILY
 import com.duckduckgo.adblocking.impl.domain.RealScriptletUpdater
 import com.duckduckgo.adblocking.impl.domain.ScriptletSignatureValidator
 import com.duckduckgo.adblocking.impl.domain.ScriptletUpdateResult
 import com.duckduckgo.adblocking.impl.domain.ScriptletValidationResult
 import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionSettings
 import com.duckduckgo.adblocking.impl.remoteconfig.ScriptletEntry
+import com.duckduckgo.app.statistics.pixels.Pixel
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.test.runTest
@@ -33,7 +42,9 @@ import org.mockito.kotlin.check
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import java.io.IOException
 
@@ -42,8 +53,9 @@ class RealScriptletUpdaterTest {
     private val repository: AdBlockingExtensionRepository = mock()
     private val downloader: ScriptletDownloader = mock()
     private val validator: ScriptletSignatureValidator = mock()
+    private val pixel: Pixel = mock()
 
-    private val updater = RealScriptletUpdater(repository, downloader, validator)
+    private val updater = RealScriptletUpdater(repository, downloader, validator, pixel)
 
     private val isolatedPath = "scriptlets/isolated/ublock-filters.js"
     private val mainPath = "scriptlets/main/ublock-filters.js"
@@ -75,6 +87,8 @@ class RealScriptletUpdaterTest {
 
         assertEquals(ScriptletUpdateResult.Retry, updater.update(validSettings))
         verify(repository, never()).storeScriptlets(any(), any())
+        verify(pixel).enqueueFire(AD_BLOCKING_SCRIPTLETS_FETCH_ERROR_DAILY, type = Pixel.PixelType.Daily())
+        verify(pixel).enqueueFire(AD_BLOCKING_SCRIPTLETS_FETCH_ERROR_COUNT)
     }
 
     @Test
@@ -88,6 +102,50 @@ class RealScriptletUpdaterTest {
 
         assertEquals(ScriptletUpdateResult.Retry, updater.update(validSettings))
         verify(repository, never()).storeScriptlets(any(), any())
+        verify(pixel).enqueueFire(
+            AD_BLOCKING_SCRIPTLETS_VALIDATION_ERROR_DAILY,
+            parameters = mapOf("reason" to "SignatureVerificationFailed"),
+            type = Pixel.PixelType.Daily(),
+        )
+        verify(pixel).enqueueFire(
+            AD_BLOCKING_SCRIPTLETS_VALIDATION_ERROR_COUNT,
+            parameters = mapOf("reason" to "SignatureVerificationFailed"),
+        )
+    }
+
+    @Test
+    fun whenMultipleDownloadsFailThenFetchErrorPixelsFiredOnlyOnce() = runTest {
+        whenever(repository.getStoredVersion()).thenReturn("0.0.0")
+        whenever(downloader.download(isolatedEntry.url)).thenReturn(kotlin.Result.failure(IOException("boom1")))
+        whenever(downloader.download(mainEntry.url)).thenReturn(kotlin.Result.failure(IOException("boom2")))
+
+        assertEquals(ScriptletUpdateResult.Retry, updater.update(validSettings))
+        verify(pixel, times(1)).enqueueFire(AD_BLOCKING_SCRIPTLETS_FETCH_ERROR_DAILY, type = Pixel.PixelType.Daily())
+        verify(pixel, times(1)).enqueueFire(AD_BLOCKING_SCRIPTLETS_FETCH_ERROR_COUNT)
+        verifyNoMoreInteractions(pixel)
+    }
+
+    @Test
+    fun whenMultipleValidationsFailThenValidationErrorPixelsFiredOnlyOnce() = runTest {
+        whenever(repository.getStoredVersion()).thenReturn("0.0.0")
+        whenever(downloader.download(isolatedEntry.url)).thenReturn(kotlin.Result.success(isolatedBytes))
+        whenever(downloader.download(mainEntry.url)).thenReturn(kotlin.Result.success(mainBytes))
+        whenever(validator.validate(isolatedBytes, isolatedEntry.signature))
+            .thenReturn(ScriptletValidationResult.Invalid.SignatureVerificationFailed)
+        whenever(validator.validate(mainBytes, mainEntry.signature))
+            .thenReturn(ScriptletValidationResult.Invalid.SignatureVerificationFailed)
+
+        assertEquals(ScriptletUpdateResult.Retry, updater.update(validSettings))
+        verify(pixel, times(1)).enqueueFire(
+            AD_BLOCKING_SCRIPTLETS_VALIDATION_ERROR_DAILY,
+            parameters = mapOf("reason" to "SignatureVerificationFailed"),
+            type = Pixel.PixelType.Daily(),
+        )
+        verify(pixel, times(1)).enqueueFire(
+            AD_BLOCKING_SCRIPTLETS_VALIDATION_ERROR_COUNT,
+            parameters = mapOf("reason" to "SignatureVerificationFailed"),
+        )
+        verifyNoMoreInteractions(pixel)
     }
 
     @Test
@@ -107,6 +165,51 @@ class RealScriptletUpdaterTest {
                 assertEquals(String(mainBytes), String(stored.getValue(mainPath)))
             },
         )
+        verify(pixel).enqueueFire(
+            AD_BLOCKING_SCRIPTLETS_INSTALLED_DAILY,
+            parameters = mapOf("version" to "2026.3.9"),
+            type = Pixel.PixelType.Daily(),
+        )
+        verify(pixel).enqueueFire(
+            AD_BLOCKING_SCRIPTLETS_INSTALLED_COUNT,
+            parameters = mapOf("version" to "2026.3.9"),
+        )
+    }
+
+    @Test
+    fun whenStoredVersionIsNullThenSuccessfulUpdateFiresInstalledPixel() = runTest {
+        whenever(repository.getStoredVersion()).thenReturn(null)
+        whenever(downloader.download(isolatedEntry.url)).thenReturn(kotlin.Result.success(isolatedBytes))
+        whenever(downloader.download(mainEntry.url)).thenReturn(kotlin.Result.success(mainBytes))
+        whenever(validator.validate(isolatedBytes, isolatedEntry.signature)).thenReturn(ScriptletValidationResult.Valid)
+        whenever(validator.validate(mainBytes, mainEntry.signature)).thenReturn(ScriptletValidationResult.Valid)
+
+        assertEquals(ScriptletUpdateResult.Success, updater.update(validSettings))
+        verify(repository).storeScriptlets(eq("2026.3.9"), any())
+        verify(pixel).enqueueFire(
+            AD_BLOCKING_SCRIPTLETS_INSTALLED_DAILY,
+            parameters = mapOf("version" to "2026.3.9"),
+            type = Pixel.PixelType.Daily(),
+        )
+        verify(pixel).enqueueFire(
+            AD_BLOCKING_SCRIPTLETS_INSTALLED_COUNT,
+            parameters = mapOf("version" to "2026.3.9"),
+        )
+    }
+
+    @Test
+    fun whenStoringScriptletsFailsThenUpdateReturnsRetryAndFiresInstallError() = runTest {
+        whenever(repository.getStoredVersion()).thenReturn("0.0.0")
+        whenever(downloader.download(isolatedEntry.url)).thenReturn(kotlin.Result.success(isolatedBytes))
+        whenever(downloader.download(mainEntry.url)).thenReturn(kotlin.Result.success(mainBytes))
+        whenever(validator.validate(isolatedBytes, isolatedEntry.signature)).thenReturn(ScriptletValidationResult.Valid)
+        whenever(validator.validate(mainBytes, mainEntry.signature)).thenReturn(ScriptletValidationResult.Valid)
+        whenever(repository.storeScriptlets(any(), any())).thenThrow(RuntimeException("db boom"))
+
+        assertEquals(ScriptletUpdateResult.Retry, updater.update(validSettings))
+        verify(pixel).enqueueFire(AD_BLOCKING_SCRIPTLETS_INSTALL_ERROR_DAILY, type = Pixel.PixelType.Daily())
+        verify(pixel).enqueueFire(AD_BLOCKING_SCRIPTLETS_INSTALL_ERROR_COUNT)
+        verify(pixel, never()).enqueueFire(AD_BLOCKING_SCRIPTLETS_INSTALLED_DAILY, type = Pixel.PixelType.Daily())
     }
 
     @Test
@@ -151,7 +254,7 @@ class RealScriptletUpdaterTest {
                 else -> error("unexpected url: $url")
             }
         }
-        val shortCircuitingUpdater = RealScriptletUpdater(repository, shortCircuitingDownloader, validator)
+        val shortCircuitingUpdater = RealScriptletUpdater(repository, shortCircuitingDownloader, validator, pixel)
 
         assertEquals(ScriptletUpdateResult.Retry, shortCircuitingUpdater.update(validSettings))
         assertTrue("isolated download should have started in parallel", isolatedDownloadStarted.isCompleted)

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/domain/RealAdBlockingStatusCheckerTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/domain/RealAdBlockingStatusCheckerTest.kt
@@ -45,6 +45,7 @@ class RealAdBlockingStatusCheckerTest {
 
     private val killSwitchEnabledFlow = MutableStateFlow(true)
     private val enabledByDefaultFlow = MutableStateFlow(false)
+    private val contingencyModeEnabledFlow = MutableStateFlow(false)
 
     private val selfToggle: Toggle = mock {
         on { isEnabled() } doAnswer { killSwitchEnabled }
@@ -52,6 +53,7 @@ class RealAdBlockingStatusCheckerTest {
     }
     private val contingencyModeToggle: Toggle = mock {
         on { isEnabled() } doAnswer { contingencyModeEnabled }
+        on { enabled() } doReturn contingencyModeEnabledFlow
     }
     private val enabledByDefaultToggle: Toggle = mock {
         on { isEnabled() } doAnswer { enabledByDefaultFlow.value }
@@ -131,6 +133,40 @@ class RealAdBlockingStatusCheckerTest {
 
         enabledByDefaultFlow.value = true
         assertTrue(checker.canInject())
+    }
+
+    @Test
+    fun whenKillSwitchOnContingencyOffAndUserEnabledThenObserveCanInjectEmitsTrue() = runTest {
+        assertTrue(checker.observeCanInject().first())
+    }
+
+    @Test
+    fun whenKillSwitchOffThenObserveCanInjectEmitsFalse() = runTest {
+        killSwitchEnabledFlow.value = false
+
+        assertFalse(checker.observeCanInject().first())
+    }
+
+    @Test
+    fun whenContingencyModeOnThenObserveCanInjectEmitsFalse() = runTest {
+        contingencyModeEnabledFlow.value = true
+
+        assertFalse(checker.observeCanInject().first())
+    }
+
+    @Test
+    fun whenUserHasDisabledThenObserveCanInjectEmitsFalse() = runTest {
+        userEnabledFlow.value = false
+
+        assertFalse(checker.observeCanInject().first())
+    }
+
+    @Test
+    fun whenUserHasNoPreferenceAndEnabledByDefaultThenObserveCanInjectEmitsTrue() = runTest {
+        userEnabledFlow.value = null
+        enabledByDefaultFlow.value = true
+
+        assertTrue(checker.observeCanInject().first())
     }
 
     @Test

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/pixels/AdBlockingStateReporterTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/pixels/AdBlockingStateReporterTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.pixels
+
+import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_STATE_DAILY
+import com.duckduckgo.adblocking.impl.domain.AdBlockingState
+import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AdBlockingStateReporterTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val statusChecker: AdBlockingStatusChecker = mock()
+    private val pixel: Pixel = mock()
+    private val owner: LifecycleOwner = mock()
+
+    private val reporter = AdBlockingStateReporter(statusChecker, pixel, coroutineRule.testScope)
+
+    @Test
+    fun whenCanInjectAndUserEnabledThenBothParamsTrue() {
+        whenever(statusChecker.observeCanInject()).thenReturn(flowOf(true))
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Enabled.UserEnabled))
+
+        reporter.onResume(owner)
+
+        verify(pixel).fire(
+            AD_BLOCKING_STATE_DAILY,
+            parameters = mapOf("is_enabled" to "true", "analytics_enabled" to "true"),
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+
+    @Test
+    fun whenCanInjectByDefaultThenIsEnabledTrueButAnalyticsFalse() {
+        whenever(statusChecker.observeCanInject()).thenReturn(flowOf(true))
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Enabled.Default))
+
+        reporter.onResume(owner)
+
+        verify(pixel).fire(
+            AD_BLOCKING_STATE_DAILY,
+            parameters = mapOf("is_enabled" to "true", "analytics_enabled" to "false"),
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+
+    @Test
+    fun whenUserOptedInButRemoteConfigGatesInjectionThenIsEnabledFalseButAnalyticsTrue() {
+        whenever(statusChecker.observeCanInject()).thenReturn(flowOf(false))
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Enabled.UserEnabled))
+
+        reporter.onResume(owner)
+
+        verify(pixel).fire(
+            AD_BLOCKING_STATE_DAILY,
+            parameters = mapOf("is_enabled" to "false", "analytics_enabled" to "true"),
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+
+    @Test
+    fun whenDisabledThenBothParamsFalse() {
+        whenever(statusChecker.observeCanInject()).thenReturn(flowOf(false))
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled))
+
+        reporter.onResume(owner)
+
+        verify(pixel).fire(
+            AD_BLOCKING_STATE_DAILY,
+            parameters = mapOf("is_enabled" to "false", "analytics_enabled" to "false"),
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/pixels/AdBlockingStateReporterTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/pixels/AdBlockingStateReporterTest.kt
@@ -51,7 +51,7 @@ class AdBlockingStateReporterTest {
 
         verify(pixel).fire(
             AD_BLOCKING_STATE_DAILY,
-            parameters = mapOf("is_enabled" to "true", "analytics_enabled" to "true"),
+            parameters = mapOf("is_enabled" to "true", "user_opted_in" to "true"),
             type = Pixel.PixelType.Daily(),
         )
     }
@@ -65,7 +65,7 @@ class AdBlockingStateReporterTest {
 
         verify(pixel).fire(
             AD_BLOCKING_STATE_DAILY,
-            parameters = mapOf("is_enabled" to "true", "analytics_enabled" to "false"),
+            parameters = mapOf("is_enabled" to "true", "user_opted_in" to "false"),
             type = Pixel.PixelType.Daily(),
         )
     }
@@ -79,7 +79,7 @@ class AdBlockingStateReporterTest {
 
         verify(pixel).fire(
             AD_BLOCKING_STATE_DAILY,
-            parameters = mapOf("is_enabled" to "false", "analytics_enabled" to "true"),
+            parameters = mapOf("is_enabled" to "false", "user_opted_in" to "true"),
             type = Pixel.PixelType.Daily(),
         )
     }
@@ -93,7 +93,7 @@ class AdBlockingStateReporterTest {
 
         verify(pixel).fire(
             AD_BLOCKING_STATE_DAILY,
-            parameters = mapOf("is_enabled" to "false", "analytics_enabled" to "false"),
+            parameters = mapOf("is_enabled" to "false", "user_opted_in" to "false"),
             type = Pixel.PixelType.Daily(),
         )
     }

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsViewModelTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsViewModelTest.kt
@@ -17,9 +17,11 @@
 package com.duckduckgo.adblocking.impl.ui
 
 import app.cash.turbine.test
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames
 import com.duckduckgo.adblocking.impl.AdBlockingSettingsRepository
 import com.duckduckgo.adblocking.impl.domain.AdBlockingState
 import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.CoroutineTestRule
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -29,6 +31,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 class AdBlockingSettingsViewModelTest {
@@ -38,8 +41,9 @@ class AdBlockingSettingsViewModelTest {
 
     private val statusChecker: AdBlockingStatusChecker = mock()
     private val repository: AdBlockingSettingsRepository = mock()
+    private val pixel: Pixel = mock()
 
-    private fun createViewModel() = AdBlockingSettingsViewModel(statusChecker, repository)
+    private fun createViewModel() = AdBlockingSettingsViewModel(statusChecker, repository, pixel)
 
     @Test
     fun whenEnabledByDefaultThenDoesNotShowConsentDescription() = runTest {
@@ -72,5 +76,37 @@ class AdBlockingSettingsViewModelTest {
             assertFalse(state.isEnabled)
             assertEquals(true, state.showConsentDescription)
         }
+    }
+
+    @Test
+    fun whenViewModelCreatedThenFiresSettingsOpenedPixels() = runTest {
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled))
+
+        createViewModel()
+
+        verify(pixel).fire(AdBlockingPixelNames.AD_BLOCKING_SETTINGS_OPENED_DAILY, type = Pixel.PixelType.Daily())
+        verify(pixel).fire(AdBlockingPixelNames.AD_BLOCKING_SETTINGS_OPENED_COUNT)
+    }
+
+    @Test
+    fun whenBlockAdsToggledOnThenFiresEnabledPixels() = runTest {
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled))
+
+        createViewModel().onBlockAdsToggled(enabled = true)
+
+        verify(repository).setEnabled(true)
+        verify(pixel).fire(AdBlockingPixelNames.AD_BLOCKING_ENABLED_DAILY, type = Pixel.PixelType.Daily())
+        verify(pixel).fire(AdBlockingPixelNames.AD_BLOCKING_ENABLED_COUNT)
+    }
+
+    @Test
+    fun whenBlockAdsToggledOffThenFiresDisabledPixels() = runTest {
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Enabled.UserEnabled))
+
+        createViewModel().onBlockAdsToggled(enabled = false)
+
+        verify(repository).setEnabled(false)
+        verify(pixel).fire(AdBlockingPixelNames.AD_BLOCKING_DISABLED_DAILY, type = Pixel.PixelType.Daily())
+        verify(pixel).fire(AdBlockingPixelNames.AD_BLOCKING_DISABLED_COUNT)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1214489455564221?focus=true
Tech Design URL (if applicable): 

### Description

### Steps to test this PR

_Feature 1_
- [ ] Apply _Patch 1: Enable YouTube Ad blocking flag, user disabled by default_
- [ ] Fresh install
- [ ] Check pixel fired `adBlocking_state_daily` with params `is_enabled=false` and `analytics_enabled=false`
- [ ] Check pixel fired `adBlocking_scriptlets_installed` (both `count` and daily`) with params `version=2026.5.12`
- [ ] Open YouTube Ad Blocking settings
- [ ] Check pixel fired `adBlocking_settings_opened` (both `count` and `daily`)
- [ ] Toggle setting on 
- [ ] Check pixel fired `adBlocking_enabled` (both `count` and `daily`)
- [ ] Toggle setting off
- [ ] Check pixel fired `adBlocking_disabled` (both `count` and `daily`)

### Patches

_Patch 1: Enable YouTube Ad blocking flag, user disabled by default_
```
Subject: [PATCH] Set RC to support webTelemetry_youtubeBuffering_test pixel for youtube_buffering event type, with YouTube ad blocking disabled by default
---
Index: privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt	(revision 7bfb042b235a1d66237dec6145e3a39a43761c2f)
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt	(date 1781019513195)
@@ -29,4 +29,4 @@
     TrackingParametersFeatureName("trackingParameters"),
 }
 
-const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v5/android-config.json"
+const val PRIVACY_REMOTE_CONFIG_URL = "https://gist.githubusercontent.com/CrisBarreiro/c78b0362dbb8ae63e1e0f8af60361fdb/raw/d7cecc98f7ce7c2eef55dac337268edc08a1ba1f/eventhub-web-interference-detection-yt-android-config.json"
```

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are telemetry and status-read plumbing for reporting; ad-blocking behavior is unchanged aside from more accurate inject-state observation for pixels.
> 
> **Overview**
> Adds **standard analytics pixels** for YouTube ad blocking: settings opens, enable/disable toggles, a **daily client state** report on app foreground, and **scriptlet update lifecycle** events (fetch/validation/install errors and successful install with version).
> 
> Wires firing through `AdBlockingSettingsViewModel`, new `AdBlockingStateReporter` (`MainProcessLifecycleObserver`), and `RealScriptletUpdater` (typed failures, install try/catch, deduped error pixels under parallel downloads). Introduces `ad_blocking.json5` definitions, `AdBlockingPixelNames`, and `AdBlockingPixelParamRemovalPlugin` (strip ATB on all ad-blocking pixels).
> 
> **`AdBlockingStatusChecker`** gains `observeCanInject()` and aligns `canInject()` with resolved `AdBlockingState` instead of a separately seeded user-enabled snapshot, so startup daily state waits for real remote-config + preference values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef21dd32dbd9927fc7141da9ee555da33b15146f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->