### PR TITLE
UTI: Improve padding and sizes of buttons

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
@@ -112,7 +112,7 @@ class AttachmentView(
     fun clearAttachmentsForNewChat() = viewModel?.clearAttachmentsForNewChat()
 
     private fun buildAttachButton(): ImageView {
-        val iconSize = context.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.toolbarIcon)
+        val iconSize = context.resources.getDimensionPixelSize(R.dimen.nativeInputButtonSize)
         return ImageView(context).apply {
             layoutParams = LayoutParams(iconSize, iconSize)
             setBackgroundResource(com.duckduckgo.mobile.android.R.drawable.selectable_item_rounded_corner_background)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsView.kt
@@ -177,7 +177,7 @@ class OptionsView(context: Context, private val host: NativeInputHost) : LinearL
     }
 
     private fun buildOptionsButton(): ImageView {
-        val iconSize = context.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.toolbarIcon)
+        val iconSize = context.resources.getDimensionPixelSize(R.dimen.nativeInputButtonSize)
         return ImageView(context).apply {
             layoutParams = LayoutParams(iconSize, iconSize)
             setBackgroundResource(com.duckduckgo.mobile.android.R.drawable.selectable_item_rounded_corner_background)

--- a/duckchat/duckchat-impl/src/main/res/layout/view_model_picker.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_model_picker.xml
@@ -22,7 +22,7 @@
         android:id="@+id/modelPickerChip"
         style="@style/Widget.MaterialComponents.Chip.Choice"
         android:layout_width="wrap_content"
-        android:layout_height="@dimen/modelPickerChipHeight"
+        android:layout_height="@dimen/nativeInputButtonSize"
         android:layout_gravity="center_vertical"
         android:clickable="true"
         android:focusable="true"

--- a/duckchat/duckchat-impl/src/main/res/layout/view_native_input_screen_buttons.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_native_input_screen_buttons.xml
@@ -23,9 +23,9 @@
 
     <ImageView
         android:id="@+id/actionVoiceSearch"
-        android:layout_width="36dp"
-        android:layout_height="36dp"
-        android:layout_marginStart="8dp"
+        android:layout_width="@dimen/nativeInputButtonSize"
+        android:layout_height="@dimen/nativeInputButtonSize"
+        android:layout_marginStart="@dimen/keyline_1"
         android:background="@drawable/selectable_item_rounded_corner_background"
         android:importantForAccessibility="no"
         android:scaleType="centerInside"
@@ -34,9 +34,9 @@
 
     <ImageView
         android:id="@+id/actionVoiceChat"
-        android:layout_width="36dp"
-        android:layout_height="36dp"
-        android:layout_marginStart="8dp"
+        android:layout_width="@dimen/nativeInputButtonSize"
+        android:layout_height="@dimen/nativeInputButtonSize"
+        android:layout_marginStart="@dimen/keyline_1"
         android:background="@drawable/background_input_screen_button"
         android:backgroundTint="?attr/daxColorControlFillPrimary"
         android:foreground="@drawable/selectable_circular_ripple"
@@ -48,9 +48,9 @@
 
     <ImageView
         android:id="@+id/actionNewLine"
-        android:layout_width="36dp"
-        android:layout_height="36dp"
-        android:layout_marginStart="8dp"
+        android:layout_width="@dimen/nativeInputButtonSize"
+        android:layout_height="@dimen/nativeInputButtonSize"
+        android:layout_marginStart="@dimen/keyline_1"
         android:background="@drawable/selectable_item_rounded_corner_background"
         android:importantForAccessibility="no"
         android:scaleType="centerInside"
@@ -59,9 +59,9 @@
 
     <ImageView
         android:id="@+id/actionSend"
-        android:layout_width="36dp"
-        android:layout_height="36dp"
-        android:layout_marginStart="8dp"
+        android:layout_width="@dimen/nativeInputButtonSize"
+        android:layout_height="@dimen/nativeInputButtonSize"
+        android:layout_marginStart="@dimen/keyline_1"
         android:background="@drawable/selectable_circular_container_ripple"
         android:importantForAccessibility="no"
         android:scaleType="centerInside"

--- a/duckchat/duckchat-impl/src/main/res/layout/view_options_chip.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_options_chip.xml
@@ -24,8 +24,8 @@
     android:focusable="true"
     android:gravity="center_vertical"
     android:orientation="horizontal"
-    android:paddingStart="@dimen/keyline_4"
-    android:paddingEnd="@dimen/keyline_4"
+    android:paddingStart="@dimen/keyline_2"
+    android:paddingEnd="@dimen/keyline_2"
     android:paddingTop="@dimen/keyline_2"
     android:paddingBottom="@dimen/keyline_2">
 
@@ -40,7 +40,7 @@
         android:id="@+id/optionsChipClose"
         android:layout_width="@dimen/keyline_4"
         android:layout_height="@dimen/keyline_4"
-        android:layout_marginStart="@dimen/keyline_2"
+        android:layout_marginStart="@dimen/keyline_1"
         android:importantForAccessibility="no"
         android:scaleType="center"
         app:srcCompat="@drawable/ic_close_16" />

--- a/duckchat/duckchat-impl/src/main/res/layout/view_reasoning_mode_picker.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_reasoning_mode_picker.xml
@@ -19,8 +19,8 @@
 
     <ImageView
         android:id="@+id/reasoningModePickerButton"
-        android:layout_width="@dimen/toolbarIcon"
-        android:layout_height="@dimen/toolbarIcon"
+        android:layout_width="@dimen/nativeInputButtonSize"
+        android:layout_height="@dimen/nativeInputButtonSize"
         android:background="@drawable/selectable_item_rounded_corner_background"
         android:contentDescription="@string/duckChatReasoningModeContentDescription"
         android:scaleType="centerInside"

--- a/duckchat/duckchat-impl/src/main/res/values/dimens.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/dimens.xml
@@ -35,6 +35,7 @@
 
     <!-- Shared width for the native input widget popup menus (options, model picker, attachment) -->
     <dimen name="nativeInputMenuWidth">260dp</dimen>
+    <dimen name="nativeInputButtonSize">36dp</dimen>
 
     <!-- Reasoning Mode Picker -->
     <dimen name="reasoningModePickerMenuWidth">220dp</dimen>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1215497088488464?focus=true
Tech Design URL (if applicable): 

### Description
Updates the paddings and sizes of the controls in the UTI

### Steps to test this PR
Usual smoke tests

### UI changes
| Before  | After |
| ------ | ----- |
|<img width="1344" height="2992" alt="Screenshot_20260612_215001" src="https://github.com/user-attachments/assets/a5c102df-08b8-4a1b-b379-f8d90957eea6" />|<img width="1344" height="2992" alt="Screenshot_20260612_214854" src="https://github.com/user-attachments/assets/7e7f1080-507e-4442-be34-d735d40f18d7" />|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only layout and dimension token changes in the native input UI; no logic or data-path changes.
> 
> **Overview**
> Introduces **`nativeInputButtonSize`** (36dp) in duckchat dimens and wires native input toolbar controls to it instead of **`toolbarIcon`**, hardcoded **36dp**, or mixed chip height references—covering attach/options buttons, model picker chip height, reasoning mode picker, and voice/send/new-line actions.
> 
> **Options chip** layout is tightened: horizontal padding moves from **`keyline_4`** to **`keyline_2`**, and the close icon start margin from **`keyline_2`** to **`keyline_1`**. Action button row margins now use **`@dimen/keyline_1`** instead of **8dp** literals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb2a4b3338887f31a062294bfac7775c076e4a8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->