### PR TITLE
Refresh the WebView when a11y settings change

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/accessibility/AccessibilityRefreshTriggerPlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/accessibility/AccessibilityRefreshTriggerPlugin.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.accessibility
+
+import com.duckduckgo.app.accessibility.data.AccessibilitySettingsDataStore
+import com.duckduckgo.browser.api.BrowserRefreshTriggerPlugin
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+/**
+ * Reloads the active tab when accessibility settings (text size / forced zoom) change, so the page
+ * re-runs layout with the new zoom instead of clipping. settingsFlow() emits the current values on
+ * subscription and a distinct value on each change, so dropping the first emission leaves only the
+ * changes that require a reflow.
+ */
+@ContributesMultibinding(AppScope::class)
+class AccessibilityRefreshTriggerPlugin @Inject constructor(
+    private val accessibilitySettings: AccessibilitySettingsDataStore,
+) : BrowserRefreshTriggerPlugin {
+
+    override fun observeRefreshRequests(): Flow<Unit> =
+        accessibilitySettings.settingsFlow()
+            .drop(1)
+            .map { }
+}

--- a/app/src/main/java/com/duckduckgo/app/accessibility/data/AccessibilityDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/accessibility/data/AccessibilityDataStore.kt
@@ -18,13 +18,10 @@ package com.duckduckgo.app.accessibility.data
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.content.SharedPreferences.OnSharedPreferenceChangeListener
 import androidx.core.content.edit
