### PR TITLE
Hide unified input for onboarding experiment users

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/DuckAiOnboardingExperimentManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/DuckAiOnboardingExperimentManager.kt
@@ -78,7 +78,9 @@ class DuckAiOnboardingExperimentManagerImpl @Inject constructor(
 
     override suspend fun isEnrolledInActiveExperiment(): Boolean = withContext(dispatcherProvider.io()) {
         val toggle = extendedOnboardingFeatureToggles.onboardingDuckAiExperimentMay26()
-        toggle.getRawStoredState()?.assignedCohort != null && toggle.isEnabled()
+        DuckAiOnboardingExperimentCohort.entries.any { cohort ->
+            toggle.isEnrolledAndEnabled(cohort)
+        }
     }
 
     private fun arePrerequisitesMet(): Boolean =

--- a/app/src/main/java/com/duckduckgo/app/onboarding/DuckAiOnboardingExperimentManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/DuckAiOnboardingExperimentManager.kt
@@ -40,6 +40,12 @@ interface DuckAiOnboardingExperimentManager {
      */
     suspend fun enroll(): DuckAiOnboardingExperimentVariant?
 
+    /**
+     * Returns true when the experiment is currently active and the user is already enrolled (assigned
+     * to any cohort, including control). This is a read-only check: it never enrolls the user.
+     */
+    suspend fun isEnrolledInActiveExperiment(): Boolean
+
     enum class DuckAiOnboardingExperimentVariant {
         CONTROL,
         TREATMENT_WITH_DUCK_AI_DEFAULT,
@@ -68,6 +74,11 @@ class DuckAiOnboardingExperimentManagerImpl @Inject constructor(
         } else {
             null
         }
+    }
+
+    override suspend fun isEnrolledInActiveExperiment(): Boolean = withContext(dispatcherProvider.io()) {
+        val toggle = extendedOnboardingFeatureToggles.onboardingDuckAiExperimentMay26()
+        toggle.getRawStoredState()?.assignedCohort != null && toggle.isEnabled()
     }
 
     private fun arePrerequisitesMet(): Boolean =

--- a/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingExperimentNativeInputFieldSuppressor.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingExperimentNativeInputFieldSuppressor.kt
@@ -24,6 +24,12 @@ import javax.inject.Inject
 /**
  * Suppresses the native (unified) input field for users enrolled in the active Duck.ai onboarding
  * experiment so they keep the legacy omnibar while the experiment runs.
+ *
+ * Note: this value is only read when `RealDuckChat.cacheConfig()` runs (app init and on privacy
+ * config download), so a user who enrolls mid-session would keep the unified input until the next
+ * refresh or restart. We don't handle that case on purpose: enrollment for this experiment is
+ * closed, so the enrolled population is already assigned before the app starts and never changes
+ * within a session.
  */
 @ContributesMultibinding(AppScope::class)
 class OnboardingExperimentNativeInputFieldSuppressor @Inject constructor(

--- a/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingExperimentNativeInputFieldSuppressor.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingExperimentNativeInputFieldSuppressor.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.impl.nativeinput.NativeInputFieldSuppressor
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+/**
+ * Suppresses the native (unified) input field for users enrolled in the active Duck.ai onboarding
+ * experiment so they keep the legacy omnibar while the experiment runs.
+ */
+@ContributesMultibinding(AppScope::class)
+class OnboardingExperimentNativeInputFieldSuppressor @Inject constructor(
+    private val duckAiOnboardingExperimentManager: DuckAiOnboardingExperimentManager,
+) : NativeInputFieldSuppressor {
+    override suspend fun isNativeInputFieldSuppressed(): Boolean =
+        duckAiOnboardingExperimentManager.isEnrolledInActiveExperiment()
+}

--- a/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingExperimentNativeInputFieldSuppressor.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingExperimentNativeInputFieldSuppressor.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.onboarding
 
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.duckchat.impl.nativeinput.NativeInputFieldSuppressor
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputFieldSuppressor
 import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingExperimentNativeInputFieldSuppressor.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingExperimentNativeInputFieldSuppressor.kt
@@ -35,6 +35,13 @@ import javax.inject.Inject
 class OnboardingExperimentNativeInputFieldSuppressor @Inject constructor(
     private val duckAiOnboardingExperimentManager: DuckAiOnboardingExperimentManager,
 ) : NativeInputFieldSuppressor {
+    /**
+     * This works as expected for users enrolled in the active Duck.ai onboarding experiment.
+     * User enrolling mid-session will keep the unified input until the next refresh/restart.
+     * Accepted on purpose — experiment enrollment is closed, so the population is fixed before app start.
+     * This implementation will be removed once the experiment is disabled (ETA Jun 17th)
+     *
+     */
     override suspend fun isNativeInputFieldSuppressed(): Boolean =
         duckAiOnboardingExperimentManager.isEnrolledInActiveExperiment()
 }

--- a/app/src/test/java/com/duckduckgo/app/onboarding/DuckAiOnboardingExperimentManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/DuckAiOnboardingExperimentManagerTest.kt
@@ -28,7 +28,9 @@ import com.duckduckgo.common.utils.device.DeviceInfo.FormFactor
 import com.duckduckgo.feature.toggles.api.Toggle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -179,6 +181,55 @@ class DuckAiOnboardingExperimentManagerTest {
 
         assertNull(result)
         verify(experimentToggle).enroll()
+    }
+
+    @Test
+    fun whenExperimentActiveAndUserEnrolledThenIsEnrolledInActiveExperimentTrueAndDoesNotEnroll() = runTest {
+        whenever(experimentToggle.isEnabled()).thenReturn(true)
+        whenever(experimentToggle.getRawStoredState()).thenReturn(
+            Toggle.State(assignedCohort = Toggle.State.Cohort(name = DuckAiOnboardingExperimentCohort.CONTROL.cohortName, weight = 1)),
+        )
+
+        val result = testee.isEnrolledInActiveExperiment()
+
+        assertTrue(result)
+        verify(experimentToggle, never()).enroll()
+        verify(experimentToggle, never()).getCohort()
+    }
+
+    @Test
+    fun whenExperimentActiveAndUserNotEnrolledThenIsEnrolledInActiveExperimentFalse() = runTest {
+        whenever(experimentToggle.isEnabled()).thenReturn(true)
+        whenever(experimentToggle.getRawStoredState()).thenReturn(Toggle.State(assignedCohort = null))
+
+        val result = testee.isEnrolledInActiveExperiment()
+
+        assertFalse(result)
+        verify(experimentToggle, never()).enroll()
+    }
+
+    @Test
+    fun whenExperimentInactiveAndUserEnrolledThenIsEnrolledInActiveExperimentFalse() = runTest {
+        whenever(experimentToggle.isEnabled()).thenReturn(false)
+        whenever(experimentToggle.getRawStoredState()).thenReturn(
+            Toggle.State(assignedCohort = Toggle.State.Cohort(name = DuckAiOnboardingExperimentCohort.CONTROL.cohortName, weight = 1)),
+        )
+
+        val result = testee.isEnrolledInActiveExperiment()
+
+        assertFalse(result)
+        verify(experimentToggle, never()).enroll()
+    }
+
+    @Test
+    fun whenExperimentInactiveAndUserNotEnrolledThenIsEnrolledInActiveExperimentFalse() = runTest {
+        whenever(experimentToggle.isEnabled()).thenReturn(false)
+        whenever(experimentToggle.getRawStoredState()).thenReturn(null)
+
+        val result = testee.isEnrolledInActiveExperiment()
+
+        assertFalse(result)
+        verify(experimentToggle, never()).enroll()
     }
 
     private suspend fun givenPrerequisitesMet() {

--- a/app/src/test/java/com/duckduckgo/app/onboarding/DuckAiOnboardingExperimentManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/DuckAiOnboardingExperimentManagerTest.kt
@@ -184,47 +184,38 @@ class DuckAiOnboardingExperimentManagerTest {
     }
 
     @Test
-    fun whenExperimentActiveAndUserEnrolledThenIsEnrolledInActiveExperimentTrueAndDoesNotEnroll() = runTest {
-        whenever(experimentToggle.isEnabled()).thenReturn(true)
-        whenever(experimentToggle.getRawStoredState()).thenReturn(
-            Toggle.State(assignedCohort = Toggle.State.Cohort(name = DuckAiOnboardingExperimentCohort.CONTROL.cohortName, weight = 1)),
-        )
+    fun whenEnrolledAndEnabledInControlThenIsEnrolledInActiveExperimentTrueAndDoesNotEnroll() = runTest {
+        givenEnrolledAndEnabledIn(DuckAiOnboardingExperimentCohort.CONTROL)
 
         val result = testee.isEnrolledInActiveExperiment()
 
         assertTrue(result)
         verify(experimentToggle, never()).enroll()
-        verify(experimentToggle, never()).getCohort()
     }
 
     @Test
-    fun whenExperimentActiveAndUserNotEnrolledThenIsEnrolledInActiveExperimentFalse() = runTest {
-        whenever(experimentToggle.isEnabled()).thenReturn(true)
-        whenever(experimentToggle.getRawStoredState()).thenReturn(Toggle.State(assignedCohort = null))
+    fun whenEnrolledAndEnabledInTreatmentWithDuckAiDefaultThenIsEnrolledInActiveExperimentTrue() = runTest {
+        givenEnrolledAndEnabledIn(DuckAiOnboardingExperimentCohort.TREATMENT_WITH_DUCK_AI_DEFAULT)
 
         val result = testee.isEnrolledInActiveExperiment()
 
-        assertFalse(result)
+        assertTrue(result)
         verify(experimentToggle, never()).enroll()
     }
 
     @Test
-    fun whenExperimentInactiveAndUserEnrolledThenIsEnrolledInActiveExperimentFalse() = runTest {
-        whenever(experimentToggle.isEnabled()).thenReturn(false)
-        whenever(experimentToggle.getRawStoredState()).thenReturn(
-            Toggle.State(assignedCohort = Toggle.State.Cohort(name = DuckAiOnboardingExperimentCohort.CONTROL.cohortName, weight = 1)),
-        )
+    fun whenEnrolledAndEnabledInTreatmentWithSearchDefaultThenIsEnrolledInActiveExperimentTrue() = runTest {
+        givenEnrolledAndEnabledIn(DuckAiOnboardingExperimentCohort.TREATMENT_WITH_SEARCH_DEFAULT)
 
         val result = testee.isEnrolledInActiveExperiment()
 
-        assertFalse(result)
+        assertTrue(result)
         verify(experimentToggle, never()).enroll()
     }
 
     @Test
-    fun whenExperimentInactiveAndUserNotEnrolledThenIsEnrolledInActiveExperimentFalse() = runTest {
-        whenever(experimentToggle.isEnabled()).thenReturn(false)
-        whenever(experimentToggle.getRawStoredState()).thenReturn(null)
+    fun whenNotEnrolledAndEnabledInAnyCohortThenIsEnrolledInActiveExperimentFalse() = runTest {
+        givenEnrolledAndEnabledIn(null)
 
         val result = testee.isEnrolledInActiveExperiment()
 
@@ -242,5 +233,11 @@ class DuckAiOnboardingExperimentManagerTest {
     private suspend fun givenCohort(name: String) {
         whenever(experimentToggle.isEnabled()).thenReturn(true)
         whenever(experimentToggle.getCohort()).thenReturn(Toggle.State.Cohort(name = name, weight = 1))
+    }
+
+    private suspend fun givenEnrolledAndEnabledIn(enrolledCohort: DuckAiOnboardingExperimentCohort?) {
+        DuckAiOnboardingExperimentCohort.entries.forEach { cohort ->
+            whenever(experimentToggle.isEnrolledAndEnabled(cohort)).thenReturn(cohort == enrolledCohort)
+        }
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/onboarding/OnboardingExperimentNativeInputFieldSuppressorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/OnboardingExperimentNativeInputFieldSuppressorTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class OnboardingExperimentNativeInputFieldSuppressorTest {
+
+    private val duckAiOnboardingExperimentManager: DuckAiOnboardingExperimentManager = mock()
+
+    private lateinit var testee: OnboardingExperimentNativeInputFieldSuppressor
+
+    @Before
+    fun setup() {
+        testee = OnboardingExperimentNativeInputFieldSuppressor(duckAiOnboardingExperimentManager)
+    }
+
+    @Test
+    fun whenEnrolledInActiveExperimentThenNativeInputFieldSuppressed() = runTest {
+        whenever(duckAiOnboardingExperimentManager.isEnrolledInActiveExperiment()).thenReturn(true)
+
+        assertTrue(testee.isNativeInputFieldSuppressed())
+    }
+
+    @Test
+    fun whenNotEnrolledInActiveExperimentThenNativeInputFieldNotSuppressed() = runTest {
+        whenever(duckAiOnboardingExperimentManager.isEnrolledInActiveExperiment()).thenReturn(false)
+
+        assertFalse(testee.isNativeInputFieldSuppressed())
+    }
+}

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/nativeinput/NativeInputFieldSuppressor.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/nativeinput/NativeInputFieldSuppressor.kt
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.duckchat.impl.nativeinput
-
-import com.duckduckgo.anvil.annotations.ContributesPluginPoint
-import com.duckduckgo.di.scopes.AppScope
+package com.duckduckgo.duckchat.api.nativeinput
 
 /**
  * Lets other modules force-disable the native (unified) input field regardless of the
- * `nativeInputField` user setting. This is the single gate read by [com.duckduckgo.duckchat.impl.RealDuckChat]
- * so every consumer of `observeNativeInputFieldUserSettingEnabled()` sees a consistent value.
+ * `nativeInputField` user setting. This is the single gate read by `RealDuckChat` so every
+ * consumer of `observeNativeInputFieldUserSettingEnabled()` sees a consistent value.
  *
  * Used to exclude users enrolled in the active Duck.ai onboarding experiment so they keep the
  * legacy omnibar while the experiment runs.
@@ -31,10 +28,3 @@ interface NativeInputFieldSuppressor {
     /** Return true to suppress the native input field for the current user. */
     suspend fun isNativeInputFieldSuppressed(): Boolean
 }
-
-@ContributesPluginPoint(
-    scope = AppScope::class,
-    boundType = NativeInputFieldSuppressor::class,
-)
-@Suppress("unused")
-private interface UnusedNativeInputFieldSuppressorPluginPoint

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/nativeinput/NativeInputFieldSuppressor.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/nativeinput/NativeInputFieldSuppressor.kt
@@ -18,11 +18,12 @@ package com.duckduckgo.duckchat.api.nativeinput
 
 /**
  * Lets other modules force-disable the native (unified) input field regardless of the
- * `nativeInputField` user setting. This is the single gate read by `RealDuckChat` so every
+ * `nativeInputField` user setting. This is the single gate read by `RealDuckChat`, so every
  * consumer of `observeNativeInputFieldUserSettingEnabled()` sees a consistent value.
  *
- * Used to exclude users enrolled in the active Duck.ai onboarding experiment so they keep the
- * legacy omnibar while the experiment runs.
+ * Temporary: added only to exclude users in the active Duck.ai onboarding experiment, removed once
+ * it's cleaned up. Not reactive — suppressors are read only when `RealDuckChat.cacheConfig()` runs
+ * (app init and privacy-config download), so use this only for state fixed before app start.
  */
 interface NativeInputFieldSuppressor {
     /** Return true to suppress the native input field for the current user. */

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -41,13 +41,13 @@ import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.DuckChatInputModeState
 import com.duckduckgo.duckchat.api.DuckChatSettingsNoParams
 import com.duckduckgo.duckchat.api.InputMode
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputFieldSuppressor
 import com.duckduckgo.duckchat.impl.feature.AIChatImageUploadFeature
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBarCallback
 import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBarOptionBottomSheetDialogFactory
 import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBarSelection
 import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBarSelection.SEARCH_AND_AI
-import com.duckduckgo.duckchat.impl.nativeinput.NativeInputFieldSuppressor
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_CANCELLED
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_CONFIRMED
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_DISPLAYED

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.AppUrl
 import com.duckduckgo.common.utils.AppUrl.ParamKey.QUERY
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
@@ -46,6 +47,7 @@ import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBa
 import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBarOptionBottomSheetDialogFactory
 import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBarSelection
 import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBarSelection.SEARCH_AND_AI
+import com.duckduckgo.duckchat.impl.nativeinput.NativeInputFieldSuppressor
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_CANCELLED
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_CONFIRMED
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_DISPLAYED
@@ -367,6 +369,7 @@ class RealDuckChat @Inject constructor(
     private val duckAiHostProvider: DuckAiHostProvider,
     private val appBuildConfig: AppBuildConfig,
     private val voiceSessionStateManager: VoiceSessionStateManager,
+    private val nativeInputFieldSuppressors: PluginPoint<NativeInputFieldSuppressor>,
 ) : DuckChatInternal,
     DuckAiFeatureState,
     DuckChatInputModeState,
@@ -894,7 +897,8 @@ class RealDuckChat @Inject constructor(
             _allowDuckAiAsDigitalAssistant.emit(featureEnabled && duckChatFeature.digitalAssistantDuckAi().isEnabled())
             isImageUploadEnabled = imageUploadFeature.self().isEnabled()
             isStandaloneMigrationEnabled = duckChatFeature.standaloneMigration().isEnabled()
-            _nativeInputFieldEnabled.value = duckChatFeature.nativeInputField().isEnabled()
+            val nativeInputFieldSuppressed = nativeInputFieldSuppressors.getPlugins().any { it.isNativeInputFieldSuppressed() }
+            _nativeInputFieldEnabled.value = duckChatFeature.nativeInputField().isEnabled() && !nativeInputFieldSuppressed
 
             keepSessionAliveInMinutes = settingsJson?.sessionTimeoutMinutes ?: DEFAULT_SESSION_ALIVE
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputFieldSuppressor.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputFieldSuppressor.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.nativeinput
+
+import com.duckduckgo.anvil.annotations.ContributesPluginPoint
+import com.duckduckgo.di.scopes.AppScope
+
+/**
+ * Lets other modules force-disable the native (unified) input field regardless of the
+ * `nativeInputField` user setting. This is the single gate read by [com.duckduckgo.duckchat.impl.RealDuckChat]
+ * so every consumer of `observeNativeInputFieldUserSettingEnabled()` sees a consistent value.
+ *
+ * Used to exclude users enrolled in the active Duck.ai onboarding experiment so they keep the
+ * legacy omnibar while the experiment runs.
+ */
+interface NativeInputFieldSuppressor {
+    /** Return true to suppress the native input field for the current user. */
+    suspend fun isNativeInputFieldSuppressed(): Boolean
+}
+
+@ContributesPluginPoint(
+    scope = AppScope::class,
+    boundType = NativeInputFieldSuppressor::class,
+)
+@Suppress("unused")
+private interface UnusedNativeInputFieldSuppressorPluginPoint

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputFieldSuppressorPluginPoint.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/nativeinput/NativeInputFieldSuppressorPluginPoint.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.nativeinput
+
+import com.duckduckgo.anvil.annotations.ContributesPluginPoint
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputFieldSuppressor
+
+@ContributesPluginPoint(
+    scope = AppScope::class,
+    boundType = NativeInputFieldSuppressor::class,
+)
+@Suppress("unused")
+private interface UnusedNativeInputFieldSuppressorPluginPoint

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.AppUrl
+import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.duckchat.api.DuckAiHostProvider
 import com.duckduckgo.duckchat.api.DuckChatSettingsNoParams
@@ -41,6 +42,7 @@ import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBa
 import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBarOptionBottomSheetDialogFactory
 import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBarSelection.SEARCH_AND_AI
 import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBarSelection.SEARCH_ONLY
+import com.duckduckgo.duckchat.impl.nativeinput.NativeInputFieldSuppressor
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_CANCELLED
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_CONFIRMED
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_DISPLAYED
@@ -108,6 +110,15 @@ class RealDuckChatTest {
     private val mockAppBuildConfig: AppBuildConfig = mock()
     private val mockVoiceSessionStateManager: VoiceSessionStateManager = mock()
 
+    private var nativeInputFieldSuppressed = false
+    private val nativeInputFieldSuppressors = object : PluginPoint<NativeInputFieldSuppressor> {
+        override fun getPlugins(): Collection<NativeInputFieldSuppressor> = listOf(
+            object : NativeInputFieldSuppressor {
+                override suspend fun isNativeInputFieldSuppressed(): Boolean = nativeInputFieldSuppressed
+            },
+        )
+    }
+
     private lateinit var testee: RealDuckChat
 
     @Before
@@ -148,6 +159,7 @@ class RealDuckChatTest {
                 mockDuckAiHostProvider,
                 mockAppBuildConfig,
                 mockVoiceSessionStateManager,
+                nativeInputFieldSuppressors,
             ),
         )
         coroutineRule.testScope.advanceUntilIdle()
@@ -303,6 +315,28 @@ class RealDuckChatTest {
         advanceUntilIdle()
 
         assertFalse(testee.observeNativeInputFieldUserSettingEnabled().first())
+    }
+
+    @Test
+    fun whenNativeInputFieldEnabledButSuppressedThenObserveEmitsFalse() = runTest {
+        duckChatFeature.nativeInputField().setRawStoredState(State(enable = true))
+        nativeInputFieldSuppressed = true
+
+        testee.onPrivacyConfigDownloaded()
+        advanceUntilIdle()
+
+        assertFalse(testee.observeNativeInputFieldUserSettingEnabled().first())
+    }
+
+    @Test
+    fun whenNativeInputFieldEnabledAndNotSuppressedThenObserveEmitsTrue() = runTest {
+        duckChatFeature.nativeInputField().setRawStoredState(State(enable = true))
+        nativeInputFieldSuppressed = false
+
+        testee.onPrivacyConfigDownloaded()
+        advanceUntilIdle()
+
+        assertTrue(testee.observeNativeInputFieldUserSettingEnabled().first())
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.duckchat.api.DuckAiHostProvider
 import com.duckduckgo.duckchat.api.DuckChatSettingsNoParams
 import com.duckduckgo.duckchat.api.InputMode
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputFieldSuppressor
 import com.duckduckgo.duckchat.impl.feature.AIChatImageUploadFeature
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBarCallback
@@ -42,7 +43,6 @@ import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBa
 import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBarOptionBottomSheetDialogFactory
 import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBarSelection.SEARCH_AND_AI
 import com.duckduckgo.duckchat.impl.inputscreen.newaddressbaroption.NewAddressBarSelection.SEARCH_ONLY
-import com.duckduckgo.duckchat.impl.nativeinput.NativeInputFieldSuppressor
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_CANCELLED
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_CONFIRMED
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_NEW_ADDRESS_BAR_PICKER_DISPLAYED


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1174433894299346/task/1214601039604909?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1174433894299346/task/1215717655642150?focus=true

### Description

Users enrolled in the `onboardingDuckAiExperimentMay26` experiment must keep the legacy omnibar and **not** see the new unified (native) input field while the experiment is active.

`observeNativeInputFieldUserSettingEnabled()` has five consumers (omnibar, native input manager, NTP logo margin, the omnibar autocomplete shadow cache, and the Duck.ai contextual input in `duckchat-impl`), so rather than gating each call site this gates the single source they all read — `RealDuckChat._nativeInputFieldEnabled`:

- New `PluginPoint<NativeInputFieldSuppressor>` in `duckchat-impl` (`@ContributesPluginPoint(AppScope)`, suspend `isNativeInputFieldSuppressed()`).
- `RealDuckChat` ANDs `!suppressors.any { isNativeInputFieldSuppressed() }` into the native-input flag, so every consumer — including the cross-module one — sees a consistent value.
- `:app` `OnboardingExperimentNativeInputFieldSuppressor` (`@ContributesMultibinding(AppScope)`) delegates to a new read-only `DuckAiOnboardingExperimentManager.isEnrolledInActiveExperiment()`.

The enrollment check is read-only — it returns true when `isEnrolledAndEnabled(cohort)` is true for any cohort (control and both treatments). `isEnrolledAndEnabled` already accounts for both being enrolled in the cohort **and** the experiment still being enabled, so it never has to inspect the raw stored state or call `getCohort()` (which can re-enroll as a side effect).

### Steps to test this PR

_Experiment participant keeps the legacy omnibar_
- [x] On an internal build, enable `nativeInputField` so the unified input would normally show.
- [x] Force-enroll the device into `onboardingDuckAiExperimentMay26` (any cohort, incl. control) and ensure the toggle is enabled.
- [x] Verify the omnibar behaves as the legacy text field — no unified-input click-catcher, no native input widget, no Duck.ai contextual native input.

_Non-participant still gets the unified input_
- [x] With `nativeInputField` enabled and the device **not** enrolled in the experiment, verify the unified input field appears as before.

### UI changes
No visual changes — this only gates which input surface is shown. (No UI changes for non-experiment users.)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which address-bar surface users see across multiple browser entry points, but the logic is centralized, experiment-scoped, and covered by tests with no auth or data-handling impact.
> 
> **Overview**
> Keeps users in the active **`onboardingDuckAiExperimentMay26`** cohort on the **legacy omnibar** by turning off the unified native input at the single source every consumer reads.
> 
> A new **`NativeInputFieldSuppressor`** plugin API and **`PluginPoint`** let modules opt out of the native field. **`RealDuckChat`** now sets `_nativeInputFieldEnabled` to the feature toggle **and** `!any(suppressor)`, so **`observeNativeInputFieldUserSettingEnabled()`** stays consistent across omnibar, NTP, autocomplete, and Duck.ai UI.
> 
> The **`:app`** binding **`OnboardingExperimentNativeInputFieldSuppressor`** returns true when **`DuckAiOnboardingExperimentManager.isEnrolledInActiveExperiment()`** is true — a **read-only** check over `isEnrolledAndEnabled` for any cohort (including control), without calling **`enroll()`**. Suppression is applied when config is cached (app init / privacy config download); mid-session enrollment is intentionally out of scope while enrollment is closed.
> 
> Unit tests cover enrollment detection and suppressor wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 927a4c1c76642f25d5d6193dd24192b6c3608eab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->