### PR TITLE
Android: Additional data for wide events / pixels to track query purchase changes

### DIFF
--- a/PixelDefinitions/pixels/definitions/subscription_pixels.json5
+++ b/PixelDefinitions/pixels/definitions/subscription_pixels.json5
@@ -145,5 +145,12 @@
         "triggers": ["other"],
         "suffixes": ["form_factor"],
         "parameters": ["appVersion", "petal", "osVersion"]
+    },
+    "m_privacy-pro_app_recover-subscription_no-active-purchase": {
+        "description": "Fired when Billing client reports no active purchase during restore flow and the automatic recovery attempt during purchase.",
+        "owners": ["karlenDimla"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count_short", "form_factor"],
+        "parameters": ["appVersion"]
     }
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -995,7 +995,10 @@ class RealSubscriptionsManager @Inject constructor(
                 }
 
                 is StoreLoginResult.Failure -> when (storeLoginResult) {
-                    StoreLoginResult.Failure.NoActivePurchase -> RecoverSubscriptionResult.Failure(SUBSCRIPTION_NOT_FOUND_ERROR)
+                    StoreLoginResult.Failure.NoActivePurchase -> {
+                        pixelSender.reportRecoverSubscriptionNoActivePurchase()
+                        RecoverSubscriptionResult.Failure(SUBSCRIPTION_NOT_FOUND_ERROR)
+                    }
                     is StoreLoginResult.Failure.PurchaseInfoNotAvailable ->
                         RecoverSubscriptionResult.Failure(message = "Store login error: PurchaseInfoNotAvailable: ${storeLoginResult.cause}")
                     else -> RecoverSubscriptionResult.Failure(message = "Store login error: ${storeLoginResult.javaClass.simpleName}")

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsManager.kt
@@ -819,14 +819,19 @@ class RealSubscriptionsManager @Inject constructor(
                             throw e
                         }
 
-                        StoreLoginResult.Failure.TokenValidationFailed,
-                        StoreLoginResult.Failure.PurchaseInfoNotAvailable,
-                        StoreLoginResult.Failure.UnknownError,
+                        is StoreLoginResult.Failure.TokenValidationFailed,
+                        is StoreLoginResult.Failure.PurchaseInfoNotAvailable,
+                        is StoreLoginResult.Failure.UnknownError,
                         -> {
+                            val loginError = when (storeLoginResult) {
+                                is StoreLoginResult.Failure.PurchaseInfoNotAvailable ->
+                                    "${storeLoginResult.javaClass.simpleName} - ${storeLoginResult.cause}"
+                                else -> storeLoginResult.javaClass.simpleName
+                            }
                             tokenRefreshWideEvent.onPlayLoginFailure(
                                 signedOut = false,
                                 refreshException = e,
-                                loginError = storeLoginResult.javaClass.simpleName,
+                                loginError = loginError,
                             )
                             throw e
                         }
@@ -940,7 +945,7 @@ class RealSubscriptionsManager @Inject constructor(
                 when (val result = playBillingManager.getLatestPurchase()) {
                     is LatestPurchaseResult.Present -> SignedPurchase(result.purchase.signature, result.purchase.originalJson)
                     LatestPurchaseResult.Absent -> return StoreLoginResult.Failure.NoActivePurchase
-                    LatestPurchaseResult.Unknown -> return StoreLoginResult.Failure.PurchaseInfoNotAvailable
+                    is LatestPurchaseResult.Unknown -> return StoreLoginResult.Failure.PurchaseInfoNotAvailable(cause = result.cause)
                 }
             } else {
                 playBillingManager.purchaseHistory.lastOrNull()
@@ -991,6 +996,8 @@ class RealSubscriptionsManager @Inject constructor(
 
                 is StoreLoginResult.Failure -> when (storeLoginResult) {
                     StoreLoginResult.Failure.NoActivePurchase -> RecoverSubscriptionResult.Failure(SUBSCRIPTION_NOT_FOUND_ERROR)
+                    is StoreLoginResult.Failure.PurchaseInfoNotAvailable ->
+                        RecoverSubscriptionResult.Failure(message = "Store login error: PurchaseInfoNotAvailable: ${storeLoginResult.cause}")
                     else -> RecoverSubscriptionResult.Failure(message = "Store login error: ${storeLoginResult.javaClass.simpleName}")
                 }
             }
@@ -1334,7 +1341,7 @@ class RealSubscriptionsManager @Inject constructor(
         sealed class Failure : StoreLoginResult() {
             data object PurchaseHistoryNotAvailable : Failure()
             data object NoActivePurchase : Failure()
-            data object PurchaseInfoNotAvailable : Failure()
+            data class PurchaseInfoNotAvailable(val cause: String) : Failure()
             data object AccountExternalIdMismatch : Failure()
             data object AuthenticationError : Failure()
             data object TokenValidationFailed : Failure()

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/billing/PlayBillingManager.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/billing/PlayBillingManager.kt
@@ -436,7 +436,7 @@ class RealPlayBillingManager @Inject constructor(
     }
 
     override suspend fun getLatestPurchase(): LatestPurchaseResult = withContext(dispatcherProvider.io()) {
-        if (!billingClient.ready) return@withContext LatestPurchaseResult.Unknown
+        if (!billingClient.ready) return@withContext LatestPurchaseResult.Unknown(cause = "billing_client_not_ready")
 
         when (val result = billingClient.queryPurchases()) {
             is QueryPurchasesResult.Success -> {
@@ -450,7 +450,7 @@ class RealPlayBillingManager @Inject constructor(
             }
             is QueryPurchasesResult.Failure -> {
                 logcat { "Billing: getLatestPurchase query failed: ${result.billingError} - ${result.debugMessage}" }
-                LatestPurchaseResult.Unknown
+                LatestPurchaseResult.Unknown(cause = "query_purchases_failed:${result.billingError?.name ?: "unknown"}")
             }
         }
     }
@@ -466,8 +466,9 @@ sealed class LatestPurchaseResult {
     /**
      * No confirmed answer yet — either we have not queried Play Billing yet,
      * or the last query failed (connection error, service unavailable, etc.).
+     * [cause] is a low-cardinality tag identifying which path produced the Unknown result.
      */
-    data object Unknown : LatestPurchaseResult()
+    data class Unknown(val cause: String) : LatestPurchaseResult()
 }
 
 sealed class PurchaseState {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixel.kt
@@ -112,6 +112,11 @@ enum class SubscriptionPixel(
         types = setOf(Count, Daily()),
         includedParameters = setOf(ATB, APP_VERSION),
     ),
+    RECOVER_SUBSCRIPTION_NO_ACTIVE_PURCHASE(
+        baseName = "m_privacy-pro_app_recover-subscription_no-active-purchase",
+        types = setOf(Count, Daily()),
+        includedParameters = setOf(APP_VERSION),
+    ),
     RESTORE_AFTER_PURCHASE_ATTEMPT_SUCCESS(
         baseName = "m_privacy-pro_app_subscription-restore-after-purchase-attempt_success",
         type = Count,

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSender.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/pixels/SubscriptionPixelSender.kt
@@ -58,6 +58,7 @@ import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.PURCHASE_FAILU
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.PURCHASE_FAILURE_STORE
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.PURCHASE_SUCCESS
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.PURCHASE_SUCCESS_ORIGIN
+import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.RECOVER_SUBSCRIPTION_NO_ACTIVE_PURCHASE
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.RESTORE_AFTER_PURCHASE_ATTEMPT_SUCCESS
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.RESTORE_USING_EMAIL_SUCCESS
 import com.duckduckgo.subscriptions.impl.pixels.SubscriptionPixel.RESTORE_USING_STORE_FAILURE_OTHER
@@ -101,6 +102,7 @@ interface SubscriptionPixelSender {
     fun reportRestoreUsingStoreSuccess()
     fun reportRestoreUsingStoreFailureSubscriptionNotFound()
     fun reportRestoreUsingStoreFailureOther()
+    fun reportRecoverSubscriptionNoActivePurchase()
     fun reportRestoreAfterPurchaseAttemptSuccess()
     fun reportSubscriptionActivated()
     fun reportOnboardingAddDeviceClick()
@@ -223,6 +225,9 @@ class SubscriptionPixelSenderImpl @Inject constructor(
 
     override fun reportRestoreUsingStoreFailureOther() =
         fire(RESTORE_USING_STORE_FAILURE_OTHER)
+
+    override fun reportRecoverSubscriptionNoActivePurchase() =
+        fire(RECOVER_SUBSCRIPTION_NO_ACTIVE_PURCHASE)
 
     override fun reportRestoreAfterPurchaseAttemptSuccess() =
         fire(RESTORE_AFTER_PURCHASE_ATTEMPT_SUCCESS)

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
@@ -254,6 +254,23 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
     }
 
     @Test
+    fun whenRecoverSubscriptionFromStoreIfStoreLoginSucceedsButSubscriptionNotActiveThenDoesNotEmitPixel() = runTest {
+        givenUseQueryPurchasesEnabled()
+        givenUserIsNotSignedIn()
+        givenActivePurchase()
+        givenStoreLoginSucceeds()
+        givenSubscriptionSucceedsWithoutEntitlements(status = "Expired")
+        givenAccessTokenSucceeds()
+        givenV2AccessTokenRefreshSucceeds()
+
+        val result = subscriptionsManager.recoverSubscriptionFromStore()
+
+        assertTrue(result is RecoverSubscriptionResult.Failure)
+        assertEquals("SubscriptionNotFound", (result as RecoverSubscriptionResult.Failure).message)
+        verify(pixelSender, never()).reportRecoverSubscriptionNoActivePurchase()
+    }
+
+    @Test
     fun whenRecoverSubscriptionFromStoreIfValidateTokenFailsReturnFailure() = runTest {
         givenUserIsSignedIn()
         givenValidateTokenFails("failure")
@@ -295,6 +312,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         assertTrue(result is RecoverSubscriptionResult.Success)
         verify(authClient).storeLogin(any(), any(), any())
         verify(playBillingManager, never()).purchaseHistory
+        verify(pixelSender, never()).reportRecoverSubscriptionNoActivePurchase()
     }
 
     @Test
@@ -308,6 +326,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         assertTrue(result is RecoverSubscriptionResult.Failure)
         assertEquals("SubscriptionNotFound", (result as RecoverSubscriptionResult.Failure).message)
         verify(authClient, never()).storeLogin(any(), any(), any())
+        verify(pixelSender).reportRecoverSubscriptionNoActivePurchase()
     }
 
     @Test
@@ -324,6 +343,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
             (result as RecoverSubscriptionResult.Failure).message,
         )
         verify(authClient, never()).storeLogin(any(), any(), any())
+        verify(pixelSender, never()).reportRecoverSubscriptionNoActivePurchase()
     }
 
     @Test

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsManagerTest.kt
@@ -320,7 +320,7 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
 
         assertTrue(result is RecoverSubscriptionResult.Failure)
         assertEquals(
-            "Store login error: PurchaseInfoNotAvailable",
+            "Store login error: PurchaseInfoNotAvailable: billing_client_not_ready",
             (result as RecoverSubscriptionResult.Failure).message,
         )
         verify(authClient, never()).storeLogin(any(), any(), any())
@@ -2008,8 +2008,8 @@ class RealSubscriptionsManagerTest(private val authApiV2Enabled: Boolean) {
         whenever(playBillingManager.getLatestPurchase()).thenReturn(LatestPurchaseResult.Absent)
     }
 
-    private suspend fun givenPurchaseInfoUnknown() {
-        whenever(playBillingManager.getLatestPurchase()).thenReturn(LatestPurchaseResult.Unknown)
+    private suspend fun givenPurchaseInfoUnknown(cause: String = "billing_client_not_ready") {
+        whenever(playBillingManager.getLatestPurchase()).thenReturn(LatestPurchaseResult.Unknown(cause = cause))
     }
 
     private suspend fun givenStoreLoginSucceeds(newAccessToken: String = FAKE_ACCESS_TOKEN_V2) {

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/billing/RealPlayBillingManagerTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/billing/RealPlayBillingManagerTest.kt
@@ -532,7 +532,7 @@ class RealPlayBillingManagerTest {
         // do not connect the billing client (no lifecycle transition to CREATED/RESUMED)
         val result = subject.getLatestPurchase()
 
-        assertEquals(LatestPurchaseResult.Unknown, result)
+        assertEquals(LatestPurchaseResult.Unknown(cause = "billing_client_not_ready"), result)
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215532568282106?focus=true 
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/481882893211075/task/1215021185439979?focus=true

### Description
  - Inline the PurchaseInfoNotAvailable cause into the play_login_error wide-event field so token-refresh failures and recoverSubscriptionFromStore() failures distinguish "billing client not ready" from "query purchases failed" instead of collapsing both into a single label. Carried via LatestPurchaseResult.Unknown(cause) → StoreLoginResult.Failure.PurchaseInfoNotAvailable(cause).
  - Add m_privacy-pro_app_recover-subscription_no-active-purchase pixel (Count + Daily), fired when recoverSubscriptionFromStore() returns StoreLoginResult.Failure.NoActivePurchase — covers both the user-initiated restore flow and the auto-recovery during purchase. Wired through SubscriptionPixel/SubscriptionPixelSender and declared in PixelDefinitions/.../subscription_pixels.json5.                                       
                                                                                                                                                                                                                                                                                                       
### Steps to test this PR
QA-optional



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subscription auth refresh and store-recovery error paths; behavior for users is largely unchanged aside from richer failure telemetry and one new pixel on confirmed no-purchase restore.
> 
> **Overview**
> Improves **observability** around Play Billing `queryPurchases` and store-login recovery by carrying low-cardinality **cause tags** through the purchase-query path instead of a single opaque failure label.
> 
> `LatestPurchaseResult.Unknown` is now a **data class with `cause`** (e.g. `billing_client_not_ready`, `query_purchases_failed:…`), propagated into `StoreLoginResult.Failure.PurchaseInfoNotAvailable(cause)`. That cause is included in **auth token refresh** wide-event `play_login_error` when store login fails without sign-out, and in **`recoverSubscriptionFromStore()`** failure messages for the same failure type.
> 
> Adds pixel **`m_privacy-pro_app_recover-subscription_no-active-purchase`** (count + daily), fired only when recovery hits **`NoActivePurchase`** (confirmed empty Play purchase), including manual restore and auto-recovery during purchase—not when login succeeds but the backend subscription is inactive or when purchase info is unknown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7becaeb6035e80e3f6c6be6dfe39b00d9764bc46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->