### PR TITLE
Sync v2: exchange-v2 transport (envelope/QR/channel) + runner

### DIFF
--- a/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -1,0 +1,319 @@
+{
+    "sync_setup_barcode_screen_shown": {
+        "description": "The sync setup barcode (QR) screen was shown to the user",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow the screen belongs to",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_manual_code_entry_screen_shown": {
+        "description": "The sync setup manual code entry screen was shown to the user",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow the screen belongs to",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_barcode_scanner_success": {
+        "description": "A scanned sync code was recognized successfully",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow the scan belongs to",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "code_version",
+                "type": "string",
+                "description": "Protocol version of the code that was scanned",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "code_type",
+                "type": "string",
+                "description": "Kind of recognized code. Sent on the v2 path only",
+                "enum": ["recovery", "linking"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_manual_code_entered_success": {
+        "description": "A manually entered/pasted sync code was recognized successfully",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow the code entry belongs to",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "code_version",
+                "type": "string",
+                "description": "Protocol version of the code that was entered",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "code_type",
+                "type": "string",
+                "description": "Kind of recognized code. Sent on the v2 path only",
+                "enum": ["recovery", "linking"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_barcode_scanner_failed": {
+        "description": "A scanned sync code could not be parsed/recognized",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow the scan belongs to",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_manual_code_entered_failed": {
+        "description": "A manually entered/pasted sync code could not be parsed/recognized",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow the code entry belongs to",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_ended_successful": {
+        "description": "Sync setup completed successfully (recovery-code login or device pairing). For a v2 pairing the host reports it after sending the recovery code, the joiner after login",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow completed",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            },
+            {
+                "key": "path",
+                "type": "string",
+                "description": "Whether the v2 setup was a recovery-code login or a device pairing. Sent on the v2 path only",
+                "enum": ["recovery", "pairing"]
+            },
+            {
+                "key": "my_role",
+                "type": "string",
+                "description": "This device's elected role in a v2 pairing. Sent for v2 pairings only",
+                "enum": ["host", "joiner"]
+            },
+            {
+                "key": "peer_kind",
+                "type": "string",
+                "description": "The peer device's credential kind in a v2 pairing. Sent for v2 pairings only",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_ended_failed": {
+        "description": "A v2 sync setup that started (code recognized) failed with an error, not a user cancellation",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Why the v2 setup failed, aligned with the error codes we handle",
+                "enum": [
+                    "needs_upgrade",
+                    "already_upgraded",
+                    "invalid_credentials",
+                    "pairing_unavailable",
+                    "protocol_error",
+                    "transport_failure",
+                    "unexpected_failure"
+                ]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on. Always v2 for this pixel",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            },
+            {
+                "key": "path",
+                "type": "string",
+                "description": "Whether the failed setup was a recovery-code login or a device pairing. Best-effort, omitted when unknown",
+                "enum": ["recovery", "pairing"]
+            },
+            {
+                "key": "my_role",
+                "type": "string",
+                "description": "This device's elected role in a v2 pairing. Best-effort, omitted when unknown",
+                "enum": ["host", "joiner"]
+            },
+            {
+                "key": "peer_kind",
+                "type": "string",
+                "description": "The peer device's credential kind in a v2 pairing. Best-effort, omitted when unknown",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_ended_abandoned": {
+        "description": "Sync setup was cancelled by the user (back navigation or denying the sync confirmation prompt)",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow was cancelled",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Why the setup was cancelled, based on the v2 protocol state at cancellation",
+                "enum": ["scanning_cancelled", "sync_confirmation_denied", "cancelled_before_finished"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ProtectedKeyManager.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ProtectedKeyManager.kt
@@ -25,9 +25,6 @@ import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
 import com.duckduckgo.sync.store.SyncStore
 import com.squareup.anvil.annotations.ContributesBinding
-import com.squareup.moshi.JsonAdapter
-import com.squareup.moshi.Moshi
-import com.squareup.moshi.Types
 import dagger.SingleInstanceIn
 import logcat.LogPriority.ERROR
 import logcat.logcat
@@ -45,11 +42,12 @@ interface ProtectedKeyManager {
      * Generates an RSA keypair for [purpose] (e.g. "ai_chats"), libsodium-encrypts the private key
      * with the account secret key, and POSTs the entry via /sync/keys/.../set-if-absent.
      *
-     * Returns the created [ProtectedKeyEntry] (the locally-generated, ddg-wrapped key) on success so
-     * callers can use it without a read-after-write GET /keys round-trip (which can lag right after
-     * the write). No-op success semantics for set-if-absent: in the newly-created case (the only case
-     * the 3party-extend caller hits, since it generates only when no keys exist) the returned entry is
-     * authoritative.
+     * Returns the authoritative [ProtectedKeyEntry] taken from the server's response. In the
+     * we-wrote-it case the returned entry equals the one we POSTed; in the race-loser case the
+     * server's `set-if-absent` returns its pre-existing entry instead, and we surface that so
+     * the caller reflects the truth on the server rather than the local key we minted.
+     *
+     * Returns the entry for [purpose] only — not all keys for the account.
      */
     fun create(purpose: String): Result<ProtectedKeyEntry>
 }
@@ -104,39 +102,26 @@ class RealProtectedKeyManager @Inject constructor(
             publicKey = RsaJwk(n = n, e = e),
         )
 
-        return when (val result = syncApi.setProtectedKeyIfAbsent(token, purpose, key)) {
+        return when (val result = syncApi.setProtectedKeyIfAbsent(token, purpose, listOf(key))) {
             is Success -> {
-                logcat { "Sync-ScopedToken: protected key for $purpose created (kid=$kid)" }
-                // Per the Access Credentials TD, the local cache should mirror what's on the
-                // server after every mutation. Append the new entry so callers don't have to
-                // re-hit /sync/keys to find it.
-                cacheLocalProtectedKey(key)
-                Success(key)
+                val entry = result.data.firstOrNull { it.purpose == purpose && it.encryptedWith == CREDENTIAL_ID_DDG }
+                    ?: return Error(reason = "CreateProtectedKey: server response missing created key for $purpose")
+                if (entry.kid != kid) {
+                    // Server returned a pre-existing entry — another device created the key for this
+                    // purpose between our (implicit) check and our POST. The server's entry wins.
+                    logcat {
+                        "Sync-ScopedToken: protected key for $purpose already existed on server " +
+                            "(server kid=${entry.kid}, our kid=$kid) — adopting server entry"
+                    }
+                } else {
+                    logcat { "Sync-ScopedToken: protected key for $purpose created (kid=$kid)" }
+                }
+                Success(entry)
             }
             is Error -> {
                 logcat(ERROR) { "Sync-ScopedToken: failed to create protected key: ${result.reason}" }
                 result
             }
         }
-    }
-
-    private fun cacheLocalProtectedKey(newEntry: ProtectedKeyEntry) {
-        val existing = syncStore.protectedKeysJson
-            ?.let { runCatching { protectedKeysAdapter.fromJson(it) }.getOrNull() }
-            ?: emptyList()
-        // De-dup on kid in case the same key is re-created (shouldn't happen but defensive).
-        val merged = existing.filterNot { it.kid == newEntry.kid } + newEntry
-        // Best-effort cache: the key was already created on the server and is returned to the caller,
-        // so a serialization failure here must not fail create().
-        runCatching { protectedKeysAdapter.toJson(merged) }
-            .onSuccess { syncStore.protectedKeysJson = it }
-            .onFailure { logcat(ERROR) { "Sync-ScopedToken: failed to serialize protected keys cache: ${it.message}" } }
-    }
-
-    private companion object {
-        private val protectedKeysAdapter: JsonAdapter<List<ProtectedKeyEntry>> =
-            Moshi.Builder().build().adapter(
-                Types.newParameterizedType(List::class.java, ProtectedKeyEntry::class.java),
-            )
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
@@ -1,0 +1,538 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import android.util.Base64
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN
+import com.duckduckgo.sync.impl.AccountErrorCodes.NEGOTIATION_ABORTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.NO_RECOVERY_CODE
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_UNAVAILABLE
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
+import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.moshi.Moshi
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.transformWhile
+import logcat.logcat
+import org.json.JSONObject
+import javax.inject.Inject
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealSyncCodeDispatcher @Inject constructor(
+    private val syncFeature: SyncFeature,
+    private val syncAccountRepository: SyncAccountRepository,
+    private val qrCode: ExchangeV2QrCode,
+    private val runner: ExchangeV2Runner,
+) : SyncCodeDispatcher {
+
+    override fun confirmJoiner() {
+        logcat { "$TAG: user confirmed Joiner side" }
+        runner.localTrigger(LocalTrigger.UserConfirmedJoiner)
+    }
+
+    override fun denyJoiner() {
+        logcat { "$TAG: user denied Joiner side" }
+        runner.localTrigger(LocalTrigger.UserDeniedJoiner)
+    }
+
+    override fun confirmHost() {
+        logcat { "$TAG: user confirmed Host side" }
+        runner.localTrigger(LocalTrigger.UserConfirmedHost)
+    }
+
+    override fun denyHost() {
+        logcat { "$TAG: user denied Host side" }
+        runner.localTrigger(LocalTrigger.UserDeniedHost)
+    }
+
+    /**
+     * Drive a v2 Presenter session: start the runner via [ExchangeV2Runner.startPresent] and map
+     * each event to a [DispatchOutcome] via [mapV2PresentEventToOutcome]. Role election may elect
+     * this device as either Host or Joiner.
+     */
+    override fun presentV2(): Flow<DispatchOutcome> = flow {
+        val sessionStartMs = System.currentTimeMillis()
+        logcat { "$TAG: V2 Presenter starting runner.startPresent (scoped to events since $sessionStartMs)" }
+        runner.startPresent()
+        var ownChannelId: String? = null
+        // Snapshot the peer kind while the session is live; the runner clears it on terminal teardown,
+        // so by the time we map the terminal event runner.peerKind is already null.
+        var peerKind: PeerKind? = null
+        emitAll(
+            runner.eventsSince(sessionStartMs)
+                .transformWhile { event ->
+                    // A later SessionStarted with a different channelId means another caller has
+                    // preempted the shared runner; terminate silently so its Flow owns the runner.
+                    if (event is ExchangeV2Event.SessionStarted) {
+                        if (ownChannelId == null) {
+                            ownChannelId = event.ownChannelId
+                        } else if (event.ownChannelId != ownChannelId) {
+                            logcat { "$TAG: V2 Presenter flow preempted (own=$ownChannelId, new=${event.ownChannelId}); terminating silently" }
+                            return@transformWhile false
+                        }
+                    }
+                    runner.peerKind.toPeerKind()?.let { peerKind = it }
+                    val outcome = (mapV2PresentEventToOutcome(event, peerKind) ?: return@transformWhile true)
+                        .withFailureContext(SetupPath.PAIRING, roleFromTerminalState(event), peerKind)
+                    emit(outcome)
+                    !outcome.isTerminal()
+                },
+        )
+        logcat { "$TAG: V2 Presenter flow completed" }
+    }.onCompletion { cause ->
+        if (cause != null) {
+            // Cancelled/threw before a terminal state — tear down the session so the channel
+            // DELETE fires. Spec: Unified Algorithm §Aborting.
+            logcat { "$TAG: V2 Presenter flow completed with cause=${cause::class.simpleName}; cancelling runner" }
+            runner.cancel()
+        }
+    }
+
+    /**
+     * Translate one runner event into a [DispatchOutcome] for the v2 Presenter flow,
+     * or null for intermediate events the caller should ignore. Both Host and Joiner roles are
+     * reachable here; mirrors [mapV2LinkingEventToOutcome] (login on Joiner.Done, preserve abort reason).
+     */
+    private fun mapV2PresentEventToOutcome(event: ExchangeV2Event, peerKind: PeerKind?): DispatchOutcome? = when (event) {
+        is ExchangeV2Event.SessionStarted -> event.linkingCode?.let { DispatchOutcome.LinkingCodeReady(it) }
+        is ExchangeV2Event.Transition -> when (event.to) {
+            ExchangeV2State.Joiner.Confirming ->
+                DispatchOutcome.JoinerConfirmationRequested(peerName = runner.peerName, peerKind = peerKind)
+            ExchangeV2State.Host.Confirming ->
+                DispatchOutcome.HostConfirmationRequested(peerName = runner.peerName, peerKind = peerKind)
+            ExchangeV2State.Host.Done -> DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST, peerKind)
+            ExchangeV2State.Host.Aborted -> hostAbortedToOutcome(event.localTrigger)
+            ExchangeV2State.SameAccountAbort -> DispatchOutcome.AlreadyConnected
+            ExchangeV2State.Joiner.Done -> {
+                val received = (event.trigger as? ExchangeV2Message.RecoveryCodeResponse)?.recoveryCode
+                if (received.isNullOrBlank()) {
+                    DispatchOutcome.Failed("Pairing completed without a recovery code", NO_RECOVERY_CODE.code)
+                } else {
+                    loginWithV2RecoveryCode(received, peerKind)
+                }
+            }
+            ExchangeV2State.Joiner.AbortedByHost -> when (event.trigger) {
+                is ExchangeV2Message.RecoveryCodeDenied ->
+                    DispatchOutcome.Failed("Pairing declined by peer", PAIRING_REJECTED.code)
+                is ExchangeV2Message.RecoveryCodeUnavailable ->
+                    DispatchOutcome.Failed("Peer has no recovery code", PAIRING_UNAVAILABLE.code)
+                else -> DispatchOutcome.Failed("Pairing aborted by peer", PAIRING_REJECTED.code)
+            }
+            ExchangeV2State.Joiner.AbortedLocal -> DispatchOutcome.Failed("Pairing cancelled on this device", PAIRING_CANCELLED.code)
+            ExchangeV2State.Aborted -> DispatchOutcome.Failed("negotiation_aborted", NEGOTIATION_ABORTED.code)
+            else -> null
+        }
+        is ExchangeV2Event.SessionError -> sessionErrorToOutcome(event.message)
+        else -> null
+    }
+
+    override fun isV2ExchangeUnderway(): Boolean = when (runner.currentState) {
+        null, ExchangeV2State.Bootstrapped -> false
+        else -> true
+    }
+
+    override fun route(pastedCode: String): RouteDecision {
+        val v2Enabled = syncFeature.canUseV2ConnectFlow().isEnabled()
+        logcat { "$TAG: route() called, canUseV2ConnectFlow=$v2Enabled" }
+        if (!v2Enabled) {
+            // Flag off → never look at v2 shapes; defer entirely to the v1 path.
+            return legacy(pastedCode, reason = "FF off")
+        }
+        return classifyV2(pastedCode)
+    }
+
+    private fun classifyV2(pastedCode: String): RouteDecision {
+        val parsed = qrCode.parse(pastedCode)
+        logcat { "$TAG: v2 parse=${parsed::class.simpleName}" }
+        return when (parsed) {
+            is ExchangeV2CodeParseResult.LinkingV2 -> {
+                logcat { "$TAG: routing → V2 LinkingV2 (runner.startScan)" }
+                RouteDecision.V2InProgress(SyncCodeType.LINKING, driveV2Linking(pastedCode))
+            }
+            is ExchangeV2CodeParseResult.RecoveryCode -> {
+                val cid = parsed.rawJson.optString("cid", "ddg")
+                logcat { "$TAG: routing → V2 RecoveryCode (cid=$cid)" }
+                RouteDecision.V2InProgress(SyncCodeType.RECOVERY, driveV2Recovery(parsed, cid))
+            }
+            ExchangeV2CodeParseResult.LinkingV1,
+            ExchangeV2CodeParseResult.Unknown,
+            -> legacy(pastedCode, reason = "v2 parser=${parsed::class.simpleName}, falling through to legacy")
+        }
+    }
+
+    private fun legacy(pastedCode: String, reason: String): RouteDecision.Legacy {
+        val authCode = syncAccountRepository.parseSyncAuthCode(pastedCode)
+        logcat { "$TAG: routing → legacy v1 ($reason); parseSyncAuthCode=${authCode::class.simpleName}" }
+        return RouteDecision.Legacy(authCode)
+    }
+
+    /**
+     * V2 recovery code (the new `{recovery:{user_id, secret, cid, v}}` shape). cid=ddg drives
+     * the existing v1 Recovery login (same fields, just renamed). cid=3party drives the
+     * 3party-join upgrade flow on [SyncAccountRepository]. Anything else → error.
+     */
+    private fun driveV2Recovery(parsed: ExchangeV2CodeParseResult.RecoveryCode, cid: String): Flow<DispatchOutcome> = flow {
+        when (cid) {
+            CID_DDG -> {
+                val userId = parsed.rawJson.optString("user_id").takeIf { it.isNotEmpty() }
+                val secret = parsed.rawJson.optString("secret").takeIf { it.isNotEmpty() }
+                if (userId == null || secret == null) {
+                    logcat { "$TAG: v2 recovery (ddg) missing user_id or secret" }
+                    emit(DispatchOutcome.Failed("v2 recovery code missing required fields"))
+                    return@flow
+                }
+                val primaryKey = v2SecretToV1PrimaryKey(secret)
+                if (primaryKey == null) {
+                    logcat { "$TAG: v2 recovery (ddg) secret is not valid base64" }
+                    emit(DispatchOutcome.Failed("v2 recovery code has a malformed secret"))
+                    return@flow
+                }
+                val authCode = SyncAuthCode.Recovery(RecoveryCode(primaryKey = primaryKey, userId = userId))
+                logcat { "$TAG: v2 recovery (ddg) → processCode(Recovery)" }
+                emit(
+                    syncAccountRepository.processCode(authCode, existingDeviceId = null).toOutcome(
+                        label = "v2 recovery (ddg)",
+                        path = SetupPath.RECOVERY,
+                        codeForAccountSwitch = encodeV1RecoveryCodeAsB64(userId = userId, secret = primaryKey),
+                    ),
+                )
+            }
+            CID_3PARTY -> {
+                // joinAccountFromThirdPartyRecoveryCode takes the bare b64 code; re-encode the
+                // inner recovery JSON. Mint via Moshi (not org.json) to match the Moshi consumer
+                // parseThirdPartyRecoveryCode and avoid non-canonical JSON escaping.
+                val rewrapped = thirdPartyRecoveryCodeAdapter.toJson(
+                    ThirdPartyRecoveryCodeWrapper(
+                        recovery = ThirdPartyRecoveryCode(
+                            userId = parsed.rawJson.optString("user_id"),
+                            secret = parsed.rawJson.optString("secret"),
+                            cid = parsed.rawJson.optString("cid", CID_3PARTY),
+                            v = parsed.rawJson.optString("v", RECOVERY_CODE_V2),
+                        ),
+                    ),
+                )
+                val b64 = Base64.encodeToString(
+                    rewrapped.toByteArray(Charsets.UTF_8),
+                    Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP,
+                )
+                logcat { "$TAG: v2 recovery (3party) → joinAccountFromThirdPartyRecoveryCode" }
+                emit(
+                    syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(
+                        b64,
+                    ).toOutcome(label = "v2 recovery (3party)", path = SetupPath.RECOVERY),
+                )
+            }
+            else -> {
+                logcat { "$TAG: v2 recovery: unknown cid='$cid'" }
+                emit(DispatchOutcome.Failed("Unknown v2 credential type: $cid"))
+            }
+        }
+    }.map { it.withFailureContext(SetupPath.RECOVERY, myRole = null, peerKind = null) }
+
+    /**
+     * V2 LinkingV2 (`code2=…`) scanner side. Starts [ExchangeV2Runner.startScan] and maps its
+     * events to outcomes via [mapV2LinkingEventToOutcome]: confirmation requests (caller shows a
+     * prompt and calls [confirmJoiner]/[denyJoiner] or [confirmHost]/[denyHost]) then a single
+     * terminal outcome that completes the Flow.
+     */
+    private fun driveV2Linking(pastedCode: String): Flow<DispatchOutcome> = flow {
+        val sessionStartMs = System.currentTimeMillis()
+        logcat { "$TAG: V2 LinkingV2 starting runner.startScan (scoped to events since $sessionStartMs)" }
+        runner.startScan(pastedCode)
+        var ownChannelId: String? = null
+        // Snapshot the peer kind while the session is live (see presentV2): the runner clears it on
+        // terminal teardown, before we map the terminal event.
+        var peerKind: PeerKind? = null
+        emitAll(
+            runner.eventsSince(sessionStartMs)
+                .transformWhile { event ->
+                    // Same preemption guard as presentV2(): bail if another caller takes over the
+                    // shared runner mid-flow.
+                    if (event is ExchangeV2Event.SessionStarted) {
+                        if (ownChannelId == null) {
+                            ownChannelId = event.ownChannelId
+                        } else if (event.ownChannelId != ownChannelId) {
+                            logcat { "$TAG: V2 LinkingV2 flow preempted (own=$ownChannelId, new=${event.ownChannelId}); terminating silently" }
+                            return@transformWhile false
+                        }
+                    }
+                    runner.peerKind.toPeerKind()?.let { peerKind = it }
+                    val outcome = (mapV2LinkingEventToOutcome(event, peerKind) ?: return@transformWhile true)
+                        .withFailureContext(SetupPath.PAIRING, roleFromTerminalState(event), peerKind)
+                    emit(outcome)
+                    !outcome.isTerminal()
+                },
+        )
+        logcat { "$TAG: V2 LinkingV2 flow completed" }
+    }.onCompletion { cause ->
+        if (cause != null) {
+            // Cancelled/threw before a terminal state — tear down the session so the channel
+            // DELETE fires. Spec: Unified Algorithm §Aborting.
+            logcat { "$TAG: V2 LinkingV2 flow completed with cause=${cause::class.simpleName}; cancelling runner" }
+            runner.cancel()
+        }
+    }
+
+    private fun DispatchOutcome.isTerminal(): Boolean = when (this) {
+        is DispatchOutcome.LinkingCodeReady,
+        is DispatchOutcome.JoinerConfirmationRequested,
+        is DispatchOutcome.HostConfirmationRequested,
+        -> false
+        is DispatchOutcome.LoggedIn,
+        is DispatchOutcome.AlreadyConnected,
+        is DispatchOutcome.UpgradeRequired,
+        is DispatchOutcome.Failed,
+        -> true
+    }
+
+    /**
+     * Translate one runner event into a terminal [DispatchOutcome] for the v2 scanner flow,
+     * or null for intermediate events the caller should ignore.
+     */
+    private fun mapV2LinkingEventToOutcome(event: ExchangeV2Event, peerKind: PeerKind?): DispatchOutcome? = when (event) {
+        is ExchangeV2Event.Transition -> when (event.to) {
+            ExchangeV2State.Joiner.Confirming ->
+                DispatchOutcome.JoinerConfirmationRequested(peerName = runner.peerName, peerKind = peerKind)
+            ExchangeV2State.Host.Confirming ->
+                DispatchOutcome.HostConfirmationRequested(peerName = runner.peerName, peerKind = peerKind)
+            ExchangeV2State.Joiner.Done -> {
+                val received = (event.trigger as? ExchangeV2Message.RecoveryCodeResponse)?.recoveryCode
+                if (received.isNullOrBlank()) {
+                    DispatchOutcome.Failed("Pairing completed without a recovery code", NO_RECOVERY_CODE.code)
+                } else {
+                    loginWithV2RecoveryCode(received, peerKind)
+                }
+            }
+            ExchangeV2State.Joiner.AbortedByHost -> when (event.trigger) {
+                is ExchangeV2Message.RecoveryCodeDenied ->
+                    DispatchOutcome.Failed("Pairing declined by peer", PAIRING_REJECTED.code)
+                is ExchangeV2Message.RecoveryCodeUnavailable ->
+                    DispatchOutcome.Failed("Peer has no recovery code", PAIRING_UNAVAILABLE.code)
+                else -> DispatchOutcome.Failed("Pairing aborted by peer", PAIRING_REJECTED.code)
+            }
+            ExchangeV2State.Joiner.AbortedLocal -> DispatchOutcome.Failed("Pairing cancelled on this device", PAIRING_CANCELLED.code)
+            ExchangeV2State.Host.Aborted -> hostAbortedToOutcome(event.localTrigger)
+            // Per spec §"Same-account case": not an abort; both devices share an account already.
+            ExchangeV2State.SameAccountAbort -> DispatchOutcome.AlreadyConnected
+            // Elected Host and shared a recovery code — success from this device's perspective.
+            ExchangeV2State.Host.Done -> DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST, peerKind)
+            ExchangeV2State.Aborted -> DispatchOutcome.Failed("negotiation_aborted", NEGOTIATION_ABORTED.code)
+            else -> null
+        }
+        is ExchangeV2Event.SessionError -> sessionErrorToOutcome(event.message)
+        else -> null
+    }
+
+    private fun sessionErrorToOutcome(message: String): DispatchOutcome {
+        val match = VERSION_TOO_NEW_REGEX.find(message)
+        return if (match != null) {
+            DispatchOutcome.UpgradeRequired(codeMajor = match.groupValues[1].toIntOrNull() ?: -1)
+        } else {
+            DispatchOutcome.Failed(message, PAIRING_FAILED.code)
+        }
+    }
+
+    private fun hostAbortedToOutcome(localTrigger: LocalTrigger?): DispatchOutcome = when (localTrigger) {
+        LocalTrigger.UserDeniedHost -> DispatchOutcome.Failed("user_denied", PAIRING_CANCELLED.code)
+        LocalTrigger.HostUnavailable -> DispatchOutcome.Failed("host_unavailable", PAIRING_UNAVAILABLE.code)
+        else -> DispatchOutcome.Failed("host_aborted", NEGOTIATION_ABORTED.code)
+    }
+
+    /**
+     * Apply a v2 recovery code received over the LinkingV2 channel (raw base64
+     * `{recovery:{user_id, secret, cid, v}}`). Per spec §"Exchange Share Recovery Code → Joiner":
+     * cid=ddg logs in directly; cid=3party upgrades the account via
+     * [SyncAccountRepository.joinAccountFromThirdPartyRecoveryCode].
+     */
+    private fun loginWithV2RecoveryCode(b64: String, peerKind: PeerKind?): DispatchOutcome {
+        val parsed = decodeV2Recovery(b64) ?: return DispatchOutcome.Failed("Couldn't parse received recovery code as v2.0")
+        return when (parsed.cid) {
+            CID_DDG -> {
+                val primaryKey = v2SecretToV1PrimaryKey(parsed.secret)
+                    ?: return DispatchOutcome.Failed("Received recovery code has a malformed secret")
+                val recovery = SyncAuthCode.Recovery(RecoveryCode(primaryKey = primaryKey, userId = parsed.userId))
+                logcat { "$TAG: v2 LinkingV2 received ddg code → $recovery" }
+                syncAccountRepository.processCode(recovery, existingDeviceId = null)
+                    .toOutcome(
+                        label = "v2 LinkingV2 login (ddg)",
+                        path = SetupPath.PAIRING,
+                        myRole = SetupRole.JOINER,
+                        peerKind = peerKind,
+                        codeForAccountSwitch = encodeV1RecoveryCodeAsB64(userId = parsed.userId, secret = primaryKey),
+                    )
+            }
+            CID_3PARTY -> {
+                logcat { "$TAG: v2 LinkingV2 received 3party code → joinAccountFromThirdPartyRecoveryCode" }
+                syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(b64)
+                    .toOutcome(
+                        label = "v2 LinkingV2 login (3party upgrade)",
+                        path = SetupPath.PAIRING,
+                        myRole = SetupRole.JOINER,
+                        peerKind = peerKind,
+                    )
+            }
+            else -> DispatchOutcome.Failed("Received unknown credential type '${parsed.cid}' over v2 linking")
+        }
+    }
+
+    private data class ParsedV2Recovery(val userId: String, val secret: String, val cid: String, val v: String)
+
+    private fun decodeV2Recovery(b64: String): ParsedV2Recovery? = runCatching {
+        val decoded = runCatching { java.util.Base64.getUrlDecoder().decode(b64) }
+            .recoverCatching { java.util.Base64.getDecoder().decode(b64) }
+            .getOrThrow()
+        val root = JSONObject(String(decoded, Charsets.UTF_8))
+        val rec = root.getJSONObject("recovery")
+        ParsedV2Recovery(
+            userId = rec.getString("user_id"),
+            secret = rec.getString("secret"),
+            cid = rec.optString("cid", CID_DDG),
+            v = rec.optString("v", "2.0"),
+        )
+    }.getOrNull()
+
+    /**
+     * v2 wire `secret` is base64url (spec 1214802412121967); re-encode to standard base64 for the
+     * v1 native login, normalising the alphabet first to also tolerate an already-standard secret.
+     * Returns null if the secret isn't valid base64.
+     */
+    private fun v2SecretToV1PrimaryKey(secret: String): String? = runCatching {
+        val bytes = Base64.decode(secret.replace('-', '+').replace('_', '/'), Base64.NO_WRAP)
+        Base64.encodeToString(bytes, Base64.NO_WRAP)
+    }.getOrNull()
+
+    /**
+     * Map a repo [Result] to a [DispatchOutcome].
+     *
+     * If [codeForAccountSwitch] is supplied and the repo failed with [ALREADY_SIGNED_IN], switch
+     * accounts transparently via [SyncAccountRepository.logoutAndJoinNewAccount] with no prompt:
+     * the Confirmations phase is already the consent step, so the v1 `AskToSwitchAccount` dialog
+     * does not apply.
+     *
+     * [codeForAccountSwitch] must be a v1 b64 shape [SyncAccountRepository.parseSyncAuthCode] can
+     * re-parse, so v2 callers convert first (see [encodeV1RecoveryCodeAsB64]).
+     */
+    /** Map the runner's raw peer credential id ("ddg"/"3party") to the telemetry [PeerKind], or null. */
+    private fun String?.toPeerKind(): PeerKind? = when (this) {
+        CID_DDG -> PeerKind.DDG
+        CID_3PARTY -> PeerKind.THIRD_PARTY
+        else -> null
+    }
+
+    /** Elected role implied by a terminal transition's target state, for "Setup failed" telemetry. */
+    private fun roleFromTerminalState(event: ExchangeV2Event): SetupRole? =
+        when ((event as? ExchangeV2Event.Transition)?.to) {
+            is ExchangeV2State.Host -> SetupRole.HOST
+            is ExchangeV2State.Joiner -> SetupRole.JOINER
+            else -> null
+        }
+
+    /**
+     * Attach best-effort failure telemetry ([path]/[myRole]/[peerKind]) to a terminal error outcome.
+     * No-op for non-error outcomes, so a [DispatchOutcome.LoggedIn] keeps the context set at its source.
+     */
+    private fun DispatchOutcome.withFailureContext(
+        path: SetupPath,
+        myRole: SetupRole?,
+        peerKind: PeerKind?,
+    ): DispatchOutcome = when (this) {
+        is DispatchOutcome.Failed -> copy(path = path, myRole = myRole, peerKind = peerKind)
+        is DispatchOutcome.UpgradeRequired -> copy(path = path, myRole = myRole, peerKind = peerKind)
+        else -> this
+    }
+
+    private fun Result<Boolean>.toOutcome(
+        label: String,
+        path: SetupPath,
+        myRole: SetupRole? = null,
+        peerKind: PeerKind? = null,
+        codeForAccountSwitch: String? = null,
+    ): DispatchOutcome = when (this) {
+        is Result.Success -> {
+            logcat { "$TAG: $label → success" }
+            DispatchOutcome.LoggedIn(path, myRole, peerKind)
+        }
+        is Result.Error -> {
+            logcat { "$TAG: $label → error: $reason (code=$code)" }
+            if (code == ALREADY_SIGNED_IN.code && codeForAccountSwitch != null) {
+                logcat { "$TAG: $label → ALREADY_SIGNED_IN, performing transparent logout+rejoin" }
+                when (val switched = syncAccountRepository.logoutAndJoinNewAccount(codeForAccountSwitch)) {
+                    is Result.Success -> {
+                        logcat { "$TAG: $label → logout+rejoin success" }
+                        DispatchOutcome.LoggedIn(path, myRole, peerKind)
+                    }
+                    is Result.Error -> {
+                        logcat { "$TAG: $label → logout+rejoin failed: ${switched.reason} (code=${switched.code})" }
+                        DispatchOutcome.Failed(switched.reason, switched.code)
+                    }
+                }
+            } else {
+                DispatchOutcome.Failed(reason, code)
+            }
+        }
+    }
+
+    /**
+     * Re-encode a v2 ddg recovery (userId + secret) as a v1-shape `{recovery:{primary_key,
+     * user_id}}` base64-url string so [SyncAccountRepository.logoutAndJoinNewAccount] (v1-only
+     * [SyncAccountRepository.parseSyncAuthCode]) can consume it on account switch.
+     */
+    private fun encodeV1RecoveryCodeAsB64(userId: String, secret: String): String {
+        // Mint via Moshi (not org.json) and reuse the v1 LinkCode shape, keeping this byte-identical
+        // to a genuine v1 code so the parseSyncAuthCode round-trip stays robust.
+        val v1Json = v1RecoveryCodeAdapter.toJson(LinkCode(recovery = RecoveryCode(primaryKey = secret, userId = userId)))
+        return Base64.encodeToString(
+            v1Json.toByteArray(Charsets.UTF_8),
+            Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP,
+        )
+    }
+
+    private val v1RecoveryCodeAdapter by lazy {
+        Moshi.Builder().build().adapter(LinkCode::class.java)
+    }
+
+    private val thirdPartyRecoveryCodeAdapter by lazy {
+        Moshi.Builder().build().adapter(ThirdPartyRecoveryCodeWrapper::class.java)
+    }
+
+    companion object {
+        private const val TAG = "Sync-CodeDispatch"
+        private const val CID_DDG = "ddg"
+        private const val CID_3PARTY = "3party"
+
+        // Extracts the major version from the EnvelopeVersionTooNew SessionError message.
+        private val VERSION_TOO_NEW_REGEX = Regex("""protocol v(\d+)""")
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
@@ -678,12 +678,12 @@ class AppSyncAccountRepository @Inject constructor(
         // SP travels in the recovery code as base64url; nativeLib + hkdfDerive* helpers expect
         // standard base64. Compute once at the boundary, reuse for all derivations.
         val spStandardB64 = kotlin.runCatching { base64UrlStringToStandardBase64(parsed.secret) }
-            .getOrElse { return Error(reason = "Upgrade: failed to decode SP: ${it.message}") }
+            .getOrElse { return Error(reason = "Upgrade: failed to decode SP") }
         val hkdfSalt = parsed.userId.toByteArray(Charsets.UTF_8)
 
         // SP-derived MEK: used to decrypt FE-written (JWE) keys we received from /sync/login.
         val spMek = kotlin.runCatching { syncJweCrypto.hkdfDeriveBytes(spStandardB64, hkdfSalt, "Main Key", 32) }
-            .getOrElse { return Error(reason = "Upgrade: failed to derive SP MEK: ${it.message}") }
+            .getOrElse { return Error(reason = "Upgrade: failed to derive SP MEK") }
 
         // Fresh DDG credential generated locally. nativeLib.generateAccountKeys returns a tuple
         // where `primaryKey` is the new account's MP (the seed for all spec-side derivations) and
@@ -699,14 +699,14 @@ class AppSyncAccountRepository @Inject constructor(
         // DDG's MEK?", this is HKDF(MP, salt=user_id, info="Main Key", 32 bytes) imported as
         // AES-GCM-256. Pinned against the TD's test3 vector in SyncJweCryptoTdVectorsTest.
         val ddgMek = kotlin.runCatching { syncJweCrypto.hkdfDeriveBytes(newDdgKeys.primaryKey, hkdfSalt, "Main Key", 32) }
-            .getOrElse { return Error(reason = "Upgrade: failed to derive DDG MEK: ${it.message}") }
+            .getOrElse { return Error(reason = "Upgrade: failed to derive DDG MEK") }
 
         // encrypted_3party_credential: JWE compact (alg=dir, enc=A256GCM, kid="ddg") of the SP
         // base64url STRING (matches the reverse direction in createThirdPartyCredential, which
         // encrypts the base64url SP string — not the raw SP bytes — so the wire is symmetrical).
         val encryptedThreePartyCredential = kotlin.runCatching {
             syncJweCrypto.jweEncryptSymmetric(parsed.secret.toByteArray(Charsets.UTF_8), ddgMek, kid = CREDENTIAL_ID_DDG)
-        }.getOrElse { return Error(reason = "Upgrade: failed to encrypt encrypted_3party_credential: ${it.message}") }
+        }.getOrElse { return Error(reason = "Upgrade: failed to encrypt encrypted_3party_credential") }
 
         // Re-wrap each FE-written key from /sync/login. Decrypt via JWE using SP MEK, then
         // re-encrypt with libsodium-secretbox using the new DDG secretKey, matching the Native
@@ -873,8 +873,6 @@ class AppSyncAccountRepository @Inject constructor(
         // pre-upgrade until this block runs.
         val spStandardB64 = kotlin.runCatching { base64UrlStringToStandardBase64(parsed.secret) }
             .getOrElse { return Error(reason = "JoinFrom3party: failed to decode SP: ${it.message}") }
-        val protectedKeysJson = kotlin.runCatching { Adapters.protectedKeysAdapter.toJson(upgradePackage.rewrappedKeys) }
-            .getOrElse { return Error(reason = "JoinFrom3party: failed to serialize protected keys: ${it.message}") }
         syncStore.storeCredentials(
             userId = parsed.userId,
             deviceId = deviceId,
@@ -885,7 +883,6 @@ class AppSyncAccountRepository @Inject constructor(
         )
         syncStore.credentialId = CREDENTIAL_ID_DDG
         syncStore.scopedPassword = ScopedPassword(spStandardB64)
-        syncStore.protectedKeysJson = protectedKeysJson
 
         logcat { "Sync-ScopedToken: 3party→ddg upgrade complete; account joined as ddg" }
 
@@ -1354,10 +1351,6 @@ class AppSyncAccountRepository @Inject constructor(
                     }
                     result.data.keys?.let { keys ->
                         logcat { "Sync-ScopedToken: ${keys.size} protected key(s) in response" }
-                        val ddgKeys = keys.filter { it.encryptedWith == CREDENTIAL_ID_DDG }
-                        runCatching { Adapters.protectedKeysAdapter.toJson(ddgKeys) }
-                            .onSuccess { syncStore.protectedKeysJson = it }
-                            .onFailure { logcat(ERROR) { "Sync-ScopedToken: failed to serialize protected keys from login: ${it.message}" } }
                     }
                 }
 
@@ -1458,8 +1451,6 @@ class AppSyncAccountRepository @Inject constructor(
 
             val invitationCodeAdapter: JsonAdapter<InvitationCodeWrapper> = moshi.adapter(InvitationCodeWrapper::class.java)
             val invitedDeviceAdapter: JsonAdapter<InvitedDeviceDetails> = moshi.adapter(InvitedDeviceDetails::class.java)
-            val protectedKeysAdapter: JsonAdapter<List<ProtectedKeyEntry>> =
-                moshi.adapter(Types.newParameterizedType(List::class.java, ProtectedKeyEntry::class.java))
         }
     }
 }
@@ -1575,6 +1566,12 @@ enum class AccountErrorCodes(val code: Int) {
     INVALID_CODE(55),
     EXCHANGE_FAILED(56),
     THIRD_PARTY_ALREADY_UPGRADED(57),
+    PAIRING_REJECTED(58),
+    PAIRING_UNAVAILABLE(59),
+    PAIRING_CANCELLED(60),
+    NEGOTIATION_ABORTED(61),
+    NO_RECOVERY_CODE(62),
+    PAIRING_FAILED(63),
 }
 
 sealed interface SyncAuthCode {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncCodeDispatcher.kt
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Routes a pasted/scanned sync code to either the v1 stack or the v2 exchange protocol, gated by
+ * [SyncFeature.canUseV2ConnectFlow]. With the flag off, [route] behaves identically to
+ * [SyncAccountRepository.parseSyncAuthCode]; v2 work is exposed via [RouteDecision.V2InProgress].
+ */
+interface SyncCodeDispatcher {
+
+    /**
+     * Inspects the pasted code and decides who handles it: [RouteDecision.Legacy] (caller processes
+     * the [SyncAuthCode] as today) or [RouteDecision.V2InProgress] (dispatcher owns the work; caller
+     * collects the returned Flow). See [DispatchOutcome] for the v2 emitted sequence.
+     */
+    fun route(pastedCode: String): RouteDecision
+
+    /**
+     * User confirmed the Joiner-side prompt ("Sync your data with …?"). Drives the SM out of
+     * Joiner.Confirming. No-op if no session is in that state.
+     */
+    fun confirmJoiner()
+
+    /**
+     * User denied the Joiner-side prompt. Drives the SM to Joiner.AbortedLocal. No message
+     * sent to peer (per spec). No-op if no session is in Joiner.Confirming.
+     */
+    fun denyJoiner()
+
+    /**
+     * User confirmed the Host-side prompt ("Allow … to join your sync & backup?"). Drives the
+     * SM out of Host.Confirming into Host.Sending. No-op if no session is in that state.
+     */
+    fun confirmHost()
+
+    /**
+     * User denied the Host-side prompt. Drives the SM to Host.Aborted and sends
+     * recovery_code_denied to the peer. No-op if no session is in Host.Confirming.
+     */
+    fun denyHost()
+
+    /**
+     * Starts a v2 Presenter session. The returned Flow emits exactly one
+     * [DispatchOutcome.LinkingCodeReady] (the URL to render as a QR), then the v2 emitted sequence
+     * (see [DispatchOutcome]). Role election runs in the runner, so the Presenter may be elected
+     * Host or Joiner. Cancelling the collecting coroutine cancels the underlying runner session.
+     */
+    fun presentV2(): Flow<DispatchOutcome>
+
+    /**
+     * Whether a v2 exchange has engaged a peer and is mid-protocol (past Bootstrapped, before a
+     * terminal).
+     */
+    fun isV2ExchangeUnderway(): Boolean
+}
+
+sealed interface RouteDecision {
+    /** Caller MUST process [authCode] as it would have today — no behaviour change from FF off. */
+    data class Legacy(val authCode: SyncAuthCode) : RouteDecision
+
+    /**
+     * Dispatcher owns the work. [codeType] is the kind of v2 code that was recognized.
+     * [outcomes] is a cold Flow that drives the v2 work when collected (see [DispatchOutcome] for the
+     * emitted sequence). Cancelling the collector cancels the work.
+     */
+    data class V2InProgress(
+        val codeType: SyncCodeType,
+        val outcomes: Flow<DispatchOutcome>,
+    ) : RouteDecision
+}
+
+enum class SyncCodeType { RECOVERY, LINKING }
+
+/**
+ * Outcomes emitted by a v2-owned dispatch, used by both [SyncCodeDispatcher.route] (Scanner) and
+ * [SyncCodeDispatcher.presentV2] (Presenter). Emitted sequence per side:
+ *
+ * Scanner (via [RouteDecision.V2InProgress.outcomes]): zero or one [JoinerConfirmationRequested] /
+ * [HostConfirmationRequested] (caller prompts and resumes via the confirm/deny calls), then exactly
+ * one terminal ([LoggedIn] / [UpgradeRequired] / [Failed]).
+ *
+ * Presenter: exactly one [LinkingCodeReady], then zero or one [JoinerConfirmationRequested] /
+ * [HostConfirmationRequested] (role is elected by the runner), then exactly one terminal
+ * ([LoggedIn] / [AlreadyConnected] / [Failed]).
+ *
+ * v2 RecoveryCode flows (cid=ddg, cid=3party) have no confirmation phase — only a terminal outcome.
+ *
+ * v2 does not surface a v1-style `AskToSwitchAccount` prompt; the spec's Confirmations phase is the
+ * consent step. On `ALREADY_SIGNED_IN` the dispatcher logs out and rejoins transparently, emitting
+ * [LoggedIn] (or [Failed] if the switch fails).
+ */
+sealed interface DispatchOutcome {
+    /**
+     * SM reached Joiner.Confirming. Caller must prompt the user ("Sync your data with [peerName]?")
+     * then call [SyncCodeDispatcher.confirmJoiner] or [SyncCodeDispatcher.denyJoiner] to resume.
+     */
+    data class JoinerConfirmationRequested(val peerName: String?, val peerKind: PeerKind? = null) : DispatchOutcome
+
+    /**
+     * SM reached Host.Confirming. Caller must prompt the user ("Allow [peerName] to join your
+     * sync & backup?") then call [SyncCodeDispatcher.confirmHost] or [SyncCodeDispatcher.denyHost].
+     */
+    data class HostConfirmationRequested(val peerName: String?, val peerKind: PeerKind? = null) : DispatchOutcome
+
+    /**
+     * Emitted once per [SyncCodeDispatcher.presentV2] session, before any confirmation or
+     * terminal outcome. [linkingCode] is the URL the caller renders as a QR for the peer
+     * to scan. Non-terminal — the Flow continues.
+     */
+    data class LinkingCodeReady(val linkingCode: String) : DispatchOutcome
+
+    /**
+     * Terminal — login completed (recovery code applied; account state updated). Carries telemetry
+     * for the "Setup success" pixel: [path] (recovery vs pairing) and, for a pairing, the elected
+     * [myRole] and the [peerKind]. [myRole]/[peerKind] are null for recovery.
+     */
+    data class LoggedIn(
+        val path: SetupPath,
+        val myRole: SetupRole? = null,
+        val peerKind: PeerKind? = null,
+    ) : DispatchOutcome
+
+    /**
+     * Terminal — peer and this device are already on the same account. Per spec §"Same-account
+     * case" this is not a failure: show a "Connected" confirmation. No account state change.
+     */
+    data object AlreadyConnected : DispatchOutcome
+
+    /**
+     * Terminal — the pasted code requires a protocol major version higher than this app supports.
+     * [path]/[myRole]/[peerKind] are best-effort telemetry for the "Setup failed" pixel (see [Failed]).
+     */
+    data class UpgradeRequired(
+        val codeMajor: Int,
+        val path: SetupPath? = null,
+        val myRole: SetupRole? = null,
+        val peerKind: PeerKind? = null,
+    ) : DispatchOutcome
+
+    /**
+     * Terminal — transport error, missing credentials on this device, BE rejection, denial, etc.
+     * [code] carries the originating [AccountErrorCodes] code (defaults to GENERIC_ERROR) so callers
+     * can map specific failures (e.g. THIRD_PARTY_ALREADY_UPGRADED) to user-facing copy.
+     * [path]/[myRole]/[peerKind] are best-effort telemetry for the "Setup failed" pixel: [path] is the
+     * flow kind, and [myRole]/[peerKind] are populated when known at the point of failure.
+     */
+    data class Failed(
+        val reason: String,
+        val code: Int = AccountErrorCodes.GENERIC_ERROR.code,
+        val path: SetupPath? = null,
+        val myRole: SetupRole? = null,
+        val peerKind: PeerKind? = null,
+    ) : DispatchOutcome
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncService.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncService.kt
@@ -141,7 +141,7 @@ interface SyncService {
         @Header("Authorization") token: String,
         @Path("purpose") purpose: String,
         @Body request: SetProtectedKeyIfAbsentRequest,
-    ): Call<Void>
+    ): Call<ProtectedKeysResponse>
 
     @GET("$SYNC_PROD_ENVIRONMENT_URL/sync/access-credentials")
     fun getAccessCredentials(
@@ -283,7 +283,7 @@ data class ProtectedKeysResponse(
 
 /** Body for POST /sync/keys/purpose/{purpose}/set-if-absent — adds a protected key only if no key exists for that purpose. */
 data class SetProtectedKeyIfAbsentRequest(
-    val key: ProtectedKeyEntry,
+    val keys: List<ProtectedKeyEntry>,
 )
 
 data class AccessCredentialsResponse(

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
@@ -120,7 +120,7 @@ interface SyncApi {
     fun getProtectedKeys(token: String): Result<List<ProtectedKeyEntry>>
 
     /** Atomically claim [purpose] with [key] or no-op if one already exists. */
-    fun setProtectedKeyIfAbsent(token: String, purpose: String, key: ProtectedKeyEntry): Result<Boolean>
+    fun setProtectedKeyIfAbsent(token: String, purpose: String, keys: List<ProtectedKeyEntry>): Result<List<ProtectedKeyEntry>>
 
     fun getAccessCredentials(token: String): Result<List<AccessCredentialEntry>>
 
@@ -539,16 +539,17 @@ class SyncServiceRemote @Inject constructor(
         }
     }
 
-    override fun setProtectedKeyIfAbsent(token: String, purpose: String, key: ProtectedKeyEntry): Result<Boolean> {
+    override fun setProtectedKeyIfAbsent(token: String, purpose: String, keys: List<ProtectedKeyEntry>): Result<List<ProtectedKeyEntry>> {
         val response = runCatching {
-            val call = syncService.setProtectedKeyIfAbsent("Bearer $token", purpose, SetProtectedKeyIfAbsentRequest(key))
+            val call = syncService.setProtectedKeyIfAbsent("Bearer $token", purpose, SetProtectedKeyIfAbsentRequest(keys))
             call.execute()
         }.getOrElse { throwable ->
             return Result.Error(reason = throwable.message.toString())
         }
 
         return onSuccess(response) {
-            Result.Success(true)
+            val keys = response.body()?.keys ?: emptyList()
+            Result.Success(keys)
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ThirdPartyCredentialManager.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ThirdPartyCredentialManager.kt
@@ -233,10 +233,12 @@ class RealThirdPartyCredentialManager @Inject constructor(
             }
         }
 
-        if (ddgKeys.isEmpty()) {
-            logcat { "Sync-ScopedToken: no ddg protected keys; generating $SYNC_SCOPE_AI_CHATS key before 3party extend" }
-            ddgKeys = when (val gen = protectedKeyManager.create(SYNC_SCOPE_AI_CHATS)) {
-                is Success -> listOf(gen.data)
+        // We ensure ai_chats (the scope's required purpose) exists, then re-wrap every
+        // ddg-wrapped key — preserving any other purposes already on the account.
+        if (ddgKeys.none { it.purpose == SYNC_SCOPE_AI_CHATS }) {
+            logcat { "Sync-ScopedToken: no ddg $SYNC_SCOPE_AI_CHATS key; generating before 3party extend" }
+            when (val gen = protectedKeyManager.create(SYNC_SCOPE_AI_CHATS)) {
+                is Success -> ddgKeys = ddgKeys + gen.data
                 is Error -> {
                     logcat(ERROR) { "Sync-ScopedToken: failed to generate $SYNC_SCOPE_AI_CHATS protected key: ${gen.reason}" }
                     return Error(code = gen.code, reason = "CreateThirdPartyCredential: generate $SYNC_SCOPE_AI_CHATS key failed: ${gen.reason}")

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Channel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Channel.kt
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.ExchangeEnvelope
+import com.duckduckgo.sync.impl.Result
+import com.duckduckgo.sync.impl.SyncApi
+import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import logcat.LogPriority.ERROR
+import logcat.logcat
+import javax.inject.Inject
+
+/**
+ * Wraps the BE relay endpoints with envelope encryption/decryption + a polling Flow.
+ *
+ * Spec: Transport TD (Asana 1214486492252757) §BE Relay + §Polling for messages.
+ */
+interface ExchangeV2Channel {
+
+    /**
+     * Create [channelId] on the relay. Returns Success on 2xx. Returns Error with code=409 on
+     * UUID collision (caller should retry with a fresh UUID).
+     */
+    fun createChannel(channelId: String): Result<Unit>
+
+    /**
+     * Encrypt [messageJson] and send it to [peerChannelId]. Sender's kid is [ownChannelId].
+     */
+    fun sendMessage(
+        messageJson: String,
+        peerChannelId: String,
+        peerPublicKeyBase64: String,
+        ownChannelId: String,
+    ): Result<Unit>
+
+    /**
+     * Long-running poll loop on [ownChannelId]. Emits decrypted + parsed messages as they
+     * arrive. The flow:
+     *  - Polls every 1s using cursor-as-ack semantics.
+     *  - Completes (returns) on 404 (peer/server closed the channel) or [PollOutcome.Closed].
+     *  - Throws [EnvelopeVersionTooNew] if an envelope arrives with a higher major version.
+     *  - Drops envelopes that fail to decrypt or that have unknown types (forward-compat).
+     */
+    fun poll(ownChannelId: String, ownPrivateKeyBase64: String): Flow<ExchangeV2Message>
+
+    /** Best-effort DELETE of our own channel. Used on user-cancel + terminal SM states. */
+    fun deleteChannel(channelId: String): Result<Unit>
+}
+
+@ContributesBinding(AppScope::class)
+class RealExchangeV2Channel @Inject constructor(
+    private val syncApi: SyncApi,
+    private val envelope: ExchangeV2Envelope,
+    private val messageParser: ExchangeV2MessageParser,
+) : ExchangeV2Channel {
+
+    override fun createChannel(channelId: String): Result<Unit> {
+        logcat { "Sync-ExchangeV2: PUT /sync/v2/exchange/$channelId" }
+        return syncApi.createExchangeChannel(channelId)
+    }
+
+    override fun sendMessage(
+        messageJson: String,
+        peerChannelId: String,
+        peerPublicKeyBase64: String,
+        ownChannelId: String,
+    ): Result<Unit> {
+        val sealed = runCatching {
+            envelope.seal(messageJson, peerPublicKeyBase64, ownChannelId)
+        }.getOrElse {
+            logcat(ERROR) { "Sync-ExchangeV2: seal failed: ${it.message}" }
+            return Result.Error(reason = "Failed to seal envelope: ${it.message}")
+        }
+        logcat { "Sync-ExchangeV2: POST /sync/v2/exchange/$peerChannelId/messages" }
+        return syncApi.sendExchangeMessages(peerChannelId, listOf(sealed))
+    }
+
+    override fun poll(ownChannelId: String, ownPrivateKeyBase64: String): Flow<ExchangeV2Message> = flow {
+        var cursor = 0
+        while (true) {
+            when (val outcome = syncApi.pollExchangeMessages(ownChannelId, cursor)) {
+                is Result.Success -> {
+                    for (entry in outcome.data) {
+                        val decoded = decode(entry, ownPrivateKeyBase64)
+                        cursor = entry.seq
+                        emit(decoded)
+                    }
+                }
+                is Result.Error -> {
+                    if (outcome.code == HTTP_NOT_FOUND) {
+                        logcat { "Sync-ExchangeV2: channel $ownChannelId gone (404), ending poll" }
+                        return@flow
+                    }
+                    logcat(ERROR) { "Sync-ExchangeV2: poll error ${outcome.code}: ${outcome.reason}" }
+                    // Transient error — back off but stay in the loop.
+                }
+            }
+            delay(POLL_INTERVAL_MS)
+        }
+    }
+
+    override fun deleteChannel(channelId: String): Result<Unit> {
+        logcat { "Sync-ExchangeV2: DELETE /sync/v2/exchange/$channelId (best effort)" }
+        return syncApi.deleteExchangeChannel(channelId)
+    }
+
+    private fun decode(entry: com.duckduckgo.sync.impl.ExchangeMessageEntry, ownPrivateKeyBase64: String): ExchangeV2Message {
+        val inner = runCatching {
+            envelope.open(ExchangeEnvelope(entry.version, entry.payload), ownPrivateKeyBase64)
+        }.getOrElse {
+            if (it is EnvelopeVersionTooNew) throw it
+            // Permanent: the same bytes will fail the same way every poll. Surface as terminal
+            // so the runner can stop the loop and emit a SessionError instead of spamming logs.
+            logcat(ERROR) { "Sync-ExchangeV2: envelope open failed seq=${entry.seq}: ${it.message}" }
+            throw EnvelopeDecryptFailure(entry.seq, it)
+        }
+        return messageParser.parse(inner)
+    }
+
+    companion object {
+        private const val POLL_INTERVAL_MS: Long = 1_000L
+        private const val HTTP_NOT_FOUND = 404
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Channel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Channel.kt
@@ -55,7 +55,8 @@ interface ExchangeV2Channel {
      * Long-running poll loop on [ownChannelId]. Emits decrypted + parsed messages as they
      * arrive. The flow:
      *  - Polls every 1s using cursor-as-ack semantics.
-     *  - Completes (returns) on 404 (peer/server closed the channel) or [PollOutcome.Closed].
+     *  - Completes (returns) on a non-recoverable HTTP status (e.g. 404 channel gone, 401/403);
+     *    transient statuses (5xx / 429 / 418 / timeouts) keep polling.
      *  - Throws [EnvelopeVersionTooNew] if an envelope arrives with a higher major version.
      *  - Drops envelopes that fail to decrypt or that have unknown types (forward-compat).
      */
@@ -105,12 +106,16 @@ class RealExchangeV2Channel @Inject constructor(
                     }
                 }
                 is Result.Error -> {
-                    if (outcome.code == HTTP_NOT_FOUND) {
-                        logcat { "Sync-ExchangeV2: channel $ownChannelId gone (404), ending poll" }
+                    if (outcome.code in NON_RECOVERABLE_HTTP_CODES) {
+                        // Channel is gone (404/410) or permanently erroring — re-polling can't
+                        // recover, so stop rather than spin until the session deadline. The
+                        // session ends via the runner's timeout; poll() only decides whether to
+                        // keep polling.
+                        logcat { "Sync-ExchangeV2: ending poll on $ownChannelId — non-recoverable status ${outcome.code} (${outcome.reason})" }
                         return@flow
                     }
-                    logcat(ERROR) { "Sync-ExchangeV2: poll error ${outcome.code}: ${outcome.reason}" }
-                    // Transient error — back off but stay in the loop.
+                    // Transient (5xx / 429 / 418 / timeout / IO) — stay in the loop and retry next tick.
+                    logcat(ERROR) { "Sync-ExchangeV2: transient poll error ${outcome.code}: ${outcome.reason}, retrying" }
                 }
             }
             delay(POLL_INTERVAL_MS)
@@ -137,6 +142,16 @@ class RealExchangeV2Channel @Inject constructor(
 
     companion object {
         private const val POLL_INTERVAL_MS: Long = 1_000L
-        private const val HTTP_NOT_FOUND = 404
+
+        // HTTP statuses that won't recover by re-polling the same channel: stop the loop instead
+        // of retrying until the 5-min session deadline. Transient statuses (5xx / 429 / 418 /
+        // timeouts / IO) are deliberately absent here so they keep polling.
+        private val NON_RECOVERABLE_HTTP_CODES = setOf(
+            400, // Bad Request — malformed poll
+            401, // Unauthorized
+            403, // Forbidden
+            404, // Not Found — channel gone (the normal end when the peer/server closed it)
+            410, // Gone — channel permanently removed
+        )
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Channel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Channel.kt
@@ -52,13 +52,10 @@ interface ExchangeV2Channel {
     ): Result<Unit>
 
     /**
-     * Long-running poll loop on [ownChannelId]. Emits decrypted + parsed messages as they
-     * arrive. The flow:
-     *  - Polls every 1s using cursor-as-ack semantics.
-     *  - Completes (returns) on a non-recoverable HTTP status (e.g. 404 channel gone, 401/403);
-     *    transient statuses (5xx / 429 / 418 / timeouts) keep polling.
-     *  - Throws [EnvelopeVersionTooNew] if an envelope arrives with a higher major version.
-     *  - Drops envelopes that fail to decrypt or that have unknown types (forward-compat).
+     * Poll loop on [ownChannelId], emitting decrypted + parsed messages. See spec §Polling.
+     *  - Completes on a non-recoverable HTTP status; transient statuses keep polling.
+     *  - Throws [EnvelopeVersionTooNew] (too-new version) and [EnvelopeDecryptFailure]
+     *    (decrypt failure) as terminal; drops unknown message types (forward-compat).
      */
     fun poll(ownChannelId: String, ownPrivateKeyBase64: String): Flow<ExchangeV2Message>
 
@@ -107,11 +104,10 @@ class RealExchangeV2Channel @Inject constructor(
                 }
                 is Result.Error -> {
                     if (outcome.code in NON_RECOVERABLE_HTTP_CODES) {
-                        // Re-polling won't recover; stop. The session ends via the runner's timeout.
+                        // Re-polling won't recover; stop.
                         logcat { "Sync-ExchangeV2: ending poll on $ownChannelId — non-recoverable status ${outcome.code} (${outcome.reason})" }
                         return@flow
                     }
-                    // Transient — retry on the next tick.
                     logcat(ERROR) { "Sync-ExchangeV2: transient poll error ${outcome.code}: ${outcome.reason}, retrying" }
                 }
             }
@@ -129,8 +125,7 @@ class RealExchangeV2Channel @Inject constructor(
             envelope.open(ExchangeEnvelope(entry.version, entry.payload), ownPrivateKeyBase64)
         }.getOrElse {
             if (it is EnvelopeVersionTooNew) throw it
-            // Permanent: the same bytes will fail the same way every poll. Surface as terminal
-            // so the runner can stop the loop and emit a SessionError instead of spamming logs.
+            // Permanent: the same bytes fail the same way every poll, so surface as terminal.
             logcat(ERROR) { "Sync-ExchangeV2: envelope open failed seq=${entry.seq}: ${it.message}" }
             throw EnvelopeDecryptFailure(entry.seq, it)
         }
@@ -140,9 +135,8 @@ class RealExchangeV2Channel @Inject constructor(
     companion object {
         private const val POLL_INTERVAL_MS: Long = 1_000L
 
-        // HTTP statuses that won't recover by re-polling the same channel: stop the loop instead
-        // of retrying until the 5-min session deadline. Transient statuses (5xx / 429 / 418 /
-        // timeouts / IO) are deliberately absent here so they keep polling.
+        // Statuses that won't recover by re-polling; transient ones (5xx / 429 / 418 / timeouts)
+        // are deliberately absent so they keep polling.
         private val NON_RECOVERABLE_HTTP_CODES = setOf(
             400, // Bad Request — malformed poll
             401, // Unauthorized

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Channel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Channel.kt
@@ -107,14 +107,11 @@ class RealExchangeV2Channel @Inject constructor(
                 }
                 is Result.Error -> {
                     if (outcome.code in NON_RECOVERABLE_HTTP_CODES) {
-                        // Channel is gone (404/410) or permanently erroring — re-polling can't
-                        // recover, so stop rather than spin until the session deadline. The
-                        // session ends via the runner's timeout; poll() only decides whether to
-                        // keep polling.
+                        // Re-polling won't recover; stop. The session ends via the runner's timeout.
                         logcat { "Sync-ExchangeV2: ending poll on $ownChannelId — non-recoverable status ${outcome.code} (${outcome.reason})" }
                         return@flow
                     }
-                    // Transient (5xx / 429 / 418 / timeout / IO) — stay in the loop and retry next tick.
+                    // Transient — retry on the next tick.
                     logcat(ERROR) { "Sync-ExchangeV2: transient poll error ${outcome.code}: ${outcome.reason}, retrying" }
                 }
             }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Envelope.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Envelope.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.ExchangeEnvelope
+import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+/**
+ * Wire-level envelope wrapping for relay messages. The outer object is `{version, payload}`
+ * with [version] unencrypted (used for protocol version negotiation) and [payload] a JWE
+ * compact string carrying the encrypted message JSON.
+ *
+ * Spec: Transport TD (Asana 1214486492252757) §Message Envelope + §Encryption.
+ *  - alg = RSA-OAEP-256 (wraps an ephemeral A256GCM key)
+ *  - enc = A256GCM
+ *  - kid = sender's channel_id
+ */
+interface ExchangeV2Envelope {
+
+    /**
+     * Build an outbound envelope. [messageJson] is the inner message JSON (e.g. produced from
+     * one of the [ExchangeV2Message] subtypes). [peerPublicKeyBase64] is the recipient's
+     * session public key (from their QR code or hello). [senderChannelId] is written as the
+     * JWE `kid` header so the recipient knows which side sent the message.
+     */
+    fun seal(messageJson: String, peerPublicKeyBase64: String, senderChannelId: String): ExchangeEnvelope
+
+    /**
+     * Decrypt an inbound envelope using our own ephemeral private key. Returns the inner
+     * message JSON string.
+     *
+     * @throws EnvelopeVersionTooNew if the envelope's `version` field has a higher major
+     *  than ours.
+     */
+    fun open(envelope: ExchangeEnvelope, ownPrivateKeyBase64: String): String
+}
+
+/** Thrown when an envelope requires a protocol version we don't support. */
+class EnvelopeVersionTooNew(val version: String) : RuntimeException(
+    "Envelope requires protocol v$version; we only support v$OUR_MAJOR",
+)
+
+/**
+ * Thrown when an envelope's payload can't be decrypted or parsed (bad key, malformed JWE,
+ * truncated bytes, etc.). Unlike a transient HTTP error this is permanent — the same bytes
+ * will fail the same way next time — so the runner treats it as terminal rather than retrying.
+ */
+class EnvelopeDecryptFailure(val seq: Int, cause: Throwable) : RuntimeException(
+    "Failed to decrypt envelope seq=$seq: ${cause.message}",
+    cause,
+)
+
+const val OUR_MAJOR: Int = 2
+const val OUR_VERSION_STRING: String = "2"
+
+@ContributesBinding(AppScope::class)
+class RealExchangeV2Envelope @Inject constructor(
+    private val jweCrypto: SyncJweCrypto,
+) : ExchangeV2Envelope {
+
+    override fun seal(messageJson: String, peerPublicKeyBase64: String, senderChannelId: String): ExchangeEnvelope {
+        val jwe = jweCrypto.jweEncryptRsaOaep(
+            plaintext = messageJson.toByteArray(Charsets.UTF_8),
+            recipientPublicKeyBase64 = peerPublicKeyBase64,
+            kid = senderChannelId,
+        )
+        return ExchangeEnvelope(version = OUR_VERSION_STRING, payload = jwe)
+    }
+
+    override fun open(envelope: ExchangeEnvelope, ownPrivateKeyBase64: String): String {
+        val major = parseMajor(envelope.version)
+        if (major > OUR_MAJOR) throw EnvelopeVersionTooNew(envelope.version)
+        if (major < OUR_MAJOR) throw IllegalArgumentException("Obsolete envelope version ${envelope.version}")
+        val decrypted = jweCrypto.jweDecryptRsaOaep(envelope.payload, ownPrivateKeyBase64)
+        return String(decrypted, Charsets.UTF_8)
+    }
+
+    private fun parseMajor(version: String): Int {
+        val majorPart = version.substringBefore('.')
+        return majorPart.toIntOrNull()
+            ?: throw IllegalArgumentException("Malformed envelope version: $version")
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Envelope.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Envelope.kt
@@ -35,19 +35,15 @@ import javax.inject.Inject
 interface ExchangeV2Envelope {
 
     /**
-     * Build an outbound envelope. [messageJson] is the inner message JSON (e.g. produced from
-     * one of the [ExchangeV2Message] subtypes). [peerPublicKeyBase64] is the recipient's
-     * session public key (from their QR code or hello). [senderChannelId] is written as the
-     * JWE `kid` header so the recipient knows which side sent the message.
+     * Build an outbound envelope encrypting [messageJson] to the recipient's [peerPublicKeyBase64].
+     * [senderChannelId] is written as the JWE `kid` header so the recipient knows the sender.
      */
     fun seal(messageJson: String, peerPublicKeyBase64: String, senderChannelId: String): ExchangeEnvelope
 
     /**
-     * Decrypt an inbound envelope using our own ephemeral private key. Returns the inner
-     * message JSON string.
+     * Decrypt an inbound envelope with our ephemeral private key, returning the inner message JSON.
      *
-     * @throws EnvelopeVersionTooNew if the envelope's `version` field has a higher major
-     *  than ours.
+     * @throws EnvelopeVersionTooNew if the envelope's major version is higher than ours.
      */
     fun open(envelope: ExchangeEnvelope, ownPrivateKeyBase64: String): String
 }
@@ -58,9 +54,8 @@ class EnvelopeVersionTooNew(val version: String) : RuntimeException(
 )
 
 /**
- * Thrown when an envelope's payload can't be decrypted or parsed (bad key, malformed JWE,
- * truncated bytes, etc.). Unlike a transient HTTP error this is permanent — the same bytes
- * will fail the same way next time — so the runner treats it as terminal rather than retrying.
+ * Thrown when an envelope's payload can't be decrypted or parsed. Permanent (the same bytes
+ * fail identically on retry), so the runner treats it as terminal rather than retrying.
  */
 class EnvelopeDecryptFailure(val seq: Int, cause: Throwable) : RuntimeException(
     "Failed to decrypt envelope seq=$seq: ${cause.message}",

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2QrCode.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2QrCode.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import android.util.Base64
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import org.json.JSONObject
+import javax.inject.Inject
+
+/**
+ * Generates and parses v2 linking codes (the QR/URL exchanged during pairing bootstrap).
+ *
+ * Wire format per Transport TD (Asana 1214486492252757):
+ *   https://duckduckgo.com/sync/pairing/#&code2=<base64(JSON)>
+ *   JSON = {"version":"2", "channel_id":"<UUID>", "public_key":"<base64url SPKI DER>"}
+ *
+ * Spec deviation note: the TD's pseudocode reads literally `base64()` for the outer `code2`
+ * value, but the deployed wire format across every client uses URL-safe + no-padding (the
+ * URL fragment isn't safe for `+`/`/`/`=`). We follow the deployed convention here. If the
+ * TD is later tightened to require strict base64, this needs revisiting.
+ */
+interface ExchangeV2QrCode {
+    fun buildLinkingCode(channelId: String, publicKeyBase64Url: String, version: String = "2"): String
+    fun parse(text: String): ExchangeV2CodeParseResult
+}
+
+sealed interface ExchangeV2CodeParseResult {
+    /** Successfully parsed v2 linking code — drives the Scanner-side flow. */
+    data class LinkingV2(
+        val channelId: String,
+        val publicKey: String,
+        val version: String,
+    ) : ExchangeV2CodeParseResult
+
+    /** v1 linking code (legacy <code=...>); fall back to v1 stack. */
+    data object LinkingV1 : ExchangeV2CodeParseResult
+
+    /** A recovery code — no URL prefix. Caller routes to recovery-handling path. */
+    data class RecoveryCode(val rawJson: JSONObject) : ExchangeV2CodeParseResult
+
+    /** Anything we couldn't interpret. */
+    data object Unknown : ExchangeV2CodeParseResult
+}
+
+@ContributesBinding(AppScope::class)
+class RealExchangeV2QrCode @Inject constructor() : ExchangeV2QrCode {
+
+    override fun buildLinkingCode(channelId: String, publicKeyBase64Url: String, version: String): String {
+        // Compact JSON, no whitespace — cross-platform clients hash/compare the encoded payload
+        // byte-for-byte, so JSON serialisation must be deterministic and minimal.
+        val payload = JSONObject().apply {
+            put("version", version)
+            put("channel_id", channelId)
+            put("public_key", publicKeyBase64Url)
+        }.toString()
+        val encoded = Base64.encodeToString(
+            payload.toByteArray(Charsets.UTF_8),
+            Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP,
+        )
+        return "$URL_PREFIX#&$PARAM_V2=$encoded"
+    }
+
+    override fun parse(text: String): ExchangeV2CodeParseResult {
+        // Tolerate common paste mishaps: leading/trailing whitespace, and a "Linking code: …"
+        // or other prefix before the actual URL. If we find an http(s):// substring, parse
+        // from there; otherwise treat the trimmed input as a bare base64url string.
+        val trimmed = text.trim()
+        val httpIndex = sequenceOf("https://", "http://").mapNotNull { trimmed.indexOf(it).takeIf { i -> i >= 0 } }.minOrNull()
+        val candidate = if (httpIndex != null) trimmed.substring(httpIndex) else trimmed
+        val b64url = extractFragmentParam(candidate) ?: candidate.takeIf(::looksLikeBase64Url)
+            ?: return ExchangeV2CodeParseResult.Unknown
+
+        val decoded = runCatching {
+            Base64.decode(b64url, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
+        }.getOrNull() ?: return ExchangeV2CodeParseResult.Unknown
+
+        val json = runCatching { JSONObject(String(decoded, Charsets.UTF_8)) }.getOrNull()
+            ?: return ExchangeV2CodeParseResult.Unknown
+
+        // Recovery code: {"recovery": { user_id, secret, ... }}
+        if (json.has("recovery")) {
+            val recovery = json.optJSONObject("recovery") ?: return ExchangeV2CodeParseResult.Unknown
+            if (recovery.has("user_id") && recovery.has("secret")) {
+                return ExchangeV2CodeParseResult.RecoveryCode(rawJson = recovery)
+            }
+        }
+
+        // v2 linking code
+        if (json.optString("version") == "2" && json.has("channel_id") && json.has("public_key")) {
+            return ExchangeV2CodeParseResult.LinkingV2(
+                channelId = json.optString("channel_id"),
+                publicKey = json.optString("public_key"),
+                version = json.optString("version"),
+            )
+        }
+
+        // v1 linking code: {"connect": {"device_id": ..., "secret_key": ...}}
+        if (json.has("connect")) {
+            return ExchangeV2CodeParseResult.LinkingV1
+        }
+
+        return ExchangeV2CodeParseResult.Unknown
+    }
+
+    /**
+     * Pull the `code2` or `code` value from a URL fragment, or return null for non-URL input.
+     * Fragment may begin with `&` (v2 uses `#&code2=…`) or be bare (v1 uses `#code=…`).
+     */
+    private fun extractFragmentParam(text: String): String? {
+        if (!text.startsWith("http://") && !text.startsWith("https://")) return null
+        val fragmentStart = text.indexOf('#').takeIf { it >= 0 } ?: return null
+        var fragment = text.substring(fragmentStart + 1)
+        if (fragment.startsWith("&")) fragment = fragment.substring(1)
+        for (pair in fragment.split('&')) {
+            val eq = pair.indexOf('=')
+            if (eq <= 0) continue
+            val key = pair.substring(0, eq)
+            val value = pair.substring(eq + 1)
+            if (key == PARAM_V2 || key == PARAM_V1) return value
+        }
+        return null
+    }
+
+    private fun looksLikeBase64Url(s: String): Boolean =
+        s.length >= 8 && s.all { it in BASE64_URL_ALPHABET }
+
+    companion object {
+        private const val URL_PREFIX = "https://duckduckgo.com/sync/pairing/"
+        private const val PARAM_V2 = "code2"
+        private const val PARAM_V1 = "code"
+        private val BASE64_URL_ALPHABET = (('A'..'Z') + ('a'..'z') + ('0'..'9') + listOf('-', '_', '=')).toSet()
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2QrCode.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2QrCode.kt
@@ -19,6 +19,8 @@ package com.duckduckgo.sync.impl.exchange.v2
 import android.util.Base64
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.moshi.Json
+import com.squareup.moshi.Moshi
 import org.json.JSONObject
 import javax.inject.Inject
 
@@ -61,18 +63,22 @@ sealed interface ExchangeV2CodeParseResult {
 class RealExchangeV2QrCode @Inject constructor() : ExchangeV2QrCode {
 
     override fun buildLinkingCode(channelId: String, publicKeyBase64Url: String, version: String): String {
-        // Compact JSON, no whitespace — cross-platform clients hash/compare the encoded payload
-        // byte-for-byte, so JSON serialisation must be deterministic and minimal.
-        val payload = JSONObject().apply {
-            put("version", version)
-            put("channel_id", channelId)
-            put("public_key", publicKeyBase64Url)
-        }.toString()
+        // Compact JSON, no whitespace. Serialized with Moshi (not org.json) because AOSP's
+        // JSONObject.toString() escapes '/' to '\/', which non-strict cross-platform decoders
+        // reject. Consumers only ever PARSE this code and read the field values — nothing
+        // hashes or byte-compares the encoded payload — so field order is not contractual.
+        val payload = linkingCodeAdapter.toJson(
+            V2LinkingCodePayload(version = version, channelId = channelId, publicKey = publicKeyBase64Url),
+        )
         val encoded = Base64.encodeToString(
             payload.toByteArray(Charsets.UTF_8),
             Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP,
         )
         return "$URL_PREFIX#&$PARAM_V2=$encoded"
+    }
+
+    private val linkingCodeAdapter by lazy {
+        Moshi.Builder().build().adapter(V2LinkingCodePayload::class.java)
     }
 
     override fun parse(text: String): ExchangeV2CodeParseResult {
@@ -146,3 +152,14 @@ class RealExchangeV2QrCode @Inject constructor() : ExchangeV2QrCode {
         private val BASE64_URL_ALPHABET = (('A'..'Z') + ('a'..'z') + ('0'..'9') + listOf('-', '_', '=')).toSet()
     }
 }
+
+/**
+ * v2 linking-code payload. Serialized with plain (reflective) Moshi, which reads `@field:Json`
+ * and emits fields alphabetically — order is fine because the code is parse-only on every
+ * platform (nothing byte-compares it). See [RealExchangeV2QrCode.buildLinkingCode].
+ */
+internal data class V2LinkingCodePayload(
+    val version: String,
+    @field:Json(name = "channel_id") val channelId: String,
+    @field:Json(name = "public_key") val publicKey: String,
+)

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2QrCode.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2QrCode.kt
@@ -106,12 +106,14 @@ class RealExchangeV2QrCode @Inject constructor() : ExchangeV2QrCode {
             }
         }
 
-        // v2 linking code
-        if (json.optString("version") == "2" && json.has("channel_id") && json.has("public_key")) {
+        // v2 linking code — accept any same-major (2.x) version per Transport TD 1214486492252757
+        // §Versioning ("same major version — proceed"). The raw version string is preserved.
+        val version = json.optString("version")
+        if (majorVersion(version) == 2 && json.has("channel_id") && json.has("public_key")) {
             return ExchangeV2CodeParseResult.LinkingV2(
                 channelId = json.optString("channel_id"),
                 publicKey = json.optString("public_key"),
-                version = json.optString("version"),
+                version = version,
             )
         }
 
@@ -141,6 +143,9 @@ class RealExchangeV2QrCode @Inject constructor() : ExchangeV2QrCode {
         }
         return null
     }
+
+    /** Major component of a "major.minor" version string (e.g. "2.1" → 2), or null if unparseable. */
+    private fun majorVersion(version: String): Int? = version.substringBefore(".").toIntOrNull()
 
     private fun looksLikeBase64Url(s: String): Boolean =
         s.length >= 8 && s.all { it in BASE64_URL_ALPHABET }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2QrCode.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2QrCode.kt
@@ -63,10 +63,6 @@ sealed interface ExchangeV2CodeParseResult {
 class RealExchangeV2QrCode @Inject constructor() : ExchangeV2QrCode {
 
     override fun buildLinkingCode(channelId: String, publicKeyBase64Url: String, version: String): String {
-        // Compact JSON, no whitespace. Serialized with Moshi (not org.json) because AOSP's
-        // JSONObject.toString() escapes '/' to '\/', which non-strict cross-platform decoders
-        // reject. Consumers only ever PARSE this code and read the field values — nothing
-        // hashes or byte-compares the encoded payload — so field order is not contractual.
         val payload = linkingCodeAdapter.toJson(
             V2LinkingCodePayload(version = version, channelId = channelId, publicKey = publicKeyBase64Url),
         )
@@ -82,14 +78,13 @@ class RealExchangeV2QrCode @Inject constructor() : ExchangeV2QrCode {
     }
 
     override fun parse(text: String): ExchangeV2CodeParseResult {
-        // Tolerate common paste mishaps: leading/trailing whitespace, and a "Linking code: …"
-        // or other prefix before the actual URL. If we find an http(s):// substring, parse
-        // from there; otherwise treat the trimmed input as a bare base64url string.
         val trimmed = text.trim()
         val httpIndex = sequenceOf("https://", "http://").mapNotNull { trimmed.indexOf(it).takeIf { i -> i >= 0 } }.minOrNull()
         val candidate = if (httpIndex != null) trimmed.substring(httpIndex) else trimmed
-        val b64url = extractFragmentParam(candidate) ?: candidate.takeIf(::looksLikeBase64Url)
-            ?: return ExchangeV2CodeParseResult.Unknown
+        // No alphabet pre-check on the bare candidate: Base64.decode + JSONObject below already
+        // reject any non-base64url / non-JSON input as Unknown, so a looksLikeBase64Url guard would
+        // be redundant. (Base64.decode skips embedded whitespace, so a line-wrapped paste decodes too.)
+        val b64url = extractFragmentParam(candidate) ?: candidate
 
         val decoded = runCatching {
             Base64.decode(b64url, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
@@ -149,14 +144,10 @@ class RealExchangeV2QrCode @Inject constructor() : ExchangeV2QrCode {
     /** Major component of a "major.minor" version string (e.g. "2.1" → 2), or null if unparseable. */
     private fun majorVersion(version: String): Int? = version.substringBefore(".").toIntOrNull()
 
-    private fun looksLikeBase64Url(s: String): Boolean =
-        s.length >= 8 && s.all { it in BASE64_URL_ALPHABET }
-
     companion object {
         private const val URL_PREFIX = "https://duckduckgo.com/sync/pairing/"
         private const val PARAM_V2 = "code2"
         private const val PARAM_V1 = "code"
-        private val BASE64_URL_ALPHABET = (('A'..'Z') + ('a'..'z') + ('0'..'9') + listOf('-', '_', '=')).toSet()
     }
 }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2QrCode.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2QrCode.kt
@@ -109,10 +109,12 @@ class RealExchangeV2QrCode @Inject constructor() : ExchangeV2QrCode {
         // v2 linking code — accept any same-major (2.x) version per Transport TD 1214486492252757
         // §Versioning ("same major version — proceed"). The raw version string is preserved.
         val version = json.optString("version")
-        if (majorVersion(version) == 2 && json.has("channel_id") && json.has("public_key")) {
+        val channelId = json.optString("channel_id")
+        val publicKey = json.optString("public_key")
+        if (majorVersion(version) == 2 && channelId.isNotEmpty() && publicKey.isNotEmpty()) {
             return ExchangeV2CodeParseResult.LinkingV2(
-                channelId = json.optString("channel_id"),
-                publicKey = json.optString("public_key"),
+                channelId = channelId,
+                publicKey = publicKey,
                 version = version,
             )
         }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2QrCode.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2QrCode.kt
@@ -128,17 +128,12 @@ class RealExchangeV2QrCode @Inject constructor() : ExchangeV2QrCode {
      */
     private fun extractFragmentParam(text: String): String? {
         if (!text.startsWith("http://") && !text.startsWith("https://")) return null
-        val fragmentStart = text.indexOf('#').takeIf { it >= 0 } ?: return null
-        var fragment = text.substring(fragmentStart + 1)
-        if (fragment.startsWith("&")) fragment = fragment.substring(1)
-        for (pair in fragment.split('&')) {
-            val eq = pair.indexOf('=')
-            if (eq <= 0) continue
-            val key = pair.substring(0, eq)
-            val value = pair.substring(eq + 1)
-            if (key == PARAM_V2 || key == PARAM_V1) return value
-        }
-        return null
+        if ('#' !in text) return null
+        // substringAfter('#') keeps the whole fragment; a leading '&' (the v2 '#&code2=' quirk)
+        // just yields an empty first split element that firstOrNull skips.
+        return text.substringAfter('#').split('&')
+            .firstOrNull { it.startsWith("$PARAM_V2=") || it.startsWith("$PARAM_V1=") }
+            ?.substringAfter('=')
     }
 
     /** Major component of a "major.minor" version string (e.g. "2.1" → 2), or null if unparseable. */

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2QrCode.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2QrCode.kt
@@ -31,10 +31,7 @@ import javax.inject.Inject
  *   https://duckduckgo.com/sync/pairing/#&code2=<base64(JSON)>
  *   JSON = {"version":"2", "channel_id":"<UUID>", "public_key":"<base64url SPKI DER>"}
  *
- * Spec deviation note: the TD's pseudocode reads literally `base64()` for the outer `code2`
- * value, but the deployed wire format across every client uses URL-safe + no-padding (the
- * URL fragment isn't safe for `+`/`/`/`=`). We follow the deployed convention here. If the
- * TD is later tightened to require strict base64, this needs revisiting.
+ * The outer `code2` value is URL-safe + no-padding base64 (the fragment isn't safe for `+`/`/`/`=`).
  */
 interface ExchangeV2QrCode {
     fun buildLinkingCode(channelId: String, publicKeyBase64Url: String, version: String = "2"): String
@@ -81,9 +78,7 @@ class RealExchangeV2QrCode @Inject constructor() : ExchangeV2QrCode {
         val trimmed = text.trim()
         val httpIndex = sequenceOf("https://", "http://").mapNotNull { trimmed.indexOf(it).takeIf { i -> i >= 0 } }.minOrNull()
         val candidate = if (httpIndex != null) trimmed.substring(httpIndex) else trimmed
-        // No alphabet pre-check on the bare candidate: Base64.decode + JSONObject below already
-        // reject any non-base64url / non-JSON input as Unknown, so a looksLikeBase64Url guard would
-        // be redundant. (Base64.decode skips embedded whitespace, so a line-wrapped paste decodes too.)
+        // No alphabet pre-check: the Base64.decode + JSONObject below already reject non-base64url/non-JSON as Unknown.
         val b64url = extractFragmentParam(candidate) ?: candidate
 
         val decoded = runCatching {
@@ -101,8 +96,7 @@ class RealExchangeV2QrCode @Inject constructor() : ExchangeV2QrCode {
             }
         }
 
-        // v2 linking code — accept any same-major (2.x) version per Transport TD 1214486492252757
-        // §Versioning ("same major version — proceed"). The raw version string is preserved.
+        // Accept any same-major (2.x) version per Transport TD 1214486492252757 §Versioning.
         val version = json.optString("version")
         val channelId = json.optString("channel_id")
         val publicKey = json.optString("public_key")
@@ -129,8 +123,7 @@ class RealExchangeV2QrCode @Inject constructor() : ExchangeV2QrCode {
     private fun extractFragmentParam(text: String): String? {
         if (!text.startsWith("http://") && !text.startsWith("https://")) return null
         if ('#' !in text) return null
-        // substringAfter('#') keeps the whole fragment; a leading '&' (the v2 '#&code2=' quirk)
-        // just yields an empty first split element that firstOrNull skips.
+        // A leading '&' (the v2 '#&code2=' form) yields an empty first split element that firstOrNull skips.
         return text.substringAfter('#').split('&')
             .firstOrNull { it.startsWith("$PARAM_V2=") || it.startsWith("$PARAM_V1=") }
             ?.substringAfter('=')
@@ -146,11 +139,7 @@ class RealExchangeV2QrCode @Inject constructor() : ExchangeV2QrCode {
     }
 }
 
-/**
- * v2 linking-code payload. Serialized with plain (reflective) Moshi, which reads `@field:Json`
- * and emits fields alphabetically — order is fine because the code is parse-only on every
- * platform (nothing byte-compares it). See [RealExchangeV2QrCode.buildLinkingCode].
- */
+/** v2 linking-code payload. Field order is irrelevant: the code is parse-only, never byte-compared. */
 internal data class V2LinkingCodePayload(
     val version: String,
     @field:Json(name = "channel_id") val channelId: String,

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -640,15 +640,19 @@ class RealExchangeV2Runner @Inject constructor(
             sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.RecoveryCodeRequest(json, DEVICE_NAME, OWN_DEVICE_KIND))
         }
         sentOwnAvailability = true
-        // Roll the maybe-auto-elect check forward in case we already received peer availability
-        // before we knew our own context.
+        // Roll the auto-elect check forward in case the peer's availability arrived before we
+        // sent ours. Delegate to [autoElectRoleLocked] (the single election path) so the
+        // RoleElected side effects actually run — notably SendAwaitingConfirmation on the Host
+        // branch. An earlier inline copy here emitted the transition but dropped the side effects.
+        //
+        // REVIEW (spec reachability): with the current eager-send ordering this looks unreachable
+        // — entering Negotiating and sending our own availability happen in the same locked pass,
+        // so we never arrive here in Negotiating with peerKind already set. Confirm against the
+        // cross-platform ordering spec (Unified Algorithm 1214739740392701) whether any client
+        // ordering can make it live; if not, this branch is dead code and can be removed.
         val sm = session ?: return
         if (sm.currentState == ExchangeV2State.Negotiating && peerKind != null) {
-            val elected = electRole()
-            if (elected != null) {
-                val r = sm.localTrigger(LocalTrigger.RoleElected(elected))
-                emit(r.event)
-            }
+            autoElectRoleLocked(sm)
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -81,6 +81,9 @@ interface ExchangeV2Runner {
     /** Peer device's human-readable name, learned from `recovery_code_available` / `recovery_code_request`. */
     val peerName: String?
 
+    /** Peer device's credential kind ("ddg" / "3party"), learned during role election. Null before then. */
+    val peerKind: String?
+
     fun startScan(pastedUrl: String)
 
     fun startPresent()
@@ -134,7 +137,7 @@ class RealExchangeV2Runner @Inject constructor(
 
     @Volatile private var peerPublicKey: String? = null
 
-    @Volatile private var peerKind: String? = null
+    @Volatile private var _peerKind: String? = null
 
     @Volatile private var peerUserId: String? = null
 
@@ -160,6 +163,7 @@ class RealExchangeV2Runner @Inject constructor(
     override val linkingCode: String? get() = _linkingCode
     override val canStartAsPresenter: Boolean get() = true
     override val peerName: String? get() = _peerName
+    override val peerKind: String? get() = _peerKind
 
     // -----------------------------------------------------------------------
     // Entry points
@@ -251,7 +255,7 @@ class RealExchangeV2Runner @Inject constructor(
                     if (r.code == HTTP_CONFLICT) {
                         logcat { "Sync-ExchangeV2: channel_id $candidate already taken, retrying (${attempt + 1}/$MAX_CHANNEL_CREATE_RETRIES)" }
                     } else {
-                        emitSessionError("Failed to create channel: ${r.reason}")
+                        emitSessionError("Failed to create channel")
                         return null
                     }
                 }
@@ -302,7 +306,7 @@ class RealExchangeV2Runner @Inject constructor(
         ownKeyPair = null
         peerChannelId = null
         peerPublicKey = null
-        peerKind = null
+        _peerKind = null
         peerUserId = null
         _peerName = null
         _linkingCode = null
@@ -463,12 +467,12 @@ class RealExchangeV2Runner @Inject constructor(
                 peerPublicKey = message.publicKey
             }
             is ExchangeV2Message.RecoveryCodeAvailable -> {
-                peerKind = message.kind
+                _peerKind = message.kind
                 peerUserId = message.userId
                 _peerName = message.name
             }
             is ExchangeV2Message.RecoveryCodeRequest -> {
-                peerKind = message.kind
+                _peerKind = message.kind
                 peerUserId = null
                 _peerName = message.name
             }
@@ -501,12 +505,12 @@ class RealExchangeV2Runner @Inject constructor(
      */
     private fun autoElectRoleLocked(sm: ExchangeV2StateMachine) {
         val elected = electRole() ?: run {
-            logcat { "Sync-ExchangeV2: cannot auto-elect role yet (role=${_pairingRole}, peerKind=$peerKind)" }
+            logcat { "Sync-ExchangeV2: cannot auto-elect role yet (role=${_pairingRole}, peerKind=$_peerKind)" }
             return
         }
         logcat {
             "Sync-ExchangeV2: auto-electing $elected " +
-                "(own role=${_pairingRole}, own userId=${syncStore.userId}, peer kind=$peerKind, peer userId=$peerUserId)"
+                "(own role=${_pairingRole}, own userId=${syncStore.userId}, peer kind=$_peerKind, peer userId=$peerUserId)"
         }
         val electResult = sm.localTrigger(LocalTrigger.RoleElected(elected))
         emit(electResult.event)
@@ -527,7 +531,7 @@ class RealExchangeV2Runner @Inject constructor(
     private fun electRole(): Role? {
         val ownRole = _pairingRole ?: return null
         val ownUserId = syncStore.userId
-        val pKind = peerKind ?: return null
+        val pKind = _peerKind ?: return null
         val pUserId = peerUserId
         return when {
             ownUserId != null && pUserId == null -> Role.Host
@@ -642,7 +646,7 @@ class RealExchangeV2Runner @Inject constructor(
         // REVIEW: likely unreachable under eager-send ordering — confirm against the ordering spec
         // (Unified Algorithm 1214739740392701) and delete if dead.
         val sm = session ?: return
-        if (sm.currentState == ExchangeV2State.Negotiating && peerKind != null) {
+        if (sm.currentState == ExchangeV2State.Negotiating && _peerKind != null) {
             autoElectRoleLocked(sm)
         }
     }
@@ -661,11 +665,11 @@ class RealExchangeV2Runner @Inject constructor(
         // failure falls through to recovery_code_unavailable below.
         // peerKind is set during role election; reaching Host.Sending without it means something
         // upstream is broken — bail rather than silently assuming ddg.
-        val codeResult = when (peerKind) {
+        val codeResult = when (_peerKind) {
             "ddg" -> provisionForDdgPeer()
             "3party" -> provisionForThirdPartyPeer()
             null -> Result.Error(reason = "Host.Sending reached without a known peer kind")
-            else -> Result.Error(reason = "Unsupported peer kind '$peerKind'")
+            else -> Result.Error(reason = "Unsupported peer kind '$_peerKind'")
         }
         return when (codeResult) {
             is Result.Success -> {
@@ -678,7 +682,7 @@ class RealExchangeV2Runner @Inject constructor(
                 sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.RecoveryCodeResponse(json, recoveryCode))
             }
             is Result.Error -> {
-                logcat(ERROR) { "Sync-ExchangeV2: recovery code unavailable for peerKind=$peerKind: ${codeResult.reason}" }
+                logcat(ERROR) { "Sync-ExchangeV2: recovery code unavailable for peerKind=$_peerKind: ${codeResult.reason}" }
                 val json = """{"type":"recovery_code_unavailable"}"""
                 sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.RecoveryCodeUnavailable(json))
                 emitSessionError("Couldn't generate a recovery code: ${codeResult.reason}")
@@ -739,7 +743,7 @@ class RealExchangeV2Runner @Inject constructor(
                 true
             }
             is Result.Error -> {
-                emitSessionError("Failed to send ${outboundMessage.messageType}: ${r.reason}")
+                emitSessionError("Failed to send message to peer over channel")
                 false
             }
         }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -653,8 +653,8 @@ class RealExchangeV2Runner @Inject constructor(
                     put("type", "recovery_code_response")
                     put("recovery_code", recoveryCode)
                 }.toString()
+                // Propagate the send result
                 sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.RecoveryCodeResponse(json, recoveryCode))
-                true
             }
             is Result.Error -> {
                 logcat(ERROR) { "Sync-ExchangeV2: recovery code unavailable for peerKind=$peerKind: ${codeResult.reason}" }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -1,0 +1,786 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.Result
+import com.duckduckgo.sync.impl.crypto.RsaKeyPair
+import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.Host
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.Joiner
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.SameAccountAbort
+import com.duckduckgo.sync.store.SyncStore
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import logcat.LogPriority.ERROR
+import logcat.logcat
+import org.json.JSONObject
+import java.util.UUID
+import javax.inject.Inject
+
+/**
+ * Drives a single Exchange V2 protocol session.
+ *
+ * Two entry points: [startPresent] generates a v2 linking code (the URL is surfaced via
+ * [SessionStarted]); [startScan] parses a peer's code and joins their session. From there
+ * the runner manages the wire I/O: bootstrap channel via PUT, send messages via POST, poll
+ * own channel for incoming envelopes, decrypt, drive the SM, auto-elect role per Unified
+ * Algorithm rules, and auto-send protocol messages as the SM advances.
+ *
+ * Manual injection paths (`deliverIncomingMessage`, `localTrigger`) remain callable from
+ * the dev tool so individual SM transitions can still be exercised in isolation.
+ */
+interface ExchangeV2Runner {
+    val events: SharedFlow<ExchangeV2Event>
+
+    /**
+     * Events emitted at or after [sinceMs]. The underlying [events] SharedFlow has a replay
+     * buffer that persists across sessions, so subscribers may see stale events from prior
+     * runs. Consumers that want to scope observation to a single session should snapshot a
+     * wall clock (`System.currentTimeMillis()`) before kicking off a new session and pass it
+     * here — events emitted with earlier timestamps (from prior sessions) are filtered out.
+     */
+    fun eventsSince(sinceMs: Long): Flow<ExchangeV2Event> = events.filter { it.timestampMs >= sinceMs }
+
+    val currentState: ExchangeV2State?
+
+    val pairingRole: PairingRole?
+
+    /** Linking code URL for the Presenter side — populated after [startPresent] completes bootstrap. */
+    val linkingCode: String?
+
+    /**
+     * Whether this device can start as Presenter. Always true: per the Unified Algorithm spec
+     * §"Exchange Share Recovery Code" — *"If host has no account yet, create it first."* — a
+     * fresh device (no account) can become Host via the Presenter-beats-Scanner tiebreak rule
+     * and creates an account during the Exchange Share Recovery Code phase. UI may still read
+     * it to vary copy (e.g. "Pair" vs "Pair & create account").
+     */
+    val canStartAsPresenter: Boolean
+
+    /** Peer device's human-readable name, learned from `recovery_code_available` / `recovery_code_request`. */
+    val peerName: String?
+
+    fun startScan(pastedUrl: String)
+
+    fun startPresent()
+
+    fun cancel()
+
+    fun deliverIncomingMessage(message: ExchangeV2Message)
+
+    fun deliverIncomingMessageJson(rawJson: String)
+
+    fun localTrigger(trigger: LocalTrigger)
+
+    fun recordSentMessage(message: ExchangeV2Message)
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealExchangeV2Runner @Inject constructor(
+    private val smFactory: ExchangeV2StateMachineFactory,
+    private val messageParser: ExchangeV2MessageParser,
+    private val clock: ExchangeV2Clock,
+    private val syncStore: SyncStore,
+    private val jweCrypto: SyncJweCrypto,
+    private val channel: ExchangeV2Channel,
+    private val qrCode: ExchangeV2QrCode,
+    private val recoveryCodeProvider: RecoveryCodeProvider,
+    @AppCoroutineScope private val appScope: CoroutineScope,
+    private val dispatchers: DispatcherProvider,
+) : ExchangeV2Runner {
+
+    private val _events = MutableSharedFlow<ExchangeV2Event>(replay = REPLAY, extraBufferCapacity = REPLAY)
+    override val events: SharedFlow<ExchangeV2Event> = _events.asSharedFlow()
+
+    // Mutex serialises SM mutations + peer-state writes across the poll loop + user clicks.
+    private val mutex = Mutex()
+
+    @Volatile private var session: ExchangeV2StateMachine? = null
+
+    @Volatile private var _pairingRole: PairingRole? = null
+
+    @Volatile private var ownChannelId: String? = null
+
+    @Volatile private var ownKeyPair: RsaKeyPair? = null
+
+    @Volatile private var peerChannelId: String? = null
+
+    @Volatile private var peerPublicKey: String? = null
+
+    @Volatile private var peerKind: String? = null
+
+    @Volatile private var peerUserId: String? = null
+
+    @Volatile private var _peerName: String? = null
+
+    @Volatile private var _linkingCode: String? = null
+
+    @Volatile private var pollJob: Job? = null
+
+    @Volatile private var sentOwnAvailability: Boolean = false
+
+    /**
+     * Host-side messages that arrive while the Joiner is still showing the user-confirm prompt
+     * are buffered here and replayed when the user confirms (Joiner.Confirming → Joiner.Waiting).
+     * Without this, a Host with auto-approve enabled races ahead and the Joiner SM rejects the
+     * arriving finalisation messages as implicit aborts before the user has tapped Confirm.
+     * Cleared on cancel, terminal, or user-deny.
+     */
+    private val pendingJoinerWaitingMessages = mutableListOf<ExchangeV2Message>()
+
+    override val currentState: ExchangeV2State? get() = session?.currentState
+    override val pairingRole: PairingRole? get() = _pairingRole
+    override val linkingCode: String? get() = _linkingCode
+    override val canStartAsPresenter: Boolean get() = true
+    override val peerName: String? get() = _peerName
+
+    // -----------------------------------------------------------------------
+    // Entry points
+    // -----------------------------------------------------------------------
+
+    override fun startScan(pastedUrl: String) {
+        appScope.launch(dispatchers.io()) {
+            logcat { "Sync-ExchangeV2: startScan (parsing pasted URL)" }
+            val parsed = qrCode.parse(pastedUrl)
+            if (parsed !is ExchangeV2CodeParseResult.LinkingV2) {
+                emitSessionError("Pasted code is not a v2 linking code: $parsed")
+                return@launch
+            }
+            cancel()
+            mutex.withLock {
+                _pairingRole = PairingRole.Scanner
+                peerChannelId = parsed.channelId
+                peerPublicKey = parsed.publicKey
+                bootstrapLocked(PairingRole.Scanner) ?: return@withLock // bootstrap reports its own error
+                // Scanner already knows the peer; SM starts directly in Negotiating.
+                session = smFactory.create(
+                    localUserId = syncStore.userId,
+                    initialState = ExchangeV2State.Negotiating,
+                )
+            }
+            emitSessionStarted()
+            if (!sendHello()) {
+                // Couldn't deliver hello — most likely the Presenter's channel has TTL'd out
+                // (5 min) or never existed (stale/typo'd code). No point sending availability
+                // or polling our own channel; tear down and let the user know.
+                emitSessionError(
+                    "Pairing aborted — couldn't reach the Presenter. Their session may have expired (5-min TTL). " +
+                        "Ask them to Start as Presenter again.",
+                )
+                cancel()
+                return@launch
+            }
+            sendOwnAvailability()
+            startPolling()
+        }
+    }
+
+    override fun startPresent() {
+        appScope.launch(dispatchers.io()) {
+            logcat { "Sync-ExchangeV2: startPresent (signedIn=${syncStore.userId != null})" }
+            // No pre-flight account check: per spec §"Exchange Share Recovery Code", a Host
+            // without an account creates one during the pairing flow. [sendRecoveryCodeResponse]
+            // calls createDdgAccountIfNeeded at Host.Sending time for ddg peers.
+            cancel()
+            mutex.withLock {
+                _pairingRole = PairingRole.Presenter
+                val keyPair = bootstrapLocked(PairingRole.Presenter) ?: return@withLock
+                _linkingCode = qrCode.buildLinkingCode(
+                    channelId = ownChannelId!!,
+                    publicKeyBase64Url = keyPair.publicKeyBase64,
+                )
+                // Presenter waits to receive hello before transitioning out of Bootstrapped.
+                session = smFactory.create(
+                    localUserId = syncStore.userId,
+                    initialState = ExchangeV2State.Bootstrapped,
+                )
+            }
+            emitSessionStarted()
+            startPolling()
+        }
+    }
+
+    /**
+     * Caller must hold [mutex]. Generates ephemeral keypair, allocates channel_id, and creates
+     * the relay channel (with 409 retry). Returns the new keypair on success, null on error
+     * (in which case an error event was already emitted).
+     */
+    private suspend fun bootstrapLocked(role: PairingRole): RsaKeyPair? {
+        val keyPair = jweCrypto.generateRsaKeyPair()
+        ownKeyPair = keyPair
+        repeat(MAX_CHANNEL_CREATE_RETRIES) { attempt ->
+            val candidate = UUID.randomUUID().toString()
+            when (val r = channel.createChannel(candidate)) {
+                is Result.Success -> {
+                    ownChannelId = candidate
+                    logcat { "Sync-ExchangeV2: bootstrap as $role channel_id=$candidate" }
+                    return keyPair
+                }
+                is Result.Error -> {
+                    if (r.code == HTTP_CONFLICT) {
+                        logcat { "Sync-ExchangeV2: channel_id $candidate already taken, retrying (${attempt + 1}/$MAX_CHANNEL_CREATE_RETRIES)" }
+                    } else {
+                        emitSessionError("Failed to create channel: ${r.reason}")
+                        return null
+                    }
+                }
+            }
+        }
+        emitSessionError("Could not allocate unique channel_id after $MAX_CHANNEL_CREATE_RETRIES attempts")
+        return null
+    }
+
+    override fun cancel() {
+        if (session != null || pollJob != null) {
+            logcat { "Sync-ExchangeV2: cancel (was in state ${session?.currentState})" }
+        }
+        pollJob?.cancel()
+        pollJob = null
+        val toDelete = ownChannelId
+        if (toDelete != null) {
+            // Best-effort DELETE per Tomek's 2026-05-26 ruling.
+            appScope.launch(dispatchers.io()) {
+                runCatching { channel.deleteChannel(toDelete) }
+            }
+        }
+        session = null
+        _pairingRole = null
+        ownChannelId = null
+        ownKeyPair = null
+        peerChannelId = null
+        peerPublicKey = null
+        peerKind = null
+        peerUserId = null
+        _peerName = null
+        _linkingCode = null
+        sentOwnAvailability = false
+        pendingJoinerWaitingMessages.clear()
+    }
+
+    // -----------------------------------------------------------------------
+    // Polling
+    // -----------------------------------------------------------------------
+
+    private fun startPolling() {
+        val ch = ownChannelId ?: return
+        val key = ownKeyPair ?: return
+        pollJob = appScope.launch(dispatchers.io()) {
+            try {
+                channel.poll(ch, key.privateKeyBase64).collect { incoming ->
+                    deliverIncomingMessage(incoming)
+                }
+            } catch (versionTooNew: EnvelopeVersionTooNew) {
+                emitSessionError("Peer requires protocol v${versionTooNew.version}; please update this app")
+                cancel()
+            } catch (decryptFailure: EnvelopeDecryptFailure) {
+                // Permanent — the cursor would just re-pull the same broken bytes forever.
+                emitSessionError(
+                    "Couldn't decrypt a message from the peer (seq=${decryptFailure.seq}): " +
+                        "${decryptFailure.cause?.message}. The keys probably don't match — try restarting pairing.",
+                )
+                cancel()
+            } catch (t: Throwable) {
+                logcat(ERROR) { "Sync-ExchangeV2: poll loop exited: ${t.message}" }
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Inbound message handling + orchestration
+    // -----------------------------------------------------------------------
+
+    override fun deliverIncomingMessage(message: ExchangeV2Message) {
+        appScope.launch(dispatchers.io()) {
+            mutex.withLock { processIncomingLocked(message) }
+        }
+    }
+
+    private suspend fun processIncomingLocked(message: ExchangeV2Message) {
+        val sm = session ?: run {
+            logcat { "Sync-ExchangeV2: deliverIncomingMessage ${message.messageType} ignored — no active session" }
+            return
+        }
+
+        // Race guard: a Host with auto-approve enabled can finish sending its messages before
+        // the Joiner's user has tapped Confirm. Stash them and replay after the SM enters Waiting.
+        if (sm.currentState == ExchangeV2State.Joiner.Confirming && message.isJoinerWaitingPhase()) {
+            logcat { "Sync-ExchangeV2: buffering ${message.messageType} (Joiner still in Confirming; will replay after user confirms)" }
+            pendingJoinerWaitingMessages.add(message)
+            return
+        }
+
+        logcat { "Sync-ExchangeV2: deliverIncomingMessage ${message.messageType} in state ${sm.currentState}" }
+        val result = sm.receive(message)
+        emit(result.event)
+
+        recordPeerContext(message)
+        result.sideEffects.forEach { applySideEffectLocked(it) }
+
+        if (canAutoElectRole(sm, message, result)) {
+            autoElectRoleLocked(sm)
+        }
+        if (canSendOwnAvailability(sm)) {
+            sendOwnAvailability()
+        }
+
+        if (sm.currentState.isTerminal()) onTerminalReachedLocked(sm.currentState)
+    }
+
+    /**
+     * Execute one spec-defined [SideEffect] emitted by the state machine. Each effect maps
+     * directly to a wire-protocol action or to a composite runner workflow (e.g.
+     * [SideEffect.RequestRecoveryCodeShare] kicks off the fetch+send+advance dance).
+     */
+    private fun applySideEffectLocked(effect: SideEffect) {
+        when (effect) {
+            SideEffect.SendAwaitingConfirmation -> {
+                logcat { "Sync-ExchangeV2: side effect → SendAwaitingConfirmation" }
+                sendMessageJson("""{"type":"recovery_code_awaiting_confirmation"}""")
+            }
+            SideEffect.SendConfirmed -> {
+                logcat { "Sync-ExchangeV2: side effect → SendConfirmed" }
+                sendMessageJson("""{"type":"recovery_code_confirmed"}""")
+            }
+            SideEffect.SendDenied -> {
+                logcat { "Sync-ExchangeV2: side effect → SendDenied" }
+                sendMessageJson("""{"type":"recovery_code_denied"}""")
+            }
+            SideEffect.RequestRecoveryCodeShare -> {
+                logcat { "Sync-ExchangeV2: side effect → RequestRecoveryCodeShare" }
+                shareRecoveryCodeAndAdvanceLocked()
+            }
+        }
+    }
+
+    /**
+     * Composite of [SideEffect.RequestRecoveryCodeShare]: fetch + send the recovery code
+     * (or `recovery_code_unavailable` if it can't be produced), then advance the SM.
+     */
+    private fun shareRecoveryCodeAndAdvanceLocked() {
+        val responseOk = sendRecoveryCodeResponse()
+        appScope.launch(dispatchers.io()) {
+            mutex.withLock {
+                val s = session ?: return@withLock
+                if (s.currentState != ExchangeV2State.Host.Sending) return@withLock
+                val terminalTrigger = if (responseOk) LocalTrigger.HostSendComplete else LocalTrigger.HostUnavailable
+                val r = s.localTrigger(terminalTrigger)
+                emit(r.event)
+                r.sideEffects.forEach { applySideEffectLocked(it) }
+                if (s.currentState.isTerminal()) onTerminalReachedLocked(s.currentState)
+            }
+        }
+    }
+
+    /**
+     * Only the success-path messages get buffered when received during Joiner.Confirming:
+     * if the peer is telling us they're aborting (denied / unavailable), we let the SM act on
+     * that immediately rather than holding the prompt open over a dead session.
+     */
+    private fun ExchangeV2Message.isJoinerWaitingPhase(): Boolean = when (this) {
+        is ExchangeV2Message.RecoveryCodeAwaitingConfirmation,
+        is ExchangeV2Message.RecoveryCodeConfirmed,
+        is ExchangeV2Message.RecoveryCodeResponse,
+        -> true
+        else -> false
+    }
+
+    private fun recordPeerContext(message: ExchangeV2Message) {
+        when (message) {
+            is ExchangeV2Message.Hello -> {
+                peerChannelId = message.channelId
+                peerPublicKey = message.publicKey
+            }
+            is ExchangeV2Message.RecoveryCodeAvailable -> {
+                peerKind = message.kind
+                peerUserId = message.userId
+                _peerName = message.name
+            }
+            is ExchangeV2Message.RecoveryCodeRequest -> {
+                peerKind = message.kind
+                peerUserId = null
+                _peerName = message.name
+            }
+            else -> Unit
+        }
+    }
+
+    /**
+     * Can we auto-elect a role right now? The transition must have been accepted, the SM
+     * must be in Negotiating, and we need a peer-side availability message ([RecoveryCodeAvailable]
+     * or [RecoveryCodeRequest]) — those carry the peer kind/userId we need to choose a role.
+     */
+    private fun canAutoElectRole(
+        sm: ExchangeV2StateMachine,
+        message: ExchangeV2Message,
+        receiveResult: TransitionResult,
+    ): Boolean {
+        if (receiveResult.outcome !is TransitionOutcome.Accepted) return false
+        if (sm.currentState != ExchangeV2State.Negotiating) return false
+        if (message !is ExchangeV2Message.RecoveryCodeAvailable &&
+            message !is ExchangeV2Message.RecoveryCodeRequest
+        ) {
+            return false
+        }
+        return true
+    }
+
+    /**
+     * Perform auto-election. Caller must have established the preconditions via
+     * [canAutoElectRole]. Drives the SM via [LocalTrigger.RoleElected] and emits the resulting
+     * transition event; also runs any side effects on the elect transition (notably
+     * [SideEffect.SendAwaitingConfirmation] for the Host branch).
+     */
+    private fun autoElectRoleLocked(sm: ExchangeV2StateMachine) {
+        val elected = electRole() ?: run {
+            logcat { "Sync-ExchangeV2: cannot auto-elect role yet (role=${_pairingRole}, peerKind=$peerKind)" }
+            return
+        }
+        logcat {
+            "Sync-ExchangeV2: auto-electing $elected " +
+                "(own role=${_pairingRole}, own userId=${syncStore.userId}, peer kind=$peerKind, peer userId=$peerUserId)"
+        }
+        val electResult = sm.localTrigger(LocalTrigger.RoleElected(elected))
+        emit(electResult.event)
+        electResult.sideEffects.forEach { applySideEffectLocked(it) }
+    }
+
+    /**
+     * True when we should send our own availability/request now: SM is in Negotiating, peer
+     * has been identified, and we haven't sent already.
+     */
+    private fun canSendOwnAvailability(sm: ExchangeV2StateMachine): Boolean {
+        if (sentOwnAvailability) return false
+        if (sm.currentState != ExchangeV2State.Negotiating) return false
+        if (peerChannelId == null || peerPublicKey == null) return false
+        return true
+    }
+
+    private fun electRole(): Role? {
+        val ownRole = _pairingRole ?: return null
+        val ownUserId = syncStore.userId
+        val pKind = peerKind ?: return null
+        val pUserId = peerUserId
+        return when {
+            ownUserId != null && pUserId == null -> Role.Host
+            ownUserId == null && pUserId != null -> Role.Joiner
+            OWN_DEVICE_KIND == "ddg" && pKind == "3party" -> Role.Host
+            OWN_DEVICE_KIND == "3party" && pKind == "ddg" -> Role.Joiner
+            ownRole == PairingRole.Presenter -> Role.Host
+            else -> Role.Joiner
+        }
+    }
+
+    override fun deliverIncomingMessageJson(rawJson: String) {
+        deliverIncomingMessage(messageParser.parse(rawJson))
+    }
+
+    // -----------------------------------------------------------------------
+    // Local triggers — drive SM + send outbound messages on Host transitions
+    // -----------------------------------------------------------------------
+
+    override fun localTrigger(trigger: LocalTrigger) {
+        appScope.launch(dispatchers.io()) {
+            mutex.withLock { processLocalTriggerLocked(trigger) }
+        }
+    }
+
+    private suspend fun processLocalTriggerLocked(trigger: LocalTrigger) {
+        val sm = session ?: run {
+            logcat { "Sync-ExchangeV2: localTrigger $trigger ignored — no active session" }
+            return
+        }
+        logcat { "Sync-ExchangeV2: localTrigger $trigger in state ${sm.currentState}" }
+        val priorState = sm.currentState
+        val result = sm.localTrigger(trigger)
+        emit(result.event)
+        result.sideEffects.forEach { applySideEffectLocked(it) }
+        if (priorState == ExchangeV2State.Joiner.Confirming) {
+            replayBufferedJoinerMessagesLocked(newState = sm.currentState)
+        }
+        if (sm.currentState.isTerminal()) onTerminalReachedLocked(sm.currentState)
+    }
+
+    /**
+     * Clean up after the SM reaches a terminal state. Clears the live-session-only fields so
+     * stale UI ("linking code still showing") doesn't suggest the session is reusable, and
+     * fires a best-effort DELETE of our own channel (Tomek 2026-05-26).
+     */
+    private fun onTerminalReachedLocked(terminal: ExchangeV2State) {
+        logcat { "Sync-ExchangeV2: session reached terminal state $terminal, clearing" }
+        session = null
+        _linkingCode = null
+        val ch = ownChannelId
+        if (ch != null) {
+            appScope.launch(dispatchers.io()) { runCatching { channel.deleteChannel(ch) } }
+        }
+    }
+
+    /**
+     * Called only when prior state was [ExchangeV2State.Joiner.Confirming] (the caller is
+     * responsible for that check). On user-confirm (transition to Joiner.Waiting), replay any
+     * host-side messages that arrived during the prompt. On user-deny (transition to
+     * Joiner.AbortedLocal) or any other exit path, discard them — the session is over.
+     */
+    private suspend fun replayBufferedJoinerMessagesLocked(newState: ExchangeV2State) {
+        if (pendingJoinerWaitingMessages.isEmpty()) return
+        if (newState == ExchangeV2State.Joiner.Waiting) {
+            val buffered = pendingJoinerWaitingMessages.toList()
+            pendingJoinerWaitingMessages.clear()
+            logcat { "Sync-ExchangeV2: replaying ${buffered.size} buffered Joiner message(s) now that user confirmed" }
+            for (m in buffered) {
+                processIncomingLocked(m)
+                if (session == null) return // terminal reached, stop replay
+            }
+        } else {
+            logcat { "Sync-ExchangeV2: discarding ${pendingJoinerWaitingMessages.size} buffered Joiner message(s) (user denied)" }
+            pendingJoinerWaitingMessages.clear()
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Outbound message helpers
+    // -----------------------------------------------------------------------
+
+    /** Returns true if hello reached the relay; false signals a fatal abort to the caller. */
+    private fun sendHello(): Boolean {
+        val own = ownChannelId ?: return false
+        val peer = peerChannelId ?: return false
+        val peerKey = peerPublicKey ?: return false
+        val ourKey = ownKeyPair ?: return false
+        val json = JSONObject().apply {
+            put("type", "hello")
+            put("channel_id", own)
+            put("public_key", ourKey.publicKeyBase64)
+            put("version", OUR_VERSION_STRING)
+        }.toString()
+        return sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.Hello(json, own, ourKey.publicKeyBase64, OUR_VERSION_STRING))
+    }
+
+    private fun sendOwnAvailability() {
+        if (sentOwnAvailability) return
+        val own = ownChannelId ?: return
+        val peer = peerChannelId ?: return
+        val peerKey = peerPublicKey ?: return
+        val userId = syncStore.userId
+        if (userId != null) {
+            val json = JSONObject().apply {
+                put("type", "recovery_code_available")
+                put("name", DEVICE_NAME)
+                put("kind", OWN_DEVICE_KIND)
+                put("user_id", userId)
+            }.toString()
+            sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.RecoveryCodeAvailable(json, userId, DEVICE_NAME, OWN_DEVICE_KIND))
+        } else {
+            val json = JSONObject().apply {
+                put("type", "recovery_code_request")
+                put("name", DEVICE_NAME)
+                put("kind", OWN_DEVICE_KIND)
+            }.toString()
+            sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.RecoveryCodeRequest(json, DEVICE_NAME, OWN_DEVICE_KIND))
+        }
+        sentOwnAvailability = true
+        // Roll the maybe-auto-elect check forward in case we already received peer availability
+        // before we knew our own context.
+        val sm = session ?: return
+        if (sm.currentState == ExchangeV2State.Negotiating && peerKind != null) {
+            val elected = electRole()
+            if (elected != null) {
+                val r = sm.localTrigger(LocalTrigger.RoleElected(elected))
+                emit(r.event)
+            }
+        }
+    }
+
+    /**
+     * Send `recovery_code_response` carrying a real recovery code. Returns true on success;
+     * false if we couldn't produce a code (in which case we've already sent
+     * `recovery_code_unavailable` to the peer + emitted a SessionError event, and the SM
+     * should be driven to [ExchangeV2State.Host.Aborted] rather than Done).
+     */
+    private fun sendRecoveryCodeResponse(): Boolean {
+        val peer = peerChannelId ?: return false
+        val peerKey = peerPublicKey ?: return false
+        // Pick the right recovery code based on peer kind: ddg peers get our DDG recovery
+        // code; 3party peers get our 3party access credential's recovery code.
+        // Per spec §"Exchange Share Recovery Code":
+        //   "If host has no account yet, create it first."
+        //   "If this is ddg and peer is 3party, if needed, extend the account."
+        // For 3party peers: ensure ddg account exists, then ensure 3party credential exists,
+        // then fetch the 3party recovery code. For ddg peers: just ensure ddg account exists.
+        // Any provisioning failure falls through to recovery_code_unavailable below.
+        //
+        // peerKind is set during role election (which requires receiving recovery_code_request
+        // or recovery_code_available carrying `kind`). If we reach Host.Sending with no
+        // peerKind, something upstream is broken — bail rather than silently assuming ddg.
+        val codeResult = when (peerKind) {
+            "ddg" -> provisionForDdgPeer()
+            "3party" -> provisionForThirdPartyPeer()
+            null -> Result.Error(reason = "Host.Sending reached without a known peer kind")
+            else -> Result.Error(reason = "Unsupported peer kind '$peerKind'")
+        }
+        return when (codeResult) {
+            is Result.Success -> {
+                val recoveryCode = codeResult.data
+                val json = JSONObject().apply {
+                    put("type", "recovery_code_response")
+                    put("recovery_code", recoveryCode)
+                }.toString()
+                sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.RecoveryCodeResponse(json, recoveryCode))
+                true
+            }
+            is Result.Error -> {
+                logcat(ERROR) { "Sync-ExchangeV2: recovery code unavailable for peerKind=$peerKind: ${codeResult.reason}" }
+                val json = """{"type":"recovery_code_unavailable"}"""
+                sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.RecoveryCodeUnavailable(json))
+                emitSessionError("Couldn't generate a recovery code: ${codeResult.reason}")
+                false
+            }
+        }
+    }
+
+    private fun provisionForDdgPeer(): Result<String> =
+        when (val provision = recoveryCodeProvider.createDdgAccountIfNeeded()) {
+            is Result.Success -> {
+                logcat { "Sync-ExchangeV2: ddg account ready, fetching ddg recovery code" }
+                recoveryCodeProvider.getDdgRecoveryCode()
+            }
+            is Result.Error -> {
+                logcat(ERROR) { "Sync-ExchangeV2: failed to provision ddg account: ${provision.reason}" }
+                Result.Error(reason = "Couldn't create a sync account: ${provision.reason}")
+            }
+        }
+
+    private fun provisionForThirdPartyPeer(): Result<String> {
+        when (val ddg = recoveryCodeProvider.createDdgAccountIfNeeded()) {
+            is Result.Success -> Unit
+            is Result.Error -> {
+                logcat(ERROR) { "Sync-ExchangeV2: failed to provision ddg account for 3party flow: ${ddg.reason}" }
+                return Result.Error(reason = "Couldn't create a sync account: ${ddg.reason}")
+            }
+        }
+        when (val extend = recoveryCodeProvider.createThirdPartyCredentialIfNeeded()) {
+            is Result.Success -> Unit
+            is Result.Error -> {
+                logcat(ERROR) { "Sync-ExchangeV2: failed to extend account with 3party credential: ${extend.reason}" }
+                return Result.Error(reason = "Couldn't extend account with 3party credential: ${extend.reason}")
+            }
+        }
+        logcat { "Sync-ExchangeV2: ddg account + 3party credential ready, fetching 3party recovery code" }
+        return recoveryCodeProvider.getThirdPartyRecoveryCode()
+    }
+
+    private fun sendMessageJson(json: String) {
+        val peer = peerChannelId ?: return
+        val peerKey = peerPublicKey ?: return
+        val parsed = messageParser.parse(json)
+        sendOnWireAndRecord(json, peer, peerKey, parsed)
+    }
+
+    /** Returns true on successful POST, false on transport error (caller decides if fatal). */
+    private fun sendOnWireAndRecord(
+        messageJson: String,
+        peerChannel: String,
+        peerKey: String,
+        outboundMessage: ExchangeV2Message,
+    ): Boolean {
+        val own = ownChannelId ?: return false
+        return when (val r = channel.sendMessage(messageJson, peerChannel, peerKey, own)) {
+            is Result.Success -> {
+                recordSentMessage(outboundMessage)
+                true
+            }
+            is Result.Error -> {
+                emitSessionError("Failed to send ${outboundMessage.messageType}: ${r.reason}")
+                false
+            }
+        }
+    }
+
+    override fun recordSentMessage(message: ExchangeV2Message) {
+        logcat { "Sync-ExchangeV2: recordSentMessage ${message.messageType}" }
+        emit(ExchangeV2Event.MessageSent(clock.nowMs(), message))
+    }
+
+    // -----------------------------------------------------------------------
+    // Event emission
+    // -----------------------------------------------------------------------
+
+    private fun emit(event: ExchangeV2Event) {
+        when (event) {
+            is ExchangeV2Event.Transition -> logcat {
+                "Sync-ExchangeV2: transition ${event.from} → ${event.to} " +
+                    "(trigger=${event.trigger?.messageType ?: event.localTrigger})"
+            }
+            is ExchangeV2Event.MessageRejected -> logcat {
+                "Sync-ExchangeV2: rejected ${event.message.messageType} in ${event.state} reason=${event.reason}"
+            }
+            is ExchangeV2Event.MessageSent -> Unit
+            is ExchangeV2Event.SessionStarted -> logcat {
+                val codeLine = event.linkingCode?.let { " linkingCode=$it" } ?: ""
+                "Sync-ExchangeV2: session started role=${event.pairingRole} channel_id=${event.ownChannelId}$codeLine"
+            }
+            is ExchangeV2Event.SessionError -> logcat(ERROR) { "Sync-ExchangeV2: session error: ${event.message}" }
+        }
+        _events.tryEmit(event)
+    }
+
+    private fun emitSessionStarted() {
+        val ch = ownChannelId ?: return
+        val role = _pairingRole ?: return
+        emit(ExchangeV2Event.SessionStarted(clock.nowMs(), role, ch, _linkingCode))
+    }
+
+    private fun emitSessionError(message: String) {
+        emit(ExchangeV2Event.SessionError(clock.nowMs(), message))
+    }
+
+    private fun ExchangeV2State.isTerminal(): Boolean = when (this) {
+        SameAccountAbort,
+        ExchangeV2State.Aborted,
+        Host.Aborted,
+        Host.Done,
+        Joiner.AbortedLocal,
+        Joiner.AbortedByHost,
+        Joiner.Done,
+        -> true
+        else -> false
+    }
+
+    companion object {
+        private const val REPLAY = 100
+
+        // Android is always a ddg-kind device.
+        private const val OWN_DEVICE_KIND = "ddg"
+        private const val DEVICE_NAME = "Android"
+        private const val MAX_CHANNEL_CREATE_RETRIES = 3
+        private const val HTTP_CONFLICT = 409
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -183,7 +183,7 @@ class RealExchangeV2Runner @Inject constructor(
                 _pairingRole = PairingRole.Scanner
                 peerChannelId = parsed.channelId
                 peerPublicKey = parsed.publicKey
-                bootstrapLocked(PairingRole.Scanner) ?: return@withLock // bootstrap reports its own error
+                bootstrapLocked(PairingRole.Scanner) ?: return@launch // bootstrap reports its own error; abort the whole flow
                 // Scanner already knows the peer; SM starts directly in Negotiating.
                 session = smFactory.create(
                     localUserId = syncStore.userId,
@@ -217,7 +217,7 @@ class RealExchangeV2Runner @Inject constructor(
             cancel()
             mutex.withLock {
                 _pairingRole = PairingRole.Presenter
-                val keyPair = bootstrapLocked(PairingRole.Presenter) ?: return@withLock
+                val keyPair = bootstrapLocked(PairingRole.Presenter) ?: return@launch
                 _linkingCode = qrCode.buildLinkingCode(
                     channelId = ownChannelId!!,
                     publicKeyBase64Url = keyPair.publicKeyBase64,

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.SameAccountAbort
 import com.duckduckgo.sync.store.SyncStore
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -314,8 +315,14 @@ class RealExchangeV2Runner @Inject constructor(
                         "${decryptFailure.cause?.message}. The keys probably don't match — try restarting pairing.",
                 )
                 cancel()
+            } catch (cancellation: CancellationException) {
+                throw cancellation // normal teardown (cancel() / scope cancellation) — let it propagate
             } catch (t: Throwable) {
-                logcat(ERROR) { "Sync-ExchangeV2: poll loop exited: ${t.message}" }
+                // Unexpected failure: fail fast — surface an error and tear down rather than
+                // dying silently and leaving the session to linger until the 5-min timeout.
+                logcat(ERROR) { "Sync-ExchangeV2: poll loop failed: ${t.message}" }
+                emitSessionError("Pairing failed: ${t.message}")
+                cancel()
             }
         }
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -568,6 +568,8 @@ class RealExchangeV2Runner @Inject constructor(
         logcat { "Sync-ExchangeV2: session reached terminal state $terminal, clearing" }
         session = null
         _linkingCode = null
+        timeoutJob?.cancel() // session is over — stop the 5-min timer so it doesn't linger
+        timeoutJob = null
         val ch = ownChannelId
         if (ch != null) {
             appScope.launch(dispatchers.io()) { runCatching { channel.deleteChannel(ch) } }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -51,24 +51,16 @@ import javax.inject.Inject
 /**
  * Drives a single Exchange V2 protocol session.
  *
- * Two entry points: [startPresent] generates a v2 linking code (the URL is surfaced via
- * [SessionStarted]); [startScan] parses a peer's code and joins their session. From there
- * the runner manages the wire I/O: bootstrap channel via PUT, send messages via POST, poll
- * own channel for incoming envelopes, decrypt, drive the SM, auto-elect role per Unified
- * Algorithm rules, and auto-send protocol messages as the SM advances.
- *
- * Manual injection paths (`deliverIncomingMessage`, `localTrigger`) remain callable from
- * the dev tool so individual SM transitions can still be exercised in isolation.
+ * Two entry points: [startPresent] generates a v2 linking code (surfaced via [SessionStarted]);
+ * [startScan] parses a peer's code and joins their session. From there the runner manages the
+ * wire I/O, drives the SM, and auto-elects role per the Unified Algorithm.
  */
 interface ExchangeV2Runner {
     val events: SharedFlow<ExchangeV2Event>
 
     /**
-     * Events emitted at or after [sinceMs]. The underlying [events] SharedFlow has a replay
-     * buffer that persists across sessions, so subscribers may see stale events from prior
-     * runs. Consumers that want to scope observation to a single session should snapshot a
-     * wall clock (`System.currentTimeMillis()`) before kicking off a new session and pass it
-     * here — events emitted with earlier timestamps (from prior sessions) are filtered out.
+     * Events emitted at or after [sinceMs]. Lets a consumer scope observation to one session,
+     * since [events] has a replay buffer that persists stale events across sessions.
      */
     fun eventsSince(sinceMs: Long): Flow<ExchangeV2Event> = events.filter { it.timestampMs >= sinceMs }
 
@@ -80,11 +72,8 @@ interface ExchangeV2Runner {
     val linkingCode: String?
 
     /**
-     * Whether this device can start as Presenter. Always true: per the Unified Algorithm spec
-     * §"Exchange Share Recovery Code" — *"If host has no account yet, create it first."* — a
-     * fresh device (no account) can become Host via the Presenter-beats-Scanner tiebreak rule
-     * and creates an account during the Exchange Share Recovery Code phase. UI may still read
-     * it to vary copy (e.g. "Pair" vs "Pair & create account").
+     * Whether this device can start as Presenter. Always true: per spec §"Exchange Share Recovery
+     * Code" a fresh device creates an account mid-flow. UI may read it to vary copy.
      */
     val canStartAsPresenter: Boolean
 
@@ -97,8 +86,7 @@ interface ExchangeV2Runner {
 
     /**
      * Tear down the active session. Suspends until done, so callers can sequence work after it
-     * (e.g. sign-out, which invalidates the recovery code). Callers that can't await — e.g.
-     * `ViewModel.onCleared` — launch it on a longer-lived scope.
+     * (e.g. sign-out, which invalidates the recovery code).
      */
     suspend fun cancel()
 
@@ -159,11 +147,9 @@ class RealExchangeV2Runner @Inject constructor(
     @Volatile private var sentOwnAvailability: Boolean = false
 
     /**
-     * Host-side messages that arrive while the Joiner is still showing the user-confirm prompt
-     * are buffered here and replayed when the user confirms (Joiner.Confirming → Joiner.Waiting).
-     * Without this, a Host with auto-approve enabled races ahead and the Joiner SM rejects the
-     * arriving finalisation messages as implicit aborts before the user has tapped Confirm.
-     * Cleared on cancel, terminal, or user-deny.
+     * Host-side messages arriving while the Joiner is still at the user-confirm prompt, buffered
+     * and replayed on confirm (Joiner.Confirming → Joiner.Waiting) so the SM doesn't reject them
+     * as implicit aborts. Cleared on cancel, terminal, or user-deny.
      */
     private val pendingJoinerWaitingMessages = mutableListOf<ExchangeV2Message>()
 
@@ -303,7 +289,7 @@ class RealExchangeV2Runner @Inject constructor(
         timeoutJob = null
         val toDelete = ownChannelId
         if (toDelete != null) {
-            // Best-effort DELETE per Tomek's 2026-05-26 ruling.
+            // Best-effort DELETE.
             appScope.launch(dispatchers.io()) {
                 runCatching { channel.deleteChannel(toDelete) }
             }
@@ -331,11 +317,9 @@ class RealExchangeV2Runner @Inject constructor(
         val key = ownKeyPair ?: return
         pollJob = appScope.launch(dispatchers.io()) {
             try {
-                // collect suspends on each deliverIncomingMessage until the message is fully
-                // processed, so envelopes are handled in the seq order poll() emits them. If a
-                // message drives the SM terminal, processIncomingLocked → cancelLocked cancels
-                // this very poll job; that self-cancellation is cooperative and the catch below
-                // rethrows the resulting CancellationException as normal teardown.
+                // collect suspends per message so envelopes are handled in poll() seq order. A
+                // message driving the SM terminal cancels this very poll job; that
+                // self-cancellation surfaces as the CancellationException caught below.
                 channel.poll(ch, key.privateKeyBase64).collect { incoming ->
                     deliverIncomingMessage(incoming)
                 }
@@ -376,9 +360,8 @@ class RealExchangeV2Runner @Inject constructor(
     // -----------------------------------------------------------------------
 
     override suspend fun deliverIncomingMessage(message: ExchangeV2Message) {
-        // Suspends until processing completes so the poll loop (its sole production caller)
-        // processes messages strictly in wire order — a fire-and-forget launch here let a
-        // multi-message poll batch race on the mutex and reach the SM out of sequence.
+        // Suspends until processing completes so the poll loop processes messages in wire order;
+        // a fire-and-forget launch here would let a poll batch race to the SM out of sequence.
         mutex.withLock { processIncomingLocked(message) }
     }
 
@@ -492,9 +475,8 @@ class RealExchangeV2Runner @Inject constructor(
     }
 
     /**
-     * Can we auto-elect a role right now? The transition must have been accepted, the SM
-     * must be in Negotiating, and we need a peer-side availability message ([RecoveryCodeAvailable]
-     * or [RecoveryCodeRequest]) — those carry the peer kind/userId we need to choose a role.
+     * Can we auto-elect a role now? Requires an accepted transition, SM in Negotiating, and a
+     * peer availability message ([RecoveryCodeAvailable]/[RecoveryCodeRequest]) carrying peer kind/userId.
      */
     private fun canAutoElectRole(
         sm: ExchangeV2StateMachine,
@@ -512,10 +494,8 @@ class RealExchangeV2Runner @Inject constructor(
     }
 
     /**
-     * Perform auto-election. Caller must have established the preconditions via
-     * [canAutoElectRole]. Drives the SM via [LocalTrigger.RoleElected] and emits the resulting
-     * transition event; also runs any side effects on the elect transition (notably
-     * [SideEffect.SendAwaitingConfirmation] for the Host branch).
+     * Perform auto-election (preconditions via [canAutoElectRole]). Drives the SM via
+     * [LocalTrigger.RoleElected], emits the transition event, and runs its side effects.
      */
     private fun autoElectRoleLocked(sm: ExchangeV2StateMachine) {
         val elected = electRole() ?: run {
@@ -594,10 +574,8 @@ class RealExchangeV2Runner @Inject constructor(
     }
 
     /**
-     * Called only when prior state was [ExchangeV2State.Joiner.Confirming] (the caller is
-     * responsible for that check). On user-confirm (transition to Joiner.Waiting), replay any
-     * host-side messages that arrived during the prompt. On user-deny (transition to
-     * Joiner.AbortedLocal) or any other exit path, discard them — the session is over.
+     * Caller must have come from [ExchangeV2State.Joiner.Confirming]. On confirm (→ Joiner.Waiting)
+     * replay buffered host-side messages; on any other exit discard them.
      */
     private suspend fun replayBufferedJoinerMessagesLocked(newState: ExchangeV2State) {
         if (pendingJoinerWaitingMessages.isEmpty()) return
@@ -657,10 +635,8 @@ class RealExchangeV2Runner @Inject constructor(
             sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.RecoveryCodeRequest(json, DEVICE_NAME, OWN_DEVICE_KIND))
         }
         sentOwnAvailability = true
-        // Re-elect in case the peer's availability arrived before we sent ours, via the one
-        // election path ([autoElectRoleLocked]) so RoleElected's side effects run.
-        // REVIEW: likely unreachable under the current eager-send ordering (Negotiating entry and
-        // our availability send happen in one locked pass) — confirm against the ordering spec
+        // Re-elect in case the peer's availability arrived before we sent ours.
+        // REVIEW: likely unreachable under eager-send ordering — confirm against the ordering spec
         // (Unified Algorithm 1214739740392701) and delete if dead.
         val sm = session ?: return
         if (sm.currentState == ExchangeV2State.Negotiating && peerKind != null) {
@@ -677,18 +653,11 @@ class RealExchangeV2Runner @Inject constructor(
     private fun sendRecoveryCodeResponse(): Boolean {
         val peer = peerChannelId ?: return false
         val peerKey = peerPublicKey ?: return false
-        // Pick the right recovery code based on peer kind: ddg peers get our DDG recovery
-        // code; 3party peers get our 3party access credential's recovery code.
-        // Per spec §"Exchange Share Recovery Code":
-        //   "If host has no account yet, create it first."
-        //   "If this is ddg and peer is 3party, if needed, extend the account."
-        // For 3party peers: ensure ddg account exists, then ensure 3party credential exists,
-        // then fetch the 3party recovery code. For ddg peers: just ensure ddg account exists.
-        // Any provisioning failure falls through to recovery_code_unavailable below.
-        //
-        // peerKind is set during role election (which requires receiving recovery_code_request
-        // or recovery_code_available carrying `kind`). If we reach Host.Sending with no
-        // peerKind, something upstream is broken — bail rather than silently assuming ddg.
+        // Recovery code per peer kind. Per spec §"Exchange Share Recovery Code": create the host
+        // account if absent; extend it with a 3party credential when peer is 3party. Provisioning
+        // failure falls through to recovery_code_unavailable below.
+        // peerKind is set during role election; reaching Host.Sending without it means something
+        // upstream is broken — bail rather than silently assuming ddg.
         val codeResult = when (peerKind) {
             "ddg" -> provisionForDdgPeer()
             "3party" -> provisionForThirdPartyPeer()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -102,9 +102,9 @@ interface ExchangeV2Runner {
      */
     suspend fun cancel()
 
-    fun deliverIncomingMessage(message: ExchangeV2Message)
+    suspend fun deliverIncomingMessage(message: ExchangeV2Message)
 
-    fun deliverIncomingMessageJson(rawJson: String)
+    suspend fun deliverIncomingMessageJson(rawJson: String)
 
     fun localTrigger(trigger: LocalTrigger)
 
@@ -331,6 +331,11 @@ class RealExchangeV2Runner @Inject constructor(
         val key = ownKeyPair ?: return
         pollJob = appScope.launch(dispatchers.io()) {
             try {
+                // collect suspends on each deliverIncomingMessage until the message is fully
+                // processed, so envelopes are handled in the seq order poll() emits them. If a
+                // message drives the SM terminal, processIncomingLocked → cancelLocked cancels
+                // this very poll job; that self-cancellation is cooperative and the catch below
+                // rethrows the resulting CancellationException as normal teardown.
                 channel.poll(ch, key.privateKeyBase64).collect { incoming ->
                     deliverIncomingMessage(incoming)
                 }
@@ -370,10 +375,11 @@ class RealExchangeV2Runner @Inject constructor(
     // Inbound message handling + orchestration
     // -----------------------------------------------------------------------
 
-    override fun deliverIncomingMessage(message: ExchangeV2Message) {
-        appScope.launch(dispatchers.io()) {
-            mutex.withLock { processIncomingLocked(message) }
-        }
+    override suspend fun deliverIncomingMessage(message: ExchangeV2Message) {
+        // Suspends until processing completes so the poll loop (its sole production caller)
+        // processes messages strictly in wire order — a fire-and-forget launch here let a
+        // multi-message poll batch race on the mutex and reach the SM out of sequence.
+        mutex.withLock { processIncomingLocked(message) }
     }
 
     private suspend fun processIncomingLocked(message: ExchangeV2Message) {
@@ -551,7 +557,7 @@ class RealExchangeV2Runner @Inject constructor(
         }
     }
 
-    override fun deliverIncomingMessageJson(rawJson: String) {
+    override suspend fun deliverIncomingMessageJson(rawJson: String) {
         deliverIncomingMessage(messageParser.parse(rawJson))
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -30,6 +30,7 @@ import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -145,6 +146,8 @@ class RealExchangeV2Runner @Inject constructor(
 
     @Volatile private var pollJob: Job? = null
 
+    @Volatile private var timeoutJob: Job? = null
+
     @Volatile private var sentOwnAvailability: Boolean = false
 
     /**
@@ -200,6 +203,7 @@ class RealExchangeV2Runner @Inject constructor(
             }
             sendOwnAvailability()
             startPolling()
+            startSessionTimer()
         }
     }
 
@@ -225,6 +229,7 @@ class RealExchangeV2Runner @Inject constructor(
             }
             emitSessionStarted()
             startPolling()
+            startSessionTimer()
         }
     }
 
@@ -264,6 +269,8 @@ class RealExchangeV2Runner @Inject constructor(
         }
         pollJob?.cancel()
         pollJob = null
+        timeoutJob?.cancel()
+        timeoutJob = null
         val toDelete = ownChannelId
         if (toDelete != null) {
             // Best-effort DELETE per Tomek's 2026-05-26 ruling.
@@ -310,6 +317,23 @@ class RealExchangeV2Runner @Inject constructor(
             } catch (t: Throwable) {
                 logcat(ERROR) { "Sync-ExchangeV2: poll loop exited: ${t.message}" }
             }
+        }
+    }
+
+    /**
+     * Client-side session deadline. Per Transport TD 1214486492252757 §Session Lifecycle, abort the
+     * session 5 minutes after the QR code is generated (a single fixed deadline, NOT reset by
+     * activity). Cancelled when the session ends (terminal state or [cancel]) — which subsumes the
+     * spec's per-event cancel conditions, since those all drive the SM to a terminal state.
+     */
+    private fun startSessionTimer() {
+        timeoutJob = appScope.launch(dispatchers.io()) {
+            delay(SESSION_TIMEOUT_MS)
+            if (session == null) return@launch // session already ended; nothing to time out
+            logcat { "Sync-ExchangeV2: session timed out after ${SESSION_TIMEOUT_MS}ms; aborting" }
+            emitSessionError("Session timed out")
+            timeoutJob = null // null before cancel() so it doesn't cancel this now-completing coroutine
+            cancel()
         }
     }
 
@@ -776,6 +800,9 @@ class RealExchangeV2Runner @Inject constructor(
 
     companion object {
         private const val REPLAY = 100
+
+        // Transport TD 1214486492252757 §Session Lifecycle: 5-minute client session deadline.
+        private const val SESSION_TIMEOUT_MS = 5 * 60 * 1000L
 
         // Android is always a ddg-kind device.
         private const val OWN_DEVICE_KIND = "ddg"

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -96,11 +96,9 @@ interface ExchangeV2Runner {
     fun startPresent()
 
     /**
-     * Tear down the active session (stop polling, discard ephemeral keys, best-effort DELETE the
-     * channel, clear state). Suspends until teardown completes so callers that must sequence work
-     * after it (e.g. signing out, which invalidates the recovery code) can await it. Lifecycle /
-     * abandon callers that can't await — e.g. `ViewModel.onCleared` — should launch this on a
-     * longer-lived scope themselves.
+     * Tear down the active session. Suspends until done, so callers can sequence work after it
+     * (e.g. sign-out, which invalidates the recovery code). Callers that can't await — e.g.
+     * `ViewModel.onCleared` — launch it on a longer-lived scope.
      */
     suspend fun cancel()
 
@@ -188,12 +186,12 @@ class RealExchangeV2Runner @Inject constructor(
                 return@launch
             }
             mutex.withLock {
-                cancelLocked() // abandon any prior session before starting a new one
+                cancelLocked() // abandon any prior session
                 _pairingRole = PairingRole.Scanner
                 peerChannelId = parsed.channelId
                 peerPublicKey = parsed.publicKey
                 bootstrapLocked(PairingRole.Scanner) ?: run {
-                    cancelLocked() // bootstrap reported its own error; discard the half-set state
+                    cancelLocked() // bootstrap already emitted the error; just clear the half-set state
                     return@launch
                 }
                 // Scanner already knows the peer; SM starts directly in Negotiating.
@@ -204,9 +202,7 @@ class RealExchangeV2Runner @Inject constructor(
             }
             emitSessionStarted()
             if (!sendHello()) {
-                // Couldn't deliver hello — most likely the Presenter's channel has TTL'd out
-                // (5 min) or never existed (stale/typo'd code). No point sending availability
-                // or polling our own channel; tear down and let the user know.
+                // Couldn't reach the Presenter (their channel TTL'd out, or a stale/typo'd code) — abort.
                 failSession(
                     "Pairing aborted — couldn't reach the Presenter. Their session may have expired (5-min TTL). " +
                         "Ask them to Start as Presenter again.",
@@ -222,14 +218,13 @@ class RealExchangeV2Runner @Inject constructor(
     override fun startPresent() {
         appScope.launch(dispatchers.io()) {
             logcat { "Sync-ExchangeV2: startPresent (signedIn=${syncStore.userId != null})" }
-            // No pre-flight account check: per spec §"Exchange Share Recovery Code", a Host
-            // without an account creates one during the pairing flow. [sendRecoveryCodeResponse]
-            // calls createDdgAccountIfNeeded at Host.Sending time for ddg peers.
+            // No pre-flight account check: per spec §"Exchange Share Recovery Code" a Host without
+            // an account creates one mid-flow ([sendRecoveryCodeResponse] at Host.Sending).
             mutex.withLock {
-                cancelLocked() // abandon any prior session before starting a new one
+                cancelLocked() // abandon any prior session
                 _pairingRole = PairingRole.Presenter
                 val keyPair = bootstrapLocked(PairingRole.Presenter) ?: run {
-                    cancelLocked() // bootstrap reported its own error; discard the half-set state
+                    cancelLocked() // bootstrap already emitted the error; just clear the half-set state
                     return@launch
                 }
                 _linkingCode = qrCode.buildLinkingCode(
@@ -279,18 +274,13 @@ class RealExchangeV2Runner @Inject constructor(
     }
 
     override suspend fun cancel() {
-        // Runs teardown under [mutex] so it can't race the locked message/trigger handlers.
-        // [NonCancellable] so a caller cancelling its own job mid-teardown can't abort it
-        // half-way (matches [failSession], which the poll loop / timer call from inside the very
-        // job [cancelLocked] cancels).
+        // NonCancellable: teardown must finish even when the caller's coroutine is itself being
+        // cancelled (e.g. the dispatcher cancels this from a flow's onCompletion).
         withContext(NonCancellable) { mutex.withLock { cancelLocked() } }
     }
 
-    /**
-     * Emit one session error and tear down, atomically under the lock. No-ops if the session
-     * already ended, so a late timeout or poll error can't surface a spurious error over a
-     * session that already completed.
-     */
+    /** Emit one error, then tear down. No-ops if the session already ended, so a late timeout or
+     *  poll error can't surface a spurious error over a completed session. */
     private suspend fun failSession(reason: String) {
         withContext(NonCancellable) {
             mutex.withLock {
@@ -301,11 +291,8 @@ class RealExchangeV2Runner @Inject constructor(
         }
     }
 
-    /**
-     * Caller MUST hold [mutex]. Stops the jobs, best-effort DELETEs our channel, discards the
-     * ephemeral key material, and clears all per-session state. Single teardown path so the
-     * field resets can't drift between call sites.
-     */
+    /** Caller MUST hold [mutex]. The single teardown path, so field resets can't drift between
+     *  call sites: stop the jobs, best-effort DELETE the channel, discard keys, clear all state. */
     private fun cancelLocked() {
         if (session != null || pollJob != null) {
             logcat { "Sync-ExchangeV2: teardown (was in state ${session?.currentState})" }
@@ -358,8 +345,7 @@ class RealExchangeV2Runner @Inject constructor(
             } catch (cancellation: CancellationException) {
                 throw cancellation // normal teardown (cancel() / scope cancellation) — let it propagate
             } catch (t: Throwable) {
-                // Unexpected failure: fail fast — surface an error and tear down rather than
-                // dying silently and leaving the session to linger until the 5-min timeout.
+                // Fail fast rather than dying silently and lingering until the 5-min timeout.
                 logcat(ERROR) { "Sync-ExchangeV2: poll loop failed: ${t.message}" }
                 failSession("Pairing failed: ${t.message}")
             }
@@ -376,7 +362,6 @@ class RealExchangeV2Runner @Inject constructor(
         timeoutJob = appScope.launch(dispatchers.io()) {
             delay(SESSION_TIMEOUT_MS)
             logcat { "Sync-ExchangeV2: session deadline (${SESSION_TIMEOUT_MS}ms) reached" }
-            // failSession no-ops if the session already ended, and tears down under the lock.
             failSession("Session timed out")
         }
     }
@@ -596,15 +581,9 @@ class RealExchangeV2Runner @Inject constructor(
         if (sm.currentState.isTerminal()) onTerminalReachedLocked(sm.currentState)
     }
 
-    /**
-     * Clean up after the SM reaches a terminal state. Clears the live-session-only fields so
-     * stale UI ("linking code still showing") doesn't suggest the session is reusable, and
-     * fires a best-effort DELETE of our own channel (Tomek 2026-05-26).
-     */
+    /** On a terminal SM state, tear down via [cancelLocked]. Caller holds [mutex]. */
     private fun onTerminalReachedLocked(terminal: ExchangeV2State) {
         logcat { "Sync-ExchangeV2: session reached terminal state $terminal, tearing down" }
-        // Full teardown via the single path: stops the poll loop, cancels the timer, discards
-        // ephemeral keys, DELETEs the channel, and clears state. Caller holds the lock.
         cancelLocked()
     }
 
@@ -672,16 +651,11 @@ class RealExchangeV2Runner @Inject constructor(
             sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.RecoveryCodeRequest(json, DEVICE_NAME, OWN_DEVICE_KIND))
         }
         sentOwnAvailability = true
-        // Roll the auto-elect check forward in case the peer's availability arrived before we
-        // sent ours. Delegate to [autoElectRoleLocked] (the single election path) so the
-        // RoleElected side effects actually run — notably SendAwaitingConfirmation on the Host
-        // branch. An earlier inline copy here emitted the transition but dropped the side effects.
-        //
-        // REVIEW (spec reachability): with the current eager-send ordering this looks unreachable
-        // — entering Negotiating and sending our own availability happen in the same locked pass,
-        // so we never arrive here in Negotiating with peerKind already set. Confirm against the
-        // cross-platform ordering spec (Unified Algorithm 1214739740392701) whether any client
-        // ordering can make it live; if not, this branch is dead code and can be removed.
+        // Re-elect in case the peer's availability arrived before we sent ours, via the one
+        // election path ([autoElectRoleLocked]) so RoleElected's side effects run.
+        // REVIEW: likely unreachable under the current eager-send ordering (Negotiating entry and
+        // our availability send happen in one locked pass) — confirm against the ordering spec
+        // (Unified Algorithm 1214739740392701) and delete if dead.
         val sm = session ?: return
         if (sm.currentState == ExchangeV2State.Negotiating && peerKind != null) {
             autoElectRoleLocked(sm)

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -20,6 +20,7 @@ import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.impl.Result
+import com.duckduckgo.sync.impl.SyncDeviceIds
 import com.duckduckgo.sync.impl.crypto.RsaKeyPair
 import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.Host
@@ -110,6 +111,7 @@ class RealExchangeV2Runner @Inject constructor(
     private val channel: ExchangeV2Channel,
     private val qrCode: ExchangeV2QrCode,
     private val recoveryCodeProvider: RecoveryCodeProvider,
+    private val syncDeviceIds: SyncDeviceIds,
     @AppCoroutineScope private val appScope: CoroutineScope,
     private val dispatchers: DispatcherProvider,
 ) : ExchangeV2Runner {
@@ -618,21 +620,22 @@ class RealExchangeV2Runner @Inject constructor(
         val peer = peerChannelId ?: return
         val peerKey = peerPublicKey ?: return
         val userId = syncStore.userId
+        val deviceName = syncDeviceIds.deviceName()
         if (userId != null) {
             val json = JSONObject().apply {
                 put("type", "recovery_code_available")
-                put("name", DEVICE_NAME)
+                put("name", deviceName)
                 put("kind", OWN_DEVICE_KIND)
                 put("user_id", userId)
             }.toString()
-            sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.RecoveryCodeAvailable(json, userId, DEVICE_NAME, OWN_DEVICE_KIND))
+            sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.RecoveryCodeAvailable(json, userId, deviceName, OWN_DEVICE_KIND))
         } else {
             val json = JSONObject().apply {
                 put("type", "recovery_code_request")
-                put("name", DEVICE_NAME)
+                put("name", deviceName)
                 put("kind", OWN_DEVICE_KIND)
             }.toString()
-            sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.RecoveryCodeRequest(json, DEVICE_NAME, OWN_DEVICE_KIND))
+            sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.RecoveryCodeRequest(json, deviceName, OWN_DEVICE_KIND))
         }
         sentOwnAvailability = true
         // Re-elect in case the peer's availability arrived before we sent ours.
@@ -800,7 +803,6 @@ class RealExchangeV2Runner @Inject constructor(
 
         // Android is always a ddg-kind device.
         private const val OWN_DEVICE_KIND = "ddg"
-        private const val DEVICE_NAME = "Android"
         private const val MAX_CHANNEL_CREATE_RETRIES = 3
         private const val HTTP_CONFLICT = 409
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -95,7 +95,14 @@ interface ExchangeV2Runner {
 
     fun startPresent()
 
-    fun cancel()
+    /**
+     * Tear down the active session (stop polling, discard ephemeral keys, best-effort DELETE the
+     * channel, clear state). Suspends until teardown completes so callers that must sequence work
+     * after it (e.g. signing out, which invalidates the recovery code) can await it. Lifecycle /
+     * abandon callers that can't await — e.g. `ViewModel.onCleared` — should launch this on a
+     * longer-lived scope themselves.
+     */
+    suspend fun cancel()
 
     fun deliverIncomingMessage(message: ExchangeV2Message)
 
@@ -271,19 +278,11 @@ class RealExchangeV2Runner @Inject constructor(
         return null
     }
 
-    override fun cancel() {
-        // Public, fire-and-forget: external callers (dispatcher/UI) abandon the session. Internal
-        // sites call [teardownSession]/[failSession] directly so they can await teardown. All
-        // teardown runs under [mutex] so it can't race the locked message/trigger handlers.
-        appScope.launch(dispatchers.io()) { teardownSession() }
-    }
-
-    /**
-     * Tear down off the lock. [NonCancellable] so a caller cancelling its own job mid-teardown
-     * (the poll loop or the session timer both call this from inside the job [cancelLocked]
-     * cancels) can't abort the teardown half-way.
-     */
-    private suspend fun teardownSession() {
+    override suspend fun cancel() {
+        // Runs teardown under [mutex] so it can't race the locked message/trigger handlers.
+        // [NonCancellable] so a caller cancelling its own job mid-teardown can't abort it
+        // half-way (matches [failSession], which the poll loop / timer call from inside the very
+        // job [cancelLocked] cancels).
         withContext(NonCancellable) { mutex.withLock { cancelLocked() } }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -31,6 +31,7 @@ import dagger.SingleInstanceIn
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -40,6 +41,7 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import logcat.LogPriority.ERROR
 import logcat.logcat
 import org.json.JSONObject
@@ -178,12 +180,15 @@ class RealExchangeV2Runner @Inject constructor(
                 emitSessionError("Pasted code is not a v2 linking code: $parsed")
                 return@launch
             }
-            cancel()
             mutex.withLock {
+                cancelLocked() // abandon any prior session before starting a new one
                 _pairingRole = PairingRole.Scanner
                 peerChannelId = parsed.channelId
                 peerPublicKey = parsed.publicKey
-                bootstrapLocked(PairingRole.Scanner) ?: return@launch // bootstrap reports its own error; abort the whole flow
+                bootstrapLocked(PairingRole.Scanner) ?: run {
+                    cancelLocked() // bootstrap reported its own error; discard the half-set state
+                    return@launch
+                }
                 // Scanner already knows the peer; SM starts directly in Negotiating.
                 session = smFactory.create(
                     localUserId = syncStore.userId,
@@ -195,11 +200,10 @@ class RealExchangeV2Runner @Inject constructor(
                 // Couldn't deliver hello — most likely the Presenter's channel has TTL'd out
                 // (5 min) or never existed (stale/typo'd code). No point sending availability
                 // or polling our own channel; tear down and let the user know.
-                emitSessionError(
+                failSession(
                     "Pairing aborted — couldn't reach the Presenter. Their session may have expired (5-min TTL). " +
                         "Ask them to Start as Presenter again.",
                 )
-                cancel()
                 return@launch
             }
             sendOwnAvailability()
@@ -214,10 +218,13 @@ class RealExchangeV2Runner @Inject constructor(
             // No pre-flight account check: per spec §"Exchange Share Recovery Code", a Host
             // without an account creates one during the pairing flow. [sendRecoveryCodeResponse]
             // calls createDdgAccountIfNeeded at Host.Sending time for ddg peers.
-            cancel()
             mutex.withLock {
+                cancelLocked() // abandon any prior session before starting a new one
                 _pairingRole = PairingRole.Presenter
-                val keyPair = bootstrapLocked(PairingRole.Presenter) ?: return@launch
+                val keyPair = bootstrapLocked(PairingRole.Presenter) ?: run {
+                    cancelLocked() // bootstrap reported its own error; discard the half-set state
+                    return@launch
+                }
                 _linkingCode = qrCode.buildLinkingCode(
                     channelId = ownChannelId!!,
                     publicKeyBase64Url = keyPair.publicKeyBase64,
@@ -265,8 +272,44 @@ class RealExchangeV2Runner @Inject constructor(
     }
 
     override fun cancel() {
+        // Public, fire-and-forget: external callers (dispatcher/UI) abandon the session. Internal
+        // sites call [teardownSession]/[failSession] directly so they can await teardown. All
+        // teardown runs under [mutex] so it can't race the locked message/trigger handlers.
+        appScope.launch(dispatchers.io()) { teardownSession() }
+    }
+
+    /**
+     * Tear down off the lock. [NonCancellable] so a caller cancelling its own job mid-teardown
+     * (the poll loop or the session timer both call this from inside the job [cancelLocked]
+     * cancels) can't abort the teardown half-way.
+     */
+    private suspend fun teardownSession() {
+        withContext(NonCancellable) { mutex.withLock { cancelLocked() } }
+    }
+
+    /**
+     * Emit one session error and tear down, atomically under the lock. No-ops if the session
+     * already ended, so a late timeout or poll error can't surface a spurious error over a
+     * session that already completed.
+     */
+    private suspend fun failSession(reason: String) {
+        withContext(NonCancellable) {
+            mutex.withLock {
+                if (session == null) return@withLock
+                emitSessionError(reason)
+                cancelLocked()
+            }
+        }
+    }
+
+    /**
+     * Caller MUST hold [mutex]. Stops the jobs, best-effort DELETEs our channel, discards the
+     * ephemeral key material, and clears all per-session state. Single teardown path so the
+     * field resets can't drift between call sites.
+     */
+    private fun cancelLocked() {
         if (session != null || pollJob != null) {
-            logcat { "Sync-ExchangeV2: cancel (was in state ${session?.currentState})" }
+            logcat { "Sync-ExchangeV2: teardown (was in state ${session?.currentState})" }
         }
         pollJob?.cancel()
         pollJob = null
@@ -306,23 +349,20 @@ class RealExchangeV2Runner @Inject constructor(
                     deliverIncomingMessage(incoming)
                 }
             } catch (versionTooNew: EnvelopeVersionTooNew) {
-                emitSessionError("Peer requires protocol v${versionTooNew.version}; please update this app")
-                cancel()
+                failSession("Peer requires protocol v${versionTooNew.version}; please update this app")
             } catch (decryptFailure: EnvelopeDecryptFailure) {
                 // Permanent — the cursor would just re-pull the same broken bytes forever.
-                emitSessionError(
+                failSession(
                     "Couldn't decrypt a message from the peer (seq=${decryptFailure.seq}): " +
                         "${decryptFailure.cause?.message}. The keys probably don't match — try restarting pairing.",
                 )
-                cancel()
             } catch (cancellation: CancellationException) {
                 throw cancellation // normal teardown (cancel() / scope cancellation) — let it propagate
             } catch (t: Throwable) {
                 // Unexpected failure: fail fast — surface an error and tear down rather than
                 // dying silently and leaving the session to linger until the 5-min timeout.
                 logcat(ERROR) { "Sync-ExchangeV2: poll loop failed: ${t.message}" }
-                emitSessionError("Pairing failed: ${t.message}")
-                cancel()
+                failSession("Pairing failed: ${t.message}")
             }
         }
     }
@@ -336,11 +376,9 @@ class RealExchangeV2Runner @Inject constructor(
     private fun startSessionTimer() {
         timeoutJob = appScope.launch(dispatchers.io()) {
             delay(SESSION_TIMEOUT_MS)
-            if (session == null) return@launch // session already ended; nothing to time out
-            logcat { "Sync-ExchangeV2: session timed out after ${SESSION_TIMEOUT_MS}ms; aborting" }
-            emitSessionError("Session timed out")
-            timeoutJob = null // null before cancel() so it doesn't cancel this now-completing coroutine
-            cancel()
+            logcat { "Sync-ExchangeV2: session deadline (${SESSION_TIMEOUT_MS}ms) reached" }
+            // failSession no-ops if the session already ended, and tears down under the lock.
+            failSession("Session timed out")
         }
     }
 
@@ -565,15 +603,10 @@ class RealExchangeV2Runner @Inject constructor(
      * fires a best-effort DELETE of our own channel (Tomek 2026-05-26).
      */
     private fun onTerminalReachedLocked(terminal: ExchangeV2State) {
-        logcat { "Sync-ExchangeV2: session reached terminal state $terminal, clearing" }
-        session = null
-        _linkingCode = null
-        timeoutJob?.cancel() // session is over — stop the 5-min timer so it doesn't linger
-        timeoutJob = null
-        val ch = ownChannelId
-        if (ch != null) {
-            appScope.launch(dispatchers.io()) { runCatching { channel.deleteChannel(ch) } }
-        }
+        logcat { "Sync-ExchangeV2: session reached terminal state $terminal, tearing down" }
+        // Full teardown via the single path: stops the poll loop, cancels the timer, discards
+        // ephemeral keys, DELETEs the channel, and clears state. Caller holds the lock.
+        cancelLocked()
     }
 
     /**

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/RecoveryCodeProvider.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/RecoveryCodeProvider.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.Result
+import com.duckduckgo.sync.impl.SyncAccountRepository
+import com.squareup.anvil.annotations.ContributesBinding
+import org.json.JSONObject
+import java.util.Base64
+import javax.inject.Inject
+
+/**
+ * Indirection over [SyncAccountRepository] so [ExchangeV2Runner] can fetch the right recovery
+ * code for the Host's `recovery_code_response` based on peer kind, without taking a direct
+ * dependency on the much wider repository surface.
+ *
+ * Returns the b64-encoded `rawCode` form (what the spec wants on the wire), not the QR form.
+ * Both raw and QR are currently the same string today, but keeping the distinction here means
+ * a future spec tweak only needs editing one line.
+ */
+interface RecoveryCodeProvider {
+
+    /** Own DDG recovery code — used when peer is a `ddg` device joining our account. */
+    fun getDdgRecoveryCode(): Result<String>
+
+    /**
+     * Own 3party access credential's recovery code — used when peer is a `3party` device
+     * (e.g. Duck.ai web). May fail with a generic error if the 3party credential hasn't been
+     * created yet on the account; the runner reports `recovery_code_unavailable` to the peer.
+     */
+    fun getThirdPartyRecoveryCode(): Result<String>
+
+    /**
+     * Spec: Unified Algorithm §"Exchange Share Recovery Code" — *"If host has no account yet,
+     * create it first."* Called by the runner at Host.Sending time when no ddg account exists
+     * locally. Returns [Result.Success] if the device is now signed in (whether already was, or
+     * the just-created), [Result.Error] if account creation failed.
+     */
+    fun createDdgAccountIfNeeded(): Result<Unit>
+
+    /**
+     * Spec: Unified Algorithm §"Exchange Share Recovery Code" — *"If this is ddg and peer is
+     * 3party, if needed, extend the account."* Ensures the device has a 3party credential
+     * locally, creating one on the BE if absent. Called by the runner before fetching a 3party
+     * recovery code to share with a 3party peer. No-op if a 3party credential already exists
+     * locally ([SyncStore.scopedPassword] is set). Failure surfaces as [Result.Error] and the
+     * runner falls through to `recovery_code_unavailable`.
+     */
+    fun createThirdPartyCredentialIfNeeded(): Result<Unit>
+}
+
+@ContributesBinding(AppScope::class)
+class RealRecoveryCodeProvider @Inject constructor(
+    private val syncAccountRepository: SyncAccountRepository,
+    private val syncStore: com.duckduckgo.sync.store.SyncStore,
+) : RecoveryCodeProvider {
+
+    override fun createDdgAccountIfNeeded(): Result<Unit> {
+        if (syncStore.userId != null) return Result.Success(Unit)
+        return when (val r = syncAccountRepository.createAccount()) {
+            is Result.Success -> Result.Success(Unit)
+            is Result.Error -> r
+        }
+    }
+
+    override fun createThirdPartyCredentialIfNeeded(): Result<Unit> {
+        if (syncStore.scopedPassword != null) return Result.Success(Unit)
+        return when (val r = syncAccountRepository.createThirdPartyCredential()) {
+            is Result.Success -> Result.Success(Unit)
+            is Result.Error -> r
+        }
+    }
+
+    /**
+     * The DDG recovery code stored on the account is v1 shape (`{recovery:{primary_key, user_id}}`).
+     * The v2 pairing wire requires v2.0 shape (`{recovery:{user_id, secret, cid, v}}`) per the
+     * Recovery Payload Shape spec. Convert here before handing off to the runner.
+     */
+    override fun getDdgRecoveryCode(): Result<String> =
+        when (val r = syncAccountRepository.getRecoveryCode()) {
+            is Result.Success -> runCatching { toV2RecoveryCode(r.data.rawCode, cid = "ddg") }
+                .fold(
+                    onSuccess = { Result.Success(it) },
+                    onFailure = { Result.Error(reason = "Failed to convert ddg recovery code to v2.0: ${it.message}") },
+                )
+            is Result.Error -> r
+        }
+
+    /** [ThirdPartyCredentialManager.getRecoveryCode] already emits v2.0 shape — no conversion. */
+    override fun getThirdPartyRecoveryCode(): Result<String> =
+        when (val r = syncAccountRepository.getThirdPartyRecoveryCode()) {
+            is Result.Success -> Result.Success(r.data.rawCode)
+            is Result.Error -> r
+        }
+
+    private fun toV2RecoveryCode(v1Base64: String, cid: String): String {
+        val decoded = decodePermissiveBase64(v1Base64)
+        val v1 = JSONObject(String(decoded, Charsets.UTF_8)).getJSONObject("recovery")
+        val userId = v1.getString("user_id")
+        val secret = v1.getString("primary_key")
+        val v2Json = JSONObject().apply {
+            put(
+                "recovery",
+                JSONObject().apply {
+                    put("user_id", userId)
+                    put("secret", secret)
+                    put("cid", cid)
+                    put("v", "2.0")
+                },
+            )
+        }.toString()
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(v2Json.toByteArray(Charsets.UTF_8))
+    }
+
+    /** Accept either standard or URL-safe base64 (with or without padding). */
+    private fun decodePermissiveBase64(s: String): ByteArray {
+        return runCatching { Base64.getUrlDecoder().decode(s) }
+            .recoverCatching { Base64.getDecoder().decode(s) }
+            .getOrThrow()
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/RecoveryCodeProvider.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/RecoveryCodeProvider.kt
@@ -29,13 +29,9 @@ import java.util.Base64
 import javax.inject.Inject
 
 /**
- * Indirection over [SyncAccountRepository] so [ExchangeV2Runner] can fetch the right recovery
- * code for the Host's `recovery_code_response` based on peer kind, without taking a direct
- * dependency on the much wider repository surface.
- *
- * Returns the b64-encoded `rawCode` form (what the spec wants on the wire), not the QR form.
- * Both raw and QR are currently the same string today, but keeping the distinction here means
- * a future spec tweak only needs editing one line.
+ * Indirection over [SyncAccountRepository] so [ExchangeV2Runner] can fetch the recovery code for
+ * a peer kind without depending on the wider repository surface. Returns the wire `rawCode` form,
+ * not the QR form (kept distinct so a future spec tweak is a one-line change).
  */
 interface RecoveryCodeProvider {
 
@@ -43,27 +39,22 @@ interface RecoveryCodeProvider {
     fun getDdgRecoveryCode(): Result<String>
 
     /**
-     * Own 3party access credential's recovery code — used when peer is a `3party` device
-     * (e.g. Duck.ai web). May fail with a generic error if the 3party credential hasn't been
-     * created yet on the account; the runner reports `recovery_code_unavailable` to the peer.
+     * Own 3party access credential's recovery code — used when peer is a `3party` device.
+     * Fails if the 3party credential doesn't exist yet; the runner then reports
+     * `recovery_code_unavailable` to the peer.
      */
     fun getThirdPartyRecoveryCode(): Result<String>
 
     /**
      * Spec: Unified Algorithm §"Exchange Share Recovery Code" — *"If host has no account yet,
-     * create it first."* Called by the runner at Host.Sending time when no ddg account exists
-     * locally. Returns [Result.Success] if the device is now signed in (whether already was, or
-     * the just-created), [Result.Error] if account creation failed.
+     * create it first."* No-op if already signed in; [Result.Error] if account creation fails.
      */
     fun createDdgAccountIfNeeded(): Result<Unit>
 
     /**
      * Spec: Unified Algorithm §"Exchange Share Recovery Code" — *"If this is ddg and peer is
-     * 3party, if needed, extend the account."* Ensures the device has a 3party credential
-     * locally, creating one on the BE if absent. Called by the runner before fetching a 3party
-     * recovery code to share with a 3party peer. No-op if a 3party credential already exists
-     * locally ([SyncStore.scopedPassword] is set). Failure surfaces as [Result.Error] and the
-     * runner falls through to `recovery_code_unavailable`.
+     * 3party, if needed, extend the account."* No-op if a 3party credential already exists locally
+     * ([SyncStore.scopedPassword] set); otherwise creates one. Failure surfaces as [Result.Error].
      */
     fun createThirdPartyCredentialIfNeeded(): Result<Unit>
 }
@@ -91,9 +82,8 @@ class RealRecoveryCodeProvider @Inject constructor(
     }
 
     /**
-     * The DDG recovery code stored on the account is v1 shape (`{recovery:{primary_key, user_id}}`).
-     * The v2 pairing wire requires v2.0 shape (`{recovery:{user_id, secret, cid, v}}`) per the
-     * Recovery Payload Shape spec. Convert here before handing off to the runner.
+     * Account stores v1 shape (`{recovery:{primary_key, user_id}}`); the v2 wire requires v2.0
+     * shape (`{recovery:{user_id, secret, cid, v}}`). Convert before handing off to the runner.
      */
     override fun getDdgRecoveryCode(): Result<String> =
         when (val r = syncAccountRepository.getRecoveryCode()) {
@@ -105,7 +95,7 @@ class RealRecoveryCodeProvider @Inject constructor(
             is Result.Error -> r
         }
 
-    /** [ThirdPartyCredentialManager.getRecoveryCode] already emits v2.0 shape — no conversion. */
+    /** Already emits v2.0 shape — no conversion. */
     override fun getThirdPartyRecoveryCode(): Result<String> =
         when (val r = syncAccountRepository.getThirdPartyRecoveryCode()) {
             is Result.Success -> Result.Success(r.data.rawCode)
@@ -116,12 +106,7 @@ class RealRecoveryCodeProvider @Inject constructor(
         val decoded = decodePermissiveBase64(v1Base64)
         val v1 = JSONObject(String(decoded, Charsets.UTF_8)).getJSONObject("recovery")
         val userId = v1.getString("user_id")
-        // The v2 wire `secret` is base64url-encoded per spec 1214802412121967 (and Gabor's sign-off
-        // on 1214804486778180: "v2 recovery keys will be base64url encoded"). Android holds the
-        // primary_key as STANDARD base64 internally, so re-encode the same key bytes to base64url
-        // here — otherwise conformant peers (macOS/iOS/FE/Windows) can't base64url-decode it, and a
-        // '+'/'/' in standard base64 also forces the org.json '\/'-escaping workaround. Moshi (not
-        // org.json) keeps the outer JSON canonical regardless.
+        // v2 wire `secret` is base64url per spec 1214802412121967; re-encode the standard-base64 primary_key.
         val secret = Base64.getUrlEncoder().withoutPadding().encodeToString(decodePermissiveBase64(v1.getString("primary_key")))
         val v2Json = recoveryCodeAdapter.toJson(
             ThirdPartyRecoveryCodeWrapper(

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/RecoveryCodeProvider.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/RecoveryCodeProvider.kt
@@ -116,11 +116,13 @@ class RealRecoveryCodeProvider @Inject constructor(
         val decoded = decodePermissiveBase64(v1Base64)
         val v1 = JSONObject(String(decoded, Charsets.UTF_8)).getJSONObject("recovery")
         val userId = v1.getString("user_id")
-        val secret = v1.getString("primary_key")
-        // Serialize with Moshi, NOT org.json: AOSP's JSONObject.toString() escapes '/' to '\/',
-        // which non-strict cross-platform decoders (e.g. Windows native) reject. The ddg secret is
-        // the v1 primary_key in standard base64 and routinely contains '/'. Spec 1214804486778180
-        // constrains only the outer base64url encoding; the secret must travel verbatim.
+        // The v2 wire `secret` is base64url-encoded per spec 1214802412121967 (and Gabor's sign-off
+        // on 1214804486778180: "v2 recovery keys will be base64url encoded"). Android holds the
+        // primary_key as STANDARD base64 internally, so re-encode the same key bytes to base64url
+        // here — otherwise conformant peers (macOS/iOS/FE/Windows) can't base64url-decode it, and a
+        // '+'/'/' in standard base64 also forces the org.json '\/'-escaping workaround. Moshi (not
+        // org.json) keeps the outer JSON canonical regardless.
+        val secret = Base64.getUrlEncoder().withoutPadding().encodeToString(decodePermissiveBase64(v1.getString("primary_key")))
         val v2Json = recoveryCodeAdapter.toJson(
             ThirdPartyRecoveryCodeWrapper(
                 recovery = ThirdPartyRecoveryCode(userId = userId, secret = secret, cid = cid, v = RECOVERY_CODE_V2),

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/RecoveryCodeProvider.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/RecoveryCodeProvider.kt
@@ -17,9 +17,13 @@
 package com.duckduckgo.sync.impl.exchange.v2
 
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.RECOVERY_CODE_V2
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncAccountRepository
+import com.duckduckgo.sync.impl.ThirdPartyRecoveryCode
+import com.duckduckgo.sync.impl.ThirdPartyRecoveryCodeWrapper
 import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.moshi.Moshi
 import org.json.JSONObject
 import java.util.Base64
 import javax.inject.Inject
@@ -113,18 +117,20 @@ class RealRecoveryCodeProvider @Inject constructor(
         val v1 = JSONObject(String(decoded, Charsets.UTF_8)).getJSONObject("recovery")
         val userId = v1.getString("user_id")
         val secret = v1.getString("primary_key")
-        val v2Json = JSONObject().apply {
-            put(
-                "recovery",
-                JSONObject().apply {
-                    put("user_id", userId)
-                    put("secret", secret)
-                    put("cid", cid)
-                    put("v", "2.0")
-                },
-            )
-        }.toString()
+        // Serialize with Moshi, NOT org.json: AOSP's JSONObject.toString() escapes '/' to '\/',
+        // which non-strict cross-platform decoders (e.g. Windows native) reject. The ddg secret is
+        // the v1 primary_key in standard base64 and routinely contains '/'. Spec 1214804486778180
+        // constrains only the outer base64url encoding; the secret must travel verbatim.
+        val v2Json = recoveryCodeAdapter.toJson(
+            ThirdPartyRecoveryCodeWrapper(
+                recovery = ThirdPartyRecoveryCode(userId = userId, secret = secret, cid = cid, v = RECOVERY_CODE_V2),
+            ),
+        )
         return Base64.getUrlEncoder().withoutPadding().encodeToString(v2Json.toByteArray(Charsets.UTF_8))
+    }
+
+    private val recoveryCodeAdapter by lazy {
+        Moshi.Builder().build().adapter(ThirdPartyRecoveryCodeWrapper::class.java)
     }
 
     /** Accept either standard or URL-safe base64 (with or without padding). */

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixelParamRemovalPlugin.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixelParamRemovalPlugin.kt
@@ -57,6 +57,7 @@ class SyncPixelParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugi
             SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_SUCCESS.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_SETUP_ENDED_ABANDONED.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_SETUP_ENDED_SUCCESS.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_SETUP_ENDED_FAILED.pixelName to PixelParameter.removeAtb(),
 
             SyncPixelName.SYNC_AUTO_RESTORE_TOGGLE_SHOWN.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_AUTO_RESTORE_TOGGLE_OPTED_OUT.pixelName to PixelParameter.removeAtb(),

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -26,14 +26,32 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.api.engine.DeletableType
 import com.duckduckgo.sync.api.engine.SyncFeatureType
 import com.duckduckgo.sync.impl.API_CODE
+import com.duckduckgo.sync.impl.AccountErrorCodes
+import com.duckduckgo.sync.impl.DispatchOutcome
 import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.SyncCodeType
+import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_DAILY
 import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_DAILY_SUCCESS_RATE_PIXEL
 import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_OBJECT_LIMIT_EXCEEDED_DAILY
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.CONNECTED_DEVICES_WHEN_DELETING
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_FEATURE_PROMOTION_SOURCE
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_CODE_TYPE
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_CODE_VERSION
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_FLOW_VERSION
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_MY_KIND
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_MY_ROLE
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_PATH
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_PEER_KIND
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_REASON
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupFailureReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
 import com.duckduckgo.sync.impl.stats.SyncStatsRepository
 import com.duckduckgo.sync.store.SharedPrefsProvider
 import com.squareup.anvil.annotations.ContributesBinding
@@ -98,18 +116,80 @@ interface SyncPixels {
     fun fireUserSwitchedLoginError()
     fun fireTimeoutOnDeepLinkSetup()
     fun fireSyncBarcodeScreenShown(screenType: ScreenType)
-    fun fireSyncSetupFinishedSuccessfully(screenType: ScreenType)
-    fun fireSyncSetupAbandoned(screenType: ScreenType)
+    fun fireSyncSetupFinishedSuccessfully(
+        screenType: ScreenType,
+        path: SetupPath? = null,
+        myRole: SetupRole? = null,
+        peerKind: PeerKind? = null,
+    )
+    fun fireSyncSetupAbandoned(screenType: ScreenType, reason: CancellationReason? = null)
     fun fireSyncSetupManualCodeScreenShown(screenType: ScreenType)
-    fun fireSyncSetupCodePastedParseSuccess(screenType: ScreenType)
+    fun fireSyncSetupCodePastedParseSuccess(screenType: ScreenType, codeVersion: CodeVersion, codeType: SyncCodeType? = null)
     fun fireSyncSetupCodePastedParseFailure(screenType: ScreenType)
     fun fireSyncSetupCodeCopiedToClipboard(screenType: ScreenType)
     fun fireBarcodeScannerParseError(screenType: ScreenType)
-    fun fireBarcodeScannerParseSuccess(screenType: ScreenType)
+    fun fireBarcodeScannerParseSuccess(screenType: ScreenType, codeVersion: CodeVersion, codeType: SyncCodeType? = null)
+
+    /**
+     * "Setup failed" — a v2 setup that started (code recognized) then failed with an error (not a
+     * user cancellation). [path]/[myRole]/[peerKind] are best-effort and omitted when unknown.
+     */
+    fun fireSyncSetupFailed(
+        reason: SetupFailureReason,
+        path: SetupPath? = null,
+        myRole: SetupRole? = null,
+        peerKind: PeerKind? = null,
+    )
 
     enum class ScreenType(val value: String) {
         SYNC_CONNECT("connect"),
         SYNC_EXCHANGE("exchange"),
+    }
+
+    /** Protocol version of the code that was scanned/pasted, per the "Code recognized" telemetry. */
+    enum class CodeVersion(val value: String) {
+        V1("v1"),
+        V2("v2"),
+    }
+
+    /** Whether a successful setup was a recovery-code login or a device pairing. v2 only. */
+    enum class SetupPath(val value: String) {
+        RECOVERY("recovery"),
+        PAIRING("pairing"),
+    }
+
+    /** This device's elected role in a v2 pairing. */
+    enum class SetupRole(val value: String) {
+        HOST("host"),
+        JOINER("joiner"),
+    }
+
+    /** The peer device's credential kind in a v2 pairing. */
+    enum class PeerKind(val value: String) {
+        DDG("ddg"),
+        THIRD_PARTY("3party"),
+    }
+
+    /**
+     * Why a setup was cancelled, per the "Cancellation" telemetry. Based on the v2 protocol state at
+     * the moment of cancellation: [SCANNING_CANCELLED] before the exchange engages a peer,
+     * [CANCELLED_BEFORE_FINISHED] mid-exchange, [CONFIRMATION_DENIED] when this device denied the prompt.
+     */
+    enum class CancellationReason(val value: String) {
+        SCANNING_CANCELLED("scanning_cancelled"),
+        CONFIRMATION_DENIED("sync_confirmation_denied"),
+        CANCELLED_BEFORE_FINISHED("cancelled_before_finished"),
+    }
+
+    /** Why a v2 setup failed, per the "Setup failed" telemetry. Aligned with the error codes we handle. */
+    enum class SetupFailureReason(val value: String) {
+        NEEDS_UPGRADE("needs_upgrade"),
+        ALREADY_UPGRADED("already_upgraded"),
+        INVALID_CREDENTIALS("invalid_credentials"),
+        PAIRING_UNAVAILABLE("pairing_unavailable"),
+        PROTOCOL_ERROR("protocol_error"),
+        TRANSPORT_FAILURE("transport_failure"),
+        UNEXPECTED_FAILURE("unexpected_failure"),
     }
     fun fireSetupDeepLinkFlowStarted()
     fun fireSetupDeepLinkFlowSuccess()
@@ -145,10 +225,62 @@ class RealSyncPixels @Inject constructor(
     private val pixel: Pixel,
     private val statsRepository: SyncStatsRepository,
     private val sharedPrefsProvider: SharedPrefsProvider,
+    private val syncFeature: SyncFeature,
 ) : SyncPixels {
 
     private val preferences: SharedPreferences by lazy {
         sharedPrefsProvider.getSharedPrefs(SYNC_PIXELS_PREF_FILE)
+    }
+
+    /**
+     * Common metadata describing the setup flow this device is opening:
+     * - [SYNC_SETUP_FLOW_VERSION]: "v2" when the device is on the v2 connect/exchange stack
+     *   ([SyncFeature.canUseV2ConnectFlow]), "v1" otherwise. Independent of which code version is
+     *   actually displayed (that is gated separately by [SyncFeature.canShowV2ConnectCode]).
+     * - [SYNC_SETUP_MY_KIND]: always "ddg" — this is the native DuckDuckGo client.
+     */
+    private fun setupFlowMetadata(): Map<String, String> = mapOf(
+        SYNC_SETUP_FLOW_VERSION to if (syncFeature.canUseV2ConnectFlow().isEnabled()) FLOW_VERSION_V2 else FLOW_VERSION_V1,
+        SYNC_SETUP_MY_KIND to MY_KIND_DDG,
+    )
+
+    /**
+     * Params for the "Code recognized" pixels (scanner/manual-entry success): the screen [source],
+     * the recognized [codeVersion] (what was scanned/pasted), the common [setupFlowMetadata]
+     * (flow_version + my_kind), and — only when known — the [codeType]. The legacy/v1 path does not
+     * report a code type, so [codeType] is omitted there; the v2 path always supplies it.
+     */
+    private fun recognizedCodeParams(
+        screenType: ScreenType,
+        codeVersion: CodeVersion,
+        codeType: SyncCodeType?,
+    ): Map<String, String> = buildMap {
+        put(SYNC_SETUP_SCREEN_TYPE, screenType.value)
+        put(SYNC_SETUP_CODE_VERSION, codeVersion.value)
+        when (codeType) {
+            SyncCodeType.RECOVERY -> put(SYNC_SETUP_CODE_TYPE, CODE_TYPE_RECOVERY)
+            SyncCodeType.LINKING -> put(SYNC_SETUP_CODE_TYPE, CODE_TYPE_LINKING)
+            null -> {}
+        }
+        putAll(setupFlowMetadata())
+    }
+
+    /**
+     * Params for the "Setup success" pixel: the screen [source], the common [setupFlowMetadata]
+     * (flow_version + my_kind), and — v2 only — the [path] (recovery/pairing) plus, for pairing, the
+     * elected [myRole] and the [peerKind]. Each is omitted when null.
+     */
+    private fun setupSuccessParams(
+        screenType: ScreenType,
+        path: SetupPath?,
+        myRole: SetupRole?,
+        peerKind: PeerKind?,
+    ): Map<String, String> = buildMap {
+        put(SYNC_SETUP_SCREEN_TYPE, screenType.value)
+        if (path != null) put(SYNC_SETUP_PATH, path.value)
+        if (myRole != null) put(SYNC_SETUP_MY_ROLE, myRole.value)
+        if (peerKind != null) put(SYNC_SETUP_PEER_KIND, peerKind.value)
+        putAll(setupFlowMetadata())
     }
 
     override fun fireDailyPixel() {
@@ -378,32 +510,57 @@ class RealSyncPixels @Inject constructor(
     }
 
     override fun fireSyncBarcodeScreenShown(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value) + setupFlowMetadata()
         pixel.fire(SyncPixelName.SYNC_SETUP_BARCODE_SCREEN_SHOWN, parameters = params)
     }
 
-    override fun fireSyncSetupAbandoned(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+    override fun fireSyncSetupAbandoned(screenType: ScreenType, reason: CancellationReason?) {
+        val params = buildMap {
+            put(SYNC_SETUP_SCREEN_TYPE, screenType.value)
+            if (reason != null) put(SYNC_SETUP_REASON, reason.value)
+            putAll(setupFlowMetadata())
+        }
         pixel.fire(SyncPixelName.SYNC_SETUP_ENDED_ABANDONED, parameters = params)
     }
 
-    override fun fireSyncSetupFinishedSuccessfully(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+    override fun fireSyncSetupFinishedSuccessfully(
+        screenType: ScreenType,
+        path: SetupPath?,
+        myRole: SetupRole?,
+        peerKind: PeerKind?,
+    ) {
+        val params = setupSuccessParams(screenType, path, myRole, peerKind)
         pixel.fire(SyncPixelName.SYNC_SETUP_ENDED_SUCCESS, parameters = params)
     }
 
+    override fun fireSyncSetupFailed(
+        reason: SetupFailureReason,
+        path: SetupPath?,
+        myRole: SetupRole?,
+        peerKind: PeerKind?,
+    ) {
+        val params = buildMap {
+            put(SYNC_SETUP_REASON, reason.value)
+            if (path != null) put(SYNC_SETUP_PATH, path.value)
+            if (myRole != null) put(SYNC_SETUP_MY_ROLE, myRole.value)
+            if (peerKind != null) put(SYNC_SETUP_PEER_KIND, peerKind.value)
+            putAll(setupFlowMetadata())
+        }
+        pixel.fire(SyncPixelName.SYNC_SETUP_ENDED_FAILED, parameters = params)
+    }
+
     override fun fireSyncSetupManualCodeScreenShown(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value) + setupFlowMetadata()
         pixel.fire(SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTRY_SCREEN_SHOWN, parameters = params)
     }
 
-    override fun fireSyncSetupCodePastedParseSuccess(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+    override fun fireSyncSetupCodePastedParseSuccess(screenType: ScreenType, codeVersion: CodeVersion, codeType: SyncCodeType?) {
+        val params = recognizedCodeParams(screenType, codeVersion, codeType)
         pixel.fire(SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_SUCCESS, parameters = params)
     }
 
     override fun fireSyncSetupCodePastedParseFailure(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value) + setupFlowMetadata()
         pixel.fire(SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_FAILED, parameters = params)
     }
 
@@ -412,13 +569,13 @@ class RealSyncPixels @Inject constructor(
         pixel.fire(SyncPixelName.SYNC_SETUP_BARCODE_CODE_COPIED, parameters = params)
     }
 
-    override fun fireBarcodeScannerParseSuccess(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+    override fun fireBarcodeScannerParseSuccess(screenType: ScreenType, codeVersion: CodeVersion, codeType: SyncCodeType?) {
+        val params = recognizedCodeParams(screenType, codeVersion, codeType)
         pixel.fire(SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_SUCCESS, parameters = params)
     }
 
     override fun fireBarcodeScannerParseError(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value) + setupFlowMetadata()
         pixel.fire(SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_FAILED, parameters = params)
     }
 
@@ -506,6 +663,11 @@ class RealSyncPixels @Inject constructor(
 
     companion object {
         private const val SYNC_PIXELS_PREF_FILE = "com.duckduckgo.sync.pixels.v1"
+        private const val FLOW_VERSION_V1 = "v1"
+        private const val FLOW_VERSION_V2 = "v2"
+        private const val MY_KIND_DDG = "ddg"
+        private const val CODE_TYPE_RECOVERY = "recovery"
+        private const val CODE_TYPE_LINKING = "linking"
     }
 }
 
@@ -573,6 +735,7 @@ enum class SyncPixelName(override val pixelName: String) : Pixel.PixelName {
     SYNC_SETUP_MANUAL_CODE_ENTERED_FAILED("sync_setup_manual_code_entered_failed"),
     SYNC_SETUP_ENDED_ABANDONED("sync_setup_ended_abandoned"),
     SYNC_SETUP_ENDED_SUCCESS("sync_setup_ended_successful"),
+    SYNC_SETUP_ENDED_FAILED("sync_setup_ended_failed"),
     SYNC_USER_CONFIRMED_TO_TURN_OFF_SYNC("sync_disabled"),
     SYNC_USER_CONFIRMED_TO_TURN_OFF_SYNC_AND_DELETE("sync_disabledanddeleted"),
     SYNC_SETUP_PROMO_BOOKMARK_ADDED_DIALOG_SHOWN("sync_setup_promo_bookmark_added_dialog_shown"),
@@ -615,6 +778,14 @@ object SyncPixelParameters {
     const val SYNC_FEATURE_PROMOTION_SOURCE = "source"
     const val GET_OTHER_DEVICES_SCREEN_LAUNCH_SOURCE = "source"
     const val SYNC_SETUP_SCREEN_TYPE = "source"
+    const val SYNC_SETUP_FLOW_VERSION = "flow_version"
+    const val SYNC_SETUP_MY_KIND = "my_kind"
+    const val SYNC_SETUP_CODE_VERSION = "code_version"
+    const val SYNC_SETUP_CODE_TYPE = "code_type"
+    const val SYNC_SETUP_PATH = "path"
+    const val SYNC_SETUP_MY_ROLE = "my_role"
+    const val SYNC_SETUP_PEER_KIND = "peer_kind"
+    const val SYNC_SETUP_REASON = "reason"
     const val CONNECTED_DEVICES_WHEN_DELETING = "connected_devices"
 
     const val AUTO_RESTORE_SOURCE = "source"
@@ -642,5 +813,55 @@ object SyncPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
             SyncPixelName.SYNC_RESCOPE_TOKEN_FAILURE.pixelName to removeAtb(),
             SyncPixelName.SYNC_AI_CHAT_ACTIVE.pixelName to removeAtb(),
         )
+    }
+}
+
+/**
+ * Maps a v2 [com.duckduckgo.sync.impl.DispatchOutcome.Failed] error code to the "Setup failed"
+ * telemetry [SetupFailureReason], aligned with the error codes we already handle. Cancellation codes
+ * (`PAIRING_CANCELLED`, `PAIRING_REJECTED`) are excluded by the caller, so they fall to the catch-all.
+ */
+internal fun Int.toSetupFailureReason(): SetupFailureReason = when (this) {
+    AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED.code -> SetupFailureReason.ALREADY_UPGRADED
+    AccountErrorCodes.LOGIN_FAILED.code,
+    AccountErrorCodes.INVALID_CODE.code,
+    AccountErrorCodes.EXCHANGE_FAILED.code,
+    -> SetupFailureReason.INVALID_CREDENTIALS
+    AccountErrorCodes.PAIRING_UNAVAILABLE.code -> SetupFailureReason.PAIRING_UNAVAILABLE
+    AccountErrorCodes.NEGOTIATION_ABORTED.code,
+    AccountErrorCodes.NO_RECOVERY_CODE.code,
+    -> SetupFailureReason.PROTOCOL_ERROR
+    AccountErrorCodes.PAIRING_FAILED.code -> SetupFailureReason.TRANSPORT_FAILURE
+    else -> SetupFailureReason.UNEXPECTED_FAILURE
+}
+
+/**
+ * Fire the "Setup failed" pixel for a v2 error [outcome]. No-op for non-error outcomes. User
+ * cancellations (`PAIRING_CANCELLED`, `PAIRING_REJECTED`) are intentionally skipped — they are not
+ * setup errors (the latter pending the cancellation-telemetry follow-up).
+ */
+
+internal fun SyncPixels.fireSetupFailed(outcome: DispatchOutcome) {
+    when (outcome) {
+        is DispatchOutcome.UpgradeRequired ->
+            fireSyncSetupFailed(SetupFailureReason.NEEDS_UPGRADE, outcome.path, outcome.myRole, outcome.peerKind)
+        is DispatchOutcome.Failed -> {
+            if (outcome.code == AccountErrorCodes.PAIRING_CANCELLED.code || outcome.code == AccountErrorCodes.PAIRING_REJECTED.code) {
+                return
+            }
+            fireSyncSetupFailed(outcome.code.toSetupFailureReason(), outcome.path, outcome.myRole, outcome.peerKind)
+        }
+        else -> {}
+    }
+}
+
+/**
+ * Fire the "Cancellation" pixel (sync_setup_ended_abandoned) when a v2 outcome is this device's own
+ * confirmation denial ([AccountErrorCodes.PAIRING_CANCELLED]). Peer denials (`PAIRING_REJECTED`) are
+ * intentionally ignored — the peer reports its own cancel. No-op for any other outcome.
+ */
+internal fun SyncPixels.fireSetupCancelledIfDenied(outcome: DispatchOutcome, screenType: SyncPixels.ScreenType) {
+    if (outcome is DispatchOutcome.Failed && outcome.code == AccountErrorCodes.PAIRING_CANCELLED.code) {
+        fireSyncSetupAbandoned(screenType, CancellationReason.CONFIRMATION_DENIED)
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.databinding.ActivityEnterCodeBinding
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState.Idle
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState.Loading
@@ -113,6 +114,8 @@ class EnterCodeActivity : DuckDuckGoActivity() {
                 showError(command)
             }
 
+            is Command.ShowV2Error -> showV2PairingError(command.content) { viewModel.onErrorDialogDismissed() }
+
             is AskToSwitchAccount -> askUserToSwitchAccount(command)
             SwitchAccountSuccess -> {
                 val resultIntent = Intent()
@@ -120,7 +123,41 @@ class EnterCodeActivity : DuckDuckGoActivity() {
                 setResult(RESULT_OK, resultIntent)
                 finish()
             }
+            is Command.AskJoinerConfirmation -> askJoinerConfirmation(command.peerName, command.peerKind)
+            is Command.AskHostConfirmation -> askHostConfirmation(command.peerName, command.peerKind)
+            Command.FinishWithError -> {
+                setResult(RESULT_CANCELED)
+                finish()
+            }
         }
+    }
+
+    private fun askJoinerConfirmation(peerName: String?, peerKind: PeerKind?) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_joiner_confirmation_title)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
+            .setPositiveButton(R.string.sync_v2_joiner_confirmation_positive)
+            .setNegativeButton(R.string.sync_v2_joiner_confirmation_negative)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() { viewModel.onJoinerConfirmed() }
+                    override fun onNegativeButtonClicked() { viewModel.onJoinerDenied() }
+                },
+            ).show()
+    }
+
+    private fun askHostConfirmation(peerName: String?, peerKind: PeerKind?) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_host_confirmation_title)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
+            .setPositiveButton(R.string.sync_v2_host_confirmation_positive)
+            .setNegativeButton(R.string.sync_v2_host_confirmation_negative)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() { viewModel.onHostConfirmed() }
+                    override fun onNegativeButtonClicked() { viewModel.onHostDenied() }
+                },
+            ).show()
     }
 
     private fun showError(it: ShowError) {
@@ -130,8 +167,7 @@ class EnterCodeActivity : DuckDuckGoActivity() {
             .setPositiveButton(R.string.sync_dialog_error_ok)
             .addEventListener(
                 object : TextAlertDialogBuilder.EventListener() {
-                    override fun onPositiveButtonClicked() {
-                    }
+                    override fun onPositiveButtonClicked() { viewModel.onErrorDialogDismissed() }
                 },
             ).show()
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
@@ -27,20 +27,29 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.CONNECT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.CREATE_ACCOUNT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.INVALID_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED
 import com.duckduckgo.sync.impl.Clipboard
+import com.duckduckgo.sync.impl.DispatchOutcome
 import com.duckduckgo.sync.impl.ExchangeResult.AccountSwitchingRequired
 import com.duckduckgo.sync.impl.ExchangeResult.LoggedIn
 import com.duckduckgo.sync.impl.ExchangeResult.Pending
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.RouteDecision
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode
+import com.duckduckgo.sync.impl.SyncCodeDispatcher
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.onFailure
 import com.duckduckgo.sync.impl.onSuccess
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
+import com.duckduckgo.sync.impl.pixels.fireSetupFailed
 import com.duckduckgo.sync.impl.ui.EnterCodeActivity.Companion.Code
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.AskToSwitchAccount
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.LoginSuccess
@@ -52,8 +61,10 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import logcat.logcat
 import javax.inject.*
 
 @ContributesViewModel(ActivityScope::class)
@@ -63,6 +74,7 @@ class EnterCodeViewModel @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val syncFeature: SyncFeature,
     private val syncPixels: SyncPixels,
+    private val codeDispatcher: SyncCodeDispatcher,
 ) : ViewModel() {
 
     private val command = Channel<Command>(1, DROP_OLDEST)
@@ -89,6 +101,15 @@ class EnterCodeViewModel @Inject constructor(
         data class AskToSwitchAccount(val encodedStringCode: String) : Command()
         data class ShowError(@StringRes val message: Int, val reason: String = "") : Command()
         data object SwitchAccountSuccess : Command()
+
+        /** v2 §"Exchange Confirmations": prompt user "Sync your data with [peerName]?". */
+        data class AskJoinerConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
+
+        /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
+        data class AskHostConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
+
+        data object FinishWithError : Command()
+        internal data class ShowV2Error(val content: V2PairingErrorContent) : Command()
     }
 
     fun onPasteCodeClicked() {
@@ -103,22 +124,78 @@ class EnterCodeViewModel @Inject constructor(
         pastedCode: String,
     ) {
         val previousPrimaryKey = syncAccountRepository.getAccountInfo().primaryKey
-        val codeType = syncAccountRepository.parseSyncAuthCode(pastedCode).also { it.onCodePasted() }
-        when (val result = syncAccountRepository.processCode(codeType)) {
-            is Result.Success -> {
-                if (codeType is SyncAuthCode.Exchange) {
-                    pollForRecoveryKey(previousPrimaryKey = previousPrimaryKey, code = pastedCode)
-                } else {
-                    onLoginSuccess(previousPrimaryKey)
+        // FF off → Legacy (v1 path below); FF on → v2 codes surface as DispatchOutcome.
+        when (val decision = codeDispatcher.route(pastedCode)) {
+            is RouteDecision.Legacy -> {
+                logcat { "Sync-CodeDispatch: EnterCodeViewModel handling Legacy(${decision.authCode::class.simpleName})" }
+                val codeType = decision.authCode.also { it.onCodePasted() }
+                when (val result = syncAccountRepository.processCode(codeType)) {
+                    is Result.Success -> {
+                        if (codeType is SyncAuthCode.Exchange) {
+                            pollForRecoveryKey(previousPrimaryKey = previousPrimaryKey, code = pastedCode)
+                        } else {
+                            onLoginSuccess(previousPrimaryKey)
+                        }
+                    }
+                    is Result.Error -> {
+                        processError(result, pastedCode)
+                    }
                 }
             }
-            is Result.Error -> {
-                processError(result, pastedCode)
+            is RouteDecision.V2InProgress -> {
+                logcat { "Sync-CodeDispatch: EnterCodeViewModel observing V2InProgress" }
+                syncPixels.fireSyncSetupCodePastedParseSuccess(codeType.asScreenType(), CodeVersion.V2, decision.codeType)
+                decision.outcomes.collect { outcome -> handleV2Outcome(outcome, previousPrimaryKey) }
             }
         }
     }
 
-    private suspend fun onLoginSuccess(previousPrimaryKey: String) {
+    /** Map a v2 [DispatchOutcome] onto the same command/error hooks the v1 path uses. */
+    private suspend fun handleV2Outcome(
+        outcome: DispatchOutcome,
+        previousPrimaryKey: String,
+    ) {
+        syncPixels.fireSetupFailed(outcome)
+        when (outcome) {
+            is DispatchOutcome.LoggedIn -> onLoginSuccess(previousPrimaryKey, outcome.path, outcome.myRole, outcome.peerKind)
+            is DispatchOutcome.AlreadyConnected -> {
+                viewState.value = viewState.value.copy(authState = AuthState.Idle)
+                command.send(Command.ShowV2Error(v2AlreadyPairedError))
+            }
+            is DispatchOutcome.UpgradeRequired -> {
+                viewState.value = viewState.value.copy(authState = AuthState.Idle)
+                logcat { "Sync v2: upgrade required, peer needs protocol v${outcome.codeMajor}" }
+                command.send(Command.ShowV2Error(v2UpgradeRequiredError))
+            }
+            is DispatchOutcome.Failed -> {
+                viewState.value = viewState.value.copy(authState = AuthState.Idle)
+                command.send(Command.ShowV2Error(outcome.code.toV2PairingError()))
+            }
+            is DispatchOutcome.JoinerConfirmationRequested ->
+                command.send(Command.AskJoinerConfirmation(outcome.peerName, outcome.peerKind))
+            is DispatchOutcome.HostConfirmationRequested ->
+                command.send(Command.AskHostConfirmation(outcome.peerName, outcome.peerKind))
+            is DispatchOutcome.LinkingCodeReady -> {} // No-op; used only by presentV2() flow
+        }
+    }
+
+    fun onJoinerConfirmed() { codeDispatcher.confirmJoiner() }
+    fun onJoinerDenied() { codeDispatcher.denyJoiner() }
+    fun onHostConfirmed() { codeDispatcher.confirmHost() }
+    fun onHostDenied() { codeDispatcher.denyHost() }
+
+    fun onErrorDialogDismissed() {
+        viewModelScope.launch(dispatchers.io()) {
+            command.send(Command.FinishWithError)
+        }
+    }
+
+    private suspend fun onLoginSuccess(
+        previousPrimaryKey: String,
+        path: SetupPath? = null,
+        myRole: SetupRole? = null,
+        peerKind: PeerKind? = null,
+    ) {
         val postProcessCodePK = syncAccountRepository.getAccountInfo().primaryKey
         val userSwitchedAccount = previousPrimaryKey.isNotBlank() && previousPrimaryKey != postProcessCodePK
         val commandSuccess = if (userSwitchedAccount) {
@@ -127,6 +204,9 @@ class EnterCodeViewModel @Inject constructor(
         } else {
             LoginSuccess
         }
+        // Owns the "Setup success" pixel for codes entered here; the launching screen fires only its
+        // login pixel on the result, so this does not double-count.
+        syncPixels.fireSyncSetupFinishedSuccessfully(codeType.asScreenType(), path, myRole, peerKind)
         command.send(commandSuccess)
     }
 
@@ -178,6 +258,8 @@ class EnterCodeViewModel @Inject constructor(
                 CONNECT_FAILED.code -> R.string.sync_connect_generic_error
                 CREATE_ACCOUNT_FAILED.code -> R.string.sync_create_account_generic_error
                 INVALID_CODE.code -> R.string.sync_invalid_code_error
+                // 3party→ddg upgrade on an already-upgraded account; generic error for now. (follow-up: 1215295182909247)
+                THIRD_PARTY_ALREADY_UPGRADED.code -> R.string.sync_connect_generic_error
                 else -> null
             }?.let { message ->
                 viewState.value = viewState.value.copy(authState = AuthState.Idle)
@@ -235,7 +317,7 @@ class EnterCodeViewModel @Inject constructor(
     private fun SyncAuthCode.onCodePasted() {
         when (this) {
             is SyncAuthCode.Unknown -> syncPixels.fireSyncSetupCodePastedParseFailure(codeType.asScreenType())
-            else -> syncPixels.fireSyncSetupCodePastedParseSuccess(codeType.asScreenType())
+            else -> syncPixels.fireSyncSetupCodePastedParseSuccess(codeType.asScreenType(), CodeVersion.V1)
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectActivity.kt
@@ -37,8 +37,11 @@ import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.databinding.ActivityConnectSyncBinding
 import com.duckduckgo.sync.impl.databinding.ActivityConnectSyncNewBinding
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.ui.EnterCodeActivity.Companion.Code.CONNECT_CODE
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command
+import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.AskHostConfirmation
+import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.AskJoinerConfirmation
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.FinishWithError
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.LoginSuccess
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.ReadTextCode
@@ -129,6 +132,8 @@ class SyncConnectActivity : DuckDuckGoActivity() {
     private fun observeUiEvents() {
         viewModel
             .viewState(extractSource())
+            // Observe at CREATED, not STARTED: STARTED re-subscribes on every foreground, re-firing
+            // viewState.onStart and regenerating the pairing code. CREATED also avoids dropping terminal commands.
             .flowWithLifecycle(lifecycle, Lifecycle.State.CREATED)
             .onEach { render(it) }
             .launchIn(lifecycleScope)
@@ -165,6 +170,9 @@ class SyncConnectActivity : DuckDuckGoActivity() {
 
             is ShowMessage -> Snackbar.make(binding.root, it.messageId, Snackbar.LENGTH_SHORT).show()
             is ShowError -> showError(it)
+            is Command.ShowV2Error -> showV2PairingError(it.content) { viewModel.onErrorDialogDismissed() }
+            is AskJoinerConfirmation -> askJoinerConfirmation(it.peerName, it.peerKind)
+            is AskHostConfirmation -> askHostConfirmation(it.peerName, it.peerKind)
         }
     }
 
@@ -187,6 +195,34 @@ class SyncConnectActivity : DuckDuckGoActivity() {
                     override fun onPositiveButtonClicked() {
                         viewModel.onErrorDialogDismissed()
                     }
+                },
+            ).show()
+    }
+
+    private fun askJoinerConfirmation(peerName: String?, peerKind: PeerKind?) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_joiner_confirmation_title)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
+            .setPositiveButton(R.string.sync_v2_joiner_confirmation_positive)
+            .setNegativeButton(R.string.sync_v2_joiner_confirmation_negative)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() { viewModel.onJoinerConfirmed() }
+                    override fun onNegativeButtonClicked() { viewModel.onJoinerDenied() }
+                },
+            ).show()
+    }
+
+    private fun askHostConfirmation(peerName: String?, peerKind: PeerKind?) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_host_confirmation_title)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
+            .setPositiveButton(R.string.sync_v2_host_confirmation_positive)
+            .setNegativeButton(R.string.sync_v2_host_confirmation_negative)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() { viewModel.onHostConfirmed() }
+                    override fun onNegativeButtonClicked() { viewModel.onHostDenied() }
                 },
             ).show()
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.CREATE_ACCOUNT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.INVALID_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
 import com.duckduckgo.sync.impl.Clipboard
+import com.duckduckgo.sync.impl.DispatchOutcome
 import com.duckduckgo.sync.impl.ExchangeResult.AccountSwitchingRequired
 import com.duckduckgo.sync.impl.ExchangeResult.LoggedIn
 import com.duckduckgo.sync.impl.ExchangeResult.Pending
@@ -37,15 +38,23 @@ import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.R.dimen
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.impl.RouteDecision
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode
 import com.duckduckgo.sync.impl.SyncAuthCode.Exchange
 import com.duckduckgo.sync.impl.SyncAuthCode.Unknown
+import com.duckduckgo.sync.impl.SyncCodeDispatcher
+import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.getOrNull
 import com.duckduckgo.sync.impl.onFailure
 import com.duckduckgo.sync.impl.onSuccess
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_CONNECT
+import com.duckduckgo.sync.impl.pixels.fireSetupCancelledIfDenied
+import com.duckduckgo.sync.impl.pixels.fireSetupFailed
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.FinishWithError
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.LoginSuccess
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.ReadTextCode
@@ -70,9 +79,17 @@ class SyncConnectViewModel @Inject constructor(
     private val clipboard: Clipboard,
     private val syncPixels: SyncPixels,
     private val dispatchers: DispatcherProvider,
+    private val syncFeature: SyncFeature,
+    private val codeDispatcher: SyncCodeDispatcher,
 ) : ViewModel() {
     private val command = Channel<Command>(1, DROP_OLDEST)
     fun commands(): Flow<Command> = command.receiveAsFlow()
+
+    // Cached v2 linking code so onCopyCodeClicked can return it for the v2 path. Null on the v1 path.
+    private var v2LinkingCode: String? = null
+
+    // Start the session exactly once per ViewModel instance.
+    private var sessionStarted = false
 
     private val viewState = MutableStateFlow(ViewState())
     fun viewState(source: String?): Flow<ViewState> = viewState.onStart {
@@ -80,7 +97,19 @@ class SyncConnectViewModel @Inject constructor(
     }
 
     private fun pollConnectionKeys(source: String?) {
+        if (sessionStarted) return
+        sessionStarted = true
         viewModelScope.launch(dispatchers.io()) {
+            // Don't start a fresh v2 session for a user already signed in via EnterCode while this
+            // activity is mid-finish (onStart can re-fire before onLoginSuccess() finishes it).
+            if (syncAccountRepository.getAccountInfo().isSignedIn) {
+                logcat { "Sync: SyncConnect already signed in; skipping new session" }
+                return@launch
+            }
+            if (shouldUseV2()) {
+                startV2Present()
+                return@launch
+            }
             showQRCode()
             var polling = true
             while (polling) {
@@ -102,6 +131,47 @@ class SyncConnectViewModel @Inject constructor(
                     }
             }
         }
+    }
+
+    private fun shouldUseV2(): Boolean =
+        syncFeature.canUseV2ConnectFlow().isEnabled() &&
+            syncFeature.canShowV2ConnectCode().isEnabled()
+
+    /** Drive a v2 Presenter session via the dispatcher. Role election may elect this device Host or Joiner. */
+    private suspend fun startV2Present() {
+        codeDispatcher.presentV2().collect { handleV2Outcome(it) }
+    }
+
+    /** Map one v2 [DispatchOutcome] onto this VM's command pipeline. Shared by the Presenter and Scanner paths. */
+    private suspend fun handleV2Outcome(outcome: DispatchOutcome) {
+        syncPixels.fireSetupFailed(outcome)
+        syncPixels.fireSetupCancelledIfDenied(outcome, SYNC_CONNECT)
+        when (outcome) {
+            is DispatchOutcome.LinkingCodeReady -> renderV2QrCode(outcome.linkingCode)
+            is DispatchOutcome.HostConfirmationRequested -> command.send(Command.AskHostConfirmation(outcome.peerName, outcome.peerKind))
+            is DispatchOutcome.JoinerConfirmationRequested -> command.send(Command.AskJoinerConfirmation(outcome.peerName, outcome.peerKind))
+            is DispatchOutcome.LoggedIn -> {
+                syncPixels.fireLoginPixel()
+                syncPixels.fireSyncSetupFinishedSuccessfully(SYNC_CONNECT, outcome.path, outcome.myRole, outcome.peerKind)
+                command.send(LoginSuccess)
+            }
+            is DispatchOutcome.AlreadyConnected ->
+                command.send(Command.ShowV2Error(v2AlreadyPairedError))
+            is DispatchOutcome.UpgradeRequired -> {
+                logcat { "Sync v2: upgrade required, peer needs protocol v${outcome.codeMajor}" }
+                command.send(Command.ShowV2Error(v2UpgradeRequiredError))
+            }
+            is DispatchOutcome.Failed ->
+                command.send(Command.ShowV2Error(outcome.code.toV2PairingError()))
+        }
+    }
+
+    private suspend fun renderV2QrCode(linkingCode: String) {
+        v2LinkingCode = linkingCode
+        val bitmap = withContext(dispatchers.io()) {
+            qrEncoder.encodeAsBitmap(linkingCode, dimen.qrSizeSmall, dimen.qrSizeSmall)
+        }
+        viewState.emit(viewState.value.copy(qrCodeBitmap = bitmap))
     }
 
     private suspend fun pollForRecoveryKey() {
@@ -149,6 +219,13 @@ class SyncConnectViewModel @Inject constructor(
 
     fun onCopyCodeClicked() {
         viewModelScope.launch(dispatchers.io()) {
+            val v2Code = v2LinkingCode
+            if (v2Code != null) {
+                clipboard.copyToClipboard(v2Code)
+                command.send(ShowMessage(R.string.sync_code_copied_message))
+                syncPixels.fireSyncSetupCodeCopiedToClipboard(SYNC_CONNECT)
+                return@launch
+            }
             syncAccountRepository.getConnectQR().getOrNull()?.let { code ->
                 logcat { "Sync: code available for sharing manually: $code" }
                 clipboard.copyToClipboard(code.rawCode)
@@ -168,6 +245,14 @@ class SyncConnectViewModel @Inject constructor(
         data class ShowMessage(val messageId: Int) : Command()
         data object FinishWithError : Command()
         data class ShowError(@StringRes val message: Int, val reason: String = "") : Command()
+
+        /** v2 §"Exchange Confirmations": prompt user "Sync your data with [peerName]?". */
+        data class AskJoinerConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
+
+        /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
+        data class AskHostConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
+
+        internal data class ShowV2Error(val content: V2PairingErrorContent) : Command()
     }
 
     fun onReadTextCodeClicked() {
@@ -178,19 +263,29 @@ class SyncConnectViewModel @Inject constructor(
 
     fun onQRCodeScanned(qrCode: String) {
         viewModelScope.launch(dispatchers.io()) {
-            val codeType = syncAccountRepository.parseSyncAuthCode(qrCode).also { it.onCodeScanned() }
-            when (val result = syncAccountRepository.processCode(codeType)) {
-                is Error -> {
-                    processError(result)
-                }
+            // Route via SyncCodeDispatcher: FF off → Legacy (v1 path unchanged); FF on → v2 codes surface via DispatchOutcome.
+            when (val decision = codeDispatcher.route(qrCode)) {
+                is RouteDecision.Legacy -> {
+                    val codeType = decision.authCode.also { it.onCodeScanned() }
+                    when (val result = syncAccountRepository.processCode(codeType)) {
+                        is Error -> {
+                            processError(result)
+                        }
 
-                is Success -> {
-                    if (codeType is Exchange) {
-                        pollForRecoveryKey()
-                    } else {
-                        fireLoginPixels()
-                        command.send(LoginSuccess)
+                        is Success -> {
+                            if (codeType is Exchange) {
+                                pollForRecoveryKey()
+                            } else {
+                                fireLoginPixels()
+                                command.send(LoginSuccess)
+                            }
+                        }
                     }
+                }
+                is RouteDecision.V2InProgress -> {
+                    logcat { "Sync-CodeDispatch: SyncConnectViewModel observing V2InProgress" }
+                    syncPixels.fireBarcodeScannerParseSuccess(SYNC_CONNECT, CodeVersion.V2, decision.codeType)
+                    decision.outcomes.collect { handleV2Outcome(it) }
                 }
             }
         }
@@ -201,7 +296,12 @@ class SyncConnectViewModel @Inject constructor(
     }
 
     fun onUserCancelledWithoutSyncSetup() {
-        syncPixels.fireSyncSetupAbandoned(SYNC_CONNECT)
+        val reason = if (codeDispatcher.isV2ExchangeUnderway()) {
+            CancellationReason.CANCELLED_BEFORE_FINISHED
+        } else {
+            CancellationReason.SCANNING_CANCELLED
+        }
+        syncPixels.fireSyncSetupAbandoned(SYNC_CONNECT, reason)
     }
 
     private suspend fun processError(result: Error) {
@@ -219,10 +319,17 @@ class SyncConnectViewModel @Inject constructor(
 
     fun onLoginSuccess() {
         viewModelScope.launch {
-            fireLoginPixels()
+            // Manual code entry: EnterCodeViewModel fires the "Setup success" pixel (it has the v2
+            // path/role/peer); here we only fire the login pixel to avoid double-counting.
+            syncPixels.fireLoginPixel()
             command.send(LoginSuccess)
         }
     }
+
+    fun onJoinerConfirmed() { codeDispatcher.confirmJoiner() }
+    fun onJoinerDenied() { codeDispatcher.denyJoiner() }
+    fun onHostConfirmed() { codeDispatcher.confirmHost() }
+    fun onHostDenied() { codeDispatcher.denyHost() }
 
     private fun fireLoginPixels() {
         syncPixels.fireLoginPixel()
@@ -232,7 +339,7 @@ class SyncConnectViewModel @Inject constructor(
     private fun SyncAuthCode.onCodeScanned() {
         when (this) {
             is Unknown -> syncPixels.fireBarcodeScannerParseError(SYNC_CONNECT)
-            else -> syncPixels.fireBarcodeScannerParseSuccess(SYNC_CONNECT)
+            else -> syncPixels.fireBarcodeScannerParseSuccess(SYNC_CONNECT, CodeVersion.V1)
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginActivity.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.databinding.ActivityLoginSyncBinding
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.ui.EnterCodeActivity.Companion.Code.RECOVERY_CODE
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command.Error
@@ -95,7 +96,38 @@ class SyncLoginActivity : DuckDuckGoActivity() {
             }
 
             is ShowError -> showError(it)
+            is Command.ShowV2Error -> showV2PairingError(it.content) { viewModel.onErrorDialogDismissed() }
+            is Command.AskJoinerConfirmation -> askJoinerConfirmation(it.peerName, it.peerKind)
+            is Command.AskHostConfirmation -> askHostConfirmation(it.peerName, it.peerKind)
         }
+    }
+
+    private fun askJoinerConfirmation(peerName: String?, peerKind: PeerKind?) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_joiner_confirmation_title)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
+            .setPositiveButton(R.string.sync_v2_joiner_confirmation_positive)
+            .setNegativeButton(R.string.sync_v2_joiner_confirmation_negative)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() { viewModel.onJoinerConfirmed() }
+                    override fun onNegativeButtonClicked() { viewModel.onJoinerDenied() }
+                },
+            ).show()
+    }
+
+    private fun askHostConfirmation(peerName: String?, peerKind: PeerKind?) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_host_confirmation_title)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
+            .setPositiveButton(R.string.sync_v2_host_confirmation_positive)
+            .setNegativeButton(R.string.sync_v2_host_confirmation_negative)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() { viewModel.onHostConfirmed() }
+                    override fun onNegativeButtonClicked() { viewModel.onHostDenied() }
+                },
+            ).show()
     }
 
     private fun configureListeners() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
@@ -27,17 +27,22 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.CONNECT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.CREATE_ACCOUNT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.INVALID_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
+import com.duckduckgo.sync.impl.DispatchOutcome
 import com.duckduckgo.sync.impl.ExchangeResult.AccountSwitchingRequired
 import com.duckduckgo.sync.impl.ExchangeResult.LoggedIn
 import com.duckduckgo.sync.impl.ExchangeResult.Pending
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.impl.RouteDecision
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode
+import com.duckduckgo.sync.impl.SyncCodeDispatcher
 import com.duckduckgo.sync.impl.onFailure
 import com.duckduckgo.sync.impl.onSuccess
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import com.duckduckgo.sync.impl.pixels.fireSetupFailed
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Companion.POLLING_INTERVAL_EXCHANGE_FLOW
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command.LoginSucess
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command.ReadTextCode
@@ -46,8 +51,10 @@ import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import logcat.logcat
 import javax.inject.*
 
 @ContributesViewModel(ActivityScope::class)
@@ -55,6 +62,7 @@ class SyncLoginViewModel @Inject constructor(
     private val syncAccountRepository: SyncAccountRepository,
     private val syncPixels: SyncPixels,
     private val dispatchers: DispatcherProvider,
+    private val codeDispatcher: SyncCodeDispatcher,
 ) : ViewModel() {
     private val command = Channel<Command>(1, DROP_OLDEST)
     fun commands(): Flow<Command> = command.receiveAsFlow()
@@ -64,6 +72,14 @@ class SyncLoginViewModel @Inject constructor(
         data object LoginSucess : Command()
         data object Error : Command()
         data class ShowError(@StringRes val message: Int, val reason: String = "") : Command()
+
+        /** v2 §"Exchange Confirmations": prompt user "Sync your data with [peerName]?". */
+        data class AskJoinerConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
+
+        /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
+        data class AskHostConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
+
+        internal data class ShowV2Error(val content: V2PairingErrorContent) : Command()
     }
 
     fun onReadTextCodeClicked() {
@@ -87,23 +103,61 @@ class SyncLoginViewModel @Inject constructor(
 
     fun onQRCodeScanned(qrCode: String) {
         viewModelScope.launch(dispatchers.io()) {
-            val codeType = syncAccountRepository.parseSyncAuthCode(qrCode)
-            when (val result = syncAccountRepository.processCode(codeType)) {
-                is Error -> {
-                    processError(result)
-                }
-
-                is Success -> {
-                    if (codeType is SyncAuthCode.Exchange) {
-                        pollForRecoveryKey()
-                    } else {
-                        syncPixels.fireLoginPixel()
-                        command.send(LoginSucess)
+            // FF off → Legacy runs the existing v1 control flow; FF on → v2 codes surface via DispatchOutcome.
+            when (val decision = codeDispatcher.route(qrCode)) {
+                is RouteDecision.Legacy -> {
+                    logcat { "Sync-CodeDispatch: SyncLoginViewModel handling Legacy(${decision.authCode::class.simpleName})" }
+                    val codeType = decision.authCode
+                    when (val result = syncAccountRepository.processCode(codeType)) {
+                        is Error -> processError(result)
+                        is Success -> {
+                            if (codeType is SyncAuthCode.Exchange) {
+                                pollForRecoveryKey()
+                            } else {
+                                syncPixels.fireLoginPixel()
+                                command.send(LoginSucess)
+                            }
+                        }
                     }
+                }
+                is RouteDecision.V2InProgress -> {
+                    logcat { "Sync-CodeDispatch: SyncLoginViewModel observing V2InProgress" }
+                    decision.outcomes.collect { outcome -> handleV2Outcome(outcome) }
                 }
             }
         }
     }
+
+    /** Map one v2 [DispatchOutcome] onto this VM's existing command pipeline. */
+    private suspend fun handleV2Outcome(outcome: DispatchOutcome) {
+        syncPixels.fireSetupFailed(outcome)
+        when (outcome) {
+            is DispatchOutcome.LoggedIn -> {
+                syncPixels.fireLoginPixel()
+                command.send(LoginSucess)
+            }
+            is DispatchOutcome.AlreadyConnected ->
+                command.send(Command.ShowV2Error(v2AlreadyPairedError))
+            is DispatchOutcome.UpgradeRequired -> {
+                logcat { "Sync v2: upgrade required, peer needs protocol v${outcome.codeMajor}" }
+                command.send(Command.ShowV2Error(v2UpgradeRequiredError))
+            }
+            is DispatchOutcome.Failed -> {
+                val content = outcome.code.toV2PairingError()
+                command.send(Command.ShowV2Error(content))
+            }
+            is DispatchOutcome.JoinerConfirmationRequested ->
+                command.send(Command.AskJoinerConfirmation(outcome.peerName, outcome.peerKind))
+            is DispatchOutcome.HostConfirmationRequested ->
+                command.send(Command.AskHostConfirmation(outcome.peerName, outcome.peerKind))
+            is DispatchOutcome.LinkingCodeReady -> {} // No-op; used only by presentV2() flow
+        }
+    }
+
+    fun onJoinerConfirmed() { codeDispatcher.confirmJoiner() }
+    fun onJoinerDenied() { codeDispatcher.denyJoiner() }
+    fun onHostConfirmed() { codeDispatcher.confirmHost() }
+    fun onHostDenied() { codeDispatcher.denyHost() }
 
     private suspend fun processError(result: Error) {
         when (result.code) {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncV2ConfirmationCopy.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncV2ConfirmationCopy.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui
+
+import android.content.Context
+import androidx.annotation.StringRes
+import com.duckduckgo.sync.impl.R
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+
+@StringRes
+internal fun syncV2ConfirmationMessageRes(
+    unknownPeer: Boolean,
+    peerKind: PeerKind?,
+): Int {
+    val thirdParty = peerKind == PeerKind.THIRD_PARTY
+    return when {
+        unknownPeer && thirdParty -> R.string.sync_v2_confirmation_message_unknown_peer_3p
+        unknownPeer -> R.string.sync_v2_confirmation_message_unknown_peer_ddg
+        thirdParty -> R.string.sync_v2_confirmation_message_3p
+        else -> R.string.sync_v2_confirmation_message_ddg
+    }
+}
+
+internal fun Context.syncV2ConfirmationMessage(
+    peerName: String?,
+    peerKind: PeerKind?,
+): String {
+    val res = syncV2ConfirmationMessageRes(unknownPeer = peerName.isNullOrBlank(), peerKind = peerKind)
+    return if (peerName.isNullOrBlank()) getString(res) else getString(res, peerName)
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.CREATE_ACCOUNT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.INVALID_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
 import com.duckduckgo.sync.impl.Clipboard
+import com.duckduckgo.sync.impl.DispatchOutcome
 import com.duckduckgo.sync.impl.ExchangeResult.AccountSwitchingRequired
 import com.duckduckgo.sync.impl.ExchangeResult.LoggedIn
 import com.duckduckgo.sync.impl.ExchangeResult.Pending
@@ -38,15 +39,24 @@ import com.duckduckgo.sync.impl.R.dimen
 import com.duckduckgo.sync.impl.R.string
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.impl.RouteDecision
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAccountRepository.AuthCode
 import com.duckduckgo.sync.impl.SyncAuthCode
 import com.duckduckgo.sync.impl.SyncAuthCode.Unknown
+import com.duckduckgo.sync.impl.SyncCodeDispatcher
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.onFailure
 import com.duckduckgo.sync.impl.onSuccess
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_EXCHANGE
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
+import com.duckduckgo.sync.impl.pixels.fireSetupCancelledIfDenied
+import com.duckduckgo.sync.impl.pixels.fireSetupFailed
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Companion.POLLING_INTERVAL_EXCHANGE_FLOW
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.AskToSwitchAccount
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.FinishWithError
@@ -77,6 +87,7 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
     private val syncPixels: SyncPixels,
     private val dispatchers: DispatcherProvider,
     private val syncFeature: SyncFeature,
+    private val codeDispatcher: SyncCodeDispatcher,
 ) : ViewModel() {
     private val command = Channel<Command>(1, DROP_OLDEST)
     fun commands(): Flow<Command> = command.receiveAsFlow()
@@ -89,6 +100,10 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
     private var canTimeout = false
     private var isDeepLink = false
 
+    // viewState.onStart re-fires on every re-collection; guard so the session starts once and
+    // re-fires don't regenerate the invitation/channel, orphaning the code the user already shared.
+    private var sessionStarted = false
+
     private val viewState = MutableStateFlow(ViewState())
     fun viewState(isDeepLink: Boolean = false): Flow<ViewState> = viewState.onStart {
         this@SyncWithAnotherActivityViewModel.canTimeout = isDeepLink
@@ -97,7 +112,13 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
     }
 
     private fun startExchangeProcess() {
+        if (sessionStarted) return
+        sessionStarted = true
         viewModelScope.launch(dispatchers.io()) {
+            if (shouldUseV2()) {
+                startV2Present()
+                return@launch
+            }
             showQRCode()
             var polling = syncFeature.exchangeKeysToSyncWithAnotherDevice().isEnabled()
             val startTime = System.currentTimeMillis()
@@ -128,6 +149,29 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
                     }
             }
         }
+    }
+
+    private fun shouldUseV2(): Boolean =
+        syncFeature.canUseV2ConnectFlow().isEnabled() &&
+            syncFeature.canShowV2ConnectCode().isEnabled()
+
+    /** Drive a v2 Presenter session via the dispatcher. On this signed-in surface role election elects Host. */
+    private suspend fun startV2Present() {
+        val previousPrimaryKey = syncAccountRepository.getAccountInfo().primaryKey
+        codeDispatcher.presentV2().collect { outcome ->
+            when (outcome) {
+                is DispatchOutcome.LinkingCodeReady -> renderV2QrCode(outcome.linkingCode)
+                else -> handleV2Outcome(outcome, previousPrimaryKey)
+            }
+        }
+    }
+
+    private suspend fun renderV2QrCode(linkingCode: String) {
+        barcodeContents = AuthCode(qrCode = linkingCode, rawCode = linkingCode)
+        val bitmap = withContext(dispatchers.io()) {
+            qrEncoder.encodeAsBitmap(linkingCode, dimen.qrSizeSmall, dimen.qrSizeSmall)
+        }
+        viewState.emit(viewState.value.copy(qrCodeBitmap = bitmap))
     }
 
     private suspend fun showQRCode() {
@@ -183,6 +227,14 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
         ) : Command()
 
         data class AskToSwitchAccount(val encodedStringCode: String) : Command()
+
+        /** v2 §"Exchange Confirmations": prompt user "Sync your data with [peerName]?". */
+        data class AskJoinerConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
+
+        /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
+        data class AskHostConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
+
+        internal data class ShowV2Error(val content: V2PairingErrorContent) : Command()
     }
 
     fun onReadTextCodeClicked() {
@@ -200,29 +252,89 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
     fun onQRCodeScanned(qrCode: String) {
         viewModelScope.launch(dispatchers.io()) {
             val previousPrimaryKey = syncAccountRepository.getAccountInfo().primaryKey
-            val codeType = syncAccountRepository.parseSyncAuthCode(qrCode).also { it.onCodeScanned() }
-            when (val result = syncAccountRepository.processCode(codeType)) {
-                is Error -> {
-                    logcat(WARN) { "Sync: error processing code ${result.reason}" }
-                    emitError(result, qrCode)
-                }
+            // Route via SyncCodeDispatcher. FF off → Legacy(parseSyncAuthCode(...)); FF on →
+            // v2-shaped codes are taken into ownership and surfaced through DispatchOutcome.
+            when (val decision = codeDispatcher.route(qrCode)) {
+                is RouteDecision.Legacy -> {
+                    logcat { "Sync-CodeDispatch: SyncWithAnotherActivityViewModel handling Legacy(${decision.authCode::class.simpleName})" }
+                    val codeType = decision.authCode.also { it.onCodeScanned() }
+                    when (val result = syncAccountRepository.processCode(codeType)) {
+                        is Error -> {
+                            logcat(WARN) { "Sync: error processing code ${result.reason}" }
+                            emitError(result, qrCode)
+                        }
 
-                is Success -> {
-                    if (codeType is SyncAuthCode.Exchange) {
-                        pollForRecoveryKey(previousPrimaryKey = previousPrimaryKey, qrCode = qrCode)
-                    } else {
-                        // Show recovery screen if QR scanned is Connect and user was not previously logged in (empty PK)
-                        val showRecovery = codeType is SyncAuthCode.Connect && previousPrimaryKey.isEmpty()
-                        onLoginSuccess(previousPrimaryKey, showRecovery)
+                        is Success -> {
+                            if (codeType is SyncAuthCode.Exchange) {
+                                pollForRecoveryKey(previousPrimaryKey = previousPrimaryKey, qrCode = qrCode)
+                            } else {
+                                // Show recovery screen if QR scanned is Connect and user was not previously logged in (empty PK)
+                                val showRecovery = codeType is SyncAuthCode.Connect && previousPrimaryKey.isEmpty()
+                                onLoginSuccess(previousPrimaryKey, showRecovery)
+                            }
+                        }
                     }
+                }
+                is RouteDecision.V2InProgress -> {
+                    logcat { "Sync-CodeDispatch: SyncWithAnotherActivityViewModel observing V2InProgress" }
+                    if (!isDeepLink) {
+                        syncPixels.fireBarcodeScannerParseSuccess(SYNC_EXCHANGE, CodeVersion.V2, decision.codeType)
+                    }
+                    decision.outcomes.collect { handleV2Outcome(it, previousPrimaryKey) }
                 }
             }
         }
     }
 
-    private suspend fun onLoginSuccess(previousPrimaryKey: String, showRecovery: Boolean) {
+    /** Map one v2 [DispatchOutcome] onto this VM's existing command pipeline. */
+    private suspend fun handleV2Outcome(
+        outcome: DispatchOutcome,
+        previousPrimaryKey: String,
+    ) {
+        syncPixels.fireSetupFailed(outcome)
+        syncPixels.fireSetupCancelledIfDenied(outcome, SYNC_EXCHANGE)
+        // Cancel the deep-link timeout only on terminal outcomes; keep it running across confirmation prompts.
+        when (outcome) {
+            is DispatchOutcome.LoggedIn -> {
+                cancelTimeout()
+                val showRecovery = previousPrimaryKey.isEmpty()
+                onLoginSuccess(previousPrimaryKey, showRecovery, outcome.path, outcome.myRole, outcome.peerKind)
+            }
+            is DispatchOutcome.AlreadyConnected -> {
+                cancelTimeout()
+                command.send(Command.ShowV2Error(v2AlreadyPairedError))
+            }
+            is DispatchOutcome.UpgradeRequired -> {
+                cancelTimeout()
+                logcat { "Sync v2: upgrade required, peer needs protocol v${outcome.codeMajor}" }
+                command.send(Command.ShowV2Error(v2UpgradeRequiredError))
+            }
+            is DispatchOutcome.Failed -> {
+                cancelTimeout()
+                command.send(Command.ShowV2Error(outcome.code.toV2PairingError()))
+            }
+            is DispatchOutcome.JoinerConfirmationRequested ->
+                command.send(Command.AskJoinerConfirmation(outcome.peerName, outcome.peerKind))
+            is DispatchOutcome.HostConfirmationRequested ->
+                command.send(Command.AskHostConfirmation(outcome.peerName, outcome.peerKind))
+            is DispatchOutcome.LinkingCodeReady -> {} // No-op; used only by presentV2() flow
+        }
+    }
+
+    fun onJoinerConfirmed() { codeDispatcher.confirmJoiner() }
+    fun onJoinerDenied() { codeDispatcher.denyJoiner() }
+    fun onHostConfirmed() { codeDispatcher.confirmHost() }
+    fun onHostDenied() { codeDispatcher.denyHost() }
+
+    private suspend fun onLoginSuccess(
+        previousPrimaryKey: String,
+        showRecovery: Boolean,
+        path: SetupPath? = null,
+        myRole: SetupRole? = null,
+        peerKind: PeerKind? = null,
+    ) {
         val postProcessCodePK = syncAccountRepository.getAccountInfo().primaryKey
-        fireLoginPixels()
+        fireLoginPixels(path, myRole, peerKind)
         val userSwitchedAccount = previousPrimaryKey.isNotBlank() && previousPrimaryKey != postProcessCodePK
         val commandSuccess = if (userSwitchedAccount) {
             syncPixels.fireUserSwitchedAccount()
@@ -233,13 +345,17 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
         command.send(commandSuccess)
     }
 
-    private fun fireLoginPixels() {
+    private fun fireLoginPixels(
+        path: SetupPath? = null,
+        myRole: SetupRole? = null,
+        peerKind: PeerKind? = null,
+    ) {
         syncPixels.fireLoginPixel()
 
         if (isDeepLink) {
             syncPixels.fireSetupDeepLinkFlowSuccess()
         } else {
-            syncPixels.fireSyncSetupFinishedSuccessfully(SYNC_EXCHANGE)
+            syncPixels.fireSyncSetupFinishedSuccessfully(SYNC_EXCHANGE, path, myRole, peerKind)
         }
     }
 
@@ -327,11 +443,12 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
             when (result) {
                 EnterCodeContractOutput.Error -> {}
                 EnterCodeContractOutput.LoginSuccess -> {
-                    fireLoginPixels()
+                    // Manual entry: EnterCodeViewModel fires "Setup success"; only fire login pixel here.
+                    syncPixels.fireLoginPixel()
                     command.send(LoginSuccess(showRecovery = true))
                 }
                 EnterCodeContractOutput.SwitchAccountSuccess -> {
-                    fireLoginPixels()
+                    syncPixels.fireLoginPixel()
                     command.send(SwitchAccountSuccess)
                 }
             }
@@ -354,7 +471,12 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
         if (isDeepLink) {
             syncPixels.fireSetupDeepLinkFlowAbandoned()
         } else {
-            syncPixels.fireSyncSetupAbandoned(SYNC_EXCHANGE)
+            val reason = if (codeDispatcher.isV2ExchangeUnderway()) {
+                CancellationReason.CANCELLED_BEFORE_FINISHED
+            } else {
+                CancellationReason.SCANNING_CANCELLED
+            }
+            syncPixels.fireSyncSetupAbandoned(SYNC_EXCHANGE, reason)
         }
     }
 
@@ -363,7 +485,7 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
 
         when (this) {
             is Unknown -> syncPixels.fireBarcodeScannerParseError(SYNC_EXCHANGE)
-            else -> syncPixels.fireBarcodeScannerParseSuccess(SYNC_EXCHANGE)
+            else -> syncPixels.fireBarcodeScannerParseSuccess(SYNC_EXCHANGE, CodeVersion.V1)
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.databinding.ActivityConnectSyncBinding
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.ui.EnterCodeActivity.Companion.Code.RECOVERY_CODE
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.AskToSwitchAccount
@@ -114,6 +115,8 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
     private fun observeUiEvents() {
         viewModel
             .viewState(isDeepLink = isDeepLinkSetup())
+            // Observe at CREATED, not STARTED: STARTED re-subscribes on every foreground, re-firing
+            // viewState.onStart and regenerating the pairing code. CREATED also avoids dropping terminal commands.
             .flowWithLifecycle(lifecycle, Lifecycle.State.CREATED)
             .onEach { render(it) }
             .launchIn(lifecycleScope)
@@ -154,6 +157,7 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
 
             is ShowMessage -> Snackbar.make(binding.root, it.messageId, Snackbar.LENGTH_SHORT).show()
             is ShowError -> showError(it)
+            is Command.ShowV2Error -> showV2PairingError(it.content) { viewModel.onErrorDialogDismissed() }
             is AskToSwitchAccount -> askUserToSwitchAccount(it)
             SwitchAccountSuccess -> {
                 val resultIntent = Intent()
@@ -161,7 +165,37 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
                 setResult(RESULT_OK, resultIntent)
                 finish()
             }
+            is Command.AskJoinerConfirmation -> askJoinerConfirmation(it.peerName, it.peerKind)
+            is Command.AskHostConfirmation -> askHostConfirmation(it.peerName, it.peerKind)
         }
+    }
+
+    private fun askJoinerConfirmation(peerName: String?, peerKind: PeerKind?) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_joiner_confirmation_title)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
+            .setPositiveButton(R.string.sync_v2_joiner_confirmation_positive)
+            .setNegativeButton(R.string.sync_v2_joiner_confirmation_negative)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() { viewModel.onJoinerConfirmed() }
+                    override fun onNegativeButtonClicked() { viewModel.onJoinerDenied() }
+                },
+            ).show()
+    }
+
+    private fun askHostConfirmation(peerName: String?, peerKind: PeerKind?) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_host_confirmation_title)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
+            .setPositiveButton(R.string.sync_v2_host_confirmation_positive)
+            .setNegativeButton(R.string.sync_v2_host_confirmation_negative)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() { viewModel.onHostConfirmed() }
+                    override fun onNegativeButtonClicked() { viewModel.onHostDenied() }
+                },
+            ).show()
     }
 
     private fun configureListeners() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/V2PairingError.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/V2PairingError.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui
+
+import android.content.Context
+import androidx.annotation.StringRes
+import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED
+import com.duckduckgo.sync.impl.R
+
+/** Dialog copy for a v2 pairing terminal outcome. A null [message] renders a title-only dialog. */
+internal data class V2PairingErrorContent(
+    @StringRes val title: Int,
+    @StringRes val message: Int?,
+)
+
+/**
+ * Maps a v2 pairing [com.duckduckgo.sync.impl.DispatchOutcome.Failed] error code to dialog copy.
+ */
+internal fun Int.toV2PairingError(): V2PairingErrorContent = when (this) {
+    PAIRING_REJECTED.code -> V2PairingErrorContent(
+        title = R.string.sync_v2_error_pairing_rejected,
+        message = R.string.sync_v2_error_try_again,
+    )
+    PAIRING_CANCELLED.code -> V2PairingErrorContent(
+        title = R.string.sync_v2_error_pairing_canceled,
+        message = null,
+    )
+    THIRD_PARTY_ALREADY_UPGRADED.code -> V2PairingErrorContent(
+        title = R.string.sync_v2_error_pairing_failed,
+        message = R.string.sync_v2_error_third_party_already_upgraded,
+    )
+    else -> V2PairingErrorContent(
+        title = R.string.sync_v2_error_pairing_failed,
+        message = R.string.sync_v2_error_try_again,
+    )
+}
+
+/** Fixed copy for [com.duckduckgo.sync.impl.DispatchOutcome.UpgradeRequired] */
+internal val v2UpgradeRequiredError = V2PairingErrorContent(
+    title = R.string.sync_v2_error_upgrade_required,
+    message = null,
+)
+
+/** Fixed copy for the same-account [com.duckduckgo.sync.impl.DispatchOutcome.AlreadyConnected] outcome. */
+internal val v2AlreadyPairedError = V2PairingErrorContent(
+    title = R.string.sync_v2_already_paired_title,
+    message = R.string.sync_v2_already_paired_message,
+)
+
+/**
+ * Renders a v2 pairing error dialog: the scenario line as the title, an optional supporting
+ * [V2PairingErrorContent.message].
+ */
+internal fun Context.showV2PairingError(
+    content: V2PairingErrorContent,
+    onDismissed: () -> Unit,
+) {
+    TextAlertDialogBuilder(this)
+        .setTitle(content.title)
+        .apply { content.message?.let { setMessage(it) } }
+        .setPositiveButton(R.string.sync_v2_error_got_it)
+        .addEventListener(
+            object : TextAlertDialogBuilder.EventListener() {
+                override fun onPositiveButtonClicked() {
+                    onDismissed()
+                }
+            },
+        )
+        .show()
+}

--- a/sync/sync-impl/src/main/res/values/donottranslate.xml
+++ b/sync/sync-impl/src/main/res/values/donottranslate.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
+    <string name="sync_v2_joiner_confirmation_title">Sync your data?</string>
+    <string name="sync_v2_joiner_confirmation_positive">Sync Now</string>
+    <string name="sync_v2_joiner_confirmation_negative">Cancel</string>
+
+    <string name="sync_v2_host_confirmation_title">Sync your data?</string>
+    <string name="sync_v2_host_confirmation_positive">Sync Now</string>
+    <string name="sync_v2_host_confirmation_negative">Cancel</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">\"%1$s\" will be able to access your synced DuckDuckGo passwords, autofill data, and Duck.ai chats.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">\"%1$s\" will be able to access your synced Duck.ai chats.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">The other device will be able to access your synced DuckDuckGo passwords, autofill data, and Duck.ai chats.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">The other device will be able to access your synced Duck.ai chats.</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
+    <string name="sync_v2_error_pairing_failed">Sync failed.</string>
+    <string name="sync_v2_error_pairing_rejected">Sync canceled from your other device.</string>
+    <string name="sync_v2_error_pairing_canceled">Sync canceled.</string>
+    <string name="sync_v2_error_upgrade_required">Update the DuckDuckGo browser and try again.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Please Sync this device from an already-connected DuckDuckGo browser on another device</string>
+    <string name="sync_v2_error_try_again">Please try again.</string>
+    <string name="sync_v2_error_got_it">Got It</string>
+    <string name="sync_v2_already_paired_title">Already synced.</string>
+    <string name="sync_v2_already_paired_message">These devices are already connected to Sync &amp; Backup.</string>
+</resources>

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/AppSyncDeviceIdsTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/AppSyncDeviceIdsTest.kt
@@ -112,7 +112,6 @@ class AppSyncDeviceIdsTest {
             override var secretKey: String? = "secretKey"
             override var credentialId: String? = null
             override var scopedPassword: ScopedPassword? = null
-            override var protectedKeysJson: String? = null
             override fun isEncryptionSupported() = true
 
             override fun isSignedInFlow() = emptyFlow<Boolean>()
@@ -147,7 +146,6 @@ class AppSyncDeviceIdsTest {
             override var secretKey: String? = null
             override var credentialId: String? = null
             override var scopedPassword: ScopedPassword? = null
-            override var protectedKeysJson: String? = null
             override fun isEncryptionSupported() = true
 
             override fun isSignedInFlow() = emptyFlow<Boolean>()

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
@@ -1167,7 +1167,6 @@ class AppSyncAccountRepositoryTest {
 
         assertEquals(Success(true), result)
         verify(syncStore, times(0)).credentialId = any()
-        verify(syncStore, times(0)).protectedKeysJson = any()
     }
 
     @Test
@@ -1202,7 +1201,6 @@ class AppSyncAccountRepositoryTest {
         assertEquals(Success(true), result)
         verify(syncStore).credentialId = "ddg"
         verify(syncStore).scopedPassword = ScopedPassword("/+//")
-        verify(syncStore).protectedKeysJson = any()
     }
 
     @Test

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ProtectedKeyManagerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ProtectedKeyManagerTest.kt
@@ -91,23 +91,76 @@ class ProtectedKeyManagerTest {
         whenever(syncJweCrypto.generateRsaKeyPair()).thenReturn(RsaKeyPair("pubKey", "cHJpdktleQ"))
         whenever(syncJweCrypto.extractJwkComponents(anyString())).thenReturn("modulus" to "AQAB")
         whenever(nativeLib.encryptData(any<ByteArray>(), eq(secretKey))).thenReturn(EncryptBytesResult(0, "encrypted".toByteArray()))
-        whenever(syncApi.setProtectedKeyIfAbsent(eq(token), eq("ai_chats"), any())).thenReturn(Success(true))
+        // Happy path: server's response contains our entry (we wrote it).
+        val serverKey = ProtectedKeyEntry(
+            kid = "server-kid",
+            purpose = "ai_chats",
+            encryptedWith = "ddg",
+            encryptedPrivateKey = "encrypted",
+            publicKey = RsaJwk(n = "modulus", e = "AQAB"),
+        )
+        whenever(syncApi.setProtectedKeyIfAbsent(eq(token), eq("ai_chats"), any())).thenReturn(Success(listOf(serverKey)))
 
         val result = manager.create("ai_chats")
 
         assertTrue(result is Success)
-        // create() returns the created entry, not a bare boolean.
-        assertEquals("ai_chats", (result as Success).data.purpose)
-        assertEquals("ddg", result.data.encryptedWith)
+        // create() returns the server's authoritative entry, not the local one.
+        assertEquals(serverKey, (result as Success).data)
         verify(syncApi).setProtectedKeyIfAbsent(
             eq(token),
             eq("ai_chats"),
             check { sent ->
-                assertEquals("ai_chats", sent.purpose)
-                assertEquals("ddg", sent.encryptedWith)
-                assertEquals(RsaJwk(n = "modulus", e = "AQAB"), sent.publicKey)
+                assertEquals(1, sent.size)
+                val first = sent.first()
+                assertEquals("ai_chats", first.purpose)
+                assertEquals("ddg", first.encryptedWith)
+                assertEquals(RsaJwk(n = "modulus", e = "AQAB"), first.publicKey)
             },
         )
+    }
+
+    @Test
+    fun whenSetProtectedKeyIfAbsentReturnsExistingServerEntryThenCreateReturnsServerEntry() {
+        // Race-loser: server returns a different kid for the same (purpose, encrypted_with).
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+        whenever(syncStore.secretKey).thenReturn(secretKey)
+        whenever(nativeLib.prepareForLogin(primaryKey)).thenReturn(validLoginKeys)
+        whenever(syncJweCrypto.generateRsaKeyPair()).thenReturn(RsaKeyPair("pubKey", "cHJpdktleQ"))
+        whenever(syncJweCrypto.extractJwkComponents(anyString())).thenReturn("modulus" to "AQAB")
+        whenever(nativeLib.encryptData(any<ByteArray>(), eq(secretKey))).thenReturn(EncryptBytesResult(0, "encrypted".toByteArray()))
+        val serverKey = ProtectedKeyEntry(
+            kid = "kid-from-server",
+            purpose = "ai_chats",
+            encryptedWith = "ddg",
+            encryptedPrivateKey = "server-jwe",
+            publicKey = RsaJwk(n = "server-modulus", e = "AQAB"),
+        )
+        whenever(syncApi.setProtectedKeyIfAbsent(eq(token), eq("ai_chats"), any())).thenReturn(Success(listOf(serverKey)))
+
+        val result = manager.create("ai_chats")
+
+        assertTrue(result is Success)
+        assertEquals(serverKey, (result as Success).data)
+    }
+
+    @Test
+    fun whenServerResponseMissingPurposeEntryThenError() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+        whenever(syncStore.secretKey).thenReturn(secretKey)
+        whenever(nativeLib.prepareForLogin(primaryKey)).thenReturn(validLoginKeys)
+        whenever(syncJweCrypto.generateRsaKeyPair()).thenReturn(RsaKeyPair("pubKey", "cHJpdktleQ"))
+        whenever(syncJweCrypto.extractJwkComponents(anyString())).thenReturn("modulus" to "AQAB")
+        whenever(nativeLib.encryptData(any<ByteArray>(), eq(secretKey))).thenReturn(EncryptBytesResult(0, "encrypted".toByteArray()))
+        // Server returns a list that doesn't include an entry for our (purpose, ddg) slot.
+        whenever(syncApi.setProtectedKeyIfAbsent(eq(token), eq("ai_chats"), any())).thenReturn(Success(emptyList()))
+
+        val result = manager.create("ai_chats")
+
+        assertTrue(result is Error)
     }
 
     @Test

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
@@ -1,0 +1,1177 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.sync.impl.AccountErrorCodes.NEGOTIATION_ABORTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.NO_RECOVERY_CODE
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_UNAVAILABLE
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
+import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
+import com.duckduckgo.sync.impl.exchange.v2.PairingRole
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
+import org.json.JSONObject
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class RealSyncCodeDispatcherTest {
+
+    private val syncFeature: SyncFeature = mock()
+    private val canUseV2: Toggle = mock()
+    private val syncAccountRepository: SyncAccountRepository = mock()
+    private val qrCode: ExchangeV2QrCode = mock()
+
+    private val runnerEventsFlow = MutableSharedFlow<com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event>(replay = 0)
+    private val runner: ExchangeV2Runner = mock<ExchangeV2Runner>().also {
+        whenever(it.events).thenReturn(runnerEventsFlow)
+        whenever(it.eventsSince(any())).thenAnswer { invocation ->
+            val sinceMs = invocation.getArgument<Long>(0)
+            runnerEventsFlow.filter { event -> event.timestampMs >= sinceMs }
+        }
+    }
+
+    private val dispatcher = RealSyncCodeDispatcher(
+        syncFeature = syncFeature,
+        syncAccountRepository = syncAccountRepository,
+        qrCode = qrCode,
+        runner = runner,
+    )
+
+    private fun setV2(enabled: Boolean) {
+        whenever(syncFeature.canUseV2ConnectFlow()).thenReturn(canUseV2)
+        whenever(canUseV2.isEnabled()).thenReturn(enabled)
+    }
+
+    @Test fun `FF off - returns Legacy with whatever parseSyncAuthCode returned, and never touches qrCode parse`() {
+        setV2(false)
+        val expectedAuthCode = SyncAuthCode.Recovery(RecoveryCode(primaryKey = "pk", userId = "u"))
+        whenever(syncAccountRepository.parseSyncAuthCode("the-code")).thenReturn(expectedAuthCode)
+
+        val decision = dispatcher.route("the-code") as RouteDecision.Legacy
+
+        assertSame(expectedAuthCode, decision.authCode)
+        verify(qrCode, never()).parse(any())
+    }
+
+    @Test fun `FF off - v1 Connect codes return Legacy(Connect) unchanged`() {
+        setV2(false)
+        val connect = SyncAuthCode.Connect(mock())
+        whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(connect)
+
+        val decision = dispatcher.route("connect-shape-code") as RouteDecision.Legacy
+
+        assertSame(connect, decision.authCode)
+    }
+
+    @Test fun `FF off - v1 Exchange codes return Legacy(Exchange) unchanged`() {
+        setV2(false)
+        val exchange = SyncAuthCode.Exchange(mock())
+        whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(exchange)
+
+        val decision = dispatcher.route("exchange-shape-code") as RouteDecision.Legacy
+
+        assertSame(exchange, decision.authCode)
+    }
+
+    @Test fun `FF off - Unknown codes still bubble back as Legacy(Unknown)`() {
+        setV2(false)
+        val unknown = SyncAuthCode.Unknown("garbage")
+        whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(unknown)
+
+        val decision = dispatcher.route("garbage") as RouteDecision.Legacy
+
+        assertSame(unknown, decision.authCode)
+    }
+
+    @Test fun `FF off - even a v2-shaped code is routed via legacy parseSyncAuthCode (no v2 parser touched)`() {
+        setV2(false)
+        whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(SyncAuthCode.Unknown("v2-shaped-input"))
+
+        dispatcher.route("https://duckduckgo.com/sync/pairing/#&code2=anything")
+
+        verify(qrCode, never()).parse(any())
+        verify(syncAccountRepository).parseSyncAuthCode("https://duckduckgo.com/sync/pairing/#&code2=anything")
+    }
+
+    @Test fun `FF on but v2 parser returns LinkingV1 - falls back to legacy stack`() {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.LinkingV1)
+        val connect = SyncAuthCode.Connect(mock())
+        whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(connect)
+
+        val decision = dispatcher.route("v1-code") as RouteDecision.Legacy
+
+        assertSame(connect, decision.authCode)
+    }
+
+    @Test fun `FF on but v2 parser returns Unknown - falls back to legacy stack`() {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.Unknown)
+        val recovery = SyncAuthCode.Recovery(RecoveryCode(primaryKey = "pk", userId = "u"))
+        whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(recovery)
+
+        val decision = dispatcher.route("recovery-code") as RouteDecision.Legacy
+
+        assertSame(recovery, decision.authCode)
+    }
+
+    @Test fun `FF on, v2 LinkingV2 - returns V2InProgress and does NOT call parseSyncAuthCode`() {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+
+        val decision = dispatcher.route("v2-link-url")
+
+        assertTrue("expected V2InProgress, got $decision", decision is RouteDecision.V2InProgress)
+        assertEquals(SyncCodeType.LINKING, (decision as RouteDecision.V2InProgress).codeType)
+        verify(syncAccountRepository, never()).parseSyncAuthCode(any())
+    }
+
+    @Test fun `isV2ExchangeUnderway is false at Bootstrapped or no session, true once exchanging`() {
+        whenever(runner.currentState).thenReturn(null)
+        assertFalse(dispatcher.isV2ExchangeUnderway())
+        whenever(runner.currentState).thenReturn(ExchangeV2State.Bootstrapped)
+        assertFalse(dispatcher.isV2ExchangeUnderway())
+        whenever(runner.currentState).thenReturn(ExchangeV2State.Negotiating)
+        assertTrue(dispatcher.isV2ExchangeUnderway())
+        whenever(runner.currentState).thenReturn(ExchangeV2State.Joiner.Waiting)
+        assertTrue(dispatcher.isV2ExchangeUnderway())
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=ddg - flow emits LoggedIn after processCode succeeds`() = runTest {
+        setV2(true)
+        val rawJson = JSONObject().apply {
+            put("user_id", "u-1")
+            put("secret", "s-1")
+            put("cid", "ddg")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
+
+        val decision = dispatcher.route("any") as RouteDecision.V2InProgress
+        assertEquals(SyncCodeType.RECOVERY, decision.codeType)
+        val outcomes = decision.outcomes.toList()
+
+        assertEquals(1, outcomes.size)
+        assertEquals(DispatchOutcome.LoggedIn(SetupPath.RECOVERY), outcomes.single())
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=ddg - base64url secret is normalised to standard base64 for v1 login`() = runTest {
+        // Spec 1214802412121967: the v2 wire `secret` is base64url; v1 login decodes as standard base64.
+        setV2(true)
+        val base64urlSecret = "rUzlGqLLlbonAC_zIeh1nrCmuDsDAn6UooUUDz-6x3o"
+        val expectedBytes = java.util.Base64.getUrlDecoder().decode(base64urlSecret)
+        val rawJson = JSONObject().apply {
+            put("user_id", "u-1")
+            put("secret", base64urlSecret)
+            put("cid", "ddg")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
+
+        (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.toList()
+
+        val captor = org.mockito.kotlin.argumentCaptor<SyncAuthCode>()
+        verify(syncAccountRepository).processCode(captor.capture(), anyOrNull())
+        val primaryKey = (captor.firstValue as SyncAuthCode.Recovery).b64Code.primaryKey
+        assertFalse("primaryKey must be standard base64 (no '-'): $primaryKey", primaryKey.contains('-'))
+        assertFalse("primaryKey must be standard base64 (no '_'): $primaryKey", primaryKey.contains('_'))
+        assertArrayEquals(expectedBytes, java.util.Base64.getDecoder().decode(primaryKey))
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=ddg with missing user_id - emits Failed without calling processCode`() = runTest {
+        setV2(true)
+        val rawJson = JSONObject().apply {
+            put("secret", "s-1")
+            put("cid", "ddg")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+
+        val decision = dispatcher.route("any") as RouteDecision.V2InProgress
+        val outcome = decision.outcomes.first()
+
+        assertTrue("expected Failed, got $outcome", outcome is DispatchOutcome.Failed)
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=3party - flow calls joinAccountFromThirdPartyRecoveryCode`() = runTest {
+        setV2(true)
+        val rawJson = JSONObject().apply {
+            put("user_id", "u-3p")
+            put("secret", "s-3p")
+            put("cid", "3party")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(any())).thenReturn(Result.Success(true))
+
+        val decision = dispatcher.route("any") as RouteDecision.V2InProgress
+        val outcomes = decision.outcomes.toList()
+
+        assertEquals(DispatchOutcome.LoggedIn(SetupPath.RECOVERY), outcomes.single())
+        verify(syncAccountRepository).joinAccountFromThirdPartyRecoveryCode(any())
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=3party - re-encoded code is canonical JSON without escaped slashes`() = runTest {
+        setV2(true)
+        val secretWithSlashes = "apZ+7PAe89rDhuG4DRyi/M3zU2/D5DZNdRsR3RM6Ujw="
+        val rawJson = JSONObject().apply {
+            put("user_id", "u-3p")
+            put("secret", secretWithSlashes)
+            put("cid", "3party")
+            put("v", "2.0")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(any())).thenReturn(Result.Success(true))
+
+        (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.toList()
+
+        val captor = org.mockito.kotlin.argumentCaptor<String>()
+        verify(syncAccountRepository).joinAccountFromThirdPartyRecoveryCode(captor.capture())
+        val decodedJson = String(java.util.Base64.getUrlDecoder().decode(captor.firstValue), Charsets.UTF_8)
+        assertFalse("re-wrapped 3party JSON must not contain escaped slashes (\\/): $decodedJson", decodedJson.contains("\\/"))
+        val recovery = JSONObject(decodedJson).getJSONObject("recovery")
+        assertEquals(secretWithSlashes, recovery.getString("secret"))
+        assertEquals("u-3p", recovery.getString("user_id"))
+        assertEquals("3party", recovery.getString("cid"))
+        assertEquals("2.0", recovery.getString("v"))
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=ddg - ALREADY_SIGNED_IN triggers logoutAndJoinNewAccount and emits LoggedIn`() = runTest {
+        setV2(true)
+        val base64urlSecret = "rUzlGqLLlbonAC_zIeh1nrCmuDsDAn6UooUUDz-6x3o"
+        val rawJson = JSONObject().apply {
+            put("user_id", "u-other")
+            put("secret", base64urlSecret)
+            put("cid", "ddg")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(
+            Result.Error(
+                code = com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN.code,
+                reason = "Already signed in",
+            ),
+        )
+        whenever(syncAccountRepository.logoutAndJoinNewAccount(any())).thenReturn(Result.Success(true))
+
+        val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
+
+        assertEquals(DispatchOutcome.LoggedIn(SetupPath.RECOVERY), outcome)
+
+        val captor = org.mockito.kotlin.argumentCaptor<String>()
+        verify(syncAccountRepository).logoutAndJoinNewAccount(captor.capture())
+        val decoded = java.util.Base64.getUrlDecoder().decode(captor.firstValue)
+        val recovery = JSONObject(String(decoded)).getJSONObject("recovery")
+        assertArrayEquals(
+            java.util.Base64.getUrlDecoder().decode(base64urlSecret),
+            java.util.Base64.getDecoder().decode(recovery.getString("primary_key")),
+        )
+        assertEquals("u-other", recovery.getString("user_id"))
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=ddg - account-switch code is canonical v1 JSON without escaped slashes`() = runTest {
+        setV2(true)
+        val secretWithSlashes = "apZ+7PAe89rDhuG4DRyi/M3zU2/D5DZNdRsR3RM6Ujw="
+        val rawJson = JSONObject().apply {
+            put("user_id", "u-other")
+            put("secret", secretWithSlashes)
+            put("cid", "ddg")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(
+            Result.Error(
+                code = com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN.code,
+                reason = "Already signed in",
+            ),
+        )
+        whenever(syncAccountRepository.logoutAndJoinNewAccount(any())).thenReturn(Result.Success(true))
+
+        (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
+
+        val captor = org.mockito.kotlin.argumentCaptor<String>()
+        verify(syncAccountRepository).logoutAndJoinNewAccount(captor.capture())
+        val decodedJson = String(java.util.Base64.getUrlDecoder().decode(captor.firstValue), Charsets.UTF_8)
+        assertFalse("v1 account-switch JSON must not contain escaped slashes (\\/): $decodedJson", decodedJson.contains("\\/"))
+        val recovery = JSONObject(decodedJson).getJSONObject("recovery")
+        assertEquals(secretWithSlashes, recovery.getString("primary_key"))
+        assertEquals("u-other", recovery.getString("user_id"))
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=ddg - ALREADY_SIGNED_IN then logoutAndJoinNewAccount failure surfaces as Failed`() = runTest {
+        setV2(true)
+        val rawJson = JSONObject().apply {
+            put("user_id", "u-other")
+            put("secret", "s-other")
+            put("cid", "ddg")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(
+            Result.Error(
+                code = com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN.code,
+                reason = "Already signed in",
+            ),
+        )
+        whenever(syncAccountRepository.logoutAndJoinNewAccount(any())).thenReturn(
+            Result.Error(code = com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED.code, reason = "Login failed"),
+        )
+
+        val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
+
+        assertEquals(
+            DispatchOutcome.Failed("Login failed", com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED.code, path = SetupPath.RECOVERY),
+            outcome,
+        )
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=3party - ALREADY_SIGNED_IN does NOT trigger transparent switch (fails as Failed)`() = runTest {
+        setV2(true)
+        val rawJson = JSONObject().apply {
+            put("user_id", "u-3p")
+            put("secret", "s-3p")
+            put("cid", "3party")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(any())).thenReturn(
+            Result.Error(
+                code = com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN.code,
+                reason = "Already signed in",
+            ),
+        )
+
+        val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
+
+        assertEquals(
+            DispatchOutcome.Failed(
+                "Already signed in",
+                com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN.code,
+                path = SetupPath.RECOVERY,
+            ),
+            outcome,
+        )
+        verify(syncAccountRepository, never()).logoutAndJoinNewAccount(any())
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=ddg - non-ALREADY_SIGNED_IN error still becomes Failed`() = runTest {
+        setV2(true)
+        val rawJson = JSONObject().apply {
+            put("user_id", "u")
+            put("secret", "AQID") // valid base64 so decoding succeeds and processCode is reached
+            put("cid", "ddg")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(
+            Result.Error(code = -1, reason = "Some other error"),
+        )
+
+        val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
+
+        assertEquals(DispatchOutcome.Failed("Some other error", path = SetupPath.RECOVERY), outcome)
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=3party - repository error becomes Failed with reason preserved`() = runTest {
+        setV2(true)
+        val rawJson = JSONObject().apply {
+            put("user_id", "u-3p")
+            put("secret", "s-3p")
+            put("cid", "3party")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(any())).thenReturn(
+            Result.Error(reason = "BE rejected"),
+        )
+
+        val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
+
+        assertEquals(DispatchOutcome.Failed("BE rejected", path = SetupPath.RECOVERY), outcome)
+    }
+
+    @Test fun `FF on, v2 RecoveryCode with unknown cid - emits Failed with the cid in the reason`() = runTest {
+        setV2(true)
+        val rawJson = JSONObject().apply {
+            put("user_id", "u")
+            put("secret", "s")
+            put("cid", "future-credential")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+
+        val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
+
+        assertTrue("expected Failed, got $outcome", outcome is DispatchOutcome.Failed)
+        assertTrue((outcome as DispatchOutcome.Failed).reason.contains("future-credential"))
+    }
+
+    @Test fun `Legacy path - dispatcher never invokes processCode (caller owns that)`() {
+        setV2(false)
+        whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(SyncAuthCode.Recovery(mock()))
+
+        dispatcher.route("any")
+
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
+        verify(syncAccountRepository, never()).joinAccountFromThirdPartyRecoveryCode(any())
+    }
+
+    @Test fun `Legacy path - dispatcher does not start the v2 runner`() {
+        setV2(false)
+        whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(SyncAuthCode.Unknown("x"))
+
+        dispatcher.route("any")
+
+        verify(runner, never()).startScan(any())
+    }
+
+    @Test fun `FF on, LinkingV2 - ignores stale terminal events from prior sessions in the replay cache`() = runTest {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        val staleJoinerDone = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event.Transition(
+            timestampMs = 1L,
+            from = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.Joiner.Waiting,
+            to = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.Joiner.Done,
+            trigger = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse(
+                rawJson = "{}",
+                recoveryCode = "stale-code-from-prior-session",
+            ),
+            localTrigger = null,
+        )
+        val staleFlow = MutableSharedFlow<com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event>(replay = 10)
+        staleFlow.tryEmit(staleJoinerDone)
+        whenever(runner.events).thenReturn(staleFlow)
+        whenever(runner.eventsSince(any())).thenAnswer { invocation ->
+            val sinceMs = invocation.getArgument<Long>(0)
+            staleFlow.filter { event -> event.timestampMs >= sinceMs }
+        }
+
+        val decision = dispatcher.route("v2-url") as RouteDecision.V2InProgress
+
+        val outcome = kotlinx.coroutines.withTimeoutOrNull(100) { decision.outcomes.first() }
+        assertEquals(null, outcome)
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
+    }
+
+    @Test fun `FF on, LinkingV2 - runner_startScan deferred until Flow is collected (cold)`() = runTest {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+
+        val decision = dispatcher.route("v2-url") as RouteDecision.V2InProgress
+
+        verify(runner, never()).startScan(any())
+
+        kotlinx.coroutines.withTimeoutOrNull(50) { decision.outcomes.first() }
+        verify(runner).startScan(eq("v2-url"))
+    }
+
+    @Test fun `FF on, LinkingV2 exchange - base64url recovery secret is normalised to standard base64 for v1 login`() = runTest {
+        // Spec 1214802412121967: the v2 wire `secret` is base64url; v1 login decodes as standard base64.
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
+        val base64urlSecret = "rUzlGqLLlbonAC_zIeh1nrCmuDsDAn6UooUUDz-6x3o"
+        val payloadJson = JSONObject().apply {
+            put(
+                "recovery",
+                JSONObject().apply {
+                    put("user_id", "u-1")
+                    put("secret", base64urlSecret)
+                    put("cid", "ddg")
+                    put("v", "2.0")
+                },
+            )
+        }.toString()
+        val recoveryCodeB64 = java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(payloadJson.toByteArray())
+
+        val flow = (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { flow.take(1).toList() }
+        runnerEventsFlow.emit(
+            ExchangeV2Event.Transition(
+                timestampMs = System.currentTimeMillis(),
+                from = ExchangeV2State.Joiner.Waiting,
+                to = ExchangeV2State.Joiner.Done,
+                trigger = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse(
+                    rawJson = payloadJson,
+                    recoveryCode = recoveryCodeB64,
+                ),
+                localTrigger = null,
+            ),
+        )
+        job.join()
+
+        val captor = org.mockito.kotlin.argumentCaptor<SyncAuthCode>()
+        verify(syncAccountRepository).processCode(captor.capture(), anyOrNull())
+        val primaryKey = (captor.firstValue as SyncAuthCode.Recovery).b64Code.primaryKey
+        assertFalse("primaryKey must be standard base64 (no '-'): $primaryKey", primaryKey.contains('-'))
+        assertFalse("primaryKey must be standard base64 (no '_'): $primaryKey", primaryKey.contains('_'))
+        assertArrayEquals(
+            java.util.Base64.getUrlDecoder().decode(base64urlSecret),
+            java.util.Base64.getDecoder().decode(primaryKey),
+        )
+    }
+
+    private fun transition(
+        from: ExchangeV2State,
+        to: ExchangeV2State,
+        trigger: ExchangeV2Message? = null,
+        localTrigger: LocalTrigger? = null,
+        timestampMs: Long = System.currentTimeMillis(),
+    ): ExchangeV2Event.Transition = ExchangeV2Event.Transition(
+        timestampMs = timestampMs,
+        from = from,
+        to = to,
+        trigger = trigger,
+        localTrigger = localTrigger,
+    )
+
+    private fun sessionStarted(linkingCode: String?, timestampMs: Long = System.currentTimeMillis()) =
+        ExchangeV2Event.SessionStarted(
+            timestampMs = timestampMs,
+            pairingRole = PairingRole.Presenter,
+            ownChannelId = "own-channel",
+            linkingCode = linkingCode,
+        )
+
+    @Test fun `presentV2 emits LinkingCodeReady when runner emits SessionStarted with a linkingCode`() = runTest {
+        val flow = dispatcher.presentV2()
+        val outcomes = mutableListOf<DispatchOutcome>()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+            flow.take(1).collect { outcomes += it }
+        }
+        runnerEventsFlow.emit(sessionStarted(linkingCode = "https://duckduckgo.com/sync/pairing?code2=abc"))
+        job.join()
+
+        assertEquals(1, outcomes.size)
+        assertEquals(
+            DispatchOutcome.LinkingCodeReady("https://duckduckgo.com/sync/pairing?code2=abc"),
+            outcomes.single(),
+        )
+    }
+
+    @Test fun `presentV2 ignores SessionStarted with null linkingCode (Scanner side leakage protection)`() = runTest {
+        val outcomes = mutableListOf<DispatchOutcome>()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().take(1).collect { outcomes += it } }
+        runnerEventsFlow.emit(sessionStarted(linkingCode = null))
+        runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Done))
+        job.join()
+
+        assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST), outcomes.single())
+    }
+
+    @Test fun `presentV2 emits HostConfirmationRequested with peerName when runner reaches Host_Confirming`() = runTest {
+        whenever(runner.peerName).thenReturn("Peer Phone")
+        val outcomes = mutableListOf<DispatchOutcome>()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().take(1).collect { outcomes += it } }
+        runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Confirming))
+        job.join()
+
+        assertEquals(DispatchOutcome.HostConfirmationRequested(peerName = "Peer Phone"), outcomes.single())
+    }
+
+    @Test fun `presentV2 carries third-party peer kind on HostConfirmationRequested`() = runTest {
+        whenever(runner.peerName).thenReturn("Peer Phone")
+        whenever(runner.peerKind).thenReturn("3party")
+        val outcomes = mutableListOf<DispatchOutcome>()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().take(1).collect { outcomes += it } }
+        runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Confirming))
+        job.join()
+
+        assertEquals(
+            DispatchOutcome.HostConfirmationRequested(peerName = "Peer Phone", peerKind = PeerKind.THIRD_PARTY),
+            outcomes.single(),
+        )
+    }
+
+    @Test fun `presentV2 carries ddg peer kind on JoinerConfirmationRequested`() = runTest {
+        whenever(runner.peerName).thenReturn("Peer Phone")
+        whenever(runner.peerKind).thenReturn("ddg")
+        val outcomes = mutableListOf<DispatchOutcome>()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().take(1).collect { outcomes += it } }
+        runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Joiner.Confirming))
+        job.join()
+
+        assertEquals(
+            DispatchOutcome.JoinerConfirmationRequested(peerName = "Peer Phone", peerKind = PeerKind.DDG),
+            outcomes.single(),
+        )
+    }
+
+    @Test fun `presentV2 emits LoggedIn with Host role and peer kind when runner reaches Host_Done`() = runTest {
+        whenever(runner.peerKind).thenReturn("3party")
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+                dispatcher.presentV2().first { it is DispatchOutcome.LoggedIn || it is DispatchOutcome.Failed }
+            }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Host.Sending, to = ExchangeV2State.Host.Done))
+            job.await()
+        }
+        assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST, PeerKind.THIRD_PARTY), outcome)
+    }
+
+    @Test fun `presentV2 maps a version-too-new SessionError to UpgradeRequired`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(
+                ExchangeV2Event.SessionError(
+                    timestampMs = System.currentTimeMillis(),
+                    message = "Peer requires protocol v3; please update this app",
+                ),
+            )
+            job.await()
+        }
+        assertEquals(DispatchOutcome.UpgradeRequired(codeMajor = 3, path = SetupPath.PAIRING), outcome)
+    }
+
+    @Test fun `route LinkingV2 maps a version-too-new SessionError to UpgradeRequired`() = runTest {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        val outcome = withTimeoutOrNull(1000) {
+            val flow = (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { flow.first() }
+            runnerEventsFlow.emit(
+                ExchangeV2Event.SessionError(
+                    timestampMs = System.currentTimeMillis(),
+                    message = "Peer requires protocol v3; please update this app",
+                ),
+            )
+            job.await()
+        }
+        assertEquals(DispatchOutcome.UpgradeRequired(codeMajor = 3, path = SetupPath.PAIRING), outcome)
+    }
+
+    @Test fun `route LinkingV2 - Host_Aborted with UserDeniedHost maps to Failed PAIRING_CANCELLED`() = runTest {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        val outcome = withTimeoutOrNull(1000) {
+            val flow = (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { flow.first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Host.Confirming,
+                    to = ExchangeV2State.Host.Aborted,
+                    localTrigger = LocalTrigger.UserDeniedHost,
+                ),
+            )
+            job.await()
+        }
+        assertEquals(
+            DispatchOutcome.Failed("user_denied", PAIRING_CANCELLED.code, path = SetupPath.PAIRING, myRole = SetupRole.HOST),
+            outcome,
+        )
+    }
+
+    @Test fun `route LinkingV2 - Host_Aborted with HostUnavailable maps to Failed PAIRING_UNAVAILABLE`() = runTest {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        val outcome = withTimeoutOrNull(1000) {
+            val flow = (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { flow.first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Host.Sending,
+                    to = ExchangeV2State.Host.Aborted,
+                    localTrigger = LocalTrigger.HostUnavailable,
+                ),
+            )
+            job.await()
+        }
+        assertEquals(
+            DispatchOutcome.Failed("host_unavailable", PAIRING_UNAVAILABLE.code, path = SetupPath.PAIRING, myRole = SetupRole.HOST),
+            outcome,
+        )
+    }
+
+    @Test fun `presentV2 emits Failed user_denied when Host_Aborted carries UserDeniedHost trigger`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Host.Confirming,
+                    to = ExchangeV2State.Host.Aborted,
+                    localTrigger = LocalTrigger.UserDeniedHost,
+                ),
+            )
+            job.await()
+        }
+        assertEquals(
+            DispatchOutcome.Failed("user_denied", PAIRING_CANCELLED.code, path = SetupPath.PAIRING, myRole = SetupRole.HOST),
+            outcome,
+        )
+    }
+
+    @Test fun `presentV2 emits Failed host_unavailable when Host_Aborted carries HostUnavailable trigger`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Host.Sending,
+                    to = ExchangeV2State.Host.Aborted,
+                    localTrigger = LocalTrigger.HostUnavailable,
+                ),
+            )
+            job.await()
+        }
+        assertEquals(
+            DispatchOutcome.Failed("host_unavailable", PAIRING_UNAVAILABLE.code, path = SetupPath.PAIRING, myRole = SetupRole.HOST),
+            outcome,
+        )
+    }
+
+    @Test fun `presentV2 emits AlreadyConnected when runner reaches SameAccountAbort`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.SameAccountAbort))
+            job.await()
+        }
+        assertEquals(DispatchOutcome.AlreadyConnected, outcome)
+    }
+
+    @Test fun `presentV2 emits Failed when runner emits SessionError`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(
+                ExchangeV2Event.SessionError(timestampMs = System.currentTimeMillis(), message = "channel 5xx"),
+            )
+            job.await()
+        }
+        assertEquals(DispatchOutcome.Failed("channel 5xx", PAIRING_FAILED.code, path = SetupPath.PAIRING), outcome)
+    }
+
+    @Test fun `presentV2 emits Failed when Joiner_Done arrives without a recovery code`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+                dispatcher.presentV2().first { it !is DispatchOutcome.LinkingCodeReady }
+            }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Joiner.Waiting, to = ExchangeV2State.Joiner.Done))
+            job.await()
+        }
+        assertEquals(
+            DispatchOutcome.Failed(
+                "Pairing completed without a recovery code",
+                NO_RECOVERY_CODE.code,
+                path = SetupPath.PAIRING,
+                myRole = SetupRole.JOINER,
+            ),
+            outcome,
+        )
+    }
+
+    @Test fun `presentV2 emits LoggedIn when Joiner_Done carries a cid=ddg recovery code`() = runTest {
+        setV2(true)
+        val recoveryJson = JSONObject().apply {
+            put(
+                "recovery",
+                JSONObject().apply {
+                    put("user_id", "u-1")
+                    put("secret", "s-1")
+                    put("cid", "ddg")
+                    put("v", "2.0")
+                },
+            )
+        }.toString()
+        val b64 = android.util.Base64.encodeToString(
+            recoveryJson.toByteArray(Charsets.UTF_8),
+            android.util.Base64.URL_SAFE or android.util.Base64.NO_PADDING or android.util.Base64.NO_WRAP,
+        )
+        val responseMessage = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse(
+            rawJson = "{}",
+            recoveryCode = b64,
+        )
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
+        whenever(runner.peerKind).thenReturn("ddg")
+
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+                dispatcher.presentV2().first { it !is DispatchOutcome.LinkingCodeReady }
+            }
+            runnerEventsFlow.emit(
+                ExchangeV2Event.Transition(
+                    timestampMs = System.currentTimeMillis(),
+                    from = ExchangeV2State.Joiner.Waiting,
+                    to = ExchangeV2State.Joiner.Done,
+                    trigger = responseMessage,
+                    localTrigger = null,
+                ),
+            )
+            job.await()
+        }
+        assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.JOINER, PeerKind.DDG), outcome)
+        verify(syncAccountRepository).processCode(any(), anyOrNull())
+        verify(syncAccountRepository, never()).joinAccountFromThirdPartyRecoveryCode(any())
+    }
+
+    @Test fun `presentV2 emits LoggedIn via 3party upgrade when Joiner_Done carries a cid=3party recovery code`() = runTest {
+        setV2(true)
+        val recoveryJson = JSONObject().apply {
+            put(
+                "recovery",
+                JSONObject().apply {
+                    put("user_id", "u-3p")
+                    put("secret", "s-3p")
+                    put("cid", "3party")
+                    put("v", "2.0")
+                },
+            )
+        }.toString()
+        val b64 = android.util.Base64.encodeToString(
+            recoveryJson.toByteArray(Charsets.UTF_8),
+            android.util.Base64.URL_SAFE or android.util.Base64.NO_PADDING or android.util.Base64.NO_WRAP,
+        )
+        val responseMessage = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse(
+            rawJson = "{}",
+            recoveryCode = b64,
+        )
+        whenever(syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(any())).thenReturn(Result.Success(true))
+
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+                dispatcher.presentV2().first { it !is DispatchOutcome.LinkingCodeReady }
+            }
+            runnerEventsFlow.emit(
+                ExchangeV2Event.Transition(
+                    timestampMs = System.currentTimeMillis(),
+                    from = ExchangeV2State.Joiner.Waiting,
+                    to = ExchangeV2State.Joiner.Done,
+                    trigger = responseMessage,
+                    localTrigger = null,
+                ),
+            )
+            job.await()
+        }
+        assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.JOINER), outcome)
+        verify(syncAccountRepository).joinAccountFromThirdPartyRecoveryCode(any())
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
+    }
+
+    @Test fun `presentV2 emits Failed with cancelled-on-this-device reason when Joiner reaches AbortedLocal`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedLocal,
+                    localTrigger = LocalTrigger.UserDeniedJoiner,
+                ),
+            )
+            job.await()
+        }
+        assertEquals(
+            DispatchOutcome.Failed(
+                "Pairing cancelled on this device",
+                PAIRING_CANCELLED.code,
+                path = SetupPath.PAIRING,
+                myRole = SetupRole.JOINER,
+            ),
+            outcome,
+        )
+    }
+
+    @Test fun `presentV2 calls runner_startPresent when Flow is collected`() = runTest {
+        val flow = dispatcher.presentV2()
+        verify(runner, never()).startPresent()
+
+        withTimeoutOrNull(50) { flow.first() }
+        verify(runner).startPresent()
+    }
+
+    @Test fun `presentV2 cancels runner when collecting coroutine is cancelled`() = runTest {
+        val flow = dispatcher.presentV2()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+            flow.collect { /* no-op */ }
+        }
+        verify(runner).startPresent()
+
+        job.cancel()
+        job.join()
+
+        verify(runner).cancel()
+    }
+
+    @Test fun `driveV2Linking cancels runner when collecting coroutine is cancelled`() = runTest {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult.LinkingV2(
+                channelId = "c",
+                publicKey = "k",
+                version = "2",
+            ),
+        )
+        val decision = dispatcher.route("v2-url") as RouteDecision.V2InProgress
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+            decision.outcomes.collect { /* no-op */ }
+        }
+        verify(runner).startScan(any())
+
+        job.cancel()
+        job.join()
+
+        verify(runner).cancel()
+    }
+
+    @Test fun `presentV2 terminates silently when another SessionStarted with different channel arrives`() = runTest {
+        val outcomes = mutableListOf<DispatchOutcome>()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+            dispatcher.presentV2().toList(outcomes)
+        }
+        runnerEventsFlow.emit(sessionStarted(linkingCode = "code-for-own-channel"))
+        runnerEventsFlow.emit(
+            ExchangeV2Event.SessionStarted(
+                timestampMs = System.currentTimeMillis(),
+                pairingRole = PairingRole.Scanner,
+                ownChannelId = "other-channel",
+                linkingCode = null,
+            ),
+        )
+        job.join()
+
+        assertEquals(1, outcomes.size)
+        assertEquals(DispatchOutcome.LinkingCodeReady("code-for-own-channel"), outcomes.single())
+    }
+
+    @Test fun `driveV2Linking terminates silently when another SessionStarted with different channel arrives`() = runTest {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult.LinkingV2(
+                channelId = "peer-channel",
+                publicKey = "k",
+                version = "2",
+            ),
+        )
+        val decision = dispatcher.route("v2-url") as RouteDecision.V2InProgress
+
+        val outcomes = mutableListOf<DispatchOutcome>()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+            decision.outcomes.toList(outcomes)
+        }
+        runnerEventsFlow.emit(
+            ExchangeV2Event.SessionStarted(
+                timestampMs = System.currentTimeMillis(),
+                pairingRole = PairingRole.Scanner,
+                ownChannelId = "scanner-own-channel",
+                linkingCode = null,
+            ),
+        )
+        runnerEventsFlow.emit(
+            ExchangeV2Event.SessionStarted(
+                timestampMs = System.currentTimeMillis(),
+                pairingRole = PairingRole.Presenter,
+                ownChannelId = "different-channel",
+                linkingCode = "code",
+            ),
+        )
+        job.join()
+
+        assertTrue("expected no outcomes, got $outcomes", outcomes.isEmpty())
+    }
+
+    @Test fun `presentV2 emits Failed when runner reaches Aborted (hello during negotiating)`() = runTest {
+        val outcomes = mutableListOf<DispatchOutcome>()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+            dispatcher.presentV2().take(1).collect { outcomes += it }
+        }
+        runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Aborted))
+        job.join()
+
+        assertTrue("expected Failed, got ${outcomes.single()}", outcomes.single() is DispatchOutcome.Failed)
+    }
+
+    @Test fun `linking flow emits Failed when runner reaches Aborted (hello during negotiating)`() = runTest {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        val decision = dispatcher.route("v2-url") as RouteDecision.V2InProgress
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+                decision.outcomes.first { it is DispatchOutcome.Failed }
+            }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Aborted))
+            job.await()
+        }
+        assertTrue("expected Failed, got $outcome", outcome is DispatchOutcome.Failed)
+    }
+
+    @Test fun `presentV2 filters out events from before session start`() = runTest {
+        val staleFlow = MutableSharedFlow<ExchangeV2Event>(replay = 10)
+        staleFlow.tryEmit(
+            ExchangeV2Event.Transition(
+                timestampMs = 1L,
+                from = ExchangeV2State.Host.Sending,
+                to = ExchangeV2State.Host.Done,
+                trigger = null,
+                localTrigger = null,
+            ),
+        )
+        whenever(runner.events).thenReturn(staleFlow)
+        whenever(runner.eventsSince(any())).thenAnswer { inv ->
+            val since = inv.getArgument<Long>(0)
+            staleFlow.filter { it.timestampMs >= since }
+        }
+
+        val outcome = withTimeoutOrNull(100) { dispatcher.presentV2().first() }
+        assertEquals(null, outcome)
+    }
+
+    private fun startLinking(): kotlinx.coroutines.flow.Flow<DispatchOutcome> {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        return (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
+    }
+
+    @Test fun `linking - AbortedByHost with RecoveryCodeDenied maps to Failed PAIRING_REJECTED`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                ),
+            )
+            job.await()
+        }
+        assertTrue("expected Failed, got $outcome", outcome is DispatchOutcome.Failed)
+        assertEquals(PAIRING_REJECTED.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `linking - AbortedByHost with RecoveryCodeUnavailable maps to Failed PAIRING_UNAVAILABLE`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.RecoveryCodeUnavailable(rawJson = "{}"),
+                ),
+            )
+            job.await()
+        }
+        assertEquals(PAIRING_UNAVAILABLE.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `linking - Joiner AbortedLocal maps to Failed PAIRING_CANCELLED`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Joiner.Confirming, to = ExchangeV2State.Joiner.AbortedLocal))
+            job.await()
+        }
+        assertEquals(PAIRING_CANCELLED.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `linking - Aborted maps to Failed NEGOTIATION_ABORTED`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Aborted))
+            job.await()
+        }
+        assertEquals(NEGOTIATION_ABORTED.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `linking - Joiner Done without recovery code maps to Failed NO_RECOVERY_CODE`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Joiner.Waiting, to = ExchangeV2State.Joiner.Done))
+            job.await()
+        }
+        assertEquals(NO_RECOVERY_CODE.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `linking - SessionError maps to Failed PAIRING_FAILED`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(ExchangeV2Event.SessionError(timestampMs = System.currentTimeMillis(), message = "channel 500"))
+            job.await()
+        }
+        assertEquals(PAIRING_FAILED.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `linking - Host Aborted maps to Failed NEGOTIATION_ABORTED`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Host.Confirming, to = ExchangeV2State.Host.Aborted))
+            job.await()
+        }
+        assertEquals(NEGOTIATION_ABORTED.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `present - AbortedByHost with RecoveryCodeDenied maps to Failed PAIRING_REJECTED`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                ),
+            )
+            job.await()
+        }
+        assertEquals(PAIRING_REJECTED.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `present - Host Aborted with no localTrigger maps to Failed NEGOTIATION_ABORTED`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Host.Confirming, to = ExchangeV2State.Host.Aborted))
+            job.await()
+        }
+        assertEquals(NEGOTIATION_ABORTED.code, (outcome as DispatchOutcome.Failed).code)
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2ChannelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2ChannelTest.kt
@@ -41,7 +41,6 @@ class RealExchangeV2ChannelTest {
     )
 
     @Test fun `poll stops without retrying when the relay returns a non-recoverable status`() = runTest {
-        // Second stub is only reached if the loop wrongly keeps polling past the 403.
         whenever(syncApi.pollExchangeMessages(any(), any())).thenReturn(
             Result.Error(code = 403, reason = "Forbidden"),
             Result.Error(code = 404, reason = "should not be reached"),

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2ChannelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2ChannelTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import com.duckduckgo.sync.impl.Result
+import com.duckduckgo.sync.impl.SyncApi
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class RealExchangeV2ChannelTest {
+
+    private val syncApi: SyncApi = mock()
+    private val envelope: ExchangeV2Envelope = mock()
+    private val messageParser: ExchangeV2MessageParser = mock()
+
+    private val channel = RealExchangeV2Channel(
+        syncApi = syncApi,
+        envelope = envelope,
+        messageParser = messageParser,
+    )
+
+    @Test fun `poll stops without retrying when the relay returns a non-recoverable status`() = runTest {
+        // 403 won't recover by re-polling the same channel, so the loop must stop immediately
+        // (like a 404) rather than spinning until the 5-min session deadline. The second stubbed
+        // response would only be consumed if the loop wrongly kept polling.
+        whenever(syncApi.pollExchangeMessages(any(), any())).thenReturn(
+            Result.Error(code = 403, reason = "Forbidden"),
+            Result.Error(code = 404, reason = "should not be reached"),
+        )
+
+        val received = channel.poll("own-channel", "own-priv").toList()
+
+        assertTrue(received.isEmpty())
+        verify(syncApi, times(1)).pollExchangeMessages(any(), any())
+    }
+
+    @Test fun `poll keeps polling after a transient status and ends on 404`() = runTest {
+        // 5xx is transient: the loop should retry on the next tick, then end normally on 404.
+        whenever(syncApi.pollExchangeMessages(any(), any())).thenReturn(
+            Result.Error(code = 500, reason = "Server error"),
+            Result.Error(code = 404, reason = "channel gone"),
+        )
+
+        val received = channel.poll("own-channel", "own-priv").toList()
+
+        assertTrue(received.isEmpty())
+        verify(syncApi, times(2)).pollExchangeMessages(any(), any())
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2ChannelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2ChannelTest.kt
@@ -41,9 +41,7 @@ class RealExchangeV2ChannelTest {
     )
 
     @Test fun `poll stops without retrying when the relay returns a non-recoverable status`() = runTest {
-        // 403 won't recover by re-polling the same channel, so the loop must stop immediately
-        // (like a 404) rather than spinning until the 5-min session deadline. The second stubbed
-        // response would only be consumed if the loop wrongly kept polling.
+        // Second stub is only reached if the loop wrongly keeps polling past the 403.
         whenever(syncApi.pollExchangeMessages(any(), any())).thenReturn(
             Result.Error(code = 403, reason = "Forbidden"),
             Result.Error(code = 404, reason = "should not be reached"),
@@ -56,7 +54,6 @@ class RealExchangeV2ChannelTest {
     }
 
     @Test fun `poll keeps polling after a transient status and ends on 404`() = runTest {
-        // 5xx is transient: the loop should retry on the next tick, then end normally on 404.
         whenever(syncApi.pollExchangeMessages(any(), any())).thenReturn(
             Result.Error(code = 500, reason = "Server error"),
             Result.Error(code = 404, reason = "channel gone"),

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2EnvelopeTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2EnvelopeTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import com.duckduckgo.sync.impl.ExchangeEnvelope
+import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class RealExchangeV2EnvelopeTest {
+
+    private val jweCrypto: SyncJweCrypto = mock()
+    private val envelope = RealExchangeV2Envelope(jweCrypto)
+
+    @Test fun `seal produces envelope with our version and JWE payload`() {
+        whenever(jweCrypto.jweEncryptRsaOaep(any(), any(), any())).thenReturn("jwe-bytes")
+
+        val result = envelope.seal(
+            messageJson = """{"type":"hello"}""",
+            peerPublicKeyBase64 = "peer-pub",
+            senderChannelId = "our-channel",
+        )
+
+        assertEquals(OUR_VERSION_STRING, result.version)
+        assertEquals("jwe-bytes", result.payload)
+        verify(jweCrypto).jweEncryptRsaOaep(
+            plaintext = """{"type":"hello"}""".toByteArray(Charsets.UTF_8),
+            recipientPublicKeyBase64 = "peer-pub",
+            kid = "our-channel",
+        )
+    }
+
+    @Test fun `open decrypts payload and returns plaintext when version matches`() {
+        whenever(jweCrypto.jweDecryptRsaOaep("payload-jwe", "our-priv"))
+            .thenReturn("""{"type":"hello"}""".toByteArray(Charsets.UTF_8))
+
+        val plain = envelope.open(ExchangeEnvelope(version = "2", payload = "payload-jwe"), "our-priv")
+
+        assertEquals("""{"type":"hello"}""", plain)
+    }
+
+    @Test fun `open tolerates 2_x minor versions (forward-compat within major)`() {
+        whenever(jweCrypto.jweDecryptRsaOaep(any(), any())).thenReturn("ok".toByteArray())
+
+        val plain = envelope.open(ExchangeEnvelope(version = "2.5", payload = "p"), "k")
+
+        assertEquals("ok", plain)
+    }
+
+    @Test fun `open throws EnvelopeVersionTooNew for major above ours`() {
+        val ex = assertThrows(EnvelopeVersionTooNew::class.java) {
+            envelope.open(ExchangeEnvelope(version = "3", payload = "anything"), "k")
+        }
+        assertEquals("3", ex.version)
+    }
+
+    @Test fun `open throws EnvelopeVersionTooNew even when minor is set`() {
+        val ex = assertThrows(EnvelopeVersionTooNew::class.java) {
+            envelope.open(ExchangeEnvelope(version = "4.2", payload = "anything"), "k")
+        }
+        assertEquals("4.2", ex.version)
+    }
+
+    @Test fun `open rejects obsolete (lower major) versions`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            envelope.open(ExchangeEnvelope(version = "1", payload = "anything"), "k")
+        }
+    }
+
+    @Test fun `open rejects malformed version strings`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            envelope.open(ExchangeEnvelope(version = "two", payload = "p"), "k")
+        }
+    }
+
+    @Test fun `open does not invoke jwe decrypt when version check fails`() {
+        runCatching { envelope.open(ExchangeEnvelope("3", "p"), "k") }
+        verify(jweCrypto, org.mockito.kotlin.never()).jweDecryptRsaOaep(any(), eq("k"))
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2QrCodeTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2QrCodeTest.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import android.util.Base64
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RealExchangeV2QrCodeTest {
+
+    private val qrCode = RealExchangeV2QrCode()
+
+    // ---- parse: LinkingV2 ----
+
+    @Test fun `parse identifies a well-formed v2 linking URL`() {
+        val url = qrCode.buildLinkingCode(channelId = "abc", publicKeyBase64Url = "pubkey", version = "2")
+
+        val result = qrCode.parse(url)
+
+        assertTrue(result is ExchangeV2CodeParseResult.LinkingV2)
+        result as ExchangeV2CodeParseResult.LinkingV2
+        assertEquals("abc", result.channelId)
+        assertEquals("pubkey", result.publicKey)
+        assertEquals("2", result.version)
+    }
+
+    @Test fun `parse tolerates leading whitespace and prefix text before the URL`() {
+        val url = qrCode.buildLinkingCode("c", "k")
+        val noisy = "   Linking code: $url"
+
+        val result = qrCode.parse(noisy)
+
+        assertTrue(result is ExchangeV2CodeParseResult.LinkingV2)
+    }
+
+    @Test fun `parse accepts a bare base64url v2 payload (no URL wrapper)`() {
+        val bareB64 = encodeUrl("""{"version":"2","channel_id":"x","public_key":"k"}""")
+
+        val result = qrCode.parse(bareB64)
+
+        assertTrue(result is ExchangeV2CodeParseResult.LinkingV2)
+    }
+
+    // ---- parse: LinkingV1 ----
+
+    @Test fun `parse routes legacy connect-shape codes to LinkingV1`() {
+        val payload = """{"connect":{"device_id":"abc","secret_key":"sk"}}"""
+        val url = "https://duckduckgo.com/sync/pairing/#&code=${encodeUrl(payload)}"
+
+        val result = qrCode.parse(url)
+
+        assertEquals(ExchangeV2CodeParseResult.LinkingV1, result)
+    }
+
+    // ---- parse: RecoveryCode ----
+
+    @Test fun `parse detects v2 recovery codes by user_id+secret fields`() {
+        val payload = """{"recovery":{"user_id":"u","secret":"s","cid":"ddg","v":"2.0"}}"""
+        val bareB64 = encodeUrl(payload)
+
+        val result = qrCode.parse(bareB64)
+
+        assertTrue(result is ExchangeV2CodeParseResult.RecoveryCode)
+        result as ExchangeV2CodeParseResult.RecoveryCode
+        assertEquals("u", result.rawJson.getString("user_id"))
+        assertEquals("ddg", result.rawJson.getString("cid"))
+    }
+
+    @Test fun `parse rejects v1 recovery codes (primary_key) so they fall through to legacy stack`() {
+        // v1 recovery uses primary_key, not secret. ExchangeV2QrCode is the v2 entry point —
+        // it should NOT claim v1 recovery codes; they need to fall through to parseSyncAuthCode.
+        val payload = """{"recovery":{"primary_key":"pk","user_id":"u"}}"""
+        val bareB64 = encodeUrl(payload)
+
+        val result = qrCode.parse(bareB64)
+
+        assertEquals(ExchangeV2CodeParseResult.Unknown, result)
+    }
+
+    // ---- parse: Unknown ----
+
+    @Test fun `parse returns Unknown for empty input`() {
+        assertEquals(ExchangeV2CodeParseResult.Unknown, qrCode.parse(""))
+    }
+
+    @Test fun `parse returns Unknown for non-base64 garbage`() {
+        assertEquals(ExchangeV2CodeParseResult.Unknown, qrCode.parse("not a code at all !!!"))
+    }
+
+    @Test fun `parse returns Unknown for URL with no code fragment`() {
+        assertEquals(ExchangeV2CodeParseResult.Unknown, qrCode.parse("https://example.com/no-fragment"))
+    }
+
+    @Test fun `parse returns Unknown when the base64 payload is not JSON`() {
+        val bareB64 = encodeUrl("not json at all")
+        assertEquals(ExchangeV2CodeParseResult.Unknown, qrCode.parse(bareB64))
+    }
+
+    @Test fun `parse returns Unknown for JSON with no recognised top-level keys`() {
+        val bareB64 = encodeUrl("""{"something":"else"}""")
+        assertEquals(ExchangeV2CodeParseResult.Unknown, qrCode.parse(bareB64))
+    }
+
+    @Test fun `parse requires version=2 (not just any version field)`() {
+        // version=3 isn't ours yet; should not be LinkingV2. Falls through to Unknown for the parser
+        // (the caller deals with version-upgrade UX separately).
+        val bareB64 = encodeUrl("""{"version":"3","channel_id":"x","public_key":"k"}""")
+        assertEquals(ExchangeV2CodeParseResult.Unknown, qrCode.parse(bareB64))
+    }
+
+    // ---- buildLinkingCode round-trip ----
+
+    @Test fun `buildLinkingCode emits a URL parse can decode back to its inputs`() {
+        val built = qrCode.buildLinkingCode(channelId = "chan-123", publicKeyBase64Url = "pubkey-456")
+
+        val parsed = qrCode.parse(built) as ExchangeV2CodeParseResult.LinkingV2
+
+        assertEquals("chan-123", parsed.channelId)
+        assertEquals("pubkey-456", parsed.publicKey)
+    }
+
+    @Test fun `buildLinkingCode produces the documented URL shape`() {
+        val built = qrCode.buildLinkingCode(channelId = "c", publicKeyBase64Url = "k")
+        assertTrue("expected URL prefix, got: $built", built.startsWith("https://duckduckgo.com/sync/pairing/#&code2="))
+    }
+
+    @Test fun `buildLinkingCode honours custom version`() {
+        val built = qrCode.buildLinkingCode("c", "k", version = "2.1")
+        // 2.1 isn't decoded by us (parse looks for exact "2"), but the wire shape carries it through.
+        val fragment = built.substringAfter("code2=")
+        val decoded = Base64.decode(fragment, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
+        assertTrue(String(decoded).contains("\"version\":\"2.1\""))
+    }
+
+    private fun encodeUrl(s: String): String =
+        Base64.encodeToString(
+            s.toByteArray(Charsets.UTF_8),
+            Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP,
+        )
+
+    @Suppress("unused")
+    private fun ExchangeV2CodeParseResult.assertIs(): Unit = run {
+        // helper hook for clarity in IDE; intentionally a no-op
+        assertNull(null)
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2QrCodeTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2QrCodeTest.kt
@@ -87,8 +87,6 @@ class RealExchangeV2QrCodeTest {
     }
 
     @Test fun `parse rejects v1 recovery codes (primary_key) so they fall through to legacy stack`() {
-        // v1 recovery uses primary_key, not secret. ExchangeV2QrCode is the v2 entry point —
-        // it should NOT claim v1 recovery codes; they need to fall through to parseSyncAuthCode.
         val payload = """{"recovery":{"primary_key":"pk","user_id":"u"}}"""
         val bareB64 = encodeUrl(payload)
 
@@ -122,15 +120,11 @@ class RealExchangeV2QrCodeTest {
     }
 
     @Test fun `parse requires version=2 (not just any version field)`() {
-        // version=3 isn't ours yet; should not be LinkingV2. Falls through to Unknown for the parser
-        // (the caller deals with version-upgrade UX separately).
         val bareB64 = encodeUrl("""{"version":"3","channel_id":"x","public_key":"k"}""")
         assertEquals(ExchangeV2CodeParseResult.Unknown, qrCode.parse(bareB64))
     }
 
     @Test fun `parse accepts a 2_x minor version as LinkingV2`() {
-        // Transport TD 1214486492252757 §Versioning: a same-major (2) code proceeds; minor bumps
-        // (2.0, 2.1, …) are tolerated. The raw version string is preserved for downstream.
         val bareB64 = encodeUrl("""{"version":"2.1","channel_id":"chan","public_key":"pub"}""")
 
         val parsed = qrCode.parse(bareB64)
@@ -143,8 +137,6 @@ class RealExchangeV2QrCodeTest {
     }
 
     @Test fun `parse rejects a v2 code with an empty public_key`() {
-        // channel_id and public_key are required + non-empty (Transport TD §QR Code); an empty one
-        // must reject at parse, not be accepted and fail later at decodePublicKey.
         val bareB64 = encodeUrl("""{"version":"2","channel_id":"chan","public_key":""}""")
         assertEquals(ExchangeV2CodeParseResult.Unknown, qrCode.parse(bareB64))
     }
@@ -171,9 +163,7 @@ class RealExchangeV2QrCodeTest {
     }
 
     @Test fun `buildLinkingCode emits the expected compact JSON shape`() {
-        // Documents the exact wire shape and catches accidental serializer drift. Field ORDER is
-        // not contractual (the code is parse-only on every platform; nothing byte-compares it) —
-        // this just pins what plain Moshi currently emits (snake_case names, alphabetical order).
+        // Field order is not contractual (codes are parse-only, never byte-compared); this pins the current serializer output.
         val built = qrCode.buildLinkingCode(channelId = "c", publicKeyBase64Url = "k", version = "2")
         val fragment = built.substringAfter("code2=")
         val decoded = String(Base64.decode(fragment, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP))
@@ -181,8 +171,6 @@ class RealExchangeV2QrCodeTest {
     }
 
     @Test fun `buildLinkingCode does not escape forward slashes (defense-in-depth)`() {
-        // Production keys are base64url (slash-free), but the JSON is byte-compared cross-platform —
-        // it must never carry Android-only '\/' escaping should any field ever contain '/'.
         val built = qrCode.buildLinkingCode(channelId = "chan/123", publicKeyBase64Url = "pub/key+raw")
         val fragment = built.substringAfter("code2=")
         val decoded = String(Base64.decode(fragment, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP))
@@ -193,7 +181,6 @@ class RealExchangeV2QrCodeTest {
 
     @Test fun `buildLinkingCode honours custom version`() {
         val built = qrCode.buildLinkingCode("c", "k", version = "2.1")
-        // Pins that the wire shape carries the custom version through (parse now accepts 2.x).
         val fragment = built.substringAfter("code2=")
         val decoded = Base64.decode(fragment, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
         assertTrue(String(decoded).contains("\"version\":\"2.1\""))
@@ -207,7 +194,6 @@ class RealExchangeV2QrCodeTest {
 
     @Suppress("unused")
     private fun ExchangeV2CodeParseResult.assertIs(): Unit = run {
-        // helper hook for clarity in IDE; intentionally a no-op
         assertNull(null)
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2QrCodeTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2QrCodeTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.sync.impl.exchange.v2
 import android.util.Base64
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -141,6 +142,27 @@ class RealExchangeV2QrCodeTest {
     @Test fun `buildLinkingCode produces the documented URL shape`() {
         val built = qrCode.buildLinkingCode(channelId = "c", publicKeyBase64Url = "k")
         assertTrue("expected URL prefix, got: $built", built.startsWith("https://duckduckgo.com/sync/pairing/#&code2="))
+    }
+
+    @Test fun `buildLinkingCode emits the expected compact JSON shape`() {
+        // Documents the exact wire shape and catches accidental serializer drift. Field ORDER is
+        // not contractual (the code is parse-only on every platform; nothing byte-compares it) —
+        // this just pins what plain Moshi currently emits (snake_case names, alphabetical order).
+        val built = qrCode.buildLinkingCode(channelId = "c", publicKeyBase64Url = "k", version = "2")
+        val fragment = built.substringAfter("code2=")
+        val decoded = String(Base64.decode(fragment, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP))
+        assertEquals("""{"channel_id":"c","public_key":"k","version":"2"}""", decoded)
+    }
+
+    @Test fun `buildLinkingCode does not escape forward slashes (defense-in-depth)`() {
+        // Production keys are base64url (slash-free), but the JSON is byte-compared cross-platform —
+        // it must never carry Android-only '\/' escaping should any field ever contain '/'.
+        val built = qrCode.buildLinkingCode(channelId = "chan/123", publicKeyBase64Url = "pub/key+raw")
+        val fragment = built.substringAfter("code2=")
+        val decoded = String(Base64.decode(fragment, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP))
+        assertFalse("linking JSON must not contain escaped slashes (\\/): $decoded", decoded.contains("\\/"))
+        assertTrue(decoded.contains("chan/123"))
+        assertTrue(decoded.contains("pub/key+raw"))
     }
 
     @Test fun `buildLinkingCode honours custom version`() {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2QrCodeTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2QrCodeTest.kt
@@ -142,6 +142,18 @@ class RealExchangeV2QrCodeTest {
         assertEquals("2.1", parsed.version)
     }
 
+    @Test fun `parse rejects a v2 code with an empty public_key`() {
+        // channel_id and public_key are required + non-empty (Transport TD §QR Code); an empty one
+        // must reject at parse, not be accepted and fail later at decodePublicKey.
+        val bareB64 = encodeUrl("""{"version":"2","channel_id":"chan","public_key":""}""")
+        assertEquals(ExchangeV2CodeParseResult.Unknown, qrCode.parse(bareB64))
+    }
+
+    @Test fun `parse rejects a v2 code with an empty channel_id`() {
+        val bareB64 = encodeUrl("""{"version":"2","channel_id":"","public_key":"pub"}""")
+        assertEquals(ExchangeV2CodeParseResult.Unknown, qrCode.parse(bareB64))
+    }
+
     // ---- buildLinkingCode round-trip ----
 
     @Test fun `buildLinkingCode emits a URL parse can decode back to its inputs`() {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2QrCodeTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2QrCodeTest.kt
@@ -128,6 +128,20 @@ class RealExchangeV2QrCodeTest {
         assertEquals(ExchangeV2CodeParseResult.Unknown, qrCode.parse(bareB64))
     }
 
+    @Test fun `parse accepts a 2_x minor version as LinkingV2`() {
+        // Transport TD 1214486492252757 §Versioning: a same-major (2) code proceeds; minor bumps
+        // (2.0, 2.1, …) are tolerated. The raw version string is preserved for downstream.
+        val bareB64 = encodeUrl("""{"version":"2.1","channel_id":"chan","public_key":"pub"}""")
+
+        val parsed = qrCode.parse(bareB64)
+
+        assertTrue("expected LinkingV2 for a 2.x code, got $parsed", parsed is ExchangeV2CodeParseResult.LinkingV2)
+        parsed as ExchangeV2CodeParseResult.LinkingV2
+        assertEquals("chan", parsed.channelId)
+        assertEquals("pub", parsed.publicKey)
+        assertEquals("2.1", parsed.version)
+    }
+
     // ---- buildLinkingCode round-trip ----
 
     @Test fun `buildLinkingCode emits a URL parse can decode back to its inputs`() {
@@ -167,7 +181,7 @@ class RealExchangeV2QrCodeTest {
 
     @Test fun `buildLinkingCode honours custom version`() {
         val built = qrCode.buildLinkingCode("c", "k", version = "2.1")
-        // 2.1 isn't decoded by us (parse looks for exact "2"), but the wire shape carries it through.
+        // Pins that the wire shape carries the custom version through (parse now accepts 2.x).
         val fragment = built.substringAfter("code2=")
         val decoded = Base64.decode(fragment, Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
         assertTrue(String(decoded).contains("\"version\":\"2.1\""))

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -27,7 +27,9 @@ import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeRespon
 import com.duckduckgo.sync.store.SyncStore
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
@@ -431,5 +433,42 @@ class RealExchangeV2RunnerTest {
         )
 
         assertSame(ExchangeV2State.Joiner.Confirming, runner.currentState)
+    }
+
+    // ---- Session timeout (Transport TD 1214486492252757 §Session Lifecycle: 5-min deadline) ----
+
+    @Test fun `session times out and tears down after the deadline`() = coroutineTestRule.testScope.runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        val runner = newRunner()
+        runner.startPresent()
+        assertSame(ExchangeV2State.Bootstrapped, runner.currentState) // session active, awaiting a peer
+
+        advanceTimeBy(6 * 60 * 1000L) // past the 5-min session deadline (virtual time, instant)
+
+        val timedOut = runner.events.replayCache
+            .filterIsInstance<ExchangeV2Event.SessionError>()
+            .any { it.message.contains("timed out", ignoreCase = true) }
+        assertTrue("expected a 'timed out' SessionError", timedOut)
+        assertNull(runner.currentState) // session torn down
+    }
+
+    @Test fun `no timeout fires after the session already reached a terminal state`() = coroutineTestRule.testScope.runTest {
+        whenever(syncStore.userId).thenReturn(null)
+        val runner = newRunner()
+        runner.startScan("")
+        // Drive to a terminal (Joiner.Done) well before the deadline; this must cancel the timer.
+        runner.deliverIncomingMessage(
+            ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "other", name = "Peer", kind = "3party"),
+        ) // auto-elects Joiner → Joiner.Confirming
+        runner.localTrigger(LocalTrigger.UserConfirmedJoiner) // → Joiner.Waiting
+        runner.deliverIncomingMessage(RecoveryCodeResponse("{}")) // → Joiner.Done (terminal)
+        assertNull(runner.currentState)
+
+        advanceTimeBy(6 * 60 * 1000L) // past the deadline
+
+        val timedOut = runner.events.replayCache
+            .filterIsInstance<ExchangeV2Event.SessionError>()
+            .any { it.message.contains("timed out", ignoreCase = true) }
+        assertFalse("a completed session must not later emit a timeout", timedOut)
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -343,6 +343,27 @@ class RealExchangeV2RunnerTest {
         )
     }
 
+    @Test fun `Host aborts (not Done) when the recovery_code_response send fails`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        whenever(recoveryCodeProvider.createDdgAccountIfNeeded()).thenReturn(Result.Success(Unit))
+        whenever(recoveryCodeProvider.getDdgRecoveryCode()).thenReturn(Result.Success("the-code"))
+        // The recovery_code_response POST fails on the relay (e.g. peer channel already TTL'd);
+        // the earlier awaiting_confirmation / confirmed sends use the default Success stub.
+        whenever(
+            channel.sendMessage(argThat { contains("recovery_code_response") }, any(), any(), any()),
+        ).thenReturn(Result.Error(reason = "relay unreachable"))
+
+        val runner = newRunner()
+        runner.startPresent()
+        runner.deliverIncomingMessage(Hello("{}"))
+        runner.deliverIncomingMessage(RecoveryCodeRequest(rawJson = "{}", name = "Joiner", kind = "ddg")) // → Host.Confirming
+        runner.localTrigger(LocalTrigger.UserConfirmedHost) // → Host.Sending; response send then fails
+
+        // A failed response delivery must abort, not complete: the host never delivered the code.
+        val lastTransition = runner.events.replayCache.filterIsInstance<ExchangeV2Event.Transition>().last()
+        assertSame(ExchangeV2State.Host.Aborted, lastTransition.to)
+    }
+
     @Test fun `Scanner ddg auto-elects Host when peer is 3party (both have accounts)`() = runTest {
         whenever(syncStore.userId).thenReturn("my-user")
         val runner = newRunner()

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -514,4 +514,15 @@ class RealExchangeV2RunnerTest {
         // emit a second, misleading "couldn't reach the Presenter" error.
         assertFalse("must not emit the misleading reach-Presenter error on a bootstrap failure", errors.any { it.contains("reach the Presenter") })
     }
+
+    @Test fun `a failed bootstrap clears the pairing role so no half-started session lingers`() = runTest {
+        whenever(channel.createChannel(any())).thenReturn(Result.Error(reason = "relay 500"))
+        val runner = newRunner()
+
+        runner.startScan("")
+
+        // _pairingRole is set before bootstrapLocked runs; a bootstrap failure must tear that
+        // (and the ephemeral keys) back down rather than leave it dangling until the next attempt.
+        assertNull("pairingRole must be cleared after a failed bootstrap", runner.pairingRole)
+    }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -74,8 +74,6 @@ class RealExchangeV2RunnerTest {
         )
 
     @Before fun stubWireDeps() {
-        // Tests exercise SM-driving + auto-elect behaviour, not wire I/O. Stub everything
-        // that touches the network or generates real keys.
         whenever(qrCode.parse(any())).thenReturn(
             ExchangeV2CodeParseResult.LinkingV2(channelId = "peer-channel", publicKey = "peer-pubkey", version = "2"),
         )
@@ -105,23 +103,20 @@ class RealExchangeV2RunnerTest {
     @Test fun `startScan called twice replaces the existing session`() = runTest {
         val runner = newRunner()
         runner.startScan("")
-        // Drive the first session along so it could leak if not cleared.
         runner.deliverIncomingMessage(
             ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "peer", name = "Peer", kind = "3party"),
         )
-        // Session should now have absorbed peer context.
 
         runner.startScan("")
 
-        // After re-start, role is set fresh and SM is back in Negotiating with no peer context applied yet.
         assertSame(ExchangeV2State.Negotiating, runner.currentState)
         assertSame(PairingRole.Scanner, runner.pairingRole)
     }
 
     @Test fun `deliverIncomingMessage forwards SM event to flow`() = runTest {
-        whenever(syncStore.userId).thenReturn("my-user") // canStartAsPresenter requires a signed-in account
+        whenever(syncStore.userId).thenReturn("my-user")
         val runner = newRunner()
-        runner.startPresent() // Presenter starts in Bootstrapped — receives hello to enter Negotiating.
+        runner.startPresent()
 
         runner.events.filterIsInstance<ExchangeV2Event.Transition>().test {
             runner.deliverIncomingMessage(Hello("""{"type":"hello"}"""))
@@ -179,10 +174,9 @@ class RealExchangeV2RunnerTest {
         whenever(syncStore.userId).thenReturn("my-user")
         val runner = newRunner()
         runner.startPresent()
-        runner.deliverIncomingMessage(Hello("{}")) // → Negotiating
+        runner.deliverIncomingMessage(Hello("{}"))
 
         runner.events.filterIsInstance<ExchangeV2Event.Transition>().test {
-            // Drain replay: SessionStarted is filtered out; Negotiating transition replays.
             awaitItem()
             runner.localTrigger(LocalTrigger.RoleElected(Role.Host))
             val event = awaitItem()
@@ -239,8 +233,7 @@ class RealExchangeV2RunnerTest {
         val runner = newRunner()
         runner.startPresent()
 
-        // Per spec §"Exchange Share Recovery Code": Host may create its account during pairing.
-        // Therefore the runner must not pre-flight-block a not-signed-in device from being Presenter.
+        // Spec §"Exchange Share Recovery Code": Host may create its account during pairing.
         assertSame(PairingRole.Presenter, runner.pairingRole)
         assertSame(ExchangeV2State.Bootstrapped, runner.currentState)
     }
@@ -269,7 +262,6 @@ class RealExchangeV2RunnerTest {
             ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "host-user", name = "Host", kind = "ddg"),
         )
 
-        // Auto-elect drives us straight to Joiner.Confirming without a manual RoleElected call.
         assertSame(ExchangeV2State.Joiner.Confirming, runner.currentState)
     }
 
@@ -296,16 +288,14 @@ class RealExchangeV2RunnerTest {
             ExchangeV2Message.RecoveryCodeRequest(rawJson = "{}", name = "Joiner", kind = "ddg"),
         )
 
-        // Per spec §"Exchange Confirmations → Host": awaiting_confirmation must be sent
-        // BEFORE the user is prompted (i.e., on entry to Confirming), so the peer can render
-        // its "confirm on the other device" UX. The user hasn't tapped UserConfirmedHost yet.
+        // Spec §"Exchange Confirmations → Host": awaiting_confirmation is sent on entry to
+        // Confirming, before the user is prompted.
         verify(channel).sendMessage(
             argThat { contains("recovery_code_awaiting_confirmation") },
             any(),
             any(),
             any(),
         )
-        // recovery_code_confirmed must NOT have been sent yet (no user confirm trigger).
         verify(channel, never()).sendMessage(
             argThat { contains("recovery_code_confirmed") },
             any(),
@@ -323,23 +313,14 @@ class RealExchangeV2RunnerTest {
         runner.deliverIncomingMessage(
             ExchangeV2Message.RecoveryCodeRequest(rawJson = "{}", name = "Joiner", kind = "ddg"),
         )
-        // Reach Host.Confirming — awaiting_confirmation has been sent once.
-        // Now user confirms locally.
         runner.localTrigger(LocalTrigger.UserConfirmedHost)
 
-        // recovery_code_confirmed was sent after UserConfirmedHost.
         verify(channel).sendMessage(
             argThat { contains("recovery_code_confirmed") && !contains("recovery_code_awaiting_confirmation") },
             any(),
             any(),
             any(),
         )
-        // awaiting_confirmation was sent only ONCE in the whole flow (on entry to Confirming),
-        // not a second time on UserConfirmedHost. Mockito's `times(1)` would be ideal but
-        // matchers across JSON-string args make argThat-with-count flaky — use never() on a
-        // payload that is *exactly* the awaiting_confirmation JSON-with-nothing-else, ensuring
-        // we never sent it twice. (One send is matched by the prior verify; a second would
-        // mean we double-sent.)
         verify(channel, org.mockito.kotlin.times(1)).sendMessage(
             argThat { contains("recovery_code_awaiting_confirmation") },
             any(),
@@ -352,8 +333,6 @@ class RealExchangeV2RunnerTest {
         whenever(syncStore.userId).thenReturn("my-user")
         whenever(recoveryCodeProvider.createDdgAccountIfNeeded()).thenReturn(Result.Success(Unit))
         whenever(recoveryCodeProvider.getDdgRecoveryCode()).thenReturn(Result.Success("the-code"))
-        // The recovery_code_response POST fails on the relay (e.g. peer channel already TTL'd);
-        // the earlier awaiting_confirmation / confirmed sends use the default Success stub.
         whenever(
             channel.sendMessage(argThat { contains("recovery_code_response") }, any(), any(), any()),
         ).thenReturn(Result.Error(reason = "relay unreachable"))
@@ -361,10 +340,9 @@ class RealExchangeV2RunnerTest {
         val runner = newRunner()
         runner.startPresent()
         runner.deliverIncomingMessage(Hello("{}"))
-        runner.deliverIncomingMessage(RecoveryCodeRequest(rawJson = "{}", name = "Joiner", kind = "ddg")) // → Host.Confirming
-        runner.localTrigger(LocalTrigger.UserConfirmedHost) // → Host.Sending; response send then fails
+        runner.deliverIncomingMessage(RecoveryCodeRequest(rawJson = "{}", name = "Joiner", kind = "ddg"))
+        runner.localTrigger(LocalTrigger.UserConfirmedHost)
 
-        // A failed response delivery must abort, not complete: the host never delivered the code.
         val lastTransition = runner.events.replayCache.filterIsInstance<ExchangeV2Event.Transition>().last()
         assertSame(ExchangeV2State.Host.Aborted, lastTransition.to)
     }
@@ -378,7 +356,6 @@ class RealExchangeV2RunnerTest {
             ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "peer-user", name = "Peer", kind = "3party"),
         )
 
-        // ddg-vs-3party rule wins over Presenter/Scanner — even though we scanned, ddg becomes Host.
         assertSame(ExchangeV2State.Host.Confirming, runner.currentState)
     }
 
@@ -392,7 +369,6 @@ class RealExchangeV2RunnerTest {
             val event = awaitItem()
             assertSame(ExchangeV2State.Aborted, event.to)
         }
-        // Aborted is terminal → runner clears the session (best-effort channel DELETE).
         assertNull(runner.currentState)
     }
 
@@ -408,8 +384,6 @@ class RealExchangeV2RunnerTest {
             val event = awaitItem()
             assertSame(ExchangeV2State.SameAccountAbort, event.to)
         }
-        // No follow-up Transition for RoleElected — auto-elect must skip after a rejected outcome.
-        // SameAccountAbort is terminal → runner clears the session.
         assertNull(runner.currentState)
     }
 
@@ -438,36 +412,35 @@ class RealExchangeV2RunnerTest {
         assertSame(ExchangeV2State.Joiner.Confirming, runner.currentState)
     }
 
-    // ---- Session timeout (Transport TD 1214486492252757 §Session Lifecycle: 5-min deadline) ----
+    // ---- Session timeout ----
 
     @Test fun `session times out and tears down after the deadline`() = coroutineTestRule.testScope.runTest {
         whenever(syncStore.userId).thenReturn("my-user")
         val runner = newRunner()
         runner.startPresent()
-        assertSame(ExchangeV2State.Bootstrapped, runner.currentState) // session active, awaiting a peer
+        assertSame(ExchangeV2State.Bootstrapped, runner.currentState)
 
-        advanceTimeBy(6 * 60 * 1000L) // past the 5-min session deadline (virtual time, instant)
+        advanceTimeBy(6 * 60 * 1000L) // past the 5-min session deadline
 
         val timedOut = runner.events.replayCache
             .filterIsInstance<ExchangeV2Event.SessionError>()
             .any { it.message.contains("timed out", ignoreCase = true) }
         assertTrue("expected a 'timed out' SessionError", timedOut)
-        assertNull(runner.currentState) // session torn down
+        assertNull(runner.currentState)
     }
 
     @Test fun `no timeout fires after the session already reached a terminal state`() = coroutineTestRule.testScope.runTest {
         whenever(syncStore.userId).thenReturn(null)
         val runner = newRunner()
         runner.startScan("")
-        // Drive to a terminal (Joiner.Done) well before the deadline; this must cancel the timer.
         runner.deliverIncomingMessage(
             ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "other", name = "Peer", kind = "3party"),
-        ) // auto-elects Joiner → Joiner.Confirming
-        runner.localTrigger(LocalTrigger.UserConfirmedJoiner) // → Joiner.Waiting
-        runner.deliverIncomingMessage(RecoveryCodeResponse("{}")) // → Joiner.Done (terminal)
+        )
+        runner.localTrigger(LocalTrigger.UserConfirmedJoiner)
+        runner.deliverIncomingMessage(RecoveryCodeResponse("{}"))
         assertNull(runner.currentState)
 
-        advanceTimeBy(6 * 60 * 1000L) // past the deadline
+        advanceTimeBy(6 * 60 * 1000L)
 
         val timedOut = runner.events.replayCache
             .filterIsInstance<ExchangeV2Event.SessionError>()
@@ -475,7 +448,7 @@ class RealExchangeV2RunnerTest {
         assertFalse("a completed session must not later emit a timeout", timedOut)
     }
 
-    // ---- Poll-loop error handling (Transport TD 1214486492252757 §Session Lifecycle) ----
+    // ---- Poll-loop error handling ----
 
     @Test fun `an unexpected poll error tears down the session with a SessionError`() = runTest {
         whenever(syncStore.userId).thenReturn("my-user")
@@ -487,13 +460,11 @@ class RealExchangeV2RunnerTest {
             .filterIsInstance<ExchangeV2Event.SessionError>()
             .any { it.message.contains("boom") }
         assertTrue("expected a SessionError from the failed poll loop", errored)
-        assertNull(runner.currentState) // session torn down, not left hanging
+        assertNull(runner.currentState)
     }
 
     @Test fun `polled messages are processed in wire order (hello before request reaches Host_Confirming)`() = runTest {
         whenever(syncStore.userId).thenReturn("my-user")
-        // The poll flow delivers a 2-message batch in seq order. recovery_code_request is only
-        // valid AFTER hello has moved us out of Bootstrapped; if processed first it would abort.
         whenever(channel.poll(any(), any())).thenReturn(
             flowOf(
                 Hello("""{"type":"hello"}"""),
@@ -502,15 +473,12 @@ class RealExchangeV2RunnerTest {
         )
 
         val runner = newRunner()
-        runner.startPresent() // Bootstrapped → poll loop drains the batch in order
+        runner.startPresent()
 
-        // hello: Bootstrapped → Negotiating; request: records peer + auto-elects Host → Host.Confirming.
         assertSame(ExchangeV2State.Host.Confirming, runner.currentState)
     }
 
     @Test fun `a polled message that reaches a terminal state tears down without a spurious error`() = runTest {
-        // Same-account: Scanner already signed in as "shared" meets a peer on the same account.
-        // The peer's availability drives the SM straight to the terminal SameAccountAbort.
         whenever(syncStore.userId).thenReturn("shared")
         whenever(channel.poll(any(), any())).thenReturn(
             flowOf(
@@ -519,10 +487,8 @@ class RealExchangeV2RunnerTest {
         )
 
         val runner = newRunner()
-        runner.startScan("") // Scanner starts in Negotiating; poll loop delivers the availability
+        runner.startScan("")
 
-        // Terminal reached through the poll path: session cleared via cancelLocked (which cancels
-        // the very poll job we were collecting on) and no "Pairing failed"/error surfaced.
         assertNull(runner.currentState)
         val spurious = runner.events.replayCache
             .filterIsInstance<ExchangeV2Event.SessionError>()
@@ -536,7 +502,7 @@ class RealExchangeV2RunnerTest {
         val runner = newRunner()
         runner.startPresent()
 
-        runner.cancel() // cancels the open poll → CancellationException must propagate, not become an error
+        runner.cancel()
 
         val spurious = runner.events.replayCache
             .filterIsInstance<ExchangeV2Event.SessionError>()
@@ -551,8 +517,6 @@ class RealExchangeV2RunnerTest {
 
         val errors = runner.events.replayCache.filterIsInstance<ExchangeV2Event.SessionError>().map { it.message }
         assertTrue("expected the bootstrap error", errors.any { it.contains("Failed to create channel") })
-        // The bootstrap failure must end the launch immediately — not fall through to sendHello and
-        // emit a second, misleading "couldn't reach the Presenter" error.
         assertFalse("must not emit the misleading reach-Presenter error on a bootstrap failure", errors.any { it.contains("reach the Presenter") })
     }
 
@@ -562,7 +526,6 @@ class RealExchangeV2RunnerTest {
 
         runner.startScan("")
 
-        // _pairingRole is set before bootstrapLocked runs, so a bootstrap failure must clear it.
         assertNull("pairingRole must be cleared after a failed bootstrap", runner.pairingRole)
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -502,4 +502,16 @@ class RealExchangeV2RunnerTest {
             .any { it.message.contains("Pairing failed") }
         assertFalse("cancellation must not surface as a 'Pairing failed' error", spurious)
     }
+
+    @Test fun `startScan with a failed channel bootstrap aborts cleanly without the misleading reach-Presenter error`() = runTest {
+        whenever(channel.createChannel(any())).thenReturn(Result.Error(reason = "relay 500"))
+        val runner = newRunner()
+        runner.startScan("")
+
+        val errors = runner.events.replayCache.filterIsInstance<ExchangeV2Event.SessionError>().map { it.message }
+        assertTrue("expected the bootstrap error", errors.any { it.contains("Failed to create channel") })
+        // The bootstrap failure must end the launch immediately — not fall through to sendHello and
+        // emit a second, misleading "couldn't reach the Presenter" error.
+        assertFalse("must not emit the misleading reach-Presenter error on a bootstrap failure", errors.any { it.contains("reach the Presenter") })
+    }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -101,7 +101,7 @@ class RealExchangeV2RunnerTest {
         assertNull(runner.currentState)
     }
 
-    @Test fun `startScan called twice replaces the existing session`() {
+    @Test fun `startScan called twice replaces the existing session`() = runTest {
         val runner = newRunner()
         runner.startScan("")
         // Drive the first session along so it could leak if not cleared.
@@ -189,7 +189,7 @@ class RealExchangeV2RunnerTest {
         }
     }
 
-    @Test fun `terminal state abandons session`() {
+    @Test fun `terminal state abandons session`() = runTest {
         whenever(syncStore.userId).thenReturn(null)
         val runner = newRunner()
         runner.startScan("")

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -25,8 +25,10 @@ import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Hello
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeRequest
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse
 import com.duckduckgo.sync.store.SyncStore
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
@@ -470,5 +472,34 @@ class RealExchangeV2RunnerTest {
             .filterIsInstance<ExchangeV2Event.SessionError>()
             .any { it.message.contains("timed out", ignoreCase = true) }
         assertFalse("a completed session must not later emit a timeout", timedOut)
+    }
+
+    // ---- Poll-loop error handling (Transport TD 1214486492252757 §Session Lifecycle) ----
+
+    @Test fun `an unexpected poll error tears down the session with a SessionError`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        whenever(channel.poll(any(), any())).thenReturn(flow<ExchangeV2Message> { throw RuntimeException("boom") })
+        val runner = newRunner()
+        runner.startPresent()
+
+        val errored = runner.events.replayCache
+            .filterIsInstance<ExchangeV2Event.SessionError>()
+            .any { it.message.contains("boom") }
+        assertTrue("expected a SessionError from the failed poll loop", errored)
+        assertNull(runner.currentState) // session torn down, not left hanging
+    }
+
+    @Test fun `cancel during an open poll does not surface a spurious error`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        whenever(channel.poll(any(), any())).thenReturn(flow<ExchangeV2Message> { awaitCancellation() })
+        val runner = newRunner()
+        runner.startPresent()
+
+        runner.cancel() // cancels the open poll → CancellationException must propagate, not become an error
+
+        val spurious = runner.events.replayCache
+            .filterIsInstance<ExchangeV2Event.SessionError>()
+            .any { it.message.contains("Pairing failed") }
+        assertFalse("cancellation must not surface as a 'Pairing failed' error", spurious)
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -521,8 +521,7 @@ class RealExchangeV2RunnerTest {
 
         runner.startScan("")
 
-        // _pairingRole is set before bootstrapLocked runs; a bootstrap failure must tear that
-        // (and the ephemeral keys) back down rather than leave it dangling until the next attempt.
+        // _pairingRole is set before bootstrapLocked runs, so a bootstrap failure must clear it.
         assertNull("pairingRole must be cleared after a failed bootstrap", runner.pairingRole)
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.sync.impl.exchange.v2
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.sync.impl.Result
+import com.duckduckgo.sync.impl.SyncDeviceIds
 import com.duckduckgo.sync.impl.crypto.RsaKeyPair
 import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Hello
@@ -58,6 +59,7 @@ class RealExchangeV2RunnerTest {
     private val channel: ExchangeV2Channel = mock()
     private val qrCode: ExchangeV2QrCode = mock()
     private val recoveryCodeProvider: RecoveryCodeProvider = mock()
+    private val syncDeviceIds: SyncDeviceIds = mock()
 
     private fun newRunner(): RealExchangeV2Runner =
         RealExchangeV2Runner(
@@ -69,6 +71,7 @@ class RealExchangeV2RunnerTest {
             channel = channel,
             qrCode = qrCode,
             recoveryCodeProvider = recoveryCodeProvider,
+            syncDeviceIds = syncDeviceIds,
             appScope = coroutineTestRule.testScope,
             dispatchers = coroutineTestRule.testDispatcherProvider,
         )
@@ -83,6 +86,7 @@ class RealExchangeV2RunnerTest {
         whenever(channel.poll(any(), any())).thenReturn(emptyFlow())
         whenever(channel.sendMessage(any(), any(), any(), any())).thenReturn(Result.Success(Unit))
         whenever(channel.deleteChannel(any())).thenReturn(Result.Success(Unit))
+        whenever(syncDeviceIds.deviceName()).thenReturn("This Device")
     }
 
     @Test fun `startScan creates a session in Negotiating (Scanner already knows the peer)`() {
@@ -208,6 +212,38 @@ class RealExchangeV2RunnerTest {
             val event = awaitItem()
             assertSame(ExchangeV2State.SameAccountAbort, event.to)
         }
+    }
+
+    @Test fun `availability without an account carries this device's real name, not a hardcoded platform string`() = runTest {
+        whenever(syncStore.userId).thenReturn(null)
+        whenever(syncDeviceIds.deviceName()).thenReturn("google Pixel 7")
+        val runner = newRunner()
+
+        runner.startScan("")
+
+        // The peer shows this name on its security-confirmation screen, so it must be the real
+        // device name (e.g. "google Pixel 7"), never a generic "Android".
+        verify(channel).sendMessage(
+            argThat { contains("recovery_code_request") && contains("\"name\":\"google Pixel 7\"") },
+            any(),
+            any(),
+            any(),
+        )
+    }
+
+    @Test fun `availability with an account carries this device's real name, not a hardcoded platform string`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        whenever(syncDeviceIds.deviceName()).thenReturn("google Pixel 7")
+        val runner = newRunner()
+
+        runner.startScan("")
+
+        verify(channel).sendMessage(
+            argThat { contains("recovery_code_available") && contains("\"name\":\"google Pixel 7\"") },
+            any(),
+            any(),
+            any(),
+        )
     }
 
     // ---- Auto role election ----

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -508,6 +508,28 @@ class RealExchangeV2RunnerTest {
         assertSame(ExchangeV2State.Host.Confirming, runner.currentState)
     }
 
+    @Test fun `a polled message that reaches a terminal state tears down without a spurious error`() = runTest {
+        // Same-account: Scanner already signed in as "shared" meets a peer on the same account.
+        // The peer's availability drives the SM straight to the terminal SameAccountAbort.
+        whenever(syncStore.userId).thenReturn("shared")
+        whenever(channel.poll(any(), any())).thenReturn(
+            flowOf(
+                ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "shared", name = "Peer", kind = "ddg"),
+            ),
+        )
+
+        val runner = newRunner()
+        runner.startScan("") // Scanner starts in Negotiating; poll loop delivers the availability
+
+        // Terminal reached through the poll path: session cleared via cancelLocked (which cancels
+        // the very poll job we were collecting on) and no "Pairing failed"/error surfaced.
+        assertNull(runner.currentState)
+        val spurious = runner.events.replayCache
+            .filterIsInstance<ExchangeV2Event.SessionError>()
+            .any { it.message.contains("Pairing failed") || it.message.contains("timed out", ignoreCase = true) }
+        assertFalse("terminal via poll must not surface a spurious error", spurious)
+    }
+
     @Test fun `cancel during an open poll does not surface a spurious error`() = runTest {
         whenever(syncStore.userId).thenReturn("my-user")
         whenever(channel.poll(any(), any())).thenReturn(flow<ExchangeV2Message> { awaitCancellation() })

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -93,7 +93,7 @@ class RealExchangeV2RunnerTest {
         assertSame(ExchangeV2State.Negotiating, runner.currentState)
     }
 
-    @Test fun `cancel abandons the session`() {
+    @Test fun `cancel abandons the session`() = runTest {
         val runner = newRunner()
         runner.startScan("")
         runner.cancel()
@@ -251,7 +251,7 @@ class RealExchangeV2RunnerTest {
         assertTrue(newRunner().canStartAsPresenter)
     }
 
-    @Test fun `cancel clears pairingRole`() {
+    @Test fun `cancel clears pairingRole`() = runTest {
         val runner = newRunner()
         runner.startScan("")
         runner.cancel()

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -1,0 +1,414 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import app.cash.turbine.test
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.sync.impl.Result
+import com.duckduckgo.sync.impl.crypto.RsaKeyPair
+import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Hello
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeRequest
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse
+import com.duckduckgo.sync.store.SyncStore
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class RealExchangeV2RunnerTest {
+
+    @get:Rule val coroutineTestRule = CoroutineTestRule()
+
+    private val clock = ExchangeV2Clock { 42L }
+    private val parser = JsonExchangeV2MessageParser()
+    private val factory = ExchangeV2StateMachineFactory(clock)
+    private val syncStore: SyncStore = mock()
+    private val jweCrypto: SyncJweCrypto = mock()
+    private val channel: ExchangeV2Channel = mock()
+    private val qrCode: ExchangeV2QrCode = mock()
+    private val recoveryCodeProvider: RecoveryCodeProvider = mock()
+
+    private fun newRunner(): RealExchangeV2Runner =
+        RealExchangeV2Runner(
+            smFactory = factory,
+            messageParser = parser,
+            clock = clock,
+            syncStore = syncStore,
+            jweCrypto = jweCrypto,
+            channel = channel,
+            qrCode = qrCode,
+            recoveryCodeProvider = recoveryCodeProvider,
+            appScope = coroutineTestRule.testScope,
+            dispatchers = coroutineTestRule.testDispatcherProvider,
+        )
+
+    @Before fun stubWireDeps() {
+        // Tests exercise SM-driving + auto-elect behaviour, not wire I/O. Stub everything
+        // that touches the network or generates real keys.
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "peer-channel", publicKey = "peer-pubkey", version = "2"),
+        )
+        whenever(qrCode.buildLinkingCode(any(), any(), any())).thenReturn("https://duckduckgo.com/sync/pairing/#&code2=fake")
+        whenever(jweCrypto.generateRsaKeyPair()).thenReturn(RsaKeyPair(publicKeyBase64 = "own-pub", privateKeyBase64 = "own-priv"))
+        whenever(channel.createChannel(any())).thenReturn(Result.Success(Unit))
+        whenever(channel.poll(any(), any())).thenReturn(emptyFlow())
+        whenever(channel.sendMessage(any(), any(), any(), any())).thenReturn(Result.Success(Unit))
+        whenever(channel.deleteChannel(any())).thenReturn(Result.Success(Unit))
+    }
+
+    @Test fun `startScan creates a session in Negotiating (Scanner already knows the peer)`() {
+        val runner = newRunner()
+        runner.startScan(pastedUrl = "ignored")
+
+        assertSame(ExchangeV2State.Negotiating, runner.currentState)
+    }
+
+    @Test fun `cancel abandons the session`() {
+        val runner = newRunner()
+        runner.startScan("")
+        runner.cancel()
+
+        assertNull(runner.currentState)
+    }
+
+    @Test fun `startScan called twice replaces the existing session`() {
+        val runner = newRunner()
+        runner.startScan("")
+        // Drive the first session along so it could leak if not cleared.
+        runner.deliverIncomingMessage(
+            ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "peer", name = "Peer", kind = "3party"),
+        )
+        // Session should now have absorbed peer context.
+
+        runner.startScan("")
+
+        // After re-start, role is set fresh and SM is back in Negotiating with no peer context applied yet.
+        assertSame(ExchangeV2State.Negotiating, runner.currentState)
+        assertSame(PairingRole.Scanner, runner.pairingRole)
+    }
+
+    @Test fun `deliverIncomingMessage forwards SM event to flow`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user") // canStartAsPresenter requires a signed-in account
+        val runner = newRunner()
+        runner.startPresent() // Presenter starts in Bootstrapped — receives hello to enter Negotiating.
+
+        runner.events.filterIsInstance<ExchangeV2Event.Transition>().test {
+            runner.deliverIncomingMessage(Hello("""{"type":"hello"}"""))
+            val event = awaitItem()
+            assertSame(ExchangeV2State.Bootstrapped, event.from)
+            assertSame(ExchangeV2State.Negotiating, event.to)
+        }
+    }
+
+    @Test fun `deliverIncomingMessage without a session is a no-op`() = runTest {
+        val runner = newRunner()
+        runner.events.test {
+            runner.deliverIncomingMessage(Hello("{}"))
+            expectNoEvents()
+        }
+    }
+
+    @Test fun `deliverIncomingMessageJson parses and forwards`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        val runner = newRunner()
+        runner.startPresent()
+
+        runner.events.filterIsInstance<ExchangeV2Event.Transition>().test {
+            runner.deliverIncomingMessageJson("""{"type":"hello"}""")
+            val event = awaitItem()
+            assertSame(ExchangeV2State.Negotiating, event.to)
+            assertTrue(event.trigger is Hello)
+        }
+    }
+
+    @Test fun `deliverIncomingMessageJson with unknown type emits dropped`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        val runner = newRunner()
+        runner.startPresent()
+
+        runner.events.filterIsInstance<ExchangeV2Event.MessageRejected>().test {
+            runner.deliverIncomingMessageJson("""{"type":"future_msg"}""")
+            val event = awaitItem()
+            assertSame(RejectReason.UnknownMessageDropped, event.reason)
+        }
+    }
+
+    @Test fun `recordSentMessage emits MessageSent with given message`() = runTest {
+        val runner = newRunner()
+        val sent = RecoveryCodeRequest(rawJson = "{}", name = "me", kind = "3party")
+
+        runner.events.test {
+            runner.recordSentMessage(sent)
+            val event = awaitItem() as ExchangeV2Event.MessageSent
+            assertSame(sent, event.message)
+        }
+    }
+
+    @Test fun `localTrigger forwards SM event to flow`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        val runner = newRunner()
+        runner.startPresent()
+        runner.deliverIncomingMessage(Hello("{}")) // → Negotiating
+
+        runner.events.filterIsInstance<ExchangeV2Event.Transition>().test {
+            // Drain replay: SessionStarted is filtered out; Negotiating transition replays.
+            awaitItem()
+            runner.localTrigger(LocalTrigger.RoleElected(Role.Host))
+            val event = awaitItem()
+            assertSame(ExchangeV2State.Host.Confirming, event.to)
+        }
+    }
+
+    @Test fun `terminal state abandons session`() {
+        whenever(syncStore.userId).thenReturn(null)
+        val runner = newRunner()
+        runner.startScan("")
+        runner.deliverIncomingMessage(ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "other", name = "Peer", kind = "3party"))
+        runner.localTrigger(LocalTrigger.RoleElected(Role.Joiner))
+        runner.localTrigger(LocalTrigger.UserConfirmedJoiner)
+        runner.deliverIncomingMessage(RecoveryCodeResponse("{}"))
+
+        assertNull(runner.currentState)
+    }
+
+    @Test fun `startScan passes local user_id from SyncStore so same-account abort fires`() = runTest {
+        whenever(syncStore.userId).thenReturn("shared-user")
+        val runner = newRunner()
+        runner.startScan("")
+
+        runner.events.filterIsInstance<ExchangeV2Event.Transition>().test {
+            runner.deliverIncomingMessage(
+                ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "shared-user", name = "Peer", kind = "3party"),
+            )
+            val event = awaitItem()
+            assertSame(ExchangeV2State.SameAccountAbort, event.to)
+        }
+    }
+
+    // ---- Auto role election ----
+
+    @Test fun `startScan sets pairingRole to Scanner`() {
+        val runner = newRunner()
+        runner.startScan("")
+
+        assertSame(PairingRole.Scanner, runner.pairingRole)
+    }
+
+    @Test fun `startPresent sets pairingRole to Presenter and bootstraps session`() {
+        whenever(syncStore.userId).thenReturn("my-user")
+        val runner = newRunner()
+        runner.startPresent()
+
+        assertSame(PairingRole.Presenter, runner.pairingRole)
+        assertSame(ExchangeV2State.Bootstrapped, runner.currentState)
+    }
+
+    @Test fun `startPresent without an account still bootstraps (spec allows account creation during pairing)`() {
+        whenever(syncStore.userId).thenReturn(null)
+        val runner = newRunner()
+        runner.startPresent()
+
+        // Per spec §"Exchange Share Recovery Code": Host may create its account during pairing.
+        // Therefore the runner must not pre-flight-block a not-signed-in device from being Presenter.
+        assertSame(PairingRole.Presenter, runner.pairingRole)
+        assertSame(ExchangeV2State.Bootstrapped, runner.currentState)
+    }
+
+    @Test fun `canStartAsPresenter is true regardless of account state`() {
+        whenever(syncStore.userId).thenReturn(null)
+        assertTrue(newRunner().canStartAsPresenter)
+        whenever(syncStore.userId).thenReturn("my-user")
+        assertTrue(newRunner().canStartAsPresenter)
+    }
+
+    @Test fun `cancel clears pairingRole`() {
+        val runner = newRunner()
+        runner.startScan("")
+        runner.cancel()
+
+        assertNull(runner.pairingRole)
+    }
+
+    @Test fun `Scanner with no account auto-elects Joiner when peer (ddg) has account`() = runTest {
+        whenever(syncStore.userId).thenReturn(null)
+        val runner = newRunner()
+        runner.startScan("")
+
+        runner.deliverIncomingMessage(
+            ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "host-user", name = "Host", kind = "ddg"),
+        )
+
+        // Auto-elect drives us straight to Joiner.Confirming without a manual RoleElected call.
+        assertSame(ExchangeV2State.Joiner.Confirming, runner.currentState)
+    }
+
+    @Test fun `Presenter with account auto-elects Host when peer has no account`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        val runner = newRunner()
+        runner.startPresent()
+        runner.deliverIncomingMessage(Hello("{}"))
+
+        runner.deliverIncomingMessage(
+            ExchangeV2Message.RecoveryCodeRequest(rawJson = "{}", name = "Joiner", kind = "ddg"),
+        )
+
+        assertSame(ExchangeV2State.Host.Confirming, runner.currentState)
+    }
+
+    @Test fun `entering Host_Confirming sends recovery_code_awaiting_confirmation immediately (spec ordering)`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        val runner = newRunner()
+        runner.startPresent()
+        runner.deliverIncomingMessage(Hello("{}"))
+
+        runner.deliverIncomingMessage(
+            ExchangeV2Message.RecoveryCodeRequest(rawJson = "{}", name = "Joiner", kind = "ddg"),
+        )
+
+        // Per spec §"Exchange Confirmations → Host": awaiting_confirmation must be sent
+        // BEFORE the user is prompted (i.e., on entry to Confirming), so the peer can render
+        // its "confirm on the other device" UX. The user hasn't tapped UserConfirmedHost yet.
+        verify(channel).sendMessage(
+            argThat { contains("recovery_code_awaiting_confirmation") },
+            any(),
+            any(),
+            any(),
+        )
+        // recovery_code_confirmed must NOT have been sent yet (no user confirm trigger).
+        verify(channel, never()).sendMessage(
+            argThat { contains("recovery_code_confirmed") },
+            any(),
+            any(),
+            any(),
+        )
+    }
+
+    @Test fun `UserConfirmedHost sends recovery_code_confirmed but does NOT re-send awaiting_confirmation`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        whenever(recoveryCodeProvider.getDdgRecoveryCode()).thenReturn(com.duckduckgo.sync.impl.Result.Success("the-code"))
+        val runner = newRunner()
+        runner.startPresent()
+        runner.deliverIncomingMessage(Hello("{}"))
+        runner.deliverIncomingMessage(
+            ExchangeV2Message.RecoveryCodeRequest(rawJson = "{}", name = "Joiner", kind = "ddg"),
+        )
+        // Reach Host.Confirming — awaiting_confirmation has been sent once.
+        // Now user confirms locally.
+        runner.localTrigger(LocalTrigger.UserConfirmedHost)
+
+        // recovery_code_confirmed was sent after UserConfirmedHost.
+        verify(channel).sendMessage(
+            argThat { contains("recovery_code_confirmed") && !contains("recovery_code_awaiting_confirmation") },
+            any(),
+            any(),
+            any(),
+        )
+        // awaiting_confirmation was sent only ONCE in the whole flow (on entry to Confirming),
+        // not a second time on UserConfirmedHost. Mockito's `times(1)` would be ideal but
+        // matchers across JSON-string args make argThat-with-count flaky — use never() on a
+        // payload that is *exactly* the awaiting_confirmation JSON-with-nothing-else, ensuring
+        // we never sent it twice. (One send is matched by the prior verify; a second would
+        // mean we double-sent.)
+        verify(channel, org.mockito.kotlin.times(1)).sendMessage(
+            argThat { contains("recovery_code_awaiting_confirmation") },
+            any(),
+            any(),
+            any(),
+        )
+    }
+
+    @Test fun `Scanner ddg auto-elects Host when peer is 3party (both have accounts)`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        val runner = newRunner()
+        runner.startScan("")
+
+        runner.deliverIncomingMessage(
+            ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "peer-user", name = "Peer", kind = "3party"),
+        )
+
+        // ddg-vs-3party rule wins over Presenter/Scanner — even though we scanned, ddg becomes Host.
+        assertSame(ExchangeV2State.Host.Confirming, runner.currentState)
+    }
+
+    @Test fun `Scanner hello during negotiating aborts and tears down the session`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        val runner = newRunner()
+        runner.startScan("")
+
+        runner.events.filterIsInstance<ExchangeV2Event.Transition>().test {
+            runner.deliverIncomingMessage(Hello("{}"))
+            val event = awaitItem()
+            assertSame(ExchangeV2State.Aborted, event.to)
+        }
+        // Aborted is terminal → runner clears the session (best-effort channel DELETE).
+        assertNull(runner.currentState)
+    }
+
+    @Test fun `same-account abort skips auto-election`() = runTest {
+        whenever(syncStore.userId).thenReturn("shared-user")
+        val runner = newRunner()
+        runner.startScan("")
+
+        runner.events.filterIsInstance<ExchangeV2Event.Transition>().test {
+            runner.deliverIncomingMessage(
+                ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "shared-user", name = "Peer", kind = "ddg"),
+            )
+            val event = awaitItem()
+            assertSame(ExchangeV2State.SameAccountAbort, event.to)
+        }
+        // No follow-up Transition for RoleElected — auto-elect must skip after a rejected outcome.
+        // SameAccountAbort is terminal → runner clears the session.
+        assertNull(runner.currentState)
+    }
+
+    @Test fun `Presenter auto-elects Host when both have accounts and peer is ddg (Presenter rule)`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        val runner = newRunner()
+        runner.startPresent()
+        runner.deliverIncomingMessage(Hello("{}"))
+
+        runner.deliverIncomingMessage(
+            ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "peer-user", name = "Peer", kind = "ddg"),
+        )
+
+        assertSame(ExchangeV2State.Host.Confirming, runner.currentState)
+    }
+
+    @Test fun `Scanner with both accounts and peer ddg auto-elects Joiner (catch-all)`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        val runner = newRunner()
+        runner.startScan("")
+
+        runner.deliverIncomingMessage(
+            ExchangeV2Message.RecoveryCodeAvailable(rawJson = "{}", userId = "peer-user", name = "Peer", kind = "ddg"),
+        )
+
+        assertSame(ExchangeV2State.Joiner.Confirming, runner.currentState)
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
@@ -487,6 +488,24 @@ class RealExchangeV2RunnerTest {
             .any { it.message.contains("boom") }
         assertTrue("expected a SessionError from the failed poll loop", errored)
         assertNull(runner.currentState) // session torn down, not left hanging
+    }
+
+    @Test fun `polled messages are processed in wire order (hello before request reaches Host_Confirming)`() = runTest {
+        whenever(syncStore.userId).thenReturn("my-user")
+        // The poll flow delivers a 2-message batch in seq order. recovery_code_request is only
+        // valid AFTER hello has moved us out of Bootstrapped; if processed first it would abort.
+        whenever(channel.poll(any(), any())).thenReturn(
+            flowOf(
+                Hello("""{"type":"hello"}"""),
+                RecoveryCodeRequest(rawJson = "{}", name = "Joiner", kind = "ddg"),
+            ),
+        )
+
+        val runner = newRunner()
+        runner.startPresent() // Bootstrapped → poll loop drains the batch in order
+
+        // hello: Bootstrapped → Negotiating; request: records peer + auto-elects Host → Host.Confirming.
+        assertSame(ExchangeV2State.Host.Confirming, runner.currentState)
     }
 
     @Test fun `cancel during an open poll does not surface a spurious error`() = runTest {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealRecoveryCodeProviderTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealRecoveryCodeProviderTest.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.exchange.v2
+
+import com.duckduckgo.sync.impl.Result
+import com.duckduckgo.sync.impl.SyncAccountRepository
+import com.duckduckgo.sync.store.ScopedPassword
+import com.duckduckgo.sync.store.SyncStore
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.Base64
+
+class RealRecoveryCodeProviderTest {
+
+    private val syncAccountRepository: SyncAccountRepository = mock()
+    private val syncStore: SyncStore = mock()
+    private val provider = RealRecoveryCodeProvider(syncAccountRepository, syncStore)
+
+    // ---- getDdgRecoveryCode ----
+
+    @Test fun `getDdgRecoveryCode converts v1 shape to v2 with cid=ddg`() {
+        val v1Json = """{"recovery":{"primary_key":"pk-abc","user_id":"user-123"}}"""
+        val v1B64 = Base64.getUrlEncoder().withoutPadding().encodeToString(v1Json.toByteArray())
+        whenever(syncAccountRepository.getRecoveryCode()).thenReturn(
+            Result.Success(SyncAccountRepository.AuthCode(qrCode = v1B64, rawCode = v1B64)),
+        )
+
+        val result = provider.getDdgRecoveryCode()
+
+        assertTrue(result is Result.Success)
+        val v2 = decodeRecovery((result as Result.Success).data)
+        assertEquals("user-123", v2.getString("user_id"))
+        assertEquals("pk-abc", v2.getString("secret"))
+        assertEquals("ddg", v2.getString("cid"))
+        assertEquals("2.0", v2.getString("v"))
+    }
+
+    @Test fun `getDdgRecoveryCode bubbles up repository errors`() {
+        whenever(syncAccountRepository.getRecoveryCode()).thenReturn(Result.Error(reason = "Not signed in"))
+
+        val result = provider.getDdgRecoveryCode()
+
+        assertTrue(result is Result.Error)
+        assertEquals("Not signed in", (result as Result.Error).reason)
+    }
+
+    @Test fun `getDdgRecoveryCode reports a conversion error when v1 shape is malformed`() {
+        whenever(syncAccountRepository.getRecoveryCode()).thenReturn(
+            Result.Success(SyncAccountRepository.AuthCode(qrCode = "not-b64-or-json", rawCode = "not-b64-or-json")),
+        )
+
+        val result = provider.getDdgRecoveryCode()
+
+        assertTrue(result is Result.Error)
+        assertTrue(
+            "expected conversion error, got: ${(result as Result.Error).reason}",
+            result.reason.startsWith("Failed to convert ddg recovery code to v2.0"),
+        )
+    }
+
+    // ---- getThirdPartyRecoveryCode ----
+
+    @Test fun `getThirdPartyRecoveryCode returns raw rawCode untouched`() {
+        // Repo already emits v2.0 shape per [ThirdPartyCredentialManager.getRecoveryCode] —
+        // the provider must not re-wrap or re-encode.
+        val already3p = "already-v2-encoded-b64"
+        whenever(syncAccountRepository.getThirdPartyRecoveryCode()).thenReturn(
+            Result.Success(SyncAccountRepository.AuthCode(qrCode = "different-qr-form", rawCode = already3p)),
+        )
+
+        val result = provider.getThirdPartyRecoveryCode()
+
+        assertTrue(result is Result.Success)
+        assertEquals(already3p, (result as Result.Success).data)
+    }
+
+    @Test fun `getThirdPartyRecoveryCode bubbles up repository errors`() {
+        whenever(syncAccountRepository.getThirdPartyRecoveryCode()).thenReturn(
+            Result.Error(reason = "No 3party credential"),
+        )
+
+        val result = provider.getThirdPartyRecoveryCode()
+
+        assertTrue(result is Result.Error)
+        assertEquals("No 3party credential", (result as Result.Error).reason)
+    }
+
+    // ---- createDdgAccountIfNeeded (spec: "If host has no account yet, create it first.") ----
+
+    @Test fun `createDdgAccountIfNeeded is a no-op when already signed in`() {
+        whenever(syncStore.userId).thenReturn("existing-user")
+
+        val result = provider.createDdgAccountIfNeeded()
+
+        assertTrue(result is Result.Success)
+        verify(syncAccountRepository, org.mockito.kotlin.never()).createAccount()
+    }
+
+    @Test fun `createDdgAccountIfNeeded calls createAccount when no user id present`() {
+        whenever(syncStore.userId).thenReturn(null)
+        whenever(syncAccountRepository.createAccount()).thenReturn(Result.Success(true))
+
+        val result = provider.createDdgAccountIfNeeded()
+
+        assertTrue(result is Result.Success)
+        verify(syncAccountRepository).createAccount()
+    }
+
+    @Test fun `createDdgAccountIfNeeded propagates repository error so caller can abort`() {
+        whenever(syncStore.userId).thenReturn(null)
+        whenever(syncAccountRepository.createAccount()).thenReturn(Result.Error(reason = "BE down"))
+
+        val result = provider.createDdgAccountIfNeeded()
+
+        assertTrue(result is Result.Error)
+        assertEquals("BE down", (result as Result.Error).reason)
+    }
+
+    // ---- createThirdPartyCredentialIfNeeded (spec: "extend the account" for 3party peer) ----
+
+    @Test fun `createThirdPartyCredentialIfNeeded is a no-op when scopedPassword already set locally`() {
+        // ScopedPassword is a `value class` so Mockito can't mock it — use a real instance.
+        whenever(syncStore.scopedPassword).thenReturn(ScopedPassword("existing"))
+
+        val result = provider.createThirdPartyCredentialIfNeeded()
+
+        assertTrue(result is Result.Success)
+        verify(syncAccountRepository, org.mockito.kotlin.never()).createThirdPartyCredential()
+    }
+
+    @Test fun `createThirdPartyCredentialIfNeeded extends the account when no scopedPassword locally`() {
+        whenever(syncStore.scopedPassword).thenReturn(null)
+        whenever(syncAccountRepository.createThirdPartyCredential()).thenReturn(Result.Success(true))
+
+        val result = provider.createThirdPartyCredentialIfNeeded()
+
+        assertTrue(result is Result.Success)
+        verify(syncAccountRepository).createThirdPartyCredential()
+    }
+
+    @Test fun `createThirdPartyCredentialIfNeeded propagates repository error`() {
+        whenever(syncStore.scopedPassword).thenReturn(null)
+        whenever(syncAccountRepository.createThirdPartyCredential())
+            .thenReturn(Result.Error(reason = "extend failed"))
+
+        val result = provider.createThirdPartyCredentialIfNeeded()
+
+        assertTrue(result is Result.Error)
+        assertEquals("extend failed", (result as Result.Error).reason)
+    }
+
+    private fun decodeRecovery(b64: String): JSONObject {
+        val bytes = Base64.getUrlDecoder().decode(b64)
+        return JSONObject(String(bytes, Charsets.UTF_8)).getJSONObject("recovery")
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealRecoveryCodeProviderTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealRecoveryCodeProviderTest.kt
@@ -54,18 +54,14 @@ class RealRecoveryCodeProviderTest {
         assertTrue(result is Result.Success)
         val v2 = decodeRecovery((result as Result.Success).data)
         assertEquals("user-123", v2.getString("user_id"))
-        // secret is re-encoded base64url but must carry the same key bytes (see the base64url test below)
         assertArrayEquals(Base64.getUrlDecoder().decode("pk-abc"), Base64.getUrlDecoder().decode(v2.getString("secret")))
         assertEquals("ddg", v2.getString("cid"))
         assertEquals("2.0", v2.getString("v"))
     }
 
     @Test fun `getDdgRecoveryCode encodes the secret as base64url per spec, not standard base64`() {
-        // Spec 1214802412121967 (Encryption Algorithms): the v2 account `secret` is base64url
-        // encoded. Android stores the primary_key as STANDARD base64 internally; we must convert
-        // at the v2 wire boundary so spec-conformant peers (macOS/iOS/FE/Windows) can base64url-
-        // decode it. Same key bytes, different alphabet. A standard-base64 emit broke macOS↔Android.
-        val standardPrimaryKey = "apZ+7PAe89rDhuG4DRyi/M3zU2/D5DZNdRsR3RM6Ujw=" // standard base64: has '+' and '/'
+        // Spec (Encryption Algorithms): the v2 account `secret` is base64url; Android stores primary_key as standard base64 internally.
+        val standardPrimaryKey = "apZ+7PAe89rDhuG4DRyi/M3zU2/D5DZNdRsR3RM6Ujw="
         val v1Json = """{"recovery":{"primary_key":"$standardPrimaryKey","user_id":"user-123"}}"""
         val v1B64 = Base64.getUrlEncoder().withoutPadding().encodeToString(v1Json.toByteArray())
         whenever(syncAccountRepository.getRecoveryCode()).thenReturn(
@@ -78,7 +74,6 @@ class RealRecoveryCodeProviderTest {
         val secret = decodeRecovery((result as Result.Success).data).getString("secret")
         assertFalse("secret must be base64url (no '+'): $secret", secret.contains('+'))
         assertFalse("secret must be base64url (no '/'): $secret", secret.contains('/'))
-        // …and it must decode back to the exact same key bytes as the standard-base64 primary_key.
         assertArrayEquals(
             Base64.getDecoder().decode(standardPrimaryKey),
             Base64.getUrlDecoder().decode(secret),
@@ -111,8 +106,7 @@ class RealRecoveryCodeProviderTest {
     // ---- getThirdPartyRecoveryCode ----
 
     @Test fun `getThirdPartyRecoveryCode returns raw rawCode untouched`() {
-        // Repo already emits v2.0 shape per [ThirdPartyCredentialManager.getRecoveryCode] —
-        // the provider must not re-wrap or re-encode.
+        // The repo already emits v2.0 shape, so the provider must not re-wrap or re-encode.
         val already3p = "already-v2-encoded-b64"
         whenever(syncAccountRepository.getThirdPartyRecoveryCode()).thenReturn(
             Result.Success(SyncAccountRepository.AuthCode(qrCode = "different-qr-form", rawCode = already3p)),
@@ -135,7 +129,7 @@ class RealRecoveryCodeProviderTest {
         assertEquals("No 3party credential", (result as Result.Error).reason)
     }
 
-    // ---- createDdgAccountIfNeeded (spec: "If host has no account yet, create it first.") ----
+    // ---- createDdgAccountIfNeeded ----
 
     @Test fun `createDdgAccountIfNeeded is a no-op when already signed in`() {
         whenever(syncStore.userId).thenReturn("existing-user")
@@ -166,7 +160,7 @@ class RealRecoveryCodeProviderTest {
         assertEquals("BE down", (result as Result.Error).reason)
     }
 
-    // ---- createThirdPartyCredentialIfNeeded (spec: "extend the account" for 3party peer) ----
+    // ---- createThirdPartyCredentialIfNeeded ----
 
     @Test fun `createThirdPartyCredentialIfNeeded is a no-op when scopedPassword already set locally`() {
         // ScopedPassword is a `value class` so Mockito can't mock it — use a real instance.

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealRecoveryCodeProviderTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealRecoveryCodeProviderTest.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.store.ScopedPassword
 import com.duckduckgo.sync.store.SyncStore
 import org.json.JSONObject
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -53,18 +54,19 @@ class RealRecoveryCodeProviderTest {
         assertTrue(result is Result.Success)
         val v2 = decodeRecovery((result as Result.Success).data)
         assertEquals("user-123", v2.getString("user_id"))
-        assertEquals("pk-abc", v2.getString("secret"))
+        // secret is re-encoded base64url but must carry the same key bytes (see the base64url test below)
+        assertArrayEquals(Base64.getUrlDecoder().decode("pk-abc"), Base64.getUrlDecoder().decode(v2.getString("secret")))
         assertEquals("ddg", v2.getString("cid"))
         assertEquals("2.0", v2.getString("v"))
     }
 
-    @Test fun `getDdgRecoveryCode does not escape forward slashes in standard-base64 secret`() {
-        // Regression (Android↔Windows interop): the ddg secret is the v1 primary_key in STANDARD
-        // base64, which routinely contains '/'. AOSP's org.json.JSONObject.toString() escapes '/'
-        // to '\/', producing a recovery code Windows native cannot decode. Spec 1214804486778180
-        // constrains only the OUTER encoding to base64url; the inner secret must travel verbatim.
-        val secretWithSlashes = "apZ+7PAe89rDhuG4DRyi/M3zU2/D5DZNdRsR3RM6Ujw="
-        val v1Json = """{"recovery":{"primary_key":"$secretWithSlashes","user_id":"user-123"}}"""
+    @Test fun `getDdgRecoveryCode encodes the secret as base64url per spec, not standard base64`() {
+        // Spec 1214802412121967 (Encryption Algorithms): the v2 account `secret` is base64url
+        // encoded. Android stores the primary_key as STANDARD base64 internally; we must convert
+        // at the v2 wire boundary so spec-conformant peers (macOS/iOS/FE/Windows) can base64url-
+        // decode it. Same key bytes, different alphabet. A standard-base64 emit broke macOS↔Android.
+        val standardPrimaryKey = "apZ+7PAe89rDhuG4DRyi/M3zU2/D5DZNdRsR3RM6Ujw=" // standard base64: has '+' and '/'
+        val v1Json = """{"recovery":{"primary_key":"$standardPrimaryKey","user_id":"user-123"}}"""
         val v1B64 = Base64.getUrlEncoder().withoutPadding().encodeToString(v1Json.toByteArray())
         whenever(syncAccountRepository.getRecoveryCode()).thenReturn(
             Result.Success(SyncAccountRepository.AuthCode(qrCode = v1B64, rawCode = v1B64)),
@@ -73,9 +75,14 @@ class RealRecoveryCodeProviderTest {
         val result = provider.getDdgRecoveryCode()
 
         assertTrue(result is Result.Success)
-        val rawJson = String(Base64.getUrlDecoder().decode((result as Result.Success).data), Charsets.UTF_8)
-        assertFalse("recovery JSON must not contain escaped slashes (\\/): $rawJson", rawJson.contains("\\/"))
-        assertTrue("secret must appear verbatim with raw '/': $rawJson", rawJson.contains(secretWithSlashes))
+        val secret = decodeRecovery((result as Result.Success).data).getString("secret")
+        assertFalse("secret must be base64url (no '+'): $secret", secret.contains('+'))
+        assertFalse("secret must be base64url (no '/'): $secret", secret.contains('/'))
+        // …and it must decode back to the exact same key bytes as the standard-base64 primary_key.
+        assertArrayEquals(
+            Base64.getDecoder().decode(standardPrimaryKey),
+            Base64.getUrlDecoder().decode(secret),
+        )
     }
 
     @Test fun `getDdgRecoveryCode bubbles up repository errors`() {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealRecoveryCodeProviderTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealRecoveryCodeProviderTest.kt
@@ -16,19 +16,23 @@
 
 package com.duckduckgo.sync.impl.exchange.v2
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.store.ScopedPassword
 import com.duckduckgo.sync.store.SyncStore
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import java.util.Base64
 
+@RunWith(AndroidJUnit4::class)
 class RealRecoveryCodeProviderTest {
 
     private val syncAccountRepository: SyncAccountRepository = mock()
@@ -52,6 +56,26 @@ class RealRecoveryCodeProviderTest {
         assertEquals("pk-abc", v2.getString("secret"))
         assertEquals("ddg", v2.getString("cid"))
         assertEquals("2.0", v2.getString("v"))
+    }
+
+    @Test fun `getDdgRecoveryCode does not escape forward slashes in standard-base64 secret`() {
+        // Regression (Android↔Windows interop): the ddg secret is the v1 primary_key in STANDARD
+        // base64, which routinely contains '/'. AOSP's org.json.JSONObject.toString() escapes '/'
+        // to '\/', producing a recovery code Windows native cannot decode. Spec 1214804486778180
+        // constrains only the OUTER encoding to base64url; the inner secret must travel verbatim.
+        val secretWithSlashes = "apZ+7PAe89rDhuG4DRyi/M3zU2/D5DZNdRsR3RM6Ujw="
+        val v1Json = """{"recovery":{"primary_key":"$secretWithSlashes","user_id":"user-123"}}"""
+        val v1B64 = Base64.getUrlEncoder().withoutPadding().encodeToString(v1Json.toByteArray())
+        whenever(syncAccountRepository.getRecoveryCode()).thenReturn(
+            Result.Success(SyncAccountRepository.AuthCode(qrCode = v1B64, rawCode = v1B64)),
+        )
+
+        val result = provider.getDdgRecoveryCode()
+
+        assertTrue(result is Result.Success)
+        val rawJson = String(Base64.getUrlDecoder().decode((result as Result.Success).data), Charsets.UTF_8)
+        assertFalse("recovery JSON must not contain escaped slashes (\\/): $rawJson", rawJson.contains("\\/"))
+        assertTrue("secret must appear verbatim with raw '/': $rawJson", rawJson.contains(secretWithSlashes))
     }
 
     @Test fun `getDdgRecoveryCode bubbles up repository errors`() {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
@@ -20,9 +20,22 @@ import android.content.SharedPreferences
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.api.InMemorySharedPreferences
 import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.sync.api.engine.SyncableType
 import com.duckduckgo.sync.impl.API_CODE
+import com.duckduckgo.sync.impl.AccountErrorCodes
+import com.duckduckgo.sync.impl.DispatchOutcome
 import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.SyncCodeType
+import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupFailureReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
 import com.duckduckgo.sync.impl.stats.DailyStats
 import com.duckduckgo.sync.impl.stats.SyncStatsRepository
 import com.duckduckgo.sync.store.SharedPrefsProvider
@@ -40,6 +53,7 @@ class RealSyncPixelsTest {
     private var pixel: Pixel = mock()
     private var syncStatsRepository: SyncStatsRepository = mock()
     private var sharedPrefsProv: SharedPrefsProvider = mock()
+    private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
 
     private lateinit var sharedPreferences: SharedPreferences
     private lateinit var testee: RealSyncPixels
@@ -55,6 +69,7 @@ class RealSyncPixelsTest {
             pixel,
             syncStatsRepository,
             sharedPrefsProv,
+            syncFeature,
         )
     }
 
@@ -118,6 +133,385 @@ class RealSyncPixelsTest {
     fun whenSignupConnectPixelCalledWithSourceThenPixelFiredIncludesSource() {
         testee.fireSignupConnectPixel(source = "foo")
         verify(pixel).fire(SyncPixelName.SYNC_SIGNUP_CONNECT, mapOf("source" to "foo"))
+    }
+
+    @Test
+    fun whenBarcodeScreenShownAndV2FlowEnabledThenPixelFiredWithV2AndDdg() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncBarcodeScreenShown(ScreenType.SYNC_CONNECT)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_BARCODE_SCREEN_SHOWN,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenBarcodeScreenShownAndV2FlowDisabledThenPixelFiredWithV1AndDdg() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireSyncBarcodeScreenShown(ScreenType.SYNC_EXCHANGE)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_BARCODE_SCREEN_SHOWN,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenManualCodeEntryScreenShownAndV2FlowEnabledThenPixelFiredWithV2AndDdg() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupManualCodeScreenShown(ScreenType.SYNC_EXCHANGE)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTRY_SCREEN_SHOWN,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenManualCodeEntryScreenShownAndV2FlowDisabledThenPixelFiredWithV1AndDdg() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireSyncSetupManualCodeScreenShown(ScreenType.SYNC_CONNECT)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTRY_SCREEN_SHOWN,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenBarcodeScannerParseSuccessOnLegacyPathThenPixelFiredWithV1AndNoCodeType() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireBarcodeScannerParseSuccess(ScreenType.SYNC_CONNECT, CodeVersion.V1)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_CODE_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenBarcodeScannerParseSuccessForV2RecoveryCodeThenPixelFiredWithCodeMetadata() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireBarcodeScannerParseSuccess(ScreenType.SYNC_EXCHANGE, CodeVersion.V2, SyncCodeType.RECOVERY)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_CODE_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_CODE_TYPE to "recovery",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenManualCodeEnteredSuccessForV2LinkingCodeThenPixelFiredWithCodeMetadata() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupCodePastedParseSuccess(ScreenType.SYNC_CONNECT, CodeVersion.V2, SyncCodeType.LINKING)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_CODE_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_CODE_TYPE to "linking",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenManualCodeEnteredSuccessOnLegacyPathThenPixelFiredWithV1AndNoCodeType() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireSyncSetupCodePastedParseSuccess(ScreenType.SYNC_EXCHANGE, CodeVersion.V1)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_CODE_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenBarcodeScannerParseErrorThenPixelFiredWithFlowMetadata() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireBarcodeScannerParseError(ScreenType.SYNC_CONNECT)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenManualCodeEnteredFailureThenPixelFiredWithFlowMetadata() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupCodePastedParseFailure(ScreenType.SYNC_EXCHANGE)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenSetupFinishedV1ThenPixelFiredWithFlowMetadataOnly() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireSyncSetupFinishedSuccessfully(ScreenType.SYNC_CONNECT)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenSetupFinishedV2RecoveryThenPixelFiredWithPathNoRoleOrPeer() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupFinishedSuccessfully(ScreenType.SYNC_EXCHANGE, SetupPath.RECOVERY)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_PATH to "recovery",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenSetupFinishedV2PairingThenPixelFiredWithPathRoleAndPeer() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupFinishedSuccessfully(
+            ScreenType.SYNC_CONNECT,
+            SetupPath.PAIRING,
+            SetupRole.HOST,
+            PeerKind.THIRD_PARTY,
+        )
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_PATH to "pairing",
+                SyncPixelParameters.SYNC_SETUP_MY_ROLE to "host",
+                SyncPixelParameters.SYNC_SETUP_PEER_KIND to "3party",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenSetupFailedWithAllDimsThenPixelFiredWithReasonPathRoleAndPeer() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupFailed(
+            SetupFailureReason.TRANSPORT_FAILURE,
+            SetupPath.PAIRING,
+            SetupRole.JOINER,
+            PeerKind.DDG,
+        )
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_REASON to "transport_failure",
+                SyncPixelParameters.SYNC_SETUP_PATH to "pairing",
+                SyncPixelParameters.SYNC_SETUP_MY_ROLE to "joiner",
+                SyncPixelParameters.SYNC_SETUP_PEER_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenSetupFailedWithReasonOnlyThenOptionalDimsOmitted() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupFailed(SetupFailureReason.UNEXPECTED_FAILURE)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_REASON to "unexpected_failure",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSetupFailedForUpgradeRequiredThenNeedsUpgrade() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSetupFailed(DispatchOutcome.UpgradeRequired(codeMajor = 3, path = SetupPath.PAIRING, myRole = SetupRole.HOST))
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_REASON to "needs_upgrade",
+                SyncPixelParameters.SYNC_SETUP_PATH to "pairing",
+                SyncPixelParameters.SYNC_SETUP_MY_ROLE to "host",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSetupFailedForFailedOutcomeThenReasonMappedFromCode() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSetupFailed(
+            DispatchOutcome.Failed(
+                reason = "boom",
+                code = AccountErrorCodes.INVALID_CODE.code,
+                path = SetupPath.RECOVERY,
+            ),
+        )
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_REASON to "invalid_credentials",
+                SyncPixelParameters.SYNC_SETUP_PATH to "recovery",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSetupFailedForCancellationCodesThenPixelNotFired() {
+        testee.fireSetupFailed(DispatchOutcome.Failed(reason = "user", code = AccountErrorCodes.PAIRING_CANCELLED.code))
+        testee.fireSetupFailed(DispatchOutcome.Failed(reason = "peer", code = AccountErrorCodes.PAIRING_REJECTED.code))
+
+        verifyNoInteractions(pixel)
+    }
+
+    @Test
+    fun whenSetupAbandonedWithReasonThenPixelFiredWithReasonAndFlowMetadata() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupAbandoned(ScreenType.SYNC_CONNECT, CancellationReason.CANCELLED_BEFORE_FINISHED)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_ABANDONED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_REASON to "cancelled_before_finished",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenSetupAbandonedWithoutReasonThenReasonOmitted() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireSyncSetupAbandoned(ScreenType.SYNC_EXCHANGE)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_ABANDONED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSetupCancelledIfDeniedForPairingCancelledThenAbandonedFired() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSetupCancelledIfDenied(
+            DispatchOutcome.Failed(reason = "user_denied", code = AccountErrorCodes.PAIRING_CANCELLED.code),
+            ScreenType.SYNC_CONNECT,
+        )
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_ABANDONED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_REASON to "sync_confirmation_denied",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSetupCancelledIfDeniedForPeerRejectionOrOtherThenNotFired() {
+        testee.fireSetupCancelledIfDenied(
+            DispatchOutcome.Failed(reason = "peer", code = AccountErrorCodes.PAIRING_REJECTED.code),
+            ScreenType.SYNC_CONNECT,
+        )
+        testee.fireSetupCancelledIfDenied(
+            DispatchOutcome.Failed(reason = "boom", code = AccountErrorCodes.PAIRING_FAILED.code),
+            ScreenType.SYNC_CONNECT,
+        )
+
+        verifyNoInteractions(pixel)
     }
 
     @Test

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
@@ -35,7 +35,10 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.CREATE_ACCOUNT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.GENERIC_ERROR
 import com.duckduckgo.sync.impl.AccountErrorCodes.INVALID_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED
 import com.duckduckgo.sync.impl.Clipboard
+import com.duckduckgo.sync.impl.RealSyncCodeDispatcher
 import com.duckduckgo.sync.impl.RecoveryCode
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
@@ -43,14 +46,23 @@ import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode.Recovery
 import com.duckduckgo.sync.impl.SyncAuthCode.Unknown
 import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState.Idle
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.AskToSwitchAccount
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.LoginSuccess
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.ShowError
+import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.ShowV2Error
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.SwitchAccountSuccess
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -73,6 +85,15 @@ internal class EnterCodeViewModelTest {
         this.seamlessAccountSwitching().setRawStoredState(State(true))
     }
     private val syncPixels: SyncPixels = mock()
+    private val qrCode: ExchangeV2QrCode = mock()
+    private val runner: ExchangeV2Runner = mock()
+
+    private val codeDispatcher = RealSyncCodeDispatcher(
+        syncFeature = syncFeature,
+        syncAccountRepository = syncAccountRepository,
+        qrCode = qrCode,
+        runner = runner,
+    )
 
     private val testee = EnterCodeViewModel(
         syncAccountRepository,
@@ -80,6 +101,7 @@ internal class EnterCodeViewModelTest {
         coroutineTestRule.testDispatcherProvider,
         syncFeature = syncFeature,
         syncPixels = syncPixels,
+        codeDispatcher = codeDispatcher,
     )
 
     @Test
@@ -104,6 +126,56 @@ internal class EnterCodeViewModelTest {
         testee.onPasteCodeClicked()
 
         verify(clipboard).pasteFromClipboard()
+    }
+
+    @Test
+    fun whenV2ThirdPartyRecoveryAlreadyUpgradedThenShowError() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
+        val pastedCode = "https://duckduckgo.com/sync/pairing/#&code2=3party-recovery"
+        whenever(clipboard.pasteFromClipboard()).thenReturn(pastedCode)
+        val recoveryJson = org.json.JSONObject().apply {
+            put("cid", "3party")
+            put("user_id", "u-1")
+            put("secret", "s-1")
+            put("v", "2.0")
+        }
+        whenever(qrCode.parse(pastedCode)).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson = recoveryJson))
+        whenever(syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(any())).thenReturn(
+            Error(code = THIRD_PARTY_ALREADY_UPGRADED.code, reason = "account already upgraded"),
+        )
+
+        testee.onPasteCodeClicked()
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(THIRD_PARTY_ALREADY_UPGRADED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2CodeRequiresNewerProtocolThenShowUpdateError() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
+        val pastedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(clipboard.pasteFromClipboard()).thenReturn(pastedCode)
+        whenever(qrCode.parse(pastedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(ExchangeV2Event.SessionError(timestampMs = 0L, message = "Peer requires protocol v3; please update this app")),
+        )
+
+        testee.onPasteCodeClicked()
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2UpgradeRequiredError, (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     @Test
@@ -319,6 +391,72 @@ internal class EnterCodeViewModelTest {
         testee.onPasteCodeClicked()
 
         testee.commands().test {
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2SameAccountThenShowAlreadyPaired() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
+        val pastedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(clipboard.pasteFromClipboard()).thenReturn(pastedCode)
+        whenever(qrCode.parse(pastedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(
+                ExchangeV2Event.Transition(
+                    timestampMs = 0L,
+                    from = ExchangeV2State.Negotiating,
+                    to = ExchangeV2State.SameAccountAbort,
+                    trigger = null,
+                    localTrigger = null,
+                ),
+            ),
+        )
+
+        testee.onPasteCodeClicked()
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2AlreadyPairedError, (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2PairingRejectedByPeerThenShowErrorAndClearLoading() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
+        val pastedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(clipboard.pasteFromClipboard()).thenReturn(pastedCode)
+        whenever(qrCode.parse(pastedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(
+                ExchangeV2Event.Transition(
+                    timestampMs = 0L,
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                    localTrigger = null,
+                ),
+            ),
+        )
+
+        testee.onPasteCodeClicked()
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_REJECTED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+        testee.viewState().test {
+            assertTrue(awaitItem().authState is Idle)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.sync.impl.ui
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.sync.TestSyncFixtures
 import com.duckduckgo.sync.TestSyncFixtures.jsonConnectKey
 import com.duckduckgo.sync.TestSyncFixtures.jsonConnectKeyEncoded
@@ -28,6 +29,10 @@ import com.duckduckgo.sync.TestSyncFixtures.primaryKey
 import com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN
 import com.duckduckgo.sync.impl.AccountErrorCodes.CONNECT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
+import com.duckduckgo.sync.impl.AccountInfo
 import com.duckduckgo.sync.impl.Clipboard
 import com.duckduckgo.sync.impl.ConnectCode
 import com.duckduckgo.sync.impl.QREncoder
@@ -37,19 +42,41 @@ import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAccountRepository.AuthCode
 import com.duckduckgo.sync.impl.SyncAuthCode.Connect
 import com.duckduckgo.sync.impl.SyncAuthCode.Recovery
+import com.duckduckgo.sync.impl.SyncCodeType
+import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
+import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
+import com.duckduckgo.sync.impl.exchange.v2.PairingRole
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_CONNECT
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupFailureReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command
+import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.AskHostConfirmation
+import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.AskJoinerConfirmation
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.LoginSuccess
+import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.ShowError
+import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.ShowV2Error
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -66,13 +93,38 @@ class SyncConnectViewModelTest {
     private val qrEncoder: QREncoder = mock()
     private val syncPixels: SyncPixels = mock()
 
+    private val syncFeature = com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory.create(SyncFeature::class.java)
+
+    private val runnerEventsFlow = kotlinx.coroutines.flow.MutableSharedFlow<com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event>(replay = 0)
+    private val qrCode: com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode = mock()
+    private val runner: com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner = mock<com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner>().also {
+        whenever(it.events).thenReturn(runnerEventsFlow)
+        whenever(it.eventsSince(any())).thenAnswer { invocation ->
+            val sinceMs = invocation.getArgument<Long>(0)
+            runnerEventsFlow.filter { event -> event.timestampMs >= sinceMs }
+        }
+    }
+    private val codeDispatcher = com.duckduckgo.sync.impl.RealSyncCodeDispatcher(
+        syncFeature = syncFeature,
+        syncAccountRepository = syncRepository,
+        qrCode = qrCode,
+        runner = runner,
+    )
+
     private val testee = SyncConnectViewModel(
         syncRepository,
         qrEncoder,
         clipboard,
         syncPixels,
         coroutineTestRule.testDispatcherProvider,
+        syncFeature,
+        codeDispatcher,
     )
+
+    @Before
+    fun setup() {
+        whenever(syncRepository.getAccountInfo()).thenReturn(AccountInfo())
+    }
 
     @Test
     fun whenScreenStartedThenShowQRCode() = runTest {
@@ -181,9 +233,9 @@ class SyncConnectViewModelTest {
             testee.onQRCodeScanned(jsonConnectKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.LoginSuccess)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_CONNECT))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_CONNECT), eq(CodeVersion.V1), isNull())
             verify(syncPixels).fireLoginPixel()
-            verify(syncPixels).fireSyncSetupFinishedSuccessfully(eq(SyncPixels.ScreenType.SYNC_CONNECT))
+            verify(syncPixels).fireSyncSetupFinishedSuccessfully(eq(SyncPixels.ScreenType.SYNC_CONNECT), isNull(), isNull(), isNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -196,9 +248,9 @@ class SyncConnectViewModelTest {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.ShowError)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_CONNECT))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_CONNECT), eq(CodeVersion.V1), isNull())
             verify(syncPixels, never()).fireLoginPixel()
-            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any())
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -212,9 +264,33 @@ class SyncConnectViewModelTest {
             testee.onQRCodeScanned(jsonConnectKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.ShowError)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_CONNECT))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_CONNECT), eq(CodeVersion.V1), isNull())
             verify(syncPixels, never()).fireLoginPixel()
-            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any())
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenUserScansV2RecoveryCodeThenBarcodeScannerParseSuccessFiredWithV2Recovery() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        val rawJson = org.json.JSONObject().apply {
+            put("user_id", "u-1")
+            put("secret", "s-1")
+            put("cid", "ddg")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
+
+        testee.commands().test {
+            testee.onQRCodeScanned("v2-recovery-code")
+            val command = awaitItem()
+            assertTrue("expected LoginSuccess, got $command", command is LoginSuccess)
+            verify(syncPixels).fireBarcodeScannerParseSuccess(
+                eq(SyncPixels.ScreenType.SYNC_CONNECT),
+                eq(CodeVersion.V2),
+                eq(SyncCodeType.RECOVERY),
+            )
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -226,7 +302,8 @@ class SyncConnectViewModelTest {
             val command = awaitItem()
             assertTrue(command is Command.LoginSuccess)
             verify(syncPixels).fireLoginPixel()
-            verify(syncPixels).fireSyncSetupFinishedSuccessfully(eq(SyncPixels.ScreenType.SYNC_CONNECT))
+            // Manual entry fires "Setup success" from EnterCodeViewModel, not here.
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -234,7 +311,7 @@ class SyncConnectViewModelTest {
     @Test
     fun whenUserCancelsThenAbandonedPixelFired() = runTest {
         testee.onUserCancelledWithoutSyncSetup()
-        verify(syncPixels).fireSyncSetupAbandoned(eq(SYNC_CONNECT))
+        verify(syncPixels).fireSyncSetupAbandoned(eq(SYNC_CONNECT), eq(CancellationReason.SCANNING_CANCELLED))
     }
 
     @Test
@@ -290,6 +367,530 @@ class SyncConnectViewModelTest {
             awaitItem()
             cancelAndIgnoreRemainingEvents()
             verify(syncRepository, times(2)).pollConnectionKeys()
+        }
+    }
+
+    private fun enableV2(displayOn: Boolean) {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        syncFeature.canShowV2ConnectCode().setRawStoredState(State(displayOn))
+    }
+
+    private fun presenterSessionStarted(linkingCode: String = "https://duckduckgo.com/sync/pairing/#&code2=xyz") =
+        ExchangeV2Event.SessionStarted(
+            timestampMs = System.currentTimeMillis(),
+            pairingRole = PairingRole.Presenter,
+            ownChannelId = "own-channel",
+            linkingCode = linkingCode,
+        )
+
+    private fun transition(
+        from: ExchangeV2State,
+        to: ExchangeV2State,
+        localTrigger: LocalTrigger? = null,
+        trigger: ExchangeV2Message? = null,
+    ) = ExchangeV2Event.Transition(
+        timestampMs = System.currentTimeMillis(),
+        from = from,
+        to = to,
+        trigger = trigger,
+        localTrigger = localTrigger,
+    )
+
+    @Test
+    fun whenBothV2FlagsOnThenRunnerStartPresentInvokedAndV1ConnectQRNotCalled() = runTest {
+        enableV2(displayOn = true)
+        val bitmap = TestSyncFixtures.qrBitmap()
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(bitmap)
+
+        testee.viewState(source = null).test {
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            val withQr = awaitItem()
+            Assert.assertEquals(bitmap, withQr.qrCodeBitmap)
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(runner).startPresent()
+        verify(syncRepository, never()).getConnectQR()
+    }
+
+    @Test
+    fun whenMasterFlagOnButCanShowV2OffThenV1PathTaken() = runTest {
+        enableV2(displayOn = false)
+        val bitmap = TestSyncFixtures.qrBitmap()
+        val authCode = AuthCode(qrCode = jsonConnectKeyEncoded, rawCode = "raw")
+        whenever(qrEncoder.encodeAsBitmap(eq(jsonConnectKeyEncoded), any(), any())).thenReturn(bitmap)
+        whenever(syncRepository.getConnectQR()).thenReturn(Result.Success(authCode))
+        whenever(syncRepository.pollConnectionKeys()).thenReturn(Result.Success(true))
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(runner, never()).startPresent()
+        verify(syncRepository).getConnectQR()
+    }
+
+    @Test
+    fun whenMasterFlagOffThenV1PathTakenRegardlessOfDisplayFlag() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+        syncFeature.canShowV2ConnectCode().setRawStoredState(State(true))
+        val bitmap = TestSyncFixtures.qrBitmap()
+        val authCode = AuthCode(qrCode = jsonConnectKeyEncoded, rawCode = "raw")
+        whenever(qrEncoder.encodeAsBitmap(eq(jsonConnectKeyEncoded), any(), any())).thenReturn(bitmap)
+        whenever(syncRepository.getConnectQR()).thenReturn(Result.Success(authCode))
+        whenever(syncRepository.pollConnectionKeys()).thenReturn(Result.Success(true))
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(runner, never()).startPresent()
+    }
+
+    @Test
+    fun whenLinkingCodeReadyThenCopyEmitsUrl() = runTest {
+        enableV2(displayOn = true)
+        val url = "https://duckduckgo.com/sync/pairing/#&code2=copy-me"
+        whenever(qrEncoder.encodeAsBitmap(eq(url), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState(source = null).test {
+            runnerEventsFlow.emit(presenterSessionStarted(linkingCode = url))
+            awaitItem()
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.onCopyCodeClicked()
+        verify(clipboard).copyToClipboard(url)
+        verify(syncRepository, never()).getConnectQR()
+    }
+
+    @Test
+    fun whenJoinerConfirmingDuringV2PresentThenAskJoinerConfirmationCommandEmitted() = runTest {
+        enableV2(displayOn = true)
+        whenever(runner.peerName).thenReturn("Peer Phone")
+        whenever(runner.peerKind).thenReturn("ddg")
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Joiner.Confirming),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected AskJoinerConfirmation, got $command", command is AskJoinerConfirmation)
+            Assert.assertEquals("Peer Phone", (command as AskJoinerConfirmation).peerName)
+            Assert.assertEquals(PeerKind.DDG, (command as AskJoinerConfirmation).peerKind)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenHostConfirmingDuringV2PresentThenAskHostConfirmationCommandEmitted() = runTest {
+        enableV2(displayOn = true)
+        whenever(runner.peerName).thenReturn("Peer Phone")
+        whenever(runner.peerKind).thenReturn("3party")
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Confirming),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected AskHostConfirmation, got $command", command is AskHostConfirmation)
+            Assert.assertEquals("Peer Phone", (command as AskHostConfirmation).peerName)
+            Assert.assertEquals(PeerKind.THIRD_PARTY, (command as AskHostConfirmation).peerKind)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenJoinerDoneWithCidDdgRecoveryCodeThenLoginSuccess() = runTest {
+        enableV2(displayOn = true)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+        val recoveryJson = org.json.JSONObject().apply {
+            put(
+                "recovery",
+                org.json.JSONObject().apply {
+                    put("user_id", "u-1")
+                    put("secret", "s-1")
+                    put("cid", "ddg")
+                    put("v", "2.0")
+                },
+            )
+        }.toString()
+        val b64 = android.util.Base64.encodeToString(
+            recoveryJson.toByteArray(Charsets.UTF_8),
+            android.util.Base64.URL_SAFE or android.util.Base64.NO_PADDING or android.util.Base64.NO_WRAP,
+        )
+        whenever(syncRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Waiting,
+                    to = ExchangeV2State.Joiner.Done,
+                    trigger = ExchangeV2Message.RecoveryCodeResponse(rawJson = "{}", recoveryCode = b64),
+                ),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected LoginSuccess, got $command", command is LoginSuccess)
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(syncRepository).processCode(any(), anyOrNull())
+    }
+
+    @Test
+    fun whenJoinerDoneViaCid3partyThenLoginSuccessAndUpgradeInvoked() = runTest {
+        enableV2(displayOn = true)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+        val recoveryJson = org.json.JSONObject().apply {
+            put(
+                "recovery",
+                org.json.JSONObject().apply {
+                    put("user_id", "u-3p")
+                    put("secret", "s-3p")
+                    put("cid", "3party")
+                    put("v", "2.0")
+                },
+            )
+        }.toString()
+        val b64 = android.util.Base64.encodeToString(
+            recoveryJson.toByteArray(Charsets.UTF_8),
+            android.util.Base64.URL_SAFE or android.util.Base64.NO_PADDING or android.util.Base64.NO_WRAP,
+        )
+        whenever(syncRepository.joinAccountFromThirdPartyRecoveryCode(any())).thenReturn(Result.Success(true))
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Waiting,
+                    to = ExchangeV2State.Joiner.Done,
+                    trigger = ExchangeV2Message.RecoveryCodeResponse(rawJson = "{}", recoveryCode = b64),
+                ),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected LoginSuccess, got $command", command is LoginSuccess)
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(syncRepository).joinAccountFromThirdPartyRecoveryCode(any())
+    }
+
+    @Test
+    fun whenV2LinkingCodeScannedThenRoutedThroughDispatcherAndLoginSuccess() = runTest {
+        enableV2(displayOn = true)
+        val scannedUrl = "https://duckduckgo.com/sync/pairing/#&code2=scan-me"
+        whenever(qrCode.parse(scannedUrl)).thenReturn(
+            com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult.LinkingV2(
+                channelId = "chan",
+                publicKey = "pk",
+                version = "2",
+            ),
+        )
+        val recoveryJson = org.json.JSONObject().apply {
+            put(
+                "recovery",
+                org.json.JSONObject().apply {
+                    put("user_id", "u-1")
+                    put("secret", "s-1")
+                    put("cid", "ddg")
+                    put("v", "2.0")
+                },
+            )
+        }.toString()
+        val recoveryB64 = android.util.Base64.encodeToString(
+            recoveryJson.toByteArray(Charsets.UTF_8),
+            android.util.Base64.URL_SAFE or android.util.Base64.NO_PADDING or android.util.Base64.NO_WRAP,
+        )
+        whenever(syncRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scannedUrl)
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Waiting,
+                    to = ExchangeV2State.Joiner.Done,
+                    trigger = ExchangeV2Message.RecoveryCodeResponse(rawJson = "{}", recoveryCode = recoveryB64),
+                ),
+            )
+            val command = awaitItem()
+            assertTrue("expected LoginSuccess, got $command", command is LoginSuccess)
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(runner).startScan(scannedUrl)
+    }
+
+    @Test
+    fun whenHostDoneDuringV2PresentThenLoginSuccess() = runTest {
+        enableV2(displayOn = true)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(from = ExchangeV2State.Host.Sending, to = ExchangeV2State.Host.Done),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected LoginSuccess, got $command", command is LoginSuccess)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenJoinerAbortedByHostThenShowError() = runTest {
+        enableV2(displayOn = true)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(from = ExchangeV2State.Joiner.Waiting, to = ExchangeV2State.Joiner.AbortedByHost),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_REJECTED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenJoinerAbortedLocalThenShowError() = runTest {
+        enableV2(displayOn = true)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedLocal,
+                    localTrigger = LocalTrigger.UserDeniedJoiner,
+                ),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_CANCELLED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenHostAbortedUserDeniedThenShowError() = runTest {
+        enableV2(displayOn = true)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Host.Confirming,
+                    to = ExchangeV2State.Host.Aborted,
+                    localTrigger = LocalTrigger.UserDeniedHost,
+                ),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_CANCELLED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        // Denying the confirmation (PAIRING_CANCELLED) fires the cancellation pixel, not the failed one.
+        verify(syncPixels).fireSyncSetupAbandoned(eq(SYNC_CONNECT), eq(CancellationReason.CONFIRMATION_DENIED))
+    }
+
+    @Test
+    fun whenUserCancelsMidExchangeThenAbandonedWithCancelledBeforeFinished() = runTest {
+        whenever(runner.currentState).thenReturn(ExchangeV2State.Negotiating)
+
+        testee.onUserCancelledWithoutSyncSetup()
+
+        verify(syncPixels).fireSyncSetupAbandoned(eq(SYNC_CONNECT), eq(CancellationReason.CANCELLED_BEFORE_FINISHED))
+    }
+
+    @Test
+    fun whenSessionErrorDuringV2PresentThenShowError() = runTest {
+        enableV2(displayOn = true)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                ExchangeV2Event.SessionError(timestampMs = System.currentTimeMillis(), message = "channel 5xx"),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_FAILED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        verify(syncPixels).fireSyncSetupFailed(
+            eq(SetupFailureReason.TRANSPORT_FAILURE),
+            eq(SetupPath.PAIRING),
+            isNull(),
+            isNull(),
+        )
+    }
+
+    @Test
+    fun whenViewStateReCollectedThenConnectQRGeneratedOnce() = runTest {
+        val authCodeToUse = AuthCode(qrCode = jsonConnectKeyEncoded, rawCode = "raw")
+        whenever(syncRepository.getConnectQR()).thenReturn(Result.Success(authCodeToUse))
+        whenever(qrEncoder.encodeAsBitmap(eq(jsonConnectKeyEncoded), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+        whenever(syncRepository.pollConnectionKeys()).thenReturn(Result.Success(true))
+        testee.viewState(source = null).test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        testee.viewState(source = null).test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(syncRepository, times(1)).getConnectQR()
+    }
+
+    @Test
+    fun whenViewStateReCollectedThenV2PresentStartedOnce() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        syncFeature.canShowV2ConnectCode().setRawStoredState(State(true))
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+        testee.viewState(source = null).test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        testee.viewState(source = null).test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(runner, times(1)).startPresent()
+    }
+
+    @Test
+    fun whenV2PairingRejectedByPeerThenShowError() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncRepository.getAccountInfo()).thenReturn(AccountInfo())
+        val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(qrCode.parse(scannedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(
+                ExchangeV2Event.Transition(
+                    timestampMs = 0L,
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                    localTrigger = null,
+                ),
+            ),
+        )
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scannedCode)
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_REJECTED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2PresentSameAccountThenShowAlreadyPaired() = runTest {
+        enableV2(displayOn = true)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.SameAccountAbort),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2AlreadyPairedError, (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2UpgradeRequiredThenShowUpdateError() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncRepository.getAccountInfo()).thenReturn(AccountInfo())
+        val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(qrCode.parse(scannedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(ExchangeV2Event.SessionError(timestampMs = 0L, message = "Peer requires protocol v3; please update this app")),
+        )
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scannedCode)
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2UpgradeRequiredError, (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
         }
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
@@ -19,16 +19,31 @@ package com.duckduckgo.sync.impl.ui
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.sync.TestSyncFixtures.jsonRecoveryKey
 import com.duckduckgo.sync.TestSyncFixtures.jsonRecoveryKeyEncoded
 import com.duckduckgo.sync.TestSyncFixtures.primaryKey
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
+import com.duckduckgo.sync.impl.RealSyncCodeDispatcher
 import com.duckduckgo.sync.impl.RecoveryCode
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode.Recovery
+import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command
+import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command.LoginSucess
+import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command.ShowV2Error
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -47,11 +62,21 @@ class SyncLoginViewModelTest {
 
     private val syncRepostitory: SyncAccountRepository = mock()
     private val syncPixels: SyncPixels = mock()
+    private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
+    private val qrCode: ExchangeV2QrCode = mock()
+    private val runner: ExchangeV2Runner = mock()
+    private val codeDispatcher = RealSyncCodeDispatcher(
+        syncFeature = syncFeature,
+        syncAccountRepository = syncRepostitory,
+        qrCode = qrCode,
+        runner = runner,
+    )
 
     private val testee = SyncLoginViewModel(
         syncRepostitory,
         syncPixels,
         coroutineTestRule.testDispatcherProvider,
+        codeDispatcher = codeDispatcher,
     )
 
     @Test
@@ -79,12 +104,88 @@ class SyncLoginViewModelTest {
     }
 
     @Test
+    fun whenV2CodeRequiresNewerProtocolThenShowUpdateError() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        val scanned = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(qrCode.parse(scanned)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(ExchangeV2Event.SessionError(timestampMs = 0L, message = "Peer requires protocol v3; please update this app")),
+        )
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scanned)
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2UpgradeRequiredError, (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2PairingRejectedByPeerThenShowError() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(qrCode.parse(scannedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(
+                ExchangeV2Event.Transition(
+                    timestampMs = 0L,
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                    localTrigger = null,
+                ),
+            ),
+        )
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scannedCode)
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_REJECTED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun whenOnLoginSuccessThenCommandIsLoginSuccess() = runTest {
         testee.commands().test {
             testee.onLoginSuccess()
             val command = awaitItem()
             assertTrue(command is Command.LoginSucess)
             verify(syncPixels).fireLoginPixel()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2SameAccountThenShowAlreadyPaired() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        val scanned = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(qrCode.parse(scanned)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(
+                ExchangeV2Event.Transition(
+                    timestampMs = 0L,
+                    from = ExchangeV2State.Negotiating,
+                    to = ExchangeV2State.SameAccountAbort,
+                    trigger = null,
+                    localTrigger = null,
+                ),
+            ),
+        )
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scanned)
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2AlreadyPairedError, (command as ShowV2Error).content)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncV2ConfirmationCopyTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncV2ConfirmationCopyTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui
+
+import com.duckduckgo.sync.impl.R
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SyncV2ConfirmationCopyTest {
+
+    @Test fun whenKnownDdgPeerThenFullDataList() {
+        assertEquals(
+            R.string.sync_v2_confirmation_message_ddg,
+            syncV2ConfirmationMessageRes(unknownPeer = false, peerKind = PeerKind.DDG),
+        )
+    }
+
+    @Test fun whenKnownThirdPartyPeerThenChatsOnly() {
+        assertEquals(
+            R.string.sync_v2_confirmation_message_3p,
+            syncV2ConfirmationMessageRes(unknownPeer = false, peerKind = PeerKind.THIRD_PARTY),
+        )
+    }
+
+    @Test fun whenUnknownDdgPeerThenFullDataListWithoutName() {
+        assertEquals(
+            R.string.sync_v2_confirmation_message_unknown_peer_ddg,
+            syncV2ConfirmationMessageRes(unknownPeer = true, peerKind = PeerKind.DDG),
+        )
+    }
+
+    @Test fun whenUnknownThirdPartyPeerThenChatsOnlyWithoutName() {
+        assertEquals(
+            R.string.sync_v2_confirmation_message_unknown_peer_3p,
+            syncV2ConfirmationMessageRes(unknownPeer = true, peerKind = PeerKind.THIRD_PARTY),
+        )
+    }
+
+    @Test fun whenKindNullThenFallsBackToFullDdgList() {
+        assertEquals(
+            R.string.sync_v2_confirmation_message_ddg,
+            syncV2ConfirmationMessageRes(unknownPeer = false, peerKind = null),
+        )
+        assertEquals(
+            R.string.sync_v2_confirmation_message_unknown_peer_ddg,
+            syncV2ConfirmationMessageRes(unknownPeer = true, peerKind = null),
+        )
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
@@ -36,11 +36,15 @@ import com.duckduckgo.sync.TestSyncFixtures.primaryKey
 import com.duckduckgo.sync.TestSyncFixtures.validLoginKeys
 import com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
 import com.duckduckgo.sync.impl.Clipboard
 import com.duckduckgo.sync.impl.ExchangeResult.AccountSwitchingRequired
 import com.duckduckgo.sync.impl.ExchangeResult.LoggedIn
 import com.duckduckgo.sync.impl.InvitationCode
 import com.duckduckgo.sync.impl.QREncoder
+import com.duckduckgo.sync.impl.RealSyncCodeDispatcher
 import com.duckduckgo.sync.impl.RecoveryCode
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.Result.Success
@@ -50,14 +54,31 @@ import com.duckduckgo.sync.impl.SyncAuthCode.Exchange
 import com.duckduckgo.sync.impl.SyncAuthCode.Recovery
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.encodeB64
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
+import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
+import com.duckduckgo.sync.impl.exchange.v2.PairingRole
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_EXCHANGE
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command
+import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.AskHostConfirmation
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.AskToSwitchAccount
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.LoginSuccess
+import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.ShowError
+import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.ShowV2Error
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.SwitchAccountSuccess
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -65,6 +86,7 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -85,6 +107,22 @@ class SyncWithAnotherDeviceViewModelTest {
         this.seamlessAccountSwitching().setRawStoredState(State(true))
         this.exchangeKeysToSyncWithAnotherDevice().setRawStoredState(State(false))
     }
+    private val qrCode: ExchangeV2QrCode = mock()
+
+    private val runnerEventsFlow = kotlinx.coroutines.flow.MutableSharedFlow<com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event>(replay = 0)
+    private val runner: ExchangeV2Runner = mock<ExchangeV2Runner>().also {
+        whenever(it.events).thenReturn(runnerEventsFlow)
+        whenever(it.eventsSince(any())).thenAnswer { invocation ->
+            val sinceMs = invocation.getArgument<Long>(0)
+            runnerEventsFlow.filter { event -> event.timestampMs >= sinceMs }
+        }
+    }
+    private val codeDispatcher = RealSyncCodeDispatcher(
+        syncFeature = syncFeature,
+        syncAccountRepository = syncRepository,
+        qrCode = qrCode,
+        runner = runner,
+    )
 
     private val testee = SyncWithAnotherActivityViewModel(
         syncRepository,
@@ -93,6 +131,7 @@ class SyncWithAnotherDeviceViewModelTest {
         syncPixels,
         coroutineTestRule.testDispatcherProvider,
         syncFeature,
+        codeDispatcher,
     )
 
     @Test
@@ -228,9 +267,9 @@ class SyncWithAnotherDeviceViewModelTest {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.ShowError)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE), eq(CodeVersion.V1), isNull())
             verify(syncPixels, never()).fireLoginPixel()
-            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any())
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -246,9 +285,9 @@ class SyncWithAnotherDeviceViewModelTest {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.ShowError)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE), eq(CodeVersion.V1), isNull())
             verify(syncPixels, never()).fireLoginPixel()
-            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any())
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -262,9 +301,9 @@ class SyncWithAnotherDeviceViewModelTest {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.AskToSwitchAccount)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE), eq(CodeVersion.V1), isNull())
             verify(syncPixels, never()).fireLoginPixel()
-            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any())
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -279,9 +318,9 @@ class SyncWithAnotherDeviceViewModelTest {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.AskToSwitchAccount)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE), eq(CodeVersion.V1), isNull())
             verify(syncPixels, never()).fireLoginPixel()
-            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any())
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -396,9 +435,9 @@ class SyncWithAnotherDeviceViewModelTest {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.ShowError)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE), eq(CodeVersion.V1), isNull())
             verify(syncPixels, never()).fireLoginPixel()
-            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any())
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -406,7 +445,7 @@ class SyncWithAnotherDeviceViewModelTest {
     @Test
     fun whenUserCancelsThenAbandonedPixelFired() = runTest {
         testee.onUserCancelledWithoutSyncSetup()
-        verify(syncPixels).fireSyncSetupAbandoned(eq(SYNC_EXCHANGE))
+        verify(syncPixels).fireSyncSetupAbandoned(eq(SYNC_EXCHANGE), eq(CancellationReason.SCANNING_CANCELLED))
     }
 
     @Test
@@ -427,5 +466,305 @@ class SyncWithAnotherDeviceViewModelTest {
         whenever(qrEncoder.encodeAsBitmap(eq(jsonExchangeKey), any(), any())).thenReturn(bitmap)
         whenever(syncRepository.processCode(any(), anyOrNull())).thenReturn(Success(true))
         return Pair(bitmap, authCodeToUse)
+    }
+
+    private fun enableV2(displayOn: Boolean) {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        syncFeature.canShowV2ConnectCode().setRawStoredState(State(displayOn))
+    }
+
+    private fun presenterSessionStarted(linkingCode: String = "https://duckduckgo.com/sync/pairing?code2=xyz") =
+        ExchangeV2Event.SessionStarted(
+            timestampMs = System.currentTimeMillis(),
+            pairingRole = PairingRole.Presenter,
+            ownChannelId = "own-channel",
+            linkingCode = linkingCode,
+        )
+
+    private fun transition(
+        from: ExchangeV2State,
+        to: ExchangeV2State,
+        localTrigger: LocalTrigger? = null,
+    ) = ExchangeV2Event.Transition(
+        timestampMs = System.currentTimeMillis(),
+        from = from,
+        to = to,
+        trigger = null,
+        localTrigger = localTrigger,
+    )
+
+    @Test
+    fun whenBothV2FlagsOnThenRunnerStartPresentInvokedAndV1RecoveryNotCalled() = runTest {
+        enableV2(displayOn = true)
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        val bitmap = TestSyncFixtures.qrBitmap()
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(bitmap)
+
+        testee.viewState().test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            val withQr = awaitItem()
+            Assert.assertEquals(bitmap, withQr.qrCodeBitmap)
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(runner).startPresent()
+        verify(syncRepository, never()).generateExchangeInvitationCode()
+        verify(syncRepository, never()).getRecoveryCode()
+    }
+
+    @Test
+    fun whenMasterFlagOnButCanShowV2OffThenV1PathTaken() = runTest {
+        enableV2(displayOn = false)
+        val bitmap = TestSyncFixtures.qrBitmap()
+        val authCode = AuthCode(qrCode = jsonRecoveryKeyEncoded, rawCode = "raw")
+        whenever(qrEncoder.encodeAsBitmap(eq(jsonRecoveryKeyEncoded), any(), any())).thenReturn(bitmap)
+        whenever(syncRepository.getRecoveryCode()).thenReturn(Result.Success(authCode))
+
+        testee.viewState().test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(runner, never()).startPresent()
+        verify(syncRepository).getRecoveryCode()
+    }
+
+    @Test
+    fun whenMasterFlagOffThenV1PathTakenRegardlessOfDisplayFlag() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+        syncFeature.canShowV2ConnectCode().setRawStoredState(State(true))
+        val bitmap = TestSyncFixtures.qrBitmap()
+        val authCode = AuthCode(qrCode = jsonRecoveryKeyEncoded, rawCode = "raw")
+        whenever(qrEncoder.encodeAsBitmap(eq(jsonRecoveryKeyEncoded), any(), any())).thenReturn(bitmap)
+        whenever(syncRepository.getRecoveryCode()).thenReturn(Result.Success(authCode))
+
+        testee.viewState().test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(runner, never()).startPresent()
+    }
+
+    @Test
+    fun whenLinkingCodeReadyThenBarcodeContentsPopulatedAndCopyEmitsUrl() = runTest {
+        enableV2(displayOn = true)
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        val url = "https://duckduckgo.com/sync/pairing?code2=copy-me"
+        val bitmap = TestSyncFixtures.qrBitmap()
+        whenever(qrEncoder.encodeAsBitmap(eq(url), any(), any())).thenReturn(bitmap)
+
+        testee.viewState().test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted(linkingCode = url))
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.onCopyCodeClicked()
+        verify(clipboard).copyToClipboard(url)
+    }
+
+    @Test
+    fun whenHostConfirmingDuringV2PresentThenAskHostConfirmationCommandEmitted() = runTest {
+        enableV2(displayOn = true)
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        whenever(runner.peerName).thenReturn("Peer Phone")
+        whenever(runner.peerKind).thenReturn("3party")
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState().test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Confirming),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected AskHostConfirmation, got $command", command is AskHostConfirmation)
+            Assert.assertEquals("Peer Phone", (command as AskHostConfirmation).peerName)
+            Assert.assertEquals(PeerKind.THIRD_PARTY, (command as AskHostConfirmation).peerKind)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenHostDoneDuringV2PresentThenLoginSuccessShowRecoveryFalse() = runTest {
+        enableV2(displayOn = true)
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState().test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(from = ExchangeV2State.Host.Sending, to = ExchangeV2State.Host.Done),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected LoginSuccess, got $command", command is LoginSuccess)
+            Assert.assertEquals(false, (command as LoginSuccess).showRecovery)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenSameAccountAbortDuringV2PresentThenShowAlreadyPaired() = runTest {
+        enableV2(displayOn = true)
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState().test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.SameAccountAbort),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2AlreadyPairedError, (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenHostAbortedUserDeniedDuringV2PresentThenShowErrorCommandEmitted() = runTest {
+        enableV2(displayOn = true)
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState().test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Host.Confirming,
+                    to = ExchangeV2State.Host.Aborted,
+                    localTrigger = LocalTrigger.UserDeniedHost,
+                ),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_CANCELLED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenSessionErrorDuringV2PresentThenShowErrorCommandEmitted() = runTest {
+        enableV2(displayOn = true)
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState().test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                ExchangeV2Event.SessionError(timestampMs = System.currentTimeMillis(), message = "channel 5xx"),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_FAILED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenViewStateReCollectedThenExchangeInvitationGeneratedOnce() = runTest {
+        configureExchangeKeysSupported()
+        testee.viewState().test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        testee.viewState().test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(syncRepository, times(1)).generateExchangeInvitationCode()
+    }
+
+    @Test
+    fun whenViewStateReCollectedThenV2PresentStartedOnce() = runTest {
+        enableV2(displayOn = true)
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+        testee.viewState().test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        testee.viewState().test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(runner, times(1)).startPresent()
+    }
+
+    @Test
+    fun whenV2PairingRejectedByPeerThenShowError() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(qrCode.parse(scannedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scannedCode)
+            runnerEventsFlow.emit(
+                ExchangeV2Event.Transition(
+                    timestampMs = System.currentTimeMillis(),
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                    localTrigger = null,
+                ),
+            )
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_REJECTED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2UpgradeRequiredThenShowUpdateError() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(qrCode.parse(scannedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(ExchangeV2Event.SessionError(timestampMs = 0L, message = "Peer requires protocol v3; please update this app")),
+        )
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scannedCode)
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2UpgradeRequiredError, (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/V2PairingErrorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/V2PairingErrorTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui
+
+import com.duckduckgo.sync.impl.AccountErrorCodes.GENERIC_ERROR
+import com.duckduckgo.sync.impl.AccountErrorCodes.NEGOTIATION_ABORTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.NO_RECOVERY_CODE
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_UNAVAILABLE
+import com.duckduckgo.sync.impl.AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED
+import com.duckduckgo.sync.impl.R
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class V2PairingErrorTest {
+
+    @Test
+    fun whenCodeIsPairingRejectedThenCanceledFromOtherDeviceTitleWithTryAgain() {
+        val content = PAIRING_REJECTED.code.toV2PairingError()
+        assertEquals(R.string.sync_v2_error_pairing_rejected, content.title)
+        assertEquals(R.string.sync_v2_error_try_again, content.message)
+    }
+
+    @Test
+    fun whenCodeIsPairingCancelledThenCanceledTitleOnly() {
+        val content = PAIRING_CANCELLED.code.toV2PairingError()
+        assertEquals(R.string.sync_v2_error_pairing_canceled, content.title)
+        assertNull(content.message)
+    }
+
+    @Test
+    fun whenCodeIsThirdPartyAlreadyUpgradedThenSyncFailedTitleWithUpgradeMessage() {
+        val content = THIRD_PARTY_ALREADY_UPGRADED.code.toV2PairingError()
+        assertEquals(R.string.sync_v2_error_pairing_failed, content.title)
+        assertEquals(R.string.sync_v2_error_third_party_already_upgraded, content.message)
+    }
+
+    @Test
+    fun whenCodeIsAnyOtherAbortThenSyncFailedTitleWithTryAgain() {
+        listOf(PAIRING_UNAVAILABLE, NEGOTIATION_ABORTED, NO_RECOVERY_CODE, PAIRING_FAILED).forEach { code ->
+            val content = code.code.toV2PairingError()
+            assertEquals("code $code title", R.string.sync_v2_error_pairing_failed, content.title)
+            assertEquals("code $code message", R.string.sync_v2_error_try_again, content.message)
+        }
+    }
+
+    @Test
+    fun whenCodeIsGenericOrUnknownThenSyncFailedTitleWithTryAgain() {
+        listOf(GENERIC_ERROR.code, 9999).forEach { code ->
+            val content = code.toV2PairingError()
+            assertEquals(R.string.sync_v2_error_pairing_failed, content.title)
+            assertEquals(R.string.sync_v2_error_try_again, content.message)
+        }
+    }
+
+    @Test
+    fun whenUpgradeRequiredThenUpdateBrowserTitleOnly() {
+        assertEquals(R.string.sync_v2_error_upgrade_required, v2UpgradeRequiredError.title)
+        assertNull(v2UpgradeRequiredError.message)
+    }
+
+    @Test
+    fun whenAlreadyPairedThenAlreadySyncedTitleWithMessage() {
+        assertEquals(R.string.sync_v2_already_paired_title, v2AlreadyPairedError.title)
+        assertEquals(R.string.sync_v2_already_paired_message, v2AlreadyPairedError.message)
+    }
+}

--- a/sync/sync-internal/build.gradle
+++ b/sync/sync-internal/build.gradle
@@ -60,4 +60,16 @@ dependencies {
     implementation "com.google.zxing:core:_"
 
     implementation "com.squareup.logcat:logcat:_"
+
+    // Testing dependencies
+    testImplementation "org.mockito.kotlin:mockito-kotlin:_"
+    testImplementation Testing.junit4
+    testImplementation AndroidX.test.ext.junit
+    testImplementation Testing.robolectric
+    testImplementation CashApp.turbine
+    testImplementation AndroidX.archCore.testing
+    testImplementation project(path: ':common-test')
+    testImplementation(KotlinX.coroutines.test) {
+        exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
+    }
 }

--- a/sync/sync-internal/src/main/AndroidManifest.xml
+++ b/sync/sync-internal/src/main/AndroidManifest.xml
@@ -23,5 +23,11 @@
             android:label="@string/sync_internal_activity_label"
             android:screenOrientation="portrait"
             android:parentActivityName="com.duckduckgo.app.settings.SettingsActivity" />
+        <activity
+            android:name=".ui.SyncV2PairingDebugActivity"
+            android:exported="false"
+            android:label="@string/sync_v2_pairing_debug_activity_label"
+            android:screenOrientation="portrait"
+            android:parentActivityName=".ui.SyncInternalSettingsActivity" />
     </application>
 </manifest>

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
@@ -110,6 +110,10 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         binding.launchSyncSettingsButton.setOnClickListener {
             startActivity(Intent(this, SyncActivity::class.java))
         }
+        binding.openV2PairingDebugButton.setOnClickListener {
+            startActivity(Intent(this, SyncV2PairingDebugActivity::class.java))
+        }
+        // this is temporary while testing
         binding.openDuckAiDevScreenButton.setOnClickListener {
             // Launch via class name so sync-internal doesn't need a direct dependency on duckchat-internal.
             val intent = Intent().setClassName(packageName, "com.duckduckgo.duckchat.internal.DuckAiDevActivity")

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncApi
+import com.duckduckgo.sync.impl.SyncAuthCode
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.autorestore.SyncAutoRestoreManager
 import com.duckduckgo.sync.impl.autorestore.SyncRecoveryPersistentStorageKey
@@ -396,7 +397,23 @@ constructor(
 
     fun useRecoveryCode(recoveryCode: String) {
         viewModelScope.launch(dispatchers.io()) {
-            authFlow(recoveryCode)
+            // 3party recovery codes are intentionally rejected by parseSyncAuthCode (production
+            // paste/scan paths must not accept them). For the dev-tool entrypoint we explicitly
+            // try the 3party→ddg upgrade path when the existing parser doesn't recognize the code.
+            val codeType = syncAccountRepository.parseSyncAuthCode(recoveryCode)
+            if (codeType is SyncAuthCode.Unknown) {
+                when (val joinResult = syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(recoveryCode)) {
+                    is Success -> {
+                        command.send(Command.LoginSuccess)
+                        updateViewState()
+                    }
+                    is Error -> {
+                        command.send(Command.ShowMessage("$joinResult"))
+                    }
+                }
+            } else {
+                authFlow(recoveryCode)
+            }
         }
     }
 
@@ -500,7 +517,6 @@ constructor(
     private fun buildV2StoreFieldsText(): String = buildString {
         appendLine("credentialId: ${syncStore.credentialId ?: "(not set)"}")
         appendLine("scopedPassword: ${syncStore.scopedPassword?.raw?.take(40)?.let { "$it..." } ?: "(not set)"}")
-        appendLine("protectedKeysJson: ${syncStore.protectedKeysJson?.take(60)?.let { "$it..." } ?: "(not set)"}")
     }.trim().also { logcat { "Sync-ScopedToken: v2 store fields:\n$it" } }
 
     fun onCreateThirdPartyCredentialClicked() {

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugActivity.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugActivity.kt
@@ -1,0 +1,327 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.internal.ui
+
+import android.annotation.SuppressLint
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.os.Bundle
+import android.view.View
+import android.widget.Toast
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.view.dialog.DaxAlertDialog
+import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
+import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.extensions.hideKeyboard
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.sync.impl.exchange.v2.Role
+import com.duckduckgo.sync.internal.databinding.ActivitySyncV2PairingDebugBinding
+import com.duckduckgo.sync.internal.databinding.ItemSyncV2PairingLogRowBinding
+import com.duckduckgo.sync.internal.ui.SyncV2PairingDebugViewModel.ConfirmationRequest
+import com.duckduckgo.sync.internal.ui.SyncV2PairingDebugViewModel.LogRow
+import com.duckduckgo.sync.internal.ui.SyncV2PairingDebugViewModel.TerminalReached
+import com.duckduckgo.sync.internal.ui.SyncV2PairingDebugViewModel.ViewState
+import com.google.zxing.BarcodeFormat.QR_CODE
+import com.journeyapps.barcodescanner.BarcodeEncoder
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.withContext
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import javax.inject.Inject
+
+@InjectWith(ActivityScope::class)
+class SyncV2PairingDebugActivity : DuckDuckGoActivity() {
+
+    @Inject
+    lateinit var dispatcherProvider: DispatcherProvider
+
+    private val binding: ActivitySyncV2PairingDebugBinding by viewBinding()
+    private val viewModel: SyncV2PairingDebugViewModel by bindViewModel()
+
+    private val timestampFormat = SimpleDateFormat("HH:mm:ss.SSS", Locale.US)
+    private val expandedRowIds = mutableSetOf<Long>()
+    private var renderedRows: List<LogRow> = emptyList()
+    private var activeConfirmationDialog: DaxAlertDialog? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(binding.root)
+        setupToolbar(binding.includeToolbar.toolbar)
+        configureListeners()
+        observeViewState()
+        observeConfirmations()
+        observeTerminals()
+        observeToasts()
+    }
+
+    private fun configureListeners() {
+        binding.runScanButton.setOnClickListener { startScanFromInput() }
+        binding.pasteAndGoButton.setOnClickListener { pasteAndStartScan() }
+        binding.runPresentButton.setOnClickListener {
+            if (!viewModel.canStartAsPresenter()) {
+                Toast.makeText(
+                    this,
+                    "Sign in to a sync account first — without one there's no recovery code to share. Set sync up in Sync Settings.",
+                    Toast.LENGTH_LONG,
+                ).show()
+                return@setOnClickListener
+            }
+            viewModel.onRunPresentClicked()
+        }
+        binding.clearPastedUrlButton.setOnClickListener { binding.pastedUrlInput.text = "" }
+        binding.cancelButton.setOnClickListener { viewModel.onCancelClicked() }
+        binding.clearLogButton.setOnClickListener {
+            expandedRowIds.clear()
+            viewModel.onClearLogClicked()
+        }
+        binding.autoApproveSetting.quietlySetIsChecked(newCheckedState = true) { _, enabled ->
+            viewModel.onAutoApproveToggled(enabled)
+        }
+
+        binding.signInOutButton.setOnClickListener { viewModel.onSignInOutClicked() }
+    }
+
+    private fun observeViewState() {
+        viewModel.viewState()
+            .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+            .onEach { render(it) }
+            .launchIn(lifecycleScope)
+    }
+
+    private fun observeConfirmations() {
+        viewModel.confirmations()
+            .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+            .onEach { showConfirmationDialog(it) }
+            .launchIn(lifecycleScope)
+    }
+
+    private fun observeTerminals() {
+        viewModel.terminals()
+            .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+            .onEach { showTerminalDialog(it) }
+            .launchIn(lifecycleScope)
+    }
+
+    private fun observeToasts() {
+        viewModel.toasts()
+            .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+            .onEach { Toast.makeText(this, it, Toast.LENGTH_LONG).show() }
+            .launchIn(lifecycleScope)
+    }
+
+    private fun showTerminalDialog(terminal: TerminalReached) {
+        // Auto-dismiss any open confirmation prompt — the session ended before the user
+        // could respond, so the prompt is no longer relevant.
+        activeConfirmationDialog?.dismiss()
+        activeConfirmationDialog = null
+        TextAlertDialogBuilder(this)
+            .setTitle(terminal.title)
+            .setMessage(terminal.message)
+            .setPositiveButton(android.R.string.ok)
+            .show()
+    }
+
+    private fun showConfirmationDialog(request: ConfirmationRequest) {
+        // Replace any prior confirmation dialog (shouldn't happen, but defensive).
+        activeConfirmationDialog?.dismiss()
+        val peer = request.peerName?.takeIf { it.isNotBlank() } ?: "the other device"
+        val (title, message) = when (request.role) {
+            Role.Host -> "Confirm pairing (Host)" to "Allow $peer to join your sync & backup?"
+            Role.Joiner -> "Confirm pairing (Joiner)" to "Sync your data with $peer?"
+        }
+        val dialog = TextAlertDialogBuilder(this)
+            .setTitle(title)
+            .setMessage(message)
+            .setPositiveButton(android.R.string.ok)
+            .setNegativeButton(android.R.string.cancel)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() {
+                        activeConfirmationDialog = null
+                        viewModel.onConfirmationApproved(request.role)
+                    }
+
+                    override fun onNegativeButtonClicked() {
+                        activeConfirmationDialog = null
+                        viewModel.onConfirmationDenied(request.role)
+                    }
+
+                    override fun onDialogDismissed() {
+                        activeConfirmationDialog = null
+                    }
+                },
+            )
+            .build()
+        activeConfirmationDialog = dialog
+        dialog.show()
+    }
+
+    private fun render(state: ViewState) {
+        renderAccountStatus(state.accountStatus)
+        binding.currentStateTextView.text = state.currentStateLabel
+        val code = state.linkingCode
+        if (code != null) {
+            binding.linkingCodeSectionHeader.visibility = View.VISIBLE
+            binding.linkingCodeTextView.visibility = View.VISIBLE
+            // Bare URL only — no "Linking code:" prefix — so long-press-select copies cleanly.
+            binding.linkingCodeTextView.text = code
+            binding.linkingCodeTextView.setOnClickListener { copyToClipboard("Linking code", code) }
+            binding.copyLinkingCodeButton.visibility = View.VISIBLE
+            binding.copyLinkingCodeButton.setOnClickListener { copyToClipboard("Linking code", code) }
+            renderQrFor(code)
+            // First time we see this code, push to clipboard automatically so the user can
+            // paste straight into the Scanner device without a manual Copy tap.
+            if (autoCopiedLinkingCode != code) {
+                autoCopiedLinkingCode = code
+                copyToClipboard("Linking code", code)
+            }
+        } else {
+            binding.linkingCodeSectionHeader.visibility = View.GONE
+            binding.linkingCodeTextView.visibility = View.GONE
+            binding.copyLinkingCodeButton.visibility = View.GONE
+            binding.linkingCodeQrImage.visibility = View.GONE
+            binding.linkingCodeQrImage.setImageBitmap(null)
+            renderedQrFor = null
+            autoCopiedLinkingCode = null
+        }
+        if (state.rows !== renderedRows) {
+            renderedRows = state.rows
+            renderRows(state.rows)
+        }
+    }
+
+    private var autoCopiedLinkingCode: String? = null
+
+    /**
+     * Encode [code] as a QR bitmap on a background thread (zxing is CPU-bound) and show it in
+     * [linkingCodeQrImage]. Skips work if we already rendered this exact code (render() runs
+     * on every event flow update — we don't want to regenerate the QR each time).
+     */
+    @SuppressLint("AvoidComputationUsage")
+    private fun renderQrFor(code: String) {
+        if (renderedQrFor == code) return
+        renderedQrFor = code
+        binding.linkingCodeQrImage.visibility = View.VISIBLE
+        lifecycleScope.launchWhenStarted {
+            val bitmap = withContext(dispatcherProvider.computation()) {
+                runCatching { BarcodeEncoder().encodeBitmap(code, QR_CODE, QR_SIZE_PX, QR_SIZE_PX) }
+                    .getOrNull()
+            }
+            if (renderedQrFor == code) binding.linkingCodeQrImage.setImageBitmap(bitmap)
+        }
+    }
+
+    private var renderedQrFor: String? = null
+
+    private fun renderRows(rows: List<LogRow>) {
+        binding.logContainer.removeAllViews()
+        rows.forEach { row ->
+            val rowBinding = ItemSyncV2PairingLogRowBinding.inflate(layoutInflater, binding.logContainer, true)
+            val timestamp = timestampFormat.format(Date(row.timestampMs))
+            rowBinding.summaryTextView.text = "[$timestamp] ${row.summary}"
+            rowBinding.rawJsonTextView.text = row.rawJson
+            applyExpansion(rowBinding, row.id in expandedRowIds)
+            rowBinding.summaryRow.setOnClickListener {
+                val newlyExpanded = row.id !in expandedRowIds
+                if (newlyExpanded) expandedRowIds.add(row.id) else expandedRowIds.remove(row.id)
+                applyExpansion(rowBinding, newlyExpanded)
+            }
+            rowBinding.copyRawButton.setOnClickListener {
+                copyToClipboard("Raw JSON", row.rawJson)
+            }
+        }
+    }
+
+    private fun applyExpansion(rowBinding: ItemSyncV2PairingLogRowBinding, expanded: Boolean) {
+        rowBinding.rawDetail.visibility = if (expanded) View.VISIBLE else View.GONE
+        rowBinding.chevronTextView.text = if (expanded) "▾" else "▸"
+    }
+
+    private fun copyToClipboard(label: String, value: String) {
+        val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        clipboard.setPrimaryClip(ClipData.newPlainText(label, value))
+        Toast.makeText(this, "$label copied", Toast.LENGTH_SHORT).show()
+    }
+
+    /** Shared handler for the "Start as Scanner" button — uses whatever is in the input field. */
+    private fun startScanFromInput() {
+        val pasted = binding.pastedUrlInput.text.trim()
+        if (pasted.isEmpty()) {
+            Toast.makeText(
+                this,
+                "Paste the Presenter's linking code into the V2 exchange URL field first.",
+                Toast.LENGTH_LONG,
+            ).show()
+            return
+        }
+        viewModel.onRunScanClicked(pasted)
+        // Clear the input now that we've handed it off — keeps the field tidy and avoids
+        // the user accidentally re-running with a stale code.
+        binding.pastedUrlInput.text = ""
+        // Dismiss the keyboard so the log + state are visible without scrolling.
+        hideKeyboard()
+    }
+
+    /**
+     * One-tap: read clipboard, fill the input (for visible feedback), then fire start-scan.
+     * Skips the keyboard / paste-menu round-trip entirely.
+     */
+    private fun pasteAndStartScan() {
+        val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        val text = clipboard.primaryClip
+            ?.takeIf { it.itemCount > 0 }
+            ?.getItemAt(0)
+            ?.coerceToText(this)
+            ?.toString()
+            ?.trim()
+            .orEmpty()
+        if (text.isEmpty()) {
+            Toast.makeText(this, "Clipboard is empty — copy the Presenter's linking code first.", Toast.LENGTH_LONG).show()
+            return
+        }
+        // Surface what was pasted so the user can see it before it disappears (input is then
+        // cleared by startScanFromInput).
+        binding.pastedUrlInput.text = text
+        startScanFromInput()
+    }
+
+    private fun renderAccountStatus(status: SyncV2PairingDebugViewModel.AccountStatus) {
+        binding.statusSignedIn.setSecondaryText(
+            if (status.signedIn) "Yes · user_id ${status.userId ?: "(unknown)"}" else "No",
+        )
+        binding.signInOutButton.text = if (status.signedIn) "Sign out" else "Sign in"
+        binding.statusThirdPartyCredential.setSecondaryText(
+            when {
+                !status.signedIn -> "(not signed in)"
+                status.thirdPartyCredentialCreated -> "Yes"
+                else -> "Not created; needed before pairing with 3party peers"
+            },
+        )
+    }
+
+    private companion object {
+        const val QR_SIZE_PX = 600
+    }
+}

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModel.kt
@@ -1,0 +1,617 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.internal.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.sync.impl.DispatchOutcome
+import com.duckduckgo.sync.impl.ExchangeResult.AccountSwitchingRequired
+import com.duckduckgo.sync.impl.ExchangeResult.LoggedIn
+import com.duckduckgo.sync.impl.ExchangeResult.Pending
+import com.duckduckgo.sync.impl.Result
+import com.duckduckgo.sync.impl.RouteDecision
+import com.duckduckgo.sync.impl.SyncAccountRepository
+import com.duckduckgo.sync.impl.SyncAuthCode
+import com.duckduckgo.sync.impl.SyncCodeDispatcher
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
+import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
+import com.duckduckgo.sync.impl.exchange.v2.RejectReason
+import com.duckduckgo.sync.impl.exchange.v2.Role
+import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Companion.POLLING_INTERVAL_EXCHANGE_FLOW
+import com.duckduckgo.sync.store.SyncStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import logcat.logcat
+import javax.inject.Inject
+
+@ContributesViewModel(ActivityScope::class)
+class SyncV2PairingDebugViewModel @Inject constructor(
+    private val runner: ExchangeV2Runner,
+    private val syncStore: SyncStore,
+    private val syncAccountRepository: SyncAccountRepository,
+    private val dispatcher: SyncCodeDispatcher,
+    private val dispatchers: DispatcherProvider,
+    @AppCoroutineScope private val appScope: CoroutineScope,
+) : ViewModel() {
+
+    data class LogRow(
+        val id: Long,
+        val timestampMs: Long,
+        val summary: String,
+        val rawJson: String,
+    )
+
+    /**
+     * Snapshot of the device's sync setup that's relevant to v2 pairing. Read from
+     * [SyncStore] at the points where it could have changed (init + after Cancel /
+     * terminal). Not reactive — this is a dev tool, the user can tap Cancel to refresh.
+     */
+    data class AccountStatus(
+        val signedIn: Boolean,
+        val userId: String?,
+        val thirdPartyCredentialCreated: Boolean,
+    )
+
+    data class ViewState(
+        val currentStateLabel: String = "(no session)",
+        val linkingCode: String? = null,
+        val rows: List<LogRow> = emptyList(),
+        val autoApproveConfirmation: Boolean = true,
+        val accountStatus: AccountStatus = AccountStatus(false, null, false),
+    )
+
+    /**
+     * One-shot prompt to show the user. The Activity renders this as an [AlertDialog] and
+     * dispatches the result back via [onConfirmationApproved] / [onConfirmationDenied].
+     */
+    data class ConfirmationRequest(
+        val role: Role,
+        val peerName: String?,
+    )
+
+    /**
+     * Emitted once when the session reaches a terminal state. The Activity shows a result
+     * alert summarising what happened.
+     */
+    data class TerminalReached(
+        val state: ExchangeV2State,
+        val title: String,
+        val message: String,
+        val isSuccess: Boolean,
+    )
+
+    private val viewState = MutableStateFlow(ViewState())
+    fun viewState(): Flow<ViewState> = viewState.asStateFlow()
+
+    /**
+     * Tear down any in-flight session when the Activity is finishing. ActivityScope VMs
+     * survive config changes but [onCleared] runs on real finish (back press, navigation away),
+     * which is when we want to dispose of a pairing session that the user has abandoned.
+     */
+    override fun onCleared() {
+        super.onCleared()
+        // cancel() suspends until teardown completes; onCleared can't await and viewModelScope is
+        // already cancelling, so fire-and-forget the teardown on the app scope (it outlives the VM).
+        appScope.launch { runner.cancel() }
+    }
+
+    private val confirmationRequests = Channel<ConfirmationRequest>(Channel.BUFFERED)
+    fun confirmations(): Flow<ConfirmationRequest> = confirmationRequests.receiveAsFlow()
+
+    private val terminalReached = Channel<TerminalReached>(Channel.BUFFERED)
+    fun terminals(): Flow<TerminalReached> = terminalReached.receiveAsFlow()
+
+    private val toasts = Channel<String>(Channel.BUFFERED)
+    fun toasts(): Flow<String> = toasts.receiveAsFlow()
+
+    private var nextRowId: Long = 0L
+
+    init {
+        viewState.update { it.copy(accountStatus = readAccountStatus()) }
+        viewModelScope.launch(dispatchers.io()) {
+            // Snapshot how many events the runner's SharedFlow will replay to us. Those events
+            // populate the log row history, but we skip side effects (terminal alerts,
+            // confirmation dialogs) for them — otherwise re-entering this Activity after a
+            // completed pairing would re-pop the "Pairing complete" dialog from a stale event.
+            val replayCount = runner.events.replayCache.size
+            var processed = 0
+            runner.events.collect { event ->
+                appendEvent(event, isReplay = processed < replayCount)
+                processed++
+            }
+        }
+    }
+
+    /**
+     * Delegate routing to [SyncCodeDispatcher] — the single source of truth for v1/v2 dispatch
+     * that the production VMs now share. The dispatcher's contract: FF off → byte-identical to
+     * direct [SyncAccountRepository.parseSyncAuthCode]; FF on → v2 shapes are taken into
+     * ownership and surfaced via a one-shot [DispatchOutcome] Flow.
+     *
+     * The VM still owns the v1 [SyncAuthCode.Exchange] two-stage polling locally (in
+     * [dispatchV1Exchange]) — the dispatcher only handles the routing decision, not the
+     * downstream v1 protocol details (preserved byte-for-byte from production).
+     */
+    fun onRunScanClicked(pastedUrl: String) {
+        viewModelScope.launch(dispatchers.io()) {
+            appendDevToolLog("Routing pasted code via SyncCodeDispatcher")
+            when (val decision = dispatcher.route(pastedUrl)) {
+                is RouteDecision.Legacy -> handleLegacyAuthCode(decision.authCode)
+                is RouteDecision.V2InProgress -> {
+                    appendDevToolLog("Dispatcher took v2 ownership — observing outcomes")
+                    decision.outcomes.collect { outcome -> handleV2Outcome(outcome) }
+                    refreshState()
+                }
+            }
+        }
+    }
+
+    /**
+     * Mirrors production v1 handling exactly: Recovery / Connect → [SyncAccountRepository.processCode];
+     * Exchange → two-stage post-then-poll loop; Unknown → user-facing error. Identical control
+     * flow to [com.duckduckgo.sync.impl.ui.EnterCodeViewModel.authFlow] but logging into the
+     * dev-tool log row stream instead of UI commands.
+     */
+    private suspend fun handleLegacyAuthCode(authCode: SyncAuthCode) {
+        appendDevToolLog("Legacy v1 auth code: ${authCode::class.simpleName}")
+        when (authCode) {
+            is SyncAuthCode.Recovery -> emitProcessCodeResult("v1 recovery", syncAccountRepository.processCode(authCode))
+            is SyncAuthCode.Connect -> emitProcessCodeResult("v1 connect", syncAccountRepository.processCode(authCode))
+            is SyncAuthCode.Exchange -> dispatchV1Exchange(authCode)
+            is SyncAuthCode.Unknown -> {
+                appendDevToolLog("Couldn't read the pasted code as v1 or v2")
+                toasts.send("Couldn't read the pasted code (no v1 or v2 shape matched)")
+            }
+        }
+        refreshState()
+    }
+
+    /**
+     * Translate one [DispatchOutcome] emitted by the v2 dispatcher into the dev tool's log +
+     * toast surface. Production VMs map these to their own command/error-dialog channels.
+     */
+    private suspend fun handleV2Outcome(outcome: DispatchOutcome) {
+        when (outcome) {
+            is DispatchOutcome.LoggedIn -> {
+                appendDevToolLog("v2 dispatch → LoggedIn")
+                toasts.send("Paired via v2 stack")
+            }
+            is DispatchOutcome.AlreadyConnected -> {
+                appendDevToolLog("v2 dispatch → AlreadyConnected (same-account, spec friendly finish)")
+                toasts.send("Already connected (same account)")
+            }
+            is DispatchOutcome.UpgradeRequired -> {
+                appendDevToolLog("v2 dispatch → UpgradeRequired (codeMajor=${outcome.codeMajor})")
+                toasts.send("This code requires a newer app version (v${outcome.codeMajor})")
+            }
+            is DispatchOutcome.Failed -> {
+                appendDevToolLog("v2 dispatch → Failed: ${outcome.reason}")
+                toasts.send("v2 dispatch failed: ${outcome.reason}")
+            }
+            is DispatchOutcome.JoinerConfirmationRequested,
+            is DispatchOutcome.HostConfirmationRequested,
+            -> {
+                // The dev tool already drives confirmation via its direct runner.events
+                // observation ([maybeHandleConfirmingTransition]). Ignoring the dispatcher's
+                // intermediate emission here avoids double-prompting.
+                appendDevToolLog("v2 dispatch → ${outcome::class.simpleName} (handled by dev tool's direct observation)")
+            }
+            is DispatchOutcome.LinkingCodeReady -> {
+                // No-op: the dev tool drives Presenter sessions directly via runner.startPresent()
+                // (onRunPresentClicked), not through dispatcher.presentV2(). This branch only exists
+                // to keep the when block exhaustive.
+                appendDevToolLog("v2 dispatch → LinkingCodeReady (handled by dev tool's direct observation)")
+            }
+        }
+    }
+
+    /**
+     * v1 Exchange is a two-stage scanner flow:
+     *   1. [SyncAccountRepository.processCode] (→ `onInvitationCodeReceived`) posts our
+     *      encrypted device details to the presenter's relay slot.
+     *   2. Poll [SyncAccountRepository.pollForRecoveryCodeAndLogin] until the presenter
+     *      replies with the encrypted recovery code, which the repo then uses to log us in.
+     *
+     * Mirrors [SyncLoginViewModel.pollForRecoveryKey] / [SyncWithAnotherActivityViewModel]
+     * — same polling cadence, same result handling. Without step 2 the device finishes step
+     * 1 with "OK" but never actually logs in (the original bug).
+     */
+    private suspend fun dispatchV1Exchange(code: SyncAuthCode.Exchange) {
+        when (val postResult = syncAccountRepository.processCode(code)) {
+            is Result.Error -> {
+                appendDevToolLog("v1 exchange step 1 (post device details) failed: ${postResult.reason}")
+                toasts.send("v1 exchange failed: ${postResult.reason}")
+                return
+            }
+            is Result.Success -> {
+                appendDevToolLog("v1 exchange step 1 (post device details) OK — polling for recovery code")
+            }
+        }
+        var polling = true
+        while (polling) {
+            delay(POLLING_INTERVAL_EXCHANGE_FLOW)
+            when (val pollResult = syncAccountRepository.pollForRecoveryCodeAndLogin()) {
+                is Result.Success -> when (pollResult.data) {
+                    is Pending -> Unit // keep polling
+                    is LoggedIn -> {
+                        polling = false
+                        appendDevToolLog("v1 exchange: logged in via received recovery code")
+                        toasts.send("Paired via v1 exchange stack")
+                    }
+                    is AccountSwitchingRequired -> {
+                        // Production prompts the user; dev tool stops short of destructive
+                        // account switching and just surfaces the situation.
+                        polling = false
+                        appendDevToolLog("v1 exchange: peer offered a different account (skipped — account switching not wired here)")
+                        toasts.send("v1 exchange: account switching required — not wired in dev tool")
+                    }
+                }
+                is Result.Error -> {
+                    polling = false
+                    appendDevToolLog("v1 exchange poll failed: ${pollResult.reason}")
+                    toasts.send("v1 exchange poll failed: ${pollResult.reason}")
+                }
+            }
+        }
+    }
+
+    private suspend fun emitProcessCodeResult(label: String, result: Result<Boolean>) {
+        when (result) {
+            is Result.Success -> {
+                appendDevToolLog("$label: OK")
+                toasts.send("Paired via $label stack")
+            }
+            is Result.Error -> {
+                appendDevToolLog("$label failed: ${result.reason}")
+                toasts.send("$label failed: ${result.reason}")
+            }
+        }
+    }
+
+    /**
+     * Push a synthetic row into the event log so v1-fallback progress is visible alongside
+     * native v2 [ExchangeV2Event]s. Reuses [LogRow] with the message in both summary and rawJson.
+     * Also tees to logcat with a `Sync-V2Debug:` prefix so the fallback path is traceable
+     * end-to-end (the in-screen log alone misses the eyes of anyone watching logcat).
+     */
+    private fun appendDevToolLog(message: String) {
+        logcat { "Sync-V2Debug: $message" }
+        viewState.update { current ->
+            current.copy(
+                rows = current.rows + LogRow(
+                    id = nextRowId++,
+                    timestampMs = System.currentTimeMillis(),
+                    summary = message,
+                    rawJson = message,
+                ),
+            )
+        }
+    }
+
+    fun onRunPresentClicked() {
+        viewModelScope.launch(dispatchers.io()) {
+            runner.startPresent()
+            refreshState()
+        }
+    }
+
+    /** True when this device has a sync account whose recovery code we could share with a Joiner. */
+    fun canStartAsPresenter(): Boolean = runner.canStartAsPresenter
+
+    /**
+     * Toggle account state: create a fresh sync account if signed out, or log out (and tear
+     * down the current session) if signed in. Status row refreshes either way.
+     */
+    fun onSignInOutClicked() {
+        viewModelScope.launch(dispatchers.io()) {
+            val signedIn = syncStore.userId != null
+            val result = if (signedIn) {
+                // If a pairing session was running on this device's old credentials, kill it
+                // before logout invalidates the recovery code under us.
+                runner.cancel()
+                val deviceId = syncStore.deviceId.orEmpty()
+                syncAccountRepository.logout(deviceId)
+            } else {
+                syncAccountRepository.createAccount()
+            }
+            val action = if (signedIn) "Sign out" else "Create account"
+            when (result) {
+                is Result.Success -> toasts.send("$action: OK")
+                is Result.Error -> toasts.send("$action failed: ${result.reason}")
+            }
+            refreshState()
+        }
+    }
+
+    fun onCancelClicked() {
+        viewModelScope.launch(dispatchers.io()) {
+            runner.cancel()
+            refreshState()
+        }
+    }
+
+    fun onClearLogClicked() {
+        viewState.update { it.copy(rows = emptyList()) }
+    }
+
+    fun onAutoApproveToggled(checked: Boolean) {
+        viewState.update { it.copy(autoApproveConfirmation = checked) }
+    }
+
+    fun onConfirmationApproved(role: Role) {
+        fireLocalTrigger(if (role == Role.Host) LocalTrigger.UserConfirmedHost else LocalTrigger.UserConfirmedJoiner)
+    }
+
+    fun onConfirmationDenied(role: Role) {
+        fireLocalTrigger(if (role == Role.Host) LocalTrigger.UserDeniedHost else LocalTrigger.UserDeniedJoiner)
+    }
+
+    private fun fireLocalTrigger(trigger: LocalTrigger) {
+        viewModelScope.launch(dispatchers.io()) {
+            runner.localTrigger(trigger)
+            refreshState()
+        }
+    }
+
+    private fun appendEvent(event: ExchangeV2Event, isReplay: Boolean = false) {
+        val row = LogRow(
+            id = nextRowId++,
+            timestampMs = event.timestampMs,
+            summary = summarise(event),
+            rawJson = rawJsonFor(event),
+        )
+        viewState.update { current ->
+            current.copy(
+                rows = current.rows + row,
+                currentStateLabel = buildStateLabel(),
+                linkingCode = runner.linkingCode,
+                // Refresh on every event so runner-driven account changes (e.g. on-demand
+                // account creation at Host.Sending per spec §"Exchange Share Recovery Code")
+                // surface immediately, not on next manual refresh.
+                accountStatus = readAccountStatus(),
+            )
+        }
+        if (!isReplay) {
+            maybeHandleConfirmingTransition(event)
+            maybeEmitTerminalAlert(event)
+            maybeToastSessionError(event)
+            maybeLoginAfterJoinerDone(event)
+        }
+    }
+
+    /**
+     * When the runner reaches [ExchangeV2State.Joiner.Done] from a session that was started
+     * via [onRunPresentClicked] (i.e. not routed through [SyncCodeDispatcher]), the dispatcher's
+     * own login Flow never runs and nothing else drives a login from the received recovery code.
+     * This handler closes that gap. Idempotent for dispatcher-routed sessions because
+     * [SyncCodeDispatcher.route] is only invoked from [onRunScanClicked] — the Presenter path
+     * never goes through it.
+     */
+    private fun maybeLoginAfterJoinerDone(event: ExchangeV2Event) {
+        if (event !is ExchangeV2Event.Transition) return
+        if (event.to != ExchangeV2State.Joiner.Done) return
+        val received = (event.trigger as? ExchangeV2Message.RecoveryCodeResponse)?.recoveryCode
+        if (received.isNullOrBlank()) return
+        viewModelScope.launch(dispatchers.io()) {
+            appendDevToolLog("Joiner.Done — driving login from received recovery code")
+            when (val decision = dispatcher.route(received)) {
+                is RouteDecision.V2InProgress -> decision.outcomes.collect { handleV2Outcome(it) }
+                is RouteDecision.Legacy -> when (decision.authCode) {
+                    is SyncAuthCode.Recovery -> emitProcessCodeResult(
+                        "Joiner.Done login",
+                        syncAccountRepository.processCode(decision.authCode),
+                    )
+                    else -> {
+                        appendDevToolLog("Joiner.Done: received code wasn't a Recovery shape, can't auto-login")
+                        toasts.send("Joiner.Done: unexpected code shape, manual login required")
+                    }
+                }
+            }
+            refreshState()
+        }
+    }
+
+    /** Surface transport-level errors (failed sends, version mismatches) so they don't just bury in the log. */
+    private fun maybeToastSessionError(event: ExchangeV2Event) {
+        if (event !is ExchangeV2Event.SessionError) return
+        viewModelScope.launch { toasts.send(event.message) }
+    }
+
+    private fun maybeEmitTerminalAlert(event: ExchangeV2Event) {
+        if (event !is ExchangeV2Event.Transition) return
+        val terminal = describeTerminal(event) ?: return
+        viewModelScope.launch { terminalReached.send(terminal) }
+    }
+
+    private fun describeTerminal(event: ExchangeV2Event.Transition): TerminalReached? = when (event.to) {
+        ExchangeV2State.Host.Done -> TerminalReached(
+            state = event.to,
+            title = "✓ Pairing complete (Host)",
+            message = "Sent recovery_code_response to peer. Session closed on this side.",
+            isSuccess = true,
+        )
+        ExchangeV2State.Joiner.Done -> {
+            val code = (event.trigger as? ExchangeV2Message.RecoveryCodeResponse)?.recoveryCode
+            TerminalReached(
+                state = event.to,
+                title = "✓ Pairing complete (Joiner)",
+                message = "Received recovery code from peer:\n\n${code ?: "(missing)"}",
+                isSuccess = true,
+            )
+        }
+        ExchangeV2State.Host.Aborted -> {
+            val (title, message) = when (event.localTrigger) {
+                LocalTrigger.HostUnavailable -> "✗ Pairing aborted (Host)" to (
+                    "Couldn't produce a recovery code on this device — sent recovery_code_unavailable to peer." +
+                        "\n\nIs this device signed in to a sync account?"
+                    )
+                else ->
+                    "✗ Pairing aborted (Host)" to
+                        "You denied the prompt on this device. Sent recovery_code_denied to peer."
+            }
+            TerminalReached(state = event.to, title = title, message = message, isSuccess = false)
+        }
+        ExchangeV2State.Joiner.AbortedLocal -> TerminalReached(
+            state = event.to,
+            title = "✗ Pairing aborted (Joiner)",
+            message = "You denied the prompt on this device. No message sent to peer (per spec).",
+            isSuccess = false,
+        )
+        ExchangeV2State.Joiner.AbortedByHost -> TerminalReached(
+            state = event.to,
+            title = "✗ Pairing aborted by peer",
+            message = "Peer sent ${event.trigger?.messageType ?: "an abort message"}.",
+            isSuccess = false,
+        )
+        ExchangeV2State.SameAccountAbort -> TerminalReached(
+            state = event.to,
+            title = "✗ Same-account abort",
+            message = "Peer reported the same user_id — devices are already paired. No action taken.",
+            isSuccess = false,
+        )
+        ExchangeV2State.Aborted -> TerminalReached(
+            state = event.to,
+            title = "✗ Negotiation aborted",
+            message = "Received an unexpected hello during negotiation (duplicate or double-scan). Channel closed.",
+            isSuccess = false,
+        )
+        else -> null
+    }
+
+    private fun maybeHandleConfirmingTransition(event: ExchangeV2Event) {
+        if (event !is ExchangeV2Event.Transition) return
+        val role = when (event.to) {
+            ExchangeV2State.Host.Confirming -> Role.Host
+            ExchangeV2State.Joiner.Confirming -> Role.Joiner
+            else -> return
+        }
+        if (viewState.value.autoApproveConfirmation) {
+            val trigger = if (role == Role.Host) LocalTrigger.UserConfirmedHost else LocalTrigger.UserConfirmedJoiner
+            viewModelScope.launch(dispatchers.io()) { runner.localTrigger(trigger) }
+        } else {
+            viewModelScope.launch {
+                confirmationRequests.send(ConfirmationRequest(role = role, peerName = runner.peerName))
+            }
+        }
+    }
+
+    private fun refreshState() {
+        viewState.update {
+            it.copy(
+                currentStateLabel = buildStateLabel(),
+                linkingCode = runner.linkingCode,
+                accountStatus = readAccountStatus(),
+            )
+        }
+    }
+
+    private fun readAccountStatus(): AccountStatus {
+        val userId = syncStore.userId
+        val signedIn = userId != null
+        val thirdParty = syncStore.scopedPassword != null
+        return AccountStatus(
+            signedIn = signedIn,
+            userId = userId,
+            thirdPartyCredentialCreated = signedIn && thirdParty,
+        )
+    }
+
+    private fun buildStateLabel(): String {
+        val state = labelFor(runner.currentState)
+        val role = runner.pairingRole ?: return state
+        return "$state · pairing as $role"
+    }
+
+    private fun summarise(event: ExchangeV2Event): String = when (event) {
+        is ExchangeV2Event.Transition -> {
+            val trigger = event.trigger?.let { "msg=${it.messageType}${peerSuffix(it)}" }
+                ?: event.localTrigger?.let { "local=${labelFor(it)}" }
+                ?: "(no trigger)"
+            "Transition ${labelFor(event.from)} → ${labelFor(event.to)} [$trigger]"
+        }
+        is ExchangeV2Event.MessageSent -> "Sent ${event.message.messageType}${peerSuffix(event.message)}"
+        is ExchangeV2Event.MessageRejected -> {
+            val verb = when (event.reason) {
+                RejectReason.ImplicitAbort -> "Aborted"
+                RejectReason.SameAccount -> "SameAccountAbort"
+                RejectReason.UnknownMessageDropped -> "Dropped (unknown)"
+            }
+            "$verb on ${event.message.messageType}${peerSuffix(event.message)} in ${labelFor(event.state)}"
+        }
+        is ExchangeV2Event.SessionStarted -> {
+            val codeLine = event.linkingCode?.let { " linkingCode=$it" } ?: ""
+            "Session started as ${event.pairingRole} ownChannelId=${event.ownChannelId}$codeLine"
+        }
+        is ExchangeV2Event.SessionError -> "Session error: ${event.message}"
+    }
+
+    private fun peerSuffix(message: ExchangeV2Message): String = when (message) {
+        is ExchangeV2Message.RecoveryCodeAvailable -> " name=${message.name} kind=${message.kind} user_id=${message.userId}"
+        is ExchangeV2Message.RecoveryCodeRequest -> " name=${message.name} kind=${message.kind}"
+        else -> ""
+    }
+
+    private fun rawJsonFor(event: ExchangeV2Event): String = when (event) {
+        is ExchangeV2Event.Transition -> event.trigger?.rawJson ?: "(local trigger: ${event.localTrigger?.let(::labelFor)})"
+        is ExchangeV2Event.MessageSent -> event.message.rawJson
+        is ExchangeV2Event.MessageRejected -> event.message.rawJson
+        is ExchangeV2Event.SessionStarted -> event.linkingCode ?: "(no linking code — Scanner side)"
+        is ExchangeV2Event.SessionError -> event.message
+    }
+
+    private fun labelFor(state: ExchangeV2State?): String = when (state) {
+        null -> "(no session)"
+        ExchangeV2State.Bootstrapped -> "Bootstrapped"
+        ExchangeV2State.Negotiating -> "Negotiating"
+        ExchangeV2State.SameAccountAbort -> "SameAccountAbort"
+        ExchangeV2State.Aborted -> "Aborted"
+        ExchangeV2State.Host.Confirming -> "Host.Confirming"
+        ExchangeV2State.Host.Sending -> "Host.Sending"
+        ExchangeV2State.Host.Aborted -> "Host.Aborted"
+        ExchangeV2State.Host.Done -> "Host.Done"
+        ExchangeV2State.Joiner.Confirming -> "Joiner.Confirming"
+        ExchangeV2State.Joiner.Waiting -> "Joiner.Waiting"
+        ExchangeV2State.Joiner.AbortedLocal -> "Joiner.AbortedLocal"
+        ExchangeV2State.Joiner.AbortedByHost -> "Joiner.AbortedByHost"
+        ExchangeV2State.Joiner.Done -> "Joiner.Done"
+    }
+
+    private fun labelFor(trigger: LocalTrigger): String = when (trigger) {
+        LocalTrigger.UserConfirmedHost -> "UserConfirmedHost"
+        LocalTrigger.UserDeniedHost -> "UserDeniedHost"
+        LocalTrigger.UserConfirmedJoiner -> "UserConfirmedJoiner"
+        LocalTrigger.UserDeniedJoiner -> "UserDeniedJoiner"
+        LocalTrigger.HostSendComplete -> "HostSendComplete"
+        LocalTrigger.HostUnavailable -> "HostUnavailable"
+        is LocalTrigger.RoleElected -> "RoleElected(${trigger.role})"
+    }
+}

--- a/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
+++ b/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
@@ -99,6 +99,13 @@
             app:primaryText="canShowV2ConnectCode (display, requires canUseV2ConnectFlow)" />
 
         <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+            android:id="@+id/openV2PairingDebugButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:text="V2 Pairing Debug" />
+
+        <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
             android:id="@+id/fetchAccessCredentialsButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/sync/sync-internal/src/main/res/layout/activity_sync_v2_pairing_debug.xml
+++ b/sync/sync-internal/src/main/res/layout/activity_sync_v2_pairing_debug.xml
@@ -1,0 +1,260 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <include
+        android:id="@+id/includeToolbar"
+        layout="@layout/include_default_toolbar" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fadeScrollbars="false"
+        android:scrollbarAlwaysDrawVerticalTrack="true"
+        android:scrollbars="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="Account status" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
+
+                <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                    android:id="@+id/statusSignedIn"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    app:primaryText="Signed in"
+                    tools:secondaryText="No" />
+
+                <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
+                    android:id="@+id/signInOutButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="@dimen/keyline_4"
+                    android:text="Sign in" />
+            </LinearLayout>
+
+            <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                android:id="@+id/statusThirdPartyCredential"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="3party credential"
+                tools:secondaryText="Not created" />
+
+            <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="Settings" />
+
+            <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                android:id="@+id/autoApproveSetting"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="Auto-approve confirmations"
+                app:secondaryText="When on, this device automatically confirms its own Host/Joiner prompt. Turn off to see the real alert dialog."
+                app:showSwitch="true" />
+
+            <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="Session" />
+
+            <!-- Presenter side: tap Start, get linking code, share it with the Scanner. -->
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_marginEnd="@dimen/keyline_4"
+                android:text="Presenter mode: tap Start to generate a v2 linking code for a Scanner to paste."
+                app:typography="caption" />
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+                android:id="@+id/runPresentButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_margin="10dp"
+                android:text="Start as Presenter" />
+
+            <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+                android:id="@+id/linkingCodeSectionHeader"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                app:primaryText="Linking code (give this to the Scanner)" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/linkingCodeTextView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_marginEnd="@dimen/keyline_4"
+                android:layout_marginBottom="@dimen/keyline_4"
+                android:visibility="gone"
+                app:typography="caption" />
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
+                android:id="@+id/copyLinkingCodeButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_marginBottom="@dimen/keyline_4"
+                android:text="Copy linking code"
+                android:visibility="gone" />
+
+            <ImageView
+                android:id="@+id/linkingCodeQrImage"
+                android:layout_width="280dp"
+                android:layout_height="280dp"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginBottom="@dimen/keyline_4"
+                android:contentDescription="QR for v2 linking code"
+                android:visibility="gone" />
+
+            <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <!-- Scanner side: paste a linking code, tap Start. -->
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_marginEnd="@dimen/keyline_4"
+                android:text="Scanner mode: paste the Presenter's linking code below, then tap Start as Scanner."
+                app:typography="caption" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextInput
+                android:id="@+id/pastedUrlInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_marginEnd="@dimen/keyline_4"
+                android:hint="Paste Presenter's https://duckduckgo.com/sync/pairing/#&amp;code2=… URL"
+                app:editable="true"
+                app:type="single_line" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+                    android:id="@+id/pasteAndGoButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="10dp"
+                    android:text="Paste &amp; Go" />
+
+                <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+                    android:id="@+id/runScanButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="10dp"
+                    android:text="Start as Scanner" />
+
+                <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
+                    android:id="@+id/clearPastedUrlButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="10dp"
+                    android:text="Clear URL" />
+            </LinearLayout>
+
+            <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
+                    android:id="@+id/cancelButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="10dp"
+                    android:text="Cancel" />
+
+                <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
+                    android:id="@+id/clearLogButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="10dp"
+                    android:text="Clear Log" />
+            </LinearLayout>
+
+            <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="State" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/currentStateTextView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_marginEnd="@dimen/keyline_4"
+                android:layout_marginBottom="@dimen/keyline_4"
+                app:typography="body2" />
+
+            <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="Log" />
+
+            <LinearLayout
+                android:id="@+id/logContainer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/keyline_4"
+                android:orientation="vertical" />
+
+        </LinearLayout>
+    </ScrollView>
+</LinearLayout>

--- a/sync/sync-internal/src/main/res/layout/item_sync_v2_pairing_log_row.xml
+++ b/sync/sync-internal/src/main/res/layout/item_sync_v2_pairing_log_row.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingStart="@dimen/keyline_4"
+    android:paddingEnd="@dimen/keyline_4"
+    android:paddingTop="6dp"
+    android:paddingBottom="6dp">
+
+    <LinearLayout
+        android:id="@+id/summaryRow"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:clickable="true"
+        android:focusable="true">
+
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/summaryTextView"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            app:typography="body2" />
+
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/chevronTextView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="8dp"
+            android:text="▸"
+            app:typography="body2" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/rawDetail"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/rawJsonTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:fontFamily="monospace"
+            android:textIsSelectable="true"
+            app:typography="caption" />
+
+        <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
+            android:id="@+id/copyRawButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="Copy JSON" />
+    </LinearLayout>
+</LinearLayout>

--- a/sync/sync-internal/src/main/res/values/donottranslate.xml
+++ b/sync/sync-internal/src/main/res/values/donottranslate.xml
@@ -21,6 +21,7 @@
 
     <!-- Internal Setting -->
     <string name="sync_internal_activity_label">Sync Setup Internal</string>
+    <string name="sync_v2_pairing_debug_activity_label">V2 Pairing Debug</string>
     <string name="sync_internal_environment_header">Environment Settings</string>
     <string name="sync_internal_environment_title">Use Dev Environment?</string>
     <string name="sync_internal_environment_subtitle_prod">https://sync.duckduckgo.com</string>

--- a/sync/sync-internal/src/test/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModelTest.kt
+++ b/sync/sync-internal/src/test/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModelTest.kt
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.internal.ui
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.sync.impl.DispatchOutcome
+import com.duckduckgo.sync.impl.Result
+import com.duckduckgo.sync.impl.RouteDecision
+import com.duckduckgo.sync.impl.SyncAccountRepository
+import com.duckduckgo.sync.impl.SyncAuthCode
+import com.duckduckgo.sync.impl.SyncCodeDispatcher
+import com.duckduckgo.sync.impl.SyncCodeType
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Hello
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
+import com.duckduckgo.sync.impl.exchange.v2.RejectReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.store.SyncStore
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class SyncV2PairingDebugViewModelTest {
+
+    @get:Rule val coroutineTestRule = CoroutineTestRule()
+
+    private val eventFlow = MutableSharedFlow<ExchangeV2Event>(replay = 0, extraBufferCapacity = 100)
+    private val runner: ExchangeV2Runner = mock<ExchangeV2Runner>().also {
+        whenever(it.events).thenReturn(eventFlow)
+        whenever(it.currentState).thenReturn(null)
+    }
+    private val syncStore: SyncStore = mock()
+    private val syncAccountRepository: SyncAccountRepository = mock()
+    private val dispatcher: SyncCodeDispatcher = mock()
+
+    private fun newViewModel() = SyncV2PairingDebugViewModel(
+        runner = runner,
+        syncStore = syncStore,
+        syncAccountRepository = syncAccountRepository,
+        dispatcher = dispatcher,
+        dispatchers = coroutineTestRule.testDispatcherProvider,
+        appScope = coroutineTestRule.testScope,
+    )
+
+    // ---- Event log ----
+
+    @Test fun `Transition event appended to rows with correct summary`() = runTest {
+        val viewModel = newViewModel()
+        viewModel.viewState().test {
+            assertEquals(emptyList<SyncV2PairingDebugViewModel.LogRow>(), awaitItem().rows)
+
+            whenever(runner.currentState).thenReturn(ExchangeV2State.Negotiating)
+            eventFlow.emit(
+                ExchangeV2Event.Transition(
+                    timestampMs = 100L,
+                    from = ExchangeV2State.Bootstrapped,
+                    to = ExchangeV2State.Negotiating,
+                    trigger = Hello("""{"type":"hello"}"""),
+                    localTrigger = null,
+                ),
+            )
+
+            val updated = awaitItem()
+            assertEquals(1, updated.rows.size)
+            assertTrue(updated.rows.single().summary.contains("Bootstrapped → Negotiating"))
+            assertEquals("Negotiating", updated.currentStateLabel)
+        }
+    }
+
+    @Test fun `MessageSent event labelled as Sent with type`() = runTest {
+        val viewModel = newViewModel()
+        viewModel.viewState().test {
+            awaitItem()
+            eventFlow.emit(
+                ExchangeV2Event.MessageSent(
+                    timestampMs = 0L,
+                    message = ExchangeV2Message.RecoveryCodeRequest(rawJson = "{}", name = "me", kind = "3party"),
+                ),
+            )
+            val state = awaitItem()
+            assertEquals(1, state.rows.size)
+            assertTrue(state.rows.single().summary.startsWith("Sent recovery_code_request"))
+        }
+    }
+
+    @Test fun `MessageRejected with SameAccount labelled SameAccountAbort`() = runTest {
+        val viewModel = newViewModel()
+        viewModel.viewState().test {
+            awaitItem()
+            eventFlow.emit(
+                ExchangeV2Event.MessageRejected(
+                    timestampMs = 0L,
+                    message = ExchangeV2Message.RecoveryCodeAvailable(
+                        rawJson = "{}",
+                        userId = "shared",
+                        name = "Peer",
+                        kind = "3party",
+                    ),
+                    state = ExchangeV2State.Negotiating,
+                    reason = RejectReason.SameAccount,
+                ),
+            )
+            val state = awaitItem()
+            assertTrue(state.rows.single().summary.startsWith("SameAccountAbort"))
+        }
+    }
+
+    @Test fun `onClearLogClicked empties rows`() = runTest {
+        val viewModel = newViewModel()
+        viewModel.viewState().test {
+            awaitItem()
+            eventFlow.emit(
+                ExchangeV2Event.Transition(
+                    timestampMs = 0L,
+                    from = ExchangeV2State.Bootstrapped,
+                    to = ExchangeV2State.Negotiating,
+                    trigger = Hello("{}"),
+                    localTrigger = null,
+                ),
+            )
+            assertEquals(1, awaitItem().rows.size)
+
+            viewModel.onClearLogClicked()
+            assertEquals(0, awaitItem().rows.size)
+        }
+    }
+
+    // ---- Lifecycle / control ----
+
+    @Test fun `onCancelClicked delegates to runner cancel`() = runTest {
+        val viewModel = newViewModel()
+        viewModel.onCancelClicked()
+        verify(runner).cancel()
+    }
+
+    // ---- Dispatch routing through SyncCodeDispatcher ----
+
+    @Test fun `onRunScanClicked delegates to dispatcher route`() {
+        val authCode = SyncAuthCode.Unknown("anything")
+        whenever(dispatcher.route(any())).thenReturn(RouteDecision.Legacy(authCode))
+        val viewModel = newViewModel()
+
+        viewModel.onRunScanClicked("the-url")
+
+        verify(dispatcher).route("the-url")
+    }
+
+    @Test fun `Legacy v1 Recovery — calls processCode and does NOT collect from a dispatcher Flow`() {
+        val recovery = SyncAuthCode.Recovery(mock())
+        whenever(dispatcher.route(any())).thenReturn(RouteDecision.Legacy(recovery))
+        whenever(syncAccountRepository.processCode(eq(recovery), anyOrNull())).thenReturn(Result.Success(true))
+        val viewModel = newViewModel()
+
+        viewModel.onRunScanClicked("v1-recovery-url")
+
+        verify(syncAccountRepository).processCode(eq(recovery), anyOrNull())
+    }
+
+    @Test fun `Legacy v1 Connect — calls processCode`() {
+        val connect = SyncAuthCode.Connect(mock())
+        whenever(dispatcher.route(any())).thenReturn(RouteDecision.Legacy(connect))
+        whenever(syncAccountRepository.processCode(eq(connect), anyOrNull())).thenReturn(Result.Success(true))
+        val viewModel = newViewModel()
+
+        viewModel.onRunScanClicked("v1-connect-url")
+
+        verify(syncAccountRepository).processCode(eq(connect), anyOrNull())
+    }
+
+    @Test fun `Legacy Unknown — does NOT call processCode (surfaces as user-facing toast)`() {
+        whenever(dispatcher.route(any())).thenReturn(RouteDecision.Legacy(SyncAuthCode.Unknown("garbage")))
+        val viewModel = newViewModel()
+
+        viewModel.onRunScanClicked("garbage")
+
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
+    }
+
+    @Test fun `V2InProgress — collects the outcomes Flow without calling parseSyncAuthCode`() {
+        whenever(dispatcher.route(any())).thenReturn(
+            RouteDecision.V2InProgress(
+                codeType = SyncCodeType.RECOVERY,
+                outcomes = flowOf(DispatchOutcome.LoggedIn(path = SetupPath.RECOVERY)),
+            ),
+        )
+        val viewModel = newViewModel()
+
+        viewModel.onRunScanClicked("v2-url")
+
+        verify(syncAccountRepository, never()).parseSyncAuthCode(any())
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
+    }
+
+    @Test fun `V2InProgress with Failed outcome — does NOT crash and does NOT fall back to legacy`() {
+        whenever(dispatcher.route(any())).thenReturn(
+            RouteDecision.V2InProgress(
+                codeType = SyncCodeType.RECOVERY,
+                outcomes = flowOf(DispatchOutcome.Failed("BE rejected")),
+            ),
+        )
+        val viewModel = newViewModel()
+
+        viewModel.onRunScanClicked("v2-url")
+
+        verify(syncAccountRepository, never()).parseSyncAuthCode(any())
+    }
+}

--- a/sync/sync-store/src/main/java/com/duckduckgo/sync/store/SyncStore.kt
+++ b/sync/sync-store/src/main/java/com/duckduckgo/sync/store/SyncStore.kt
@@ -30,9 +30,6 @@ interface SyncStore {
     /** Scoped password (SP primary key) for the 3party credential. Only present when a 3party credential exists. */
     var scopedPassword: ScopedPassword?
 
-    /** JSON array of protected keys with kid, purpose, encrypted_with, encrypted_private_key. */
-    var protectedKeysJson: String?
-
     fun isEncryptionSupported(): Boolean
     fun isSignedInFlow(): Flow<Boolean>
     fun isSignedIn(): Boolean
@@ -166,14 +163,6 @@ constructor(
             }
         }
 
-    override var protectedKeysJson: String?
-        get() = encryptedPreferences?.getString(KEY_PROTECTED_KEYS_JSON, null)
-        set(value) {
-            encryptedPreferences?.edit(commit = true) {
-                if (value == null) remove(KEY_PROTECTED_KEYS_JSON) else putString(KEY_PROTECTED_KEYS_JSON, value)
-            }
-        }
-
     override fun isEncryptionSupported(): Boolean = encryptedPreferences != null
 
     override fun isSignedInFlow(): Flow<Boolean> = isSignedInStateFlow
@@ -218,6 +207,5 @@ constructor(
         private const val KEY_SK = "KEY_SK"
         private const val KEY_CREDENTIAL_ID = "KEY_CREDENTIAL_ID"
         private const val KEY_SCOPED_PASSWORD = "KEY_SCOPED_PASSWORD"
-        private const val KEY_PROTECTED_KEYS_JSON = "KEY_PROTECTED_KEYS_JSON"
     }
 }

--- a/sync/sync-store/src/test/java/com/duckduckgo/sync/store/SyncSharedPrefsStoreTest.kt
+++ b/sync/sync-store/src/test/java/com/duckduckgo/sync/store/SyncSharedPrefsStoreTest.kt
@@ -134,25 +134,13 @@ class SyncSharedPrefsStoreTest {
     }
 
     @Test
-    fun whenProtectedKeysJsonStoredThenValueUpdatedInPrefsStore() {
-        assertNull(store.protectedKeysJson)
-        val keysJson = """[{"kid":"k1","purpose":"ai_chats","encrypted_with":"ddg","encrypted_private_key":"jwe_data"}]"""
-        store.protectedKeysJson = keysJson
-        assertEquals(keysJson, store.protectedKeysJson)
-        store.protectedKeysJson = null
-        assertNull(store.protectedKeysJson)
-    }
-
-    @Test
     fun whenClearAllThenV2FieldsAlsoCleared() {
         store.credentialId = "ddg"
         store.scopedPassword = ScopedPassword("encrypted_sp")
-        store.protectedKeysJson = """[{"kid":"k1"}]"""
 
         store.clearAll()
 
         assertNull(store.credentialId)
         assertNull(store.scopedPassword)
-        assertNull(store.protectedKeysJson)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1149059203486286/task/1215628433324573?focus=true 

### Description
  Part of the Sync v2 pairing stack (stacked on top of `…_03_account_service`). This branch adds the **transport + session-runner layer** for the Exchange V2 pairing protocol — the piece that actually talks to the relay and drives a pairing session from start to finish. It is not yet wired to any UI or to the code dispatcher; that happens in the PRs above this one in the stack.
  
  New components (all under `sync/.../exchange/v2/`):

  - **`ExchangeV2Runner`** — drives a single pairing session. Two entry points (`startPresent` generates a linking code; `startScan` joins a
  peer's session), then it manages the wire I/O, decrypts incoming messages, drives the protocol state machine, auto-elects the Host/Joiner role
  per the Unified Algorithm, and auto-sends protocol messages as the session advances.
  - **`ExchangeV2Channel`** — wraps the BE relay endpoints (create / send / poll / delete) with envelope encryption and a polling `Flow`.
  - **`ExchangeV2Envelope`** — JWE seal/open of relay messages, with protocol-version negotiation.
  - **`ExchangeV2QrCode`** — builds and parses v2 linking codes (the QR/URL).
  - **`RecoveryCodeProvider`** — thin indirection over `SyncAccountRepository` to fetch/provision the right recovery code for the peer's kind.

### Steps to test this PR
  There's nothing user-facing to exercise on this branch yet (no UI / dispatcher wiring), so there's no manual/E2E path here.

  - The layer is covered by JVM unit tests (`RealExchangeV2RunnerTest`, `…ChannelTest`, `…EnvelopeTest`, `…QrCodeTest`,
  `RealRecoveryCodeProviderTest`) — including role election, the session timeout, poll-loop error/teardown handling, in-order message
  processing, and code build/parse round-trips.
  - **CI (`jvm_checks`) should pass.** End-to-end pairing will be exercised in the upstack dispatcher/UI PRs.

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large changes to sync account login, pairing, protected keys, and credential upgrade paths—security- and data-sensitive—with broad UI wiring under feature flags.
> 
> **Overview**
> This PR extends the Sync v2 stack beyond transport-only work by **routing scanned/pasted codes through `SyncCodeDispatcher`** (v1 legacy vs v2 linking/recovery flows) and **driving `ExchangeV2Runner`** for Presenter/Scanner sessions, including host/joiner confirmation and transparent account switch on `ALREADY_SIGNED_IN`.
> 
> It introduces the **Exchange v2 building blocks** (`ExchangeV2Channel`, envelope seal/open, QR `code2` parsing, state-machine runner, `RecoveryCodeProvider`) and maps runner events to **`DispatchOutcome`** for the UI layer.
> 
> **Connect, login, and manual enter-code** screens now collect v2 outcome flows, show v2 confirmation dialogs, and surface v2-specific errors; connect can **present a v2 QR** when feature flags allow and avoids restarting sessions on lifecycle re-subscribe.
> 
> **Setup analytics** gain a new `sync_setup.json5` schema plus **`flow_version`**, code type/version, path/role/peer metadata, **`sync_setup_ended_failed`**, and cancellation reasons on abandon pixels.
> 
> **Account/key plumbing** changes: `set-if-absent` posts a **keys list** and returns server authoritative entries (race losers adopt server kid); **local `protectedKeysJson` caching is removed** from login/upgrade/create paths; 3party extend **merges** new `ai_chats` keys with existing ddg keys; upgrade error strings drop exception details; new **pairing-related `AccountErrorCodes`** support dispatcher telemetry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cebc55a9f6a321a290428f2d31386278974b30a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->