### PR TITLE
Pin Autofill nightly Maestro tests to API level 34

### DIFF
--- a/.github/workflows/e2e-nightly-autofill.yml
+++ b/.github/workflows/e2e-nightly-autofill.yml
@@ -44,6 +44,7 @@ jobs:
           maestro_test_name: autofill_critical_path_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_file: ${{ steps.assemble.outputs.play_apk_path }}
+          maestro_api_level: '34'
           maestro_include_tags: autofillNoAuthTests
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -60,6 +61,7 @@ jobs:
           maestro_test_name: autofill_secondary_functionality_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_file: ${{ steps.assemble.outputs.play_apk_path }}
+          maestro_api_level: '34'
           maestro_include_tags: autofillBackfillingUsername,autofillPasswordGeneration
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1215650752453527?focus=true
Tech Design URL (if applicable): 

### Description
Fixes [E2E Tests Failure - Autofill Critical Path](https://app.asana.com/1/137249556945/task/1215578839049039)
Failure runs: https://github.com/duckduckgo/Android/actions/workflows/e2e-nightly-autofill.yml

### Steps to test this PR
https://github.com/duckduckgo/Android/actions/runs/27402249558 should pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow input change; no production, auth, or app runtime behavior is modified.
> 
> **Overview**
> Pins the nightly **Autofill** Maestro jobs to **Android API 34** instead of the composite action default (**35**).
> 
> Both **Run Autofill Critical Path E2E Flows** and **Run Autofill Web Flows** in `e2e-nightly-autofill.yml` now pass `maestro_api_level: '34'` into `maestro-cloud-asana-reporter`, which forwards it to Maestro Cloud as `android-api-level`. This targets flaky/failing Autofill critical-path nightly runs without changing app code or test logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a35a07b59a09a53728c314c4585c126efea2436. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->