### PR TITLE
Add brand-design Duck.AI fire button onboarding dialog

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -205,6 +205,7 @@ import com.duckduckgo.app.cta.ui.Cta
 import com.duckduckgo.app.cta.ui.CtaViewModel
 import com.duckduckgo.app.cta.ui.DaxBubbleCta
 import com.duckduckgo.app.cta.ui.DaxBubbleCta.DaxDialogIntroOption
+import com.duckduckgo.app.cta.ui.DaxDuckAiFireButtonBrandDesignUpdateContextualCta
 import com.duckduckgo.app.cta.ui.HomePanelCta
 import com.duckduckgo.app.cta.ui.HomePanelCta.AddWidgetAutoOnboarding
 import com.duckduckgo.app.cta.ui.OnboardingDaxDialogCta
@@ -1620,7 +1621,9 @@ class BrowserTabFragment :
 
     private fun onFireButtonPressed() {
         val isFocusedNtp = omnibar.viewMode == ViewMode.NewTab && omnibar.getText().isEmpty() && omnibar.omnibarTextInput.hasFocus()
-        val isDuckAiOnboarding = viewModel.ctaViewState.value?.cta is OnboardingDaxDialogCta.DaxDuckAiFireButtonCta
+        val cta = viewModel.ctaViewState.value?.cta
+        val isDuckAiOnboarding =
+            cta is OnboardingDaxDialogCta.DaxDuckAiFireButtonCta || cta is DaxDuckAiFireButtonBrandDesignUpdateContextualCta
         browserActivity?.launchFire(launchedFromFocusedNtp = isFocusedNtp, isDuckAiOnboarding = isDuckAiOnboarding)
         viewModel.onFireMenuSelected(omnibar.viewMode)
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -246,6 +246,7 @@ import com.duckduckgo.app.cta.ui.BrokenSitePromptDialogCta
 import com.duckduckgo.app.cta.ui.Cta
 import com.duckduckgo.app.cta.ui.CtaViewModel
 import com.duckduckgo.app.cta.ui.DaxBubbleCta
+import com.duckduckgo.app.cta.ui.DaxDuckAiFireButtonBrandDesignUpdateContextualCta
 import com.duckduckgo.app.cta.ui.DaxEndBrandDesignUpdateBubbleCta
 import com.duckduckgo.app.cta.ui.DaxFireButtonBrandDesignUpdateContextualCta
 import com.duckduckgo.app.cta.ui.DaxMainNetworkBrandDesignUpdateContextualCta
@@ -704,7 +705,9 @@ class BrowserTabViewModel @Inject constructor(
     @FlowPreview
     private val showPulseAnimation: LiveData<Boolean> =
         combine(
-            ctaViewState.asFlow().map { it.cta is OnboardingDaxDialogCta.DaxDuckAiFireButtonCta }.distinctUntilChanged(),
+            ctaViewState.asFlow().map {
+                it.cta is OnboardingDaxDialogCta.DaxDuckAiFireButtonCta || it.cta is DaxDuckAiFireButtonBrandDesignUpdateContextualCta
+            }.distinctUntilChanged(),
             ctaViewModel.showFireButtonPulseAnimation,
         ) { isShowingDuckAiFireButtonCta, showPulseAnimation -> isShowingDuckAiFireButtonCta || showPulseAnimation }
             .asLiveData(context = viewModelScope.coroutineContext)
@@ -5173,7 +5176,7 @@ class BrowserTabViewModel @Inject constructor(
         val cta = currentCtaViewState().cta
 
         // Defer cleanup (CTA dismiss, highlight removal) until the fire action actually completes.
-        if (cta is OnboardingDaxDialogCta.DaxDuckAiFireButtonCta) {
+        if (cta is OnboardingDaxDialogCta.DaxDuckAiFireButtonCta || cta is DaxDuckAiFireButtonBrandDesignUpdateContextualCta) {
             viewModelScope.launch {
                 ctaViewModel.onDuckAiFireButtonCtaPressed()
             }
@@ -5592,11 +5595,10 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun dismissDuckAiFireOnboardingCta() {
-        ctaViewState.value?.cta
-            ?.let { it as? OnboardingDaxDialogCta.DaxDuckAiFireButtonCta }
-            ?.let { duckAiFireCta ->
-                viewModelScope.launch { ctaViewModel.onUserDismissedCta(cta = duckAiFireCta) }
-            }
+        val cta = ctaViewState.value?.cta ?: return
+        if (cta is OnboardingDaxDialogCta.DaxDuckAiFireButtonCta || cta is DaxDuckAiFireButtonBrandDesignUpdateContextualCta) {
+            viewModelScope.launch { ctaViewModel.onUserDismissedCta(cta = cta) }
+        }
     }
 
     private fun trackersCount(): String =

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -659,6 +659,14 @@ sealed class OnboardingDaxDialogCta(
         abstract val showArrow: Boolean
 
         /**
+         * Whether the persistent top-right dismiss button is shown for this CTA. Defaults to true.
+         * Override to `false` for CTAs that have no in-dialog dismissal affordance — for instance,
+         * a contextual prompt that the user is expected to resolve by interacting with a target
+         * UI element outside the card (e.g. the fire button in the toolbar).
+         */
+        open val showDismiss: Boolean = true
+
+        /**
          * Populate the card with subclass-specific content: set title/description text, configure
          * option buttons, etc. Called before the card fade-in begins so all text is set while views
          * have `alpha=0` to avoid visible growth.
@@ -943,6 +951,7 @@ sealed class OnboardingDaxDialogCta(
             resetSharedViewState(container, isContentTransition = isContentTransition)
             resetAllIncludesExcept(container, activeInclude)
             applyPrimaryCtaText(container)
+            applyDismissButtonVisibility(container)
             configureContentViews(container)
             applyWingBottomState(container)
             hiddenTitle.text = titleView.text
@@ -1108,6 +1117,10 @@ sealed class OnboardingDaxDialogCta(
             container.findViewById<DaxButtonPrimary>(R.id.contextualBrandDesignPrimaryCta)?.setText(text)
         }
 
+        private fun applyDismissButtonVisibility(container: View) {
+            container.findViewById<View>(R.id.contextualBrandDesignDismissButton)?.isVisible = showDismiss
+        }
+
         // GONE (not INVISIBLE) so the FrameLayout's marginBottom drops out of the LinearLayout
         // flow, leaving the description sitting at the card's top padding.
         private fun applyTitleSlotVisibility(container: View, titleView: DaxTypeAnimationTextView) {
@@ -1229,6 +1242,7 @@ sealed class OnboardingDaxDialogCta(
         protected open val allContentIncludeIds: List<Int> = listOf(
             R.id.contextualBrandDesignPrimaryCtaContent,
             R.id.contextualBrandDesignOptionsContent,
+            R.id.contextualBrandDesignNoCtaContent,
         )
 
         /** Returns all content-include slots in the card. Used to hide inactive includes. */

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/Cta.kt
@@ -650,8 +650,11 @@ sealed class OnboardingDaxDialogCta(
                 cardContainer?.interceptChildTouches = value
             }
 
-        /** Id of the content-include slot this CTA renders (e.g. [R.id.contextualBrandDesignPrimaryCtaContent]). */
-        abstract val activeIncludeId: Int
+        /**
+         * Id of the content-include slot this CTA renders (e.g. [R.id.contextualBrandDesignPrimaryCtaContent]).
+         * `null` means the CTA renders only title + description, with no in-card content slot.
+         */
+        open val activeIncludeId: Int? = null
 
         abstract val showArrow: Boolean
 
@@ -759,7 +762,7 @@ sealed class OnboardingDaxDialogCta(
             this.cardContainer = cardContainer
             isAnimating = true
 
-            val activeInclude = container.findViewById<View>(activeIncludeId)
+            val activeInclude: View? = activeIncludeId?.let { container.findViewById(it) }
 
             val notifySettled = {
                 if (isAnimating) {
@@ -776,9 +779,11 @@ sealed class OnboardingDaxDialogCta(
                     val animators = mutableListOf<Animator>(
                         ObjectAnimator.ofFloat(descriptionView, View.ALPHA, 1f)
                             .setDuration(DIALOG_CONTENT_FADE_IN_DURATION),
-                        ObjectAnimator.ofFloat(activeInclude, View.ALPHA, 1f)
-                            .setDuration(DIALOG_CONTENT_FADE_IN_DURATION),
                     )
+                    activeInclude?.let {
+                        animators += ObjectAnimator.ofFloat(it, View.ALPHA, 1f)
+                            .setDuration(DIALOG_CONTENT_FADE_IN_DURATION)
+                    }
                     // Dismiss button is persistent: fade it in only if it isn't already fully shown,
                     // which covers both the first-show path (alpha=0) and the case where a previous
                     // animation was cancelled mid-flight leaving it at a fractional alpha.
@@ -896,7 +901,7 @@ sealed class OnboardingDaxDialogCta(
             val descriptionView = container.findViewById<DaxTextView>(R.id.contextualBrandDesignDescription)
             val dismissButton = container.findViewById<ImageView>(R.id.contextualBrandDesignDismissButton)
             val cardContainer = container.findViewById<TouchInterceptingLinearLayout>(R.id.contextualBrandDesignCardContainer)
-            val activeInclude = container.findViewById<View>(activeIncludeId)
+            val activeInclude: View? = activeIncludeId?.let { container.findViewById(it) }
 
             applyContent(container, isContentTransition = false)
             container.alpha = 1f
@@ -933,7 +938,7 @@ sealed class OnboardingDaxDialogCta(
         private fun applyContent(container: View, isContentTransition: Boolean) {
             val titleView = container.findViewById<DaxTypeAnimationTextView>(R.id.contextualBrandDesignTitle)
             val hiddenTitle = container.findViewById<DaxTextView>(R.id.contextualBrandDesignHiddenTitle)
-            val activeInclude = container.findViewById<View>(activeIncludeId)
+            val activeInclude: View? = activeIncludeId?.let { container.findViewById(it) }
 
             resetSharedViewState(container, isContentTransition = isContentTransition)
             resetAllIncludesExcept(container, activeInclude)
@@ -1063,7 +1068,7 @@ sealed class OnboardingDaxDialogCta(
             titleView: DaxTypeAnimationTextView,
             descriptionView: DaxTextView,
             dismissButton: ImageView,
-            activeInclude: View,
+            activeInclude: View?,
             cardContainer: TouchInterceptingLinearLayout,
             alreadySettled: Boolean,
             contentFadeInAnimator: AnimatorSet?,
@@ -1086,7 +1091,7 @@ sealed class OnboardingDaxDialogCta(
             }
             descriptionView.alpha = 1f
             dismissButton.alpha = 1f
-            activeInclude.alpha = 1f
+            activeInclude?.alpha = 1f
             container.alpha = 1f
             bannerFor(container)?.snapToFinalPosition()
             contentFadeInAnimator?.let { if (it.isRunning) it.end() }
@@ -1230,9 +1235,9 @@ sealed class OnboardingDaxDialogCta(
         internal fun getAllContentIncludes(view: View): List<View> =
             allContentIncludeIds.mapNotNull { view.findViewById(it) }
 
-        internal fun resetAllIncludesExcept(view: View, active: View) {
+        internal fun resetAllIncludesExcept(view: View, active: View?) {
             getAllContentIncludes(view).forEach { include ->
-                if (include == active) {
+                if (active != null && include == active) {
                     include.show()
                     include.alpha = 0f
                 } else {

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -502,6 +502,14 @@ class CtaViewModel @Inject constructor(
             if (duckChat.isDuckChatUrl(it.url.toUri())) {
                 if (onboardingStore.isDuckAiOnboardingFlow() && !suppressDuckAiOnboardingCta) {
                     if (!duckAiFireButtonShown()) {
+                        if (isBrandDesignUpdateEnabled()) {
+                            return DaxDuckAiFireButtonBrandDesignUpdateContextualCta(
+                                onboardingStore = onboardingStore,
+                                appInstallStore = appInstallStore,
+                                isLightTheme = appTheme.isLightModeEnabled(),
+                                deviceInfo = deviceInfo,
+                            )
+                        }
                         return OnboardingDaxDialogCta.DaxDuckAiFireButtonCta(onboardingStore, appInstallStore)
                     }
                 }

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -167,7 +167,7 @@ class CtaViewModel @Inject constructor(
                     pixel.fire(it, cta.pixelShownParameters())
                 }
             }
-            if (cta is OnboardingDaxDialogCta.DaxDuckAiFireButtonCta) {
+            if (cta is OnboardingDaxDialogCta.DaxDuckAiFireButtonCta || cta is DaxDuckAiFireButtonBrandDesignUpdateContextualCta) {
                 duckAiOnboardingExperimentMetrics.fireFireDialogImpression()
             }
             if (cta is DaxCta && cta.markAsReadOnShow) {

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxDuckAiFireButtonBrandDesignUpdateContextualCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxDuckAiFireButtonBrandDesignUpdateContextualCta.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.cta.ui
+
+import android.view.View
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.cta.model.CtaId
+import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.onboarding.store.OnboardingStore
+import com.duckduckgo.app.onboarding.ui.view.DaxTypeAnimationTextView
+import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.common.ui.view.text.DaxTextView
+import com.duckduckgo.common.utils.device.DeviceInfo
+import com.duckduckgo.common.utils.extensions.html
+
+data class DaxDuckAiFireButtonBrandDesignUpdateContextualCta(
+    override val onboardingStore: OnboardingStore,
+    override val appInstallStore: AppInstallStore,
+    override val isLightTheme: Boolean,
+    override val deviceInfo: DeviceInfo,
+) : OnboardingDaxDialogCta.BrandDesignContextualDaxDialogCta(
+    ctaId = CtaId.DAX_DUCK_AI_FIRE_BUTTON,
+    description = R.string.onboardingDuckAiFireButtonDaxDialogDescription,
+    buttonText = null,
+    shownPixel = AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
+    okPixel = AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
+    cancelPixel = null,
+    closePixel = AppPixelName.ONBOARDING_DAX_CTA_DISMISS_BUTTON,
+    ctaPixelParam = "duck_ai_fire_button_cta",
+    onboardingStore = onboardingStore,
+    appInstallStore = appInstallStore,
+    isLightTheme = isLightTheme,
+    deviceInfo = deviceInfo,
+    backgroundRes = R.drawable.bg_onboarding_fire_button,
+),
+    OnboardingDaxDialogCta.ShowsWingBottom {
+    override val activeIncludeId: Int = R.id.contextualBrandDesignNoCtaContent
+
+    override val showArrow: Boolean = true
+
+    override val showDismiss: Boolean = false
+
+    override fun configureContentViews(view: View) {
+        val context = view.context
+        view.findViewById<DaxTypeAnimationTextView>(R.id.contextualBrandDesignTitle)
+            ?.setText(R.string.onboardingDuckAiFireButtonDaxDialogTitle)
+        view.findViewById<DaxTextView>(R.id.contextualBrandDesignDescription)?.text =
+            context.getString(R.string.onboardingDuckAiFireButtonDaxDialogDescription).html(context)
+    }
+}

--- a/app/src/main/res/layout/include_onboarding_in_context_dax_dialog_brand_design_update.xml
+++ b/app/src/main/res/layout/include_onboarding_in_context_dax_dialog_brand_design_update.xml
@@ -129,6 +129,20 @@
                 android:visibility="gone"
                 tools:visibility="gone" />
 
+            <!--
+              ~ Padding compensator for CTAs that have no in-card content slot. The card container
+              ~ uses paddingTop=keyline_6 vs paddingBottom=20dp; other slots' button mass masks the
+              ~ 12dp asymmetry, but no-content CTAs have no button to compensate, so this Space
+              ~ adds the missing keyline_3 when it's the active slot. Portrait only — landscape's
+              ~ container padding is already symmetric.
+              -->
+            <Space
+                android:id="@+id/contextualBrandDesignNoCtaContent"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/keyline_3"
+                android:visibility="gone"
+                tools:visibility="gone" />
+
         </com.duckduckgo.app.onboarding.ui.view.TouchInterceptingLinearLayout>
 
     </com.duckduckgo.common.ui.view.shape.DaxOnboardingBubbleBrandDesignUpdateCardView>

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -175,6 +175,7 @@ import com.duckduckgo.app.cta.ui.Cta
 import com.duckduckgo.app.cta.ui.CtaViewModel
 import com.duckduckgo.app.cta.ui.DaxBubbleCta
 import com.duckduckgo.app.cta.ui.DaxBubbleCta.DaxIntroSearchOptionsCta
+import com.duckduckgo.app.cta.ui.DaxDuckAiFireButtonBrandDesignUpdateContextualCta
 import com.duckduckgo.app.cta.ui.DaxTryASearchBrandDesignUpdateBubbleCta
 import com.duckduckgo.app.cta.ui.HomePanelCta
 import com.duckduckgo.app.cta.ui.OnboardingDaxDialogCta.DaxDuckAiFireButtonCta
@@ -8967,6 +8968,17 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenFireMenuSelectedAndDuckAiFireButtonBrandDesignUpdateCtaShownThenFireFireButtonPressedMetric() = runTest {
+        testee.browserViewState.value = browserViewState()
+        testee.ctaViewState.value = ctaViewState().copy(cta = brandDesignDuckAiFireButtonCta())
+
+        testee.onFireMenuSelected(Omnibar.ViewMode.Browser(exampleUrl))
+        advanceUntilIdle()
+
+        verify(mockDuckAiOnboardingExperimentMetrics).fireFireButtonPressed()
+    }
+
+    @Test
     fun whenFireMenuSelectedAndNoDuckAiFireButtonCtaThenDoNotFireFireButtonPressedMetric() = runTest {
         testee.browserViewState.value = browserViewState()
         testee.ctaViewState.value = ctaViewState().copy(cta = null)
@@ -9831,6 +9843,13 @@ class BrowserTabViewModelTest {
     private fun ctaViewState() = testee.ctaViewState.value!!
 
     private fun browserViewState() = testee.browserViewState.value!!
+
+    private fun brandDesignDuckAiFireButtonCta() = DaxDuckAiFireButtonBrandDesignUpdateContextualCta(
+        onboardingStore = mockOnboardingStore,
+        appInstallStore = mockAppInstallStore,
+        isLightTheme = true,
+        deviceInfo = mockDeviceInfo,
+    )
 
     private fun omnibarViewState() = testee.omnibarViewState.value!!
 
@@ -11465,6 +11484,19 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenDaxDuckAiFireButtonBrandDesignUpdateCtaShownThenFireButtonHighlighted() = runTest {
+        val observer = ValueCaptorObserver<BrowserViewState>(false)
+        testee.browserViewState.observeForever(observer)
+        dismissedCtaDaoChannel.send(emptyList())
+
+        testee.ctaViewState.value = ctaViewState().copy(cta = brandDesignDuckAiFireButtonCta())
+
+        advanceUntilIdle()
+
+        assertTrue((browserViewState().fireButton as HighlightableButton.Visible).highlighted)
+    }
+
+    @Test
     fun whenDaxDuckAiFireButtonCtaDismissedThenFireButtonNotHighlighted() = runTest {
         val observer = ValueCaptorObserver<BrowserViewState>(false)
         testee.browserViewState.observeForever(observer)
@@ -11473,6 +11505,21 @@ class BrowserTabViewModelTest {
         testee.ctaViewState.value = ctaViewState().copy(
             cta = DaxDuckAiFireButtonCta(mockOnboardingStore, mockAppInstallStore),
         )
+        advanceUntilIdle()
+
+        testee.ctaViewState.value = ctaViewState().copy(cta = null)
+        advanceUntilIdle()
+
+        assertFalse((browserViewState().fireButton as HighlightableButton.Visible).highlighted)
+    }
+
+    @Test
+    fun whenDaxDuckAiFireButtonBrandDesignUpdateCtaDismissedThenFireButtonNotHighlighted() = runTest {
+        val observer = ValueCaptorObserver<BrowserViewState>(false)
+        testee.browserViewState.observeForever(observer)
+        dismissedCtaDaoChannel.send(emptyList())
+
+        testee.ctaViewState.value = ctaViewState().copy(cta = brandDesignDuckAiFireButtonCta())
         advanceUntilIdle()
 
         testee.ctaViewState.value = ctaViewState().copy(cta = null)
@@ -11555,6 +11602,17 @@ class BrowserTabViewModelTest {
         dismissedCtaDaoChannel.send(emptyList())
         val cta = DaxDuckAiFireButtonCta(mockOnboardingStore, mockAppInstallStore)
         testee.ctaViewState.value = ctaViewState().copy(cta = cta)
+
+        testee.dismissDuckAiFireOnboardingCta()
+        advanceUntilIdle()
+
+        verify(mockDismissedCtaDao).insert(DismissedCta(CtaId.DAX_DUCK_AI_FIRE_BUTTON))
+    }
+
+    @Test
+    fun whenDismissDuckAiFireOnboardingCtaCalledWithBrandDesignUpdateCtaThenCtaDismissed() = runTest {
+        dismissedCtaDaoChannel.send(emptyList())
+        testee.ctaViewState.value = ctaViewState().copy(cta = brandDesignDuckAiFireButtonCta())
 
         testee.dismissDuckAiFireOnboardingCta()
         advanceUntilIdle()

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxDuckAiFireButtonBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxDuckAiFireButtonBrandDesignUpdateContextualCtaTest.kt
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.cta.ui
+
+import android.net.Uri
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.adblocking.api.duckplayer.DuckPlayer
+import com.duckduckgo.adblocking.api.duckplayer.DuckPlayer.DuckPlayerState.DISABLED
+import com.duckduckgo.adblocking.api.duckplayer.DuckPlayer.UserPreferences
+import com.duckduckgo.adblocking.api.duckplayer.PrivatePlayerMode.AlwaysAsk
+import com.duckduckgo.app.browser.DuckDuckGoUrlDetectorImpl
+import com.duckduckgo.app.cta.db.DismissedCtaDao
+import com.duckduckgo.app.cta.model.CtaId
+import com.duckduckgo.app.cta.model.DismissedCta
+import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.global.model.Site
+import com.duckduckgo.app.onboarding.DuckAiOnboardingExperimentMetrics
+import com.duckduckgo.app.onboarding.store.AppStage
+import com.duckduckgo.app.onboarding.store.OnboardingStore
+import com.duckduckgo.app.onboarding.store.UserStageStore
+import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardingFeatureToggles
+import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
+import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.privacy.db.UserAllowListRepository
+import com.duckduckgo.app.settings.db.SettingsDataStore
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
+import com.duckduckgo.app.tabs.model.AggregateTabProvider
+import com.duckduckgo.app.widget.ui.WidgetCapabilities
+import com.duckduckgo.brokensite.api.BrokenSitePrompt
+import com.duckduckgo.brokensite.api.RefreshPattern
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.test.InstantSchedulersRule
+import com.duckduckgo.common.ui.store.AppTheme
+import com.duckduckgo.common.utils.device.DeviceInfo
+import com.duckduckgo.common.utils.plugins.PluginPoint
+import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.subscriptions.api.SubscriptionPromoCtaShownPlugin
+import com.duckduckgo.subscriptions.api.Subscriptions
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.concurrent.TimeUnit
+
+/**
+ * Verifies the brand-design variant of the Duck.AI fire-button contextual dialog CTA. Mirrors
+ * [DaxFireButtonBrandDesignUpdateContextualCtaTest] but covers the Duck.AI-focused onboarding flow:
+ * the CTA is reached via [CtaViewModel.refreshCta] with a Duck.ai URL and the Duck.AI onboarding
+ * flag active.
+ */
+@FlowPreview
+@RunWith(AndroidJUnit4::class)
+class DaxDuckAiFireButtonBrandDesignUpdateContextualCtaTest {
+
+    @get:Rule
+    @Suppress("unused")
+    var instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    @Suppress("unused")
+    val schedulers = InstantSchedulersRule()
+
+    @get:Rule
+    @Suppress("unused")
+    val coroutineRule = CoroutineTestRule()
+
+    private val mockWidgetCapabilities: WidgetCapabilities = mock()
+    private val mockDismissedCtaDao: DismissedCtaDao = mock()
+    private val mockPixel: Pixel = mock()
+    private val mockAppInstallStore: AppInstallStore = mock()
+    private val mockSettingsDataStore: SettingsDataStore = mock()
+    private val mockOnboardingStore: OnboardingStore = mock()
+    private val mockUserAllowListRepository: UserAllowListRepository = mock()
+    private val mockUserStageStore: UserStageStore = mock()
+    private val mockAggregateTabProvider: AggregateTabProvider = mock()
+    private val mockExtendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles = mock()
+    private val mockDuckPlayer: DuckPlayer = mock()
+    private val mockSubscriptions: Subscriptions = mock()
+    private val mockBrokenSitePrompt: BrokenSitePrompt = mock()
+    private val mockSubscriptionPromoCtaShownPlugin: SubscriptionPromoCtaShownPlugin = mock()
+    private val mockSubscriptionPromoCtaShownPlugins: PluginPoint<SubscriptionPromoCtaShownPlugin> = mock {
+        on { getPlugins() } doReturn listOf(mockSubscriptionPromoCtaShownPlugin)
+    }
+    private val mockDuckChat: DuckChat = mock()
+    private val mockOnboardingBrandDesignUpdateToggles: OnboardingBrandDesignUpdateToggles = mock()
+    private val mockAppTheme: AppTheme = mock { on { isLightModeEnabled() } doReturn true }
+    private val mockDuckAiOnboardingExperimentMetrics: DuckAiOnboardingExperimentMetrics = mock()
+
+    private val mockDeviceInfo: DeviceInfo = mock()
+
+    private val enabledToggle: Toggle = mock { on { it.isEnabled() } doReturn true }
+    private val disabledToggle: Toggle = mock { on { it.isEnabled() } doReturn false }
+
+    private val detectedRefreshPatterns = emptySet<RefreshPattern>()
+
+    private lateinit var testee: CtaViewModel
+
+    @Before
+    fun before() = runTest {
+        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(disabledToggle)
+        whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCta()).thenReturn(disabledToggle)
+        whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1))
+        whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)
+        whenever(mockDuckPlayer.getDuckPlayerState()).thenReturn(DISABLED)
+        whenever(mockDuckPlayer.isDuckPlayerUri(any())).thenReturn(false)
+        whenever(mockDuckPlayer.getUserPreferences()).thenReturn(UserPreferences(false, AlwaysAsk))
+        whenever(mockDuckPlayer.isYouTubeUrl(any())).thenReturn(false)
+        whenever(mockDuckPlayer.isSimulatedYoutubeNoCookie(any())).thenReturn(false)
+        whenever(mockBrokenSitePrompt.shouldShowBrokenSitePrompt(any(), any())).thenReturn(false)
+        whenever(mockBrokenSitePrompt.isFeatureEnabled()).thenReturn(false)
+        whenever(mockBrokenSitePrompt.getUserRefreshPatterns()).thenReturn(emptySet())
+        whenever(mockSubscriptions.isEligible()).thenReturn(false)
+        whenever(mockOnboardingBrandDesignUpdateToggles.self()).thenReturn(disabledToggle)
+        whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(disabledToggle)
+        whenever(mockUserStageStore.getUserAppStage()).thenReturn(AppStage.DAX_ONBOARDING)
+        whenever(mockOnboardingStore.isDuckAiOnboardingFlow()).thenReturn(true)
+        whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_DUCK_AI_FIRE_BUTTON)).thenReturn(false)
+
+        testee = CtaViewModel(
+            appInstallStore = mockAppInstallStore,
+            pixel = mockPixel,
+            widgetCapabilities = mockWidgetCapabilities,
+            dismissedCtaDao = mockDismissedCtaDao,
+            userAllowListRepository = mockUserAllowListRepository,
+            settingsDataStore = mockSettingsDataStore,
+            onboardingStore = mockOnboardingStore,
+            userStageStore = mockUserStageStore,
+            aggregateTabProvider = mockAggregateTabProvider,
+            dispatchers = coroutineRule.testDispatcherProvider,
+            duckChat = mockDuckChat,
+            duckDuckGoUrlDetector = DuckDuckGoUrlDetectorImpl(),
+            extendedOnboardingFeatureToggles = mockExtendedOnboardingFeatureToggles,
+            subscriptions = mockSubscriptions,
+            duckPlayer = mockDuckPlayer,
+            brokenSitePrompt = mockBrokenSitePrompt,
+            subscriptionPromoCtaShownPlugins = mockSubscriptionPromoCtaShownPlugins,
+            onboardingBrandDesignUpdateToggles = mockOnboardingBrandDesignUpdateToggles,
+            appTheme = mockAppTheme,
+            duckAiOnboardingExperimentMetrics = mockDuckAiOnboardingExperimentMetrics,
+            deviceInfo = mockDeviceInfo,
+        )
+    }
+
+    @Test
+    fun whenBrandDesignFlagEnabledThenDuckAiFireButtonCtaReturnsBrandDesignVariant() = runTest {
+        givenBrandDesignFlagEnabled()
+
+        val cta = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = true,
+            site = duckAiSite(),
+            detectedRefreshPatterns = detectedRefreshPatterns,
+        )
+
+        assertTrue(cta is DaxDuckAiFireButtonBrandDesignUpdateContextualCta)
+    }
+
+    @Test
+    fun whenBrandDesignFlagDisabledThenDuckAiFireButtonCtaReturnsLegacyVariant() = runTest {
+        val cta = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = true,
+            site = duckAiSite(),
+            detectedRefreshPatterns = detectedRefreshPatterns,
+        )
+
+        assertTrue(cta is OnboardingDaxDialogCta.DaxDuckAiFireButtonCta)
+        assertFalse(cta is DaxDuckAiFireButtonBrandDesignUpdateContextualCta)
+    }
+
+    @Test
+    fun whenBrandDesignCtaShownThenShownPixelFiredWithDuckAiFireButtonCtaParam() = runTest {
+        val cta = newBrandDesignCta()
+
+        testee.onCtaShown(cta)
+
+        verify(mockPixel).fire(
+            eq(AppPixelName.ONBOARDING_DAX_CTA_SHOWN),
+            argThat<Map<String, String>> { get(Pixel.PixelParameter.CTA_SHOWN)?.contains("duck_ai_fire_button_cta") == true },
+            any(),
+            eq(Count),
+        )
+    }
+
+    @Test
+    fun whenBrandDesignCtaOkClickedThenOkPixelFiredWithDuckAiFireButtonCtaParam() = runTest {
+        val cta = newBrandDesignCta()
+
+        testee.onUserClickCtaOkButton(cta)
+
+        verify(mockPixel).fire(
+            eq(AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON),
+            eq(mapOf(Pixel.PixelParameter.CTA_SHOWN to "duck_ai_fire_button_cta")),
+            any(),
+            eq(Count),
+        )
+    }
+
+    @Test
+    fun whenBrandDesignCtaDismissedViaCloseButtonThenClosePixelFiredWithDuckAiFireButtonCtaParam() = runTest {
+        val cta = newBrandDesignCta()
+
+        testee.onUserDismissedCta(cta, viaCloseBtn = true)
+
+        verify(mockPixel).fire(
+            eq(AppPixelName.ONBOARDING_DAX_CTA_DISMISS_BUTTON),
+            eq(mapOf(Pixel.PixelParameter.CTA_SHOWN to "duck_ai_fire_button_cta")),
+            any(),
+            eq(Count),
+        )
+        verify(mockDismissedCtaDao).insert(DismissedCta(CtaId.DAX_DUCK_AI_FIRE_BUTTON))
+    }
+
+    @Test
+    fun brandDesignCtaExposesDuckAiFireButtonCtaId() {
+        assertEquals(CtaId.DAX_DUCK_AI_FIRE_BUTTON, newBrandDesignCta().ctaId)
+    }
+
+    @Test
+    fun brandDesignCtaSuppressesDismissAndButton() {
+        val cta = newBrandDesignCta()
+
+        assertFalse(cta.showDismiss)
+        assertTrue(cta.showArrow)
+        assertTrue(cta is OnboardingDaxDialogCta.ShowsWingBottom)
+    }
+
+    private fun newBrandDesignCta() = DaxDuckAiFireButtonBrandDesignUpdateContextualCta(
+        onboardingStore = mockOnboardingStore,
+        appInstallStore = mockAppInstallStore,
+        isLightTheme = true,
+        deviceInfo = mockDeviceInfo,
+    )
+
+    private fun givenBrandDesignFlagEnabled() {
+        whenever(mockOnboardingBrandDesignUpdateToggles.self()).thenReturn(enabledToggle)
+        whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(enabledToggle)
+    }
+
+    private fun duckAiSite(): Site {
+        val url = "https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=5"
+        val site: Site = mock()
+        whenever(site.url).thenReturn(url)
+        whenever(site.uri).thenReturn(Uri.parse(url))
+        return site
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205648422731273/task/1215626471231067?focus=true
Tech Design URL (if applicable):

### Description

Adds a brand-design-update variant of the Duck.AI in-context **fire button** onboarding
CTA (`CtaId.DAX_DUCK_AI_FIRE_BUTTON`).

The new CTA mirrors `DaxFireButtonBrandDesignUpdateContextualCta` but preserves the legacy
Duck.AI UX: no in-card primary button and no dismiss button — the user dismisses by tapping
the actual fire button.

Supporting changes:
- `BrandDesignContextualDaxDialogCta` now supports CTAs that render **title + description
  only**: `activeIncludeId` becomes optional (`open val … = 0`) and the render pipeline
  gracefully skips slot work when no content slot is present. A new empty content-include
  slot (`contextualBrandDesignNoCtaContent`) and a `showDismiss` flag (default `true`)
  back this.
- Four `BrowserTab` call sites that drove fire-button behaviour (pulse highlight,
  `isDuckAiOnboarding` flag, `fireFireButtonPressed` metric, dismissal) only matched the
  legacy `DaxDuckAiFireButtonCta`; they now treat the brand-design variant equivalently.
- The brand-design variant is gated behind a **new** `onboardingDuckAiExperimentMay26BrandDesignUpdate`
  toggle (default `INTERNAL`).

### Steps to test this PR
_Prerequisites_
- [x] Apply patch included in asana task 


_Brand-design Duck.AI fire-button dialog_
- [x] Run the Duck.AI onboarding flow until the in-context fire-button CTA appears; confirm
      it renders in the **brand-design** style (title + description, no in-card button, no
      dismiss button).
- [x] Tap the fire button the arrow points at; confirm the fire flow runs and the CTA
      dismisses.

_Legacy fallback_
- [ ] The toggle defaults to `INTERNAL` (on in internal builds). Override
      `onboardingDuckAiExperimentMay26BrandDesignUpdate` to disabled; confirm the
      **legacy** Duck.AI fire-button CTA renders instead.

### UI changes
| Before  | After |
| ------ | ----- |
<img width="1080" height="2400" alt="Screenshot_20260612_110935" src="https://github.com/user-attachments/assets/59638135-6e72-4d59-9aee-4a2e4acef4db" />|<img width="1080" height="2400" alt="Screenshot_20260612_105603" src="https://github.com/user-attachments/assets/ad44b1d3-1b02-4538-86bf-e86b80507f01" />|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding UI and CTA selection only; legacy path remains when brand-design is off, with broad test coverage for parity.
> 
> **Overview**
> Introduces **`DaxDuckAiFireButtonBrandDesignUpdateContextualCta`** for Duck.AI onboarding on Duck Chat URLs when the brand-design update flag is on, replacing the legacy **`DaxDuckAiFireButtonCta`** in that path while keeping the same **`CtaId.DAX_DUCK_AI_FIRE_BUTTON`** and “resolve via toolbar fire button” behavior (no in-card primary button, **`showDismiss = false`**).
> 
> **`BrandDesignContextualDaxDialogCta`** now supports title/description-only cards: **`activeIncludeId`** is optional, animations and include reset handle a missing slot, **`showDismiss`** hides the corner dismiss control, and layout adds **`contextualBrandDesignNoCtaContent`** as a padding compensator for no-button CTAs.
> 
> **`BrowserTabFragment`**, **`BrowserTabViewModel`**, and **`CtaViewModel`** treat the new CTA like the legacy Duck.AI fire CTA for fire-button pulse/highlight, **`isDuckAiOnboarding`**, deferred fire-menu handling, impression metrics, and dismissal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65bc4e2f883fdb19689f8dce9203b0db7d1b269b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->