### PR TITLE
  Fix duplicated-word typos in code comments and log message

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/navigation/bar/BrowserNavigationBarViewIntegration.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/navigation/bar/BrowserNavigationBarViewIntegration.kt
@@ -39,7 +39,7 @@ import kotlinx.coroutines.launch
  * Helper class that extracts business logic that manages the [BrowserNavigationBarView] from the [BrowserTabFragment].
  *
  * The class needs to be instantiated strictly after the fragment's view has been created,
- * and [onDestroyView] has to be called when the the fragment's view is destroyed.
+ * and [onDestroyView] has to be called when the fragment's view is destroyed.
  * After the view is destroyed, the class becomes no-op and needs to be re-instantiated with a valid view binding.
  */
 class BrowserNavigationBarViewIntegration(

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/autoexclude/AutoExcludeAppsRepository.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/autoexclude/AutoExcludeAppsRepository.kt
@@ -63,19 +63,19 @@ interface AutoExcludeAppsRepository {
     fun markAppsAsShown(app: List<VpnIncompatibleApp>)
 
     /**
-     * Returns a list of apps that is is part of the auto exclude list
+     * Returns a list of apps that is part of the auto exclude list
      *
      * This method is internally dispatched to be executed in IO.
      */
     suspend fun getAllIncompatibleApps(): List<VpnIncompatibleApp>
 
     /**
-     * Returns a flow of list of apps that is is part of the auto exclude list
+     * Returns a flow of list of apps that is part of the auto exclude list
      */
     fun getAllIncompatibleAppPackagesFlow(): Flow<List<String>>
 
     /**
-     * Returns a list of apps that is is part of the auto exclude list and is installed in this device
+     * Returns a list of apps that is part of the auto exclude list and is installed in this device
      *
      * This method is internally dispatched to be executed in IO.
      */

--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/Gpc.kt
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/Gpc.kt
@@ -23,7 +23,7 @@ interface Gpc {
      * 1. If the user enabled or not the GPC feature
      * 2. If the remote configuration has enabled or not the GPC feature. When disabled, the remote
      * configuration value prevails over the user choice.
-     * @return `true` if the feature is enabled and `false` is is not.
+     * @return `true` if the feature is enabled and `false` if not.
      */
     fun isEnabled(): Boolean
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
@@ -358,7 +358,7 @@ class AppSyncAccountRepository @Inject constructor(
         // Sync: InviteFlow - A (https://app.asana.com/0/72649045549333/1209571867429615)
         logcat { "Sync-exchange: InviteFlow - A. Generating invitation code" }
 
-        // generate new ID and and public/private key-pair for inviter device
+        // generate new ID and public/private key-pair for inviter device
         val deviceDetailsAsInviter = kotlin.runCatching {
             generateInviterDeviceDetails()
         }.getOrElse {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/SyncApiClient.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/engine/SyncApiClient.kt
@@ -160,7 +160,7 @@ class AppSyncApiClient @Inject constructor(
 
         return when (val result = syncApi.deleteAiChats(token, until)) {
             is Result.Error -> {
-                logcat(LogPriority.ERROR) { "DuckChat-Sync: failed to inform sync of of deleted duck ai chats $result" }
+                logcat(LogPriority.ERROR) { "DuckChat-Sync: failed to inform sync of deleted duck ai chats $result" }
                 syncApiErrorRecorder.record(DeletableType.DUCK_AI_CHATS, result)
                 result
             }


### PR DESCRIPTION
 Task/Issue URL: https://github.com/duckduckgo/Android/issues/8859
  Tech Design URL (if applicable):

  ### Description
  
  Fixes #8859.

  Removes accidental duplicated words in code comments / KDoc and one error
  log message. These are documentation-only, no-op cleanups with no behavior
  change:
  
  - `BrowserNavigationBarViewIntegration` — "when **the the** fragment's view" → "when the fragment's view"
  - `AutoExcludeAppsRepository` (3 KDoc blocks) — "apps that **is is** part of" → "apps that is part of"
  - `Gpc` — "`false` **is is** not" → "`false` if not"
  - `SyncAccountRepository` — "new ID **and and** public/private key-pair" → "new ID and public/private key-pair"
  - `SyncApiClient` — error log "inform sync **of of** deleted duck ai chats" → "inform sync of deleted duck ai chats"

  No production code paths, public APIs, or string resources are affected.

  ### Steps to test this PR
  
  _Typo fixes (no runtime behavior change)_
  - [ ] Review the diff and confirm each edited comment/log line now reads without the duplicated word
  - [ ] Confirm the touched modules still compile, e.g. `./gradlew :sync-impl:testDebugUnitTest :network-protection-impl:testDebugUnitTest`
  - [ ] Confirm Spotless passes: `./gradlew spotlessCheck`

  ### UI changes
  | Before  | After |
  | ------ | ----- |
  | No UI changes | No UI changes |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and log-message edits only; no runtime, security, or API behavior is modified.
> 
> **Overview**
> Fixes duplicated-word typos in **KDoc**, class comments, and one **sync error log** across browser navigation, VPN auto-exclude, GPC API, and sync modules. Examples include “the the”, “is is”, “and and”, and “of of” in documentation strings; `SyncApiClient`’s Duck AI chat deletion failure log is corrected the same way.
> 
> No executable logic, APIs, or user-facing strings change—documentation and logging text only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97f7eac4bcb41c83d8f29d74bd142b9460ff3ceb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->