### PR TITLE
Sync v2: Sync Code Dispatcher and runner integration

### DIFF
--- a/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -1,0 +1,319 @@
+{
+    "sync_setup_barcode_screen_shown": {
+        "description": "The sync setup barcode (QR) screen was shown to the user",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow the screen belongs to",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_manual_code_entry_screen_shown": {
+        "description": "The sync setup manual code entry screen was shown to the user",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow the screen belongs to",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_barcode_scanner_success": {
+        "description": "A scanned sync code was recognized successfully",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow the scan belongs to",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "code_version",
+                "type": "string",
+                "description": "Protocol version of the code that was scanned",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "code_type",
+                "type": "string",
+                "description": "Kind of recognized code. Sent on the v2 path only",
+                "enum": ["recovery", "linking"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_manual_code_entered_success": {
+        "description": "A manually entered/pasted sync code was recognized successfully",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow the code entry belongs to",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "code_version",
+                "type": "string",
+                "description": "Protocol version of the code that was entered",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "code_type",
+                "type": "string",
+                "description": "Kind of recognized code. Sent on the v2 path only",
+                "enum": ["recovery", "linking"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_barcode_scanner_failed": {
+        "description": "A scanned sync code could not be parsed/recognized",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow the scan belongs to",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_manual_code_entered_failed": {
+        "description": "A manually entered/pasted sync code could not be parsed/recognized",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow the code entry belongs to",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_ended_successful": {
+        "description": "Sync setup completed successfully (recovery-code login or device pairing). For a v2 pairing the host reports it after sending the recovery code, the joiner after login",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow completed",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            },
+            {
+                "key": "path",
+                "type": "string",
+                "description": "Whether the v2 setup was a recovery-code login or a device pairing. Sent on the v2 path only",
+                "enum": ["recovery", "pairing"]
+            },
+            {
+                "key": "my_role",
+                "type": "string",
+                "description": "This device's elected role in a v2 pairing. Sent for v2 pairings only",
+                "enum": ["host", "joiner"]
+            },
+            {
+                "key": "peer_kind",
+                "type": "string",
+                "description": "The peer device's credential kind in a v2 pairing. Sent for v2 pairings only",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_ended_failed": {
+        "description": "A v2 sync setup that started (code recognized) failed with an error, not a user cancellation",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Why the v2 setup failed, aligned with the error codes we handle",
+                "enum": [
+                    "needs_upgrade",
+                    "already_upgraded",
+                    "invalid_credentials",
+                    "pairing_unavailable",
+                    "protocol_error",
+                    "transport_failure",
+                    "unexpected_failure"
+                ]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on. Always v2 for this pixel",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            },
+            {
+                "key": "path",
+                "type": "string",
+                "description": "Whether the failed setup was a recovery-code login or a device pairing. Best-effort, omitted when unknown",
+                "enum": ["recovery", "pairing"]
+            },
+            {
+                "key": "my_role",
+                "type": "string",
+                "description": "This device's elected role in a v2 pairing. Best-effort, omitted when unknown",
+                "enum": ["host", "joiner"]
+            },
+            {
+                "key": "peer_kind",
+                "type": "string",
+                "description": "The peer device's credential kind in a v2 pairing. Best-effort, omitted when unknown",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_ended_abandoned": {
+        "description": "Sync setup was cancelled by the user (back navigation or denying the sync confirmation prompt)",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow was cancelled",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Why the setup was cancelled, based on the v2 protocol state at cancellation",
+                "enum": ["scanning_cancelled", "sync_confirmation_denied", "cancelled_before_finished"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ProtectedKeyManager.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ProtectedKeyManager.kt
@@ -25,9 +25,6 @@ import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
 import com.duckduckgo.sync.store.SyncStore
 import com.squareup.anvil.annotations.ContributesBinding
-import com.squareup.moshi.JsonAdapter
-import com.squareup.moshi.Moshi
-import com.squareup.moshi.Types
 import dagger.SingleInstanceIn
 import logcat.LogPriority.ERROR
 import logcat.logcat
@@ -45,11 +42,12 @@ interface ProtectedKeyManager {
      * Generates an RSA keypair for [purpose] (e.g. "ai_chats"), libsodium-encrypts the private key
      * with the account secret key, and POSTs the entry via /sync/keys/.../set-if-absent.
      *
-     * Returns the created [ProtectedKeyEntry] (the locally-generated, ddg-wrapped key) on success so
-     * callers can use it without a read-after-write GET /keys round-trip (which can lag right after
-     * the write). No-op success semantics for set-if-absent: in the newly-created case (the only case
-     * the 3party-extend caller hits, since it generates only when no keys exist) the returned entry is
-     * authoritative.
+     * Returns the authoritative [ProtectedKeyEntry] taken from the server's response. In the
+     * we-wrote-it case the returned entry equals the one we POSTed; in the race-loser case the
+     * server's `set-if-absent` returns its pre-existing entry instead, and we surface that so
+     * the caller reflects the truth on the server rather than the local key we minted.
+     *
+     * Returns the entry for [purpose] only — not all keys for the account.
      */
     fun create(purpose: String): Result<ProtectedKeyEntry>
 }
@@ -104,39 +102,26 @@ class RealProtectedKeyManager @Inject constructor(
             publicKey = RsaJwk(n = n, e = e),
         )
 
-        return when (val result = syncApi.setProtectedKeyIfAbsent(token, purpose, key)) {
+        return when (val result = syncApi.setProtectedKeyIfAbsent(token, purpose, listOf(key))) {
             is Success -> {
-                logcat { "Sync-ScopedToken: protected key for $purpose created (kid=$kid)" }
-                // Per the Access Credentials TD, the local cache should mirror what's on the
-                // server after every mutation. Append the new entry so callers don't have to
-                // re-hit /sync/keys to find it.
-                cacheLocalProtectedKey(key)
-                Success(key)
+                val entry = result.data.firstOrNull { it.purpose == purpose && it.encryptedWith == CREDENTIAL_ID_DDG }
+                    ?: return Error(reason = "CreateProtectedKey: server response missing created key for $purpose")
+                if (entry.kid != kid) {
+                    // Server returned a pre-existing entry — another device created the key for this
+                    // purpose between our (implicit) check and our POST. The server's entry wins.
+                    logcat {
+                        "Sync-ScopedToken: protected key for $purpose already existed on server " +
+                            "(server kid=${entry.kid}, our kid=$kid) — adopting server entry"
+                    }
+                } else {
+                    logcat { "Sync-ScopedToken: protected key for $purpose created (kid=$kid)" }
+                }
+                Success(entry)
             }
             is Error -> {
                 logcat(ERROR) { "Sync-ScopedToken: failed to create protected key: ${result.reason}" }
                 result
             }
         }
-    }
-
-    private fun cacheLocalProtectedKey(newEntry: ProtectedKeyEntry) {
-        val existing = syncStore.protectedKeysJson
-            ?.let { runCatching { protectedKeysAdapter.fromJson(it) }.getOrNull() }
-            ?: emptyList()
-        // De-dup on kid in case the same key is re-created (shouldn't happen but defensive).
-        val merged = existing.filterNot { it.kid == newEntry.kid } + newEntry
-        // Best-effort cache: the key was already created on the server and is returned to the caller,
-        // so a serialization failure here must not fail create().
-        runCatching { protectedKeysAdapter.toJson(merged) }
-            .onSuccess { syncStore.protectedKeysJson = it }
-            .onFailure { logcat(ERROR) { "Sync-ScopedToken: failed to serialize protected keys cache: ${it.message}" } }
-    }
-
-    private companion object {
-        private val protectedKeysAdapter: JsonAdapter<List<ProtectedKeyEntry>> =
-            Moshi.Builder().build().adapter(
-                Types.newParameterizedType(List::class.java, ProtectedKeyEntry::class.java),
-            )
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
@@ -1,0 +1,469 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import android.util.Base64
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
+import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.transformWhile
+import logcat.logcat
+import org.json.JSONObject
+import javax.inject.Inject
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealSyncCodeDispatcher @Inject constructor(
+    private val syncFeature: SyncFeature,
+    private val syncAccountRepository: SyncAccountRepository,
+    private val qrCode: ExchangeV2QrCode,
+    private val runner: ExchangeV2Runner,
+) : SyncCodeDispatcher {
+
+    override fun confirmJoiner() {
+        logcat { "$TAG: user confirmed Joiner side" }
+        runner.localTrigger(LocalTrigger.UserConfirmedJoiner)
+    }
+
+    override fun denyJoiner() {
+        logcat { "$TAG: user denied Joiner side" }
+        runner.localTrigger(LocalTrigger.UserDeniedJoiner)
+    }
+
+    override fun confirmHost() {
+        logcat { "$TAG: user confirmed Host side" }
+        runner.localTrigger(LocalTrigger.UserConfirmedHost)
+    }
+
+    override fun denyHost() {
+        logcat { "$TAG: user denied Host side" }
+        runner.localTrigger(LocalTrigger.UserDeniedHost)
+    }
+
+    /**
+     * Drive a v2 Presenter session. Mirrors [driveV2Linking] but for the Presenter side:
+     * starts the runner via [ExchangeV2Runner.startPresent], scopes to events emitted after
+     * session start (defensive against the runner's SharedFlow replay cache), and maps each
+     * event to a [DispatchOutcome] via [mapV2PresentEventToOutcome].
+     *
+     * Today's callers include both the signed-in `SyncWithAnotherActivityViewModel` and the
+     * signed-out `SyncConnectViewModel` (per M1.5, Asana subtask `1215246284113165`). Role
+     * election in the runner can elect this device as Host (signed-in surface, or signed-out
+     * against a signed-out peer with account-creation-on-demand at Host.Sending — see
+     * `1215168582640073`) or as Joiner (signed-out surface against a signed-in or 3party peer).
+     * All terminal mappings are first-class; see `mapV2PresentEventToOutcome` for the table.
+     */
+    override fun presentV2(): Flow<DispatchOutcome> = flow {
+        val sessionStartMs = System.currentTimeMillis()
+        logcat { "$TAG: V2 Presenter starting runner.startPresent (scoped to events since $sessionStartMs)" }
+        runner.startPresent()
+        var ownChannelId: String? = null
+        emitAll(
+            runner.eventsSince(sessionStartMs)
+                .transformWhile { event ->
+                    // Latch our session's channelId on the first SessionStarted. If a later
+                    // SessionStarted arrives with a different channelId, the shared runner has
+                    // been preempted by another caller (route()/startScan from EnterCode, for
+                    // example). Terminate silently without emitting any DispatchOutcome — the
+                    // new caller's Flow now owns the runner. Defence-in-depth against the
+                    // duplicate-login race; the activity-side lifecycle scope normally prevents
+                    // this from happening at all, but this catches the transition window.
+                    if (event is ExchangeV2Event.SessionStarted) {
+                        if (ownChannelId == null) {
+                            ownChannelId = event.ownChannelId
+                        } else if (event.ownChannelId != ownChannelId) {
+                            logcat { "$TAG: V2 Presenter flow preempted (own=$ownChannelId, new=${event.ownChannelId}); terminating silently" }
+                            return@transformWhile false
+                        }
+                    }
+                    val outcome = mapV2PresentEventToOutcome(event) ?: return@transformWhile true
+                    emit(outcome)
+                    !outcome.isTerminal()
+                },
+        )
+        logcat { "$TAG: V2 Presenter flow completed" }
+    }.onCompletion { cause ->
+        if (cause != null) {
+            // Flow cancelled or threw before reaching a terminal SM state — tear down the
+            // runner session so the channel DELETE fires (best-effort).
+            // Spec: Unified Algorithm §Aborting; Track B subtask 1215139308232508.
+            logcat { "$TAG: V2 Presenter flow completed with cause=${cause::class.simpleName}; cancelling runner" }
+            runner.cancel()
+        }
+    }
+
+    /**
+     * Translate one runner event into a [DispatchOutcome] for the v2 Presenter flow,
+     * or null for intermediate events the caller should ignore.
+     *
+     * The Joiner.* branches were defensive stubs in M1 (the signed-in surface always elects
+     * Host via role-election rule 1: account-beats-no-account). M1.5 wires `SyncConnectViewModel`
+     * (signed-out surface) to `presentV2`, so a signed-out Presenter facing a signed-in peer
+     * is now elected Joiner — these branches are first-class. Mirrors mapV2LinkingEventToOutcome
+     * behaviour (login on Joiner.Done; preserve abort reason).
+     *
+     * See Asana subtask `1215246284113165` for the M1.5 wire-up and `1215168582640073` for the
+     * runner-side account-provisioning at Host.Sending (used by signed-out Presenter ↔ signed-out
+     * peer scenarios where this device wins Presenter-beats-Scanner).
+     */
+    private fun mapV2PresentEventToOutcome(event: ExchangeV2Event): DispatchOutcome? = when (event) {
+        is ExchangeV2Event.SessionStarted -> event.linkingCode?.let { DispatchOutcome.LinkingCodeReady(it) }
+        is ExchangeV2Event.Transition -> when (event.to) {
+            ExchangeV2State.Joiner.Confirming ->
+                DispatchOutcome.JoinerConfirmationRequested(peerName = runner.peerName)
+            ExchangeV2State.Host.Confirming ->
+                DispatchOutcome.HostConfirmationRequested(peerName = runner.peerName)
+            ExchangeV2State.Host.Done -> DispatchOutcome.LoggedIn
+            ExchangeV2State.Host.Aborted -> when (event.localTrigger) {
+                LocalTrigger.UserDeniedHost -> DispatchOutcome.Failed("user_denied")
+                LocalTrigger.HostUnavailable -> DispatchOutcome.Failed("host_unavailable")
+                else -> DispatchOutcome.Failed("host_aborted")
+            }
+            ExchangeV2State.SameAccountAbort -> DispatchOutcome.AlreadyConnected
+            ExchangeV2State.Joiner.Done -> {
+                val received = (event.trigger as? ExchangeV2Message.RecoveryCodeResponse)?.recoveryCode
+                if (received.isNullOrBlank()) {
+                    DispatchOutcome.Failed("Pairing completed without a recovery code")
+                } else {
+                    loginWithV2RecoveryCode(received)
+                }
+            }
+            ExchangeV2State.Joiner.AbortedByHost -> {
+                val msgType = event.trigger?.messageType ?: "abort"
+                DispatchOutcome.Failed("Pairing aborted by peer ($msgType)")
+            }
+            ExchangeV2State.Joiner.AbortedLocal -> DispatchOutcome.Failed("Pairing cancelled on this device")
+            ExchangeV2State.Aborted -> DispatchOutcome.Failed("negotiation_aborted")
+            else -> null
+        }
+        is ExchangeV2Event.SessionError -> DispatchOutcome.Failed(event.message)
+        else -> null
+    }
+
+    override fun route(pastedCode: String): RouteDecision {
+        val v2Enabled = syncFeature.canUseV2ConnectFlow().isEnabled()
+        logcat { "$TAG: route() called, canUseV2ConnectFlow=$v2Enabled" }
+        if (!v2Enabled) {
+            // Flag off → never look at v2 shapes. Behaviour is byte-identical to direct
+            // parseSyncAuthCode + the caller's existing handling.
+            return legacy(pastedCode, reason = "FF off")
+        }
+        return classifyV2(pastedCode)
+    }
+
+    private fun classifyV2(pastedCode: String): RouteDecision {
+        val parsed = qrCode.parse(pastedCode)
+        logcat { "$TAG: v2 parse=${parsed::class.simpleName}" }
+        return when (parsed) {
+            is ExchangeV2CodeParseResult.LinkingV2 -> {
+                logcat { "$TAG: routing → V2 LinkingV2 (runner.startScan)" }
+                RouteDecision.V2InProgress(driveV2Linking(pastedCode))
+            }
+            is ExchangeV2CodeParseResult.RecoveryCode -> {
+                val cid = parsed.rawJson.optString("cid", "ddg")
+                logcat { "$TAG: routing → V2 RecoveryCode (cid=$cid)" }
+                RouteDecision.V2InProgress(driveV2Recovery(parsed, cid))
+            }
+            ExchangeV2CodeParseResult.LinkingV1,
+            ExchangeV2CodeParseResult.Unknown,
+            -> legacy(pastedCode, reason = "v2 parser=${parsed::class.simpleName}, falling through to legacy")
+        }
+    }
+
+    private fun legacy(pastedCode: String, reason: String): RouteDecision.Legacy {
+        val authCode = syncAccountRepository.parseSyncAuthCode(pastedCode)
+        logcat { "$TAG: routing → legacy v1 ($reason); parseSyncAuthCode=${authCode::class.simpleName}" }
+        return RouteDecision.Legacy(authCode)
+    }
+
+    /**
+     * V2 recovery code (the new `{recovery:{user_id, secret, cid, v}}` shape). cid=ddg drives
+     * the existing v1 Recovery login (same fields, just renamed). cid=3party drives the
+     * 3party-join upgrade flow on [SyncAccountRepository]. Anything else → error.
+     */
+    private fun driveV2Recovery(parsed: ExchangeV2CodeParseResult.RecoveryCode, cid: String): Flow<DispatchOutcome> = flow {
+        when (cid) {
+            CID_DDG -> {
+                val userId = parsed.rawJson.optString("user_id").takeIf { it.isNotEmpty() }
+                val secret = parsed.rawJson.optString("secret").takeIf { it.isNotEmpty() }
+                if (userId == null || secret == null) {
+                    logcat { "$TAG: v2 recovery (ddg) missing user_id or secret" }
+                    emit(DispatchOutcome.Failed("v2 recovery code missing required fields"))
+                    return@flow
+                }
+                val authCode = SyncAuthCode.Recovery(RecoveryCode(primaryKey = secret, userId = userId))
+                logcat { "$TAG: v2 recovery (ddg) → processCode(Recovery)" }
+                emit(
+                    syncAccountRepository.processCode(authCode, existingDeviceId = null).toOutcome(
+                        label = "v2 recovery (ddg)",
+                        codeForAccountSwitch = encodeV1RecoveryCodeAsB64(userId = userId, secret = secret),
+                    ),
+                )
+            }
+            CID_3PARTY -> {
+                // joinAccountFromThirdPartyRecoveryCode takes the bare b64 code; re-encode the
+                // inner recovery JSON so we don't need to crack the original URL fragment.
+                val rewrapped = JSONObject().put("recovery", parsed.rawJson).toString()
+                val b64 = Base64.encodeToString(
+                    rewrapped.toByteArray(Charsets.UTF_8),
+                    Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP,
+                )
+                logcat { "$TAG: v2 recovery (3party) → joinAccountFromThirdPartyRecoveryCode" }
+                emit(syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(b64).toOutcome(label = "v2 recovery (3party)"))
+            }
+            else -> {
+                logcat { "$TAG: v2 recovery: unknown cid='$cid'" }
+                emit(DispatchOutcome.Failed("Unknown v2 credential type: $cid"))
+            }
+        }
+    }
+
+    /**
+     * V2 LinkingV2 (`code2=…`) scanner side. Kicks off [ExchangeV2Runner.startScan] and observes
+     * its event stream — scoped via [ExchangeV2Runner.eventsSince] to ignore stale replayed
+     * events from prior sessions — emitting outcomes as the SM progresses:
+     *
+     *  - [DispatchOutcome.JoinerConfirmationRequested] when the SM reaches Joiner.Confirming
+     *    (caller must show a prompt and call [confirmJoiner] / [denyJoiner])
+     *  - [DispatchOutcome.HostConfirmationRequested] when the SM reaches Host.Confirming
+     *    (caller must show a prompt and call [confirmHost] / [denyHost])
+     *  - A single terminal outcome ([LoggedIn] / [Failed] / etc.), after which the Flow completes
+     *
+     * Intermediate events (non-terminal transitions, MessageSent, etc.) are filtered via
+     * [mapV2LinkingEventToOutcome] returning null and don't trigger emissions.
+     */
+    private fun driveV2Linking(pastedCode: String): Flow<DispatchOutcome> = flow {
+        val sessionStartMs = System.currentTimeMillis()
+        logcat { "$TAG: V2 LinkingV2 starting runner.startScan (scoped to events since $sessionStartMs)" }
+        runner.startScan(pastedCode)
+        var ownChannelId: String? = null
+        emitAll(
+            runner.eventsSince(sessionStartMs)
+                .transformWhile { event ->
+                    // Same preemption guard as presentV2(). Defence-in-depth against another
+                    // caller invoking startScan or startPresent on the shared runner mid-flow.
+                    if (event is ExchangeV2Event.SessionStarted) {
+                        if (ownChannelId == null) {
+                            ownChannelId = event.ownChannelId
+                        } else if (event.ownChannelId != ownChannelId) {
+                            logcat { "$TAG: V2 LinkingV2 flow preempted (own=$ownChannelId, new=${event.ownChannelId}); terminating silently" }
+                            return@transformWhile false
+                        }
+                    }
+                    val outcome = mapV2LinkingEventToOutcome(event) ?: return@transformWhile true
+                    emit(outcome)
+                    !outcome.isTerminal()
+                },
+        )
+        logcat { "$TAG: V2 LinkingV2 flow completed" }
+    }.onCompletion { cause ->
+        if (cause != null) {
+            // Flow cancelled or threw before reaching a terminal SM state — tear down the
+            // runner session so the channel DELETE fires (best-effort).
+            // Spec: Unified Algorithm §Aborting; Track B subtask 1215139308232508.
+            logcat { "$TAG: V2 LinkingV2 flow completed with cause=${cause::class.simpleName}; cancelling runner" }
+            runner.cancel()
+        }
+    }
+
+    private fun DispatchOutcome.isTerminal(): Boolean = when (this) {
+        is DispatchOutcome.LinkingCodeReady,
+        is DispatchOutcome.JoinerConfirmationRequested,
+        is DispatchOutcome.HostConfirmationRequested,
+        -> false
+        is DispatchOutcome.LoggedIn,
+        is DispatchOutcome.AlreadyConnected,
+        is DispatchOutcome.UpgradeRequired,
+        is DispatchOutcome.Failed,
+        -> true
+    }
+
+    /**
+     * Translate one runner event into a terminal [DispatchOutcome] for the v2 scanner flow,
+     * or null for intermediate events the caller should ignore.
+     */
+    private fun mapV2LinkingEventToOutcome(event: ExchangeV2Event): DispatchOutcome? = when (event) {
+        is ExchangeV2Event.Transition -> when (event.to) {
+            ExchangeV2State.Joiner.Confirming ->
+                DispatchOutcome.JoinerConfirmationRequested(peerName = runner.peerName)
+            ExchangeV2State.Host.Confirming ->
+                DispatchOutcome.HostConfirmationRequested(peerName = runner.peerName)
+            ExchangeV2State.Joiner.Done -> {
+                val received = (event.trigger as? ExchangeV2Message.RecoveryCodeResponse)?.recoveryCode
+                if (received.isNullOrBlank()) {
+                    DispatchOutcome.Failed("Pairing completed without a recovery code")
+                } else {
+                    loginWithV2RecoveryCode(received)
+                }
+            }
+            ExchangeV2State.Joiner.AbortedByHost -> {
+                val msgType = event.trigger?.messageType ?: "abort"
+                DispatchOutcome.Failed("Pairing aborted by peer ($msgType)")
+            }
+            ExchangeV2State.Joiner.AbortedLocal -> DispatchOutcome.Failed("Pairing cancelled on this device")
+            ExchangeV2State.Host.Aborted -> DispatchOutcome.Failed("Pairing aborted")
+            // Per spec §"Same-account case": NOT an abort. Surface as a friendly "Connected"
+            // finish — both devices are already on the same account, nothing to do.
+            ExchangeV2State.SameAccountAbort -> DispatchOutcome.AlreadyConnected
+            // Scanner-side Host.Done means we were elected Host and have shared a recovery
+            // code with the peer — successful pairing from this device's perspective.
+            ExchangeV2State.Host.Done -> DispatchOutcome.LoggedIn
+            ExchangeV2State.Aborted -> DispatchOutcome.Failed("negotiation_aborted")
+            else -> null
+        }
+        is ExchangeV2Event.SessionError -> {
+            val match = VERSION_TOO_NEW_REGEX.find(event.message)
+            if (match != null) {
+                DispatchOutcome.UpgradeRequired(codeMajor = match.groupValues[1].toIntOrNull() ?: -1)
+            } else {
+                DispatchOutcome.Failed(event.message)
+            }
+        }
+        else -> null
+    }
+
+    /**
+     * Apply a v2 recovery code received over the LinkingV2 channel. The received string is the
+     * raw base64-encoded v2 recovery payload (`{recovery:{user_id, secret, cid, v}}`).
+     *
+     * Per spec §"Exchange Share Recovery Code → Joiner":
+     *   - cid=ddg: log in directly (processCode with v1 Recovery shape, same primary_key+user_id fields)
+     *   - cid=3party: upgrade the account (joinAccountFromThirdPartyRecoveryCode wraps the
+     *     "Native joining a 3party account" subroutine — POST /access-credentials/ddg, re-encrypt
+     *     keys, log in with ddg credentials)
+     */
+    private fun loginWithV2RecoveryCode(b64: String): DispatchOutcome {
+        val parsed = decodeV2Recovery(b64) ?: return DispatchOutcome.Failed("Couldn't parse received recovery code as v2.0")
+        return when (parsed.cid) {
+            CID_DDG -> {
+                val recovery = SyncAuthCode.Recovery(RecoveryCode(primaryKey = parsed.secret, userId = parsed.userId))
+                syncAccountRepository.processCode(recovery, existingDeviceId = null)
+                    .toOutcome(
+                        label = "v2 LinkingV2 login (ddg)",
+                        codeForAccountSwitch = encodeV1RecoveryCodeAsB64(userId = parsed.userId, secret = parsed.secret),
+                    )
+            }
+            CID_3PARTY -> {
+                logcat { "$TAG: v2 LinkingV2 received 3party code → joinAccountFromThirdPartyRecoveryCode" }
+                syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(b64)
+                    .toOutcome(label = "v2 LinkingV2 login (3party upgrade)")
+            }
+            else -> DispatchOutcome.Failed("Received unknown credential type '${parsed.cid}' over v2 linking")
+        }
+    }
+
+    private data class ParsedV2Recovery(val userId: String, val secret: String, val cid: String, val v: String)
+
+    private fun decodeV2Recovery(b64: String): ParsedV2Recovery? = runCatching {
+        val decoded = runCatching { java.util.Base64.getUrlDecoder().decode(b64) }
+            .recoverCatching { java.util.Base64.getDecoder().decode(b64) }
+            .getOrThrow()
+        val root = JSONObject(String(decoded, Charsets.UTF_8))
+        val rec = root.getJSONObject("recovery")
+        ParsedV2Recovery(
+            userId = rec.getString("user_id"),
+            secret = rec.getString("secret"),
+            cid = rec.optString("cid", CID_DDG),
+            v = rec.optString("v", "2.0"),
+        )
+    }.getOrNull()
+
+    /**
+     * Map a repo [Result] to a [DispatchOutcome].
+     *
+     * If [codeForAccountSwitch] is supplied AND the repo failed with [ALREADY_SIGNED_IN], the
+     * dispatcher transparently calls [SyncAccountRepository.logoutAndJoinNewAccount] with the
+     * supplied code and emits the result. No user prompt — per spec the Confirmations phase
+     * (or the act of pasting a recovery code) is already the consent step, so the v1-style
+     * `AskToSwitchAccount` dialog does not apply.
+     *
+     * [codeForAccountSwitch] must be in a shape that [SyncAccountRepository.logoutAndJoinNewAccount]
+     * can re-parse via [SyncAccountRepository.parseSyncAuthCode] — that's v1-only, so v2
+     * callers must convert to v1 b64 shape first (see [encodeV1RecoveryCodeAsB64]).
+     */
+    private fun Result<Boolean>.toOutcome(
+        label: String,
+        codeForAccountSwitch: String? = null,
+    ): DispatchOutcome = when (this) {
+        is Result.Success -> {
+            logcat { "$TAG: $label → success" }
+            DispatchOutcome.LoggedIn
+        }
+        is Result.Error -> {
+            logcat { "$TAG: $label → error: $reason (code=$code)" }
+            if (code == ALREADY_SIGNED_IN.code && codeForAccountSwitch != null) {
+                logcat { "$TAG: $label → ALREADY_SIGNED_IN, performing transparent logout+rejoin" }
+                when (val switched = syncAccountRepository.logoutAndJoinNewAccount(codeForAccountSwitch)) {
+                    is Result.Success -> {
+                        logcat { "$TAG: $label → logout+rejoin success" }
+                        DispatchOutcome.LoggedIn
+                    }
+                    is Result.Error -> {
+                        logcat { "$TAG: $label → logout+rejoin failed: ${switched.reason} (code=${switched.code})" }
+                        DispatchOutcome.Failed(switched.reason, switched.code)
+                    }
+                }
+            } else {
+                DispatchOutcome.Failed(reason, code)
+            }
+        }
+    }
+
+    /**
+     * Re-encode a v2 ddg recovery (userId + secret) as a v1-shape `{recovery:{primary_key,
+     * user_id}}` base64-url string, so the existing [SyncAccountRepository.logoutAndJoinNewAccount]
+     * (which uses v1-only [SyncAccountRepository.parseSyncAuthCode]) can consume it when the
+     * user accepts the account-switch prompt.
+     */
+    private fun encodeV1RecoveryCodeAsB64(userId: String, secret: String): String {
+        val v1Json = JSONObject().apply {
+            put(
+                "recovery",
+                JSONObject().apply {
+                    put("primary_key", secret)
+                    put("user_id", userId)
+                },
+            )
+        }.toString()
+        return Base64.encodeToString(
+            v1Json.toByteArray(Charsets.UTF_8),
+            Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP,
+        )
+    }
+
+    companion object {
+        private const val TAG = "Sync-CodeDispatch"
+        private const val CID_DDG = "ddg"
+        private const val CID_3PARTY = "3party"
+
+        // Matches the SessionError message format thrown when EnvelopeVersionTooNew bubbles up
+        // from the runner's poll loop ("Peer requires protocol v3; please update this app").
+        private val VERSION_TOO_NEW_REGEX = Regex("""protocol v(\d+)""")
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
 import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
 import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.moshi.Moshi
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
@@ -228,8 +229,20 @@ class RealSyncCodeDispatcher @Inject constructor(
             }
             CID_3PARTY -> {
                 // joinAccountFromThirdPartyRecoveryCode takes the bare b64 code; re-encode the
-                // inner recovery JSON so we don't need to crack the original URL fragment.
-                val rewrapped = JSONObject().put("recovery", parsed.rawJson).toString()
+                // inner recovery JSON so we don't need to crack the original URL fragment. Mint via
+                // Moshi (NOT org.json) so we never emit AOSP JSONObject.toString()'s '/' -> '\/'
+                // escaping; the consumer (parseThirdPartyRecoveryCode) is Moshi too. Real 3party
+                // secrets are base64url (slash-free) but this keeps every v2 producer consistent.
+                val rewrapped = thirdPartyRecoveryCodeAdapter.toJson(
+                    ThirdPartyRecoveryCodeWrapper(
+                        recovery = ThirdPartyRecoveryCode(
+                            userId = parsed.rawJson.optString("user_id"),
+                            secret = parsed.rawJson.optString("secret"),
+                            cid = parsed.rawJson.optString("cid", CID_3PARTY),
+                            v = parsed.rawJson.optString("v", RECOVERY_CODE_V2),
+                        ),
+                    ),
+                )
                 val b64 = Base64.encodeToString(
                     rewrapped.toByteArray(Charsets.UTF_8),
                     Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP,
@@ -442,19 +455,24 @@ class RealSyncCodeDispatcher @Inject constructor(
      * user accepts the account-switch prompt.
      */
     private fun encodeV1RecoveryCodeAsB64(userId: String, secret: String): String {
-        val v1Json = JSONObject().apply {
-            put(
-                "recovery",
-                JSONObject().apply {
-                    put("primary_key", secret)
-                    put("user_id", userId)
-                },
-            )
-        }.toString()
+        // Mint via Moshi (NOT org.json): the ddg secret is standard base64 and routinely contains
+        // '/', and AOSP's JSONObject.toString() escapes it to '\/'. Reusing the same LinkCode shape
+        // the v1 stack uses to MINT recovery codes keeps this byte-identical to a genuine v1 code,
+        // so the local logoutAndJoinNewAccount → parseSyncAuthCode round-trip stays robust without
+        // depending on the consumer to tolerate non-canonical escaping.
+        val v1Json = v1RecoveryCodeAdapter.toJson(LinkCode(recovery = RecoveryCode(primaryKey = secret, userId = userId)))
         return Base64.encodeToString(
             v1Json.toByteArray(Charsets.UTF_8),
             Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP,
         )
+    }
+
+    private val v1RecoveryCodeAdapter by lazy {
+        Moshi.Builder().build().adapter(LinkCode::class.java)
+    }
+
+    private val thirdPartyRecoveryCodeAdapter by lazy {
+        Moshi.Builder().build().adapter(ThirdPartyRecoveryCodeWrapper::class.java)
     }
 
     companion object {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
@@ -68,17 +68,9 @@ class RealSyncCodeDispatcher @Inject constructor(
     }
 
     /**
-     * Drive a v2 Presenter session. Mirrors [driveV2Linking] but for the Presenter side:
-     * starts the runner via [ExchangeV2Runner.startPresent], scopes to events emitted after
-     * session start (defensive against the runner's SharedFlow replay cache), and maps each
-     * event to a [DispatchOutcome] via [mapV2PresentEventToOutcome].
-     *
-     * Today's callers include both the signed-in `SyncWithAnotherActivityViewModel` and the
-     * signed-out `SyncConnectViewModel` (per M1.5, Asana subtask `1215246284113165`). Role
-     * election in the runner can elect this device as Host (signed-in surface, or signed-out
-     * against a signed-out peer with account-creation-on-demand at Host.Sending — see
-     * `1215168582640073`) or as Joiner (signed-out surface against a signed-in or 3party peer).
-     * All terminal mappings are first-class; see `mapV2PresentEventToOutcome` for the table.
+     * Drive a v2 Presenter session: start the runner via [ExchangeV2Runner.startPresent] and map
+     * each event to a [DispatchOutcome] via [mapV2PresentEventToOutcome]. Role election may elect
+     * this device as either Host or Joiner.
      */
     override fun presentV2(): Flow<DispatchOutcome> = flow {
         val sessionStartMs = System.currentTimeMillis()
@@ -88,13 +80,8 @@ class RealSyncCodeDispatcher @Inject constructor(
         emitAll(
             runner.eventsSince(sessionStartMs)
                 .transformWhile { event ->
-                    // Latch our session's channelId on the first SessionStarted. If a later
-                    // SessionStarted arrives with a different channelId, the shared runner has
-                    // been preempted by another caller (route()/startScan from EnterCode, for
-                    // example). Terminate silently without emitting any DispatchOutcome — the
-                    // new caller's Flow now owns the runner. Defence-in-depth against the
-                    // duplicate-login race; the activity-side lifecycle scope normally prevents
-                    // this from happening at all, but this catches the transition window.
+                    // A later SessionStarted with a different channelId means another caller has
+                    // preempted the shared runner; terminate silently so its Flow owns the runner.
                     if (event is ExchangeV2Event.SessionStarted) {
                         if (ownChannelId == null) {
                             ownChannelId = event.ownChannelId
@@ -111,9 +98,8 @@ class RealSyncCodeDispatcher @Inject constructor(
         logcat { "$TAG: V2 Presenter flow completed" }
     }.onCompletion { cause ->
         if (cause != null) {
-            // Flow cancelled or threw before reaching a terminal SM state — tear down the
-            // runner session so the channel DELETE fires (best-effort).
-            // Spec: Unified Algorithm §Aborting; Track B subtask 1215139308232508.
+            // Cancelled/threw before a terminal state — tear down the session so the channel
+            // DELETE fires. Spec: Unified Algorithm §Aborting.
             logcat { "$TAG: V2 Presenter flow completed with cause=${cause::class.simpleName}; cancelling runner" }
             runner.cancel()
         }
@@ -121,17 +107,8 @@ class RealSyncCodeDispatcher @Inject constructor(
 
     /**
      * Translate one runner event into a [DispatchOutcome] for the v2 Presenter flow,
-     * or null for intermediate events the caller should ignore.
-     *
-     * The Joiner.* branches were defensive stubs in M1 (the signed-in surface always elects
-     * Host via role-election rule 1: account-beats-no-account). M1.5 wires `SyncConnectViewModel`
-     * (signed-out surface) to `presentV2`, so a signed-out Presenter facing a signed-in peer
-     * is now elected Joiner — these branches are first-class. Mirrors mapV2LinkingEventToOutcome
-     * behaviour (login on Joiner.Done; preserve abort reason).
-     *
-     * See Asana subtask `1215246284113165` for the M1.5 wire-up and `1215168582640073` for the
-     * runner-side account-provisioning at Host.Sending (used by signed-out Presenter ↔ signed-out
-     * peer scenarios where this device wins Presenter-beats-Scanner).
+     * or null for intermediate events the caller should ignore. Both Host and Joiner roles are
+     * reachable here; mirrors [mapV2LinkingEventToOutcome] (login on Joiner.Done, preserve abort reason).
      */
     private fun mapV2PresentEventToOutcome(event: ExchangeV2Event): DispatchOutcome? = when (event) {
         is ExchangeV2Event.SessionStarted -> event.linkingCode?.let { DispatchOutcome.LinkingCodeReady(it) }
@@ -171,8 +148,7 @@ class RealSyncCodeDispatcher @Inject constructor(
         val v2Enabled = syncFeature.canUseV2ConnectFlow().isEnabled()
         logcat { "$TAG: route() called, canUseV2ConnectFlow=$v2Enabled" }
         if (!v2Enabled) {
-            // Flag off → never look at v2 shapes. Behaviour is byte-identical to direct
-            // parseSyncAuthCode + the caller's existing handling.
+            // Flag off → never look at v2 shapes; defer entirely to the v1 path.
             return legacy(pastedCode, reason = "FF off")
         }
         return classifyV2(pastedCode)
@@ -235,10 +211,8 @@ class RealSyncCodeDispatcher @Inject constructor(
             }
             CID_3PARTY -> {
                 // joinAccountFromThirdPartyRecoveryCode takes the bare b64 code; re-encode the
-                // inner recovery JSON so we don't need to crack the original URL fragment. Mint via
-                // Moshi (NOT org.json) so we never emit AOSP JSONObject.toString()'s '/' -> '\/'
-                // escaping; the consumer (parseThirdPartyRecoveryCode) is Moshi too. Real 3party
-                // secrets are base64url (slash-free) but this keeps every v2 producer consistent.
+                // inner recovery JSON. Mint via Moshi (not org.json) to match the Moshi consumer
+                // parseThirdPartyRecoveryCode and avoid non-canonical JSON escaping.
                 val rewrapped = thirdPartyRecoveryCodeAdapter.toJson(
                     ThirdPartyRecoveryCodeWrapper(
                         recovery = ThirdPartyRecoveryCode(
@@ -264,18 +238,10 @@ class RealSyncCodeDispatcher @Inject constructor(
     }
 
     /**
-     * V2 LinkingV2 (`code2=…`) scanner side. Kicks off [ExchangeV2Runner.startScan] and observes
-     * its event stream — scoped via [ExchangeV2Runner.eventsSince] to ignore stale replayed
-     * events from prior sessions — emitting outcomes as the SM progresses:
-     *
-     *  - [DispatchOutcome.JoinerConfirmationRequested] when the SM reaches Joiner.Confirming
-     *    (caller must show a prompt and call [confirmJoiner] / [denyJoiner])
-     *  - [DispatchOutcome.HostConfirmationRequested] when the SM reaches Host.Confirming
-     *    (caller must show a prompt and call [confirmHost] / [denyHost])
-     *  - A single terminal outcome ([LoggedIn] / [Failed] / etc.), after which the Flow completes
-     *
-     * Intermediate events (non-terminal transitions, MessageSent, etc.) are filtered via
-     * [mapV2LinkingEventToOutcome] returning null and don't trigger emissions.
+     * V2 LinkingV2 (`code2=…`) scanner side. Starts [ExchangeV2Runner.startScan] and maps its
+     * events to outcomes via [mapV2LinkingEventToOutcome]: confirmation requests (caller shows a
+     * prompt and calls [confirmJoiner]/[denyJoiner] or [confirmHost]/[denyHost]) then a single
+     * terminal outcome that completes the Flow.
      */
     private fun driveV2Linking(pastedCode: String): Flow<DispatchOutcome> = flow {
         val sessionStartMs = System.currentTimeMillis()
@@ -285,8 +251,8 @@ class RealSyncCodeDispatcher @Inject constructor(
         emitAll(
             runner.eventsSince(sessionStartMs)
                 .transformWhile { event ->
-                    // Same preemption guard as presentV2(). Defence-in-depth against another
-                    // caller invoking startScan or startPresent on the shared runner mid-flow.
+                    // Same preemption guard as presentV2(): bail if another caller takes over the
+                    // shared runner mid-flow.
                     if (event is ExchangeV2Event.SessionStarted) {
                         if (ownChannelId == null) {
                             ownChannelId = event.ownChannelId
@@ -303,9 +269,8 @@ class RealSyncCodeDispatcher @Inject constructor(
         logcat { "$TAG: V2 LinkingV2 flow completed" }
     }.onCompletion { cause ->
         if (cause != null) {
-            // Flow cancelled or threw before reaching a terminal SM state — tear down the
-            // runner session so the channel DELETE fires (best-effort).
-            // Spec: Unified Algorithm §Aborting; Track B subtask 1215139308232508.
+            // Cancelled/threw before a terminal state — tear down the session so the channel
+            // DELETE fires. Spec: Unified Algorithm §Aborting.
             logcat { "$TAG: V2 LinkingV2 flow completed with cause=${cause::class.simpleName}; cancelling runner" }
             runner.cancel()
         }
@@ -347,11 +312,9 @@ class RealSyncCodeDispatcher @Inject constructor(
             }
             ExchangeV2State.Joiner.AbortedLocal -> DispatchOutcome.Failed("Pairing cancelled on this device")
             ExchangeV2State.Host.Aborted -> DispatchOutcome.Failed("Pairing aborted")
-            // Per spec §"Same-account case": NOT an abort. Surface as a friendly "Connected"
-            // finish — both devices are already on the same account, nothing to do.
+            // Per spec §"Same-account case": not an abort; both devices share an account already.
             ExchangeV2State.SameAccountAbort -> DispatchOutcome.AlreadyConnected
-            // Scanner-side Host.Done means we were elected Host and have shared a recovery
-            // code with the peer — successful pairing from this device's perspective.
+            // Elected Host and shared a recovery code — success from this device's perspective.
             ExchangeV2State.Host.Done -> DispatchOutcome.LoggedIn
             ExchangeV2State.Aborted -> DispatchOutcome.Failed("negotiation_aborted")
             else -> null
@@ -368,14 +331,10 @@ class RealSyncCodeDispatcher @Inject constructor(
     }
 
     /**
-     * Apply a v2 recovery code received over the LinkingV2 channel. The received string is the
-     * raw base64-encoded v2 recovery payload (`{recovery:{user_id, secret, cid, v}}`).
-     *
-     * Per spec §"Exchange Share Recovery Code → Joiner":
-     *   - cid=ddg: log in directly (processCode with v1 Recovery shape, same primary_key+user_id fields)
-     *   - cid=3party: upgrade the account (joinAccountFromThirdPartyRecoveryCode wraps the
-     *     "Native joining a 3party account" subroutine — POST /access-credentials/ddg, re-encrypt
-     *     keys, log in with ddg credentials)
+     * Apply a v2 recovery code received over the LinkingV2 channel (raw base64
+     * `{recovery:{user_id, secret, cid, v}}`). Per spec §"Exchange Share Recovery Code → Joiner":
+     * cid=ddg logs in directly; cid=3party upgrades the account via
+     * [SyncAccountRepository.joinAccountFromThirdPartyRecoveryCode].
      */
     private fun loginWithV2RecoveryCode(b64: String): DispatchOutcome {
         val parsed = decodeV2Recovery(b64) ?: return DispatchOutcome.Failed("Couldn't parse received recovery code as v2.0")
@@ -416,12 +375,9 @@ class RealSyncCodeDispatcher @Inject constructor(
     }.getOrNull()
 
     /**
-     * The v2 wire `secret` is base64url-encoded per spec 1214802412121967; Android's native v1
-     * login (SyncNativeLib.decodeKey → android.util.Base64 standard) decodes the primary_key as
-     * STANDARD base64. Re-encode the same key bytes to canonical standard base64 at the v2->v1
-     * boundary, otherwise a conformant peer's base64url secret (macOS/iOS/FE) throws "bad base-64"
-     * (LOGIN_FAILED). Normalising the alphabet first also tolerates an already-standard secret from
-     * a non-conformant/older Android peer. Returns null if the secret isn't valid base64 at all.
+     * v2 wire `secret` is base64url (spec 1214802412121967); re-encode to standard base64 for the
+     * v1 native login, normalising the alphabet first to also tolerate an already-standard secret.
+     * Returns null if the secret isn't valid base64.
      */
     private fun v2SecretToV1PrimaryKey(secret: String): String? = runCatching {
         val bytes = Base64.decode(secret.replace('-', '+').replace('_', '/'), Base64.NO_WRAP)
@@ -431,15 +387,13 @@ class RealSyncCodeDispatcher @Inject constructor(
     /**
      * Map a repo [Result] to a [DispatchOutcome].
      *
-     * If [codeForAccountSwitch] is supplied AND the repo failed with [ALREADY_SIGNED_IN], the
-     * dispatcher transparently calls [SyncAccountRepository.logoutAndJoinNewAccount] with the
-     * supplied code and emits the result. No user prompt — per spec the Confirmations phase
-     * (or the act of pasting a recovery code) is already the consent step, so the v1-style
-     * `AskToSwitchAccount` dialog does not apply.
+     * If [codeForAccountSwitch] is supplied and the repo failed with [ALREADY_SIGNED_IN], switch
+     * accounts transparently via [SyncAccountRepository.logoutAndJoinNewAccount] with no prompt:
+     * the Confirmations phase is already the consent step, so the v1 `AskToSwitchAccount` dialog
+     * does not apply.
      *
-     * [codeForAccountSwitch] must be in a shape that [SyncAccountRepository.logoutAndJoinNewAccount]
-     * can re-parse via [SyncAccountRepository.parseSyncAuthCode] — that's v1-only, so v2
-     * callers must convert to v1 b64 shape first (see [encodeV1RecoveryCodeAsB64]).
+     * [codeForAccountSwitch] must be a v1 b64 shape [SyncAccountRepository.parseSyncAuthCode] can
+     * re-parse, so v2 callers convert first (see [encodeV1RecoveryCodeAsB64]).
      */
     private fun Result<Boolean>.toOutcome(
         label: String,
@@ -471,16 +425,12 @@ class RealSyncCodeDispatcher @Inject constructor(
 
     /**
      * Re-encode a v2 ddg recovery (userId + secret) as a v1-shape `{recovery:{primary_key,
-     * user_id}}` base64-url string, so the existing [SyncAccountRepository.logoutAndJoinNewAccount]
-     * (which uses v1-only [SyncAccountRepository.parseSyncAuthCode]) can consume it when the
-     * user accepts the account-switch prompt.
+     * user_id}}` base64-url string so [SyncAccountRepository.logoutAndJoinNewAccount] (v1-only
+     * [SyncAccountRepository.parseSyncAuthCode]) can consume it on account switch.
      */
     private fun encodeV1RecoveryCodeAsB64(userId: String, secret: String): String {
-        // Mint via Moshi (NOT org.json): the ddg secret is standard base64 and routinely contains
-        // '/', and AOSP's JSONObject.toString() escapes it to '\/'. Reusing the same LinkCode shape
-        // the v1 stack uses to MINT recovery codes keeps this byte-identical to a genuine v1 code,
-        // so the local logoutAndJoinNewAccount → parseSyncAuthCode round-trip stays robust without
-        // depending on the consumer to tolerate non-canonical escaping.
+        // Mint via Moshi (not org.json) and reuse the v1 LinkCode shape, keeping this byte-identical
+        // to a genuine v1 code so the parseSyncAuthCode round-trip stays robust.
         val v1Json = v1RecoveryCodeAdapter.toJson(LinkCode(recovery = RecoveryCode(primaryKey = secret, userId = userId)))
         return Base64.encodeToString(
             v1Json.toByteArray(Charsets.UTF_8),
@@ -501,8 +451,7 @@ class RealSyncCodeDispatcher @Inject constructor(
         private const val CID_DDG = "ddg"
         private const val CID_3PARTY = "3party"
 
-        // Matches the SessionError message format thrown when EnvelopeVersionTooNew bubbles up
-        // from the runner's poll loop ("Peer requires protocol v3; please update this app").
+        // Extracts the major version from the EnvelopeVersionTooNew SessionError message.
         private val VERSION_TOO_NEW_REGEX = Regex("""protocol v(\d+)""")
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
@@ -19,6 +19,12 @@ package com.duckduckgo.sync.impl
 import android.util.Base64
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN
+import com.duckduckgo.sync.impl.AccountErrorCodes.NEGOTIATION_ABORTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.NO_RECOVERY_CODE
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_UNAVAILABLE
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
@@ -26,12 +32,16 @@ import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
 import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.moshi.Moshi
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.transformWhile
 import logcat.logcat
@@ -77,6 +87,9 @@ class RealSyncCodeDispatcher @Inject constructor(
         logcat { "$TAG: V2 Presenter starting runner.startPresent (scoped to events since $sessionStartMs)" }
         runner.startPresent()
         var ownChannelId: String? = null
+        // Snapshot the peer kind while the session is live; the runner clears it on terminal teardown,
+        // so by the time we map the terminal event runner.peerKind is already null.
+        var peerKind: PeerKind? = null
         emitAll(
             runner.eventsSince(sessionStartMs)
                 .transformWhile { event ->
@@ -90,7 +103,9 @@ class RealSyncCodeDispatcher @Inject constructor(
                             return@transformWhile false
                         }
                     }
-                    val outcome = mapV2PresentEventToOutcome(event) ?: return@transformWhile true
+                    runner.peerKind.toPeerKind()?.let { peerKind = it }
+                    val outcome = (mapV2PresentEventToOutcome(event, peerKind) ?: return@transformWhile true)
+                        .withFailureContext(SetupPath.PAIRING, roleFromTerminalState(event), peerKind)
                     emit(outcome)
                     !outcome.isTerminal()
                 },
@@ -110,38 +125,42 @@ class RealSyncCodeDispatcher @Inject constructor(
      * or null for intermediate events the caller should ignore. Both Host and Joiner roles are
      * reachable here; mirrors [mapV2LinkingEventToOutcome] (login on Joiner.Done, preserve abort reason).
      */
-    private fun mapV2PresentEventToOutcome(event: ExchangeV2Event): DispatchOutcome? = when (event) {
+    private fun mapV2PresentEventToOutcome(event: ExchangeV2Event, peerKind: PeerKind?): DispatchOutcome? = when (event) {
         is ExchangeV2Event.SessionStarted -> event.linkingCode?.let { DispatchOutcome.LinkingCodeReady(it) }
         is ExchangeV2Event.Transition -> when (event.to) {
             ExchangeV2State.Joiner.Confirming ->
-                DispatchOutcome.JoinerConfirmationRequested(peerName = runner.peerName)
+                DispatchOutcome.JoinerConfirmationRequested(peerName = runner.peerName, peerKind = peerKind)
             ExchangeV2State.Host.Confirming ->
-                DispatchOutcome.HostConfirmationRequested(peerName = runner.peerName)
-            ExchangeV2State.Host.Done -> DispatchOutcome.LoggedIn
-            ExchangeV2State.Host.Aborted -> when (event.localTrigger) {
-                LocalTrigger.UserDeniedHost -> DispatchOutcome.Failed("user_denied")
-                LocalTrigger.HostUnavailable -> DispatchOutcome.Failed("host_unavailable")
-                else -> DispatchOutcome.Failed("host_aborted")
-            }
+                DispatchOutcome.HostConfirmationRequested(peerName = runner.peerName, peerKind = peerKind)
+            ExchangeV2State.Host.Done -> DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST, peerKind)
+            ExchangeV2State.Host.Aborted -> hostAbortedToOutcome(event.localTrigger)
             ExchangeV2State.SameAccountAbort -> DispatchOutcome.AlreadyConnected
             ExchangeV2State.Joiner.Done -> {
                 val received = (event.trigger as? ExchangeV2Message.RecoveryCodeResponse)?.recoveryCode
                 if (received.isNullOrBlank()) {
-                    DispatchOutcome.Failed("Pairing completed without a recovery code")
+                    DispatchOutcome.Failed("Pairing completed without a recovery code", NO_RECOVERY_CODE.code)
                 } else {
-                    loginWithV2RecoveryCode(received)
+                    loginWithV2RecoveryCode(received, peerKind)
                 }
             }
-            ExchangeV2State.Joiner.AbortedByHost -> {
-                val msgType = event.trigger?.messageType ?: "abort"
-                DispatchOutcome.Failed("Pairing aborted by peer ($msgType)")
+            ExchangeV2State.Joiner.AbortedByHost -> when (event.trigger) {
+                is ExchangeV2Message.RecoveryCodeDenied ->
+                    DispatchOutcome.Failed("Pairing declined by peer", PAIRING_REJECTED.code)
+                is ExchangeV2Message.RecoveryCodeUnavailable ->
+                    DispatchOutcome.Failed("Peer has no recovery code", PAIRING_UNAVAILABLE.code)
+                else -> DispatchOutcome.Failed("Pairing aborted by peer", PAIRING_REJECTED.code)
             }
-            ExchangeV2State.Joiner.AbortedLocal -> DispatchOutcome.Failed("Pairing cancelled on this device")
-            ExchangeV2State.Aborted -> DispatchOutcome.Failed("negotiation_aborted")
+            ExchangeV2State.Joiner.AbortedLocal -> DispatchOutcome.Failed("Pairing cancelled on this device", PAIRING_CANCELLED.code)
+            ExchangeV2State.Aborted -> DispatchOutcome.Failed("negotiation_aborted", NEGOTIATION_ABORTED.code)
             else -> null
         }
-        is ExchangeV2Event.SessionError -> DispatchOutcome.Failed(event.message)
+        is ExchangeV2Event.SessionError -> sessionErrorToOutcome(event.message)
         else -> null
+    }
+
+    override fun isV2ExchangeUnderway(): Boolean = when (runner.currentState) {
+        null, ExchangeV2State.Bootstrapped -> false
+        else -> true
     }
 
     override fun route(pastedCode: String): RouteDecision {
@@ -160,12 +179,12 @@ class RealSyncCodeDispatcher @Inject constructor(
         return when (parsed) {
             is ExchangeV2CodeParseResult.LinkingV2 -> {
                 logcat { "$TAG: routing → V2 LinkingV2 (runner.startScan)" }
-                RouteDecision.V2InProgress(driveV2Linking(pastedCode))
+                RouteDecision.V2InProgress(SyncCodeType.LINKING, driveV2Linking(pastedCode))
             }
             is ExchangeV2CodeParseResult.RecoveryCode -> {
                 val cid = parsed.rawJson.optString("cid", "ddg")
                 logcat { "$TAG: routing → V2 RecoveryCode (cid=$cid)" }
-                RouteDecision.V2InProgress(driveV2Recovery(parsed, cid))
+                RouteDecision.V2InProgress(SyncCodeType.RECOVERY, driveV2Recovery(parsed, cid))
             }
             ExchangeV2CodeParseResult.LinkingV1,
             ExchangeV2CodeParseResult.Unknown,
@@ -205,6 +224,7 @@ class RealSyncCodeDispatcher @Inject constructor(
                 emit(
                     syncAccountRepository.processCode(authCode, existingDeviceId = null).toOutcome(
                         label = "v2 recovery (ddg)",
+                        path = SetupPath.RECOVERY,
                         codeForAccountSwitch = encodeV1RecoveryCodeAsB64(userId = userId, secret = primaryKey),
                     ),
                 )
@@ -228,14 +248,18 @@ class RealSyncCodeDispatcher @Inject constructor(
                     Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP,
                 )
                 logcat { "$TAG: v2 recovery (3party) → joinAccountFromThirdPartyRecoveryCode" }
-                emit(syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(b64).toOutcome(label = "v2 recovery (3party)"))
+                emit(
+                    syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(
+                        b64,
+                    ).toOutcome(label = "v2 recovery (3party)", path = SetupPath.RECOVERY),
+                )
             }
             else -> {
                 logcat { "$TAG: v2 recovery: unknown cid='$cid'" }
                 emit(DispatchOutcome.Failed("Unknown v2 credential type: $cid"))
             }
         }
-    }
+    }.map { it.withFailureContext(SetupPath.RECOVERY, myRole = null, peerKind = null) }
 
     /**
      * V2 LinkingV2 (`code2=…`) scanner side. Starts [ExchangeV2Runner.startScan] and maps its
@@ -248,6 +272,9 @@ class RealSyncCodeDispatcher @Inject constructor(
         logcat { "$TAG: V2 LinkingV2 starting runner.startScan (scoped to events since $sessionStartMs)" }
         runner.startScan(pastedCode)
         var ownChannelId: String? = null
+        // Snapshot the peer kind while the session is live (see presentV2): the runner clears it on
+        // terminal teardown, before we map the terminal event.
+        var peerKind: PeerKind? = null
         emitAll(
             runner.eventsSince(sessionStartMs)
                 .transformWhile { event ->
@@ -261,7 +288,9 @@ class RealSyncCodeDispatcher @Inject constructor(
                             return@transformWhile false
                         }
                     }
-                    val outcome = mapV2LinkingEventToOutcome(event) ?: return@transformWhile true
+                    runner.peerKind.toPeerKind()?.let { peerKind = it }
+                    val outcome = (mapV2LinkingEventToOutcome(event, peerKind) ?: return@transformWhile true)
+                        .withFailureContext(SetupPath.PAIRING, roleFromTerminalState(event), peerKind)
                     emit(outcome)
                     !outcome.isTerminal()
                 },
@@ -292,42 +321,53 @@ class RealSyncCodeDispatcher @Inject constructor(
      * Translate one runner event into a terminal [DispatchOutcome] for the v2 scanner flow,
      * or null for intermediate events the caller should ignore.
      */
-    private fun mapV2LinkingEventToOutcome(event: ExchangeV2Event): DispatchOutcome? = when (event) {
+    private fun mapV2LinkingEventToOutcome(event: ExchangeV2Event, peerKind: PeerKind?): DispatchOutcome? = when (event) {
         is ExchangeV2Event.Transition -> when (event.to) {
             ExchangeV2State.Joiner.Confirming ->
-                DispatchOutcome.JoinerConfirmationRequested(peerName = runner.peerName)
+                DispatchOutcome.JoinerConfirmationRequested(peerName = runner.peerName, peerKind = peerKind)
             ExchangeV2State.Host.Confirming ->
-                DispatchOutcome.HostConfirmationRequested(peerName = runner.peerName)
+                DispatchOutcome.HostConfirmationRequested(peerName = runner.peerName, peerKind = peerKind)
             ExchangeV2State.Joiner.Done -> {
                 val received = (event.trigger as? ExchangeV2Message.RecoveryCodeResponse)?.recoveryCode
                 if (received.isNullOrBlank()) {
-                    DispatchOutcome.Failed("Pairing completed without a recovery code")
+                    DispatchOutcome.Failed("Pairing completed without a recovery code", NO_RECOVERY_CODE.code)
                 } else {
-                    loginWithV2RecoveryCode(received)
+                    loginWithV2RecoveryCode(received, peerKind)
                 }
             }
-            ExchangeV2State.Joiner.AbortedByHost -> {
-                val msgType = event.trigger?.messageType ?: "abort"
-                DispatchOutcome.Failed("Pairing aborted by peer ($msgType)")
+            ExchangeV2State.Joiner.AbortedByHost -> when (event.trigger) {
+                is ExchangeV2Message.RecoveryCodeDenied ->
+                    DispatchOutcome.Failed("Pairing declined by peer", PAIRING_REJECTED.code)
+                is ExchangeV2Message.RecoveryCodeUnavailable ->
+                    DispatchOutcome.Failed("Peer has no recovery code", PAIRING_UNAVAILABLE.code)
+                else -> DispatchOutcome.Failed("Pairing aborted by peer", PAIRING_REJECTED.code)
             }
-            ExchangeV2State.Joiner.AbortedLocal -> DispatchOutcome.Failed("Pairing cancelled on this device")
-            ExchangeV2State.Host.Aborted -> DispatchOutcome.Failed("Pairing aborted")
+            ExchangeV2State.Joiner.AbortedLocal -> DispatchOutcome.Failed("Pairing cancelled on this device", PAIRING_CANCELLED.code)
+            ExchangeV2State.Host.Aborted -> hostAbortedToOutcome(event.localTrigger)
             // Per spec §"Same-account case": not an abort; both devices share an account already.
             ExchangeV2State.SameAccountAbort -> DispatchOutcome.AlreadyConnected
             // Elected Host and shared a recovery code — success from this device's perspective.
-            ExchangeV2State.Host.Done -> DispatchOutcome.LoggedIn
-            ExchangeV2State.Aborted -> DispatchOutcome.Failed("negotiation_aborted")
+            ExchangeV2State.Host.Done -> DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST, peerKind)
+            ExchangeV2State.Aborted -> DispatchOutcome.Failed("negotiation_aborted", NEGOTIATION_ABORTED.code)
             else -> null
         }
-        is ExchangeV2Event.SessionError -> {
-            val match = VERSION_TOO_NEW_REGEX.find(event.message)
-            if (match != null) {
-                DispatchOutcome.UpgradeRequired(codeMajor = match.groupValues[1].toIntOrNull() ?: -1)
-            } else {
-                DispatchOutcome.Failed(event.message)
-            }
-        }
+        is ExchangeV2Event.SessionError -> sessionErrorToOutcome(event.message)
         else -> null
+    }
+
+    private fun sessionErrorToOutcome(message: String): DispatchOutcome {
+        val match = VERSION_TOO_NEW_REGEX.find(message)
+        return if (match != null) {
+            DispatchOutcome.UpgradeRequired(codeMajor = match.groupValues[1].toIntOrNull() ?: -1)
+        } else {
+            DispatchOutcome.Failed(message, PAIRING_FAILED.code)
+        }
+    }
+
+    private fun hostAbortedToOutcome(localTrigger: LocalTrigger?): DispatchOutcome = when (localTrigger) {
+        LocalTrigger.UserDeniedHost -> DispatchOutcome.Failed("user_denied", PAIRING_CANCELLED.code)
+        LocalTrigger.HostUnavailable -> DispatchOutcome.Failed("host_unavailable", PAIRING_UNAVAILABLE.code)
+        else -> DispatchOutcome.Failed("host_aborted", NEGOTIATION_ABORTED.code)
     }
 
     /**
@@ -336,23 +376,32 @@ class RealSyncCodeDispatcher @Inject constructor(
      * cid=ddg logs in directly; cid=3party upgrades the account via
      * [SyncAccountRepository.joinAccountFromThirdPartyRecoveryCode].
      */
-    private fun loginWithV2RecoveryCode(b64: String): DispatchOutcome {
+    private fun loginWithV2RecoveryCode(b64: String, peerKind: PeerKind?): DispatchOutcome {
         val parsed = decodeV2Recovery(b64) ?: return DispatchOutcome.Failed("Couldn't parse received recovery code as v2.0")
         return when (parsed.cid) {
             CID_DDG -> {
                 val primaryKey = v2SecretToV1PrimaryKey(parsed.secret)
                     ?: return DispatchOutcome.Failed("Received recovery code has a malformed secret")
                 val recovery = SyncAuthCode.Recovery(RecoveryCode(primaryKey = primaryKey, userId = parsed.userId))
+                logcat { "$TAG: v2 LinkingV2 received ddg code → $recovery" }
                 syncAccountRepository.processCode(recovery, existingDeviceId = null)
                     .toOutcome(
                         label = "v2 LinkingV2 login (ddg)",
+                        path = SetupPath.PAIRING,
+                        myRole = SetupRole.JOINER,
+                        peerKind = peerKind,
                         codeForAccountSwitch = encodeV1RecoveryCodeAsB64(userId = parsed.userId, secret = primaryKey),
                     )
             }
             CID_3PARTY -> {
                 logcat { "$TAG: v2 LinkingV2 received 3party code → joinAccountFromThirdPartyRecoveryCode" }
                 syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(b64)
-                    .toOutcome(label = "v2 LinkingV2 login (3party upgrade)")
+                    .toOutcome(
+                        label = "v2 LinkingV2 login (3party upgrade)",
+                        path = SetupPath.PAIRING,
+                        myRole = SetupRole.JOINER,
+                        peerKind = peerKind,
+                    )
             }
             else -> DispatchOutcome.Failed("Received unknown credential type '${parsed.cid}' over v2 linking")
         }
@@ -395,13 +444,45 @@ class RealSyncCodeDispatcher @Inject constructor(
      * [codeForAccountSwitch] must be a v1 b64 shape [SyncAccountRepository.parseSyncAuthCode] can
      * re-parse, so v2 callers convert first (see [encodeV1RecoveryCodeAsB64]).
      */
+    /** Map the runner's raw peer credential id ("ddg"/"3party") to the telemetry [PeerKind], or null. */
+    private fun String?.toPeerKind(): PeerKind? = when (this) {
+        CID_DDG -> PeerKind.DDG
+        CID_3PARTY -> PeerKind.THIRD_PARTY
+        else -> null
+    }
+
+    /** Elected role implied by a terminal transition's target state, for "Setup failed" telemetry. */
+    private fun roleFromTerminalState(event: ExchangeV2Event): SetupRole? =
+        when ((event as? ExchangeV2Event.Transition)?.to) {
+            is ExchangeV2State.Host -> SetupRole.HOST
+            is ExchangeV2State.Joiner -> SetupRole.JOINER
+            else -> null
+        }
+
+    /**
+     * Attach best-effort failure telemetry ([path]/[myRole]/[peerKind]) to a terminal error outcome.
+     * No-op for non-error outcomes, so a [DispatchOutcome.LoggedIn] keeps the context set at its source.
+     */
+    private fun DispatchOutcome.withFailureContext(
+        path: SetupPath,
+        myRole: SetupRole?,
+        peerKind: PeerKind?,
+    ): DispatchOutcome = when (this) {
+        is DispatchOutcome.Failed -> copy(path = path, myRole = myRole, peerKind = peerKind)
+        is DispatchOutcome.UpgradeRequired -> copy(path = path, myRole = myRole, peerKind = peerKind)
+        else -> this
+    }
+
     private fun Result<Boolean>.toOutcome(
         label: String,
+        path: SetupPath,
+        myRole: SetupRole? = null,
+        peerKind: PeerKind? = null,
         codeForAccountSwitch: String? = null,
     ): DispatchOutcome = when (this) {
         is Result.Success -> {
             logcat { "$TAG: $label → success" }
-            DispatchOutcome.LoggedIn
+            DispatchOutcome.LoggedIn(path, myRole, peerKind)
         }
         is Result.Error -> {
             logcat { "$TAG: $label → error: $reason (code=$code)" }
@@ -410,7 +491,7 @@ class RealSyncCodeDispatcher @Inject constructor(
                 when (val switched = syncAccountRepository.logoutAndJoinNewAccount(codeForAccountSwitch)) {
                     is Result.Success -> {
                         logcat { "$TAG: $label → logout+rejoin success" }
-                        DispatchOutcome.LoggedIn
+                        DispatchOutcome.LoggedIn(path, myRole, peerKind)
                     }
                     is Result.Error -> {
                         logcat { "$TAG: $label → logout+rejoin failed: ${switched.reason} (code=${switched.code})" }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
@@ -218,12 +218,18 @@ class RealSyncCodeDispatcher @Inject constructor(
                     emit(DispatchOutcome.Failed("v2 recovery code missing required fields"))
                     return@flow
                 }
-                val authCode = SyncAuthCode.Recovery(RecoveryCode(primaryKey = secret, userId = userId))
+                val primaryKey = v2SecretToV1PrimaryKey(secret)
+                if (primaryKey == null) {
+                    logcat { "$TAG: v2 recovery (ddg) secret is not valid base64" }
+                    emit(DispatchOutcome.Failed("v2 recovery code has a malformed secret"))
+                    return@flow
+                }
+                val authCode = SyncAuthCode.Recovery(RecoveryCode(primaryKey = primaryKey, userId = userId))
                 logcat { "$TAG: v2 recovery (ddg) → processCode(Recovery)" }
                 emit(
                     syncAccountRepository.processCode(authCode, existingDeviceId = null).toOutcome(
                         label = "v2 recovery (ddg)",
-                        codeForAccountSwitch = encodeV1RecoveryCodeAsB64(userId = userId, secret = secret),
+                        codeForAccountSwitch = encodeV1RecoveryCodeAsB64(userId = userId, secret = primaryKey),
                     ),
                 )
             }
@@ -375,11 +381,13 @@ class RealSyncCodeDispatcher @Inject constructor(
         val parsed = decodeV2Recovery(b64) ?: return DispatchOutcome.Failed("Couldn't parse received recovery code as v2.0")
         return when (parsed.cid) {
             CID_DDG -> {
-                val recovery = SyncAuthCode.Recovery(RecoveryCode(primaryKey = parsed.secret, userId = parsed.userId))
+                val primaryKey = v2SecretToV1PrimaryKey(parsed.secret)
+                    ?: return DispatchOutcome.Failed("Received recovery code has a malformed secret")
+                val recovery = SyncAuthCode.Recovery(RecoveryCode(primaryKey = primaryKey, userId = parsed.userId))
                 syncAccountRepository.processCode(recovery, existingDeviceId = null)
                     .toOutcome(
                         label = "v2 LinkingV2 login (ddg)",
-                        codeForAccountSwitch = encodeV1RecoveryCodeAsB64(userId = parsed.userId, secret = parsed.secret),
+                        codeForAccountSwitch = encodeV1RecoveryCodeAsB64(userId = parsed.userId, secret = primaryKey),
                     )
             }
             CID_3PARTY -> {
@@ -405,6 +413,19 @@ class RealSyncCodeDispatcher @Inject constructor(
             cid = rec.optString("cid", CID_DDG),
             v = rec.optString("v", "2.0"),
         )
+    }.getOrNull()
+
+    /**
+     * The v2 wire `secret` is base64url-encoded per spec 1214802412121967; Android's native v1
+     * login (SyncNativeLib.decodeKey → android.util.Base64 standard) decodes the primary_key as
+     * STANDARD base64. Re-encode the same key bytes to canonical standard base64 at the v2->v1
+     * boundary, otherwise a conformant peer's base64url secret (macOS/iOS/FE) throws "bad base-64"
+     * (LOGIN_FAILED). Normalising the alphabet first also tolerates an already-standard secret from
+     * a non-conformant/older Android peer. Returns null if the secret isn't valid base64 at all.
+     */
+    private fun v2SecretToV1PrimaryKey(secret: String): String? = runCatching {
+        val bytes = Base64.decode(secret.replace('-', '+').replace('_', '/'), Base64.NO_WRAP)
+        Base64.encodeToString(bytes, Base64.NO_WRAP)
     }.getOrNull()
 
     /**

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
@@ -678,12 +678,12 @@ class AppSyncAccountRepository @Inject constructor(
         // SP travels in the recovery code as base64url; nativeLib + hkdfDerive* helpers expect
         // standard base64. Compute once at the boundary, reuse for all derivations.
         val spStandardB64 = kotlin.runCatching { base64UrlStringToStandardBase64(parsed.secret) }
-            .getOrElse { return Error(reason = "Upgrade: failed to decode SP: ${it.message}") }
+            .getOrElse { return Error(reason = "Upgrade: failed to decode SP") }
         val hkdfSalt = parsed.userId.toByteArray(Charsets.UTF_8)
 
         // SP-derived MEK: used to decrypt FE-written (JWE) keys we received from /sync/login.
         val spMek = kotlin.runCatching { syncJweCrypto.hkdfDeriveBytes(spStandardB64, hkdfSalt, "Main Key", 32) }
-            .getOrElse { return Error(reason = "Upgrade: failed to derive SP MEK: ${it.message}") }
+            .getOrElse { return Error(reason = "Upgrade: failed to derive SP MEK") }
 
         // Fresh DDG credential generated locally. nativeLib.generateAccountKeys returns a tuple
         // where `primaryKey` is the new account's MP (the seed for all spec-side derivations) and
@@ -699,14 +699,14 @@ class AppSyncAccountRepository @Inject constructor(
         // DDG's MEK?", this is HKDF(MP, salt=user_id, info="Main Key", 32 bytes) imported as
         // AES-GCM-256. Pinned against the TD's test3 vector in SyncJweCryptoTdVectorsTest.
         val ddgMek = kotlin.runCatching { syncJweCrypto.hkdfDeriveBytes(newDdgKeys.primaryKey, hkdfSalt, "Main Key", 32) }
-            .getOrElse { return Error(reason = "Upgrade: failed to derive DDG MEK: ${it.message}") }
+            .getOrElse { return Error(reason = "Upgrade: failed to derive DDG MEK") }
 
         // encrypted_3party_credential: JWE compact (alg=dir, enc=A256GCM, kid="ddg") of the SP
         // base64url STRING (matches the reverse direction in createThirdPartyCredential, which
         // encrypts the base64url SP string — not the raw SP bytes — so the wire is symmetrical).
         val encryptedThreePartyCredential = kotlin.runCatching {
             syncJweCrypto.jweEncryptSymmetric(parsed.secret.toByteArray(Charsets.UTF_8), ddgMek, kid = CREDENTIAL_ID_DDG)
-        }.getOrElse { return Error(reason = "Upgrade: failed to encrypt encrypted_3party_credential: ${it.message}") }
+        }.getOrElse { return Error(reason = "Upgrade: failed to encrypt encrypted_3party_credential") }
 
         // Re-wrap each FE-written key from /sync/login. Decrypt via JWE using SP MEK, then
         // re-encrypt with libsodium-secretbox using the new DDG secretKey, matching the Native
@@ -873,8 +873,6 @@ class AppSyncAccountRepository @Inject constructor(
         // pre-upgrade until this block runs.
         val spStandardB64 = kotlin.runCatching { base64UrlStringToStandardBase64(parsed.secret) }
             .getOrElse { return Error(reason = "JoinFrom3party: failed to decode SP: ${it.message}") }
-        val protectedKeysJson = kotlin.runCatching { Adapters.protectedKeysAdapter.toJson(upgradePackage.rewrappedKeys) }
-            .getOrElse { return Error(reason = "JoinFrom3party: failed to serialize protected keys: ${it.message}") }
         syncStore.storeCredentials(
             userId = parsed.userId,
             deviceId = deviceId,
@@ -885,7 +883,6 @@ class AppSyncAccountRepository @Inject constructor(
         )
         syncStore.credentialId = CREDENTIAL_ID_DDG
         syncStore.scopedPassword = ScopedPassword(spStandardB64)
-        syncStore.protectedKeysJson = protectedKeysJson
 
         logcat { "Sync-ScopedToken: 3party→ddg upgrade complete; account joined as ddg" }
 
@@ -1354,10 +1351,6 @@ class AppSyncAccountRepository @Inject constructor(
                     }
                     result.data.keys?.let { keys ->
                         logcat { "Sync-ScopedToken: ${keys.size} protected key(s) in response" }
-                        val ddgKeys = keys.filter { it.encryptedWith == CREDENTIAL_ID_DDG }
-                        runCatching { Adapters.protectedKeysAdapter.toJson(ddgKeys) }
-                            .onSuccess { syncStore.protectedKeysJson = it }
-                            .onFailure { logcat(ERROR) { "Sync-ScopedToken: failed to serialize protected keys from login: ${it.message}" } }
                     }
                 }
 
@@ -1458,8 +1451,6 @@ class AppSyncAccountRepository @Inject constructor(
 
             val invitationCodeAdapter: JsonAdapter<InvitationCodeWrapper> = moshi.adapter(InvitationCodeWrapper::class.java)
             val invitedDeviceAdapter: JsonAdapter<InvitedDeviceDetails> = moshi.adapter(InvitedDeviceDetails::class.java)
-            val protectedKeysAdapter: JsonAdapter<List<ProtectedKeyEntry>> =
-                moshi.adapter(Types.newParameterizedType(List::class.java, ProtectedKeyEntry::class.java))
         }
     }
 }
@@ -1575,6 +1566,12 @@ enum class AccountErrorCodes(val code: Int) {
     INVALID_CODE(55),
     EXCHANGE_FAILED(56),
     THIRD_PARTY_ALREADY_UPGRADED(57),
+    PAIRING_REJECTED(58),
+    PAIRING_UNAVAILABLE(59),
+    PAIRING_CANCELLED(60),
+    NEGOTIATION_ABORTED(61),
+    NO_RECOVERY_CODE(62),
+    PAIRING_FAILED(63),
 }
 
 sealed interface SyncAuthCode {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncCodeDispatcher.kt
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Routes a pasted/scanned sync code to either the existing v1 stack or the new v2 exchange
+ * protocol, based on the [SyncFeature.canUseV2ConnectFlow] flag. The router is designed so
+ * that **with the flag off, behaviour is identical to direct calls to
+ * [SyncAccountRepository.parseSyncAuthCode]** — same return value, same side effects (none),
+ * same downstream processing. Callers keep their existing v1 handling intact and only need
+ * to add a new branch for [RouteDecision.V2InProgress] when they want to opt into v2.
+ *
+ * Why this split: v2 codes need richer outcomes (e.g. an in-flight pairing session, an
+ * upgrade prompt for v3 codes that arrive at a v2 client) that don't map onto the existing
+ * [SyncAuthCode] type. v1 codes still flow through the well-trodden production paths
+ * unchanged.
+ */
+interface SyncCodeDispatcher {
+
+    /**
+     * Inspect the pasted code and decide who handles it.
+     *
+     *  - [RouteDecision.Legacy]: caller processes the returned [SyncAuthCode] exactly as today
+     *    ([SyncAccountRepository.processCode], etc.).
+     *  - [RouteDecision.V2InProgress]: dispatcher owns the work end-to-end; caller collects the
+     *    returned [Flow] which emits zero or one [DispatchOutcome.JoinerConfirmationRequested] /
+     *    [DispatchOutcome.HostConfirmationRequested] prompt requests (which the VM should surface
+     *    as a dialog), followed by exactly one terminal outcome.
+     */
+    fun route(pastedCode: String): RouteDecision
+
+    /**
+     * User confirmed the Joiner-side prompt ("Sync your data with …?"). Drives the SM out of
+     * Joiner.Confirming. No-op if no session is in that state.
+     */
+    fun confirmJoiner()
+
+    /**
+     * User denied the Joiner-side prompt. Drives the SM to Joiner.AbortedLocal. No message
+     * sent to peer (per spec). No-op if no session is in Joiner.Confirming.
+     */
+    fun denyJoiner()
+
+    /**
+     * User confirmed the Host-side prompt ("Allow … to join your sync & backup?"). Drives the
+     * SM out of Host.Confirming into Host.Sending. No-op if no session is in that state.
+     */
+    fun confirmHost()
+
+    /**
+     * User denied the Host-side prompt. Drives the SM to Host.Aborted and sends
+     * recovery_code_denied to the peer. No-op if no session is in Host.Confirming.
+     */
+    fun denyHost()
+
+    /**
+     * Starts a v2 Presenter session. The returned Flow emits exactly one
+     * [DispatchOutcome.LinkingCodeReady] once the v2 channel is established (caller renders
+     * the URL as a QR), then zero or one [DispatchOutcome.HostConfirmationRequested] prompt
+     * (caller surfaces a dialog and resumes via [confirmHost] / [denyHost]), then exactly
+     * one terminal outcome ([LoggedIn] for Host.Done, [AlreadyConnected] for SameAccountAbort,
+     * [Failed] otherwise).
+     *
+     * Cancelling the collecting coroutine cancels the underlying runner session
+     * (best-effort channel DELETE).
+     *
+     * As of M1.5 (subtask `1215246284113165`), this method is called from both the signed-in
+     * `SyncWithAnotherActivityViewModel` and the signed-out `SyncConnectViewModel`. Role election
+     * runs in the runner — the Presenter can end up as Host (signed-in surface, or signed-out
+     * surface with a signed-out peer) or as Joiner (signed-out surface with a signed-in peer,
+     * or with a 3party peer). All terminal mappings are first-class; none are defensive.
+     */
+    fun presentV2(): Flow<DispatchOutcome>
+}
+
+sealed interface RouteDecision {
+    /** Caller MUST process [authCode] as it would have today — no behaviour change from FF off. */
+    data class Legacy(val authCode: SyncAuthCode) : RouteDecision
+
+    /**
+     * Dispatcher has accepted ownership. [outcomes] is a cold Flow that, when collected,
+     * drives the v2 work and emits **exactly one** [DispatchOutcome] before completing.
+     * Cancelling the collecting coroutine cancels any in-flight v2 work the dispatcher started.
+     */
+    data class V2InProgress(val outcomes: Flow<DispatchOutcome>) : RouteDecision
+}
+
+/**
+ * Outcomes emitted by a v2-owned dispatch. Used by both [SyncCodeDispatcher.route]
+ * (Scanner side) and [SyncCodeDispatcher.presentV2] (Presenter side); the emitted
+ * sequence differs by side.
+ *
+ * Scanner side (returned via [RouteDecision.V2InProgress.outcomes]): zero or one
+ * [JoinerConfirmationRequested] / [HostConfirmationRequested] (intermediate — caller
+ * must show a prompt and call [SyncCodeDispatcher.confirmJoiner] / [denyJoiner] /
+ * [confirmHost] / [denyHost] to resume the SM), followed by exactly one terminal
+ * ([LoggedIn] / [UpgradeRequired] / [Failed]).
+ *
+ * Presenter side: exactly one [LinkingCodeReady] first (the URL to render as a QR),
+ * then zero or one [HostConfirmationRequested] (caller surfaces a dialog and resumes
+ * via [confirmHost] / [denyHost]), then exactly one terminal ([LoggedIn] for Host.Done,
+ * [AlreadyConnected] for SameAccountAbort, [Failed] otherwise). [JoinerConfirmationRequested]
+ * is also possible on the Presenter side as of M1.5 (subtask
+ * `1215246284113165`) when a signed-out Presenter is elected Joiner via role-election rule 1
+ * (account beats no-account) against a signed-in peer.
+ *
+ * For v2 RecoveryCode flows (cid=ddg, cid=3party) there's no confirmation phase — only
+ * a single terminal outcome.
+ *
+ * Note: v2 does **not** surface a v1-style `AskToSwitchAccount` prompt. The spec's
+ * Confirmations phase is the consent step ("Sync your data with [peer]?"); by the
+ * time login runs, the user has already opted out of any existing account. When the
+ * BE returns `ALREADY_SIGNED_IN`, the dispatcher performs the logout-and-rejoin
+ * transparently and emits [LoggedIn] (or [Failed] if the switch itself fails).
+ */
+sealed interface DispatchOutcome {
+    /**
+     * SM reached Joiner.Confirming. Caller must prompt the user ("Sync your data with [peerName]?")
+     * then call [SyncCodeDispatcher.confirmJoiner] or [SyncCodeDispatcher.denyJoiner] to resume.
+     */
+    data class JoinerConfirmationRequested(val peerName: String?) : DispatchOutcome
+
+    /**
+     * SM reached Host.Confirming. Caller must prompt the user ("Allow [peerName] to join your
+     * sync & backup?") then call [SyncCodeDispatcher.confirmHost] or [SyncCodeDispatcher.denyHost].
+     */
+    data class HostConfirmationRequested(val peerName: String?) : DispatchOutcome
+
+    /**
+     * Emitted once per [SyncCodeDispatcher.presentV2] session, before any confirmation or
+     * terminal outcome. [linkingCode] is the URL the caller renders as a QR for the peer
+     * to scan. Non-terminal — the Flow continues.
+     */
+    data class LinkingCodeReady(val linkingCode: String) : DispatchOutcome
+
+    /** Terminal — login completed (recovery code applied; account state updated). */
+    data object LoggedIn : DispatchOutcome
+
+    /**
+     * Terminal — peer and this device are already on the same account. Per spec
+     * §"Same-account case", this is **not a failure** — show a friendly "Connected"
+     * confirmation and finish. No account state change happened or is needed.
+     */
+    data object AlreadyConnected : DispatchOutcome
+
+    /** Terminal — the pasted code requires a protocol major version higher than this app supports. */
+    data class UpgradeRequired(val codeMajor: Int) : DispatchOutcome
+
+    /**
+     * Terminal — transport error, missing credentials on this device, BE rejection, denial, etc.
+     * [code] carries the originating [AccountErrorCodes] code (defaults to GENERIC_ERROR) so callers
+     * can map specific failures (e.g. THIRD_PARTY_ALREADY_UPGRADED) to user-facing copy.
+     */
+    data class Failed(
+        val reason: String,
+        val code: Int = AccountErrorCodes.GENERIC_ERROR.code,
+    ) : DispatchOutcome
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncCodeDispatcher.kt
@@ -19,29 +19,16 @@ package com.duckduckgo.sync.impl
 import kotlinx.coroutines.flow.Flow
 
 /**
- * Routes a pasted/scanned sync code to either the existing v1 stack or the new v2 exchange
- * protocol, based on the [SyncFeature.canUseV2ConnectFlow] flag. The router is designed so
- * that **with the flag off, behaviour is identical to direct calls to
- * [SyncAccountRepository.parseSyncAuthCode]** — same return value, same side effects (none),
- * same downstream processing. Callers keep their existing v1 handling intact and only need
- * to add a new branch for [RouteDecision.V2InProgress] when they want to opt into v2.
- *
- * Why this split: v2 codes need richer outcomes (e.g. an in-flight pairing session, an
- * upgrade prompt for v3 codes that arrive at a v2 client) that don't map onto the existing
- * [SyncAuthCode] type. v1 codes still flow through the well-trodden production paths
- * unchanged.
+ * Routes a pasted/scanned sync code to either the v1 stack or the v2 exchange protocol, gated by
+ * [SyncFeature.canUseV2ConnectFlow]. With the flag off, [route] behaves identically to
+ * [SyncAccountRepository.parseSyncAuthCode]; v2 work is exposed via [RouteDecision.V2InProgress].
  */
 interface SyncCodeDispatcher {
 
     /**
-     * Inspect the pasted code and decide who handles it.
-     *
-     *  - [RouteDecision.Legacy]: caller processes the returned [SyncAuthCode] exactly as today
-     *    ([SyncAccountRepository.processCode], etc.).
-     *  - [RouteDecision.V2InProgress]: dispatcher owns the work end-to-end; caller collects the
-     *    returned [Flow] which emits zero or one [DispatchOutcome.JoinerConfirmationRequested] /
-     *    [DispatchOutcome.HostConfirmationRequested] prompt requests (which the VM should surface
-     *    as a dialog), followed by exactly one terminal outcome.
+     * Inspects the pasted code and decides who handles it: [RouteDecision.Legacy] (caller processes
+     * the [SyncAuthCode] as today) or [RouteDecision.V2InProgress] (dispatcher owns the work; caller
+     * collects the returned Flow). See [DispatchOutcome] for the v2 emitted sequence.
      */
     fun route(pastedCode: String): RouteDecision
 
@@ -71,20 +58,9 @@ interface SyncCodeDispatcher {
 
     /**
      * Starts a v2 Presenter session. The returned Flow emits exactly one
-     * [DispatchOutcome.LinkingCodeReady] once the v2 channel is established (caller renders
-     * the URL as a QR), then zero or one [DispatchOutcome.HostConfirmationRequested] prompt
-     * (caller surfaces a dialog and resumes via [confirmHost] / [denyHost]), then exactly
-     * one terminal outcome ([LoggedIn] for Host.Done, [AlreadyConnected] for SameAccountAbort,
-     * [Failed] otherwise).
-     *
-     * Cancelling the collecting coroutine cancels the underlying runner session
-     * (best-effort channel DELETE).
-     *
-     * As of M1.5 (subtask `1215246284113165`), this method is called from both the signed-in
-     * `SyncWithAnotherActivityViewModel` and the signed-out `SyncConnectViewModel`. Role election
-     * runs in the runner — the Presenter can end up as Host (signed-in surface, or signed-out
-     * surface with a signed-out peer) or as Joiner (signed-out surface with a signed-in peer,
-     * or with a 3party peer). All terminal mappings are first-class; none are defensive.
+     * [DispatchOutcome.LinkingCodeReady] (the URL to render as a QR), then the v2 emitted sequence
+     * (see [DispatchOutcome]). Role election runs in the runner, so the Presenter may be elected
+     * Host or Joiner. Cancelling the collecting coroutine cancels the underlying runner session.
      */
     fun presentV2(): Flow<DispatchOutcome>
 }
@@ -94,40 +70,29 @@ sealed interface RouteDecision {
     data class Legacy(val authCode: SyncAuthCode) : RouteDecision
 
     /**
-     * Dispatcher has accepted ownership. [outcomes] is a cold Flow that, when collected,
-     * drives the v2 work and emits **exactly one** [DispatchOutcome] before completing.
-     * Cancelling the collecting coroutine cancels any in-flight v2 work the dispatcher started.
+     * Dispatcher owns the work. [outcomes] is a cold Flow that drives the v2 work when collected
+     * (see [DispatchOutcome] for the emitted sequence). Cancelling the collector cancels the work.
      */
     data class V2InProgress(val outcomes: Flow<DispatchOutcome>) : RouteDecision
 }
 
 /**
- * Outcomes emitted by a v2-owned dispatch. Used by both [SyncCodeDispatcher.route]
- * (Scanner side) and [SyncCodeDispatcher.presentV2] (Presenter side); the emitted
- * sequence differs by side.
+ * Outcomes emitted by a v2-owned dispatch, used by both [SyncCodeDispatcher.route] (Scanner) and
+ * [SyncCodeDispatcher.presentV2] (Presenter). Emitted sequence per side:
  *
- * Scanner side (returned via [RouteDecision.V2InProgress.outcomes]): zero or one
- * [JoinerConfirmationRequested] / [HostConfirmationRequested] (intermediate — caller
- * must show a prompt and call [SyncCodeDispatcher.confirmJoiner] / [denyJoiner] /
- * [confirmHost] / [denyHost] to resume the SM), followed by exactly one terminal
- * ([LoggedIn] / [UpgradeRequired] / [Failed]).
+ * Scanner (via [RouteDecision.V2InProgress.outcomes]): zero or one [JoinerConfirmationRequested] /
+ * [HostConfirmationRequested] (caller prompts and resumes via the confirm/deny calls), then exactly
+ * one terminal ([LoggedIn] / [UpgradeRequired] / [Failed]).
  *
- * Presenter side: exactly one [LinkingCodeReady] first (the URL to render as a QR),
- * then zero or one [HostConfirmationRequested] (caller surfaces a dialog and resumes
- * via [confirmHost] / [denyHost]), then exactly one terminal ([LoggedIn] for Host.Done,
- * [AlreadyConnected] for SameAccountAbort, [Failed] otherwise). [JoinerConfirmationRequested]
- * is also possible on the Presenter side as of M1.5 (subtask
- * `1215246284113165`) when a signed-out Presenter is elected Joiner via role-election rule 1
- * (account beats no-account) against a signed-in peer.
+ * Presenter: exactly one [LinkingCodeReady], then zero or one [JoinerConfirmationRequested] /
+ * [HostConfirmationRequested] (role is elected by the runner), then exactly one terminal
+ * ([LoggedIn] / [AlreadyConnected] / [Failed]).
  *
- * For v2 RecoveryCode flows (cid=ddg, cid=3party) there's no confirmation phase — only
- * a single terminal outcome.
+ * v2 RecoveryCode flows (cid=ddg, cid=3party) have no confirmation phase — only a terminal outcome.
  *
- * Note: v2 does **not** surface a v1-style `AskToSwitchAccount` prompt. The spec's
- * Confirmations phase is the consent step ("Sync your data with [peer]?"); by the
- * time login runs, the user has already opted out of any existing account. When the
- * BE returns `ALREADY_SIGNED_IN`, the dispatcher performs the logout-and-rejoin
- * transparently and emits [LoggedIn] (or [Failed] if the switch itself fails).
+ * v2 does not surface a v1-style `AskToSwitchAccount` prompt; the spec's Confirmations phase is the
+ * consent step. On `ALREADY_SIGNED_IN` the dispatcher logs out and rejoins transparently, emitting
+ * [LoggedIn] (or [Failed] if the switch fails).
  */
 sealed interface DispatchOutcome {
     /**
@@ -153,9 +118,8 @@ sealed interface DispatchOutcome {
     data object LoggedIn : DispatchOutcome
 
     /**
-     * Terminal — peer and this device are already on the same account. Per spec
-     * §"Same-account case", this is **not a failure** — show a friendly "Connected"
-     * confirmation and finish. No account state change happened or is needed.
+     * Terminal — peer and this device are already on the same account. Per spec §"Same-account
+     * case" this is not a failure: show a "Connected" confirmation. No account state change.
      */
     data object AlreadyConnected : DispatchOutcome
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncCodeDispatcher.kt
@@ -16,6 +16,9 @@
 
 package com.duckduckgo.sync.impl
 
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -63,6 +66,12 @@ interface SyncCodeDispatcher {
      * Host or Joiner. Cancelling the collecting coroutine cancels the underlying runner session.
      */
     fun presentV2(): Flow<DispatchOutcome>
+
+    /**
+     * Whether a v2 exchange has engaged a peer and is mid-protocol (past Bootstrapped, before a
+     * terminal).
+     */
+    fun isV2ExchangeUnderway(): Boolean
 }
 
 sealed interface RouteDecision {
@@ -70,11 +79,17 @@ sealed interface RouteDecision {
     data class Legacy(val authCode: SyncAuthCode) : RouteDecision
 
     /**
-     * Dispatcher owns the work. [outcomes] is a cold Flow that drives the v2 work when collected
-     * (see [DispatchOutcome] for the emitted sequence). Cancelling the collector cancels the work.
+     * Dispatcher owns the work. [codeType] is the kind of v2 code that was recognized.
+     * [outcomes] is a cold Flow that drives the v2 work when collected (see [DispatchOutcome] for the
+     * emitted sequence). Cancelling the collector cancels the work.
      */
-    data class V2InProgress(val outcomes: Flow<DispatchOutcome>) : RouteDecision
+    data class V2InProgress(
+        val codeType: SyncCodeType,
+        val outcomes: Flow<DispatchOutcome>,
+    ) : RouteDecision
 }
+
+enum class SyncCodeType { RECOVERY, LINKING }
 
 /**
  * Outcomes emitted by a v2-owned dispatch, used by both [SyncCodeDispatcher.route] (Scanner) and
@@ -99,13 +114,13 @@ sealed interface DispatchOutcome {
      * SM reached Joiner.Confirming. Caller must prompt the user ("Sync your data with [peerName]?")
      * then call [SyncCodeDispatcher.confirmJoiner] or [SyncCodeDispatcher.denyJoiner] to resume.
      */
-    data class JoinerConfirmationRequested(val peerName: String?) : DispatchOutcome
+    data class JoinerConfirmationRequested(val peerName: String?, val peerKind: PeerKind? = null) : DispatchOutcome
 
     /**
      * SM reached Host.Confirming. Caller must prompt the user ("Allow [peerName] to join your
      * sync & backup?") then call [SyncCodeDispatcher.confirmHost] or [SyncCodeDispatcher.denyHost].
      */
-    data class HostConfirmationRequested(val peerName: String?) : DispatchOutcome
+    data class HostConfirmationRequested(val peerName: String?, val peerKind: PeerKind? = null) : DispatchOutcome
 
     /**
      * Emitted once per [SyncCodeDispatcher.presentV2] session, before any confirmation or
@@ -114,8 +129,16 @@ sealed interface DispatchOutcome {
      */
     data class LinkingCodeReady(val linkingCode: String) : DispatchOutcome
 
-    /** Terminal — login completed (recovery code applied; account state updated). */
-    data object LoggedIn : DispatchOutcome
+    /**
+     * Terminal — login completed (recovery code applied; account state updated). Carries telemetry
+     * for the "Setup success" pixel: [path] (recovery vs pairing) and, for a pairing, the elected
+     * [myRole] and the [peerKind]. [myRole]/[peerKind] are null for recovery.
+     */
+    data class LoggedIn(
+        val path: SetupPath,
+        val myRole: SetupRole? = null,
+        val peerKind: PeerKind? = null,
+    ) : DispatchOutcome
 
     /**
      * Terminal — peer and this device are already on the same account. Per spec §"Same-account
@@ -123,16 +146,29 @@ sealed interface DispatchOutcome {
      */
     data object AlreadyConnected : DispatchOutcome
 
-    /** Terminal — the pasted code requires a protocol major version higher than this app supports. */
-    data class UpgradeRequired(val codeMajor: Int) : DispatchOutcome
+    /**
+     * Terminal — the pasted code requires a protocol major version higher than this app supports.
+     * [path]/[myRole]/[peerKind] are best-effort telemetry for the "Setup failed" pixel (see [Failed]).
+     */
+    data class UpgradeRequired(
+        val codeMajor: Int,
+        val path: SetupPath? = null,
+        val myRole: SetupRole? = null,
+        val peerKind: PeerKind? = null,
+    ) : DispatchOutcome
 
     /**
      * Terminal — transport error, missing credentials on this device, BE rejection, denial, etc.
      * [code] carries the originating [AccountErrorCodes] code (defaults to GENERIC_ERROR) so callers
      * can map specific failures (e.g. THIRD_PARTY_ALREADY_UPGRADED) to user-facing copy.
+     * [path]/[myRole]/[peerKind] are best-effort telemetry for the "Setup failed" pixel: [path] is the
+     * flow kind, and [myRole]/[peerKind] are populated when known at the point of failure.
      */
     data class Failed(
         val reason: String,
         val code: Int = AccountErrorCodes.GENERIC_ERROR.code,
+        val path: SetupPath? = null,
+        val myRole: SetupRole? = null,
+        val peerKind: PeerKind? = null,
     ) : DispatchOutcome
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncService.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncService.kt
@@ -141,7 +141,7 @@ interface SyncService {
         @Header("Authorization") token: String,
         @Path("purpose") purpose: String,
         @Body request: SetProtectedKeyIfAbsentRequest,
-    ): Call<Void>
+    ): Call<ProtectedKeysResponse>
 
     @GET("$SYNC_PROD_ENVIRONMENT_URL/sync/access-credentials")
     fun getAccessCredentials(
@@ -283,7 +283,7 @@ data class ProtectedKeysResponse(
 
 /** Body for POST /sync/keys/purpose/{purpose}/set-if-absent — adds a protected key only if no key exists for that purpose. */
 data class SetProtectedKeyIfAbsentRequest(
-    val key: ProtectedKeyEntry,
+    val keys: List<ProtectedKeyEntry>,
 )
 
 data class AccessCredentialsResponse(

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
@@ -120,7 +120,7 @@ interface SyncApi {
     fun getProtectedKeys(token: String): Result<List<ProtectedKeyEntry>>
 
     /** Atomically claim [purpose] with [key] or no-op if one already exists. */
-    fun setProtectedKeyIfAbsent(token: String, purpose: String, key: ProtectedKeyEntry): Result<Boolean>
+    fun setProtectedKeyIfAbsent(token: String, purpose: String, keys: List<ProtectedKeyEntry>): Result<List<ProtectedKeyEntry>>
 
     fun getAccessCredentials(token: String): Result<List<AccessCredentialEntry>>
 
@@ -539,16 +539,17 @@ class SyncServiceRemote @Inject constructor(
         }
     }
 
-    override fun setProtectedKeyIfAbsent(token: String, purpose: String, key: ProtectedKeyEntry): Result<Boolean> {
+    override fun setProtectedKeyIfAbsent(token: String, purpose: String, keys: List<ProtectedKeyEntry>): Result<List<ProtectedKeyEntry>> {
         val response = runCatching {
-            val call = syncService.setProtectedKeyIfAbsent("Bearer $token", purpose, SetProtectedKeyIfAbsentRequest(key))
+            val call = syncService.setProtectedKeyIfAbsent("Bearer $token", purpose, SetProtectedKeyIfAbsentRequest(keys))
             call.execute()
         }.getOrElse { throwable ->
             return Result.Error(reason = throwable.message.toString())
         }
 
         return onSuccess(response) {
-            Result.Success(true)
+            val keys = response.body()?.keys ?: emptyList()
+            Result.Success(keys)
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ThirdPartyCredentialManager.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ThirdPartyCredentialManager.kt
@@ -233,10 +233,12 @@ class RealThirdPartyCredentialManager @Inject constructor(
             }
         }
 
-        if (ddgKeys.isEmpty()) {
-            logcat { "Sync-ScopedToken: no ddg protected keys; generating $SYNC_SCOPE_AI_CHATS key before 3party extend" }
-            ddgKeys = when (val gen = protectedKeyManager.create(SYNC_SCOPE_AI_CHATS)) {
-                is Success -> listOf(gen.data)
+        // We ensure ai_chats (the scope's required purpose) exists, then re-wrap every
+        // ddg-wrapped key — preserving any other purposes already on the account.
+        if (ddgKeys.none { it.purpose == SYNC_SCOPE_AI_CHATS }) {
+            logcat { "Sync-ScopedToken: no ddg $SYNC_SCOPE_AI_CHATS key; generating before 3party extend" }
+            when (val gen = protectedKeyManager.create(SYNC_SCOPE_AI_CHATS)) {
+                is Success -> ddgKeys = ddgKeys + gen.data
                 is Error -> {
                     logcat(ERROR) { "Sync-ScopedToken: failed to generate $SYNC_SCOPE_AI_CHATS protected key: ${gen.reason}" }
                     return Error(code = gen.code, reason = "CreateThirdPartyCredential: generate $SYNC_SCOPE_AI_CHATS key failed: ${gen.reason}")

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -81,6 +81,9 @@ interface ExchangeV2Runner {
     /** Peer device's human-readable name, learned from `recovery_code_available` / `recovery_code_request`. */
     val peerName: String?
 
+    /** Peer device's credential kind ("ddg" / "3party"), learned during role election. Null before then. */
+    val peerKind: String?
+
     fun startScan(pastedUrl: String)
 
     fun startPresent()
@@ -134,7 +137,7 @@ class RealExchangeV2Runner @Inject constructor(
 
     @Volatile private var peerPublicKey: String? = null
 
-    @Volatile private var peerKind: String? = null
+    @Volatile private var _peerKind: String? = null
 
     @Volatile private var peerUserId: String? = null
 
@@ -160,6 +163,7 @@ class RealExchangeV2Runner @Inject constructor(
     override val linkingCode: String? get() = _linkingCode
     override val canStartAsPresenter: Boolean get() = true
     override val peerName: String? get() = _peerName
+    override val peerKind: String? get() = _peerKind
 
     // -----------------------------------------------------------------------
     // Entry points
@@ -251,7 +255,7 @@ class RealExchangeV2Runner @Inject constructor(
                     if (r.code == HTTP_CONFLICT) {
                         logcat { "Sync-ExchangeV2: channel_id $candidate already taken, retrying (${attempt + 1}/$MAX_CHANNEL_CREATE_RETRIES)" }
                     } else {
-                        emitSessionError("Failed to create channel: ${r.reason}")
+                        emitSessionError("Failed to create channel")
                         return null
                     }
                 }
@@ -302,7 +306,7 @@ class RealExchangeV2Runner @Inject constructor(
         ownKeyPair = null
         peerChannelId = null
         peerPublicKey = null
-        peerKind = null
+        _peerKind = null
         peerUserId = null
         _peerName = null
         _linkingCode = null
@@ -463,12 +467,12 @@ class RealExchangeV2Runner @Inject constructor(
                 peerPublicKey = message.publicKey
             }
             is ExchangeV2Message.RecoveryCodeAvailable -> {
-                peerKind = message.kind
+                _peerKind = message.kind
                 peerUserId = message.userId
                 _peerName = message.name
             }
             is ExchangeV2Message.RecoveryCodeRequest -> {
-                peerKind = message.kind
+                _peerKind = message.kind
                 peerUserId = null
                 _peerName = message.name
             }
@@ -501,12 +505,12 @@ class RealExchangeV2Runner @Inject constructor(
      */
     private fun autoElectRoleLocked(sm: ExchangeV2StateMachine) {
         val elected = electRole() ?: run {
-            logcat { "Sync-ExchangeV2: cannot auto-elect role yet (role=${_pairingRole}, peerKind=$peerKind)" }
+            logcat { "Sync-ExchangeV2: cannot auto-elect role yet (role=${_pairingRole}, peerKind=$_peerKind)" }
             return
         }
         logcat {
             "Sync-ExchangeV2: auto-electing $elected " +
-                "(own role=${_pairingRole}, own userId=${syncStore.userId}, peer kind=$peerKind, peer userId=$peerUserId)"
+                "(own role=${_pairingRole}, own userId=${syncStore.userId}, peer kind=$_peerKind, peer userId=$peerUserId)"
         }
         val electResult = sm.localTrigger(LocalTrigger.RoleElected(elected))
         emit(electResult.event)
@@ -527,7 +531,7 @@ class RealExchangeV2Runner @Inject constructor(
     private fun electRole(): Role? {
         val ownRole = _pairingRole ?: return null
         val ownUserId = syncStore.userId
-        val pKind = peerKind ?: return null
+        val pKind = _peerKind ?: return null
         val pUserId = peerUserId
         return when {
             ownUserId != null && pUserId == null -> Role.Host
@@ -642,7 +646,7 @@ class RealExchangeV2Runner @Inject constructor(
         // REVIEW: likely unreachable under eager-send ordering — confirm against the ordering spec
         // (Unified Algorithm 1214739740392701) and delete if dead.
         val sm = session ?: return
-        if (sm.currentState == ExchangeV2State.Negotiating && peerKind != null) {
+        if (sm.currentState == ExchangeV2State.Negotiating && _peerKind != null) {
             autoElectRoleLocked(sm)
         }
     }
@@ -661,11 +665,11 @@ class RealExchangeV2Runner @Inject constructor(
         // failure falls through to recovery_code_unavailable below.
         // peerKind is set during role election; reaching Host.Sending without it means something
         // upstream is broken — bail rather than silently assuming ddg.
-        val codeResult = when (peerKind) {
+        val codeResult = when (_peerKind) {
             "ddg" -> provisionForDdgPeer()
             "3party" -> provisionForThirdPartyPeer()
             null -> Result.Error(reason = "Host.Sending reached without a known peer kind")
-            else -> Result.Error(reason = "Unsupported peer kind '$peerKind'")
+            else -> Result.Error(reason = "Unsupported peer kind '$_peerKind'")
         }
         return when (codeResult) {
             is Result.Success -> {
@@ -678,7 +682,7 @@ class RealExchangeV2Runner @Inject constructor(
                 sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.RecoveryCodeResponse(json, recoveryCode))
             }
             is Result.Error -> {
-                logcat(ERROR) { "Sync-ExchangeV2: recovery code unavailable for peerKind=$peerKind: ${codeResult.reason}" }
+                logcat(ERROR) { "Sync-ExchangeV2: recovery code unavailable for peerKind=$_peerKind: ${codeResult.reason}" }
                 val json = """{"type":"recovery_code_unavailable"}"""
                 sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.RecoveryCodeUnavailable(json))
                 emitSessionError("Couldn't generate a recovery code: ${codeResult.reason}")
@@ -739,7 +743,7 @@ class RealExchangeV2Runner @Inject constructor(
                 true
             }
             is Result.Error -> {
-                emitSessionError("Failed to send ${outboundMessage.messageType}: ${r.reason}")
+                emitSessionError("Failed to send message to peer over channel")
                 false
             }
         }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixelParamRemovalPlugin.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixelParamRemovalPlugin.kt
@@ -57,6 +57,7 @@ class SyncPixelParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugi
             SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_SUCCESS.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_SETUP_ENDED_ABANDONED.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_SETUP_ENDED_SUCCESS.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_SETUP_ENDED_FAILED.pixelName to PixelParameter.removeAtb(),
 
             SyncPixelName.SYNC_AUTO_RESTORE_TOGGLE_SHOWN.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_AUTO_RESTORE_TOGGLE_OPTED_OUT.pixelName to PixelParameter.removeAtb(),

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -26,14 +26,32 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.api.engine.DeletableType
 import com.duckduckgo.sync.api.engine.SyncFeatureType
 import com.duckduckgo.sync.impl.API_CODE
+import com.duckduckgo.sync.impl.AccountErrorCodes
+import com.duckduckgo.sync.impl.DispatchOutcome
 import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.SyncCodeType
+import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_DAILY
 import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_DAILY_SUCCESS_RATE_PIXEL
 import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_OBJECT_LIMIT_EXCEEDED_DAILY
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.CONNECTED_DEVICES_WHEN_DELETING
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_FEATURE_PROMOTION_SOURCE
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_CODE_TYPE
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_CODE_VERSION
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_FLOW_VERSION
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_MY_KIND
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_MY_ROLE
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_PATH
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_PEER_KIND
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_REASON
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupFailureReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
 import com.duckduckgo.sync.impl.stats.SyncStatsRepository
 import com.duckduckgo.sync.store.SharedPrefsProvider
 import com.squareup.anvil.annotations.ContributesBinding
@@ -98,18 +116,80 @@ interface SyncPixels {
     fun fireUserSwitchedLoginError()
     fun fireTimeoutOnDeepLinkSetup()
     fun fireSyncBarcodeScreenShown(screenType: ScreenType)
-    fun fireSyncSetupFinishedSuccessfully(screenType: ScreenType)
-    fun fireSyncSetupAbandoned(screenType: ScreenType)
+    fun fireSyncSetupFinishedSuccessfully(
+        screenType: ScreenType,
+        path: SetupPath? = null,
+        myRole: SetupRole? = null,
+        peerKind: PeerKind? = null,
+    )
+    fun fireSyncSetupAbandoned(screenType: ScreenType, reason: CancellationReason? = null)
     fun fireSyncSetupManualCodeScreenShown(screenType: ScreenType)
-    fun fireSyncSetupCodePastedParseSuccess(screenType: ScreenType)
+    fun fireSyncSetupCodePastedParseSuccess(screenType: ScreenType, codeVersion: CodeVersion, codeType: SyncCodeType? = null)
     fun fireSyncSetupCodePastedParseFailure(screenType: ScreenType)
     fun fireSyncSetupCodeCopiedToClipboard(screenType: ScreenType)
     fun fireBarcodeScannerParseError(screenType: ScreenType)
-    fun fireBarcodeScannerParseSuccess(screenType: ScreenType)
+    fun fireBarcodeScannerParseSuccess(screenType: ScreenType, codeVersion: CodeVersion, codeType: SyncCodeType? = null)
+
+    /**
+     * "Setup failed" — a v2 setup that started (code recognized) then failed with an error (not a
+     * user cancellation). [path]/[myRole]/[peerKind] are best-effort and omitted when unknown.
+     */
+    fun fireSyncSetupFailed(
+        reason: SetupFailureReason,
+        path: SetupPath? = null,
+        myRole: SetupRole? = null,
+        peerKind: PeerKind? = null,
+    )
 
     enum class ScreenType(val value: String) {
         SYNC_CONNECT("connect"),
         SYNC_EXCHANGE("exchange"),
+    }
+
+    /** Protocol version of the code that was scanned/pasted, per the "Code recognized" telemetry. */
+    enum class CodeVersion(val value: String) {
+        V1("v1"),
+        V2("v2"),
+    }
+
+    /** Whether a successful setup was a recovery-code login or a device pairing. v2 only. */
+    enum class SetupPath(val value: String) {
+        RECOVERY("recovery"),
+        PAIRING("pairing"),
+    }
+
+    /** This device's elected role in a v2 pairing. */
+    enum class SetupRole(val value: String) {
+        HOST("host"),
+        JOINER("joiner"),
+    }
+
+    /** The peer device's credential kind in a v2 pairing. */
+    enum class PeerKind(val value: String) {
+        DDG("ddg"),
+        THIRD_PARTY("3party"),
+    }
+
+    /**
+     * Why a setup was cancelled, per the "Cancellation" telemetry. Based on the v2 protocol state at
+     * the moment of cancellation: [SCANNING_CANCELLED] before the exchange engages a peer,
+     * [CANCELLED_BEFORE_FINISHED] mid-exchange, [CONFIRMATION_DENIED] when this device denied the prompt.
+     */
+    enum class CancellationReason(val value: String) {
+        SCANNING_CANCELLED("scanning_cancelled"),
+        CONFIRMATION_DENIED("sync_confirmation_denied"),
+        CANCELLED_BEFORE_FINISHED("cancelled_before_finished"),
+    }
+
+    /** Why a v2 setup failed, per the "Setup failed" telemetry. Aligned with the error codes we handle. */
+    enum class SetupFailureReason(val value: String) {
+        NEEDS_UPGRADE("needs_upgrade"),
+        ALREADY_UPGRADED("already_upgraded"),
+        INVALID_CREDENTIALS("invalid_credentials"),
+        PAIRING_UNAVAILABLE("pairing_unavailable"),
+        PROTOCOL_ERROR("protocol_error"),
+        TRANSPORT_FAILURE("transport_failure"),
+        UNEXPECTED_FAILURE("unexpected_failure"),
     }
     fun fireSetupDeepLinkFlowStarted()
     fun fireSetupDeepLinkFlowSuccess()
@@ -145,10 +225,62 @@ class RealSyncPixels @Inject constructor(
     private val pixel: Pixel,
     private val statsRepository: SyncStatsRepository,
     private val sharedPrefsProvider: SharedPrefsProvider,
+    private val syncFeature: SyncFeature,
 ) : SyncPixels {
 
     private val preferences: SharedPreferences by lazy {
         sharedPrefsProvider.getSharedPrefs(SYNC_PIXELS_PREF_FILE)
+    }
+
+    /**
+     * Common metadata describing the setup flow this device is opening:
+     * - [SYNC_SETUP_FLOW_VERSION]: "v2" when the device is on the v2 connect/exchange stack
+     *   ([SyncFeature.canUseV2ConnectFlow]), "v1" otherwise. Independent of which code version is
+     *   actually displayed (that is gated separately by [SyncFeature.canShowV2ConnectCode]).
+     * - [SYNC_SETUP_MY_KIND]: always "ddg" — this is the native DuckDuckGo client.
+     */
+    private fun setupFlowMetadata(): Map<String, String> = mapOf(
+        SYNC_SETUP_FLOW_VERSION to if (syncFeature.canUseV2ConnectFlow().isEnabled()) FLOW_VERSION_V2 else FLOW_VERSION_V1,
+        SYNC_SETUP_MY_KIND to MY_KIND_DDG,
+    )
+
+    /**
+     * Params for the "Code recognized" pixels (scanner/manual-entry success): the screen [source],
+     * the recognized [codeVersion] (what was scanned/pasted), the common [setupFlowMetadata]
+     * (flow_version + my_kind), and — only when known — the [codeType]. The legacy/v1 path does not
+     * report a code type, so [codeType] is omitted there; the v2 path always supplies it.
+     */
+    private fun recognizedCodeParams(
+        screenType: ScreenType,
+        codeVersion: CodeVersion,
+        codeType: SyncCodeType?,
+    ): Map<String, String> = buildMap {
+        put(SYNC_SETUP_SCREEN_TYPE, screenType.value)
+        put(SYNC_SETUP_CODE_VERSION, codeVersion.value)
+        when (codeType) {
+            SyncCodeType.RECOVERY -> put(SYNC_SETUP_CODE_TYPE, CODE_TYPE_RECOVERY)
+            SyncCodeType.LINKING -> put(SYNC_SETUP_CODE_TYPE, CODE_TYPE_LINKING)
+            null -> {}
+        }
+        putAll(setupFlowMetadata())
+    }
+
+    /**
+     * Params for the "Setup success" pixel: the screen [source], the common [setupFlowMetadata]
+     * (flow_version + my_kind), and — v2 only — the [path] (recovery/pairing) plus, for pairing, the
+     * elected [myRole] and the [peerKind]. Each is omitted when null.
+     */
+    private fun setupSuccessParams(
+        screenType: ScreenType,
+        path: SetupPath?,
+        myRole: SetupRole?,
+        peerKind: PeerKind?,
+    ): Map<String, String> = buildMap {
+        put(SYNC_SETUP_SCREEN_TYPE, screenType.value)
+        if (path != null) put(SYNC_SETUP_PATH, path.value)
+        if (myRole != null) put(SYNC_SETUP_MY_ROLE, myRole.value)
+        if (peerKind != null) put(SYNC_SETUP_PEER_KIND, peerKind.value)
+        putAll(setupFlowMetadata())
     }
 
     override fun fireDailyPixel() {
@@ -378,32 +510,57 @@ class RealSyncPixels @Inject constructor(
     }
 
     override fun fireSyncBarcodeScreenShown(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value) + setupFlowMetadata()
         pixel.fire(SyncPixelName.SYNC_SETUP_BARCODE_SCREEN_SHOWN, parameters = params)
     }
 
-    override fun fireSyncSetupAbandoned(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+    override fun fireSyncSetupAbandoned(screenType: ScreenType, reason: CancellationReason?) {
+        val params = buildMap {
+            put(SYNC_SETUP_SCREEN_TYPE, screenType.value)
+            if (reason != null) put(SYNC_SETUP_REASON, reason.value)
+            putAll(setupFlowMetadata())
+        }
         pixel.fire(SyncPixelName.SYNC_SETUP_ENDED_ABANDONED, parameters = params)
     }
 
-    override fun fireSyncSetupFinishedSuccessfully(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+    override fun fireSyncSetupFinishedSuccessfully(
+        screenType: ScreenType,
+        path: SetupPath?,
+        myRole: SetupRole?,
+        peerKind: PeerKind?,
+    ) {
+        val params = setupSuccessParams(screenType, path, myRole, peerKind)
         pixel.fire(SyncPixelName.SYNC_SETUP_ENDED_SUCCESS, parameters = params)
     }
 
+    override fun fireSyncSetupFailed(
+        reason: SetupFailureReason,
+        path: SetupPath?,
+        myRole: SetupRole?,
+        peerKind: PeerKind?,
+    ) {
+        val params = buildMap {
+            put(SYNC_SETUP_REASON, reason.value)
+            if (path != null) put(SYNC_SETUP_PATH, path.value)
+            if (myRole != null) put(SYNC_SETUP_MY_ROLE, myRole.value)
+            if (peerKind != null) put(SYNC_SETUP_PEER_KIND, peerKind.value)
+            putAll(setupFlowMetadata())
+        }
+        pixel.fire(SyncPixelName.SYNC_SETUP_ENDED_FAILED, parameters = params)
+    }
+
     override fun fireSyncSetupManualCodeScreenShown(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value) + setupFlowMetadata()
         pixel.fire(SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTRY_SCREEN_SHOWN, parameters = params)
     }
 
-    override fun fireSyncSetupCodePastedParseSuccess(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+    override fun fireSyncSetupCodePastedParseSuccess(screenType: ScreenType, codeVersion: CodeVersion, codeType: SyncCodeType?) {
+        val params = recognizedCodeParams(screenType, codeVersion, codeType)
         pixel.fire(SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_SUCCESS, parameters = params)
     }
 
     override fun fireSyncSetupCodePastedParseFailure(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value) + setupFlowMetadata()
         pixel.fire(SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_FAILED, parameters = params)
     }
 
@@ -412,13 +569,13 @@ class RealSyncPixels @Inject constructor(
         pixel.fire(SyncPixelName.SYNC_SETUP_BARCODE_CODE_COPIED, parameters = params)
     }
 
-    override fun fireBarcodeScannerParseSuccess(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+    override fun fireBarcodeScannerParseSuccess(screenType: ScreenType, codeVersion: CodeVersion, codeType: SyncCodeType?) {
+        val params = recognizedCodeParams(screenType, codeVersion, codeType)
         pixel.fire(SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_SUCCESS, parameters = params)
     }
 
     override fun fireBarcodeScannerParseError(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value) + setupFlowMetadata()
         pixel.fire(SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_FAILED, parameters = params)
     }
 
@@ -506,6 +663,11 @@ class RealSyncPixels @Inject constructor(
 
     companion object {
         private const val SYNC_PIXELS_PREF_FILE = "com.duckduckgo.sync.pixels.v1"
+        private const val FLOW_VERSION_V1 = "v1"
+        private const val FLOW_VERSION_V2 = "v2"
+        private const val MY_KIND_DDG = "ddg"
+        private const val CODE_TYPE_RECOVERY = "recovery"
+        private const val CODE_TYPE_LINKING = "linking"
     }
 }
 
@@ -573,6 +735,7 @@ enum class SyncPixelName(override val pixelName: String) : Pixel.PixelName {
     SYNC_SETUP_MANUAL_CODE_ENTERED_FAILED("sync_setup_manual_code_entered_failed"),
     SYNC_SETUP_ENDED_ABANDONED("sync_setup_ended_abandoned"),
     SYNC_SETUP_ENDED_SUCCESS("sync_setup_ended_successful"),
+    SYNC_SETUP_ENDED_FAILED("sync_setup_ended_failed"),
     SYNC_USER_CONFIRMED_TO_TURN_OFF_SYNC("sync_disabled"),
     SYNC_USER_CONFIRMED_TO_TURN_OFF_SYNC_AND_DELETE("sync_disabledanddeleted"),
     SYNC_SETUP_PROMO_BOOKMARK_ADDED_DIALOG_SHOWN("sync_setup_promo_bookmark_added_dialog_shown"),
@@ -615,6 +778,14 @@ object SyncPixelParameters {
     const val SYNC_FEATURE_PROMOTION_SOURCE = "source"
     const val GET_OTHER_DEVICES_SCREEN_LAUNCH_SOURCE = "source"
     const val SYNC_SETUP_SCREEN_TYPE = "source"
+    const val SYNC_SETUP_FLOW_VERSION = "flow_version"
+    const val SYNC_SETUP_MY_KIND = "my_kind"
+    const val SYNC_SETUP_CODE_VERSION = "code_version"
+    const val SYNC_SETUP_CODE_TYPE = "code_type"
+    const val SYNC_SETUP_PATH = "path"
+    const val SYNC_SETUP_MY_ROLE = "my_role"
+    const val SYNC_SETUP_PEER_KIND = "peer_kind"
+    const val SYNC_SETUP_REASON = "reason"
     const val CONNECTED_DEVICES_WHEN_DELETING = "connected_devices"
 
     const val AUTO_RESTORE_SOURCE = "source"
@@ -642,5 +813,55 @@ object SyncPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
             SyncPixelName.SYNC_RESCOPE_TOKEN_FAILURE.pixelName to removeAtb(),
             SyncPixelName.SYNC_AI_CHAT_ACTIVE.pixelName to removeAtb(),
         )
+    }
+}
+
+/**
+ * Maps a v2 [com.duckduckgo.sync.impl.DispatchOutcome.Failed] error code to the "Setup failed"
+ * telemetry [SetupFailureReason], aligned with the error codes we already handle. Cancellation codes
+ * (`PAIRING_CANCELLED`, `PAIRING_REJECTED`) are excluded by the caller, so they fall to the catch-all.
+ */
+internal fun Int.toSetupFailureReason(): SetupFailureReason = when (this) {
+    AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED.code -> SetupFailureReason.ALREADY_UPGRADED
+    AccountErrorCodes.LOGIN_FAILED.code,
+    AccountErrorCodes.INVALID_CODE.code,
+    AccountErrorCodes.EXCHANGE_FAILED.code,
+    -> SetupFailureReason.INVALID_CREDENTIALS
+    AccountErrorCodes.PAIRING_UNAVAILABLE.code -> SetupFailureReason.PAIRING_UNAVAILABLE
+    AccountErrorCodes.NEGOTIATION_ABORTED.code,
+    AccountErrorCodes.NO_RECOVERY_CODE.code,
+    -> SetupFailureReason.PROTOCOL_ERROR
+    AccountErrorCodes.PAIRING_FAILED.code -> SetupFailureReason.TRANSPORT_FAILURE
+    else -> SetupFailureReason.UNEXPECTED_FAILURE
+}
+
+/**
+ * Fire the "Setup failed" pixel for a v2 error [outcome]. No-op for non-error outcomes. User
+ * cancellations (`PAIRING_CANCELLED`, `PAIRING_REJECTED`) are intentionally skipped — they are not
+ * setup errors (the latter pending the cancellation-telemetry follow-up).
+ */
+
+internal fun SyncPixels.fireSetupFailed(outcome: DispatchOutcome) {
+    when (outcome) {
+        is DispatchOutcome.UpgradeRequired ->
+            fireSyncSetupFailed(SetupFailureReason.NEEDS_UPGRADE, outcome.path, outcome.myRole, outcome.peerKind)
+        is DispatchOutcome.Failed -> {
+            if (outcome.code == AccountErrorCodes.PAIRING_CANCELLED.code || outcome.code == AccountErrorCodes.PAIRING_REJECTED.code) {
+                return
+            }
+            fireSyncSetupFailed(outcome.code.toSetupFailureReason(), outcome.path, outcome.myRole, outcome.peerKind)
+        }
+        else -> {}
+    }
+}
+
+/**
+ * Fire the "Cancellation" pixel (sync_setup_ended_abandoned) when a v2 outcome is this device's own
+ * confirmation denial ([AccountErrorCodes.PAIRING_CANCELLED]). Peer denials (`PAIRING_REJECTED`) are
+ * intentionally ignored — the peer reports its own cancel. No-op for any other outcome.
+ */
+internal fun SyncPixels.fireSetupCancelledIfDenied(outcome: DispatchOutcome, screenType: SyncPixels.ScreenType) {
+    if (outcome is DispatchOutcome.Failed && outcome.code == AccountErrorCodes.PAIRING_CANCELLED.code) {
+        fireSyncSetupAbandoned(screenType, CancellationReason.CONFIRMATION_DENIED)
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.databinding.ActivityEnterCodeBinding
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState.Idle
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState.Loading
@@ -113,6 +114,8 @@ class EnterCodeActivity : DuckDuckGoActivity() {
                 showError(command)
             }
 
+            is Command.ShowV2Error -> showV2PairingError(command.content) { viewModel.onErrorDialogDismissed() }
+
             is AskToSwitchAccount -> askUserToSwitchAccount(command)
             SwitchAccountSuccess -> {
                 val resultIntent = Intent()
@@ -120,7 +123,41 @@ class EnterCodeActivity : DuckDuckGoActivity() {
                 setResult(RESULT_OK, resultIntent)
                 finish()
             }
+            is Command.AskJoinerConfirmation -> askJoinerConfirmation(command.peerName, command.peerKind)
+            is Command.AskHostConfirmation -> askHostConfirmation(command.peerName, command.peerKind)
+            Command.FinishWithError -> {
+                setResult(RESULT_CANCELED)
+                finish()
+            }
         }
+    }
+
+    private fun askJoinerConfirmation(peerName: String?, peerKind: PeerKind?) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_joiner_confirmation_title)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
+            .setPositiveButton(R.string.sync_v2_joiner_confirmation_positive)
+            .setNegativeButton(R.string.sync_v2_joiner_confirmation_negative)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() { viewModel.onJoinerConfirmed() }
+                    override fun onNegativeButtonClicked() { viewModel.onJoinerDenied() }
+                },
+            ).show()
+    }
+
+    private fun askHostConfirmation(peerName: String?, peerKind: PeerKind?) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_host_confirmation_title)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
+            .setPositiveButton(R.string.sync_v2_host_confirmation_positive)
+            .setNegativeButton(R.string.sync_v2_host_confirmation_negative)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() { viewModel.onHostConfirmed() }
+                    override fun onNegativeButtonClicked() { viewModel.onHostDenied() }
+                },
+            ).show()
     }
 
     private fun showError(it: ShowError) {
@@ -130,8 +167,7 @@ class EnterCodeActivity : DuckDuckGoActivity() {
             .setPositiveButton(R.string.sync_dialog_error_ok)
             .addEventListener(
                 object : TextAlertDialogBuilder.EventListener() {
-                    override fun onPositiveButtonClicked() {
-                    }
+                    override fun onPositiveButtonClicked() { viewModel.onErrorDialogDismissed() }
                 },
             ).show()
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
@@ -27,20 +27,29 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.CONNECT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.CREATE_ACCOUNT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.INVALID_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED
 import com.duckduckgo.sync.impl.Clipboard
+import com.duckduckgo.sync.impl.DispatchOutcome
 import com.duckduckgo.sync.impl.ExchangeResult.AccountSwitchingRequired
 import com.duckduckgo.sync.impl.ExchangeResult.LoggedIn
 import com.duckduckgo.sync.impl.ExchangeResult.Pending
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.RouteDecision
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode
+import com.duckduckgo.sync.impl.SyncCodeDispatcher
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.onFailure
 import com.duckduckgo.sync.impl.onSuccess
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
+import com.duckduckgo.sync.impl.pixels.fireSetupFailed
 import com.duckduckgo.sync.impl.ui.EnterCodeActivity.Companion.Code
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.AskToSwitchAccount
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.LoginSuccess
@@ -52,8 +61,10 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import logcat.logcat
 import javax.inject.*
 
 @ContributesViewModel(ActivityScope::class)
@@ -63,6 +74,7 @@ class EnterCodeViewModel @Inject constructor(
     private val dispatchers: DispatcherProvider,
     private val syncFeature: SyncFeature,
     private val syncPixels: SyncPixels,
+    private val codeDispatcher: SyncCodeDispatcher,
 ) : ViewModel() {
 
     private val command = Channel<Command>(1, DROP_OLDEST)
@@ -89,6 +101,15 @@ class EnterCodeViewModel @Inject constructor(
         data class AskToSwitchAccount(val encodedStringCode: String) : Command()
         data class ShowError(@StringRes val message: Int, val reason: String = "") : Command()
         data object SwitchAccountSuccess : Command()
+
+        /** v2 §"Exchange Confirmations": prompt user "Sync your data with [peerName]?". */
+        data class AskJoinerConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
+
+        /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
+        data class AskHostConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
+
+        data object FinishWithError : Command()
+        internal data class ShowV2Error(val content: V2PairingErrorContent) : Command()
     }
 
     fun onPasteCodeClicked() {
@@ -103,22 +124,78 @@ class EnterCodeViewModel @Inject constructor(
         pastedCode: String,
     ) {
         val previousPrimaryKey = syncAccountRepository.getAccountInfo().primaryKey
-        val codeType = syncAccountRepository.parseSyncAuthCode(pastedCode).also { it.onCodePasted() }
-        when (val result = syncAccountRepository.processCode(codeType)) {
-            is Result.Success -> {
-                if (codeType is SyncAuthCode.Exchange) {
-                    pollForRecoveryKey(previousPrimaryKey = previousPrimaryKey, code = pastedCode)
-                } else {
-                    onLoginSuccess(previousPrimaryKey)
+        // FF off → Legacy (v1 path below); FF on → v2 codes surface as DispatchOutcome.
+        when (val decision = codeDispatcher.route(pastedCode)) {
+            is RouteDecision.Legacy -> {
+                logcat { "Sync-CodeDispatch: EnterCodeViewModel handling Legacy(${decision.authCode::class.simpleName})" }
+                val codeType = decision.authCode.also { it.onCodePasted() }
+                when (val result = syncAccountRepository.processCode(codeType)) {
+                    is Result.Success -> {
+                        if (codeType is SyncAuthCode.Exchange) {
+                            pollForRecoveryKey(previousPrimaryKey = previousPrimaryKey, code = pastedCode)
+                        } else {
+                            onLoginSuccess(previousPrimaryKey)
+                        }
+                    }
+                    is Result.Error -> {
+                        processError(result, pastedCode)
+                    }
                 }
             }
-            is Result.Error -> {
-                processError(result, pastedCode)
+            is RouteDecision.V2InProgress -> {
+                logcat { "Sync-CodeDispatch: EnterCodeViewModel observing V2InProgress" }
+                syncPixels.fireSyncSetupCodePastedParseSuccess(codeType.asScreenType(), CodeVersion.V2, decision.codeType)
+                decision.outcomes.collect { outcome -> handleV2Outcome(outcome, previousPrimaryKey) }
             }
         }
     }
 
-    private suspend fun onLoginSuccess(previousPrimaryKey: String) {
+    /** Map a v2 [DispatchOutcome] onto the same command/error hooks the v1 path uses. */
+    private suspend fun handleV2Outcome(
+        outcome: DispatchOutcome,
+        previousPrimaryKey: String,
+    ) {
+        syncPixels.fireSetupFailed(outcome)
+        when (outcome) {
+            is DispatchOutcome.LoggedIn -> onLoginSuccess(previousPrimaryKey, outcome.path, outcome.myRole, outcome.peerKind)
+            is DispatchOutcome.AlreadyConnected -> {
+                viewState.value = viewState.value.copy(authState = AuthState.Idle)
+                command.send(Command.ShowV2Error(v2AlreadyPairedError))
+            }
+            is DispatchOutcome.UpgradeRequired -> {
+                viewState.value = viewState.value.copy(authState = AuthState.Idle)
+                logcat { "Sync v2: upgrade required, peer needs protocol v${outcome.codeMajor}" }
+                command.send(Command.ShowV2Error(v2UpgradeRequiredError))
+            }
+            is DispatchOutcome.Failed -> {
+                viewState.value = viewState.value.copy(authState = AuthState.Idle)
+                command.send(Command.ShowV2Error(outcome.code.toV2PairingError()))
+            }
+            is DispatchOutcome.JoinerConfirmationRequested ->
+                command.send(Command.AskJoinerConfirmation(outcome.peerName, outcome.peerKind))
+            is DispatchOutcome.HostConfirmationRequested ->
+                command.send(Command.AskHostConfirmation(outcome.peerName, outcome.peerKind))
+            is DispatchOutcome.LinkingCodeReady -> {} // No-op; used only by presentV2() flow
+        }
+    }
+
+    fun onJoinerConfirmed() { codeDispatcher.confirmJoiner() }
+    fun onJoinerDenied() { codeDispatcher.denyJoiner() }
+    fun onHostConfirmed() { codeDispatcher.confirmHost() }
+    fun onHostDenied() { codeDispatcher.denyHost() }
+
+    fun onErrorDialogDismissed() {
+        viewModelScope.launch(dispatchers.io()) {
+            command.send(Command.FinishWithError)
+        }
+    }
+
+    private suspend fun onLoginSuccess(
+        previousPrimaryKey: String,
+        path: SetupPath? = null,
+        myRole: SetupRole? = null,
+        peerKind: PeerKind? = null,
+    ) {
         val postProcessCodePK = syncAccountRepository.getAccountInfo().primaryKey
         val userSwitchedAccount = previousPrimaryKey.isNotBlank() && previousPrimaryKey != postProcessCodePK
         val commandSuccess = if (userSwitchedAccount) {
@@ -127,6 +204,9 @@ class EnterCodeViewModel @Inject constructor(
         } else {
             LoginSuccess
         }
+        // Owns the "Setup success" pixel for codes entered here; the launching screen fires only its
+        // login pixel on the result, so this does not double-count.
+        syncPixels.fireSyncSetupFinishedSuccessfully(codeType.asScreenType(), path, myRole, peerKind)
         command.send(commandSuccess)
     }
 
@@ -178,6 +258,8 @@ class EnterCodeViewModel @Inject constructor(
                 CONNECT_FAILED.code -> R.string.sync_connect_generic_error
                 CREATE_ACCOUNT_FAILED.code -> R.string.sync_create_account_generic_error
                 INVALID_CODE.code -> R.string.sync_invalid_code_error
+                // 3party→ddg upgrade on an already-upgraded account; generic error for now. (follow-up: 1215295182909247)
+                THIRD_PARTY_ALREADY_UPGRADED.code -> R.string.sync_connect_generic_error
                 else -> null
             }?.let { message ->
                 viewState.value = viewState.value.copy(authState = AuthState.Idle)
@@ -235,7 +317,7 @@ class EnterCodeViewModel @Inject constructor(
     private fun SyncAuthCode.onCodePasted() {
         when (this) {
             is SyncAuthCode.Unknown -> syncPixels.fireSyncSetupCodePastedParseFailure(codeType.asScreenType())
-            else -> syncPixels.fireSyncSetupCodePastedParseSuccess(codeType.asScreenType())
+            else -> syncPixels.fireSyncSetupCodePastedParseSuccess(codeType.asScreenType(), CodeVersion.V1)
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectActivity.kt
@@ -37,8 +37,11 @@ import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.databinding.ActivityConnectSyncBinding
 import com.duckduckgo.sync.impl.databinding.ActivityConnectSyncNewBinding
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.ui.EnterCodeActivity.Companion.Code.CONNECT_CODE
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command
+import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.AskHostConfirmation
+import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.AskJoinerConfirmation
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.FinishWithError
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.LoginSuccess
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.ReadTextCode
@@ -129,6 +132,8 @@ class SyncConnectActivity : DuckDuckGoActivity() {
     private fun observeUiEvents() {
         viewModel
             .viewState(extractSource())
+            // Observe at CREATED, not STARTED: STARTED re-subscribes on every foreground, re-firing
+            // viewState.onStart and regenerating the pairing code. CREATED also avoids dropping terminal commands.
             .flowWithLifecycle(lifecycle, Lifecycle.State.CREATED)
             .onEach { render(it) }
             .launchIn(lifecycleScope)
@@ -165,6 +170,9 @@ class SyncConnectActivity : DuckDuckGoActivity() {
 
             is ShowMessage -> Snackbar.make(binding.root, it.messageId, Snackbar.LENGTH_SHORT).show()
             is ShowError -> showError(it)
+            is Command.ShowV2Error -> showV2PairingError(it.content) { viewModel.onErrorDialogDismissed() }
+            is AskJoinerConfirmation -> askJoinerConfirmation(it.peerName, it.peerKind)
+            is AskHostConfirmation -> askHostConfirmation(it.peerName, it.peerKind)
         }
     }
 
@@ -187,6 +195,34 @@ class SyncConnectActivity : DuckDuckGoActivity() {
                     override fun onPositiveButtonClicked() {
                         viewModel.onErrorDialogDismissed()
                     }
+                },
+            ).show()
+    }
+
+    private fun askJoinerConfirmation(peerName: String?, peerKind: PeerKind?) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_joiner_confirmation_title)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
+            .setPositiveButton(R.string.sync_v2_joiner_confirmation_positive)
+            .setNegativeButton(R.string.sync_v2_joiner_confirmation_negative)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() { viewModel.onJoinerConfirmed() }
+                    override fun onNegativeButtonClicked() { viewModel.onJoinerDenied() }
+                },
+            ).show()
+    }
+
+    private fun askHostConfirmation(peerName: String?, peerKind: PeerKind?) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_host_confirmation_title)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
+            .setPositiveButton(R.string.sync_v2_host_confirmation_positive)
+            .setNegativeButton(R.string.sync_v2_host_confirmation_negative)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() { viewModel.onHostConfirmed() }
+                    override fun onNegativeButtonClicked() { viewModel.onHostDenied() }
                 },
             ).show()
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.CREATE_ACCOUNT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.INVALID_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
 import com.duckduckgo.sync.impl.Clipboard
+import com.duckduckgo.sync.impl.DispatchOutcome
 import com.duckduckgo.sync.impl.ExchangeResult.AccountSwitchingRequired
 import com.duckduckgo.sync.impl.ExchangeResult.LoggedIn
 import com.duckduckgo.sync.impl.ExchangeResult.Pending
@@ -37,15 +38,23 @@ import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.R.dimen
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.impl.RouteDecision
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode
 import com.duckduckgo.sync.impl.SyncAuthCode.Exchange
 import com.duckduckgo.sync.impl.SyncAuthCode.Unknown
+import com.duckduckgo.sync.impl.SyncCodeDispatcher
+import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.getOrNull
 import com.duckduckgo.sync.impl.onFailure
 import com.duckduckgo.sync.impl.onSuccess
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_CONNECT
+import com.duckduckgo.sync.impl.pixels.fireSetupCancelledIfDenied
+import com.duckduckgo.sync.impl.pixels.fireSetupFailed
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.FinishWithError
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.LoginSuccess
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.ReadTextCode
@@ -70,9 +79,17 @@ class SyncConnectViewModel @Inject constructor(
     private val clipboard: Clipboard,
     private val syncPixels: SyncPixels,
     private val dispatchers: DispatcherProvider,
+    private val syncFeature: SyncFeature,
+    private val codeDispatcher: SyncCodeDispatcher,
 ) : ViewModel() {
     private val command = Channel<Command>(1, DROP_OLDEST)
     fun commands(): Flow<Command> = command.receiveAsFlow()
+
+    // Cached v2 linking code so onCopyCodeClicked can return it for the v2 path. Null on the v1 path.
+    private var v2LinkingCode: String? = null
+
+    // Start the session exactly once per ViewModel instance.
+    private var sessionStarted = false
 
     private val viewState = MutableStateFlow(ViewState())
     fun viewState(source: String?): Flow<ViewState> = viewState.onStart {
@@ -80,7 +97,19 @@ class SyncConnectViewModel @Inject constructor(
     }
 
     private fun pollConnectionKeys(source: String?) {
+        if (sessionStarted) return
+        sessionStarted = true
         viewModelScope.launch(dispatchers.io()) {
+            // Don't start a fresh v2 session for a user already signed in via EnterCode while this
+            // activity is mid-finish (onStart can re-fire before onLoginSuccess() finishes it).
+            if (syncAccountRepository.getAccountInfo().isSignedIn) {
+                logcat { "Sync: SyncConnect already signed in; skipping new session" }
+                return@launch
+            }
+            if (shouldUseV2()) {
+                startV2Present()
+                return@launch
+            }
             showQRCode()
             var polling = true
             while (polling) {
@@ -102,6 +131,47 @@ class SyncConnectViewModel @Inject constructor(
                     }
             }
         }
+    }
+
+    private fun shouldUseV2(): Boolean =
+        syncFeature.canUseV2ConnectFlow().isEnabled() &&
+            syncFeature.canShowV2ConnectCode().isEnabled()
+
+    /** Drive a v2 Presenter session via the dispatcher. Role election may elect this device Host or Joiner. */
+    private suspend fun startV2Present() {
+        codeDispatcher.presentV2().collect { handleV2Outcome(it) }
+    }
+
+    /** Map one v2 [DispatchOutcome] onto this VM's command pipeline. Shared by the Presenter and Scanner paths. */
+    private suspend fun handleV2Outcome(outcome: DispatchOutcome) {
+        syncPixels.fireSetupFailed(outcome)
+        syncPixels.fireSetupCancelledIfDenied(outcome, SYNC_CONNECT)
+        when (outcome) {
+            is DispatchOutcome.LinkingCodeReady -> renderV2QrCode(outcome.linkingCode)
+            is DispatchOutcome.HostConfirmationRequested -> command.send(Command.AskHostConfirmation(outcome.peerName, outcome.peerKind))
+            is DispatchOutcome.JoinerConfirmationRequested -> command.send(Command.AskJoinerConfirmation(outcome.peerName, outcome.peerKind))
+            is DispatchOutcome.LoggedIn -> {
+                syncPixels.fireLoginPixel()
+                syncPixels.fireSyncSetupFinishedSuccessfully(SYNC_CONNECT, outcome.path, outcome.myRole, outcome.peerKind)
+                command.send(LoginSuccess)
+            }
+            is DispatchOutcome.AlreadyConnected ->
+                command.send(Command.ShowV2Error(v2AlreadyPairedError))
+            is DispatchOutcome.UpgradeRequired -> {
+                logcat { "Sync v2: upgrade required, peer needs protocol v${outcome.codeMajor}" }
+                command.send(Command.ShowV2Error(v2UpgradeRequiredError))
+            }
+            is DispatchOutcome.Failed ->
+                command.send(Command.ShowV2Error(outcome.code.toV2PairingError()))
+        }
+    }
+
+    private suspend fun renderV2QrCode(linkingCode: String) {
+        v2LinkingCode = linkingCode
+        val bitmap = withContext(dispatchers.io()) {
+            qrEncoder.encodeAsBitmap(linkingCode, dimen.qrSizeSmall, dimen.qrSizeSmall)
+        }
+        viewState.emit(viewState.value.copy(qrCodeBitmap = bitmap))
     }
 
     private suspend fun pollForRecoveryKey() {
@@ -149,6 +219,13 @@ class SyncConnectViewModel @Inject constructor(
 
     fun onCopyCodeClicked() {
         viewModelScope.launch(dispatchers.io()) {
+            val v2Code = v2LinkingCode
+            if (v2Code != null) {
+                clipboard.copyToClipboard(v2Code)
+                command.send(ShowMessage(R.string.sync_code_copied_message))
+                syncPixels.fireSyncSetupCodeCopiedToClipboard(SYNC_CONNECT)
+                return@launch
+            }
             syncAccountRepository.getConnectQR().getOrNull()?.let { code ->
                 logcat { "Sync: code available for sharing manually: $code" }
                 clipboard.copyToClipboard(code.rawCode)
@@ -168,6 +245,14 @@ class SyncConnectViewModel @Inject constructor(
         data class ShowMessage(val messageId: Int) : Command()
         data object FinishWithError : Command()
         data class ShowError(@StringRes val message: Int, val reason: String = "") : Command()
+
+        /** v2 §"Exchange Confirmations": prompt user "Sync your data with [peerName]?". */
+        data class AskJoinerConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
+
+        /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
+        data class AskHostConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
+
+        internal data class ShowV2Error(val content: V2PairingErrorContent) : Command()
     }
 
     fun onReadTextCodeClicked() {
@@ -178,19 +263,29 @@ class SyncConnectViewModel @Inject constructor(
 
     fun onQRCodeScanned(qrCode: String) {
         viewModelScope.launch(dispatchers.io()) {
-            val codeType = syncAccountRepository.parseSyncAuthCode(qrCode).also { it.onCodeScanned() }
-            when (val result = syncAccountRepository.processCode(codeType)) {
-                is Error -> {
-                    processError(result)
-                }
+            // Route via SyncCodeDispatcher: FF off → Legacy (v1 path unchanged); FF on → v2 codes surface via DispatchOutcome.
+            when (val decision = codeDispatcher.route(qrCode)) {
+                is RouteDecision.Legacy -> {
+                    val codeType = decision.authCode.also { it.onCodeScanned() }
+                    when (val result = syncAccountRepository.processCode(codeType)) {
+                        is Error -> {
+                            processError(result)
+                        }
 
-                is Success -> {
-                    if (codeType is Exchange) {
-                        pollForRecoveryKey()
-                    } else {
-                        fireLoginPixels()
-                        command.send(LoginSuccess)
+                        is Success -> {
+                            if (codeType is Exchange) {
+                                pollForRecoveryKey()
+                            } else {
+                                fireLoginPixels()
+                                command.send(LoginSuccess)
+                            }
+                        }
                     }
+                }
+                is RouteDecision.V2InProgress -> {
+                    logcat { "Sync-CodeDispatch: SyncConnectViewModel observing V2InProgress" }
+                    syncPixels.fireBarcodeScannerParseSuccess(SYNC_CONNECT, CodeVersion.V2, decision.codeType)
+                    decision.outcomes.collect { handleV2Outcome(it) }
                 }
             }
         }
@@ -201,7 +296,12 @@ class SyncConnectViewModel @Inject constructor(
     }
 
     fun onUserCancelledWithoutSyncSetup() {
-        syncPixels.fireSyncSetupAbandoned(SYNC_CONNECT)
+        val reason = if (codeDispatcher.isV2ExchangeUnderway()) {
+            CancellationReason.CANCELLED_BEFORE_FINISHED
+        } else {
+            CancellationReason.SCANNING_CANCELLED
+        }
+        syncPixels.fireSyncSetupAbandoned(SYNC_CONNECT, reason)
     }
 
     private suspend fun processError(result: Error) {
@@ -219,10 +319,17 @@ class SyncConnectViewModel @Inject constructor(
 
     fun onLoginSuccess() {
         viewModelScope.launch {
-            fireLoginPixels()
+            // Manual code entry: EnterCodeViewModel fires the "Setup success" pixel (it has the v2
+            // path/role/peer); here we only fire the login pixel to avoid double-counting.
+            syncPixels.fireLoginPixel()
             command.send(LoginSuccess)
         }
     }
+
+    fun onJoinerConfirmed() { codeDispatcher.confirmJoiner() }
+    fun onJoinerDenied() { codeDispatcher.denyJoiner() }
+    fun onHostConfirmed() { codeDispatcher.confirmHost() }
+    fun onHostDenied() { codeDispatcher.denyHost() }
 
     private fun fireLoginPixels() {
         syncPixels.fireLoginPixel()
@@ -232,7 +339,7 @@ class SyncConnectViewModel @Inject constructor(
     private fun SyncAuthCode.onCodeScanned() {
         when (this) {
             is Unknown -> syncPixels.fireBarcodeScannerParseError(SYNC_CONNECT)
-            else -> syncPixels.fireBarcodeScannerParseSuccess(SYNC_CONNECT)
+            else -> syncPixels.fireBarcodeScannerParseSuccess(SYNC_CONNECT, CodeVersion.V1)
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginActivity.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.databinding.ActivityLoginSyncBinding
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.ui.EnterCodeActivity.Companion.Code.RECOVERY_CODE
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command.Error
@@ -95,7 +96,38 @@ class SyncLoginActivity : DuckDuckGoActivity() {
             }
 
             is ShowError -> showError(it)
+            is Command.ShowV2Error -> showV2PairingError(it.content) { viewModel.onErrorDialogDismissed() }
+            is Command.AskJoinerConfirmation -> askJoinerConfirmation(it.peerName, it.peerKind)
+            is Command.AskHostConfirmation -> askHostConfirmation(it.peerName, it.peerKind)
         }
+    }
+
+    private fun askJoinerConfirmation(peerName: String?, peerKind: PeerKind?) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_joiner_confirmation_title)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
+            .setPositiveButton(R.string.sync_v2_joiner_confirmation_positive)
+            .setNegativeButton(R.string.sync_v2_joiner_confirmation_negative)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() { viewModel.onJoinerConfirmed() }
+                    override fun onNegativeButtonClicked() { viewModel.onJoinerDenied() }
+                },
+            ).show()
+    }
+
+    private fun askHostConfirmation(peerName: String?, peerKind: PeerKind?) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_host_confirmation_title)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
+            .setPositiveButton(R.string.sync_v2_host_confirmation_positive)
+            .setNegativeButton(R.string.sync_v2_host_confirmation_negative)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() { viewModel.onHostConfirmed() }
+                    override fun onNegativeButtonClicked() { viewModel.onHostDenied() }
+                },
+            ).show()
     }
 
     private fun configureListeners() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
@@ -27,17 +27,22 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.CONNECT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.CREATE_ACCOUNT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.INVALID_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
+import com.duckduckgo.sync.impl.DispatchOutcome
 import com.duckduckgo.sync.impl.ExchangeResult.AccountSwitchingRequired
 import com.duckduckgo.sync.impl.ExchangeResult.LoggedIn
 import com.duckduckgo.sync.impl.ExchangeResult.Pending
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.impl.RouteDecision
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode
+import com.duckduckgo.sync.impl.SyncCodeDispatcher
 import com.duckduckgo.sync.impl.onFailure
 import com.duckduckgo.sync.impl.onSuccess
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import com.duckduckgo.sync.impl.pixels.fireSetupFailed
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Companion.POLLING_INTERVAL_EXCHANGE_FLOW
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command.LoginSucess
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command.ReadTextCode
@@ -46,8 +51,10 @@ import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.launch
+import logcat.logcat
 import javax.inject.*
 
 @ContributesViewModel(ActivityScope::class)
@@ -55,6 +62,7 @@ class SyncLoginViewModel @Inject constructor(
     private val syncAccountRepository: SyncAccountRepository,
     private val syncPixels: SyncPixels,
     private val dispatchers: DispatcherProvider,
+    private val codeDispatcher: SyncCodeDispatcher,
 ) : ViewModel() {
     private val command = Channel<Command>(1, DROP_OLDEST)
     fun commands(): Flow<Command> = command.receiveAsFlow()
@@ -64,6 +72,14 @@ class SyncLoginViewModel @Inject constructor(
         data object LoginSucess : Command()
         data object Error : Command()
         data class ShowError(@StringRes val message: Int, val reason: String = "") : Command()
+
+        /** v2 §"Exchange Confirmations": prompt user "Sync your data with [peerName]?". */
+        data class AskJoinerConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
+
+        /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
+        data class AskHostConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
+
+        internal data class ShowV2Error(val content: V2PairingErrorContent) : Command()
     }
 
     fun onReadTextCodeClicked() {
@@ -87,23 +103,61 @@ class SyncLoginViewModel @Inject constructor(
 
     fun onQRCodeScanned(qrCode: String) {
         viewModelScope.launch(dispatchers.io()) {
-            val codeType = syncAccountRepository.parseSyncAuthCode(qrCode)
-            when (val result = syncAccountRepository.processCode(codeType)) {
-                is Error -> {
-                    processError(result)
-                }
-
-                is Success -> {
-                    if (codeType is SyncAuthCode.Exchange) {
-                        pollForRecoveryKey()
-                    } else {
-                        syncPixels.fireLoginPixel()
-                        command.send(LoginSucess)
+            // FF off → Legacy runs the existing v1 control flow; FF on → v2 codes surface via DispatchOutcome.
+            when (val decision = codeDispatcher.route(qrCode)) {
+                is RouteDecision.Legacy -> {
+                    logcat { "Sync-CodeDispatch: SyncLoginViewModel handling Legacy(${decision.authCode::class.simpleName})" }
+                    val codeType = decision.authCode
+                    when (val result = syncAccountRepository.processCode(codeType)) {
+                        is Error -> processError(result)
+                        is Success -> {
+                            if (codeType is SyncAuthCode.Exchange) {
+                                pollForRecoveryKey()
+                            } else {
+                                syncPixels.fireLoginPixel()
+                                command.send(LoginSucess)
+                            }
+                        }
                     }
+                }
+                is RouteDecision.V2InProgress -> {
+                    logcat { "Sync-CodeDispatch: SyncLoginViewModel observing V2InProgress" }
+                    decision.outcomes.collect { outcome -> handleV2Outcome(outcome) }
                 }
             }
         }
     }
+
+    /** Map one v2 [DispatchOutcome] onto this VM's existing command pipeline. */
+    private suspend fun handleV2Outcome(outcome: DispatchOutcome) {
+        syncPixels.fireSetupFailed(outcome)
+        when (outcome) {
+            is DispatchOutcome.LoggedIn -> {
+                syncPixels.fireLoginPixel()
+                command.send(LoginSucess)
+            }
+            is DispatchOutcome.AlreadyConnected ->
+                command.send(Command.ShowV2Error(v2AlreadyPairedError))
+            is DispatchOutcome.UpgradeRequired -> {
+                logcat { "Sync v2: upgrade required, peer needs protocol v${outcome.codeMajor}" }
+                command.send(Command.ShowV2Error(v2UpgradeRequiredError))
+            }
+            is DispatchOutcome.Failed -> {
+                val content = outcome.code.toV2PairingError()
+                command.send(Command.ShowV2Error(content))
+            }
+            is DispatchOutcome.JoinerConfirmationRequested ->
+                command.send(Command.AskJoinerConfirmation(outcome.peerName, outcome.peerKind))
+            is DispatchOutcome.HostConfirmationRequested ->
+                command.send(Command.AskHostConfirmation(outcome.peerName, outcome.peerKind))
+            is DispatchOutcome.LinkingCodeReady -> {} // No-op; used only by presentV2() flow
+        }
+    }
+
+    fun onJoinerConfirmed() { codeDispatcher.confirmJoiner() }
+    fun onJoinerDenied() { codeDispatcher.denyJoiner() }
+    fun onHostConfirmed() { codeDispatcher.confirmHost() }
+    fun onHostDenied() { codeDispatcher.denyHost() }
 
     private suspend fun processError(result: Error) {
         when (result.code) {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncV2ConfirmationCopy.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncV2ConfirmationCopy.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui
+
+import android.content.Context
+import androidx.annotation.StringRes
+import com.duckduckgo.sync.impl.R
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+
+@StringRes
+internal fun syncV2ConfirmationMessageRes(
+    unknownPeer: Boolean,
+    peerKind: PeerKind?,
+): Int {
+    val thirdParty = peerKind == PeerKind.THIRD_PARTY
+    return when {
+        unknownPeer && thirdParty -> R.string.sync_v2_confirmation_message_unknown_peer_3p
+        unknownPeer -> R.string.sync_v2_confirmation_message_unknown_peer_ddg
+        thirdParty -> R.string.sync_v2_confirmation_message_3p
+        else -> R.string.sync_v2_confirmation_message_ddg
+    }
+}
+
+internal fun Context.syncV2ConfirmationMessage(
+    peerName: String?,
+    peerKind: PeerKind?,
+): String {
+    val res = syncV2ConfirmationMessageRes(unknownPeer = peerName.isNullOrBlank(), peerKind = peerKind)
+    return if (peerName.isNullOrBlank()) getString(res) else getString(res, peerName)
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.CREATE_ACCOUNT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.INVALID_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
 import com.duckduckgo.sync.impl.Clipboard
+import com.duckduckgo.sync.impl.DispatchOutcome
 import com.duckduckgo.sync.impl.ExchangeResult.AccountSwitchingRequired
 import com.duckduckgo.sync.impl.ExchangeResult.LoggedIn
 import com.duckduckgo.sync.impl.ExchangeResult.Pending
@@ -38,15 +39,24 @@ import com.duckduckgo.sync.impl.R.dimen
 import com.duckduckgo.sync.impl.R.string
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.impl.RouteDecision
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAccountRepository.AuthCode
 import com.duckduckgo.sync.impl.SyncAuthCode
 import com.duckduckgo.sync.impl.SyncAuthCode.Unknown
+import com.duckduckgo.sync.impl.SyncCodeDispatcher
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.onFailure
 import com.duckduckgo.sync.impl.onSuccess
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_EXCHANGE
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
+import com.duckduckgo.sync.impl.pixels.fireSetupCancelledIfDenied
+import com.duckduckgo.sync.impl.pixels.fireSetupFailed
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Companion.POLLING_INTERVAL_EXCHANGE_FLOW
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.AskToSwitchAccount
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.FinishWithError
@@ -77,6 +87,7 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
     private val syncPixels: SyncPixels,
     private val dispatchers: DispatcherProvider,
     private val syncFeature: SyncFeature,
+    private val codeDispatcher: SyncCodeDispatcher,
 ) : ViewModel() {
     private val command = Channel<Command>(1, DROP_OLDEST)
     fun commands(): Flow<Command> = command.receiveAsFlow()
@@ -89,6 +100,10 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
     private var canTimeout = false
     private var isDeepLink = false
 
+    // viewState.onStart re-fires on every re-collection; guard so the session starts once and
+    // re-fires don't regenerate the invitation/channel, orphaning the code the user already shared.
+    private var sessionStarted = false
+
     private val viewState = MutableStateFlow(ViewState())
     fun viewState(isDeepLink: Boolean = false): Flow<ViewState> = viewState.onStart {
         this@SyncWithAnotherActivityViewModel.canTimeout = isDeepLink
@@ -97,7 +112,13 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
     }
 
     private fun startExchangeProcess() {
+        if (sessionStarted) return
+        sessionStarted = true
         viewModelScope.launch(dispatchers.io()) {
+            if (shouldUseV2()) {
+                startV2Present()
+                return@launch
+            }
             showQRCode()
             var polling = syncFeature.exchangeKeysToSyncWithAnotherDevice().isEnabled()
             val startTime = System.currentTimeMillis()
@@ -128,6 +149,29 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
                     }
             }
         }
+    }
+
+    private fun shouldUseV2(): Boolean =
+        syncFeature.canUseV2ConnectFlow().isEnabled() &&
+            syncFeature.canShowV2ConnectCode().isEnabled()
+
+    /** Drive a v2 Presenter session via the dispatcher. On this signed-in surface role election elects Host. */
+    private suspend fun startV2Present() {
+        val previousPrimaryKey = syncAccountRepository.getAccountInfo().primaryKey
+        codeDispatcher.presentV2().collect { outcome ->
+            when (outcome) {
+                is DispatchOutcome.LinkingCodeReady -> renderV2QrCode(outcome.linkingCode)
+                else -> handleV2Outcome(outcome, previousPrimaryKey)
+            }
+        }
+    }
+
+    private suspend fun renderV2QrCode(linkingCode: String) {
+        barcodeContents = AuthCode(qrCode = linkingCode, rawCode = linkingCode)
+        val bitmap = withContext(dispatchers.io()) {
+            qrEncoder.encodeAsBitmap(linkingCode, dimen.qrSizeSmall, dimen.qrSizeSmall)
+        }
+        viewState.emit(viewState.value.copy(qrCodeBitmap = bitmap))
     }
 
     private suspend fun showQRCode() {
@@ -183,6 +227,14 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
         ) : Command()
 
         data class AskToSwitchAccount(val encodedStringCode: String) : Command()
+
+        /** v2 §"Exchange Confirmations": prompt user "Sync your data with [peerName]?". */
+        data class AskJoinerConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
+
+        /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
+        data class AskHostConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
+
+        internal data class ShowV2Error(val content: V2PairingErrorContent) : Command()
     }
 
     fun onReadTextCodeClicked() {
@@ -200,29 +252,89 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
     fun onQRCodeScanned(qrCode: String) {
         viewModelScope.launch(dispatchers.io()) {
             val previousPrimaryKey = syncAccountRepository.getAccountInfo().primaryKey
-            val codeType = syncAccountRepository.parseSyncAuthCode(qrCode).also { it.onCodeScanned() }
-            when (val result = syncAccountRepository.processCode(codeType)) {
-                is Error -> {
-                    logcat(WARN) { "Sync: error processing code ${result.reason}" }
-                    emitError(result, qrCode)
-                }
+            // Route via SyncCodeDispatcher. FF off → Legacy(parseSyncAuthCode(...)); FF on →
+            // v2-shaped codes are taken into ownership and surfaced through DispatchOutcome.
+            when (val decision = codeDispatcher.route(qrCode)) {
+                is RouteDecision.Legacy -> {
+                    logcat { "Sync-CodeDispatch: SyncWithAnotherActivityViewModel handling Legacy(${decision.authCode::class.simpleName})" }
+                    val codeType = decision.authCode.also { it.onCodeScanned() }
+                    when (val result = syncAccountRepository.processCode(codeType)) {
+                        is Error -> {
+                            logcat(WARN) { "Sync: error processing code ${result.reason}" }
+                            emitError(result, qrCode)
+                        }
 
-                is Success -> {
-                    if (codeType is SyncAuthCode.Exchange) {
-                        pollForRecoveryKey(previousPrimaryKey = previousPrimaryKey, qrCode = qrCode)
-                    } else {
-                        // Show recovery screen if QR scanned is Connect and user was not previously logged in (empty PK)
-                        val showRecovery = codeType is SyncAuthCode.Connect && previousPrimaryKey.isEmpty()
-                        onLoginSuccess(previousPrimaryKey, showRecovery)
+                        is Success -> {
+                            if (codeType is SyncAuthCode.Exchange) {
+                                pollForRecoveryKey(previousPrimaryKey = previousPrimaryKey, qrCode = qrCode)
+                            } else {
+                                // Show recovery screen if QR scanned is Connect and user was not previously logged in (empty PK)
+                                val showRecovery = codeType is SyncAuthCode.Connect && previousPrimaryKey.isEmpty()
+                                onLoginSuccess(previousPrimaryKey, showRecovery)
+                            }
+                        }
                     }
+                }
+                is RouteDecision.V2InProgress -> {
+                    logcat { "Sync-CodeDispatch: SyncWithAnotherActivityViewModel observing V2InProgress" }
+                    if (!isDeepLink) {
+                        syncPixels.fireBarcodeScannerParseSuccess(SYNC_EXCHANGE, CodeVersion.V2, decision.codeType)
+                    }
+                    decision.outcomes.collect { handleV2Outcome(it, previousPrimaryKey) }
                 }
             }
         }
     }
 
-    private suspend fun onLoginSuccess(previousPrimaryKey: String, showRecovery: Boolean) {
+    /** Map one v2 [DispatchOutcome] onto this VM's existing command pipeline. */
+    private suspend fun handleV2Outcome(
+        outcome: DispatchOutcome,
+        previousPrimaryKey: String,
+    ) {
+        syncPixels.fireSetupFailed(outcome)
+        syncPixels.fireSetupCancelledIfDenied(outcome, SYNC_EXCHANGE)
+        // Cancel the deep-link timeout only on terminal outcomes; keep it running across confirmation prompts.
+        when (outcome) {
+            is DispatchOutcome.LoggedIn -> {
+                cancelTimeout()
+                val showRecovery = previousPrimaryKey.isEmpty()
+                onLoginSuccess(previousPrimaryKey, showRecovery, outcome.path, outcome.myRole, outcome.peerKind)
+            }
+            is DispatchOutcome.AlreadyConnected -> {
+                cancelTimeout()
+                command.send(Command.ShowV2Error(v2AlreadyPairedError))
+            }
+            is DispatchOutcome.UpgradeRequired -> {
+                cancelTimeout()
+                logcat { "Sync v2: upgrade required, peer needs protocol v${outcome.codeMajor}" }
+                command.send(Command.ShowV2Error(v2UpgradeRequiredError))
+            }
+            is DispatchOutcome.Failed -> {
+                cancelTimeout()
+                command.send(Command.ShowV2Error(outcome.code.toV2PairingError()))
+            }
+            is DispatchOutcome.JoinerConfirmationRequested ->
+                command.send(Command.AskJoinerConfirmation(outcome.peerName, outcome.peerKind))
+            is DispatchOutcome.HostConfirmationRequested ->
+                command.send(Command.AskHostConfirmation(outcome.peerName, outcome.peerKind))
+            is DispatchOutcome.LinkingCodeReady -> {} // No-op; used only by presentV2() flow
+        }
+    }
+
+    fun onJoinerConfirmed() { codeDispatcher.confirmJoiner() }
+    fun onJoinerDenied() { codeDispatcher.denyJoiner() }
+    fun onHostConfirmed() { codeDispatcher.confirmHost() }
+    fun onHostDenied() { codeDispatcher.denyHost() }
+
+    private suspend fun onLoginSuccess(
+        previousPrimaryKey: String,
+        showRecovery: Boolean,
+        path: SetupPath? = null,
+        myRole: SetupRole? = null,
+        peerKind: PeerKind? = null,
+    ) {
         val postProcessCodePK = syncAccountRepository.getAccountInfo().primaryKey
-        fireLoginPixels()
+        fireLoginPixels(path, myRole, peerKind)
         val userSwitchedAccount = previousPrimaryKey.isNotBlank() && previousPrimaryKey != postProcessCodePK
         val commandSuccess = if (userSwitchedAccount) {
             syncPixels.fireUserSwitchedAccount()
@@ -233,13 +345,17 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
         command.send(commandSuccess)
     }
 
-    private fun fireLoginPixels() {
+    private fun fireLoginPixels(
+        path: SetupPath? = null,
+        myRole: SetupRole? = null,
+        peerKind: PeerKind? = null,
+    ) {
         syncPixels.fireLoginPixel()
 
         if (isDeepLink) {
             syncPixels.fireSetupDeepLinkFlowSuccess()
         } else {
-            syncPixels.fireSyncSetupFinishedSuccessfully(SYNC_EXCHANGE)
+            syncPixels.fireSyncSetupFinishedSuccessfully(SYNC_EXCHANGE, path, myRole, peerKind)
         }
     }
 
@@ -327,11 +443,12 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
             when (result) {
                 EnterCodeContractOutput.Error -> {}
                 EnterCodeContractOutput.LoginSuccess -> {
-                    fireLoginPixels()
+                    // Manual entry: EnterCodeViewModel fires "Setup success"; only fire login pixel here.
+                    syncPixels.fireLoginPixel()
                     command.send(LoginSuccess(showRecovery = true))
                 }
                 EnterCodeContractOutput.SwitchAccountSuccess -> {
-                    fireLoginPixels()
+                    syncPixels.fireLoginPixel()
                     command.send(SwitchAccountSuccess)
                 }
             }
@@ -354,7 +471,12 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
         if (isDeepLink) {
             syncPixels.fireSetupDeepLinkFlowAbandoned()
         } else {
-            syncPixels.fireSyncSetupAbandoned(SYNC_EXCHANGE)
+            val reason = if (codeDispatcher.isV2ExchangeUnderway()) {
+                CancellationReason.CANCELLED_BEFORE_FINISHED
+            } else {
+                CancellationReason.SCANNING_CANCELLED
+            }
+            syncPixels.fireSyncSetupAbandoned(SYNC_EXCHANGE, reason)
         }
     }
 
@@ -363,7 +485,7 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
 
         when (this) {
             is Unknown -> syncPixels.fireBarcodeScannerParseError(SYNC_EXCHANGE)
-            else -> syncPixels.fireBarcodeScannerParseSuccess(SYNC_EXCHANGE)
+            else -> syncPixels.fireBarcodeScannerParseSuccess(SYNC_EXCHANGE, CodeVersion.V1)
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.databinding.ActivityConnectSyncBinding
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.ui.EnterCodeActivity.Companion.Code.RECOVERY_CODE
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.AskToSwitchAccount
@@ -114,6 +115,8 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
     private fun observeUiEvents() {
         viewModel
             .viewState(isDeepLink = isDeepLinkSetup())
+            // Observe at CREATED, not STARTED: STARTED re-subscribes on every foreground, re-firing
+            // viewState.onStart and regenerating the pairing code. CREATED also avoids dropping terminal commands.
             .flowWithLifecycle(lifecycle, Lifecycle.State.CREATED)
             .onEach { render(it) }
             .launchIn(lifecycleScope)
@@ -154,6 +157,7 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
 
             is ShowMessage -> Snackbar.make(binding.root, it.messageId, Snackbar.LENGTH_SHORT).show()
             is ShowError -> showError(it)
+            is Command.ShowV2Error -> showV2PairingError(it.content) { viewModel.onErrorDialogDismissed() }
             is AskToSwitchAccount -> askUserToSwitchAccount(it)
             SwitchAccountSuccess -> {
                 val resultIntent = Intent()
@@ -161,7 +165,37 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
                 setResult(RESULT_OK, resultIntent)
                 finish()
             }
+            is Command.AskJoinerConfirmation -> askJoinerConfirmation(it.peerName, it.peerKind)
+            is Command.AskHostConfirmation -> askHostConfirmation(it.peerName, it.peerKind)
         }
+    }
+
+    private fun askJoinerConfirmation(peerName: String?, peerKind: PeerKind?) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_joiner_confirmation_title)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
+            .setPositiveButton(R.string.sync_v2_joiner_confirmation_positive)
+            .setNegativeButton(R.string.sync_v2_joiner_confirmation_negative)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() { viewModel.onJoinerConfirmed() }
+                    override fun onNegativeButtonClicked() { viewModel.onJoinerDenied() }
+                },
+            ).show()
+    }
+
+    private fun askHostConfirmation(peerName: String?, peerKind: PeerKind?) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_host_confirmation_title)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
+            .setPositiveButton(R.string.sync_v2_host_confirmation_positive)
+            .setNegativeButton(R.string.sync_v2_host_confirmation_negative)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() { viewModel.onHostConfirmed() }
+                    override fun onNegativeButtonClicked() { viewModel.onHostDenied() }
+                },
+            ).show()
     }
 
     private fun configureListeners() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/V2PairingError.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/V2PairingError.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui
+
+import android.content.Context
+import androidx.annotation.StringRes
+import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED
+import com.duckduckgo.sync.impl.R
+
+/** Dialog copy for a v2 pairing terminal outcome. A null [message] renders a title-only dialog. */
+internal data class V2PairingErrorContent(
+    @StringRes val title: Int,
+    @StringRes val message: Int?,
+)
+
+/**
+ * Maps a v2 pairing [com.duckduckgo.sync.impl.DispatchOutcome.Failed] error code to dialog copy.
+ */
+internal fun Int.toV2PairingError(): V2PairingErrorContent = when (this) {
+    PAIRING_REJECTED.code -> V2PairingErrorContent(
+        title = R.string.sync_v2_error_pairing_rejected,
+        message = R.string.sync_v2_error_try_again,
+    )
+    PAIRING_CANCELLED.code -> V2PairingErrorContent(
+        title = R.string.sync_v2_error_pairing_canceled,
+        message = null,
+    )
+    THIRD_PARTY_ALREADY_UPGRADED.code -> V2PairingErrorContent(
+        title = R.string.sync_v2_error_pairing_failed,
+        message = R.string.sync_v2_error_third_party_already_upgraded,
+    )
+    else -> V2PairingErrorContent(
+        title = R.string.sync_v2_error_pairing_failed,
+        message = R.string.sync_v2_error_try_again,
+    )
+}
+
+/** Fixed copy for [com.duckduckgo.sync.impl.DispatchOutcome.UpgradeRequired] */
+internal val v2UpgradeRequiredError = V2PairingErrorContent(
+    title = R.string.sync_v2_error_upgrade_required,
+    message = null,
+)
+
+/** Fixed copy for the same-account [com.duckduckgo.sync.impl.DispatchOutcome.AlreadyConnected] outcome. */
+internal val v2AlreadyPairedError = V2PairingErrorContent(
+    title = R.string.sync_v2_already_paired_title,
+    message = R.string.sync_v2_already_paired_message,
+)
+
+/**
+ * Renders a v2 pairing error dialog: the scenario line as the title, an optional supporting
+ * [V2PairingErrorContent.message].
+ */
+internal fun Context.showV2PairingError(
+    content: V2PairingErrorContent,
+    onDismissed: () -> Unit,
+) {
+    TextAlertDialogBuilder(this)
+        .setTitle(content.title)
+        .apply { content.message?.let { setMessage(it) } }
+        .setPositiveButton(R.string.sync_v2_error_got_it)
+        .addEventListener(
+            object : TextAlertDialogBuilder.EventListener() {
+                override fun onPositiveButtonClicked() {
+                    onDismissed()
+                }
+            },
+        )
+        .show()
+}

--- a/sync/sync-impl/src/main/res/values/donottranslate.xml
+++ b/sync/sync-impl/src/main/res/values/donottranslate.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
+    <string name="sync_v2_joiner_confirmation_title">Sync your data?</string>
+    <string name="sync_v2_joiner_confirmation_positive">Sync Now</string>
+    <string name="sync_v2_joiner_confirmation_negative">Cancel</string>
+
+    <string name="sync_v2_host_confirmation_title">Sync your data?</string>
+    <string name="sync_v2_host_confirmation_positive">Sync Now</string>
+    <string name="sync_v2_host_confirmation_negative">Cancel</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">\"%1$s\" will be able to access your synced DuckDuckGo passwords, autofill data, and Duck.ai chats.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">\"%1$s\" will be able to access your synced Duck.ai chats.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">The other device will be able to access your synced DuckDuckGo passwords, autofill data, and Duck.ai chats.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">The other device will be able to access your synced Duck.ai chats.</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
+    <string name="sync_v2_error_pairing_failed">Sync failed.</string>
+    <string name="sync_v2_error_pairing_rejected">Sync canceled from your other device.</string>
+    <string name="sync_v2_error_pairing_canceled">Sync canceled.</string>
+    <string name="sync_v2_error_upgrade_required">Update the DuckDuckGo browser and try again.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Please Sync this device from an already-connected DuckDuckGo browser on another device</string>
+    <string name="sync_v2_error_try_again">Please try again.</string>
+    <string name="sync_v2_error_got_it">Got It</string>
+    <string name="sync_v2_already_paired_title">Already synced.</string>
+    <string name="sync_v2_already_paired_message">These devices are already connected to Sync &amp; Backup.</string>
+</resources>

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/AppSyncDeviceIdsTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/AppSyncDeviceIdsTest.kt
@@ -112,7 +112,6 @@ class AppSyncDeviceIdsTest {
             override var secretKey: String? = "secretKey"
             override var credentialId: String? = null
             override var scopedPassword: ScopedPassword? = null
-            override var protectedKeysJson: String? = null
             override fun isEncryptionSupported() = true
 
             override fun isSignedInFlow() = emptyFlow<Boolean>()
@@ -147,7 +146,6 @@ class AppSyncDeviceIdsTest {
             override var secretKey: String? = null
             override var credentialId: String? = null
             override var scopedPassword: ScopedPassword? = null
-            override var protectedKeysJson: String? = null
             override fun isEncryptionSupported() = true
 
             override fun isSignedInFlow() = emptyFlow<Boolean>()

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
@@ -1167,7 +1167,6 @@ class AppSyncAccountRepositoryTest {
 
         assertEquals(Success(true), result)
         verify(syncStore, times(0)).credentialId = any()
-        verify(syncStore, times(0)).protectedKeysJson = any()
     }
 
     @Test
@@ -1202,7 +1201,6 @@ class AppSyncAccountRepositoryTest {
         assertEquals(Success(true), result)
         verify(syncStore).credentialId = "ddg"
         verify(syncStore).scopedPassword = ScopedPassword("/+//")
-        verify(syncStore).protectedKeysJson = any()
     }
 
     @Test

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ProtectedKeyManagerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ProtectedKeyManagerTest.kt
@@ -91,23 +91,76 @@ class ProtectedKeyManagerTest {
         whenever(syncJweCrypto.generateRsaKeyPair()).thenReturn(RsaKeyPair("pubKey", "cHJpdktleQ"))
         whenever(syncJweCrypto.extractJwkComponents(anyString())).thenReturn("modulus" to "AQAB")
         whenever(nativeLib.encryptData(any<ByteArray>(), eq(secretKey))).thenReturn(EncryptBytesResult(0, "encrypted".toByteArray()))
-        whenever(syncApi.setProtectedKeyIfAbsent(eq(token), eq("ai_chats"), any())).thenReturn(Success(true))
+        // Happy path: server's response contains our entry (we wrote it).
+        val serverKey = ProtectedKeyEntry(
+            kid = "server-kid",
+            purpose = "ai_chats",
+            encryptedWith = "ddg",
+            encryptedPrivateKey = "encrypted",
+            publicKey = RsaJwk(n = "modulus", e = "AQAB"),
+        )
+        whenever(syncApi.setProtectedKeyIfAbsent(eq(token), eq("ai_chats"), any())).thenReturn(Success(listOf(serverKey)))
 
         val result = manager.create("ai_chats")
 
         assertTrue(result is Success)
-        // create() returns the created entry, not a bare boolean.
-        assertEquals("ai_chats", (result as Success).data.purpose)
-        assertEquals("ddg", result.data.encryptedWith)
+        // create() returns the server's authoritative entry, not the local one.
+        assertEquals(serverKey, (result as Success).data)
         verify(syncApi).setProtectedKeyIfAbsent(
             eq(token),
             eq("ai_chats"),
             check { sent ->
-                assertEquals("ai_chats", sent.purpose)
-                assertEquals("ddg", sent.encryptedWith)
-                assertEquals(RsaJwk(n = "modulus", e = "AQAB"), sent.publicKey)
+                assertEquals(1, sent.size)
+                val first = sent.first()
+                assertEquals("ai_chats", first.purpose)
+                assertEquals("ddg", first.encryptedWith)
+                assertEquals(RsaJwk(n = "modulus", e = "AQAB"), first.publicKey)
             },
         )
+    }
+
+    @Test
+    fun whenSetProtectedKeyIfAbsentReturnsExistingServerEntryThenCreateReturnsServerEntry() {
+        // Race-loser: server returns a different kid for the same (purpose, encrypted_with).
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+        whenever(syncStore.secretKey).thenReturn(secretKey)
+        whenever(nativeLib.prepareForLogin(primaryKey)).thenReturn(validLoginKeys)
+        whenever(syncJweCrypto.generateRsaKeyPair()).thenReturn(RsaKeyPair("pubKey", "cHJpdktleQ"))
+        whenever(syncJweCrypto.extractJwkComponents(anyString())).thenReturn("modulus" to "AQAB")
+        whenever(nativeLib.encryptData(any<ByteArray>(), eq(secretKey))).thenReturn(EncryptBytesResult(0, "encrypted".toByteArray()))
+        val serverKey = ProtectedKeyEntry(
+            kid = "kid-from-server",
+            purpose = "ai_chats",
+            encryptedWith = "ddg",
+            encryptedPrivateKey = "server-jwe",
+            publicKey = RsaJwk(n = "server-modulus", e = "AQAB"),
+        )
+        whenever(syncApi.setProtectedKeyIfAbsent(eq(token), eq("ai_chats"), any())).thenReturn(Success(listOf(serverKey)))
+
+        val result = manager.create("ai_chats")
+
+        assertTrue(result is Success)
+        assertEquals(serverKey, (result as Success).data)
+    }
+
+    @Test
+    fun whenServerResponseMissingPurposeEntryThenError() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+        whenever(syncStore.secretKey).thenReturn(secretKey)
+        whenever(nativeLib.prepareForLogin(primaryKey)).thenReturn(validLoginKeys)
+        whenever(syncJweCrypto.generateRsaKeyPair()).thenReturn(RsaKeyPair("pubKey", "cHJpdktleQ"))
+        whenever(syncJweCrypto.extractJwkComponents(anyString())).thenReturn("modulus" to "AQAB")
+        whenever(nativeLib.encryptData(any<ByteArray>(), eq(secretKey))).thenReturn(EncryptBytesResult(0, "encrypted".toByteArray()))
+        // Server returns a list that doesn't include an entry for our (purpose, ddg) slot.
+        whenever(syncApi.setProtectedKeyIfAbsent(eq(token), eq("ai_chats"), any())).thenReturn(Success(emptyList()))
+
+        val result = manager.create("ai_chats")
+
+        assertTrue(result is Error)
     }
 
     @Test

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONObject
+import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertSame
@@ -195,6 +196,33 @@ class RealSyncCodeDispatcherTest {
         assertEquals(DispatchOutcome.LoggedIn, outcomes.single())
     }
 
+    @Test fun `FF on, v2 RecoveryCode cid=ddg - base64url secret is normalised to standard base64 for v1 login`() = runTest {
+        // Spec 1214802412121967: the v2 wire `secret` is base64url. Android's native v1 login
+        // (SyncNativeLib.decodeKey) decodes the primary_key as STANDARD base64, so the dispatcher
+        // must convert at the v2->v1 boundary. A base64url secret from a conformant peer (macOS/
+        // iOS/FE) fed verbatim to prepareForLogin throws "bad base-64" (LOGIN_FAILED). Same key
+        // bytes, different alphabet.
+        setV2(true)
+        val base64urlSecret = "rUzlGqLLlbonAC_zIeh1nrCmuDsDAn6UooUUDz-6x3o" // spec example: base64url, has '_' and '-'
+        val expectedBytes = java.util.Base64.getUrlDecoder().decode(base64urlSecret)
+        val rawJson = JSONObject().apply {
+            put("user_id", "u-1")
+            put("secret", base64urlSecret)
+            put("cid", "ddg")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
+
+        (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.toList()
+
+        val captor = org.mockito.kotlin.argumentCaptor<SyncAuthCode>()
+        verify(syncAccountRepository).processCode(captor.capture(), anyOrNull())
+        val primaryKey = (captor.firstValue as SyncAuthCode.Recovery).b64Code.primaryKey
+        assertFalse("primaryKey must be standard base64 (no '-'): $primaryKey", primaryKey.contains('-'))
+        assertFalse("primaryKey must be standard base64 (no '_'): $primaryKey", primaryKey.contains('_'))
+        assertArrayEquals(expectedBytes, java.util.Base64.getDecoder().decode(primaryKey))
+    }
+
     @Test fun `FF on, v2 RecoveryCode cid=ddg with missing user_id - emits Failed without calling processCode`() = runTest {
         setV2(true)
         val rawJson = JSONObject().apply {
@@ -264,9 +292,10 @@ class RealSyncCodeDispatcherTest {
         // calls logoutAndJoinNewAccount with a re-encoded v1-shape recovery code and emits
         // LoggedIn (success) without bubbling AccountSwitchingRequired up to the VM.
         setV2(true)
+        val base64urlSecret = "rUzlGqLLlbonAC_zIeh1nrCmuDsDAn6UooUUDz-6x3o" // spec base64url secret
         val rawJson = JSONObject().apply {
             put("user_id", "u-other")
-            put("secret", "s-other")
+            put("secret", base64urlSecret)
             put("cid", "ddg")
         }
         whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
@@ -284,12 +313,15 @@ class RealSyncCodeDispatcherTest {
 
         // Verify the v1-shape recovery code passed to logoutAndJoinNewAccount: base64url-encoded
         // JSON with primary_key+user_id (so the v1-only parseSyncAuthCode inside the repo can
-        // re-parse it).
+        // re-parse it). The primary_key is the secret normalised to STANDARD base64 (v1 form).
         val captor = org.mockito.kotlin.argumentCaptor<String>()
         verify(syncAccountRepository).logoutAndJoinNewAccount(captor.capture())
         val decoded = java.util.Base64.getUrlDecoder().decode(captor.firstValue)
         val recovery = JSONObject(String(decoded)).getJSONObject("recovery")
-        assertEquals("s-other", recovery.getString("primary_key"))
+        assertArrayEquals(
+            java.util.Base64.getUrlDecoder().decode(base64urlSecret),
+            java.util.Base64.getDecoder().decode(recovery.getString("primary_key")),
+        )
         assertEquals("u-other", recovery.getString("user_id"))
     }
 
@@ -382,7 +414,7 @@ class RealSyncCodeDispatcherTest {
         setV2(true)
         val rawJson = JSONObject().apply {
             put("user_id", "u")
-            put("secret", "s")
+            put("secret", "AQID") // valid base64 so we reach processCode (the error path under test)
             put("cid", "ddg")
         }
         whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
@@ -509,6 +541,57 @@ class RealSyncCodeDispatcherTest {
         // an empty SharedFlow in this test). We just verify startScan was hit on first collection.
         kotlinx.coroutines.withTimeoutOrNull(50) { decision.outcomes.first() }
         verify(runner).startScan(eq("v2-url"))
+    }
+
+    @Test fun `FF on, LinkingV2 exchange - base64url recovery secret is normalised to standard base64 for v1 login`() = runTest {
+        // The actual macOS↔Android failure: Joiner reaches Done with a RecoveryCodeResponse whose
+        // payload carries a base64url secret (spec 1214802412121967). loginWithV2RecoveryCode must
+        // normalise it to standard base64 before the native v1 login, or prepareForLogin throws
+        // "bad base-64" (LOGIN_FAILED). Same key bytes, different alphabet.
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
+        val base64urlSecret = "rUzlGqLLlbonAC_zIeh1nrCmuDsDAn6UooUUDz-6x3o" // spec example: base64url, has '_' and '-'
+        val payloadJson = JSONObject().apply {
+            put(
+                "recovery",
+                JSONObject().apply {
+                    put("user_id", "u-1")
+                    put("secret", base64urlSecret)
+                    put("cid", "ddg")
+                    put("v", "2.0")
+                },
+            )
+        }.toString()
+        val recoveryCodeB64 = java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(payloadJson.toByteArray())
+
+        val flow = (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { flow.take(1).toList() }
+        runnerEventsFlow.emit(
+            ExchangeV2Event.Transition(
+                timestampMs = System.currentTimeMillis(),
+                from = ExchangeV2State.Joiner.Waiting,
+                to = ExchangeV2State.Joiner.Done,
+                trigger = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse(
+                    rawJson = payloadJson,
+                    recoveryCode = recoveryCodeB64,
+                ),
+                localTrigger = null,
+            ),
+        )
+        job.join()
+
+        val captor = org.mockito.kotlin.argumentCaptor<SyncAuthCode>()
+        verify(syncAccountRepository).processCode(captor.capture(), anyOrNull())
+        val primaryKey = (captor.firstValue as SyncAuthCode.Recovery).b64Code.primaryKey
+        assertFalse("primaryKey must be standard base64 (no '-'): $primaryKey", primaryKey.contains('-'))
+        assertFalse("primaryKey must be standard base64 (no '_'): $primaryKey", primaryKey.contains('_'))
+        assertArrayEquals(
+            java.util.Base64.getUrlDecoder().decode(base64urlSecret),
+            java.util.Base64.getDecoder().decode(primaryKey),
+        )
     }
 
     // ---- presentV2() — Presenter-side mapping ----

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
@@ -58,15 +58,9 @@ class RealSyncCodeDispatcherTest {
     private val syncAccountRepository: SyncAccountRepository = mock()
     private val qrCode: ExchangeV2QrCode = mock()
 
-    // Backing flow that the mocked runner exposes through `events`/`eventsSince`. Keeping it as a
-    // standalone reference (rather than reading `mock.events` inside answer lambdas) avoids a
-    // Mockito matcher-state issue where re-entrant getter calls during answer dispatch cause
-    // ArrayIndexOutOfBoundsException on `invocation.getArgument`.
     private val runnerEventsFlow = MutableSharedFlow<com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event>(replay = 0)
     private val runner: ExchangeV2Runner = mock<ExchangeV2Runner>().also {
         whenever(it.events).thenReturn(runnerEventsFlow)
-        // Mockito doesn't call interface default methods automatically; wire eventsSince to
-        // match the default impl on the interface (filter by timestamp).
         whenever(it.eventsSince(any())).thenAnswer { invocation ->
             val sinceMs = invocation.getArgument<Long>(0)
             runnerEventsFlow.filter { event -> event.timestampMs >= sinceMs }
@@ -84,8 +78,6 @@ class RealSyncCodeDispatcherTest {
         whenever(syncFeature.canUseV2ConnectFlow()).thenReturn(canUseV2)
         whenever(canUseV2.isEnabled()).thenReturn(enabled)
     }
-
-    // ---- FF off: byte-identical to direct parseSyncAuthCode ----
 
     @Test fun `FF off - returns Legacy with whatever parseSyncAuthCode returned, and never touches qrCode parse`() {
         setV2(false)
@@ -129,9 +121,6 @@ class RealSyncCodeDispatcherTest {
     }
 
     @Test fun `FF off - even a v2-shaped code is routed via legacy parseSyncAuthCode (no v2 parser touched)`() {
-        // Critical safety property: when FF is off, v2 detection is COMPLETELY skipped.
-        // A v2 code pasted under FF off becomes Unknown via parseSyncAuthCode - same as
-        // production behaviour today.
         setV2(false)
         whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(SyncAuthCode.Unknown("v2-shaped-input"))
 
@@ -140,8 +129,6 @@ class RealSyncCodeDispatcherTest {
         verify(qrCode, never()).parse(any())
         verify(syncAccountRepository).parseSyncAuthCode("https://duckduckgo.com/sync/pairing/#&code2=anything")
     }
-
-    // ---- FF on: v1 shapes still go through legacy stack ----
 
     @Test fun `FF on but v2 parser returns LinkingV1 - falls back to legacy stack`() {
         setV2(true)
@@ -164,8 +151,6 @@ class RealSyncCodeDispatcherTest {
 
         assertSame(recovery, decision.authCode)
     }
-
-    // ---- FF on: v2 paths take ownership ----
 
     @Test fun `FF on, v2 LinkingV2 - returns V2InProgress and does NOT call parseSyncAuthCode`() {
         setV2(true)
@@ -197,13 +182,9 @@ class RealSyncCodeDispatcherTest {
     }
 
     @Test fun `FF on, v2 RecoveryCode cid=ddg - base64url secret is normalised to standard base64 for v1 login`() = runTest {
-        // Spec 1214802412121967: the v2 wire `secret` is base64url. Android's native v1 login
-        // (SyncNativeLib.decodeKey) decodes the primary_key as STANDARD base64, so the dispatcher
-        // must convert at the v2->v1 boundary. A base64url secret from a conformant peer (macOS/
-        // iOS/FE) fed verbatim to prepareForLogin throws "bad base-64" (LOGIN_FAILED). Same key
-        // bytes, different alphabet.
+        // Spec 1214802412121967: the v2 wire `secret` is base64url; v1 login decodes as standard base64.
         setV2(true)
-        val base64urlSecret = "rUzlGqLLlbonAC_zIeh1nrCmuDsDAn6UooUUDz-6x3o" // spec example: base64url, has '_' and '-'
+        val base64urlSecret = "rUzlGqLLlbonAC_zIeh1nrCmuDsDAn6UooUUDz-6x3o"
         val expectedBytes = java.util.Base64.getUrlDecoder().decode(base64urlSecret)
         val rawJson = JSONObject().apply {
             put("user_id", "u-1")
@@ -228,7 +209,7 @@ class RealSyncCodeDispatcherTest {
         val rawJson = JSONObject().apply {
             put("secret", "s-1")
             put("cid", "ddg")
-        } // no user_id
+        }
         whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
 
         val decision = dispatcher.route("any") as RouteDecision.V2InProgress
@@ -257,9 +238,6 @@ class RealSyncCodeDispatcherTest {
     }
 
     @Test fun `FF on, v2 RecoveryCode cid=3party - re-encoded code is canonical JSON without escaped slashes`() = runTest {
-        // Real 3party secrets are base64url (slash-free), but the re-wrapped code handed to
-        // joinAccountFromThirdPartyRecoveryCode must never carry AOSP org.json '\/' escaping should
-        // any field contain '/'. Defence-in-depth, consistent with the other v2 wire-JSON producers.
         setV2(true)
         val secretWithSlashes = "apZ+7PAe89rDhuG4DRyi/M3zU2/D5DZNdRsR3RM6Ujw="
         val rawJson = JSONObject().apply {
@@ -277,7 +255,6 @@ class RealSyncCodeDispatcherTest {
         verify(syncAccountRepository).joinAccountFromThirdPartyRecoveryCode(captor.capture())
         val decodedJson = String(java.util.Base64.getUrlDecoder().decode(captor.firstValue), Charsets.UTF_8)
         assertFalse("re-wrapped 3party JSON must not contain escaped slashes (\\/): $decodedJson", decodedJson.contains("\\/"))
-        // …and the wrapped recovery must round-trip back to the original fields.
         val recovery = JSONObject(decodedJson).getJSONObject("recovery")
         assertEquals(secretWithSlashes, recovery.getString("secret"))
         assertEquals("u-3p", recovery.getString("user_id"))
@@ -286,13 +263,8 @@ class RealSyncCodeDispatcherTest {
     }
 
     @Test fun `FF on, v2 RecoveryCode cid=ddg - ALREADY_SIGNED_IN triggers logoutAndJoinNewAccount and emits LoggedIn`() = runTest {
-        // Per spec, the v2 path does NOT surface a v1-style AskToSwitchAccount prompt - the
-        // Confirmations phase (or the act of pasting a recovery code) is already the consent
-        // step. So when processCode reports ALREADY_SIGNED_IN, the dispatcher transparently
-        // calls logoutAndJoinNewAccount with a re-encoded v1-shape recovery code and emits
-        // LoggedIn (success) without bubbling AccountSwitchingRequired up to the VM.
         setV2(true)
-        val base64urlSecret = "rUzlGqLLlbonAC_zIeh1nrCmuDsDAn6UooUUDz-6x3o" // spec base64url secret
+        val base64urlSecret = "rUzlGqLLlbonAC_zIeh1nrCmuDsDAn6UooUUDz-6x3o"
         val rawJson = JSONObject().apply {
             put("user_id", "u-other")
             put("secret", base64urlSecret)
@@ -311,9 +283,6 @@ class RealSyncCodeDispatcherTest {
 
         assertEquals(DispatchOutcome.LoggedIn, outcome)
 
-        // Verify the v1-shape recovery code passed to logoutAndJoinNewAccount: base64url-encoded
-        // JSON with primary_key+user_id (so the v1-only parseSyncAuthCode inside the repo can
-        // re-parse it). The primary_key is the secret normalised to STANDARD base64 (v1 form).
         val captor = org.mockito.kotlin.argumentCaptor<String>()
         verify(syncAccountRepository).logoutAndJoinNewAccount(captor.capture())
         val decoded = java.util.Base64.getUrlDecoder().decode(captor.firstValue)
@@ -326,9 +295,6 @@ class RealSyncCodeDispatcherTest {
     }
 
     @Test fun `FF on, v2 RecoveryCode cid=ddg - account-switch code is canonical v1 JSON without escaped slashes`() = runTest {
-        // The ddg secret is standard base64 and routinely contains '/'. The re-encoded v1 code fed
-        // to logoutAndJoinNewAccount must be canonical (Moshi, no AOSP org.json '\/' escaping) so it
-        // is byte-identical to genuine v1 codes and never depends on a lenient consumer to unescape.
         setV2(true)
         val secretWithSlashes = "apZ+7PAe89rDhuG4DRyi/M3zU2/D5DZNdRsR3RM6Ujw="
         val rawJson = JSONObject().apply {
@@ -351,7 +317,6 @@ class RealSyncCodeDispatcherTest {
         verify(syncAccountRepository).logoutAndJoinNewAccount(captor.capture())
         val decodedJson = String(java.util.Base64.getUrlDecoder().decode(captor.firstValue), Charsets.UTF_8)
         assertFalse("v1 account-switch JSON must not contain escaped slashes (\\/): $decodedJson", decodedJson.contains("\\/"))
-        // …and it must still round-trip back to the exact secret.
         val recovery = JSONObject(decodedJson).getJSONObject("recovery")
         assertEquals(secretWithSlashes, recovery.getString("primary_key"))
         assertEquals("u-other", recovery.getString("user_id"))
@@ -384,9 +349,6 @@ class RealSyncCodeDispatcherTest {
     }
 
     @Test fun `FF on, v2 RecoveryCode cid=3party - ALREADY_SIGNED_IN does NOT trigger transparent switch (fails as Failed)`() = runTest {
-        // 3party upgrade uses a different subroutine (POST /access-credentials/ddg + re-encrypt
-        // keys); we can't safely substitute a plain logoutAndJoinNewAccount for it. Spec stays
-        // silent on this edge, so we fail rather than guess.
         setV2(true)
         val rawJson = JSONObject().apply {
             put("user_id", "u-3p")
@@ -414,7 +376,7 @@ class RealSyncCodeDispatcherTest {
         setV2(true)
         val rawJson = JSONObject().apply {
             put("user_id", "u")
-            put("secret", "AQID") // valid base64 so we reach processCode (the error path under test)
+            put("secret", "AQID") // valid base64 so decoding succeeds and processCode is reached
             put("cid", "ddg")
         }
         whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
@@ -459,8 +421,6 @@ class RealSyncCodeDispatcherTest {
         assertTrue((outcome as DispatchOutcome.Failed).reason.contains("future-credential"))
     }
 
-    // ---- Pixel + side effects: dispatcher must NOT fire any of these ----
-
     @Test fun `Legacy path - dispatcher never invokes processCode (caller owns that)`() {
         setV2(false)
         whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(SyncAuthCode.Recovery(mock()))
@@ -481,19 +441,12 @@ class RealSyncCodeDispatcherTest {
     }
 
     @Test fun `FF on, LinkingV2 - ignores stale terminal events from prior sessions in the replay cache`() = runTest {
-        // Regression: previously the dispatcher would pick up a Joiner.Done event sitting in
-        // the runner's events replay cache from a prior successful pairing, treat it as the
-        // outcome of THIS session, and call processCode immediately - logging the user in
-        // without ever showing the user-confirmation step of the new session.
         setV2(true)
         whenever(qrCode.parse(any())).thenReturn(
             ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
         )
-        // Pre-seed the class-level events flow with a stale Joiner.Done from a prior session
-        // (timestampMs well before this test starts). The class-level eventsSince stub will
-        // filter it out based on the dispatcher's sessionStart timestamp.
         val staleJoinerDone = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event.Transition(
-            timestampMs = 1L, // ancient
+            timestampMs = 1L,
             from = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.Joiner.Waiting,
             to = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.Joiner.Done,
             trigger = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse(
@@ -502,7 +455,6 @@ class RealSyncCodeDispatcherTest {
             ),
             localTrigger = null,
         )
-        // Make the backing flow replay-enabled so the stale event is observable.
         val staleFlow = MutableSharedFlow<com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event>(replay = 10)
         staleFlow.tryEmit(staleJoinerDone)
         whenever(runner.events).thenReturn(staleFlow)
@@ -513,13 +465,8 @@ class RealSyncCodeDispatcherTest {
 
         val decision = dispatcher.route("v2-url") as RouteDecision.V2InProgress
 
-        // Race the dispatcher's flow against a timeout - without the fix, .first() would
-        // immediately pick up the stale Joiner.Done from replay and emit LoggedIn.
-        // With the fix, the flow filters out events older than session start and waits
-        // for genuine new-session events that never arrive in this test setup.
         val outcome = kotlinx.coroutines.withTimeoutOrNull(100) { decision.outcomes.first() }
-        assertEquals(null, outcome) // no premature emission
-        // And processCode must NOT have been called for the stale code.
+        assertEquals(null, outcome)
         verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
     }
 
@@ -531,29 +478,20 @@ class RealSyncCodeDispatcherTest {
 
         val decision = dispatcher.route("v2-url") as RouteDecision.V2InProgress
 
-        // Returning V2InProgress alone must not start the session - the caller hasn't decided to
-        // commit yet. The runner is only kicked off when the Flow is collected. This matters for
-        // safety: callers that do dispatcher.route(...) for inspection won't accidentally bootstrap
-        // a channel.
         verify(runner, never()).startScan(any())
 
-        // Now actually collect - but cancel after seeing zero emissions (since runner.events is
-        // an empty SharedFlow in this test). We just verify startScan was hit on first collection.
         kotlinx.coroutines.withTimeoutOrNull(50) { decision.outcomes.first() }
         verify(runner).startScan(eq("v2-url"))
     }
 
     @Test fun `FF on, LinkingV2 exchange - base64url recovery secret is normalised to standard base64 for v1 login`() = runTest {
-        // The actual macOS↔Android failure: Joiner reaches Done with a RecoveryCodeResponse whose
-        // payload carries a base64url secret (spec 1214802412121967). loginWithV2RecoveryCode must
-        // normalise it to standard base64 before the native v1 login, or prepareForLogin throws
-        // "bad base-64" (LOGIN_FAILED). Same key bytes, different alphabet.
+        // Spec 1214802412121967: the v2 wire `secret` is base64url; v1 login decodes as standard base64.
         setV2(true)
         whenever(qrCode.parse(any())).thenReturn(
             ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
         )
         whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
-        val base64urlSecret = "rUzlGqLLlbonAC_zIeh1nrCmuDsDAn6UooUUDz-6x3o" // spec example: base64url, has '_' and '-'
+        val base64urlSecret = "rUzlGqLLlbonAC_zIeh1nrCmuDsDAn6UooUUDz-6x3o"
         val payloadJson = JSONObject().apply {
             put(
                 "recovery",
@@ -594,8 +532,6 @@ class RealSyncCodeDispatcherTest {
         )
     }
 
-    // ---- presentV2() — Presenter-side mapping ----
-
     private fun transition(
         from: ExchangeV2State,
         to: ExchangeV2State,
@@ -619,7 +555,6 @@ class RealSyncCodeDispatcherTest {
 
     @Test fun `presentV2 emits LinkingCodeReady when runner emits SessionStarted with a linkingCode`() = runTest {
         val flow = dispatcher.presentV2()
-        // Start collection in the background; emit the session event after a tiny delay.
         val outcomes = mutableListOf<DispatchOutcome>()
         val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
             flow.take(1).collect { outcomes += it }
@@ -635,16 +570,12 @@ class RealSyncCodeDispatcherTest {
     }
 
     @Test fun `presentV2 ignores SessionStarted with null linkingCode (Scanner side leakage protection)`() = runTest {
-        // Defensive — startPresent() should always produce a non-null linkingCode, but if the
-        // runner ever emits SessionStarted with null we don't want to emit a malformed outcome.
         val outcomes = mutableListOf<DispatchOutcome>()
         val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().take(1).collect { outcomes += it } }
         runnerEventsFlow.emit(sessionStarted(linkingCode = null))
-        // Send a follow-up terminal so collection completes.
         runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Done))
         job.join()
 
-        // First outcome should be LoggedIn (from Host.Done), not a malformed LinkingCodeReady(null/empty).
         assertEquals(DispatchOutcome.LoggedIn, outcomes.single())
     }
 
@@ -732,7 +663,6 @@ class RealSyncCodeDispatcherTest {
 
     @Test fun `presentV2 emits LoggedIn when Joiner_Done carries a cid=ddg recovery code`() = runTest {
         setV2(true)
-        // Build a v2 recovery code payload with cid=ddg.
         val recoveryJson = JSONObject().apply {
             put(
                 "recovery",
@@ -770,7 +700,6 @@ class RealSyncCodeDispatcherTest {
             job.await()
         }
         assertEquals(DispatchOutcome.LoggedIn, outcome)
-        // Confirm the v1 Recovery shape was constructed and the login was attempted.
         verify(syncAccountRepository).processCode(any(), anyOrNull())
         verify(syncAccountRepository, never()).joinAccountFromThirdPartyRecoveryCode(any())
     }
@@ -837,7 +766,6 @@ class RealSyncCodeDispatcherTest {
         val flow = dispatcher.presentV2()
         verify(runner, never()).startPresent()
 
-        // Collect briefly (no events emitted → first() never resolves; rely on timeout).
         withTimeoutOrNull(50) { flow.first() }
         verify(runner).startPresent()
     }
@@ -881,9 +809,7 @@ class RealSyncCodeDispatcherTest {
         val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
             dispatcher.presentV2().toList(outcomes)
         }
-        // First SessionStarted establishes the Flow's own channel.
         runnerEventsFlow.emit(sessionStarted(linkingCode = "code-for-own-channel"))
-        // Second SessionStarted with a different channel — simulates preemption by another caller.
         runnerEventsFlow.emit(
             ExchangeV2Event.SessionStarted(
                 timestampMs = System.currentTimeMillis(),
@@ -894,7 +820,6 @@ class RealSyncCodeDispatcherTest {
         )
         job.join()
 
-        // The Flow should have completed silently after emitting just the first LinkingCodeReady.
         assertEquals(1, outcomes.size)
         assertEquals(DispatchOutcome.LinkingCodeReady("code-for-own-channel"), outcomes.single())
     }
@@ -914,7 +839,6 @@ class RealSyncCodeDispatcherTest {
         val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
             decision.outcomes.toList(outcomes)
         }
-        // First SessionStarted establishes the Scanner's own channel.
         runnerEventsFlow.emit(
             ExchangeV2Event.SessionStarted(
                 timestampMs = System.currentTimeMillis(),
@@ -923,7 +847,6 @@ class RealSyncCodeDispatcherTest {
                 linkingCode = null,
             ),
         )
-        // Second SessionStarted with a different channel — simulates preemption.
         runnerEventsFlow.emit(
             ExchangeV2Event.SessionStarted(
                 timestampMs = System.currentTimeMillis(),
@@ -934,8 +857,6 @@ class RealSyncCodeDispatcherTest {
         )
         job.join()
 
-        // The Flow should have completed silently — no outcomes emitted (Scanner side never
-        // emits anything for the initial SessionStarted because linkingCode=null on its side).
         assertTrue("expected no outcomes, got $outcomes", outcomes.isEmpty())
     }
 
@@ -967,7 +888,6 @@ class RealSyncCodeDispatcherTest {
     }
 
     @Test fun `presentV2 filters out events from before session start`() = runTest {
-        // Seed a stale Host_Done from a prior session with timestamp=1L (well before now).
         val staleFlow = MutableSharedFlow<ExchangeV2Event>(replay = 10)
         staleFlow.tryEmit(
             ExchangeV2Event.Transition(
@@ -984,7 +904,6 @@ class RealSyncCodeDispatcherTest {
             staleFlow.filter { it.timestampMs >= since }
         }
 
-        // No fresh event emitted; outcome should never arrive within timeout.
         val outcome = withTimeoutOrNull(100) { dispatcher.presentV2().first() }
         assertEquals(null, outcome)
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
@@ -18,13 +18,23 @@ package com.duckduckgo.sync.impl
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.sync.impl.AccountErrorCodes.NEGOTIATION_ABORTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.NO_RECOVERY_CODE
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_UNAVAILABLE
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
 import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
 import com.duckduckgo.sync.impl.exchange.v2.PairingRole
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.filter
@@ -161,7 +171,19 @@ class RealSyncCodeDispatcherTest {
         val decision = dispatcher.route("v2-link-url")
 
         assertTrue("expected V2InProgress, got $decision", decision is RouteDecision.V2InProgress)
+        assertEquals(SyncCodeType.LINKING, (decision as RouteDecision.V2InProgress).codeType)
         verify(syncAccountRepository, never()).parseSyncAuthCode(any())
+    }
+
+    @Test fun `isV2ExchangeUnderway is false at Bootstrapped or no session, true once exchanging`() {
+        whenever(runner.currentState).thenReturn(null)
+        assertFalse(dispatcher.isV2ExchangeUnderway())
+        whenever(runner.currentState).thenReturn(ExchangeV2State.Bootstrapped)
+        assertFalse(dispatcher.isV2ExchangeUnderway())
+        whenever(runner.currentState).thenReturn(ExchangeV2State.Negotiating)
+        assertTrue(dispatcher.isV2ExchangeUnderway())
+        whenever(runner.currentState).thenReturn(ExchangeV2State.Joiner.Waiting)
+        assertTrue(dispatcher.isV2ExchangeUnderway())
     }
 
     @Test fun `FF on, v2 RecoveryCode cid=ddg - flow emits LoggedIn after processCode succeeds`() = runTest {
@@ -175,10 +197,11 @@ class RealSyncCodeDispatcherTest {
         whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
 
         val decision = dispatcher.route("any") as RouteDecision.V2InProgress
+        assertEquals(SyncCodeType.RECOVERY, decision.codeType)
         val outcomes = decision.outcomes.toList()
 
         assertEquals(1, outcomes.size)
-        assertEquals(DispatchOutcome.LoggedIn, outcomes.single())
+        assertEquals(DispatchOutcome.LoggedIn(SetupPath.RECOVERY), outcomes.single())
     }
 
     @Test fun `FF on, v2 RecoveryCode cid=ddg - base64url secret is normalised to standard base64 for v1 login`() = runTest {
@@ -232,7 +255,7 @@ class RealSyncCodeDispatcherTest {
         val decision = dispatcher.route("any") as RouteDecision.V2InProgress
         val outcomes = decision.outcomes.toList()
 
-        assertEquals(DispatchOutcome.LoggedIn, outcomes.single())
+        assertEquals(DispatchOutcome.LoggedIn(SetupPath.RECOVERY), outcomes.single())
         verify(syncAccountRepository).joinAccountFromThirdPartyRecoveryCode(any())
         verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
     }
@@ -281,7 +304,7 @@ class RealSyncCodeDispatcherTest {
 
         val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
 
-        assertEquals(DispatchOutcome.LoggedIn, outcome)
+        assertEquals(DispatchOutcome.LoggedIn(SetupPath.RECOVERY), outcome)
 
         val captor = org.mockito.kotlin.argumentCaptor<String>()
         verify(syncAccountRepository).logoutAndJoinNewAccount(captor.capture())
@@ -343,7 +366,7 @@ class RealSyncCodeDispatcherTest {
         val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
 
         assertEquals(
-            DispatchOutcome.Failed("Login failed", com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED.code),
+            DispatchOutcome.Failed("Login failed", com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED.code, path = SetupPath.RECOVERY),
             outcome,
         )
     }
@@ -366,7 +389,11 @@ class RealSyncCodeDispatcherTest {
         val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
 
         assertEquals(
-            DispatchOutcome.Failed("Already signed in", com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN.code),
+            DispatchOutcome.Failed(
+                "Already signed in",
+                com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN.code,
+                path = SetupPath.RECOVERY,
+            ),
             outcome,
         )
         verify(syncAccountRepository, never()).logoutAndJoinNewAccount(any())
@@ -386,7 +413,7 @@ class RealSyncCodeDispatcherTest {
 
         val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
 
-        assertEquals(DispatchOutcome.Failed("Some other error"), outcome)
+        assertEquals(DispatchOutcome.Failed("Some other error", path = SetupPath.RECOVERY), outcome)
     }
 
     @Test fun `FF on, v2 RecoveryCode cid=3party - repository error becomes Failed with reason preserved`() = runTest {
@@ -403,7 +430,7 @@ class RealSyncCodeDispatcherTest {
 
         val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
 
-        assertEquals(DispatchOutcome.Failed("BE rejected"), outcome)
+        assertEquals(DispatchOutcome.Failed("BE rejected", path = SetupPath.RECOVERY), outcome)
     }
 
     @Test fun `FF on, v2 RecoveryCode with unknown cid - emits Failed with the cid in the reason`() = runTest {
@@ -535,13 +562,14 @@ class RealSyncCodeDispatcherTest {
     private fun transition(
         from: ExchangeV2State,
         to: ExchangeV2State,
+        trigger: ExchangeV2Message? = null,
         localTrigger: LocalTrigger? = null,
         timestampMs: Long = System.currentTimeMillis(),
     ): ExchangeV2Event.Transition = ExchangeV2Event.Transition(
         timestampMs = timestampMs,
         from = from,
         to = to,
-        trigger = null,
+        trigger = trigger,
         localTrigger = localTrigger,
     )
 
@@ -576,7 +604,7 @@ class RealSyncCodeDispatcherTest {
         runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Done))
         job.join()
 
-        assertEquals(DispatchOutcome.LoggedIn, outcomes.single())
+        assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST), outcomes.single())
     }
 
     @Test fun `presentV2 emits HostConfirmationRequested with peerName when runner reaches Host_Confirming`() = runTest {
@@ -589,7 +617,36 @@ class RealSyncCodeDispatcherTest {
         assertEquals(DispatchOutcome.HostConfirmationRequested(peerName = "Peer Phone"), outcomes.single())
     }
 
-    @Test fun `presentV2 emits LoggedIn when runner reaches Host_Done`() = runTest {
+    @Test fun `presentV2 carries third-party peer kind on HostConfirmationRequested`() = runTest {
+        whenever(runner.peerName).thenReturn("Peer Phone")
+        whenever(runner.peerKind).thenReturn("3party")
+        val outcomes = mutableListOf<DispatchOutcome>()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().take(1).collect { outcomes += it } }
+        runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Confirming))
+        job.join()
+
+        assertEquals(
+            DispatchOutcome.HostConfirmationRequested(peerName = "Peer Phone", peerKind = PeerKind.THIRD_PARTY),
+            outcomes.single(),
+        )
+    }
+
+    @Test fun `presentV2 carries ddg peer kind on JoinerConfirmationRequested`() = runTest {
+        whenever(runner.peerName).thenReturn("Peer Phone")
+        whenever(runner.peerKind).thenReturn("ddg")
+        val outcomes = mutableListOf<DispatchOutcome>()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().take(1).collect { outcomes += it } }
+        runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Joiner.Confirming))
+        job.join()
+
+        assertEquals(
+            DispatchOutcome.JoinerConfirmationRequested(peerName = "Peer Phone", peerKind = PeerKind.DDG),
+            outcomes.single(),
+        )
+    }
+
+    @Test fun `presentV2 emits LoggedIn with Host role and peer kind when runner reaches Host_Done`() = runTest {
+        whenever(runner.peerKind).thenReturn("3party")
         val outcome = withTimeoutOrNull(1000) {
             val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
                 dispatcher.presentV2().first { it is DispatchOutcome.LoggedIn || it is DispatchOutcome.Failed }
@@ -597,7 +654,86 @@ class RealSyncCodeDispatcherTest {
             runnerEventsFlow.emit(transition(from = ExchangeV2State.Host.Sending, to = ExchangeV2State.Host.Done))
             job.await()
         }
-        assertEquals(DispatchOutcome.LoggedIn, outcome)
+        assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST, PeerKind.THIRD_PARTY), outcome)
+    }
+
+    @Test fun `presentV2 maps a version-too-new SessionError to UpgradeRequired`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(
+                ExchangeV2Event.SessionError(
+                    timestampMs = System.currentTimeMillis(),
+                    message = "Peer requires protocol v3; please update this app",
+                ),
+            )
+            job.await()
+        }
+        assertEquals(DispatchOutcome.UpgradeRequired(codeMajor = 3, path = SetupPath.PAIRING), outcome)
+    }
+
+    @Test fun `route LinkingV2 maps a version-too-new SessionError to UpgradeRequired`() = runTest {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        val outcome = withTimeoutOrNull(1000) {
+            val flow = (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { flow.first() }
+            runnerEventsFlow.emit(
+                ExchangeV2Event.SessionError(
+                    timestampMs = System.currentTimeMillis(),
+                    message = "Peer requires protocol v3; please update this app",
+                ),
+            )
+            job.await()
+        }
+        assertEquals(DispatchOutcome.UpgradeRequired(codeMajor = 3, path = SetupPath.PAIRING), outcome)
+    }
+
+    @Test fun `route LinkingV2 - Host_Aborted with UserDeniedHost maps to Failed PAIRING_CANCELLED`() = runTest {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        val outcome = withTimeoutOrNull(1000) {
+            val flow = (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { flow.first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Host.Confirming,
+                    to = ExchangeV2State.Host.Aborted,
+                    localTrigger = LocalTrigger.UserDeniedHost,
+                ),
+            )
+            job.await()
+        }
+        assertEquals(
+            DispatchOutcome.Failed("user_denied", PAIRING_CANCELLED.code, path = SetupPath.PAIRING, myRole = SetupRole.HOST),
+            outcome,
+        )
+    }
+
+    @Test fun `route LinkingV2 - Host_Aborted with HostUnavailable maps to Failed PAIRING_UNAVAILABLE`() = runTest {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        val outcome = withTimeoutOrNull(1000) {
+            val flow = (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { flow.first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Host.Sending,
+                    to = ExchangeV2State.Host.Aborted,
+                    localTrigger = LocalTrigger.HostUnavailable,
+                ),
+            )
+            job.await()
+        }
+        assertEquals(
+            DispatchOutcome.Failed("host_unavailable", PAIRING_UNAVAILABLE.code, path = SetupPath.PAIRING, myRole = SetupRole.HOST),
+            outcome,
+        )
     }
 
     @Test fun `presentV2 emits Failed user_denied when Host_Aborted carries UserDeniedHost trigger`() = runTest {
@@ -612,7 +748,10 @@ class RealSyncCodeDispatcherTest {
             )
             job.await()
         }
-        assertEquals(DispatchOutcome.Failed("user_denied"), outcome)
+        assertEquals(
+            DispatchOutcome.Failed("user_denied", PAIRING_CANCELLED.code, path = SetupPath.PAIRING, myRole = SetupRole.HOST),
+            outcome,
+        )
     }
 
     @Test fun `presentV2 emits Failed host_unavailable when Host_Aborted carries HostUnavailable trigger`() = runTest {
@@ -627,7 +766,10 @@ class RealSyncCodeDispatcherTest {
             )
             job.await()
         }
-        assertEquals(DispatchOutcome.Failed("host_unavailable"), outcome)
+        assertEquals(
+            DispatchOutcome.Failed("host_unavailable", PAIRING_UNAVAILABLE.code, path = SetupPath.PAIRING, myRole = SetupRole.HOST),
+            outcome,
+        )
     }
 
     @Test fun `presentV2 emits AlreadyConnected when runner reaches SameAccountAbort`() = runTest {
@@ -647,7 +789,7 @@ class RealSyncCodeDispatcherTest {
             )
             job.await()
         }
-        assertEquals(DispatchOutcome.Failed("channel 5xx"), outcome)
+        assertEquals(DispatchOutcome.Failed("channel 5xx", PAIRING_FAILED.code, path = SetupPath.PAIRING), outcome)
     }
 
     @Test fun `presentV2 emits Failed when Joiner_Done arrives without a recovery code`() = runTest {
@@ -658,7 +800,15 @@ class RealSyncCodeDispatcherTest {
             runnerEventsFlow.emit(transition(from = ExchangeV2State.Joiner.Waiting, to = ExchangeV2State.Joiner.Done))
             job.await()
         }
-        assertEquals(DispatchOutcome.Failed("Pairing completed without a recovery code"), outcome)
+        assertEquals(
+            DispatchOutcome.Failed(
+                "Pairing completed without a recovery code",
+                NO_RECOVERY_CODE.code,
+                path = SetupPath.PAIRING,
+                myRole = SetupRole.JOINER,
+            ),
+            outcome,
+        )
     }
 
     @Test fun `presentV2 emits LoggedIn when Joiner_Done carries a cid=ddg recovery code`() = runTest {
@@ -683,6 +833,7 @@ class RealSyncCodeDispatcherTest {
             recoveryCode = b64,
         )
         whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
+        whenever(runner.peerKind).thenReturn("ddg")
 
         val outcome = withTimeoutOrNull(1000) {
             val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
@@ -699,7 +850,7 @@ class RealSyncCodeDispatcherTest {
             )
             job.await()
         }
-        assertEquals(DispatchOutcome.LoggedIn, outcome)
+        assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.JOINER, PeerKind.DDG), outcome)
         verify(syncAccountRepository).processCode(any(), anyOrNull())
         verify(syncAccountRepository, never()).joinAccountFromThirdPartyRecoveryCode(any())
     }
@@ -742,7 +893,7 @@ class RealSyncCodeDispatcherTest {
             )
             job.await()
         }
-        assertEquals(DispatchOutcome.LoggedIn, outcome)
+        assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.JOINER), outcome)
         verify(syncAccountRepository).joinAccountFromThirdPartyRecoveryCode(any())
         verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
     }
@@ -759,7 +910,15 @@ class RealSyncCodeDispatcherTest {
             )
             job.await()
         }
-        assertEquals(DispatchOutcome.Failed("Pairing cancelled on this device"), outcome)
+        assertEquals(
+            DispatchOutcome.Failed(
+                "Pairing cancelled on this device",
+                PAIRING_CANCELLED.code,
+                path = SetupPath.PAIRING,
+                myRole = SetupRole.JOINER,
+            ),
+            outcome,
+        )
     }
 
     @Test fun `presentV2 calls runner_startPresent when Flow is collected`() = runTest {
@@ -906,5 +1065,113 @@ class RealSyncCodeDispatcherTest {
 
         val outcome = withTimeoutOrNull(100) { dispatcher.presentV2().first() }
         assertEquals(null, outcome)
+    }
+
+    private fun startLinking(): kotlinx.coroutines.flow.Flow<DispatchOutcome> {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        return (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
+    }
+
+    @Test fun `linking - AbortedByHost with RecoveryCodeDenied maps to Failed PAIRING_REJECTED`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                ),
+            )
+            job.await()
+        }
+        assertTrue("expected Failed, got $outcome", outcome is DispatchOutcome.Failed)
+        assertEquals(PAIRING_REJECTED.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `linking - AbortedByHost with RecoveryCodeUnavailable maps to Failed PAIRING_UNAVAILABLE`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.RecoveryCodeUnavailable(rawJson = "{}"),
+                ),
+            )
+            job.await()
+        }
+        assertEquals(PAIRING_UNAVAILABLE.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `linking - Joiner AbortedLocal maps to Failed PAIRING_CANCELLED`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Joiner.Confirming, to = ExchangeV2State.Joiner.AbortedLocal))
+            job.await()
+        }
+        assertEquals(PAIRING_CANCELLED.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `linking - Aborted maps to Failed NEGOTIATION_ABORTED`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Aborted))
+            job.await()
+        }
+        assertEquals(NEGOTIATION_ABORTED.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `linking - Joiner Done without recovery code maps to Failed NO_RECOVERY_CODE`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Joiner.Waiting, to = ExchangeV2State.Joiner.Done))
+            job.await()
+        }
+        assertEquals(NO_RECOVERY_CODE.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `linking - SessionError maps to Failed PAIRING_FAILED`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(ExchangeV2Event.SessionError(timestampMs = System.currentTimeMillis(), message = "channel 500"))
+            job.await()
+        }
+        assertEquals(PAIRING_FAILED.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `linking - Host Aborted maps to Failed NEGOTIATION_ABORTED`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Host.Confirming, to = ExchangeV2State.Host.Aborted))
+            job.await()
+        }
+        assertEquals(NEGOTIATION_ABORTED.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `present - AbortedByHost with RecoveryCodeDenied maps to Failed PAIRING_REJECTED`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                ),
+            )
+            job.await()
+        }
+        assertEquals(PAIRING_REJECTED.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `present - Host Aborted with no localTrigger maps to Failed NEGOTIATION_ABORTED`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Host.Confirming, to = ExchangeV2State.Host.Aborted))
+            job.await()
+        }
+        assertEquals(NEGOTIATION_ABORTED.code, (outcome as DispatchOutcome.Failed).code)
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
@@ -1,0 +1,846 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
+import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
+import com.duckduckgo.sync.impl.exchange.v2.PairingRole
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class RealSyncCodeDispatcherTest {
+
+    private val syncFeature: SyncFeature = mock()
+    private val canUseV2: Toggle = mock()
+    private val syncAccountRepository: SyncAccountRepository = mock()
+    private val qrCode: ExchangeV2QrCode = mock()
+
+    // Backing flow that the mocked runner exposes through `events`/`eventsSince`. Keeping it as a
+    // standalone reference (rather than reading `mock.events` inside answer lambdas) avoids a
+    // Mockito matcher-state issue where re-entrant getter calls during answer dispatch cause
+    // ArrayIndexOutOfBoundsException on `invocation.getArgument`.
+    private val runnerEventsFlow = MutableSharedFlow<com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event>(replay = 0)
+    private val runner: ExchangeV2Runner = mock<ExchangeV2Runner>().also {
+        whenever(it.events).thenReturn(runnerEventsFlow)
+        // Mockito doesn't call interface default methods automatically; wire eventsSince to
+        // match the default impl on the interface (filter by timestamp).
+        whenever(it.eventsSince(any())).thenAnswer { invocation ->
+            val sinceMs = invocation.getArgument<Long>(0)
+            runnerEventsFlow.filter { event -> event.timestampMs >= sinceMs }
+        }
+    }
+
+    private val dispatcher = RealSyncCodeDispatcher(
+        syncFeature = syncFeature,
+        syncAccountRepository = syncAccountRepository,
+        qrCode = qrCode,
+        runner = runner,
+    )
+
+    private fun setV2(enabled: Boolean) {
+        whenever(syncFeature.canUseV2ConnectFlow()).thenReturn(canUseV2)
+        whenever(canUseV2.isEnabled()).thenReturn(enabled)
+    }
+
+    // ---- FF off: byte-identical to direct parseSyncAuthCode ----
+
+    @Test fun `FF off - returns Legacy with whatever parseSyncAuthCode returned, and never touches qrCode parse`() {
+        setV2(false)
+        val expectedAuthCode = SyncAuthCode.Recovery(RecoveryCode(primaryKey = "pk", userId = "u"))
+        whenever(syncAccountRepository.parseSyncAuthCode("the-code")).thenReturn(expectedAuthCode)
+
+        val decision = dispatcher.route("the-code") as RouteDecision.Legacy
+
+        assertSame(expectedAuthCode, decision.authCode)
+        verify(qrCode, never()).parse(any())
+    }
+
+    @Test fun `FF off - v1 Connect codes return Legacy(Connect) unchanged`() {
+        setV2(false)
+        val connect = SyncAuthCode.Connect(mock())
+        whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(connect)
+
+        val decision = dispatcher.route("connect-shape-code") as RouteDecision.Legacy
+
+        assertSame(connect, decision.authCode)
+    }
+
+    @Test fun `FF off - v1 Exchange codes return Legacy(Exchange) unchanged`() {
+        setV2(false)
+        val exchange = SyncAuthCode.Exchange(mock())
+        whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(exchange)
+
+        val decision = dispatcher.route("exchange-shape-code") as RouteDecision.Legacy
+
+        assertSame(exchange, decision.authCode)
+    }
+
+    @Test fun `FF off - Unknown codes still bubble back as Legacy(Unknown)`() {
+        setV2(false)
+        val unknown = SyncAuthCode.Unknown("garbage")
+        whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(unknown)
+
+        val decision = dispatcher.route("garbage") as RouteDecision.Legacy
+
+        assertSame(unknown, decision.authCode)
+    }
+
+    @Test fun `FF off - even a v2-shaped code is routed via legacy parseSyncAuthCode (no v2 parser touched)`() {
+        // Critical safety property: when FF is off, v2 detection is COMPLETELY skipped.
+        // A v2 code pasted under FF off becomes Unknown via parseSyncAuthCode - same as
+        // production behaviour today.
+        setV2(false)
+        whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(SyncAuthCode.Unknown("v2-shaped-input"))
+
+        dispatcher.route("https://duckduckgo.com/sync/pairing/#&code2=anything")
+
+        verify(qrCode, never()).parse(any())
+        verify(syncAccountRepository).parseSyncAuthCode("https://duckduckgo.com/sync/pairing/#&code2=anything")
+    }
+
+    // ---- FF on: v1 shapes still go through legacy stack ----
+
+    @Test fun `FF on but v2 parser returns LinkingV1 - falls back to legacy stack`() {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.LinkingV1)
+        val connect = SyncAuthCode.Connect(mock())
+        whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(connect)
+
+        val decision = dispatcher.route("v1-code") as RouteDecision.Legacy
+
+        assertSame(connect, decision.authCode)
+    }
+
+    @Test fun `FF on but v2 parser returns Unknown - falls back to legacy stack`() {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.Unknown)
+        val recovery = SyncAuthCode.Recovery(RecoveryCode(primaryKey = "pk", userId = "u"))
+        whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(recovery)
+
+        val decision = dispatcher.route("recovery-code") as RouteDecision.Legacy
+
+        assertSame(recovery, decision.authCode)
+    }
+
+    // ---- FF on: v2 paths take ownership ----
+
+    @Test fun `FF on, v2 LinkingV2 - returns V2InProgress and does NOT call parseSyncAuthCode`() {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+
+        val decision = dispatcher.route("v2-link-url")
+
+        assertTrue("expected V2InProgress, got $decision", decision is RouteDecision.V2InProgress)
+        verify(syncAccountRepository, never()).parseSyncAuthCode(any())
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=ddg - flow emits LoggedIn after processCode succeeds`() = runTest {
+        setV2(true)
+        val rawJson = JSONObject().apply {
+            put("user_id", "u-1")
+            put("secret", "s-1")
+            put("cid", "ddg")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
+
+        val decision = dispatcher.route("any") as RouteDecision.V2InProgress
+        val outcomes = decision.outcomes.toList()
+
+        assertEquals(1, outcomes.size)
+        assertEquals(DispatchOutcome.LoggedIn, outcomes.single())
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=ddg with missing user_id - emits Failed without calling processCode`() = runTest {
+        setV2(true)
+        val rawJson = JSONObject().apply {
+            put("secret", "s-1")
+            put("cid", "ddg")
+        } // no user_id
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+
+        val decision = dispatcher.route("any") as RouteDecision.V2InProgress
+        val outcome = decision.outcomes.first()
+
+        assertTrue("expected Failed, got $outcome", outcome is DispatchOutcome.Failed)
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=3party - flow calls joinAccountFromThirdPartyRecoveryCode`() = runTest {
+        setV2(true)
+        val rawJson = JSONObject().apply {
+            put("user_id", "u-3p")
+            put("secret", "s-3p")
+            put("cid", "3party")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(any())).thenReturn(Result.Success(true))
+
+        val decision = dispatcher.route("any") as RouteDecision.V2InProgress
+        val outcomes = decision.outcomes.toList()
+
+        assertEquals(DispatchOutcome.LoggedIn, outcomes.single())
+        verify(syncAccountRepository).joinAccountFromThirdPartyRecoveryCode(any())
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=ddg - ALREADY_SIGNED_IN triggers logoutAndJoinNewAccount and emits LoggedIn`() = runTest {
+        // Per spec, the v2 path does NOT surface a v1-style AskToSwitchAccount prompt - the
+        // Confirmations phase (or the act of pasting a recovery code) is already the consent
+        // step. So when processCode reports ALREADY_SIGNED_IN, the dispatcher transparently
+        // calls logoutAndJoinNewAccount with a re-encoded v1-shape recovery code and emits
+        // LoggedIn (success) without bubbling AccountSwitchingRequired up to the VM.
+        setV2(true)
+        val rawJson = JSONObject().apply {
+            put("user_id", "u-other")
+            put("secret", "s-other")
+            put("cid", "ddg")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(
+            Result.Error(
+                code = com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN.code,
+                reason = "Already signed in",
+            ),
+        )
+        whenever(syncAccountRepository.logoutAndJoinNewAccount(any())).thenReturn(Result.Success(true))
+
+        val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
+
+        assertEquals(DispatchOutcome.LoggedIn, outcome)
+
+        // Verify the v1-shape recovery code passed to logoutAndJoinNewAccount: base64url-encoded
+        // JSON with primary_key+user_id (so the v1-only parseSyncAuthCode inside the repo can
+        // re-parse it).
+        val captor = org.mockito.kotlin.argumentCaptor<String>()
+        verify(syncAccountRepository).logoutAndJoinNewAccount(captor.capture())
+        val decoded = java.util.Base64.getUrlDecoder().decode(captor.firstValue)
+        val recovery = JSONObject(String(decoded)).getJSONObject("recovery")
+        assertEquals("s-other", recovery.getString("primary_key"))
+        assertEquals("u-other", recovery.getString("user_id"))
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=ddg - ALREADY_SIGNED_IN then logoutAndJoinNewAccount failure surfaces as Failed`() = runTest {
+        setV2(true)
+        val rawJson = JSONObject().apply {
+            put("user_id", "u-other")
+            put("secret", "s-other")
+            put("cid", "ddg")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(
+            Result.Error(
+                code = com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN.code,
+                reason = "Already signed in",
+            ),
+        )
+        whenever(syncAccountRepository.logoutAndJoinNewAccount(any())).thenReturn(
+            Result.Error(code = com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED.code, reason = "Login failed"),
+        )
+
+        val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
+
+        assertEquals(
+            DispatchOutcome.Failed("Login failed", com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED.code),
+            outcome,
+        )
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=3party - ALREADY_SIGNED_IN does NOT trigger transparent switch (fails as Failed)`() = runTest {
+        // 3party upgrade uses a different subroutine (POST /access-credentials/ddg + re-encrypt
+        // keys); we can't safely substitute a plain logoutAndJoinNewAccount for it. Spec stays
+        // silent on this edge, so we fail rather than guess.
+        setV2(true)
+        val rawJson = JSONObject().apply {
+            put("user_id", "u-3p")
+            put("secret", "s-3p")
+            put("cid", "3party")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(any())).thenReturn(
+            Result.Error(
+                code = com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN.code,
+                reason = "Already signed in",
+            ),
+        )
+
+        val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
+
+        assertEquals(
+            DispatchOutcome.Failed("Already signed in", com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN.code),
+            outcome,
+        )
+        verify(syncAccountRepository, never()).logoutAndJoinNewAccount(any())
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=ddg - non-ALREADY_SIGNED_IN error still becomes Failed`() = runTest {
+        setV2(true)
+        val rawJson = JSONObject().apply {
+            put("user_id", "u")
+            put("secret", "s")
+            put("cid", "ddg")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(
+            Result.Error(code = -1, reason = "Some other error"),
+        )
+
+        val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
+
+        assertEquals(DispatchOutcome.Failed("Some other error"), outcome)
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=3party - repository error becomes Failed with reason preserved`() = runTest {
+        setV2(true)
+        val rawJson = JSONObject().apply {
+            put("user_id", "u-3p")
+            put("secret", "s-3p")
+            put("cid", "3party")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(any())).thenReturn(
+            Result.Error(reason = "BE rejected"),
+        )
+
+        val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
+
+        assertEquals(DispatchOutcome.Failed("BE rejected"), outcome)
+    }
+
+    @Test fun `FF on, v2 RecoveryCode with unknown cid - emits Failed with the cid in the reason`() = runTest {
+        setV2(true)
+        val rawJson = JSONObject().apply {
+            put("user_id", "u")
+            put("secret", "s")
+            put("cid", "future-credential")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+
+        val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
+
+        assertTrue("expected Failed, got $outcome", outcome is DispatchOutcome.Failed)
+        assertTrue((outcome as DispatchOutcome.Failed).reason.contains("future-credential"))
+    }
+
+    // ---- Pixel + side effects: dispatcher must NOT fire any of these ----
+
+    @Test fun `Legacy path - dispatcher never invokes processCode (caller owns that)`() {
+        setV2(false)
+        whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(SyncAuthCode.Recovery(mock()))
+
+        dispatcher.route("any")
+
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
+        verify(syncAccountRepository, never()).joinAccountFromThirdPartyRecoveryCode(any())
+    }
+
+    @Test fun `Legacy path - dispatcher does not start the v2 runner`() {
+        setV2(false)
+        whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(SyncAuthCode.Unknown("x"))
+
+        dispatcher.route("any")
+
+        verify(runner, never()).startScan(any())
+    }
+
+    @Test fun `FF on, LinkingV2 - ignores stale terminal events from prior sessions in the replay cache`() = runTest {
+        // Regression: previously the dispatcher would pick up a Joiner.Done event sitting in
+        // the runner's events replay cache from a prior successful pairing, treat it as the
+        // outcome of THIS session, and call processCode immediately - logging the user in
+        // without ever showing the user-confirmation step of the new session.
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        // Pre-seed the class-level events flow with a stale Joiner.Done from a prior session
+        // (timestampMs well before this test starts). The class-level eventsSince stub will
+        // filter it out based on the dispatcher's sessionStart timestamp.
+        val staleJoinerDone = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event.Transition(
+            timestampMs = 1L, // ancient
+            from = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.Joiner.Waiting,
+            to = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.Joiner.Done,
+            trigger = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse(
+                rawJson = "{}",
+                recoveryCode = "stale-code-from-prior-session",
+            ),
+            localTrigger = null,
+        )
+        // Make the backing flow replay-enabled so the stale event is observable.
+        val staleFlow = MutableSharedFlow<com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event>(replay = 10)
+        staleFlow.tryEmit(staleJoinerDone)
+        whenever(runner.events).thenReturn(staleFlow)
+        whenever(runner.eventsSince(any())).thenAnswer { invocation ->
+            val sinceMs = invocation.getArgument<Long>(0)
+            staleFlow.filter { event -> event.timestampMs >= sinceMs }
+        }
+
+        val decision = dispatcher.route("v2-url") as RouteDecision.V2InProgress
+
+        // Race the dispatcher's flow against a timeout - without the fix, .first() would
+        // immediately pick up the stale Joiner.Done from replay and emit LoggedIn.
+        // With the fix, the flow filters out events older than session start and waits
+        // for genuine new-session events that never arrive in this test setup.
+        val outcome = kotlinx.coroutines.withTimeoutOrNull(100) { decision.outcomes.first() }
+        assertEquals(null, outcome) // no premature emission
+        // And processCode must NOT have been called for the stale code.
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
+    }
+
+    @Test fun `FF on, LinkingV2 - runner_startScan deferred until Flow is collected (cold)`() = runTest {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+
+        val decision = dispatcher.route("v2-url") as RouteDecision.V2InProgress
+
+        // Returning V2InProgress alone must not start the session - the caller hasn't decided to
+        // commit yet. The runner is only kicked off when the Flow is collected. This matters for
+        // safety: callers that do dispatcher.route(...) for inspection won't accidentally bootstrap
+        // a channel.
+        verify(runner, never()).startScan(any())
+
+        // Now actually collect - but cancel after seeing zero emissions (since runner.events is
+        // an empty SharedFlow in this test). We just verify startScan was hit on first collection.
+        kotlinx.coroutines.withTimeoutOrNull(50) { decision.outcomes.first() }
+        verify(runner).startScan(eq("v2-url"))
+    }
+
+    // ---- presentV2() — Presenter-side mapping ----
+
+    private fun transition(
+        from: ExchangeV2State,
+        to: ExchangeV2State,
+        localTrigger: LocalTrigger? = null,
+        timestampMs: Long = System.currentTimeMillis(),
+    ): ExchangeV2Event.Transition = ExchangeV2Event.Transition(
+        timestampMs = timestampMs,
+        from = from,
+        to = to,
+        trigger = null,
+        localTrigger = localTrigger,
+    )
+
+    private fun sessionStarted(linkingCode: String?, timestampMs: Long = System.currentTimeMillis()) =
+        ExchangeV2Event.SessionStarted(
+            timestampMs = timestampMs,
+            pairingRole = PairingRole.Presenter,
+            ownChannelId = "own-channel",
+            linkingCode = linkingCode,
+        )
+
+    @Test fun `presentV2 emits LinkingCodeReady when runner emits SessionStarted with a linkingCode`() = runTest {
+        val flow = dispatcher.presentV2()
+        // Start collection in the background; emit the session event after a tiny delay.
+        val outcomes = mutableListOf<DispatchOutcome>()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+            flow.take(1).collect { outcomes += it }
+        }
+        runnerEventsFlow.emit(sessionStarted(linkingCode = "https://duckduckgo.com/sync/pairing?code2=abc"))
+        job.join()
+
+        assertEquals(1, outcomes.size)
+        assertEquals(
+            DispatchOutcome.LinkingCodeReady("https://duckduckgo.com/sync/pairing?code2=abc"),
+            outcomes.single(),
+        )
+    }
+
+    @Test fun `presentV2 ignores SessionStarted with null linkingCode (Scanner side leakage protection)`() = runTest {
+        // Defensive — startPresent() should always produce a non-null linkingCode, but if the
+        // runner ever emits SessionStarted with null we don't want to emit a malformed outcome.
+        val outcomes = mutableListOf<DispatchOutcome>()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().take(1).collect { outcomes += it } }
+        runnerEventsFlow.emit(sessionStarted(linkingCode = null))
+        // Send a follow-up terminal so collection completes.
+        runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Done))
+        job.join()
+
+        // First outcome should be LoggedIn (from Host.Done), not a malformed LinkingCodeReady(null/empty).
+        assertEquals(DispatchOutcome.LoggedIn, outcomes.single())
+    }
+
+    @Test fun `presentV2 emits HostConfirmationRequested with peerName when runner reaches Host_Confirming`() = runTest {
+        whenever(runner.peerName).thenReturn("Peer Phone")
+        val outcomes = mutableListOf<DispatchOutcome>()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().take(1).collect { outcomes += it } }
+        runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Confirming))
+        job.join()
+
+        assertEquals(DispatchOutcome.HostConfirmationRequested(peerName = "Peer Phone"), outcomes.single())
+    }
+
+    @Test fun `presentV2 emits LoggedIn when runner reaches Host_Done`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+                dispatcher.presentV2().first { it is DispatchOutcome.LoggedIn || it is DispatchOutcome.Failed }
+            }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Host.Sending, to = ExchangeV2State.Host.Done))
+            job.await()
+        }
+        assertEquals(DispatchOutcome.LoggedIn, outcome)
+    }
+
+    @Test fun `presentV2 emits Failed user_denied when Host_Aborted carries UserDeniedHost trigger`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Host.Confirming,
+                    to = ExchangeV2State.Host.Aborted,
+                    localTrigger = LocalTrigger.UserDeniedHost,
+                ),
+            )
+            job.await()
+        }
+        assertEquals(DispatchOutcome.Failed("user_denied"), outcome)
+    }
+
+    @Test fun `presentV2 emits Failed host_unavailable when Host_Aborted carries HostUnavailable trigger`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Host.Sending,
+                    to = ExchangeV2State.Host.Aborted,
+                    localTrigger = LocalTrigger.HostUnavailable,
+                ),
+            )
+            job.await()
+        }
+        assertEquals(DispatchOutcome.Failed("host_unavailable"), outcome)
+    }
+
+    @Test fun `presentV2 emits AlreadyConnected when runner reaches SameAccountAbort`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.SameAccountAbort))
+            job.await()
+        }
+        assertEquals(DispatchOutcome.AlreadyConnected, outcome)
+    }
+
+    @Test fun `presentV2 emits Failed when runner emits SessionError`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(
+                ExchangeV2Event.SessionError(timestampMs = System.currentTimeMillis(), message = "channel 5xx"),
+            )
+            job.await()
+        }
+        assertEquals(DispatchOutcome.Failed("channel 5xx"), outcome)
+    }
+
+    @Test fun `presentV2 emits Failed when Joiner_Done arrives without a recovery code`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+                dispatcher.presentV2().first { it !is DispatchOutcome.LinkingCodeReady }
+            }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Joiner.Waiting, to = ExchangeV2State.Joiner.Done))
+            job.await()
+        }
+        assertEquals(DispatchOutcome.Failed("Pairing completed without a recovery code"), outcome)
+    }
+
+    @Test fun `presentV2 emits LoggedIn when Joiner_Done carries a cid=ddg recovery code`() = runTest {
+        setV2(true)
+        // Build a v2 recovery code payload with cid=ddg.
+        val recoveryJson = JSONObject().apply {
+            put(
+                "recovery",
+                JSONObject().apply {
+                    put("user_id", "u-1")
+                    put("secret", "s-1")
+                    put("cid", "ddg")
+                    put("v", "2.0")
+                },
+            )
+        }.toString()
+        val b64 = android.util.Base64.encodeToString(
+            recoveryJson.toByteArray(Charsets.UTF_8),
+            android.util.Base64.URL_SAFE or android.util.Base64.NO_PADDING or android.util.Base64.NO_WRAP,
+        )
+        val responseMessage = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse(
+            rawJson = "{}",
+            recoveryCode = b64,
+        )
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
+
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+                dispatcher.presentV2().first { it !is DispatchOutcome.LinkingCodeReady }
+            }
+            runnerEventsFlow.emit(
+                ExchangeV2Event.Transition(
+                    timestampMs = System.currentTimeMillis(),
+                    from = ExchangeV2State.Joiner.Waiting,
+                    to = ExchangeV2State.Joiner.Done,
+                    trigger = responseMessage,
+                    localTrigger = null,
+                ),
+            )
+            job.await()
+        }
+        assertEquals(DispatchOutcome.LoggedIn, outcome)
+        // Confirm the v1 Recovery shape was constructed and the login was attempted.
+        verify(syncAccountRepository).processCode(any(), anyOrNull())
+        verify(syncAccountRepository, never()).joinAccountFromThirdPartyRecoveryCode(any())
+    }
+
+    @Test fun `presentV2 emits LoggedIn via 3party upgrade when Joiner_Done carries a cid=3party recovery code`() = runTest {
+        setV2(true)
+        val recoveryJson = JSONObject().apply {
+            put(
+                "recovery",
+                JSONObject().apply {
+                    put("user_id", "u-3p")
+                    put("secret", "s-3p")
+                    put("cid", "3party")
+                    put("v", "2.0")
+                },
+            )
+        }.toString()
+        val b64 = android.util.Base64.encodeToString(
+            recoveryJson.toByteArray(Charsets.UTF_8),
+            android.util.Base64.URL_SAFE or android.util.Base64.NO_PADDING or android.util.Base64.NO_WRAP,
+        )
+        val responseMessage = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse(
+            rawJson = "{}",
+            recoveryCode = b64,
+        )
+        whenever(syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(any())).thenReturn(Result.Success(true))
+
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+                dispatcher.presentV2().first { it !is DispatchOutcome.LinkingCodeReady }
+            }
+            runnerEventsFlow.emit(
+                ExchangeV2Event.Transition(
+                    timestampMs = System.currentTimeMillis(),
+                    from = ExchangeV2State.Joiner.Waiting,
+                    to = ExchangeV2State.Joiner.Done,
+                    trigger = responseMessage,
+                    localTrigger = null,
+                ),
+            )
+            job.await()
+        }
+        assertEquals(DispatchOutcome.LoggedIn, outcome)
+        verify(syncAccountRepository).joinAccountFromThirdPartyRecoveryCode(any())
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
+    }
+
+    @Test fun `presentV2 emits Failed with cancelled-on-this-device reason when Joiner reaches AbortedLocal`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedLocal,
+                    localTrigger = LocalTrigger.UserDeniedJoiner,
+                ),
+            )
+            job.await()
+        }
+        assertEquals(DispatchOutcome.Failed("Pairing cancelled on this device"), outcome)
+    }
+
+    @Test fun `presentV2 calls runner_startPresent when Flow is collected`() = runTest {
+        val flow = dispatcher.presentV2()
+        verify(runner, never()).startPresent()
+
+        // Collect briefly (no events emitted → first() never resolves; rely on timeout).
+        withTimeoutOrNull(50) { flow.first() }
+        verify(runner).startPresent()
+    }
+
+    @Test fun `presentV2 cancels runner when collecting coroutine is cancelled`() = runTest {
+        val flow = dispatcher.presentV2()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+            flow.collect { /* no-op */ }
+        }
+        verify(runner).startPresent()
+
+        job.cancel()
+        job.join()
+
+        verify(runner).cancel()
+    }
+
+    @Test fun `driveV2Linking cancels runner when collecting coroutine is cancelled`() = runTest {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult.LinkingV2(
+                channelId = "c",
+                publicKey = "k",
+                version = "2",
+            ),
+        )
+        val decision = dispatcher.route("v2-url") as RouteDecision.V2InProgress
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+            decision.outcomes.collect { /* no-op */ }
+        }
+        verify(runner).startScan(any())
+
+        job.cancel()
+        job.join()
+
+        verify(runner).cancel()
+    }
+
+    @Test fun `presentV2 terminates silently when another SessionStarted with different channel arrives`() = runTest {
+        val outcomes = mutableListOf<DispatchOutcome>()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+            dispatcher.presentV2().toList(outcomes)
+        }
+        // First SessionStarted establishes the Flow's own channel.
+        runnerEventsFlow.emit(sessionStarted(linkingCode = "code-for-own-channel"))
+        // Second SessionStarted with a different channel — simulates preemption by another caller.
+        runnerEventsFlow.emit(
+            ExchangeV2Event.SessionStarted(
+                timestampMs = System.currentTimeMillis(),
+                pairingRole = PairingRole.Scanner,
+                ownChannelId = "other-channel",
+                linkingCode = null,
+            ),
+        )
+        job.join()
+
+        // The Flow should have completed silently after emitting just the first LinkingCodeReady.
+        assertEquals(1, outcomes.size)
+        assertEquals(DispatchOutcome.LinkingCodeReady("code-for-own-channel"), outcomes.single())
+    }
+
+    @Test fun `driveV2Linking terminates silently when another SessionStarted with different channel arrives`() = runTest {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult.LinkingV2(
+                channelId = "peer-channel",
+                publicKey = "k",
+                version = "2",
+            ),
+        )
+        val decision = dispatcher.route("v2-url") as RouteDecision.V2InProgress
+
+        val outcomes = mutableListOf<DispatchOutcome>()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+            decision.outcomes.toList(outcomes)
+        }
+        // First SessionStarted establishes the Scanner's own channel.
+        runnerEventsFlow.emit(
+            ExchangeV2Event.SessionStarted(
+                timestampMs = System.currentTimeMillis(),
+                pairingRole = PairingRole.Scanner,
+                ownChannelId = "scanner-own-channel",
+                linkingCode = null,
+            ),
+        )
+        // Second SessionStarted with a different channel — simulates preemption.
+        runnerEventsFlow.emit(
+            ExchangeV2Event.SessionStarted(
+                timestampMs = System.currentTimeMillis(),
+                pairingRole = PairingRole.Presenter,
+                ownChannelId = "different-channel",
+                linkingCode = "code",
+            ),
+        )
+        job.join()
+
+        // The Flow should have completed silently — no outcomes emitted (Scanner side never
+        // emits anything for the initial SessionStarted because linkingCode=null on its side).
+        assertTrue("expected no outcomes, got $outcomes", outcomes.isEmpty())
+    }
+
+    @Test fun `presentV2 emits Failed when runner reaches Aborted (hello during negotiating)`() = runTest {
+        val outcomes = mutableListOf<DispatchOutcome>()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+            dispatcher.presentV2().take(1).collect { outcomes += it }
+        }
+        runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Aborted))
+        job.join()
+
+        assertTrue("expected Failed, got ${outcomes.single()}", outcomes.single() is DispatchOutcome.Failed)
+    }
+
+    @Test fun `linking flow emits Failed when runner reaches Aborted (hello during negotiating)`() = runTest {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        val decision = dispatcher.route("v2-url") as RouteDecision.V2InProgress
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
+                decision.outcomes.first { it is DispatchOutcome.Failed }
+            }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Aborted))
+            job.await()
+        }
+        assertTrue("expected Failed, got $outcome", outcome is DispatchOutcome.Failed)
+    }
+
+    @Test fun `presentV2 filters out events from before session start`() = runTest {
+        // Seed a stale Host_Done from a prior session with timestamp=1L (well before now).
+        val staleFlow = MutableSharedFlow<ExchangeV2Event>(replay = 10)
+        staleFlow.tryEmit(
+            ExchangeV2Event.Transition(
+                timestampMs = 1L,
+                from = ExchangeV2State.Host.Sending,
+                to = ExchangeV2State.Host.Done,
+                trigger = null,
+                localTrigger = null,
+            ),
+        )
+        whenever(runner.events).thenReturn(staleFlow)
+        whenever(runner.eventsSince(any())).thenAnswer { inv ->
+            val since = inv.getArgument<Long>(0)
+            staleFlow.filter { it.timestampMs >= since }
+        }
+
+        // No fresh event emitted; outcome should never arrive within timeout.
+        val outcome = withTimeoutOrNull(100) { dispatcher.presentV2().first() }
+        assertEquals(null, outcome)
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -227,6 +228,35 @@ class RealSyncCodeDispatcherTest {
         verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
     }
 
+    @Test fun `FF on, v2 RecoveryCode cid=3party - re-encoded code is canonical JSON without escaped slashes`() = runTest {
+        // Real 3party secrets are base64url (slash-free), but the re-wrapped code handed to
+        // joinAccountFromThirdPartyRecoveryCode must never carry AOSP org.json '\/' escaping should
+        // any field contain '/'. Defence-in-depth, consistent with the other v2 wire-JSON producers.
+        setV2(true)
+        val secretWithSlashes = "apZ+7PAe89rDhuG4DRyi/M3zU2/D5DZNdRsR3RM6Ujw="
+        val rawJson = JSONObject().apply {
+            put("user_id", "u-3p")
+            put("secret", secretWithSlashes)
+            put("cid", "3party")
+            put("v", "2.0")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(any())).thenReturn(Result.Success(true))
+
+        (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.toList()
+
+        val captor = org.mockito.kotlin.argumentCaptor<String>()
+        verify(syncAccountRepository).joinAccountFromThirdPartyRecoveryCode(captor.capture())
+        val decodedJson = String(java.util.Base64.getUrlDecoder().decode(captor.firstValue), Charsets.UTF_8)
+        assertFalse("re-wrapped 3party JSON must not contain escaped slashes (\\/): $decodedJson", decodedJson.contains("\\/"))
+        // …and the wrapped recovery must round-trip back to the original fields.
+        val recovery = JSONObject(decodedJson).getJSONObject("recovery")
+        assertEquals(secretWithSlashes, recovery.getString("secret"))
+        assertEquals("u-3p", recovery.getString("user_id"))
+        assertEquals("3party", recovery.getString("cid"))
+        assertEquals("2.0", recovery.getString("v"))
+    }
+
     @Test fun `FF on, v2 RecoveryCode cid=ddg - ALREADY_SIGNED_IN triggers logoutAndJoinNewAccount and emits LoggedIn`() = runTest {
         // Per spec, the v2 path does NOT surface a v1-style AskToSwitchAccount prompt - the
         // Confirmations phase (or the act of pasting a recovery code) is already the consent
@@ -260,6 +290,38 @@ class RealSyncCodeDispatcherTest {
         val decoded = java.util.Base64.getUrlDecoder().decode(captor.firstValue)
         val recovery = JSONObject(String(decoded)).getJSONObject("recovery")
         assertEquals("s-other", recovery.getString("primary_key"))
+        assertEquals("u-other", recovery.getString("user_id"))
+    }
+
+    @Test fun `FF on, v2 RecoveryCode cid=ddg - account-switch code is canonical v1 JSON without escaped slashes`() = runTest {
+        // The ddg secret is standard base64 and routinely contains '/'. The re-encoded v1 code fed
+        // to logoutAndJoinNewAccount must be canonical (Moshi, no AOSP org.json '\/' escaping) so it
+        // is byte-identical to genuine v1 codes and never depends on a lenient consumer to unescape.
+        setV2(true)
+        val secretWithSlashes = "apZ+7PAe89rDhuG4DRyi/M3zU2/D5DZNdRsR3RM6Ujw="
+        val rawJson = JSONObject().apply {
+            put("user_id", "u-other")
+            put("secret", secretWithSlashes)
+            put("cid", "ddg")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(
+            Result.Error(
+                code = com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN.code,
+                reason = "Already signed in",
+            ),
+        )
+        whenever(syncAccountRepository.logoutAndJoinNewAccount(any())).thenReturn(Result.Success(true))
+
+        (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
+
+        val captor = org.mockito.kotlin.argumentCaptor<String>()
+        verify(syncAccountRepository).logoutAndJoinNewAccount(captor.capture())
+        val decodedJson = String(java.util.Base64.getUrlDecoder().decode(captor.firstValue), Charsets.UTF_8)
+        assertFalse("v1 account-switch JSON must not contain escaped slashes (\\/): $decodedJson", decodedJson.contains("\\/"))
+        // …and it must still round-trip back to the exact secret.
+        val recovery = JSONObject(decodedJson).getJSONObject("recovery")
+        assertEquals(secretWithSlashes, recovery.getString("primary_key"))
         assertEquals("u-other", recovery.getString("user_id"))
     }
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
@@ -20,9 +20,22 @@ import android.content.SharedPreferences
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.api.InMemorySharedPreferences
 import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.sync.api.engine.SyncableType
 import com.duckduckgo.sync.impl.API_CODE
+import com.duckduckgo.sync.impl.AccountErrorCodes
+import com.duckduckgo.sync.impl.DispatchOutcome
 import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.SyncCodeType
+import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupFailureReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
 import com.duckduckgo.sync.impl.stats.DailyStats
 import com.duckduckgo.sync.impl.stats.SyncStatsRepository
 import com.duckduckgo.sync.store.SharedPrefsProvider
@@ -40,6 +53,7 @@ class RealSyncPixelsTest {
     private var pixel: Pixel = mock()
     private var syncStatsRepository: SyncStatsRepository = mock()
     private var sharedPrefsProv: SharedPrefsProvider = mock()
+    private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
 
     private lateinit var sharedPreferences: SharedPreferences
     private lateinit var testee: RealSyncPixels
@@ -55,6 +69,7 @@ class RealSyncPixelsTest {
             pixel,
             syncStatsRepository,
             sharedPrefsProv,
+            syncFeature,
         )
     }
 
@@ -118,6 +133,385 @@ class RealSyncPixelsTest {
     fun whenSignupConnectPixelCalledWithSourceThenPixelFiredIncludesSource() {
         testee.fireSignupConnectPixel(source = "foo")
         verify(pixel).fire(SyncPixelName.SYNC_SIGNUP_CONNECT, mapOf("source" to "foo"))
+    }
+
+    @Test
+    fun whenBarcodeScreenShownAndV2FlowEnabledThenPixelFiredWithV2AndDdg() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncBarcodeScreenShown(ScreenType.SYNC_CONNECT)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_BARCODE_SCREEN_SHOWN,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenBarcodeScreenShownAndV2FlowDisabledThenPixelFiredWithV1AndDdg() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireSyncBarcodeScreenShown(ScreenType.SYNC_EXCHANGE)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_BARCODE_SCREEN_SHOWN,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenManualCodeEntryScreenShownAndV2FlowEnabledThenPixelFiredWithV2AndDdg() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupManualCodeScreenShown(ScreenType.SYNC_EXCHANGE)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTRY_SCREEN_SHOWN,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenManualCodeEntryScreenShownAndV2FlowDisabledThenPixelFiredWithV1AndDdg() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireSyncSetupManualCodeScreenShown(ScreenType.SYNC_CONNECT)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTRY_SCREEN_SHOWN,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenBarcodeScannerParseSuccessOnLegacyPathThenPixelFiredWithV1AndNoCodeType() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireBarcodeScannerParseSuccess(ScreenType.SYNC_CONNECT, CodeVersion.V1)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_CODE_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenBarcodeScannerParseSuccessForV2RecoveryCodeThenPixelFiredWithCodeMetadata() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireBarcodeScannerParseSuccess(ScreenType.SYNC_EXCHANGE, CodeVersion.V2, SyncCodeType.RECOVERY)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_CODE_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_CODE_TYPE to "recovery",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenManualCodeEnteredSuccessForV2LinkingCodeThenPixelFiredWithCodeMetadata() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupCodePastedParseSuccess(ScreenType.SYNC_CONNECT, CodeVersion.V2, SyncCodeType.LINKING)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_CODE_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_CODE_TYPE to "linking",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenManualCodeEnteredSuccessOnLegacyPathThenPixelFiredWithV1AndNoCodeType() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireSyncSetupCodePastedParseSuccess(ScreenType.SYNC_EXCHANGE, CodeVersion.V1)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_CODE_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenBarcodeScannerParseErrorThenPixelFiredWithFlowMetadata() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireBarcodeScannerParseError(ScreenType.SYNC_CONNECT)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenManualCodeEnteredFailureThenPixelFiredWithFlowMetadata() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupCodePastedParseFailure(ScreenType.SYNC_EXCHANGE)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenSetupFinishedV1ThenPixelFiredWithFlowMetadataOnly() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireSyncSetupFinishedSuccessfully(ScreenType.SYNC_CONNECT)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenSetupFinishedV2RecoveryThenPixelFiredWithPathNoRoleOrPeer() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupFinishedSuccessfully(ScreenType.SYNC_EXCHANGE, SetupPath.RECOVERY)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_PATH to "recovery",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenSetupFinishedV2PairingThenPixelFiredWithPathRoleAndPeer() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupFinishedSuccessfully(
+            ScreenType.SYNC_CONNECT,
+            SetupPath.PAIRING,
+            SetupRole.HOST,
+            PeerKind.THIRD_PARTY,
+        )
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_PATH to "pairing",
+                SyncPixelParameters.SYNC_SETUP_MY_ROLE to "host",
+                SyncPixelParameters.SYNC_SETUP_PEER_KIND to "3party",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenSetupFailedWithAllDimsThenPixelFiredWithReasonPathRoleAndPeer() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupFailed(
+            SetupFailureReason.TRANSPORT_FAILURE,
+            SetupPath.PAIRING,
+            SetupRole.JOINER,
+            PeerKind.DDG,
+        )
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_REASON to "transport_failure",
+                SyncPixelParameters.SYNC_SETUP_PATH to "pairing",
+                SyncPixelParameters.SYNC_SETUP_MY_ROLE to "joiner",
+                SyncPixelParameters.SYNC_SETUP_PEER_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenSetupFailedWithReasonOnlyThenOptionalDimsOmitted() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupFailed(SetupFailureReason.UNEXPECTED_FAILURE)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_REASON to "unexpected_failure",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSetupFailedForUpgradeRequiredThenNeedsUpgrade() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSetupFailed(DispatchOutcome.UpgradeRequired(codeMajor = 3, path = SetupPath.PAIRING, myRole = SetupRole.HOST))
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_REASON to "needs_upgrade",
+                SyncPixelParameters.SYNC_SETUP_PATH to "pairing",
+                SyncPixelParameters.SYNC_SETUP_MY_ROLE to "host",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSetupFailedForFailedOutcomeThenReasonMappedFromCode() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSetupFailed(
+            DispatchOutcome.Failed(
+                reason = "boom",
+                code = AccountErrorCodes.INVALID_CODE.code,
+                path = SetupPath.RECOVERY,
+            ),
+        )
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_REASON to "invalid_credentials",
+                SyncPixelParameters.SYNC_SETUP_PATH to "recovery",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSetupFailedForCancellationCodesThenPixelNotFired() {
+        testee.fireSetupFailed(DispatchOutcome.Failed(reason = "user", code = AccountErrorCodes.PAIRING_CANCELLED.code))
+        testee.fireSetupFailed(DispatchOutcome.Failed(reason = "peer", code = AccountErrorCodes.PAIRING_REJECTED.code))
+
+        verifyNoInteractions(pixel)
+    }
+
+    @Test
+    fun whenSetupAbandonedWithReasonThenPixelFiredWithReasonAndFlowMetadata() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupAbandoned(ScreenType.SYNC_CONNECT, CancellationReason.CANCELLED_BEFORE_FINISHED)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_ABANDONED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_REASON to "cancelled_before_finished",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenSetupAbandonedWithoutReasonThenReasonOmitted() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireSyncSetupAbandoned(ScreenType.SYNC_EXCHANGE)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_ABANDONED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSetupCancelledIfDeniedForPairingCancelledThenAbandonedFired() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSetupCancelledIfDenied(
+            DispatchOutcome.Failed(reason = "user_denied", code = AccountErrorCodes.PAIRING_CANCELLED.code),
+            ScreenType.SYNC_CONNECT,
+        )
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_ABANDONED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_REASON to "sync_confirmation_denied",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSetupCancelledIfDeniedForPeerRejectionOrOtherThenNotFired() {
+        testee.fireSetupCancelledIfDenied(
+            DispatchOutcome.Failed(reason = "peer", code = AccountErrorCodes.PAIRING_REJECTED.code),
+            ScreenType.SYNC_CONNECT,
+        )
+        testee.fireSetupCancelledIfDenied(
+            DispatchOutcome.Failed(reason = "boom", code = AccountErrorCodes.PAIRING_FAILED.code),
+            ScreenType.SYNC_CONNECT,
+        )
+
+        verifyNoInteractions(pixel)
     }
 
     @Test

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
@@ -35,7 +35,10 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.CREATE_ACCOUNT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.GENERIC_ERROR
 import com.duckduckgo.sync.impl.AccountErrorCodes.INVALID_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED
 import com.duckduckgo.sync.impl.Clipboard
+import com.duckduckgo.sync.impl.RealSyncCodeDispatcher
 import com.duckduckgo.sync.impl.RecoveryCode
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
@@ -43,14 +46,23 @@ import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode.Recovery
 import com.duckduckgo.sync.impl.SyncAuthCode.Unknown
 import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState.Idle
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.AskToSwitchAccount
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.LoginSuccess
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.ShowError
+import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.ShowV2Error
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.SwitchAccountSuccess
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -73,6 +85,15 @@ internal class EnterCodeViewModelTest {
         this.seamlessAccountSwitching().setRawStoredState(State(true))
     }
     private val syncPixels: SyncPixels = mock()
+    private val qrCode: ExchangeV2QrCode = mock()
+    private val runner: ExchangeV2Runner = mock()
+
+    private val codeDispatcher = RealSyncCodeDispatcher(
+        syncFeature = syncFeature,
+        syncAccountRepository = syncAccountRepository,
+        qrCode = qrCode,
+        runner = runner,
+    )
 
     private val testee = EnterCodeViewModel(
         syncAccountRepository,
@@ -80,6 +101,7 @@ internal class EnterCodeViewModelTest {
         coroutineTestRule.testDispatcherProvider,
         syncFeature = syncFeature,
         syncPixels = syncPixels,
+        codeDispatcher = codeDispatcher,
     )
 
     @Test
@@ -104,6 +126,56 @@ internal class EnterCodeViewModelTest {
         testee.onPasteCodeClicked()
 
         verify(clipboard).pasteFromClipboard()
+    }
+
+    @Test
+    fun whenV2ThirdPartyRecoveryAlreadyUpgradedThenShowError() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
+        val pastedCode = "https://duckduckgo.com/sync/pairing/#&code2=3party-recovery"
+        whenever(clipboard.pasteFromClipboard()).thenReturn(pastedCode)
+        val recoveryJson = org.json.JSONObject().apply {
+            put("cid", "3party")
+            put("user_id", "u-1")
+            put("secret", "s-1")
+            put("v", "2.0")
+        }
+        whenever(qrCode.parse(pastedCode)).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson = recoveryJson))
+        whenever(syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(any())).thenReturn(
+            Error(code = THIRD_PARTY_ALREADY_UPGRADED.code, reason = "account already upgraded"),
+        )
+
+        testee.onPasteCodeClicked()
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(THIRD_PARTY_ALREADY_UPGRADED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2CodeRequiresNewerProtocolThenShowUpdateError() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
+        val pastedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(clipboard.pasteFromClipboard()).thenReturn(pastedCode)
+        whenever(qrCode.parse(pastedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(ExchangeV2Event.SessionError(timestampMs = 0L, message = "Peer requires protocol v3; please update this app")),
+        )
+
+        testee.onPasteCodeClicked()
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2UpgradeRequiredError, (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     @Test
@@ -319,6 +391,72 @@ internal class EnterCodeViewModelTest {
         testee.onPasteCodeClicked()
 
         testee.commands().test {
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2SameAccountThenShowAlreadyPaired() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
+        val pastedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(clipboard.pasteFromClipboard()).thenReturn(pastedCode)
+        whenever(qrCode.parse(pastedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(
+                ExchangeV2Event.Transition(
+                    timestampMs = 0L,
+                    from = ExchangeV2State.Negotiating,
+                    to = ExchangeV2State.SameAccountAbort,
+                    trigger = null,
+                    localTrigger = null,
+                ),
+            ),
+        )
+
+        testee.onPasteCodeClicked()
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2AlreadyPairedError, (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2PairingRejectedByPeerThenShowErrorAndClearLoading() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
+        val pastedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(clipboard.pasteFromClipboard()).thenReturn(pastedCode)
+        whenever(qrCode.parse(pastedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(
+                ExchangeV2Event.Transition(
+                    timestampMs = 0L,
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                    localTrigger = null,
+                ),
+            ),
+        )
+
+        testee.onPasteCodeClicked()
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_REJECTED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+        testee.viewState().test {
+            assertTrue(awaitItem().authState is Idle)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.sync.impl.ui
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.sync.TestSyncFixtures
 import com.duckduckgo.sync.TestSyncFixtures.jsonConnectKey
 import com.duckduckgo.sync.TestSyncFixtures.jsonConnectKeyEncoded
@@ -28,6 +29,10 @@ import com.duckduckgo.sync.TestSyncFixtures.primaryKey
 import com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN
 import com.duckduckgo.sync.impl.AccountErrorCodes.CONNECT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
+import com.duckduckgo.sync.impl.AccountInfo
 import com.duckduckgo.sync.impl.Clipboard
 import com.duckduckgo.sync.impl.ConnectCode
 import com.duckduckgo.sync.impl.QREncoder
@@ -37,19 +42,41 @@ import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAccountRepository.AuthCode
 import com.duckduckgo.sync.impl.SyncAuthCode.Connect
 import com.duckduckgo.sync.impl.SyncAuthCode.Recovery
+import com.duckduckgo.sync.impl.SyncCodeType
+import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
+import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
+import com.duckduckgo.sync.impl.exchange.v2.PairingRole
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_CONNECT
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupFailureReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command
+import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.AskHostConfirmation
+import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.AskJoinerConfirmation
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.LoginSuccess
+import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.ShowError
+import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.ShowV2Error
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -66,13 +93,38 @@ class SyncConnectViewModelTest {
     private val qrEncoder: QREncoder = mock()
     private val syncPixels: SyncPixels = mock()
 
+    private val syncFeature = com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory.create(SyncFeature::class.java)
+
+    private val runnerEventsFlow = kotlinx.coroutines.flow.MutableSharedFlow<com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event>(replay = 0)
+    private val qrCode: com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode = mock()
+    private val runner: com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner = mock<com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner>().also {
+        whenever(it.events).thenReturn(runnerEventsFlow)
+        whenever(it.eventsSince(any())).thenAnswer { invocation ->
+            val sinceMs = invocation.getArgument<Long>(0)
+            runnerEventsFlow.filter { event -> event.timestampMs >= sinceMs }
+        }
+    }
+    private val codeDispatcher = com.duckduckgo.sync.impl.RealSyncCodeDispatcher(
+        syncFeature = syncFeature,
+        syncAccountRepository = syncRepository,
+        qrCode = qrCode,
+        runner = runner,
+    )
+
     private val testee = SyncConnectViewModel(
         syncRepository,
         qrEncoder,
         clipboard,
         syncPixels,
         coroutineTestRule.testDispatcherProvider,
+        syncFeature,
+        codeDispatcher,
     )
+
+    @Before
+    fun setup() {
+        whenever(syncRepository.getAccountInfo()).thenReturn(AccountInfo())
+    }
 
     @Test
     fun whenScreenStartedThenShowQRCode() = runTest {
@@ -181,9 +233,9 @@ class SyncConnectViewModelTest {
             testee.onQRCodeScanned(jsonConnectKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.LoginSuccess)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_CONNECT))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_CONNECT), eq(CodeVersion.V1), isNull())
             verify(syncPixels).fireLoginPixel()
-            verify(syncPixels).fireSyncSetupFinishedSuccessfully(eq(SyncPixels.ScreenType.SYNC_CONNECT))
+            verify(syncPixels).fireSyncSetupFinishedSuccessfully(eq(SyncPixels.ScreenType.SYNC_CONNECT), isNull(), isNull(), isNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -196,9 +248,9 @@ class SyncConnectViewModelTest {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.ShowError)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_CONNECT))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_CONNECT), eq(CodeVersion.V1), isNull())
             verify(syncPixels, never()).fireLoginPixel()
-            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any())
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -212,9 +264,33 @@ class SyncConnectViewModelTest {
             testee.onQRCodeScanned(jsonConnectKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.ShowError)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_CONNECT))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_CONNECT), eq(CodeVersion.V1), isNull())
             verify(syncPixels, never()).fireLoginPixel()
-            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any())
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenUserScansV2RecoveryCodeThenBarcodeScannerParseSuccessFiredWithV2Recovery() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        val rawJson = org.json.JSONObject().apply {
+            put("user_id", "u-1")
+            put("secret", "s-1")
+            put("cid", "ddg")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
+
+        testee.commands().test {
+            testee.onQRCodeScanned("v2-recovery-code")
+            val command = awaitItem()
+            assertTrue("expected LoginSuccess, got $command", command is LoginSuccess)
+            verify(syncPixels).fireBarcodeScannerParseSuccess(
+                eq(SyncPixels.ScreenType.SYNC_CONNECT),
+                eq(CodeVersion.V2),
+                eq(SyncCodeType.RECOVERY),
+            )
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -226,7 +302,8 @@ class SyncConnectViewModelTest {
             val command = awaitItem()
             assertTrue(command is Command.LoginSuccess)
             verify(syncPixels).fireLoginPixel()
-            verify(syncPixels).fireSyncSetupFinishedSuccessfully(eq(SyncPixels.ScreenType.SYNC_CONNECT))
+            // Manual entry fires "Setup success" from EnterCodeViewModel, not here.
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -234,7 +311,7 @@ class SyncConnectViewModelTest {
     @Test
     fun whenUserCancelsThenAbandonedPixelFired() = runTest {
         testee.onUserCancelledWithoutSyncSetup()
-        verify(syncPixels).fireSyncSetupAbandoned(eq(SYNC_CONNECT))
+        verify(syncPixels).fireSyncSetupAbandoned(eq(SYNC_CONNECT), eq(CancellationReason.SCANNING_CANCELLED))
     }
 
     @Test
@@ -290,6 +367,530 @@ class SyncConnectViewModelTest {
             awaitItem()
             cancelAndIgnoreRemainingEvents()
             verify(syncRepository, times(2)).pollConnectionKeys()
+        }
+    }
+
+    private fun enableV2(displayOn: Boolean) {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        syncFeature.canShowV2ConnectCode().setRawStoredState(State(displayOn))
+    }
+
+    private fun presenterSessionStarted(linkingCode: String = "https://duckduckgo.com/sync/pairing/#&code2=xyz") =
+        ExchangeV2Event.SessionStarted(
+            timestampMs = System.currentTimeMillis(),
+            pairingRole = PairingRole.Presenter,
+            ownChannelId = "own-channel",
+            linkingCode = linkingCode,
+        )
+
+    private fun transition(
+        from: ExchangeV2State,
+        to: ExchangeV2State,
+        localTrigger: LocalTrigger? = null,
+        trigger: ExchangeV2Message? = null,
+    ) = ExchangeV2Event.Transition(
+        timestampMs = System.currentTimeMillis(),
+        from = from,
+        to = to,
+        trigger = trigger,
+        localTrigger = localTrigger,
+    )
+
+    @Test
+    fun whenBothV2FlagsOnThenRunnerStartPresentInvokedAndV1ConnectQRNotCalled() = runTest {
+        enableV2(displayOn = true)
+        val bitmap = TestSyncFixtures.qrBitmap()
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(bitmap)
+
+        testee.viewState(source = null).test {
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            val withQr = awaitItem()
+            Assert.assertEquals(bitmap, withQr.qrCodeBitmap)
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(runner).startPresent()
+        verify(syncRepository, never()).getConnectQR()
+    }
+
+    @Test
+    fun whenMasterFlagOnButCanShowV2OffThenV1PathTaken() = runTest {
+        enableV2(displayOn = false)
+        val bitmap = TestSyncFixtures.qrBitmap()
+        val authCode = AuthCode(qrCode = jsonConnectKeyEncoded, rawCode = "raw")
+        whenever(qrEncoder.encodeAsBitmap(eq(jsonConnectKeyEncoded), any(), any())).thenReturn(bitmap)
+        whenever(syncRepository.getConnectQR()).thenReturn(Result.Success(authCode))
+        whenever(syncRepository.pollConnectionKeys()).thenReturn(Result.Success(true))
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(runner, never()).startPresent()
+        verify(syncRepository).getConnectQR()
+    }
+
+    @Test
+    fun whenMasterFlagOffThenV1PathTakenRegardlessOfDisplayFlag() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+        syncFeature.canShowV2ConnectCode().setRawStoredState(State(true))
+        val bitmap = TestSyncFixtures.qrBitmap()
+        val authCode = AuthCode(qrCode = jsonConnectKeyEncoded, rawCode = "raw")
+        whenever(qrEncoder.encodeAsBitmap(eq(jsonConnectKeyEncoded), any(), any())).thenReturn(bitmap)
+        whenever(syncRepository.getConnectQR()).thenReturn(Result.Success(authCode))
+        whenever(syncRepository.pollConnectionKeys()).thenReturn(Result.Success(true))
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(runner, never()).startPresent()
+    }
+
+    @Test
+    fun whenLinkingCodeReadyThenCopyEmitsUrl() = runTest {
+        enableV2(displayOn = true)
+        val url = "https://duckduckgo.com/sync/pairing/#&code2=copy-me"
+        whenever(qrEncoder.encodeAsBitmap(eq(url), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState(source = null).test {
+            runnerEventsFlow.emit(presenterSessionStarted(linkingCode = url))
+            awaitItem()
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.onCopyCodeClicked()
+        verify(clipboard).copyToClipboard(url)
+        verify(syncRepository, never()).getConnectQR()
+    }
+
+    @Test
+    fun whenJoinerConfirmingDuringV2PresentThenAskJoinerConfirmationCommandEmitted() = runTest {
+        enableV2(displayOn = true)
+        whenever(runner.peerName).thenReturn("Peer Phone")
+        whenever(runner.peerKind).thenReturn("ddg")
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Joiner.Confirming),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected AskJoinerConfirmation, got $command", command is AskJoinerConfirmation)
+            Assert.assertEquals("Peer Phone", (command as AskJoinerConfirmation).peerName)
+            Assert.assertEquals(PeerKind.DDG, (command as AskJoinerConfirmation).peerKind)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenHostConfirmingDuringV2PresentThenAskHostConfirmationCommandEmitted() = runTest {
+        enableV2(displayOn = true)
+        whenever(runner.peerName).thenReturn("Peer Phone")
+        whenever(runner.peerKind).thenReturn("3party")
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Confirming),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected AskHostConfirmation, got $command", command is AskHostConfirmation)
+            Assert.assertEquals("Peer Phone", (command as AskHostConfirmation).peerName)
+            Assert.assertEquals(PeerKind.THIRD_PARTY, (command as AskHostConfirmation).peerKind)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenJoinerDoneWithCidDdgRecoveryCodeThenLoginSuccess() = runTest {
+        enableV2(displayOn = true)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+        val recoveryJson = org.json.JSONObject().apply {
+            put(
+                "recovery",
+                org.json.JSONObject().apply {
+                    put("user_id", "u-1")
+                    put("secret", "s-1")
+                    put("cid", "ddg")
+                    put("v", "2.0")
+                },
+            )
+        }.toString()
+        val b64 = android.util.Base64.encodeToString(
+            recoveryJson.toByteArray(Charsets.UTF_8),
+            android.util.Base64.URL_SAFE or android.util.Base64.NO_PADDING or android.util.Base64.NO_WRAP,
+        )
+        whenever(syncRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Waiting,
+                    to = ExchangeV2State.Joiner.Done,
+                    trigger = ExchangeV2Message.RecoveryCodeResponse(rawJson = "{}", recoveryCode = b64),
+                ),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected LoginSuccess, got $command", command is LoginSuccess)
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(syncRepository).processCode(any(), anyOrNull())
+    }
+
+    @Test
+    fun whenJoinerDoneViaCid3partyThenLoginSuccessAndUpgradeInvoked() = runTest {
+        enableV2(displayOn = true)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+        val recoveryJson = org.json.JSONObject().apply {
+            put(
+                "recovery",
+                org.json.JSONObject().apply {
+                    put("user_id", "u-3p")
+                    put("secret", "s-3p")
+                    put("cid", "3party")
+                    put("v", "2.0")
+                },
+            )
+        }.toString()
+        val b64 = android.util.Base64.encodeToString(
+            recoveryJson.toByteArray(Charsets.UTF_8),
+            android.util.Base64.URL_SAFE or android.util.Base64.NO_PADDING or android.util.Base64.NO_WRAP,
+        )
+        whenever(syncRepository.joinAccountFromThirdPartyRecoveryCode(any())).thenReturn(Result.Success(true))
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Waiting,
+                    to = ExchangeV2State.Joiner.Done,
+                    trigger = ExchangeV2Message.RecoveryCodeResponse(rawJson = "{}", recoveryCode = b64),
+                ),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected LoginSuccess, got $command", command is LoginSuccess)
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(syncRepository).joinAccountFromThirdPartyRecoveryCode(any())
+    }
+
+    @Test
+    fun whenV2LinkingCodeScannedThenRoutedThroughDispatcherAndLoginSuccess() = runTest {
+        enableV2(displayOn = true)
+        val scannedUrl = "https://duckduckgo.com/sync/pairing/#&code2=scan-me"
+        whenever(qrCode.parse(scannedUrl)).thenReturn(
+            com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult.LinkingV2(
+                channelId = "chan",
+                publicKey = "pk",
+                version = "2",
+            ),
+        )
+        val recoveryJson = org.json.JSONObject().apply {
+            put(
+                "recovery",
+                org.json.JSONObject().apply {
+                    put("user_id", "u-1")
+                    put("secret", "s-1")
+                    put("cid", "ddg")
+                    put("v", "2.0")
+                },
+            )
+        }.toString()
+        val recoveryB64 = android.util.Base64.encodeToString(
+            recoveryJson.toByteArray(Charsets.UTF_8),
+            android.util.Base64.URL_SAFE or android.util.Base64.NO_PADDING or android.util.Base64.NO_WRAP,
+        )
+        whenever(syncRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scannedUrl)
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Waiting,
+                    to = ExchangeV2State.Joiner.Done,
+                    trigger = ExchangeV2Message.RecoveryCodeResponse(rawJson = "{}", recoveryCode = recoveryB64),
+                ),
+            )
+            val command = awaitItem()
+            assertTrue("expected LoginSuccess, got $command", command is LoginSuccess)
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(runner).startScan(scannedUrl)
+    }
+
+    @Test
+    fun whenHostDoneDuringV2PresentThenLoginSuccess() = runTest {
+        enableV2(displayOn = true)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(from = ExchangeV2State.Host.Sending, to = ExchangeV2State.Host.Done),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected LoginSuccess, got $command", command is LoginSuccess)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenJoinerAbortedByHostThenShowError() = runTest {
+        enableV2(displayOn = true)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(from = ExchangeV2State.Joiner.Waiting, to = ExchangeV2State.Joiner.AbortedByHost),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_REJECTED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenJoinerAbortedLocalThenShowError() = runTest {
+        enableV2(displayOn = true)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedLocal,
+                    localTrigger = LocalTrigger.UserDeniedJoiner,
+                ),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_CANCELLED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenHostAbortedUserDeniedThenShowError() = runTest {
+        enableV2(displayOn = true)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Host.Confirming,
+                    to = ExchangeV2State.Host.Aborted,
+                    localTrigger = LocalTrigger.UserDeniedHost,
+                ),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_CANCELLED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        // Denying the confirmation (PAIRING_CANCELLED) fires the cancellation pixel, not the failed one.
+        verify(syncPixels).fireSyncSetupAbandoned(eq(SYNC_CONNECT), eq(CancellationReason.CONFIRMATION_DENIED))
+    }
+
+    @Test
+    fun whenUserCancelsMidExchangeThenAbandonedWithCancelledBeforeFinished() = runTest {
+        whenever(runner.currentState).thenReturn(ExchangeV2State.Negotiating)
+
+        testee.onUserCancelledWithoutSyncSetup()
+
+        verify(syncPixels).fireSyncSetupAbandoned(eq(SYNC_CONNECT), eq(CancellationReason.CANCELLED_BEFORE_FINISHED))
+    }
+
+    @Test
+    fun whenSessionErrorDuringV2PresentThenShowError() = runTest {
+        enableV2(displayOn = true)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                ExchangeV2Event.SessionError(timestampMs = System.currentTimeMillis(), message = "channel 5xx"),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_FAILED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        verify(syncPixels).fireSyncSetupFailed(
+            eq(SetupFailureReason.TRANSPORT_FAILURE),
+            eq(SetupPath.PAIRING),
+            isNull(),
+            isNull(),
+        )
+    }
+
+    @Test
+    fun whenViewStateReCollectedThenConnectQRGeneratedOnce() = runTest {
+        val authCodeToUse = AuthCode(qrCode = jsonConnectKeyEncoded, rawCode = "raw")
+        whenever(syncRepository.getConnectQR()).thenReturn(Result.Success(authCodeToUse))
+        whenever(qrEncoder.encodeAsBitmap(eq(jsonConnectKeyEncoded), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+        whenever(syncRepository.pollConnectionKeys()).thenReturn(Result.Success(true))
+        testee.viewState(source = null).test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        testee.viewState(source = null).test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(syncRepository, times(1)).getConnectQR()
+    }
+
+    @Test
+    fun whenViewStateReCollectedThenV2PresentStartedOnce() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        syncFeature.canShowV2ConnectCode().setRawStoredState(State(true))
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+        testee.viewState(source = null).test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        testee.viewState(source = null).test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(runner, times(1)).startPresent()
+    }
+
+    @Test
+    fun whenV2PairingRejectedByPeerThenShowError() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncRepository.getAccountInfo()).thenReturn(AccountInfo())
+        val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(qrCode.parse(scannedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(
+                ExchangeV2Event.Transition(
+                    timestampMs = 0L,
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                    localTrigger = null,
+                ),
+            ),
+        )
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scannedCode)
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_REJECTED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2PresentSameAccountThenShowAlreadyPaired() = runTest {
+        enableV2(displayOn = true)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.SameAccountAbort),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2AlreadyPairedError, (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2UpgradeRequiredThenShowUpdateError() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncRepository.getAccountInfo()).thenReturn(AccountInfo())
+        val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(qrCode.parse(scannedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(ExchangeV2Event.SessionError(timestampMs = 0L, message = "Peer requires protocol v3; please update this app")),
+        )
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scannedCode)
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2UpgradeRequiredError, (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
         }
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
@@ -19,16 +19,31 @@ package com.duckduckgo.sync.impl.ui
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.sync.TestSyncFixtures.jsonRecoveryKey
 import com.duckduckgo.sync.TestSyncFixtures.jsonRecoveryKeyEncoded
 import com.duckduckgo.sync.TestSyncFixtures.primaryKey
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
+import com.duckduckgo.sync.impl.RealSyncCodeDispatcher
 import com.duckduckgo.sync.impl.RecoveryCode
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode.Recovery
+import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command
+import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command.LoginSucess
+import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command.ShowV2Error
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -47,11 +62,21 @@ class SyncLoginViewModelTest {
 
     private val syncRepostitory: SyncAccountRepository = mock()
     private val syncPixels: SyncPixels = mock()
+    private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
+    private val qrCode: ExchangeV2QrCode = mock()
+    private val runner: ExchangeV2Runner = mock()
+    private val codeDispatcher = RealSyncCodeDispatcher(
+        syncFeature = syncFeature,
+        syncAccountRepository = syncRepostitory,
+        qrCode = qrCode,
+        runner = runner,
+    )
 
     private val testee = SyncLoginViewModel(
         syncRepostitory,
         syncPixels,
         coroutineTestRule.testDispatcherProvider,
+        codeDispatcher = codeDispatcher,
     )
 
     @Test
@@ -79,12 +104,88 @@ class SyncLoginViewModelTest {
     }
 
     @Test
+    fun whenV2CodeRequiresNewerProtocolThenShowUpdateError() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        val scanned = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(qrCode.parse(scanned)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(ExchangeV2Event.SessionError(timestampMs = 0L, message = "Peer requires protocol v3; please update this app")),
+        )
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scanned)
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2UpgradeRequiredError, (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2PairingRejectedByPeerThenShowError() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(qrCode.parse(scannedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(
+                ExchangeV2Event.Transition(
+                    timestampMs = 0L,
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                    localTrigger = null,
+                ),
+            ),
+        )
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scannedCode)
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_REJECTED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun whenOnLoginSuccessThenCommandIsLoginSuccess() = runTest {
         testee.commands().test {
             testee.onLoginSuccess()
             val command = awaitItem()
             assertTrue(command is Command.LoginSucess)
             verify(syncPixels).fireLoginPixel()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2SameAccountThenShowAlreadyPaired() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        val scanned = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(qrCode.parse(scanned)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(
+                ExchangeV2Event.Transition(
+                    timestampMs = 0L,
+                    from = ExchangeV2State.Negotiating,
+                    to = ExchangeV2State.SameAccountAbort,
+                    trigger = null,
+                    localTrigger = null,
+                ),
+            ),
+        )
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scanned)
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2AlreadyPairedError, (command as ShowV2Error).content)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncV2ConfirmationCopyTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncV2ConfirmationCopyTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui
+
+import com.duckduckgo.sync.impl.R
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SyncV2ConfirmationCopyTest {
+
+    @Test fun whenKnownDdgPeerThenFullDataList() {
+        assertEquals(
+            R.string.sync_v2_confirmation_message_ddg,
+            syncV2ConfirmationMessageRes(unknownPeer = false, peerKind = PeerKind.DDG),
+        )
+    }
+
+    @Test fun whenKnownThirdPartyPeerThenChatsOnly() {
+        assertEquals(
+            R.string.sync_v2_confirmation_message_3p,
+            syncV2ConfirmationMessageRes(unknownPeer = false, peerKind = PeerKind.THIRD_PARTY),
+        )
+    }
+
+    @Test fun whenUnknownDdgPeerThenFullDataListWithoutName() {
+        assertEquals(
+            R.string.sync_v2_confirmation_message_unknown_peer_ddg,
+            syncV2ConfirmationMessageRes(unknownPeer = true, peerKind = PeerKind.DDG),
+        )
+    }
+
+    @Test fun whenUnknownThirdPartyPeerThenChatsOnlyWithoutName() {
+        assertEquals(
+            R.string.sync_v2_confirmation_message_unknown_peer_3p,
+            syncV2ConfirmationMessageRes(unknownPeer = true, peerKind = PeerKind.THIRD_PARTY),
+        )
+    }
+
+    @Test fun whenKindNullThenFallsBackToFullDdgList() {
+        assertEquals(
+            R.string.sync_v2_confirmation_message_ddg,
+            syncV2ConfirmationMessageRes(unknownPeer = false, peerKind = null),
+        )
+        assertEquals(
+            R.string.sync_v2_confirmation_message_unknown_peer_ddg,
+            syncV2ConfirmationMessageRes(unknownPeer = true, peerKind = null),
+        )
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
@@ -36,11 +36,15 @@ import com.duckduckgo.sync.TestSyncFixtures.primaryKey
 import com.duckduckgo.sync.TestSyncFixtures.validLoginKeys
 import com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
 import com.duckduckgo.sync.impl.Clipboard
 import com.duckduckgo.sync.impl.ExchangeResult.AccountSwitchingRequired
 import com.duckduckgo.sync.impl.ExchangeResult.LoggedIn
 import com.duckduckgo.sync.impl.InvitationCode
 import com.duckduckgo.sync.impl.QREncoder
+import com.duckduckgo.sync.impl.RealSyncCodeDispatcher
 import com.duckduckgo.sync.impl.RecoveryCode
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.Result.Success
@@ -50,14 +54,31 @@ import com.duckduckgo.sync.impl.SyncAuthCode.Exchange
 import com.duckduckgo.sync.impl.SyncAuthCode.Recovery
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.encodeB64
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
+import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
+import com.duckduckgo.sync.impl.exchange.v2.PairingRole
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_EXCHANGE
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command
+import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.AskHostConfirmation
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.AskToSwitchAccount
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.LoginSuccess
+import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.ShowError
+import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.ShowV2Error
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.SwitchAccountSuccess
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -65,6 +86,7 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -85,6 +107,22 @@ class SyncWithAnotherDeviceViewModelTest {
         this.seamlessAccountSwitching().setRawStoredState(State(true))
         this.exchangeKeysToSyncWithAnotherDevice().setRawStoredState(State(false))
     }
+    private val qrCode: ExchangeV2QrCode = mock()
+
+    private val runnerEventsFlow = kotlinx.coroutines.flow.MutableSharedFlow<com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event>(replay = 0)
+    private val runner: ExchangeV2Runner = mock<ExchangeV2Runner>().also {
+        whenever(it.events).thenReturn(runnerEventsFlow)
+        whenever(it.eventsSince(any())).thenAnswer { invocation ->
+            val sinceMs = invocation.getArgument<Long>(0)
+            runnerEventsFlow.filter { event -> event.timestampMs >= sinceMs }
+        }
+    }
+    private val codeDispatcher = RealSyncCodeDispatcher(
+        syncFeature = syncFeature,
+        syncAccountRepository = syncRepository,
+        qrCode = qrCode,
+        runner = runner,
+    )
 
     private val testee = SyncWithAnotherActivityViewModel(
         syncRepository,
@@ -93,6 +131,7 @@ class SyncWithAnotherDeviceViewModelTest {
         syncPixels,
         coroutineTestRule.testDispatcherProvider,
         syncFeature,
+        codeDispatcher,
     )
 
     @Test
@@ -228,9 +267,9 @@ class SyncWithAnotherDeviceViewModelTest {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.ShowError)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE), eq(CodeVersion.V1), isNull())
             verify(syncPixels, never()).fireLoginPixel()
-            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any())
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -246,9 +285,9 @@ class SyncWithAnotherDeviceViewModelTest {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.ShowError)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE), eq(CodeVersion.V1), isNull())
             verify(syncPixels, never()).fireLoginPixel()
-            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any())
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -262,9 +301,9 @@ class SyncWithAnotherDeviceViewModelTest {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.AskToSwitchAccount)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE), eq(CodeVersion.V1), isNull())
             verify(syncPixels, never()).fireLoginPixel()
-            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any())
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -279,9 +318,9 @@ class SyncWithAnotherDeviceViewModelTest {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.AskToSwitchAccount)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE), eq(CodeVersion.V1), isNull())
             verify(syncPixels, never()).fireLoginPixel()
-            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any())
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -396,9 +435,9 @@ class SyncWithAnotherDeviceViewModelTest {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.ShowError)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE), eq(CodeVersion.V1), isNull())
             verify(syncPixels, never()).fireLoginPixel()
-            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any())
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -406,7 +445,7 @@ class SyncWithAnotherDeviceViewModelTest {
     @Test
     fun whenUserCancelsThenAbandonedPixelFired() = runTest {
         testee.onUserCancelledWithoutSyncSetup()
-        verify(syncPixels).fireSyncSetupAbandoned(eq(SYNC_EXCHANGE))
+        verify(syncPixels).fireSyncSetupAbandoned(eq(SYNC_EXCHANGE), eq(CancellationReason.SCANNING_CANCELLED))
     }
 
     @Test
@@ -427,5 +466,305 @@ class SyncWithAnotherDeviceViewModelTest {
         whenever(qrEncoder.encodeAsBitmap(eq(jsonExchangeKey), any(), any())).thenReturn(bitmap)
         whenever(syncRepository.processCode(any(), anyOrNull())).thenReturn(Success(true))
         return Pair(bitmap, authCodeToUse)
+    }
+
+    private fun enableV2(displayOn: Boolean) {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        syncFeature.canShowV2ConnectCode().setRawStoredState(State(displayOn))
+    }
+
+    private fun presenterSessionStarted(linkingCode: String = "https://duckduckgo.com/sync/pairing?code2=xyz") =
+        ExchangeV2Event.SessionStarted(
+            timestampMs = System.currentTimeMillis(),
+            pairingRole = PairingRole.Presenter,
+            ownChannelId = "own-channel",
+            linkingCode = linkingCode,
+        )
+
+    private fun transition(
+        from: ExchangeV2State,
+        to: ExchangeV2State,
+        localTrigger: LocalTrigger? = null,
+    ) = ExchangeV2Event.Transition(
+        timestampMs = System.currentTimeMillis(),
+        from = from,
+        to = to,
+        trigger = null,
+        localTrigger = localTrigger,
+    )
+
+    @Test
+    fun whenBothV2FlagsOnThenRunnerStartPresentInvokedAndV1RecoveryNotCalled() = runTest {
+        enableV2(displayOn = true)
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        val bitmap = TestSyncFixtures.qrBitmap()
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(bitmap)
+
+        testee.viewState().test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            val withQr = awaitItem()
+            Assert.assertEquals(bitmap, withQr.qrCodeBitmap)
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(runner).startPresent()
+        verify(syncRepository, never()).generateExchangeInvitationCode()
+        verify(syncRepository, never()).getRecoveryCode()
+    }
+
+    @Test
+    fun whenMasterFlagOnButCanShowV2OffThenV1PathTaken() = runTest {
+        enableV2(displayOn = false)
+        val bitmap = TestSyncFixtures.qrBitmap()
+        val authCode = AuthCode(qrCode = jsonRecoveryKeyEncoded, rawCode = "raw")
+        whenever(qrEncoder.encodeAsBitmap(eq(jsonRecoveryKeyEncoded), any(), any())).thenReturn(bitmap)
+        whenever(syncRepository.getRecoveryCode()).thenReturn(Result.Success(authCode))
+
+        testee.viewState().test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(runner, never()).startPresent()
+        verify(syncRepository).getRecoveryCode()
+    }
+
+    @Test
+    fun whenMasterFlagOffThenV1PathTakenRegardlessOfDisplayFlag() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+        syncFeature.canShowV2ConnectCode().setRawStoredState(State(true))
+        val bitmap = TestSyncFixtures.qrBitmap()
+        val authCode = AuthCode(qrCode = jsonRecoveryKeyEncoded, rawCode = "raw")
+        whenever(qrEncoder.encodeAsBitmap(eq(jsonRecoveryKeyEncoded), any(), any())).thenReturn(bitmap)
+        whenever(syncRepository.getRecoveryCode()).thenReturn(Result.Success(authCode))
+
+        testee.viewState().test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(runner, never()).startPresent()
+    }
+
+    @Test
+    fun whenLinkingCodeReadyThenBarcodeContentsPopulatedAndCopyEmitsUrl() = runTest {
+        enableV2(displayOn = true)
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        val url = "https://duckduckgo.com/sync/pairing?code2=copy-me"
+        val bitmap = TestSyncFixtures.qrBitmap()
+        whenever(qrEncoder.encodeAsBitmap(eq(url), any(), any())).thenReturn(bitmap)
+
+        testee.viewState().test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted(linkingCode = url))
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.onCopyCodeClicked()
+        verify(clipboard).copyToClipboard(url)
+    }
+
+    @Test
+    fun whenHostConfirmingDuringV2PresentThenAskHostConfirmationCommandEmitted() = runTest {
+        enableV2(displayOn = true)
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        whenever(runner.peerName).thenReturn("Peer Phone")
+        whenever(runner.peerKind).thenReturn("3party")
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState().test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Confirming),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected AskHostConfirmation, got $command", command is AskHostConfirmation)
+            Assert.assertEquals("Peer Phone", (command as AskHostConfirmation).peerName)
+            Assert.assertEquals(PeerKind.THIRD_PARTY, (command as AskHostConfirmation).peerKind)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenHostDoneDuringV2PresentThenLoginSuccessShowRecoveryFalse() = runTest {
+        enableV2(displayOn = true)
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState().test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(from = ExchangeV2State.Host.Sending, to = ExchangeV2State.Host.Done),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected LoginSuccess, got $command", command is LoginSuccess)
+            Assert.assertEquals(false, (command as LoginSuccess).showRecovery)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenSameAccountAbortDuringV2PresentThenShowAlreadyPaired() = runTest {
+        enableV2(displayOn = true)
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState().test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.SameAccountAbort),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2AlreadyPairedError, (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenHostAbortedUserDeniedDuringV2PresentThenShowErrorCommandEmitted() = runTest {
+        enableV2(displayOn = true)
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState().test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Host.Confirming,
+                    to = ExchangeV2State.Host.Aborted,
+                    localTrigger = LocalTrigger.UserDeniedHost,
+                ),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_CANCELLED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenSessionErrorDuringV2PresentThenShowErrorCommandEmitted() = runTest {
+        enableV2(displayOn = true)
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState().test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                ExchangeV2Event.SessionError(timestampMs = System.currentTimeMillis(), message = "channel 5xx"),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_FAILED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenViewStateReCollectedThenExchangeInvitationGeneratedOnce() = runTest {
+        configureExchangeKeysSupported()
+        testee.viewState().test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        testee.viewState().test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(syncRepository, times(1)).generateExchangeInvitationCode()
+    }
+
+    @Test
+    fun whenViewStateReCollectedThenV2PresentStartedOnce() = runTest {
+        enableV2(displayOn = true)
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+        testee.viewState().test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        testee.viewState().test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(runner, times(1)).startPresent()
+    }
+
+    @Test
+    fun whenV2PairingRejectedByPeerThenShowError() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(qrCode.parse(scannedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scannedCode)
+            runnerEventsFlow.emit(
+                ExchangeV2Event.Transition(
+                    timestampMs = System.currentTimeMillis(),
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                    localTrigger = null,
+                ),
+            )
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_REJECTED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2UpgradeRequiredThenShowUpdateError() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(qrCode.parse(scannedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(ExchangeV2Event.SessionError(timestampMs = 0L, message = "Peer requires protocol v3; please update this app")),
+        )
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scannedCode)
+            val command = awaitItem()
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2UpgradeRequiredError, (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/V2PairingErrorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/V2PairingErrorTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui
+
+import com.duckduckgo.sync.impl.AccountErrorCodes.GENERIC_ERROR
+import com.duckduckgo.sync.impl.AccountErrorCodes.NEGOTIATION_ABORTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.NO_RECOVERY_CODE
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_UNAVAILABLE
+import com.duckduckgo.sync.impl.AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED
+import com.duckduckgo.sync.impl.R
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class V2PairingErrorTest {
+
+    @Test
+    fun whenCodeIsPairingRejectedThenCanceledFromOtherDeviceTitleWithTryAgain() {
+        val content = PAIRING_REJECTED.code.toV2PairingError()
+        assertEquals(R.string.sync_v2_error_pairing_rejected, content.title)
+        assertEquals(R.string.sync_v2_error_try_again, content.message)
+    }
+
+    @Test
+    fun whenCodeIsPairingCancelledThenCanceledTitleOnly() {
+        val content = PAIRING_CANCELLED.code.toV2PairingError()
+        assertEquals(R.string.sync_v2_error_pairing_canceled, content.title)
+        assertNull(content.message)
+    }
+
+    @Test
+    fun whenCodeIsThirdPartyAlreadyUpgradedThenSyncFailedTitleWithUpgradeMessage() {
+        val content = THIRD_PARTY_ALREADY_UPGRADED.code.toV2PairingError()
+        assertEquals(R.string.sync_v2_error_pairing_failed, content.title)
+        assertEquals(R.string.sync_v2_error_third_party_already_upgraded, content.message)
+    }
+
+    @Test
+    fun whenCodeIsAnyOtherAbortThenSyncFailedTitleWithTryAgain() {
+        listOf(PAIRING_UNAVAILABLE, NEGOTIATION_ABORTED, NO_RECOVERY_CODE, PAIRING_FAILED).forEach { code ->
+            val content = code.code.toV2PairingError()
+            assertEquals("code $code title", R.string.sync_v2_error_pairing_failed, content.title)
+            assertEquals("code $code message", R.string.sync_v2_error_try_again, content.message)
+        }
+    }
+
+    @Test
+    fun whenCodeIsGenericOrUnknownThenSyncFailedTitleWithTryAgain() {
+        listOf(GENERIC_ERROR.code, 9999).forEach { code ->
+            val content = code.toV2PairingError()
+            assertEquals(R.string.sync_v2_error_pairing_failed, content.title)
+            assertEquals(R.string.sync_v2_error_try_again, content.message)
+        }
+    }
+
+    @Test
+    fun whenUpgradeRequiredThenUpdateBrowserTitleOnly() {
+        assertEquals(R.string.sync_v2_error_upgrade_required, v2UpgradeRequiredError.title)
+        assertNull(v2UpgradeRequiredError.message)
+    }
+
+    @Test
+    fun whenAlreadyPairedThenAlreadySyncedTitleWithMessage() {
+        assertEquals(R.string.sync_v2_already_paired_title, v2AlreadyPairedError.title)
+        assertEquals(R.string.sync_v2_already_paired_message, v2AlreadyPairedError.message)
+    }
+}

--- a/sync/sync-internal/build.gradle
+++ b/sync/sync-internal/build.gradle
@@ -60,4 +60,16 @@ dependencies {
     implementation "com.google.zxing:core:_"
 
     implementation "com.squareup.logcat:logcat:_"
+
+    // Testing dependencies
+    testImplementation "org.mockito.kotlin:mockito-kotlin:_"
+    testImplementation Testing.junit4
+    testImplementation AndroidX.test.ext.junit
+    testImplementation Testing.robolectric
+    testImplementation CashApp.turbine
+    testImplementation AndroidX.archCore.testing
+    testImplementation project(path: ':common-test')
+    testImplementation(KotlinX.coroutines.test) {
+        exclude group: "org.jetbrains.kotlinx", module: "kotlinx-coroutines-debug"
+    }
 }

--- a/sync/sync-internal/src/main/AndroidManifest.xml
+++ b/sync/sync-internal/src/main/AndroidManifest.xml
@@ -23,5 +23,11 @@
             android:label="@string/sync_internal_activity_label"
             android:screenOrientation="portrait"
             android:parentActivityName="com.duckduckgo.app.settings.SettingsActivity" />
+        <activity
+            android:name=".ui.SyncV2PairingDebugActivity"
+            android:exported="false"
+            android:label="@string/sync_v2_pairing_debug_activity_label"
+            android:screenOrientation="portrait"
+            android:parentActivityName=".ui.SyncInternalSettingsActivity" />
     </application>
 </manifest>

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
@@ -110,6 +110,10 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         binding.launchSyncSettingsButton.setOnClickListener {
             startActivity(Intent(this, SyncActivity::class.java))
         }
+        binding.openV2PairingDebugButton.setOnClickListener {
+            startActivity(Intent(this, SyncV2PairingDebugActivity::class.java))
+        }
+        // this is temporary while testing
         binding.openDuckAiDevScreenButton.setOnClickListener {
             // Launch via class name so sync-internal doesn't need a direct dependency on duckchat-internal.
             val intent = Intent().setClassName(packageName, "com.duckduckgo.duckchat.internal.DuckAiDevActivity")

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncApi
+import com.duckduckgo.sync.impl.SyncAuthCode
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.autorestore.SyncAutoRestoreManager
 import com.duckduckgo.sync.impl.autorestore.SyncRecoveryPersistentStorageKey
@@ -396,7 +397,23 @@ constructor(
 
     fun useRecoveryCode(recoveryCode: String) {
         viewModelScope.launch(dispatchers.io()) {
-            authFlow(recoveryCode)
+            // 3party recovery codes are intentionally rejected by parseSyncAuthCode (production
+            // paste/scan paths must not accept them). For the dev-tool entrypoint we explicitly
+            // try the 3party→ddg upgrade path when the existing parser doesn't recognize the code.
+            val codeType = syncAccountRepository.parseSyncAuthCode(recoveryCode)
+            if (codeType is SyncAuthCode.Unknown) {
+                when (val joinResult = syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(recoveryCode)) {
+                    is Success -> {
+                        command.send(Command.LoginSuccess)
+                        updateViewState()
+                    }
+                    is Error -> {
+                        command.send(Command.ShowMessage("$joinResult"))
+                    }
+                }
+            } else {
+                authFlow(recoveryCode)
+            }
         }
     }
 
@@ -500,7 +517,6 @@ constructor(
     private fun buildV2StoreFieldsText(): String = buildString {
         appendLine("credentialId: ${syncStore.credentialId ?: "(not set)"}")
         appendLine("scopedPassword: ${syncStore.scopedPassword?.raw?.take(40)?.let { "$it..." } ?: "(not set)"}")
-        appendLine("protectedKeysJson: ${syncStore.protectedKeysJson?.take(60)?.let { "$it..." } ?: "(not set)"}")
     }.trim().also { logcat { "Sync-ScopedToken: v2 store fields:\n$it" } }
 
     fun onCreateThirdPartyCredentialClicked() {

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugActivity.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugActivity.kt
@@ -1,0 +1,327 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.internal.ui
+
+import android.annotation.SuppressLint
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.os.Bundle
+import android.view.View
+import android.widget.Toast
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.view.dialog.DaxAlertDialog
+import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
+import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.extensions.hideKeyboard
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.sync.impl.exchange.v2.Role
+import com.duckduckgo.sync.internal.databinding.ActivitySyncV2PairingDebugBinding
+import com.duckduckgo.sync.internal.databinding.ItemSyncV2PairingLogRowBinding
+import com.duckduckgo.sync.internal.ui.SyncV2PairingDebugViewModel.ConfirmationRequest
+import com.duckduckgo.sync.internal.ui.SyncV2PairingDebugViewModel.LogRow
+import com.duckduckgo.sync.internal.ui.SyncV2PairingDebugViewModel.TerminalReached
+import com.duckduckgo.sync.internal.ui.SyncV2PairingDebugViewModel.ViewState
+import com.google.zxing.BarcodeFormat.QR_CODE
+import com.journeyapps.barcodescanner.BarcodeEncoder
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.withContext
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import javax.inject.Inject
+
+@InjectWith(ActivityScope::class)
+class SyncV2PairingDebugActivity : DuckDuckGoActivity() {
+
+    @Inject
+    lateinit var dispatcherProvider: DispatcherProvider
+
+    private val binding: ActivitySyncV2PairingDebugBinding by viewBinding()
+    private val viewModel: SyncV2PairingDebugViewModel by bindViewModel()
+
+    private val timestampFormat = SimpleDateFormat("HH:mm:ss.SSS", Locale.US)
+    private val expandedRowIds = mutableSetOf<Long>()
+    private var renderedRows: List<LogRow> = emptyList()
+    private var activeConfirmationDialog: DaxAlertDialog? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(binding.root)
+        setupToolbar(binding.includeToolbar.toolbar)
+        configureListeners()
+        observeViewState()
+        observeConfirmations()
+        observeTerminals()
+        observeToasts()
+    }
+
+    private fun configureListeners() {
+        binding.runScanButton.setOnClickListener { startScanFromInput() }
+        binding.pasteAndGoButton.setOnClickListener { pasteAndStartScan() }
+        binding.runPresentButton.setOnClickListener {
+            if (!viewModel.canStartAsPresenter()) {
+                Toast.makeText(
+                    this,
+                    "Sign in to a sync account first — without one there's no recovery code to share. Set sync up in Sync Settings.",
+                    Toast.LENGTH_LONG,
+                ).show()
+                return@setOnClickListener
+            }
+            viewModel.onRunPresentClicked()
+        }
+        binding.clearPastedUrlButton.setOnClickListener { binding.pastedUrlInput.text = "" }
+        binding.cancelButton.setOnClickListener { viewModel.onCancelClicked() }
+        binding.clearLogButton.setOnClickListener {
+            expandedRowIds.clear()
+            viewModel.onClearLogClicked()
+        }
+        binding.autoApproveSetting.quietlySetIsChecked(newCheckedState = true) { _, enabled ->
+            viewModel.onAutoApproveToggled(enabled)
+        }
+
+        binding.signInOutButton.setOnClickListener { viewModel.onSignInOutClicked() }
+    }
+
+    private fun observeViewState() {
+        viewModel.viewState()
+            .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+            .onEach { render(it) }
+            .launchIn(lifecycleScope)
+    }
+
+    private fun observeConfirmations() {
+        viewModel.confirmations()
+            .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+            .onEach { showConfirmationDialog(it) }
+            .launchIn(lifecycleScope)
+    }
+
+    private fun observeTerminals() {
+        viewModel.terminals()
+            .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+            .onEach { showTerminalDialog(it) }
+            .launchIn(lifecycleScope)
+    }
+
+    private fun observeToasts() {
+        viewModel.toasts()
+            .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+            .onEach { Toast.makeText(this, it, Toast.LENGTH_LONG).show() }
+            .launchIn(lifecycleScope)
+    }
+
+    private fun showTerminalDialog(terminal: TerminalReached) {
+        // Auto-dismiss any open confirmation prompt — the session ended before the user
+        // could respond, so the prompt is no longer relevant.
+        activeConfirmationDialog?.dismiss()
+        activeConfirmationDialog = null
+        TextAlertDialogBuilder(this)
+            .setTitle(terminal.title)
+            .setMessage(terminal.message)
+            .setPositiveButton(android.R.string.ok)
+            .show()
+    }
+
+    private fun showConfirmationDialog(request: ConfirmationRequest) {
+        // Replace any prior confirmation dialog (shouldn't happen, but defensive).
+        activeConfirmationDialog?.dismiss()
+        val peer = request.peerName?.takeIf { it.isNotBlank() } ?: "the other device"
+        val (title, message) = when (request.role) {
+            Role.Host -> "Confirm pairing (Host)" to "Allow $peer to join your sync & backup?"
+            Role.Joiner -> "Confirm pairing (Joiner)" to "Sync your data with $peer?"
+        }
+        val dialog = TextAlertDialogBuilder(this)
+            .setTitle(title)
+            .setMessage(message)
+            .setPositiveButton(android.R.string.ok)
+            .setNegativeButton(android.R.string.cancel)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() {
+                        activeConfirmationDialog = null
+                        viewModel.onConfirmationApproved(request.role)
+                    }
+
+                    override fun onNegativeButtonClicked() {
+                        activeConfirmationDialog = null
+                        viewModel.onConfirmationDenied(request.role)
+                    }
+
+                    override fun onDialogDismissed() {
+                        activeConfirmationDialog = null
+                    }
+                },
+            )
+            .build()
+        activeConfirmationDialog = dialog
+        dialog.show()
+    }
+
+    private fun render(state: ViewState) {
+        renderAccountStatus(state.accountStatus)
+        binding.currentStateTextView.text = state.currentStateLabel
+        val code = state.linkingCode
+        if (code != null) {
+            binding.linkingCodeSectionHeader.visibility = View.VISIBLE
+            binding.linkingCodeTextView.visibility = View.VISIBLE
+            // Bare URL only — no "Linking code:" prefix — so long-press-select copies cleanly.
+            binding.linkingCodeTextView.text = code
+            binding.linkingCodeTextView.setOnClickListener { copyToClipboard("Linking code", code) }
+            binding.copyLinkingCodeButton.visibility = View.VISIBLE
+            binding.copyLinkingCodeButton.setOnClickListener { copyToClipboard("Linking code", code) }
+            renderQrFor(code)
+            // First time we see this code, push to clipboard automatically so the user can
+            // paste straight into the Scanner device without a manual Copy tap.
+            if (autoCopiedLinkingCode != code) {
+                autoCopiedLinkingCode = code
+                copyToClipboard("Linking code", code)
+            }
+        } else {
+            binding.linkingCodeSectionHeader.visibility = View.GONE
+            binding.linkingCodeTextView.visibility = View.GONE
+            binding.copyLinkingCodeButton.visibility = View.GONE
+            binding.linkingCodeQrImage.visibility = View.GONE
+            binding.linkingCodeQrImage.setImageBitmap(null)
+            renderedQrFor = null
+            autoCopiedLinkingCode = null
+        }
+        if (state.rows !== renderedRows) {
+            renderedRows = state.rows
+            renderRows(state.rows)
+        }
+    }
+
+    private var autoCopiedLinkingCode: String? = null
+
+    /**
+     * Encode [code] as a QR bitmap on a background thread (zxing is CPU-bound) and show it in
+     * [linkingCodeQrImage]. Skips work if we already rendered this exact code (render() runs
+     * on every event flow update — we don't want to regenerate the QR each time).
+     */
+    @SuppressLint("AvoidComputationUsage")
+    private fun renderQrFor(code: String) {
+        if (renderedQrFor == code) return
+        renderedQrFor = code
+        binding.linkingCodeQrImage.visibility = View.VISIBLE
+        lifecycleScope.launchWhenStarted {
+            val bitmap = withContext(dispatcherProvider.computation()) {
+                runCatching { BarcodeEncoder().encodeBitmap(code, QR_CODE, QR_SIZE_PX, QR_SIZE_PX) }
+                    .getOrNull()
+            }
+            if (renderedQrFor == code) binding.linkingCodeQrImage.setImageBitmap(bitmap)
+        }
+    }
+
+    private var renderedQrFor: String? = null
+
+    private fun renderRows(rows: List<LogRow>) {
+        binding.logContainer.removeAllViews()
+        rows.forEach { row ->
+            val rowBinding = ItemSyncV2PairingLogRowBinding.inflate(layoutInflater, binding.logContainer, true)
+            val timestamp = timestampFormat.format(Date(row.timestampMs))
+            rowBinding.summaryTextView.text = "[$timestamp] ${row.summary}"
+            rowBinding.rawJsonTextView.text = row.rawJson
+            applyExpansion(rowBinding, row.id in expandedRowIds)
+            rowBinding.summaryRow.setOnClickListener {
+                val newlyExpanded = row.id !in expandedRowIds
+                if (newlyExpanded) expandedRowIds.add(row.id) else expandedRowIds.remove(row.id)
+                applyExpansion(rowBinding, newlyExpanded)
+            }
+            rowBinding.copyRawButton.setOnClickListener {
+                copyToClipboard("Raw JSON", row.rawJson)
+            }
+        }
+    }
+
+    private fun applyExpansion(rowBinding: ItemSyncV2PairingLogRowBinding, expanded: Boolean) {
+        rowBinding.rawDetail.visibility = if (expanded) View.VISIBLE else View.GONE
+        rowBinding.chevronTextView.text = if (expanded) "▾" else "▸"
+    }
+
+    private fun copyToClipboard(label: String, value: String) {
+        val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        clipboard.setPrimaryClip(ClipData.newPlainText(label, value))
+        Toast.makeText(this, "$label copied", Toast.LENGTH_SHORT).show()
+    }
+
+    /** Shared handler for the "Start as Scanner" button — uses whatever is in the input field. */
+    private fun startScanFromInput() {
+        val pasted = binding.pastedUrlInput.text.trim()
+        if (pasted.isEmpty()) {
+            Toast.makeText(
+                this,
+                "Paste the Presenter's linking code into the V2 exchange URL field first.",
+                Toast.LENGTH_LONG,
+            ).show()
+            return
+        }
+        viewModel.onRunScanClicked(pasted)
+        // Clear the input now that we've handed it off — keeps the field tidy and avoids
+        // the user accidentally re-running with a stale code.
+        binding.pastedUrlInput.text = ""
+        // Dismiss the keyboard so the log + state are visible without scrolling.
+        hideKeyboard()
+    }
+
+    /**
+     * One-tap: read clipboard, fill the input (for visible feedback), then fire start-scan.
+     * Skips the keyboard / paste-menu round-trip entirely.
+     */
+    private fun pasteAndStartScan() {
+        val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        val text = clipboard.primaryClip
+            ?.takeIf { it.itemCount > 0 }
+            ?.getItemAt(0)
+            ?.coerceToText(this)
+            ?.toString()
+            ?.trim()
+            .orEmpty()
+        if (text.isEmpty()) {
+            Toast.makeText(this, "Clipboard is empty — copy the Presenter's linking code first.", Toast.LENGTH_LONG).show()
+            return
+        }
+        // Surface what was pasted so the user can see it before it disappears (input is then
+        // cleared by startScanFromInput).
+        binding.pastedUrlInput.text = text
+        startScanFromInput()
+    }
+
+    private fun renderAccountStatus(status: SyncV2PairingDebugViewModel.AccountStatus) {
+        binding.statusSignedIn.setSecondaryText(
+            if (status.signedIn) "Yes · user_id ${status.userId ?: "(unknown)"}" else "No",
+        )
+        binding.signInOutButton.text = if (status.signedIn) "Sign out" else "Sign in"
+        binding.statusThirdPartyCredential.setSecondaryText(
+            when {
+                !status.signedIn -> "(not signed in)"
+                status.thirdPartyCredentialCreated -> "Yes"
+                else -> "Not created; needed before pairing with 3party peers"
+            },
+        )
+    }
+
+    private companion object {
+        const val QR_SIZE_PX = 600
+    }
+}

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModel.kt
@@ -1,0 +1,617 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.internal.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.sync.impl.DispatchOutcome
+import com.duckduckgo.sync.impl.ExchangeResult.AccountSwitchingRequired
+import com.duckduckgo.sync.impl.ExchangeResult.LoggedIn
+import com.duckduckgo.sync.impl.ExchangeResult.Pending
+import com.duckduckgo.sync.impl.Result
+import com.duckduckgo.sync.impl.RouteDecision
+import com.duckduckgo.sync.impl.SyncAccountRepository
+import com.duckduckgo.sync.impl.SyncAuthCode
+import com.duckduckgo.sync.impl.SyncCodeDispatcher
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
+import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
+import com.duckduckgo.sync.impl.exchange.v2.RejectReason
+import com.duckduckgo.sync.impl.exchange.v2.Role
+import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Companion.POLLING_INTERVAL_EXCHANGE_FLOW
+import com.duckduckgo.sync.store.SyncStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import logcat.logcat
+import javax.inject.Inject
+
+@ContributesViewModel(ActivityScope::class)
+class SyncV2PairingDebugViewModel @Inject constructor(
+    private val runner: ExchangeV2Runner,
+    private val syncStore: SyncStore,
+    private val syncAccountRepository: SyncAccountRepository,
+    private val dispatcher: SyncCodeDispatcher,
+    private val dispatchers: DispatcherProvider,
+    @AppCoroutineScope private val appScope: CoroutineScope,
+) : ViewModel() {
+
+    data class LogRow(
+        val id: Long,
+        val timestampMs: Long,
+        val summary: String,
+        val rawJson: String,
+    )
+
+    /**
+     * Snapshot of the device's sync setup that's relevant to v2 pairing. Read from
+     * [SyncStore] at the points where it could have changed (init + after Cancel /
+     * terminal). Not reactive — this is a dev tool, the user can tap Cancel to refresh.
+     */
+    data class AccountStatus(
+        val signedIn: Boolean,
+        val userId: String?,
+        val thirdPartyCredentialCreated: Boolean,
+    )
+
+    data class ViewState(
+        val currentStateLabel: String = "(no session)",
+        val linkingCode: String? = null,
+        val rows: List<LogRow> = emptyList(),
+        val autoApproveConfirmation: Boolean = true,
+        val accountStatus: AccountStatus = AccountStatus(false, null, false),
+    )
+
+    /**
+     * One-shot prompt to show the user. The Activity renders this as an [AlertDialog] and
+     * dispatches the result back via [onConfirmationApproved] / [onConfirmationDenied].
+     */
+    data class ConfirmationRequest(
+        val role: Role,
+        val peerName: String?,
+    )
+
+    /**
+     * Emitted once when the session reaches a terminal state. The Activity shows a result
+     * alert summarising what happened.
+     */
+    data class TerminalReached(
+        val state: ExchangeV2State,
+        val title: String,
+        val message: String,
+        val isSuccess: Boolean,
+    )
+
+    private val viewState = MutableStateFlow(ViewState())
+    fun viewState(): Flow<ViewState> = viewState.asStateFlow()
+
+    /**
+     * Tear down any in-flight session when the Activity is finishing. ActivityScope VMs
+     * survive config changes but [onCleared] runs on real finish (back press, navigation away),
+     * which is when we want to dispose of a pairing session that the user has abandoned.
+     */
+    override fun onCleared() {
+        super.onCleared()
+        // cancel() suspends until teardown completes; onCleared can't await and viewModelScope is
+        // already cancelling, so fire-and-forget the teardown on the app scope (it outlives the VM).
+        appScope.launch { runner.cancel() }
+    }
+
+    private val confirmationRequests = Channel<ConfirmationRequest>(Channel.BUFFERED)
+    fun confirmations(): Flow<ConfirmationRequest> = confirmationRequests.receiveAsFlow()
+
+    private val terminalReached = Channel<TerminalReached>(Channel.BUFFERED)
+    fun terminals(): Flow<TerminalReached> = terminalReached.receiveAsFlow()
+
+    private val toasts = Channel<String>(Channel.BUFFERED)
+    fun toasts(): Flow<String> = toasts.receiveAsFlow()
+
+    private var nextRowId: Long = 0L
+
+    init {
+        viewState.update { it.copy(accountStatus = readAccountStatus()) }
+        viewModelScope.launch(dispatchers.io()) {
+            // Snapshot how many events the runner's SharedFlow will replay to us. Those events
+            // populate the log row history, but we skip side effects (terminal alerts,
+            // confirmation dialogs) for them — otherwise re-entering this Activity after a
+            // completed pairing would re-pop the "Pairing complete" dialog from a stale event.
+            val replayCount = runner.events.replayCache.size
+            var processed = 0
+            runner.events.collect { event ->
+                appendEvent(event, isReplay = processed < replayCount)
+                processed++
+            }
+        }
+    }
+
+    /**
+     * Delegate routing to [SyncCodeDispatcher] — the single source of truth for v1/v2 dispatch
+     * that the production VMs now share. The dispatcher's contract: FF off → byte-identical to
+     * direct [SyncAccountRepository.parseSyncAuthCode]; FF on → v2 shapes are taken into
+     * ownership and surfaced via a one-shot [DispatchOutcome] Flow.
+     *
+     * The VM still owns the v1 [SyncAuthCode.Exchange] two-stage polling locally (in
+     * [dispatchV1Exchange]) — the dispatcher only handles the routing decision, not the
+     * downstream v1 protocol details (preserved byte-for-byte from production).
+     */
+    fun onRunScanClicked(pastedUrl: String) {
+        viewModelScope.launch(dispatchers.io()) {
+            appendDevToolLog("Routing pasted code via SyncCodeDispatcher")
+            when (val decision = dispatcher.route(pastedUrl)) {
+                is RouteDecision.Legacy -> handleLegacyAuthCode(decision.authCode)
+                is RouteDecision.V2InProgress -> {
+                    appendDevToolLog("Dispatcher took v2 ownership — observing outcomes")
+                    decision.outcomes.collect { outcome -> handleV2Outcome(outcome) }
+                    refreshState()
+                }
+            }
+        }
+    }
+
+    /**
+     * Mirrors production v1 handling exactly: Recovery / Connect → [SyncAccountRepository.processCode];
+     * Exchange → two-stage post-then-poll loop; Unknown → user-facing error. Identical control
+     * flow to [com.duckduckgo.sync.impl.ui.EnterCodeViewModel.authFlow] but logging into the
+     * dev-tool log row stream instead of UI commands.
+     */
+    private suspend fun handleLegacyAuthCode(authCode: SyncAuthCode) {
+        appendDevToolLog("Legacy v1 auth code: ${authCode::class.simpleName}")
+        when (authCode) {
+            is SyncAuthCode.Recovery -> emitProcessCodeResult("v1 recovery", syncAccountRepository.processCode(authCode))
+            is SyncAuthCode.Connect -> emitProcessCodeResult("v1 connect", syncAccountRepository.processCode(authCode))
+            is SyncAuthCode.Exchange -> dispatchV1Exchange(authCode)
+            is SyncAuthCode.Unknown -> {
+                appendDevToolLog("Couldn't read the pasted code as v1 or v2")
+                toasts.send("Couldn't read the pasted code (no v1 or v2 shape matched)")
+            }
+        }
+        refreshState()
+    }
+
+    /**
+     * Translate one [DispatchOutcome] emitted by the v2 dispatcher into the dev tool's log +
+     * toast surface. Production VMs map these to their own command/error-dialog channels.
+     */
+    private suspend fun handleV2Outcome(outcome: DispatchOutcome) {
+        when (outcome) {
+            is DispatchOutcome.LoggedIn -> {
+                appendDevToolLog("v2 dispatch → LoggedIn")
+                toasts.send("Paired via v2 stack")
+            }
+            is DispatchOutcome.AlreadyConnected -> {
+                appendDevToolLog("v2 dispatch → AlreadyConnected (same-account, spec friendly finish)")
+                toasts.send("Already connected (same account)")
+            }
+            is DispatchOutcome.UpgradeRequired -> {
+                appendDevToolLog("v2 dispatch → UpgradeRequired (codeMajor=${outcome.codeMajor})")
+                toasts.send("This code requires a newer app version (v${outcome.codeMajor})")
+            }
+            is DispatchOutcome.Failed -> {
+                appendDevToolLog("v2 dispatch → Failed: ${outcome.reason}")
+                toasts.send("v2 dispatch failed: ${outcome.reason}")
+            }
+            is DispatchOutcome.JoinerConfirmationRequested,
+            is DispatchOutcome.HostConfirmationRequested,
+            -> {
+                // The dev tool already drives confirmation via its direct runner.events
+                // observation ([maybeHandleConfirmingTransition]). Ignoring the dispatcher's
+                // intermediate emission here avoids double-prompting.
+                appendDevToolLog("v2 dispatch → ${outcome::class.simpleName} (handled by dev tool's direct observation)")
+            }
+            is DispatchOutcome.LinkingCodeReady -> {
+                // No-op: the dev tool drives Presenter sessions directly via runner.startPresent()
+                // (onRunPresentClicked), not through dispatcher.presentV2(). This branch only exists
+                // to keep the when block exhaustive.
+                appendDevToolLog("v2 dispatch → LinkingCodeReady (handled by dev tool's direct observation)")
+            }
+        }
+    }
+
+    /**
+     * v1 Exchange is a two-stage scanner flow:
+     *   1. [SyncAccountRepository.processCode] (→ `onInvitationCodeReceived`) posts our
+     *      encrypted device details to the presenter's relay slot.
+     *   2. Poll [SyncAccountRepository.pollForRecoveryCodeAndLogin] until the presenter
+     *      replies with the encrypted recovery code, which the repo then uses to log us in.
+     *
+     * Mirrors [SyncLoginViewModel.pollForRecoveryKey] / [SyncWithAnotherActivityViewModel]
+     * — same polling cadence, same result handling. Without step 2 the device finishes step
+     * 1 with "OK" but never actually logs in (the original bug).
+     */
+    private suspend fun dispatchV1Exchange(code: SyncAuthCode.Exchange) {
+        when (val postResult = syncAccountRepository.processCode(code)) {
+            is Result.Error -> {
+                appendDevToolLog("v1 exchange step 1 (post device details) failed: ${postResult.reason}")
+                toasts.send("v1 exchange failed: ${postResult.reason}")
+                return
+            }
+            is Result.Success -> {
+                appendDevToolLog("v1 exchange step 1 (post device details) OK — polling for recovery code")
+            }
+        }
+        var polling = true
+        while (polling) {
+            delay(POLLING_INTERVAL_EXCHANGE_FLOW)
+            when (val pollResult = syncAccountRepository.pollForRecoveryCodeAndLogin()) {
+                is Result.Success -> when (pollResult.data) {
+                    is Pending -> Unit // keep polling
+                    is LoggedIn -> {
+                        polling = false
+                        appendDevToolLog("v1 exchange: logged in via received recovery code")
+                        toasts.send("Paired via v1 exchange stack")
+                    }
+                    is AccountSwitchingRequired -> {
+                        // Production prompts the user; dev tool stops short of destructive
+                        // account switching and just surfaces the situation.
+                        polling = false
+                        appendDevToolLog("v1 exchange: peer offered a different account (skipped — account switching not wired here)")
+                        toasts.send("v1 exchange: account switching required — not wired in dev tool")
+                    }
+                }
+                is Result.Error -> {
+                    polling = false
+                    appendDevToolLog("v1 exchange poll failed: ${pollResult.reason}")
+                    toasts.send("v1 exchange poll failed: ${pollResult.reason}")
+                }
+            }
+        }
+    }
+
+    private suspend fun emitProcessCodeResult(label: String, result: Result<Boolean>) {
+        when (result) {
+            is Result.Success -> {
+                appendDevToolLog("$label: OK")
+                toasts.send("Paired via $label stack")
+            }
+            is Result.Error -> {
+                appendDevToolLog("$label failed: ${result.reason}")
+                toasts.send("$label failed: ${result.reason}")
+            }
+        }
+    }
+
+    /**
+     * Push a synthetic row into the event log so v1-fallback progress is visible alongside
+     * native v2 [ExchangeV2Event]s. Reuses [LogRow] with the message in both summary and rawJson.
+     * Also tees to logcat with a `Sync-V2Debug:` prefix so the fallback path is traceable
+     * end-to-end (the in-screen log alone misses the eyes of anyone watching logcat).
+     */
+    private fun appendDevToolLog(message: String) {
+        logcat { "Sync-V2Debug: $message" }
+        viewState.update { current ->
+            current.copy(
+                rows = current.rows + LogRow(
+                    id = nextRowId++,
+                    timestampMs = System.currentTimeMillis(),
+                    summary = message,
+                    rawJson = message,
+                ),
+            )
+        }
+    }
+
+    fun onRunPresentClicked() {
+        viewModelScope.launch(dispatchers.io()) {
+            runner.startPresent()
+            refreshState()
+        }
+    }
+
+    /** True when this device has a sync account whose recovery code we could share with a Joiner. */
+    fun canStartAsPresenter(): Boolean = runner.canStartAsPresenter
+
+    /**
+     * Toggle account state: create a fresh sync account if signed out, or log out (and tear
+     * down the current session) if signed in. Status row refreshes either way.
+     */
+    fun onSignInOutClicked() {
+        viewModelScope.launch(dispatchers.io()) {
+            val signedIn = syncStore.userId != null
+            val result = if (signedIn) {
+                // If a pairing session was running on this device's old credentials, kill it
+                // before logout invalidates the recovery code under us.
+                runner.cancel()
+                val deviceId = syncStore.deviceId.orEmpty()
+                syncAccountRepository.logout(deviceId)
+            } else {
+                syncAccountRepository.createAccount()
+            }
+            val action = if (signedIn) "Sign out" else "Create account"
+            when (result) {
+                is Result.Success -> toasts.send("$action: OK")
+                is Result.Error -> toasts.send("$action failed: ${result.reason}")
+            }
+            refreshState()
+        }
+    }
+
+    fun onCancelClicked() {
+        viewModelScope.launch(dispatchers.io()) {
+            runner.cancel()
+            refreshState()
+        }
+    }
+
+    fun onClearLogClicked() {
+        viewState.update { it.copy(rows = emptyList()) }
+    }
+
+    fun onAutoApproveToggled(checked: Boolean) {
+        viewState.update { it.copy(autoApproveConfirmation = checked) }
+    }
+
+    fun onConfirmationApproved(role: Role) {
+        fireLocalTrigger(if (role == Role.Host) LocalTrigger.UserConfirmedHost else LocalTrigger.UserConfirmedJoiner)
+    }
+
+    fun onConfirmationDenied(role: Role) {
+        fireLocalTrigger(if (role == Role.Host) LocalTrigger.UserDeniedHost else LocalTrigger.UserDeniedJoiner)
+    }
+
+    private fun fireLocalTrigger(trigger: LocalTrigger) {
+        viewModelScope.launch(dispatchers.io()) {
+            runner.localTrigger(trigger)
+            refreshState()
+        }
+    }
+
+    private fun appendEvent(event: ExchangeV2Event, isReplay: Boolean = false) {
+        val row = LogRow(
+            id = nextRowId++,
+            timestampMs = event.timestampMs,
+            summary = summarise(event),
+            rawJson = rawJsonFor(event),
+        )
+        viewState.update { current ->
+            current.copy(
+                rows = current.rows + row,
+                currentStateLabel = buildStateLabel(),
+                linkingCode = runner.linkingCode,
+                // Refresh on every event so runner-driven account changes (e.g. on-demand
+                // account creation at Host.Sending per spec §"Exchange Share Recovery Code")
+                // surface immediately, not on next manual refresh.
+                accountStatus = readAccountStatus(),
+            )
+        }
+        if (!isReplay) {
+            maybeHandleConfirmingTransition(event)
+            maybeEmitTerminalAlert(event)
+            maybeToastSessionError(event)
+            maybeLoginAfterJoinerDone(event)
+        }
+    }
+
+    /**
+     * When the runner reaches [ExchangeV2State.Joiner.Done] from a session that was started
+     * via [onRunPresentClicked] (i.e. not routed through [SyncCodeDispatcher]), the dispatcher's
+     * own login Flow never runs and nothing else drives a login from the received recovery code.
+     * This handler closes that gap. Idempotent for dispatcher-routed sessions because
+     * [SyncCodeDispatcher.route] is only invoked from [onRunScanClicked] — the Presenter path
+     * never goes through it.
+     */
+    private fun maybeLoginAfterJoinerDone(event: ExchangeV2Event) {
+        if (event !is ExchangeV2Event.Transition) return
+        if (event.to != ExchangeV2State.Joiner.Done) return
+        val received = (event.trigger as? ExchangeV2Message.RecoveryCodeResponse)?.recoveryCode
+        if (received.isNullOrBlank()) return
+        viewModelScope.launch(dispatchers.io()) {
+            appendDevToolLog("Joiner.Done — driving login from received recovery code")
+            when (val decision = dispatcher.route(received)) {
+                is RouteDecision.V2InProgress -> decision.outcomes.collect { handleV2Outcome(it) }
+                is RouteDecision.Legacy -> when (decision.authCode) {
+                    is SyncAuthCode.Recovery -> emitProcessCodeResult(
+                        "Joiner.Done login",
+                        syncAccountRepository.processCode(decision.authCode),
+                    )
+                    else -> {
+                        appendDevToolLog("Joiner.Done: received code wasn't a Recovery shape, can't auto-login")
+                        toasts.send("Joiner.Done: unexpected code shape, manual login required")
+                    }
+                }
+            }
+            refreshState()
+        }
+    }
+
+    /** Surface transport-level errors (failed sends, version mismatches) so they don't just bury in the log. */
+    private fun maybeToastSessionError(event: ExchangeV2Event) {
+        if (event !is ExchangeV2Event.SessionError) return
+        viewModelScope.launch { toasts.send(event.message) }
+    }
+
+    private fun maybeEmitTerminalAlert(event: ExchangeV2Event) {
+        if (event !is ExchangeV2Event.Transition) return
+        val terminal = describeTerminal(event) ?: return
+        viewModelScope.launch { terminalReached.send(terminal) }
+    }
+
+    private fun describeTerminal(event: ExchangeV2Event.Transition): TerminalReached? = when (event.to) {
+        ExchangeV2State.Host.Done -> TerminalReached(
+            state = event.to,
+            title = "✓ Pairing complete (Host)",
+            message = "Sent recovery_code_response to peer. Session closed on this side.",
+            isSuccess = true,
+        )
+        ExchangeV2State.Joiner.Done -> {
+            val code = (event.trigger as? ExchangeV2Message.RecoveryCodeResponse)?.recoveryCode
+            TerminalReached(
+                state = event.to,
+                title = "✓ Pairing complete (Joiner)",
+                message = "Received recovery code from peer:\n\n${code ?: "(missing)"}",
+                isSuccess = true,
+            )
+        }
+        ExchangeV2State.Host.Aborted -> {
+            val (title, message) = when (event.localTrigger) {
+                LocalTrigger.HostUnavailable -> "✗ Pairing aborted (Host)" to (
+                    "Couldn't produce a recovery code on this device — sent recovery_code_unavailable to peer." +
+                        "\n\nIs this device signed in to a sync account?"
+                    )
+                else ->
+                    "✗ Pairing aborted (Host)" to
+                        "You denied the prompt on this device. Sent recovery_code_denied to peer."
+            }
+            TerminalReached(state = event.to, title = title, message = message, isSuccess = false)
+        }
+        ExchangeV2State.Joiner.AbortedLocal -> TerminalReached(
+            state = event.to,
+            title = "✗ Pairing aborted (Joiner)",
+            message = "You denied the prompt on this device. No message sent to peer (per spec).",
+            isSuccess = false,
+        )
+        ExchangeV2State.Joiner.AbortedByHost -> TerminalReached(
+            state = event.to,
+            title = "✗ Pairing aborted by peer",
+            message = "Peer sent ${event.trigger?.messageType ?: "an abort message"}.",
+            isSuccess = false,
+        )
+        ExchangeV2State.SameAccountAbort -> TerminalReached(
+            state = event.to,
+            title = "✗ Same-account abort",
+            message = "Peer reported the same user_id — devices are already paired. No action taken.",
+            isSuccess = false,
+        )
+        ExchangeV2State.Aborted -> TerminalReached(
+            state = event.to,
+            title = "✗ Negotiation aborted",
+            message = "Received an unexpected hello during negotiation (duplicate or double-scan). Channel closed.",
+            isSuccess = false,
+        )
+        else -> null
+    }
+
+    private fun maybeHandleConfirmingTransition(event: ExchangeV2Event) {
+        if (event !is ExchangeV2Event.Transition) return
+        val role = when (event.to) {
+            ExchangeV2State.Host.Confirming -> Role.Host
+            ExchangeV2State.Joiner.Confirming -> Role.Joiner
+            else -> return
+        }
+        if (viewState.value.autoApproveConfirmation) {
+            val trigger = if (role == Role.Host) LocalTrigger.UserConfirmedHost else LocalTrigger.UserConfirmedJoiner
+            viewModelScope.launch(dispatchers.io()) { runner.localTrigger(trigger) }
+        } else {
+            viewModelScope.launch {
+                confirmationRequests.send(ConfirmationRequest(role = role, peerName = runner.peerName))
+            }
+        }
+    }
+
+    private fun refreshState() {
+        viewState.update {
+            it.copy(
+                currentStateLabel = buildStateLabel(),
+                linkingCode = runner.linkingCode,
+                accountStatus = readAccountStatus(),
+            )
+        }
+    }
+
+    private fun readAccountStatus(): AccountStatus {
+        val userId = syncStore.userId
+        val signedIn = userId != null
+        val thirdParty = syncStore.scopedPassword != null
+        return AccountStatus(
+            signedIn = signedIn,
+            userId = userId,
+            thirdPartyCredentialCreated = signedIn && thirdParty,
+        )
+    }
+
+    private fun buildStateLabel(): String {
+        val state = labelFor(runner.currentState)
+        val role = runner.pairingRole ?: return state
+        return "$state · pairing as $role"
+    }
+
+    private fun summarise(event: ExchangeV2Event): String = when (event) {
+        is ExchangeV2Event.Transition -> {
+            val trigger = event.trigger?.let { "msg=${it.messageType}${peerSuffix(it)}" }
+                ?: event.localTrigger?.let { "local=${labelFor(it)}" }
+                ?: "(no trigger)"
+            "Transition ${labelFor(event.from)} → ${labelFor(event.to)} [$trigger]"
+        }
+        is ExchangeV2Event.MessageSent -> "Sent ${event.message.messageType}${peerSuffix(event.message)}"
+        is ExchangeV2Event.MessageRejected -> {
+            val verb = when (event.reason) {
+                RejectReason.ImplicitAbort -> "Aborted"
+                RejectReason.SameAccount -> "SameAccountAbort"
+                RejectReason.UnknownMessageDropped -> "Dropped (unknown)"
+            }
+            "$verb on ${event.message.messageType}${peerSuffix(event.message)} in ${labelFor(event.state)}"
+        }
+        is ExchangeV2Event.SessionStarted -> {
+            val codeLine = event.linkingCode?.let { " linkingCode=$it" } ?: ""
+            "Session started as ${event.pairingRole} ownChannelId=${event.ownChannelId}$codeLine"
+        }
+        is ExchangeV2Event.SessionError -> "Session error: ${event.message}"
+    }
+
+    private fun peerSuffix(message: ExchangeV2Message): String = when (message) {
+        is ExchangeV2Message.RecoveryCodeAvailable -> " name=${message.name} kind=${message.kind} user_id=${message.userId}"
+        is ExchangeV2Message.RecoveryCodeRequest -> " name=${message.name} kind=${message.kind}"
+        else -> ""
+    }
+
+    private fun rawJsonFor(event: ExchangeV2Event): String = when (event) {
+        is ExchangeV2Event.Transition -> event.trigger?.rawJson ?: "(local trigger: ${event.localTrigger?.let(::labelFor)})"
+        is ExchangeV2Event.MessageSent -> event.message.rawJson
+        is ExchangeV2Event.MessageRejected -> event.message.rawJson
+        is ExchangeV2Event.SessionStarted -> event.linkingCode ?: "(no linking code — Scanner side)"
+        is ExchangeV2Event.SessionError -> event.message
+    }
+
+    private fun labelFor(state: ExchangeV2State?): String = when (state) {
+        null -> "(no session)"
+        ExchangeV2State.Bootstrapped -> "Bootstrapped"
+        ExchangeV2State.Negotiating -> "Negotiating"
+        ExchangeV2State.SameAccountAbort -> "SameAccountAbort"
+        ExchangeV2State.Aborted -> "Aborted"
+        ExchangeV2State.Host.Confirming -> "Host.Confirming"
+        ExchangeV2State.Host.Sending -> "Host.Sending"
+        ExchangeV2State.Host.Aborted -> "Host.Aborted"
+        ExchangeV2State.Host.Done -> "Host.Done"
+        ExchangeV2State.Joiner.Confirming -> "Joiner.Confirming"
+        ExchangeV2State.Joiner.Waiting -> "Joiner.Waiting"
+        ExchangeV2State.Joiner.AbortedLocal -> "Joiner.AbortedLocal"
+        ExchangeV2State.Joiner.AbortedByHost -> "Joiner.AbortedByHost"
+        ExchangeV2State.Joiner.Done -> "Joiner.Done"
+    }
+
+    private fun labelFor(trigger: LocalTrigger): String = when (trigger) {
+        LocalTrigger.UserConfirmedHost -> "UserConfirmedHost"
+        LocalTrigger.UserDeniedHost -> "UserDeniedHost"
+        LocalTrigger.UserConfirmedJoiner -> "UserConfirmedJoiner"
+        LocalTrigger.UserDeniedJoiner -> "UserDeniedJoiner"
+        LocalTrigger.HostSendComplete -> "HostSendComplete"
+        LocalTrigger.HostUnavailable -> "HostUnavailable"
+        is LocalTrigger.RoleElected -> "RoleElected(${trigger.role})"
+    }
+}

--- a/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
+++ b/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
@@ -99,6 +99,13 @@
             app:primaryText="canShowV2ConnectCode (display, requires canUseV2ConnectFlow)" />
 
         <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+            android:id="@+id/openV2PairingDebugButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:text="V2 Pairing Debug" />
+
+        <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
             android:id="@+id/fetchAccessCredentialsButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/sync/sync-internal/src/main/res/layout/activity_sync_v2_pairing_debug.xml
+++ b/sync/sync-internal/src/main/res/layout/activity_sync_v2_pairing_debug.xml
@@ -1,0 +1,260 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <include
+        android:id="@+id/includeToolbar"
+        layout="@layout/include_default_toolbar" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fadeScrollbars="false"
+        android:scrollbarAlwaysDrawVerticalTrack="true"
+        android:scrollbars="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="Account status" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
+
+                <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                    android:id="@+id/statusSignedIn"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    app:primaryText="Signed in"
+                    tools:secondaryText="No" />
+
+                <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
+                    android:id="@+id/signInOutButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="@dimen/keyline_4"
+                    android:text="Sign in" />
+            </LinearLayout>
+
+            <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                android:id="@+id/statusThirdPartyCredential"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="3party credential"
+                tools:secondaryText="Not created" />
+
+            <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="Settings" />
+
+            <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                android:id="@+id/autoApproveSetting"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="Auto-approve confirmations"
+                app:secondaryText="When on, this device automatically confirms its own Host/Joiner prompt. Turn off to see the real alert dialog."
+                app:showSwitch="true" />
+
+            <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="Session" />
+
+            <!-- Presenter side: tap Start, get linking code, share it with the Scanner. -->
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_marginEnd="@dimen/keyline_4"
+                android:text="Presenter mode: tap Start to generate a v2 linking code for a Scanner to paste."
+                app:typography="caption" />
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+                android:id="@+id/runPresentButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_margin="10dp"
+                android:text="Start as Presenter" />
+
+            <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+                android:id="@+id/linkingCodeSectionHeader"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                app:primaryText="Linking code (give this to the Scanner)" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/linkingCodeTextView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_marginEnd="@dimen/keyline_4"
+                android:layout_marginBottom="@dimen/keyline_4"
+                android:visibility="gone"
+                app:typography="caption" />
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
+                android:id="@+id/copyLinkingCodeButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_marginBottom="@dimen/keyline_4"
+                android:text="Copy linking code"
+                android:visibility="gone" />
+
+            <ImageView
+                android:id="@+id/linkingCodeQrImage"
+                android:layout_width="280dp"
+                android:layout_height="280dp"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginBottom="@dimen/keyline_4"
+                android:contentDescription="QR for v2 linking code"
+                android:visibility="gone" />
+
+            <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <!-- Scanner side: paste a linking code, tap Start. -->
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_marginEnd="@dimen/keyline_4"
+                android:text="Scanner mode: paste the Presenter's linking code below, then tap Start as Scanner."
+                app:typography="caption" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextInput
+                android:id="@+id/pastedUrlInput"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_marginEnd="@dimen/keyline_4"
+                android:hint="Paste Presenter's https://duckduckgo.com/sync/pairing/#&amp;code2=… URL"
+                app:editable="true"
+                app:type="single_line" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+                    android:id="@+id/pasteAndGoButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="10dp"
+                    android:text="Paste &amp; Go" />
+
+                <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+                    android:id="@+id/runScanButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="10dp"
+                    android:text="Start as Scanner" />
+
+                <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
+                    android:id="@+id/clearPastedUrlButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="10dp"
+                    android:text="Clear URL" />
+            </LinearLayout>
+
+            <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
+                    android:id="@+id/cancelButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="10dp"
+                    android:text="Cancel" />
+
+                <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
+                    android:id="@+id/clearLogButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_margin="10dp"
+                    android:text="Clear Log" />
+            </LinearLayout>
+
+            <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+
+            <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="State" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/currentStateTextView"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_4"
+                android:layout_marginEnd="@dimen/keyline_4"
+                android:layout_marginBottom="@dimen/keyline_4"
+                app:typography="body2" />
+
+            <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:primaryText="Log" />
+
+            <LinearLayout
+                android:id="@+id/logContainer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/keyline_4"
+                android:orientation="vertical" />
+
+        </LinearLayout>
+    </ScrollView>
+</LinearLayout>

--- a/sync/sync-internal/src/main/res/layout/item_sync_v2_pairing_log_row.xml
+++ b/sync/sync-internal/src/main/res/layout/item_sync_v2_pairing_log_row.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingStart="@dimen/keyline_4"
+    android:paddingEnd="@dimen/keyline_4"
+    android:paddingTop="6dp"
+    android:paddingBottom="6dp">
+
+    <LinearLayout
+        android:id="@+id/summaryRow"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:clickable="true"
+        android:focusable="true">
+
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/summaryTextView"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            app:typography="body2" />
+
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/chevronTextView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingStart="8dp"
+            android:text="▸"
+            app:typography="body2" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/rawDetail"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/rawJsonTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:fontFamily="monospace"
+            android:textIsSelectable="true"
+            app:typography="caption" />
+
+        <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
+            android:id="@+id/copyRawButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:text="Copy JSON" />
+    </LinearLayout>
+</LinearLayout>

--- a/sync/sync-internal/src/main/res/values/donottranslate.xml
+++ b/sync/sync-internal/src/main/res/values/donottranslate.xml
@@ -21,6 +21,7 @@
 
     <!-- Internal Setting -->
     <string name="sync_internal_activity_label">Sync Setup Internal</string>
+    <string name="sync_v2_pairing_debug_activity_label">V2 Pairing Debug</string>
     <string name="sync_internal_environment_header">Environment Settings</string>
     <string name="sync_internal_environment_title">Use Dev Environment?</string>
     <string name="sync_internal_environment_subtitle_prod">https://sync.duckduckgo.com</string>

--- a/sync/sync-internal/src/test/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModelTest.kt
+++ b/sync/sync-internal/src/test/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModelTest.kt
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.internal.ui
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.sync.impl.DispatchOutcome
+import com.duckduckgo.sync.impl.Result
+import com.duckduckgo.sync.impl.RouteDecision
+import com.duckduckgo.sync.impl.SyncAccountRepository
+import com.duckduckgo.sync.impl.SyncAuthCode
+import com.duckduckgo.sync.impl.SyncCodeDispatcher
+import com.duckduckgo.sync.impl.SyncCodeType
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Hello
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
+import com.duckduckgo.sync.impl.exchange.v2.RejectReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.store.SyncStore
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class SyncV2PairingDebugViewModelTest {
+
+    @get:Rule val coroutineTestRule = CoroutineTestRule()
+
+    private val eventFlow = MutableSharedFlow<ExchangeV2Event>(replay = 0, extraBufferCapacity = 100)
+    private val runner: ExchangeV2Runner = mock<ExchangeV2Runner>().also {
+        whenever(it.events).thenReturn(eventFlow)
+        whenever(it.currentState).thenReturn(null)
+    }
+    private val syncStore: SyncStore = mock()
+    private val syncAccountRepository: SyncAccountRepository = mock()
+    private val dispatcher: SyncCodeDispatcher = mock()
+
+    private fun newViewModel() = SyncV2PairingDebugViewModel(
+        runner = runner,
+        syncStore = syncStore,
+        syncAccountRepository = syncAccountRepository,
+        dispatcher = dispatcher,
+        dispatchers = coroutineTestRule.testDispatcherProvider,
+        appScope = coroutineTestRule.testScope,
+    )
+
+    // ---- Event log ----
+
+    @Test fun `Transition event appended to rows with correct summary`() = runTest {
+        val viewModel = newViewModel()
+        viewModel.viewState().test {
+            assertEquals(emptyList<SyncV2PairingDebugViewModel.LogRow>(), awaitItem().rows)
+
+            whenever(runner.currentState).thenReturn(ExchangeV2State.Negotiating)
+            eventFlow.emit(
+                ExchangeV2Event.Transition(
+                    timestampMs = 100L,
+                    from = ExchangeV2State.Bootstrapped,
+                    to = ExchangeV2State.Negotiating,
+                    trigger = Hello("""{"type":"hello"}"""),
+                    localTrigger = null,
+                ),
+            )
+
+            val updated = awaitItem()
+            assertEquals(1, updated.rows.size)
+            assertTrue(updated.rows.single().summary.contains("Bootstrapped → Negotiating"))
+            assertEquals("Negotiating", updated.currentStateLabel)
+        }
+    }
+
+    @Test fun `MessageSent event labelled as Sent with type`() = runTest {
+        val viewModel = newViewModel()
+        viewModel.viewState().test {
+            awaitItem()
+            eventFlow.emit(
+                ExchangeV2Event.MessageSent(
+                    timestampMs = 0L,
+                    message = ExchangeV2Message.RecoveryCodeRequest(rawJson = "{}", name = "me", kind = "3party"),
+                ),
+            )
+            val state = awaitItem()
+            assertEquals(1, state.rows.size)
+            assertTrue(state.rows.single().summary.startsWith("Sent recovery_code_request"))
+        }
+    }
+
+    @Test fun `MessageRejected with SameAccount labelled SameAccountAbort`() = runTest {
+        val viewModel = newViewModel()
+        viewModel.viewState().test {
+            awaitItem()
+            eventFlow.emit(
+                ExchangeV2Event.MessageRejected(
+                    timestampMs = 0L,
+                    message = ExchangeV2Message.RecoveryCodeAvailable(
+                        rawJson = "{}",
+                        userId = "shared",
+                        name = "Peer",
+                        kind = "3party",
+                    ),
+                    state = ExchangeV2State.Negotiating,
+                    reason = RejectReason.SameAccount,
+                ),
+            )
+            val state = awaitItem()
+            assertTrue(state.rows.single().summary.startsWith("SameAccountAbort"))
+        }
+    }
+
+    @Test fun `onClearLogClicked empties rows`() = runTest {
+        val viewModel = newViewModel()
+        viewModel.viewState().test {
+            awaitItem()
+            eventFlow.emit(
+                ExchangeV2Event.Transition(
+                    timestampMs = 0L,
+                    from = ExchangeV2State.Bootstrapped,
+                    to = ExchangeV2State.Negotiating,
+                    trigger = Hello("{}"),
+                    localTrigger = null,
+                ),
+            )
+            assertEquals(1, awaitItem().rows.size)
+
+            viewModel.onClearLogClicked()
+            assertEquals(0, awaitItem().rows.size)
+        }
+    }
+
+    // ---- Lifecycle / control ----
+
+    @Test fun `onCancelClicked delegates to runner cancel`() = runTest {
+        val viewModel = newViewModel()
+        viewModel.onCancelClicked()
+        verify(runner).cancel()
+    }
+
+    // ---- Dispatch routing through SyncCodeDispatcher ----
+
+    @Test fun `onRunScanClicked delegates to dispatcher route`() {
+        val authCode = SyncAuthCode.Unknown("anything")
+        whenever(dispatcher.route(any())).thenReturn(RouteDecision.Legacy(authCode))
+        val viewModel = newViewModel()
+
+        viewModel.onRunScanClicked("the-url")
+
+        verify(dispatcher).route("the-url")
+    }
+
+    @Test fun `Legacy v1 Recovery — calls processCode and does NOT collect from a dispatcher Flow`() {
+        val recovery = SyncAuthCode.Recovery(mock())
+        whenever(dispatcher.route(any())).thenReturn(RouteDecision.Legacy(recovery))
+        whenever(syncAccountRepository.processCode(eq(recovery), anyOrNull())).thenReturn(Result.Success(true))
+        val viewModel = newViewModel()
+
+        viewModel.onRunScanClicked("v1-recovery-url")
+
+        verify(syncAccountRepository).processCode(eq(recovery), anyOrNull())
+    }
+
+    @Test fun `Legacy v1 Connect — calls processCode`() {
+        val connect = SyncAuthCode.Connect(mock())
+        whenever(dispatcher.route(any())).thenReturn(RouteDecision.Legacy(connect))
+        whenever(syncAccountRepository.processCode(eq(connect), anyOrNull())).thenReturn(Result.Success(true))
+        val viewModel = newViewModel()
+
+        viewModel.onRunScanClicked("v1-connect-url")
+
+        verify(syncAccountRepository).processCode(eq(connect), anyOrNull())
+    }
+
+    @Test fun `Legacy Unknown — does NOT call processCode (surfaces as user-facing toast)`() {
+        whenever(dispatcher.route(any())).thenReturn(RouteDecision.Legacy(SyncAuthCode.Unknown("garbage")))
+        val viewModel = newViewModel()
+
+        viewModel.onRunScanClicked("garbage")
+
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
+    }
+
+    @Test fun `V2InProgress — collects the outcomes Flow without calling parseSyncAuthCode`() {
+        whenever(dispatcher.route(any())).thenReturn(
+            RouteDecision.V2InProgress(
+                codeType = SyncCodeType.RECOVERY,
+                outcomes = flowOf(DispatchOutcome.LoggedIn(path = SetupPath.RECOVERY)),
+            ),
+        )
+        val viewModel = newViewModel()
+
+        viewModel.onRunScanClicked("v2-url")
+
+        verify(syncAccountRepository, never()).parseSyncAuthCode(any())
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
+    }
+
+    @Test fun `V2InProgress with Failed outcome — does NOT crash and does NOT fall back to legacy`() {
+        whenever(dispatcher.route(any())).thenReturn(
+            RouteDecision.V2InProgress(
+                codeType = SyncCodeType.RECOVERY,
+                outcomes = flowOf(DispatchOutcome.Failed("BE rejected")),
+            ),
+        )
+        val viewModel = newViewModel()
+
+        viewModel.onRunScanClicked("v2-url")
+
+        verify(syncAccountRepository, never()).parseSyncAuthCode(any())
+    }
+}

--- a/sync/sync-store/src/main/java/com/duckduckgo/sync/store/SyncStore.kt
+++ b/sync/sync-store/src/main/java/com/duckduckgo/sync/store/SyncStore.kt
@@ -30,9 +30,6 @@ interface SyncStore {
     /** Scoped password (SP primary key) for the 3party credential. Only present when a 3party credential exists. */
     var scopedPassword: ScopedPassword?
 
-    /** JSON array of protected keys with kid, purpose, encrypted_with, encrypted_private_key. */
-    var protectedKeysJson: String?
-
     fun isEncryptionSupported(): Boolean
     fun isSignedInFlow(): Flow<Boolean>
     fun isSignedIn(): Boolean
@@ -166,14 +163,6 @@ constructor(
             }
         }
 
-    override var protectedKeysJson: String?
-        get() = encryptedPreferences?.getString(KEY_PROTECTED_KEYS_JSON, null)
-        set(value) {
-            encryptedPreferences?.edit(commit = true) {
-                if (value == null) remove(KEY_PROTECTED_KEYS_JSON) else putString(KEY_PROTECTED_KEYS_JSON, value)
-            }
-        }
-
     override fun isEncryptionSupported(): Boolean = encryptedPreferences != null
 
     override fun isSignedInFlow(): Flow<Boolean> = isSignedInStateFlow
@@ -218,6 +207,5 @@ constructor(
         private const val KEY_SK = "KEY_SK"
         private const val KEY_CREDENTIAL_ID = "KEY_CREDENTIAL_ID"
         private const val KEY_SCOPED_PASSWORD = "KEY_SCOPED_PASSWORD"
-        private const val KEY_PROTECTED_KEYS_JSON = "KEY_PROTECTED_KEYS_JSON"
     }
 }

--- a/sync/sync-store/src/test/java/com/duckduckgo/sync/store/SyncSharedPrefsStoreTest.kt
+++ b/sync/sync-store/src/test/java/com/duckduckgo/sync/store/SyncSharedPrefsStoreTest.kt
@@ -134,25 +134,13 @@ class SyncSharedPrefsStoreTest {
     }
 
     @Test
-    fun whenProtectedKeysJsonStoredThenValueUpdatedInPrefsStore() {
-        assertNull(store.protectedKeysJson)
-        val keysJson = """[{"kid":"k1","purpose":"ai_chats","encrypted_with":"ddg","encrypted_private_key":"jwe_data"}]"""
-        store.protectedKeysJson = keysJson
-        assertEquals(keysJson, store.protectedKeysJson)
-        store.protectedKeysJson = null
-        assertNull(store.protectedKeysJson)
-    }
-
-    @Test
     fun whenClearAllThenV2FieldsAlsoCleared() {
         store.credentialId = "ddg"
         store.scopedPassword = ScopedPassword("encrypted_sp")
-        store.protectedKeysJson = """[{"kid":"k1"}]"""
 
         store.clearAll()
 
         assertNull(store.credentialId)
         assertNull(store.scopedPassword)
-        assertNull(store.protectedKeysJson)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1149059203486286/task/1215628433324575?focus=true 

### Description
The code dispatcher between the connect UI and the transport runner.

`SyncCodeDispatcher.route(code)` classifies a pasted/scanned code, gated by `canUseV2ConnectFlow`, **with the flag off, behaviour is identical to today's `parseSyncAuthCode`** (v2 detection is fully skipped).

On the v2 path it drives a session over the runner (Scanner via `route`, Presenter via `presentV2`), exposing outcomes as a cold `Flow<DispatchOutcome>`: linking-code-ready, confirmation prompts, and a single terminal (logged-in / already-connected / upgrade-required / failed).

Handles v2 recovery codes (`cid=ddg`/`3party`), confirmation resume, and a transparent account switch on `ALREADY_SIGNED_IN`. Pure orchestration over 03–04; not yet called by any UI (that's 06).

**Note:**
- Not yet called by any UI (that's https://app.asana.com/1/137249556945/project/1149059203486286/task/1215628433324577?focus=true).

**New components**
- `SyncCodeDispatcher` (interface) + `RouteDecision` / `DispatchOutcome` — the routing contract and outcome types.
- `RealSyncCodeDispatcher` — classifies a code (v1 legacy vs v2), drives v2 Scanner (`route`) / Presenter (`presentV2`) sessions over the runner, exposes outcomes as a cold Flow, and handles v2 recovery codes + the transparent account switch.


### Steps to test this PR
- CI should pass; E2E exercised by the upstack UI PRs.

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes account login, pairing, 3party upgrade, and protected-key handling with transparent account switching—core sync/auth paths gated by feature flags but high impact when enabled.
> 
> **Overview**
> Introduces **`SyncCodeDispatcher`** (with **`RealSyncCodeDispatcher`**) to classify pasted/scanned codes behind **`canUseV2ConnectFlow`**: flag off keeps the legacy **`parseSyncAuthCode`** path; flag on runs v2 recovery or linking via **`ExchangeV2Runner`**, emitting **`Flow<DispatchOutcome>`** (QR ready, host/joiner confirmations, terminals including transparent **`ALREADY_SIGNED_IN`** logout+rejoin).
> 
> **Connect, exchange, login, and manual enter-code** screens now route through the dispatcher, show v2 confirmation dialogs and pairing error copy, and can **`presentV2()`** for v2 QR instead of v1 polling when both v2 flags are on. Lifecycle collection moves to **`CREATED`** and session start is guarded to avoid regenerating pairing codes.
> 
> Adds **`sync_setup.json5`** pixel definitions and extends **`SyncPixels`** with **`flow_version`**, code type/version, success/failure/cancel reasons, and **`sync_setup_ended_failed`**.
> 
> **Protected keys**: **`set-if-absent`** POSTs a **`keys`** list and returns server keys; **`ProtectedKeyManager`** adopts the server entry on races and drops local **`protectedKeysJson`** caching. **`SyncAccountRepository`** stops persisting protected keys locally; **`ThirdPartyCredentialManager`** merges new **`ai_chats`** keys with existing ddg keys. New **`AccountErrorCodes`** for pairing failures; **`ExchangeV2Runner`** exposes **`peerKind`** and uses generic session error strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11f5f4efe1a030b5620e5c25a0836096c0b6371b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->