-import com.duckduckgo.common.utils.DispatcherProvider
-import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.*
-import kotlinx.coroutines.launch
-import logcat.LogPriority.VERBOSE
-import logcat.logcat
 
 interface AccessibilitySettingsDataStore {
     val systemFontSize: Float
@@ -37,19 +34,12 @@ interface AccessibilitySettingsDataStore {
 
 class AccessibilitySettingsSharedPreferences(
     private val context: Context,
-    private val dispatcherProvider: DispatcherProvider,
-    private val appCoroutineScope: CoroutineScope,
 ) : AccessibilitySettingsDataStore {
 
-    private val accessibilityStateFlow = MutableStateFlow(
-        AccessibilitySettings(
-            overrideSystemFontSize = false,
-            fontSize = FONT_SIZE_DEFAULT,
-            forceZoom = false,
-        ),
-    )
-
     private val preferences: SharedPreferences by lazy { context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE) }
+
+    override val systemFontSize: Float
+        get() = context.resources.configuration.fontScale * FONT_SIZE_DEFAULT
 
     override val fontSize: Float
         get() {
@@ -60,40 +50,33 @@ class AccessibilitySettingsSharedPreferences(
             }
         }
 
-    override val systemFontSize: Float
-        get() = context.resources.configuration.fontScale * FONT_SIZE_DEFAULT
-
     override var appFontSize: Float
         get() = preferences.getFloat(KEY_FONT_SIZE, FONT_SIZE_DEFAULT)
         set(value) {
             preferences.edit { putFloat(KEY_FONT_SIZE, value) }
-            emitNewValues()
         }
 
     override var forceZoom: Boolean
         get() = preferences.getBoolean(KEY_FORCE_ZOOM, false)
         set(enabled) {
             preferences.edit { putBoolean(KEY_FORCE_ZOOM, enabled) }
-            emitNewValues()
         }
 
     override var overrideSystemFontSize: Boolean
         get() = preferences.getBoolean(KEY_OVERRIDE_SYSTEM_FONT_SIZE, false)
         set(enabled) {
             preferences.edit { putBoolean(KEY_OVERRIDE_SYSTEM_FONT_SIZE, enabled) }
-            emitNewValues()
         }
 
-    override fun settingsFlow() = accessibilityStateFlow.asStateFlow().onSubscription {
-        emitNewValues()
-    }
+    override fun settingsFlow(): Flow<AccessibilitySettings> = callbackFlow {
+        val listener = OnSharedPreferenceChangeListener { _, _ -> trySend(currentSettings) }
+        preferences.registerOnSharedPreferenceChangeListener(listener)
+        trySend(currentSettings)
+        awaitClose { preferences.unregisterOnSharedPreferenceChangeListener(listener) }
+    }.distinctUntilChanged()
 
-    private fun emitNewValues() {
-        appCoroutineScope.launch(dispatcherProvider.io()) {
-            accessibilityStateFlow.emit(AccessibilitySettings(overrideSystemFontSize, fontSize, forceZoom))
-            logcat(VERBOSE) { "AccessibilityActSettings: new value emitted ${AccessibilitySettings(overrideSystemFontSize, fontSize, forceZoom)}" }
-        }
-    }
+    private val currentSettings: AccessibilitySettings
+        get() = AccessibilitySettings(overrideSystemFontSize, fontSize, forceZoom)
 
     companion object {
         const val FILENAME = "com.duckduckgo.app.accessibility.settings"

--- a/app/src/main/java/com/duckduckgo/app/accessibility/di/AccessibilityModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/accessibility/di/AccessibilityModule.kt
@@ -19,14 +19,11 @@ package com.duckduckgo.app.accessibility.di
 import android.content.Context
 import com.duckduckgo.app.accessibility.data.AccessibilitySettingsDataStore
 import com.duckduckgo.app.accessibility.data.AccessibilitySettingsSharedPreferences
-import com.duckduckgo.app.di.AppCoroutineScope
-import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
 import dagger.Provides
 import dagger.SingleInstanceIn
-import kotlinx.coroutines.CoroutineScope
 
 @Module
 @ContributesTo(AppScope::class)
@@ -36,7 +33,5 @@ class AccessibilityModule {
     @SingleInstanceIn(AppScope::class)
     fun providesAccessibilitySettingsDataStore(
         context: Context,
-        dispatcherProvider: DispatcherProvider,
-        @AppCoroutineScope appCoroutineScope: CoroutineScope,
-    ): AccessibilitySettingsDataStore = AccessibilitySettingsSharedPreferences(context, dispatcherProvider, appCoroutineScope)
+    ): AccessibilitySettingsDataStore = AccessibilitySettingsSharedPreferences(context)
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -5982,7 +5982,7 @@ class BrowserTabFragment :
 
             if (this@BrowserTabFragment.isHidden && viewState.refreshWebView) return
             if (viewState.refreshWebView) {
-                logcat(INFO) { "Accessibility: UpdateAccessibilitySetting forceZoomChanged" }
+                logcat(INFO) { "Accessibility: refreshing WebView to reflow content after a text-size or forced-zoom change" }
                 refresh()
             }
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -5970,20 +5970,12 @@ class BrowserTabFragment :
             logcat(INFO) { "Accessibility: render state applyAccessibilitySettings $viewState" }
             val webView = webView ?: return
 
+            // Apply the text size in place. Reloading the page so the layout reflows with the new zoom is
+            // handled by AccessibilityRefreshTriggerPlugin (a debounced refresh, deferred until visible).
             val fontSizeChanged = webView.settings.textZoom != viewState.fontSize.toInt()
             if (fontSizeChanged) {
-                logcat(INFO) {
-                    "Accessibility: UpdateAccessibilitySetting fontSizeChanged " +
-                        "from ${webView.settings.textZoom} to ${viewState.fontSize.toInt()}"
-                }
-
+                logcat(INFO) { "Accessibility: textZoom from ${webView.settings.textZoom} to ${viewState.fontSize.toInt()}" }
                 webView.settings.textZoom = viewState.fontSize.toInt()
-            }
-
-            if (this@BrowserTabFragment.isHidden && viewState.refreshWebView) return
-            if (viewState.refreshWebView) {
-                logcat(INFO) { "Accessibility: refreshing WebView to reflow content after a text-size or forced-zoom change" }
-                refresh()
             }
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -50,7 +50,6 @@ import com.duckduckgo.adblocking.api.duckplayer.DuckPlayer
 import com.duckduckgo.adblocking.api.duckplayer.DuckPlayer.DuckPlayerState.ENABLED
 import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.anvil.annotations.ContributesViewModel
-import com.duckduckgo.app.accessibility.data.AccessibilitySettings
 import com.duckduckgo.app.accessibility.data.AccessibilitySettingsDataStore
 import com.duckduckgo.app.browser.LongPressHandler.RequiredAction
 import com.duckduckgo.app.browser.SSLErrorType.EXPIRED
@@ -1063,28 +1062,14 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun observeAccessibilitySettings() {
+        // Applies the current text size to the WebView. Reloading on a change is handled separately by
+        // AccessibilityRefreshTriggerPlugin via observeRefreshTriggers().
         accessibilityObserver?.cancel()
-        var previousSettings: AccessibilitySettings? = null
         accessibilityObserver =
             accessibilitySettingsDataStore
                 .settingsFlow()
-                .combine(refreshOnViewVisible.asStateFlow(), ::Pair)
-                .onEach { (settings, viewVisible) ->
-                    logcat(VERBOSE) { "Accessibility: newSettings $settings, $viewVisible" }
-
-                    // Reload the WebView when a11y changes, so the page re-runs layout with the new zoom.
-                    // Skip the first emission so that opening a tab with a non-default text size does not trigger an unnecessary reload
-                    val settingsChanged =
-                        previousSettings?.let { it.fontSize != settings.fontSize || it.forceZoom != settings.forceZoom } ?: false
-                    previousSettings = settings
-
-                    val shouldRefreshWebview = settingsChanged || currentAccessibilityViewState().refreshWebView
-                    accessibilityViewState.value =
-                        currentAccessibilityViewState().copy(
-                            fontSize = settings.fontSize,
-                            forceZoom = settings.forceZoom,
-                            refreshWebView = shouldRefreshWebview,
-                        )
+                .onEach { settings ->
+                    accessibilityViewState.value = currentAccessibilityViewState().copy(fontSize = settings.fontSize)
                 }.launchIn(viewModelScope)
     }
 
@@ -4266,7 +4251,6 @@ class BrowserTabViewModel @Inject constructor(
         resetTrackersCount()
         refreshBrowserError()
         resetAutoConsent()
-        accessibilityViewState.value = currentAccessibilityViewState().copy(refreshWebView = false)
         canAutofillSelectCredentialsDialogCanAutomaticallyShow = true
     }
 
@@ -4681,7 +4665,7 @@ class BrowserTabViewModel @Inject constructor(
                             JSONObject(
                                 mapOf(
                                     "desktopModeEnabled" to (getSite()?.isDesktopMode ?: false),
-                                    "forcedZoomEnabled" to (accessibilityViewState.value?.forceZoom ?: false),
+                                    "forcedZoomEnabled" to accessibilitySettingsDataStore.forceZoom,
                                 ),
                             )
                         viewModelScope.launch {
@@ -4737,7 +4721,7 @@ class BrowserTabViewModel @Inject constructor(
                             params = JSONObject(
                                 mapOf(
                                     "desktopModeEnabled" to (getSite()?.isDesktopMode ?: false),
-                                    "forcedZoomEnabled" to (accessibilityViewState.value?.forceZoom ?: false),
+                                    "forcedZoomEnabled" to accessibilitySettingsDataStore.forceZoom,
                                 ),
                             ),
                             featureName = featureName,

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -50,6 +50,7 @@ import com.duckduckgo.adblocking.api.duckplayer.DuckPlayer
 import com.duckduckgo.adblocking.api.duckplayer.DuckPlayer.DuckPlayerState.ENABLED
 import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.app.accessibility.data.AccessibilitySettings
 import com.duckduckgo.app.accessibility.data.AccessibilitySettingsDataStore
 import com.duckduckgo.app.browser.LongPressHandler.RequiredAction
 import com.duckduckgo.app.browser.SSLErrorType.EXPIRED
@@ -1056,14 +1057,21 @@ class BrowserTabViewModel @Inject constructor(
 
     fun observeAccessibilitySettings() {
         accessibilityObserver?.cancel()
+        var previousSettings: AccessibilitySettings? = null
         accessibilityObserver =
             accessibilitySettingsDataStore
                 .settingsFlow()
                 .combine(refreshOnViewVisible.asStateFlow(), ::Pair)
                 .onEach { (settings, viewVisible) ->
                     logcat(VERBOSE) { "Accessibility: newSettings $settings, $viewVisible" }
-                    val shouldRefreshWebview =
-                        (currentAccessibilityViewState().forceZoom != settings.forceZoom) || currentAccessibilityViewState().refreshWebView
+
+                    // Reload the WebView when a11y changes, so the page re-runs layout with the new zoom.
+                    // Skip the first emission so that opening a tab with a non-default text size does not trigger an unnecessary reload
+                    val settingsChanged =
+                        previousSettings?.let { it.fontSize != settings.fontSize || it.forceZoom != settings.forceZoom } ?: false
+                    previousSettings = settings
+
+                    val shouldRefreshWebview = settingsChanged || currentAccessibilityViewState().refreshWebView
                     accessibilityViewState.value =
                         currentAccessibilityViewState().copy(
                             fontSize = settings.fontSize,

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3310,13 +3310,16 @@ class BrowserTabViewModel @Inject constructor(
             },
         )
 
-        if (desktopSiteRequested && uri.isMobileSite) {
-            val desktopUrl = uri.toDesktopUri().toString()
-            logcat(INFO) { "Original URL $url - attempting $desktopUrl with desktop site UA string" }
-            command.value = NavigationCommand.Navigate(desktopUrl, getUrlHeaders(desktopUrl))
+        // Re-load via Navigate (loadUrl) rather than Refresh (reload) so the WebView performs a fresh
+        // layout and re-applies overview mode (loadWithOverviewMode + useWideViewPort). reload() keeps the
+        // previous zoom scale, which would leave the wider desktop layout rendered at the old mobile scale.
+        val targetUrl = if (desktopSiteRequested && uri.isMobileSite) {
+            uri.toDesktopUri().toString()
         } else {
-            command.value = NavigationCommand.Refresh
+            uri.toString()
         }
+        logcat(INFO) { "Original URL $url - reloading $targetUrl with ${if (desktopSiteRequested) "desktop" else "mobile"} site UA string" }
+        command.value = NavigationCommand.Navigate(targetUrl, getUrlHeaders(targetUrl))
     }
 
     private fun initializeViewStates() {

--- a/app/src/main/java/com/duckduckgo/app/browser/viewstate/AccessibilityViewState.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/viewstate/AccessibilityViewState.kt
@@ -20,6 +20,4 @@ import com.duckduckgo.app.accessibility.data.AccessibilitySettingsSharedPreferen
 
 data class AccessibilityViewState(
     val fontSize: Float = AccessibilitySettingsSharedPreferences.FONT_SIZE_DEFAULT,
-    val forceZoom: Boolean = false,
-    val refreshWebView: Boolean = false,
 )

--- a/app/src/test/java/com/duckduckgo/app/accessibility/AccessibilityRefreshTriggerPluginTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/accessibility/AccessibilityRefreshTriggerPluginTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.accessibility
+
+import app.cash.turbine.test
+import com.duckduckgo.app.accessibility.data.AccessibilitySettings
+import com.duckduckgo.app.accessibility.data.AccessibilitySettingsDataStore
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AccessibilityRefreshTriggerPluginTest {
+
+    private val settingsFlow = MutableStateFlow(AccessibilitySettings(overrideSystemFontSize = false, fontSize = 100f, forceZoom = false))
+    private val accessibilitySettings: AccessibilitySettingsDataStore = mock {
+        on { settingsFlow() } doReturn settingsFlow
+    }
+    private val plugin = AccessibilityRefreshTriggerPlugin(accessibilitySettings)
+
+    @Test
+    fun whenSubscribedAndNoChangeThenDoesNotEmitForCurrentSettings() = runTest {
+        plugin.observeRefreshRequests().test {
+            expectNoEvents()
+            cancel()
+        }
+    }
+
+    @Test
+    fun whenFontSizeChangesThenEmits() = runTest {
+        plugin.observeRefreshRequests().test {
+            settingsFlow.value = settingsFlow.value.copy(fontSize = 140f)
+
+            awaitItem()
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenForceZoomChangesThenEmits() = runTest {
+        plugin.observeRefreshRequests().test {
+            settingsFlow.value = settingsFlow.value.copy(forceZoom = true)
+
+            awaitItem()
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenSettingsRepeatSameValueThenDoesNotEmit() = runTest {
+        plugin.observeRefreshRequests().test {
+            settingsFlow.value = settingsFlow.value.copy()
+
+            expectNoEvents()
+            cancel()
+        }
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/accessibility/data/AccessibilitySettingsSharedPreferencesTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/accessibility/data/AccessibilitySettingsSharedPreferencesTest.kt
@@ -24,7 +24,6 @@ import app.cash.turbine.test
 import com.duckduckgo.app.accessibility.data.AccessibilitySettingsSharedPreferences.Companion.FONT_SIZE_DEFAULT
 import com.duckduckgo.common.test.CoroutineTestRule
 import junit.framework.Assert.*
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Rule
@@ -41,7 +40,7 @@ class AccessibilitySettingsSharedPreferencesTest {
 
     private val context = ApplicationProvider.getApplicationContext<Context>()
 
-    private val testee = AccessibilitySettingsSharedPreferences(context, coroutineRule.testDispatcherProvider, TestScope())
+    private val testee = AccessibilitySettingsSharedPreferences(context)
 
     @After
     fun after() {
@@ -128,6 +127,21 @@ class AccessibilitySettingsSharedPreferencesTest {
             accessibilitySetting = accessibilitySetting.copy(overrideSystemFontSize = false, fontSize = 100f)
             assertEquals(accessibilitySetting, awaitItem())
 
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @SuppressLint("DenyListedApi")
+    @Test
+    fun whenPersistedSettingsAreNonDefaultThenFirstEmittedValueReflectsThem() = runTest {
+        context.getSharedPreferences(AccessibilitySettingsSharedPreferences.FILENAME, Context.MODE_PRIVATE)
+            .edit()
+            .putBoolean(AccessibilitySettingsSharedPreferences.KEY_OVERRIDE_SYSTEM_FONT_SIZE, true)
+            .putFloat(AccessibilitySettingsSharedPreferences.KEY_FONT_SIZE, 150f)
+            .commit()
+
+        AccessibilitySettingsSharedPreferences(context).settingsFlow().test {
+            assertEquals(AccessibilitySettings(overrideSystemFontSize = true, fontSize = 140f, forceZoom = false), awaitItem())
             cancelAndConsumeRemainingEvents()
         }
     }

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -821,12 +821,7 @@ class BrowserTabViewModelTest {
                     deviceInfo = mockDeviceInfo,
                 )
 
-            accessibilitySettingsDataStore =
-                AccessibilitySettingsSharedPreferences(
-                    context,
-                    coroutineRule.testDispatcherProvider,
-                    coroutineRule.testScope,
-                )
+            accessibilitySettingsDataStore = AccessibilitySettingsSharedPreferences(context)
 
             whenever(mockOmnibarConverter.convertQueryToUrl(any(), any(), any(), any())).thenReturn("duckduckgo.com")
             whenever(mockTabRepository.liveSelectedTab).thenReturn(selectedTabLiveData)

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -5313,52 +5313,11 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenForceZoomEnabledThenEmitNewState() {
-        accessibilitySettingsDataStore.forceZoom = true
-        assertTrue(accessibilityViewState().forceZoom)
-        assertTrue(accessibilityViewState().refreshWebView)
-    }
-
-    @Test
-    fun whenForceZoomEnabledAndWebViewRefreshedThenEmitNewState() {
-        accessibilitySettingsDataStore.forceZoom = true
-        assertTrue(accessibilityViewState().forceZoom)
-        assertTrue(accessibilityViewState().refreshWebView)
-
-        testee.onWebViewRefreshed()
-
-        assertFalse(accessibilityViewState().refreshWebView)
-    }
-
-    @Test
-    fun whenFontSizeChangedThenEmitNewState() {
-        accessibilitySettingsDataStore.appFontSize = 150f
-        accessibilitySettingsDataStore.overrideSystemFontSize = false
-
-        assertFalse(accessibilityViewState().refreshWebView)
-        assertEquals(accessibilitySettingsDataStore.fontSize, accessibilityViewState().fontSize)
-    }
-
-    @Test
-    fun whenFontSizeActuallyChangesThenRefreshWebView() {
+    fun whenFontSizeChangedThenViewStateFontSizeUpdated() {
         accessibilitySettingsDataStore.overrideSystemFontSize = true
         accessibilitySettingsDataStore.appFontSize = 150f
 
         assertEquals(accessibilitySettingsDataStore.fontSize, accessibilityViewState().fontSize)
-        assertTrue(accessibilityViewState().refreshWebView)
-    }
-
-    @Test
-    fun whenAccessibilitySettingsFirstObservedWithNonDefaultFontSizeThenDoNotRefreshWebView() {
-        // Simulate a user who already has a non-default text size persisted before the tab observes settings.
-        accessibilitySettingsDataStore.overrideSystemFontSize = true
-        accessibilitySettingsDataStore.appFontSize = 150f
-        testee.onWebViewRefreshed() // clear the pending refresh caused by the change above
-
-        testee.observeAccessibilitySettings() // re-subscribe, as happens on tab init/restore
-
-        assertEquals(accessibilitySettingsDataStore.fontSize, accessibilityViewState().fontSize)
-        assertFalse(accessibilityViewState().refreshWebView)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -2685,33 +2685,33 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenUserSelectsDesktopSiteWhenNotOnMobileSpecificSiteThenUrlNotModified() {
+    fun whenUserSelectsDesktopSiteWhenNotOnMobileSpecificSiteThenNavigatesToSameUrl() {
         loadUrl(exampleUrl)
         setDesktopBrowsingMode(false)
         testee.onChangeBrowserModeClicked()
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
-        val ultimateCommand = commandCaptor.lastValue
-        assertTrue(ultimateCommand == NavigationCommand.Refresh)
+        val ultimateCommand = commandCaptor.lastValue as Navigate
+        assertEquals(exampleUrl, ultimateCommand.url)
     }
 
     @Test
-    fun whenUserSelectsMobileSiteWhenOnMobileSpecificSiteThenUrlNotModified() {
+    fun whenUserSelectsMobileSiteWhenOnMobileSpecificSiteThenNavigatesToSameUrl() {
         loadUrl("http://m.example.com")
         setDesktopBrowsingMode(true)
         testee.onChangeBrowserModeClicked()
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
-        val ultimateCommand = commandCaptor.lastValue
-        assertTrue(ultimateCommand == NavigationCommand.Refresh)
+        val ultimateCommand = commandCaptor.lastValue as Navigate
+        assertEquals("http://m.example.com", ultimateCommand.url)
     }
 
     @Test
-    fun whenUserSelectsMobileSiteWhenNotOnMobileSpecificSiteThenUrlNotModified() {
+    fun whenUserSelectsMobileSiteWhenNotOnMobileSpecificSiteThenNavigatesToSameUrl() {
         loadUrl(exampleUrl)
         setDesktopBrowsingMode(true)
         testee.onChangeBrowserModeClicked()
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
-        val ultimateCommand = commandCaptor.lastValue
-        assertTrue(ultimateCommand == NavigationCommand.Refresh)
+        val ultimateCommand = commandCaptor.lastValue as Navigate
+        assertEquals(exampleUrl, ultimateCommand.url)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -5336,6 +5336,28 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenFontSizeActuallyChangesThenRefreshWebView() {
+        accessibilitySettingsDataStore.overrideSystemFontSize = true
+        accessibilitySettingsDataStore.appFontSize = 150f
+
+        assertEquals(accessibilitySettingsDataStore.fontSize, accessibilityViewState().fontSize)
+        assertTrue(accessibilityViewState().refreshWebView)
+    }
+
+    @Test
+    fun whenAccessibilitySettingsFirstObservedWithNonDefaultFontSizeThenDoNotRefreshWebView() {
+        // Simulate a user who already has a non-default text size persisted before the tab observes settings.
+        accessibilitySettingsDataStore.overrideSystemFontSize = true
+        accessibilitySettingsDataStore.appFontSize = 150f
+        testee.onWebViewRefreshed() // clear the pending refresh caused by the change above
+
+        testee.observeAccessibilitySettings() // re-subscribe, as happens on tab init/restore
+
+        assertEquals(accessibilitySettingsDataStore.fontSize, accessibilityViewState().fontSize)
+        assertFalse(accessibilityViewState().refreshWebView)
+    }
+
+    @Test
     fun whenDownloadIsCalledThenDownloadRequestedForUrl() =
         runTest {
             val pendingFileDownload = buildPendingDownload(url = "http://www.example.com/download.pdf", contentDisposition = null, mimeType = null)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1212606114413553?focus=true

### Description

This PR fixes an issue on certain sites (FB), when the text size is changed in a11y settings and the text is the cut off on the site.

### Steps to test this PR

- [x] Log in to FB
- [x] Go to Settings -> A11y
- [x] Change the default text size to large
- [x] Go back to the browser
- [x] Notice the WebView automatically reloads and the text is now displayed correctly 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core WebView navigation/reload and accessibility zoom behavior; desktop/mobile toggle behavior changes from refresh to navigate for all cases.
> 
> **Overview**
> Fixes clipped text on some sites (e.g. Facebook) after changing accessibility text size by **reloading the active tab** when settings change, instead of only updating `textZoom` in place.
> 
> **Accessibility reload** is moved onto the existing `BrowserRefreshTriggerPlugin` pipeline via new `AccessibilityRefreshTriggerPlugin` (debounced refresh, deferred until the tab is visible). `BrowserTabFragment` / `AccessibilityViewState` no longer carry `refreshWebView` or `forceZoom`; the fragment only applies font size, and `forceZoom` for JS is read from `AccessibilitySettingsDataStore`.
> 
> **Settings observation** in `AccessibilitySettingsSharedPreferences` is rewritten to a `SharedPreferences` listener + `callbackFlow` with `distinctUntilChanged`, replacing the coroutine-scoped `MutableStateFlow` and manual `emitNewValues()` on each property write.
> 
> **Desktop/mobile site toggle** now issues `NavigationCommand.Navigate` (same or desktop URL) instead of `Refresh`, so overview/wide viewport layout is reapplied rather than keeping the old zoom scale on `reload()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd96cf58c7d4150647a4d5dfebbc63524234936b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->