### PR TITLE
Fix ad blocking broken by new file in scriptlets

### DIFF
--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionJsInjectorPlugin.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionJsInjectorPlugin.kt
@@ -79,6 +79,7 @@ class AdBlockingExtensionJsInjectorPlugin @Inject constructor(
 
     private fun buildScript(scriptlets: List<Scriptlet>): String? =
         scriptlets
+            .filter { it.name.endsWith(".js") }
             .takeUnless { it.isEmpty() }
             ?.sortedBy { it.name }
             ?.joinToString(separator = "\n") { it.content }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionJsInjectorPlugin.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionJsInjectorPlugin.kt
@@ -79,7 +79,7 @@ class AdBlockingExtensionJsInjectorPlugin @Inject constructor(
 
     private fun buildScript(scriptlets: List<Scriptlet>): String? =
         scriptlets
-            .filter { it.name.endsWith(".js") }
+            .filter { it.name in ALLOWED_SCRIPTLET_NAMES }
             .takeUnless { it.isEmpty() }
             ?.sortedBy { it.name }
             ?.joinToString(separator = "\n") { it.content }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/Scriptlet.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/Scriptlet.kt
@@ -20,3 +20,10 @@ data class Scriptlet(
     val name: String,
     val content: String,
 )
+
+internal val ALLOWED_SCRIPTLET_NAMES = setOf(
+    "scriptlets/isolated/ublock-filters.js",
+    "scriptlets/main/ublock-filters.js",
+    "scriptlets/isolated/ublock-experimental.js",
+    "scriptlets/main/ublock-experimental.js",
+)

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/ScriptletUpdater.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/ScriptletUpdater.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.adblocking.impl.domain
 
+import com.duckduckgo.adblocking.impl.ALLOWED_SCRIPTLET_NAMES
 import com.duckduckgo.adblocking.impl.AdBlockingExtensionRepository
 import com.duckduckgo.adblocking.impl.ScriptletDownloader
 import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionSettings
@@ -52,11 +53,11 @@ class RealScriptletUpdater @Inject constructor(
             return ScriptletUpdateResult.Success
         }
 
-        val jsScriptlets = settings.scriptlets.filterKeys { it.endsWith(".js") }
+        val allowedScriptlets = settings.scriptlets.filterKeys { it in ALLOWED_SCRIPTLET_NAMES }
 
         val downloaded = try {
             coroutineScope {
-                jsScriptlets.map { (name, entry) ->
+                allowedScriptlets.map { (name, entry) ->
                     async {
                         logcat { "Downloading ${entry.url}" }
                         val bytes = downloader.download(entry.url).getOrElse {

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/ScriptletUpdater.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/ScriptletUpdater.kt
@@ -52,9 +52,11 @@ class RealScriptletUpdater @Inject constructor(
             return ScriptletUpdateResult.Success
         }
 
+        val jsScriptlets = settings.scriptlets.filterKeys { it.endsWith(".js") }
+
         val downloaded = try {
             coroutineScope {
-                settings.scriptlets.map { (name, entry) ->
+                jsScriptlets.map { (name, entry) ->
                     async {
                         logcat { "Downloading ${entry.url}" }
                         val bytes = downloader.download(entry.url).getOrElse {

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/store/AdBlockingExtensionDatabase.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/store/AdBlockingExtensionDatabase.kt
@@ -32,7 +32,16 @@ abstract class AdBlockingExtensionDatabase : RoomDatabase() {
 
 private val MIGRATION_2_TO_3 = object : Migration(2, 3) {
     override fun migrate(db: SupportSQLiteDatabase) {
-        db.execSQL("DELETE FROM ad_blocking_scriptlets WHERE name NOT LIKE '%.js'")
+        db.execSQL(
+            """
+            DELETE FROM ad_blocking_scriptlets WHERE name NOT IN (
+                'scriptlets/isolated/ublock-filters.js',
+                'scriptlets/main/ublock-filters.js',
+                'scriptlets/isolated/ublock-experimental.js',
+                'scriptlets/main/ublock-experimental.js'
+            )
+            """.trimIndent(),
+        )
     }
 }
 

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/store/AdBlockingExtensionDatabase.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/store/AdBlockingExtensionDatabase.kt
@@ -19,7 +19,6 @@ package com.duckduckgo.adblocking.impl.store
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
-import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     exportSchema = true,
@@ -30,19 +29,4 @@ abstract class AdBlockingExtensionDatabase : RoomDatabase() {
     abstract fun adBlockingExtensionDao(): AdBlockingExtensionDao
 }
 
-private val MIGRATION_2_TO_3 = object : Migration(2, 3) {
-    override fun migrate(db: SupportSQLiteDatabase) {
-        db.execSQL(
-            """
-            DELETE FROM ad_blocking_scriptlets WHERE name NOT IN (
-                'scriptlets/isolated/ublock-filters.js',
-                'scriptlets/main/ublock-filters.js',
-                'scriptlets/isolated/ublock-experimental.js',
-                'scriptlets/main/ublock-experimental.js'
-            )
-            """.trimIndent(),
-        )
-    }
-}
-
-val AD_BLOCKING_EXTENSION_MIGRATIONS = arrayOf<Migration>(MIGRATION_2_TO_3)
+val AD_BLOCKING_EXTENSION_MIGRATIONS = emptyArray<Migration>()

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/store/AdBlockingExtensionDatabase.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/store/AdBlockingExtensionDatabase.kt
@@ -19,14 +19,21 @@ package com.duckduckgo.adblocking.impl.store
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     exportSchema = true,
-    version = 2,
+    version = 3,
     entities = [ScriptletEntity::class, ScriptletMetadataEntity::class],
 )
 abstract class AdBlockingExtensionDatabase : RoomDatabase() {
     abstract fun adBlockingExtensionDao(): AdBlockingExtensionDao
 }
 
-val AD_BLOCKING_EXTENSION_MIGRATIONS = emptyArray<Migration>()
+private val MIGRATION_2_TO_3 = object : Migration(2, 3) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("DELETE FROM ad_blocking_scriptlets WHERE name NOT LIKE '%.js'")
+    }
+}
+
+val AD_BLOCKING_EXTENSION_MIGRATIONS = arrayOf<Migration>(MIGRATION_2_TO_3)

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionJsInjectorPluginTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionJsInjectorPluginTest.kt
@@ -194,6 +194,33 @@ class AdBlockingExtensionJsInjectorPluginTest {
     }
 
     @Test
+    fun whenScriptletsIncludeNonJsEntriesThenOnlyJsEntriesAreInjected() {
+        scriptletsFlow.value = listOf(
+            Scriptlet(name = "a.js", content = "console.log('a')"),
+            Scriptlet(name = "rules/youtube.json", content = "{\"some\":\"json\"}"),
+            Scriptlet(name = "b.js", content = "console.log('b')"),
+        )
+
+        plugin.onPageStarted(webView, url = "https://youtube.com/page", isDesktopMode = null)
+
+        verify(webView).evaluateJavascript(
+            eq("javascript:console.log('a')\nconsole.log('b')"),
+            isNull(),
+        )
+    }
+
+    @Test
+    fun whenScriptletsAreAllNonJsEntriesThenNoInjection() {
+        scriptletsFlow.value = listOf(
+            Scriptlet(name = "rules/youtube.json", content = "{\"some\":\"json\"}"),
+        )
+
+        plugin.onPageStarted(webView, url = "https://youtube.com/page", isDesktopMode = null)
+
+        verify(webView, never()).evaluateJavascript(any(), isNull())
+    }
+
+    @Test
     fun whenOnPageFinishedCalledThenNoInjection() {
         scriptletsFlow.value = singleScriptlet
 

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionJsInjectorPluginTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionJsInjectorPluginTest.kt
@@ -52,10 +52,12 @@ class AdBlockingExtensionJsInjectorPluginTest {
     private val webView: WebView = mock()
     private val testScope = CoroutineScope(UnconfinedTestDispatcher())
 
-    private val singleScriptlet = listOf(Scriptlet(name = "a.js", content = "console.log('a')"))
+    private val isolatedName = "scriptlets/isolated/ublock-filters.js"
+    private val mainName = "scriptlets/main/ublock-filters.js"
+    private val singleScriptlet = listOf(Scriptlet(name = isolatedName, content = "console.log('a')"))
     private val twoScriptlets = listOf(
-        Scriptlet(name = "b.js", content = "console.log('b')"),
-        Scriptlet(name = "a.js", content = "console.log('a')"),
+        Scriptlet(name = mainName, content = "console.log('b')"),
+        Scriptlet(name = isolatedName, content = "console.log('a')"),
     )
 
     private val plugin by lazy {
@@ -173,7 +175,7 @@ class AdBlockingExtensionJsInjectorPluginTest {
         scriptletsFlow.value = singleScriptlet
         plugin.onPageStarted(webView, url = "https://youtube.com/page", isDesktopMode = null)
 
-        scriptletsFlow.value = listOf(Scriptlet(name = "a.js", content = "console.log('updated')"))
+        scriptletsFlow.value = listOf(Scriptlet(name = isolatedName, content = "console.log('updated')"))
         plugin.onPageStarted(webView, url = "https://youtube.com/page", isDesktopMode = null)
 
         verify(webView).evaluateJavascript(
@@ -194,11 +196,12 @@ class AdBlockingExtensionJsInjectorPluginTest {
     }
 
     @Test
-    fun whenScriptletsIncludeNonJsEntriesThenOnlyJsEntriesAreInjected() {
+    fun whenScriptletsIncludeNamesNotInAllowlistThenOnlyAllowlistedScriptletsAreInjected() {
         scriptletsFlow.value = listOf(
-            Scriptlet(name = "a.js", content = "console.log('a')"),
+            Scriptlet(name = isolatedName, content = "console.log('a')"),
             Scriptlet(name = "rules/youtube.json", content = "{\"some\":\"json\"}"),
-            Scriptlet(name = "b.js", content = "console.log('b')"),
+            Scriptlet(name = "scriptlets/other/something.js", content = "console.log('other')"),
+            Scriptlet(name = mainName, content = "console.log('b')"),
         )
 
         plugin.onPageStarted(webView, url = "https://youtube.com/page", isDesktopMode = null)
@@ -210,9 +213,10 @@ class AdBlockingExtensionJsInjectorPluginTest {
     }
 
     @Test
-    fun whenScriptletsAreAllNonJsEntriesThenNoInjection() {
+    fun whenAllScriptletNamesAreNotInAllowlistThenNoInjection() {
         scriptletsFlow.value = listOf(
             Scriptlet(name = "rules/youtube.json", content = "{\"some\":\"json\"}"),
+            Scriptlet(name = "scriptlets/other/something.js", content = "console.log('other')"),
         )
 
         plugin.onPageStarted(webView, url = "https://youtube.com/page", isDesktopMode = null)

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/RealScriptletUpdaterTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/RealScriptletUpdaterTest.kt
@@ -138,6 +138,33 @@ class RealScriptletUpdaterTest {
     }
 
     @Test
+    fun whenScriptletsContainNonJsEntriesThenOnlyJsEntriesAreDownloadedAndStored() = runTest {
+        val rulesPath = "rules/youtube.json"
+        val rulesEntry = ScriptletEntry(url = "https://cdn.example/rules.json", signature = "rules-sig")
+        val settings = validSettings.copy(
+            scriptlets = mapOf(
+                isolatedPath to isolatedEntry,
+                rulesPath to rulesEntry,
+                mainPath to mainEntry,
+            ),
+        )
+        whenever(repository.getStoredVersion()).thenReturn("0.0.0")
+        whenever(downloader.download(isolatedEntry.url)).thenReturn(kotlin.Result.success(isolatedBytes))
+        whenever(downloader.download(mainEntry.url)).thenReturn(kotlin.Result.success(mainBytes))
+        whenever(validator.validate(isolatedBytes, isolatedEntry.signature)).thenReturn(ScriptletValidationResult.Valid)
+        whenever(validator.validate(mainBytes, mainEntry.signature)).thenReturn(ScriptletValidationResult.Valid)
+
+        assertEquals(ScriptletUpdateResult.Success, updater.update(settings))
+        verify(downloader, never()).download(rulesEntry.url)
+        verify(repository).storeScriptlets(
+            eq("2026.3.9"),
+            check { stored ->
+                assertEquals(setOf(isolatedPath, mainPath), stored.keys)
+            },
+        )
+    }
+
+    @Test
     fun whenOneDownloadFailsThenUpdateShortCircuitsAndCancelsInFlightDownloads() = runTest {
         whenever(repository.getStoredVersion()).thenReturn("0.0.0")
         val isolatedDownloadStarted = CompletableDeferred<Unit>()

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/RealScriptletUpdaterTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/RealScriptletUpdaterTest.kt
@@ -138,13 +138,16 @@ class RealScriptletUpdaterTest {
     }
 
     @Test
-    fun whenScriptletsContainNonJsEntriesThenOnlyJsEntriesAreDownloadedAndStored() = runTest {
+    fun whenScriptletsContainNamesNotInAllowlistThenOnlyAllowlistedEntriesAreDownloadedAndStored() = runTest {
         val rulesPath = "rules/youtube.json"
         val rulesEntry = ScriptletEntry(url = "https://cdn.example/rules.json", signature = "rules-sig")
+        val unknownJsPath = "scriptlets/other/something.js"
+        val unknownJsEntry = ScriptletEntry(url = "https://cdn.example/other.js", signature = "other-sig")
         val settings = validSettings.copy(
             scriptlets = mapOf(
                 isolatedPath to isolatedEntry,
                 rulesPath to rulesEntry,
+                unknownJsPath to unknownJsEntry,
                 mainPath to mainEntry,
             ),
         )
@@ -156,6 +159,7 @@ class RealScriptletUpdaterTest {
 
         assertEquals(ScriptletUpdateResult.Success, updater.update(settings))
         verify(downloader, never()).download(rulesEntry.url)
+        verify(downloader, never()).download(unknownJsEntry.url)
         verify(repository).storeScriptlets(
             eq("2026.3.9"),
             check { stored ->


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1215659866808504?focus=true
Tech Design URL (if applicable): 

### Description
Limit injection and download to a known set of files. Delete problematic files through db migration

### Steps to test this PR

_Feature 1_
- [x] Install from develop
- [x] Open YouTube Ad Blocking settings and enable the feature
- [x] Install this branch on top of it
- [x] Open a couple of videos on YouTube and check no ads are shown

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes what runs in the WebView on YouTube and how scriptlets are persisted; wrong allowlist would break ad blocking or skip needed scriptlets, but scope is limited to the extension pipeline.
> 
> **Overview**
> Introduces **`ALLOWED_SCRIPTLET_NAMES`** (four uBlock filter/experimental scriptlet paths) and applies that allowlist in both **remote update** and **WebView injection**, so non-JS entries such as `rules/youtube.json` are no longer downloaded, stored, or concatenated into injected JavaScript.
> 
> **`ScriptletUpdater`** now filters remote-config scriptlets before download; **`AdBlockingExtensionJsInjectorPlugin.buildScript`** filters before building the injection payload. The ad-blocking extension Room DB version is bumped to **3** (no custom migration in this diff; existing **destructive fallback** clears stale rows on upgrade). Tests cover allowlist-only injection and updater behavior when the config includes extra scriptlet names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 729bc369440c7a69e52bc065b6aec1b5bcd4a89b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->