### PR TITLE
Update content scope scripts to version 15.2.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -236,6 +236,9 @@
     }
   };
   function processAttr(configSetting, defaultValue) {
+    if (typeof defaultValue === "number" && isNaN(defaultValue)) {
+      defaultValue = void 0;
+    }
     if (configSetting === void 0) {
       return defaultValue;
     }
@@ -3256,9 +3259,10 @@
       const conditionalChanges = this._getFeatureSettings()?.[featureKeyName] || [];
       return conditionalChanges.filter((rule) => {
         let condition = rule.condition;
-        if (condition === void 0 && "domain" in rule) {
+        if (condition === void 0 && rule.domain !== void 0) {
           condition = this._domainToConditonBlocks(rule.domain);
         }
+        if (condition === void 0) return true;
         return this._matchConditionalBlockOrArray(condition);
       });
     }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -1742,6 +1742,9 @@
     }
   };
   function processAttr(configSetting, defaultValue) {
+    if (typeof defaultValue === "number" && isNaN(defaultValue)) {
+      defaultValue = void 0;
+    }
     if (configSetting === void 0) {
       return defaultValue;
     }
@@ -4822,9 +4825,10 @@
       const conditionalChanges = this._getFeatureSettings()?.[featureKeyName] || [];
       return conditionalChanges.filter((rule) => {
         let condition2 = rule.condition;
-        if (condition2 === void 0 && "domain" in rule) {
+        if (condition2 === void 0 && rule.domain !== void 0) {
           condition2 = this._domainToConditonBlocks(rule.domain);
         }
+        if (condition2 === void 0) return true;
         return this._matchConditionalBlockOrArray(condition2);
       });
     }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -1742,6 +1742,9 @@
     }
   };
   function processAttr(configSetting, defaultValue) {
+    if (typeof defaultValue === "number" && isNaN(defaultValue)) {
+      defaultValue = void 0;
+    }
     if (configSetting === void 0) {
       return defaultValue;
     }
@@ -4791,9 +4794,10 @@
       const conditionalChanges = this._getFeatureSettings()?.[featureKeyName] || [];
       return conditionalChanges.filter((rule) => {
         let condition2 = rule.condition;
-        if (condition2 === void 0 && "domain" in rule) {
+        if (condition2 === void 0 && rule.domain !== void 0) {
           condition2 = this._domainToConditonBlocks(rule.domain);
         }
+        if (condition2 === void 0) return true;
         return this._matchConditionalBlockOrArray(condition2);
       });
     }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -1098,6 +1098,9 @@
     }
   };
   function processAttr(configSetting, defaultValue) {
+    if (typeof defaultValue === "number" && isNaN(defaultValue)) {
+      defaultValue = void 0;
+    }
     if (configSetting === void 0) {
       return defaultValue;
     }
@@ -4695,9 +4698,10 @@
       const conditionalChanges = this._getFeatureSettings()?.[featureKeyName] || [];
       return conditionalChanges.filter((rule) => {
         let condition = rule.condition;
-        if (condition === void 0 && "domain" in rule) {
+        if (condition === void 0 && rule.domain !== void 0) {
           condition = this._domainToConditonBlocks(rule.domain);
         }
+        if (condition === void 0) return true;
         return this._matchConditionalBlockOrArray(condition);
       });
     }
@@ -6574,6 +6578,9 @@
   var hideTimeouts = [0, 100, 300, 500, 1e3, 2e3, 3e3];
   var unhideTimeouts = [1250, 2250, 3e3];
   var featureInstance;
+  function hasSelector(rule) {
+    return "selector" in rule;
+  }
   function collapseDomNode(element, rule, previousElement) {
     if (!element) {
       return;
@@ -6715,16 +6722,9 @@
     let selector = "";
     rules.forEach((rule, i) => {
       if (i !== rules.length - 1) {
-        selector = selector.concat(
-          /** @type {ElementHidingRuleHide | ElementHidingRuleModify} */
-          rule.selector,
-          ","
-        );
+        selector = selector.concat(rule.selector, ",");
       } else {
-        selector = selector.concat(
-          /** @type {ElementHidingRuleHide | ElementHidingRuleModify} */
-          rule.selector
-        );
+        selector = selector.concat(rule.selector);
       }
     });
     const styleTagProperties = "display:none!important;min-height:0!important;height:0!important;";
@@ -6734,11 +6734,8 @@
   }
   function hideAdNodes(rules) {
     const document2 = globalThis.document;
-    rules.forEach((rule) => {
-      const selector = forgivingSelector(
-        /** @type {ElementHidingRuleHide | ElementHidingRuleModify} */
-        rule.selector
-      );
+    rules.filter(hasSelector).forEach((rule) => {
+      const selector = forgivingSelector(rule.selector);
       const matchingElementArray = [...document2.querySelectorAll(selector)];
       matchingElementArray.forEach((element) => {
         collapseDomNode(element, rule);
@@ -6778,14 +6775,15 @@
         shouldInjectStyleTag = this.matchConditionalFeatureSetting("styleTagExceptions").length === 0;
       }
       const activeDomainRules = this.matchConditionalFeatureSetting("domains").flatMap((item) => {
-        return (
+        return Array.isArray(item.rules) ? (
           /** @type {ElementHidingRule[]} */
-          item.rules || []
-        );
+          item.rules
+        ) : [];
       });
-      const overrideRules = activeDomainRules.filter((rule) => {
-        return rule.type === "override";
-      });
+      const overrideRules = activeDomainRules.filter(
+        /** @returns {rule is ElementHidingRuleHide} */
+        (rule) => rule.type === "override"
+      );
       const disableDefault = activeDomainRules.some((rule) => {
         return rule.type === "disable-default";
       });
@@ -6798,7 +6796,7 @@
       }
       overrideRules.forEach((override) => {
         activeRules = activeRules.filter((rule) => {
-          return rule.selector !== override.selector;
+          return !hasSelector(rule) || rule.selector !== override.selector;
         });
       });
       const applyRules = this.applyRules.bind(this);
@@ -9645,14 +9643,24 @@
      * @param {(userValues: import("../duck-player.js").UserValues) => void} cb
      */
     onUserValuesChanged(cb) {
-      return this.messaging.subscribe("onUserValuesChanged", cb);
+      return this.messaging.subscribe("onUserValuesChanged", (value) => {
+        cb(
+          /** @type {import("../duck-player.js").UserValues} */
+          value
+        );
+      });
     }
     /**
      * Get notification when ui settings changed
      * @param {(userValues: import("../duck-player.js").UISettings) => void} cb
      */
     onUIValuesChanged(cb) {
-      return this.messaging.subscribe("onUIValuesChanged", cb);
+      return this.messaging.subscribe("onUIValuesChanged", (value) => {
+        cb(
+          /** @type {import("../duck-player.js").UISettings} */
+          value
+        );
+      });
     }
     /**
      * This allows our SERP to interact with Duck Player settings.
@@ -9896,7 +9904,7 @@
     /**
      * Convert a relative pathname into VideoParams
      *
-     * @param pathname
+     * @param {string} pathname
      * @returns {VideoParams|null}
      */
     static fromPathname(pathname) {
@@ -9912,7 +9920,7 @@
      * Convert a href into valid video params. Those can then be converted into a private player
      * link when needed
      *
-     * @param href
+     * @param {string} href
      * @returns {VideoParams|null}
      */
     static fromHref(href) {
@@ -9943,12 +9951,16 @@
   var DomState = class {
     constructor() {
       __publicField(this, "loaded", false);
+      /** @type {Array<() => void>} */
       __publicField(this, "loadedCallbacks", []);
       window.addEventListener("DOMContentLoaded", () => {
         this.loaded = true;
         this.loadedCallbacks.forEach((cb) => cb());
       });
     }
+    /**
+     * @param {() => void} loadedCallback
+     */
     onLoaded(loadedCallback) {
       if (this.loaded) return loadedCallback();
       this.loadedCallbacks.push(loadedCallback);
@@ -10397,10 +10409,17 @@
       }
       return window.location.href;
     }
+    /**
+     * @param {string} videoId
+     * @returns {string}
+     */
     getLargeThumbnailSrc(videoId) {
       const url = new URL(`/vi/${videoId}/maxresdefault.jpg`, "https://i.ytimg.com");
       return url.href;
     }
+    /**
+     * @param {string} href
+     */
     setHref(href) {
       window.location.href = href;
     }
@@ -10476,8 +10495,12 @@
         });
         let clicked = false;
         const clickHandler = (e) => {
-          const overlay = icon.getHoverOverlay();
-          if (overlay?.contains(e.target)) {
+          const overlay = (
+            /** @type {HTMLElement | null} */
+            icon.getHoverOverlay()
+          );
+          const target = e.target;
+          if (overlay && target instanceof Node && overlay.contains(target)) {
           } else if (overlay) {
             clicked = true;
             icon.hideOverlay(overlay);
@@ -10489,7 +10512,10 @@
         };
         parentNode.addEventListener("click", clickHandler, true);
         const removeOverlay = () => {
-          const overlay = icon.getHoverOverlay();
+          const overlay = (
+            /** @type {HTMLElement | null} */
+            icon.getHoverOverlay()
+          );
           if (overlay) {
             icon.hideOverlay(overlay);
             icon.hoverOverlayVisible = false;
@@ -10513,10 +10539,11 @@
           if (!hoverElement.querySelector("img")) {
             return removeOverlay();
           }
-          if (e.target === hoverElement || hoverElement?.contains(e.target)) {
+          const target = e.target;
+          if (target === hoverElement || target instanceof Node && hoverElement?.contains(target)) {
             return appendOverlay(hoverElement);
           }
-          const matched = selectors.allowedEventTargets.find((css) => e.target.matches(css));
+          const matched = target instanceof Element && selectors.allowedEventTargets.find((css) => target.matches(css));
           if (matched) {
             appendOverlay(hoverElement);
           }
@@ -10561,10 +10588,11 @@
           if (!validLink) {
             return;
           }
-          if (e.target === elementInStack || elementInStack?.contains(e.target)) {
+          const target = e.target;
+          if (target === elementInStack || target instanceof Node && elementInStack?.contains(target)) {
             return block(validLink);
           }
-          const matched = selectors.allowedEventTargets.find((css) => e.target.matches(css));
+          const matched = target instanceof Element && selectors.allowedEventTargets.find((css) => target.matches(css));
           if (matched) {
             block(validLink);
           }
@@ -10603,8 +10631,10 @@
       return false;
     });
     if (existsInExcludedParent) return null;
-    if (!("href" in element)) return null;
-    return VideoParams.fromHref(element.href)?.toPrivatePlayerUrl();
+    if (!("href" in element) || typeof element.href !== "string") return null;
+    const href = element.href;
+    if (typeof href !== "string") return null;
+    return VideoParams.fromHref(href)?.toPrivatePlayerUrl();
   }
 
   // src/features/duckplayer/video-overlay.js
@@ -11424,8 +11454,8 @@
      */
     appendThumbnail(overlayElement) {
       const params = VideoParams.forWatchPage(this.environment.getPlayerPageHref());
-      const videoId = params?.id;
-      const imageUrl = this.environment.getLargeThumbnailSrc(videoId);
+      if (!params) return;
+      const imageUrl = this.environment.getLargeThumbnailSrc(params.id);
       appendImageAsBackground(overlayElement, ".ddg-vpo-bg", imageUrl);
     }
     /**

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
@@ -218,6 +218,9 @@
     }
   };
   function processAttr(configSetting, defaultValue) {
+    if (typeof defaultValue === "number" && isNaN(defaultValue)) {
+      defaultValue = void 0;
+    }
     if (configSetting === void 0) {
       return defaultValue;
     }
@@ -3220,9 +3223,10 @@
       const conditionalChanges = this._getFeatureSettings()?.[featureKeyName] || [];
       return conditionalChanges.filter((rule) => {
         let condition = rule.condition;
-        if (condition === void 0 && "domain" in rule) {
+        if (condition === void 0 && rule.domain !== void 0) {
           condition = this._domainToConditonBlocks(rule.domain);
         }
+        if (condition === void 0) return true;
         return this._matchConditionalBlockOrArray(condition);
       });
     }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiDataClearing.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiDataClearing.js
@@ -218,6 +218,9 @@
     }
   };
   function processAttr(configSetting, defaultValue) {
+    if (typeof defaultValue === "number" && isNaN(defaultValue)) {
+      defaultValue = void 0;
+    }
     if (configSetting === void 0) {
       return defaultValue;
     }
@@ -3220,9 +3223,10 @@
       const conditionalChanges = this._getFeatureSettings()?.[featureKeyName] || [];
       return conditionalChanges.filter((rule) => {
         let condition = rule.condition;
-        if (condition === void 0 && "domain" in rule) {
+        if (condition === void 0 && rule.domain !== void 0) {
           condition = this._domainToConditonBlocks(rule.domain);
         }
+        if (condition === void 0) return true;
         return this._matchConditionalBlockOrArray(condition);
       });
     }
@@ -4000,15 +4004,19 @@
   // src/features/duck-ai-data-clearing.js
   var DuckAiDataClearing = class extends ContentFeature {
     init() {
-      this.messaging.subscribe("duckAiClearData", (params) => this.clearData(params));
+      this.messaging.subscribe("duckAiClearData", (params) => {
+        void this.clearData(params);
+      });
       this.notify("duckAiClearDataReady");
     }
     /**
-     * @param {object} [params]
-     * @param {string} [params.chatId] - If provided, only delete this specific chat; otherwise clear all data
+     * @param {unknown} [params]
      */
     clearData(params) {
-      const chatId = params?.chatId;
+      const chatId = params !== null && typeof params === "object" && "chatId" in params ? (
+        /** @type {{ chatId?: string }} */
+        params.chatId
+      ) : void 0;
       if (chatId) {
         return this.deleteSingleChat(chatId);
       } else {
@@ -4062,7 +4070,7 @@
         try {
           operation(key);
         } catch (error) {
-          errors.push(error);
+          errors.push(error instanceof Error ? error : new Error(String(error)));
           this.log.error("Error in localStorage operation:", error);
         }
       }
@@ -4080,7 +4088,7 @@
             operation(objectStore, transaction, dbName, storeName);
           });
         } catch (error) {
-          errors.push(error);
+          errors.push(error instanceof Error ? error : new Error(String(error)));
           this.log.error("Error in IndexedDB operation:", error);
         }
       }
@@ -4125,6 +4133,9 @@
         this.log.info(`Chat '${chatId}' not found in '${localStorageKey}'`);
       }
     }
+    /**
+     * @param {string} localStorageKey
+     */
     clearSavedAIChats(localStorageKey) {
       this.log.info(`Clearing '${localStorageKey}'`);
       window.localStorage.removeItem(localStorageKey);

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
@@ -2987,7 +2987,7 @@
   }
   function getErrorType(windowObject, signInRequiredSelector, logger) {
     const currentWindow = (
-      /** @type {Window & typeof globalThis & { ytcfg: object }} */
+      /** @type {Window & typeof globalThis & { ytcfg?: { get: (key: string) => unknown } }} */
       windowObject
     );
     const currentDocument = currentWindow.document;
@@ -3002,9 +3002,13 @@
       logger?.log("Got ytcfg", currentWindow.ytcfg);
     }
     try {
-      const playerResponseJSON = currentWindow.ytcfg?.get("PLAYER_VARS")?.embedded_player_response;
+      const playVars = currentWindow.ytcfg?.get("PLAYER_VARS");
+      const raw = typeof playVars === "object" && playVars !== null && "embedded_player_response" in playVars ? playVars.embedded_player_response : void 0;
+      const playerResponseJSON = typeof raw === "string" ? raw : void 0;
       logger?.log("Player response", playerResponseJSON);
-      playerResponse = JSON.parse(playerResponseJSON);
+      if (playerResponseJSON) {
+        playerResponse = JSON.parse(playerResponseJSON);
+      }
     } catch (e3) {
       logger?.log("Could not parse player response", e3);
     }
@@ -3300,7 +3304,7 @@
     /**
      * Convert a relative pathname into VideoParams
      *
-     * @param pathname
+     * @param {string} pathname
      * @returns {VideoParams|null}
      */
     static fromPathname(pathname) {
@@ -3316,7 +3320,7 @@
      * Convert a href into valid video params. Those can then be converted into a private player
      * link when needed
      *
-     * @param href
+     * @param {string} href
      * @returns {VideoParams|null}
      */
     static fromHref(href) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.95.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.1.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.2.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#24a5cd08938f22092dcd0c140b153b36d6468736",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#5d05cc82a8f5e3bacf35132e00f35315461f1d4e",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -89,33 +89,33 @@
       "license": "Apache-2.0"
     },
     "node_modules/@ghostery/adblocker": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.17.3.tgz",
-      "integrity": "sha512-E2jcCtlkdJFm0gUH1GL+99CgAGudlOpMfpWJqKUL9lfPFbEuw//xypbyLUdTJcz31eBJaHq1ql163dIJ00/m1A==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker/-/adblocker-2.18.0.tgz",
+      "integrity": "sha512-u0XWX+kZtBTqjfa+saNXMI2ZLzaoeT3tASjDuBqQ3WYKquLh15Z3nCBIPruT63nMRr41MZLwB8F6jZPIhsM3dA==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-content": "^2.17.3",
-        "@ghostery/adblocker-extended-selectors": "^2.17.3",
+        "@ghostery/adblocker-content": "^2.18.0",
+        "@ghostery/adblocker-extended-selectors": "^2.18.0",
         "@ghostery/url-parser": "^1.3.1",
         "@remusao/guess-url-type": "^2.1.0",
         "@remusao/small": "^2.1.0",
         "@remusao/smaz": "^2.2.0",
-        "tldts-experimental": "^7.0.30"
+        "tldts-experimental": "^7.4.2"
       }
     },
     "node_modules/@ghostery/adblocker-content": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.17.3.tgz",
-      "integrity": "sha512-Fm+hj0zhCkBzn3C3Ha/99dV0IRRW5gCP83ivya2JUgqb8styEBC62EGv6pPWOBEHqSvlLr4EygcWMlSZH4zISg==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-content/-/adblocker-content-2.18.0.tgz",
+      "integrity": "sha512-hO+SHBKzx8PBqppjO6Haj0d4h+4RUQ+0tpVZjs9wUgxLKZlvvYzlQ9sAHilzIT5ixSn+8LSlrYm+ngf2ugH9XQ==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@ghostery/adblocker-extended-selectors": "^2.17.3"
+        "@ghostery/adblocker-extended-selectors": "^2.18.0"
       }
     },
     "node_modules/@ghostery/adblocker-extended-selectors": {
-      "version": "2.17.3",
-      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.17.3.tgz",
-      "integrity": "sha512-LlKTpvD8mscNb6NXPJ0yqLv4qvMP9ZRf33HNuQvQxY+nf4nU+ipYjhoNjvPrKAIrvHtIT4DhE+FeD4pAtp5GXQ==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/@ghostery/adblocker-extended-selectors/-/adblocker-extended-selectors-2.18.0.tgz",
+      "integrity": "sha512-oeSb/1liYplCq76rrPDmR7A69kNB6WsWjPfcsJFkrPip+WUd83Xbc+I5fnZ36Id3IOyegozZG1ucr3ywwC7OyQ==",
       "license": "MPL-2.0"
     },
     "node_modules/@ghostery/url-parser": {
@@ -280,9 +280,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -300,9 +300,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.95.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.1.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.2.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [x] All tests must pass
- [x] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [x] All tests must pass
- [x] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect in-page privacy features (conditional config, ad hiding, Duck Player, Duck AI data clearing) across many sites; incorrect matching could alter blocking or clearing behavior until privacy tests pass.
> 
> **Overview**
> Bumps **`@duckduckgo/content-scope-scripts`** from **15.1.0** to **15.2.0** and refreshes the vendored Android build bundles under `node_modules`.
> 
> The **15.2.0** injected scripts tighten config and feature matching: **`processAttr`** treats a numeric default of **NaN** as unset; **`matchConditionalFeatureSetting`** only derives conditions when **`domain`** is present and **includes rules with no condition** instead of dropping them. **Element hiding** only applies rules that have a **`selector`**, validates **`item.rules`** as an array, and skips override comparisons for selector-less rules.
> 
> **Duck Player** gains stricter DOM/event typing ( **`Node`/`Element`** checks before **`contains`/`matches`** ), wraps messaging subscription payloads, and avoids thumbnail work when watch params are missing. **Duck AI data clearing** validates clear-data params, normalizes caught values to **`Error`**, and fires async clears without unhandled promises. The **duck player page** bundle parses **`ytcfg`** / embedded player response more defensively.
> 
> **`package-lock.json`** also records transitive bumps (e.g. **`@ghostery/adblocker`** 2.17.3→2.18.0) from the resolved dependency tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b9d038c6f4ab7802e5cfcc9bab71feca1c02b64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->