### PR TITLE
Handle Duck.ai model recovery in native input

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1448,6 +1448,18 @@ class BrowserTabFragment :
                         ),
                     )
                 },
+                onChangeModelSubmitted = { modelId ->
+                    contentScopeScripts.sendSubscriptionEvent(
+                        SubscriptionEventData(
+                            featureName = "aiChat",
+                            subscriptionName = "submitChangeModelAction",
+                            params = JSONObject().apply {
+                                put("platform", "android")
+                                put("modelId", modelId)
+                            },
+                        ),
+                    )
+                },
                 onFireButtonPressed = { onFireButtonPressed() },
                 onVoiceSearchPressed = { isChatTab ->
                     val mode = if (isChatTab) VoiceSearchMode.DUCK_AI else VoiceSearchMode.SEARCH

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -74,6 +74,8 @@ class NativeInputCallbacks(
     ) -> Unit,
     val onChatSuggestionSelected: (String) -> Unit,
     val onDuckAiQuerySubmitted: (query: String) -> Unit = {},
+    /** User picked a model in the native picker (→ submitChangeModelAction). */
+    val onChangeModelSubmitted: (modelId: String) -> Unit = {},
     val onChatUrlSuggestionClicked: (AutoCompleteSuggestion) -> Unit = {},
     val onChatHistoryShortcutClicked: () -> Unit = {},
     val onClearAutocomplete: () -> Unit,
@@ -451,6 +453,7 @@ class RealNativeInputManager @Inject constructor(
                         filesJson,
                     )
                     widget.clearSelectedTool()
+                    widget.onPromptSubmitted()
                 } else if (queryUrlPredictor.isUrl(query)) {
                     // Not in a Duck.ai chat (e.g. on the NTP with the Duck.ai toggle selected): a
                     // URL is an address, so navigate to it exactly like Search mode rather than
@@ -480,6 +483,7 @@ class RealNativeInputManager @Inject constructor(
                 }
             },
         )
+        widget.onChangeModelSubmitted = { modelId -> callbacks.onChangeModelSubmitted(modelId) }
         widget.onBack = {
             widget.hideKeyboard()
             hideNativeInput()

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/nativeinput/NativeInputState.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/nativeinput/NativeInputState.kt
@@ -26,6 +26,16 @@ data class NativeInputState(
     val chatId: String? = null,
     /** True while the active chat is streaming a response (ChatState.STREAMING or LOADING). */
     val isChatStreaming: Boolean = false,
+    /**
+     * Set when we are in model change mode in ongoing chats
+     * (between `showModelPicker` message and the next prompt submit, chat change, or dismissal without selection).
+     * Routes picker taps to `submitChangeModelAction` instead of normal behaviour.
+     */
+    val modelChangeMode: Boolean = false,
+    /**
+     * Whether the native input submit button is enabled for this tab.
+     */
+    val submitEnabled: Boolean = true,
 ) {
     enum class InputMode {
         SEARCH_AND_DUCK_AI,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -67,6 +67,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
@@ -213,6 +214,16 @@ interface DuckChatInternal : DuckChat {
      * Returns the current chat state.
      */
     val chatState: StateFlow<ChatState>
+
+    /**
+     * Requests the native model picker to open for [tabId].
+     */
+    fun requestShowModelPicker(tabId: String)
+
+    /**
+     * Events asking the native input to open the model picker.
+     */
+    val showModelPickerEvents: Flow<String>
 
     /**
      * Returns whether image upload is enabled or not.
@@ -384,6 +395,7 @@ class RealDuckChat @Inject constructor(
     private val _showMainButtonsInInputScreen = MutableStateFlow(false)
 
     private val _chatState = MutableStateFlow(ChatState.HIDE)
+    private val _showModelPickerEvents = MutableSharedFlow<String>(extraBufferCapacity = 1)
     private val _nativeInputFieldEnabled = MutableStateFlow(false)
     private val _showInputScreenOnSystemSearchLaunch = MutableStateFlow(false)
     private val _showVoiceSearchToggle = MutableStateFlow(false)
@@ -558,6 +570,12 @@ class RealDuckChat @Inject constructor(
     override fun updateChatState(state: ChatState) {
         _chatState.value = state
     }
+
+    override fun requestShowModelPicker(tabId: String) {
+        _showModelPickerEvents.tryEmit(tabId)
+    }
+
+    override val showModelPickerEvents: Flow<String> = _showModelPickerEvents.asSharedFlow()
 
     override val showSettings: StateFlow<Boolean> = _showSettings.asStateFlow()
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.common.ui.view.encodeBitmapToBase64
 import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
 import com.duckduckgo.duckchat.impl.ChatState
 import com.duckduckgo.duckchat.impl.ChatState.HIDE
 import com.duckduckgo.duckchat.impl.ChatState.SHOW
@@ -100,6 +101,7 @@ class RealDuckChatJSHelper @Inject constructor(
     private val duckChatFeature: DuckChatFeature,
     private val voiceSessionStateManager: VoiceSessionStateManager,
     private val limitsHandler: LimitsHandler,
+    private val nativeInputStatePublisher: NativeInputStatePublisher,
 ) : DuckChatJSHelper {
 
     private val registerOpenedJob = ConflatedJob()
@@ -184,6 +186,22 @@ class RealDuckChatJSHelper @Inject constructor(
 
             METHOD_SHOW_CHAT_INPUT -> {
                 duckChat.updateChatState(SHOW)
+                null
+            }
+            METHOD_DISABLE_CHAT_INPUT -> {
+                // submitEnabled is per-tab state and we have the tabId here, so we write it directly via
+                // the publisher. The widget VM reads it from NativeInputState.
+                if (tabId.isNotEmpty()) nativeInputStatePublisher.update(tabId) { it.copy(submitEnabled = false) }
+                null
+            }
+
+            METHOD_ENABLE_CHAT_INPUT -> {
+                if (tabId.isNotEmpty()) nativeInputStatePublisher.update(tabId) { it.copy(submitEnabled = true) }
+                null
+            }
+
+            METHOD_SHOW_MODEL_PICKER -> {
+                if (tabId.isNotEmpty()) duckChat.requestShowModelPicker(tabId)
                 null
             }
 
@@ -531,6 +549,9 @@ class RealDuckChatJSHelper @Inject constructor(
         private const val METHOD_RESPONSE_STATE = "responseState"
         private const val METHOD_HIDE_CHAT_INPUT = "hideChatInput"
         private const val METHOD_SHOW_CHAT_INPUT = "showChatInput"
+        private const val METHOD_DISABLE_CHAT_INPUT = "disableChatInput"
+        private const val METHOD_ENABLE_CHAT_INPUT = "enableChatInput"
+        private const val METHOD_SHOW_MODEL_PICKER = "showModelPicker"
         const val METHOD_GET_PAGE_CONTEXT = "getAIChatPageContext"
         const val METHOD_OPEN_KEYBOARD = "openKeyboard"
         private const val METHOD_TOGGLE_PAGE_CONTEXT = "togglePageContextTelemetry"

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputScreenButtons.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputScreenButtons.kt
@@ -87,6 +87,7 @@ class InputScreenButtons @JvmOverloads constructor(
 
     fun showStopButton() {
         actionSend.isEnabled = true
+        actionSend.alpha = ENABLED_ALPHA
         actionSend.setImageResource(R.drawable.ic_stop_16)
         actionSend.setOnClickListener { onStopClick?.invoke() }
     }
@@ -102,6 +103,7 @@ class InputScreenButtons @JvmOverloads constructor(
 
     fun setSendButtonEnabled(enabled: Boolean) {
         actionSend.isEnabled = enabled
+        actionSend.alpha = if (enabled) ENABLED_ALPHA else DISABLED_ALPHA
     }
 
     fun setSendButtonVisible(visible: Boolean) {
@@ -156,5 +158,10 @@ class InputScreenButtons @JvmOverloads constructor(
         actionNewLine.foreground = circularRippleDrawable
         actionVoiceSearch?.foreground = circularRippleDrawable
         actionVoiceChat?.foreground = circularRippleDrawable
+    }
+
+    companion object {
+        private const val ENABLED_ALPHA = 1f
+        private const val DISABLED_ALPHA = 0.4f
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/messaging/DuckChatContentScopeJsMessageHandler.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/messaging/DuckChatContentScopeJsMessageHandler.kt
@@ -68,6 +68,9 @@ class DuckChatContentScopeJsMessageHandler @Inject constructor(
                     "voiceSessionStarted",
                     "voiceSessionEnded",
                     "responseReceived",
+                    "showModelPicker",
+                    "disableChatInput",
+                    "enableChatInput",
                 )
         }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -72,6 +72,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flatMapLatest
@@ -152,7 +153,23 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         viewModelScope.launch {
             _isHistoryAvailable.value = duckChatInternal.isChatHistoryAvailable()
         }
+        viewModelScope.launch {
+            // FE recovery "Switch Model": enter the model-change mode, but only when the event
+            // targets this widget's tab. The event carries a tabId, so other tabs' VMs ignore it.
+            duckChatInternal.showModelPickerEvents.collect { eventTabId ->
+                if (eventTabId == activeTabId.value) {
+                    nativeInputStatePublisher.update(eventTabId) { it.copy(modelChangeMode = true) }
+                }
+            }
+        }
     }
+
+    /**
+     * Events asking the widget to open the model picker (e.g. for the FE recovery flow) for the related tabId.
+     */
+    val showModelPickerEvents: Flow<Unit> = duckChatInternal.showModelPickerEvents
+        .filter { it == activeTabId.value }
+        .map { }
 
     fun setModelPickerEnabled(enabled: Boolean) {
         _modelPickerEnabled.value = enabled
@@ -262,6 +279,18 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         .map { it.chatId }
         .distinctUntilChanged()
 
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val submitEnabled: Flow<Boolean> = activeTabId.filterNotNull()
+        .flatMapLatest { tabId -> nativeInputStateProvider.stateForTab(tabId) }
+        .map { it.submitEnabled }
+        .distinctUntilChanged()
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val modelChangeMode: Flow<Boolean> = activeTabId.filterNotNull()
+        .flatMapLatest { tabId -> nativeInputStateProvider.stateForTab(tabId) }
+        .map { it.modelChangeMode }
+        .distinctUntilChanged()
+
     val state: SharedFlow<NativeInputState> = combine(
         baseState,
         duckChatInternal.chatState,
@@ -341,6 +370,26 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         nativeInputStatePublisher.update(tabId) { it.copy(selectedTool = tool) }
     }
 
+    /**
+     * Called when a prompt is submitted
+     * */
+    fun onPromptSubmitted() {
+        // Ends the FE recovery model-change window for the active tab.
+        endModelChangeMode()
+    }
+
+    /**
+     * Called when the recovery model picker is dismissed without picking a model.
+     */
+    fun exitModelChangeMode() {
+        endModelChangeMode()
+    }
+
+    private fun endModelChangeMode() {
+        val tabId = activeTabId.value ?: return
+        nativeInputStatePublisher.update(tabId) { it.copy(modelChangeMode = false) }
+    }
+
     fun setActiveChatId(chatId: String?) {
         val tabId = activeTabId.value
         if (tabId == null) {
@@ -353,7 +402,12 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     }
 
     private fun applyChatId(tabId: String, chatId: String?) {
-        nativeInputStatePublisher.update(tabId) { it.copy(chatId = chatId) }
+        nativeInputStatePublisher.update(tabId) { current ->
+            // Reset submitEnabled to true if we changed chats.
+            // Always end the model-change window since it's per-visit.
+            val submitEnabled = if (current.chatId != chatId) true else current.submitEnabled
+            current.copy(chatId = chatId, submitEnabled = submitEnabled, modelChangeMode = false)
+        }
         currentChatJob?.cancel()
         currentChat.value = null
         currentChatJob = viewModelScope.launch {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
@@ -29,6 +29,7 @@ import android.widget.PopupWindow
 import android.widget.ScrollView
 import androidx.annotation.DrawableRes
 import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.view.doOnLayout
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.lifecycle.ViewModelProvider
@@ -63,11 +64,20 @@ interface ModelPicker {
     var onMenuShown: (() -> Unit)?
     var onMenuDismissed: (() -> Unit)?
     var onModelSelected: (() -> Unit)?
+
+    /** Invoked when the user picks a model during the FE recovery model-change flow. */
+    var onChangeModelSubmitted: ((modelId: String) -> Unit)?
     fun getSelectedModelId(): String?
     fun isImageGenerationSupported(): Boolean
     fun isWebSearchSupported(): Boolean
     fun setPickerEnabled(enabled: Boolean)
     fun setHost(host: NativeInputHost)
+
+    /** Programmatically open the selection list (FE recovery: showModelPicker). */
+    fun openPicker()
+
+    /** True if a model was picked during the current recovery window (set synchronously on tap). */
+    fun hasPendingRecoverySelection(): Boolean
 }
 
 @InjectWith(ViewScope::class)
@@ -88,8 +98,10 @@ class ModelPickerView @JvmOverloads constructor(
     }
     private val chip: Chip by lazy { findViewById(R.id.modelPickerChip) }
     private var stateJob: Job? = null
+    private var chipLabelJob: Job? = null
     private var inputContextJob: Job? = null
     private var commandJob: Job? = null
+    private var modelChangeJob: Job? = null
     private var popupWindow: PopupWindow? = null
     private var lastObservedModelId: String? = null
     private var lastNativeInputState: NativeInputState? = null
@@ -101,6 +113,7 @@ class ModelPickerView @JvmOverloads constructor(
     override var onMenuShown: (() -> Unit)? = null
     override var onMenuDismissed: (() -> Unit)? = null
     override var onModelSelected: (() -> Unit)? = null
+    override var onChangeModelSubmitted: ((modelId: String) -> Unit)? = null
 
     init {
         inflate(context, R.layout.view_model_picker, this)
@@ -168,7 +181,6 @@ class ModelPickerView @JvmOverloads constructor(
         lastObservedModelId = viewModel.state.value.selectedModelId
         stateJob = viewModel.state
             .onEach { state ->
-                state.selectedModelShortName?.let { chip.text = it }
                 updateVisibility()
                 val newId = state.selectedModelId
                 if (newId != null && newId != lastObservedModelId) {
@@ -178,10 +190,34 @@ class ModelPickerView @JvmOverloads constructor(
             }
             .launchIn(scope)
 
+        chipLabelJob?.cancel()
+        chipLabelJob = viewModel.chipLabel
+            .onEach { label -> label?.let { chip.text = it } }
+            .launchIn(scope)
+
         commandJob?.cancel()
         commandJob = viewModel.commands
             .onEach { processCommand(it) }
             .launchIn(scope)
+
+        modelChangeJob?.cancel()
+        modelChangeJob = viewModel.modelChanges
+            .onEach { change ->
+                when (change) {
+                    is PickerModelChange.ChangeModel -> {
+                        onChangeModelSubmitted?.invoke(change.modelId)
+                        dismissPopup()
+                    }
+                }
+            }
+            .launchIn(scope)
+    }
+
+    override fun hasPendingRecoverySelection(): Boolean = viewModel.hasPendingRecoverySelection()
+
+    override fun openPicker() {
+        if (!isAttachedToWindow) return
+        chip.doOnLayout { if (isAttachedToWindow) showMenu() }
     }
 
     private fun processCommand(command: UpsellCommand) {
@@ -200,6 +236,7 @@ class ModelPickerView @JvmOverloads constructor(
         }
 
     private fun showMenu() {
+        if (popupWindow?.isShowing == true) return
         val state = viewModel.state.value
         if (state.models.isEmpty()) return
 
@@ -259,10 +296,14 @@ class ModelPickerView @JvmOverloads constructor(
         super.onDetachedFromWindow()
         stateJob?.cancel()
         stateJob = null
+        chipLabelJob?.cancel()
+        chipLabelJob = null
         inputContextJob?.cancel()
         inputContextJob = null
         commandJob?.cancel()
         commandJob = null
+        modelChangeJob?.cancel()
+        modelChangeJob = null
         lastNativeInputState = null
         dismissPopup()
     }
@@ -277,11 +318,12 @@ class ModelPickerView @JvmOverloads constructor(
     }
 
     private fun LinearLayout.populateMenu(state: ModelState, popup: PopupWindow) {
+        val selectedId = viewModel.selectedModelIdForMenu()
         viewModel.buildSections(state).forEachIndexed { index, section ->
             if (index > 0) addDivider()
             section.headerRes?.let { addSectionHeader(context.getString(it)) }
             for (model in section.models) {
-                addModelItem(model, selected = model.id == state.selectedModelId, popup)
+                addModelItem(model, selected = model.id == selectedId, popup)
             }
         }
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
@@ -102,8 +102,8 @@ class ModelPickerView @JvmOverloads constructor(
     private var inputContextJob: Job? = null
     private var commandJob: Job? = null
     private var modelChangeJob: Job? = null
+    private var effectiveModelJob: Job? = null
     private var popupWindow: PopupWindow? = null
-    private var lastObservedModelId: String? = null
     private var lastNativeInputState: NativeInputState? = null
 
     // Mirrors the input context from the per-tab native input state so currentSurface() can be
@@ -178,16 +178,15 @@ class ModelPickerView @JvmOverloads constructor(
     private fun observeState() {
         val scope = findViewTreeLifecycleOwner()?.lifecycleScope ?: return
         stateJob?.cancel()
-        lastObservedModelId = viewModel.state.value.selectedModelId
         stateJob = viewModel.state
-            .onEach { state ->
-                updateVisibility()
-                val newId = state.selectedModelId
-                if (newId != null && newId != lastObservedModelId) {
-                    lastObservedModelId = newId
-                    onModelSelected?.invoke()
-                }
-            }
+            .onEach { updateVisibility() }
+            .launchIn(scope)
+
+        // Refresh option tool-visibility whenever the effective (chat-aware / recovery) model
+        // changes, not only on global model changes — otherwise options reflect the wrong model.
+        effectiveModelJob?.cancel()
+        effectiveModelJob = viewModel.effectiveModelId
+            .onEach { onModelSelected?.invoke() }
             .launchIn(scope)
 
         chipLabelJob?.cancel()
@@ -304,6 +303,8 @@ class ModelPickerView @JvmOverloads constructor(
         commandJob = null
         modelChangeJob?.cancel()
         modelChangeJob = null
+        effectiveModelJob?.cancel()
+        effectiveModelJob = null
         lastNativeInputState = null
         dismissPopup()
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
@@ -94,22 +94,33 @@ class ModelPickerViewModel @Inject constructor(
     }
 
     /**
-     * Chat-aware chip label: in an ongoing chat (chatId set) shows that chat's model short name,
-     * falling back to the global selection when the chat's model isn't in the list (e.g. lost
-     * access). For a new chat (chatId null) it shows the global selection.
+     * The model the chip displays and whose capabilities the options should reflect: a just-picked
+     * recovery model, else the active chat's model (when in the list, e.g. not lost access), else
+     * the global selection. Single source of truth for [chipLabel] and [getSelectedModel].
      */
-    val chipLabel: StateFlow<String?> = combine(
+    val effectiveModelId: StateFlow<String?> = combine(
         modelManager.modelState,
         nativeInputStateProvider.state,
         currentChat,
         recoverySelectedModelId,
     ) { modelState, nativeState, chat, recoveryId ->
-        // A just-picked recovery model wins (only for display, before the chat's model syncs back).
-        val recoveryShortName = recoveryId?.let { id -> modelState.models.firstOrNull { it.id == id }?.shortName }
-        if (recoveryShortName != null) return@combine recoveryShortName
+        val modelIds = modelState.models.mapTo(HashSet()) { it.id }
+        // A just-picked recovery model wins (display, before the chat's model syncs back).
+        recoveryId?.takeIf { it in modelIds }?.let { return@combine it }
         val activeChat = chat?.takeIf { it.chatId == nativeState.chatId }
-        val chatShortName = activeChat?.let { c -> modelState.models.firstOrNull { it.id == c.model }?.shortName }
-        chatShortName ?: modelState.selectedModelShortName
+        activeChat?.model?.takeIf { it in modelIds } ?: modelState.selectedModelId
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = modelManager.modelState.value.selectedModelId,
+    )
+
+    /**
+     * Chat-aware chip label derived from [effectiveModelId]: that model's short name, falling back
+     * to the global selection's short name when it isn't in the list.
+     */
+    val chipLabel: StateFlow<String?> = combine(modelManager.modelState, effectiveModelId) { modelState, id ->
+        modelState.models.firstOrNull { it.id == id }?.shortName ?: modelState.selectedModelShortName
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.Eagerly,
@@ -135,7 +146,7 @@ class ModelPickerViewModel @Inject constructor(
 
     fun getSelectedModelId(): String? = modelManager.getSelectedModelId()
 
-    fun getSelectedModel(): AIChatModel? = state.value.run { models.find { it.id == selectedModelId } }
+    fun getSelectedModel(): AIChatModel? = state.value.models.firstOrNull { it.id == effectiveModelId.value }
 
     fun isImageGenerationSupported(): Boolean = getSelectedModel()?.supportsTool(Tool.IMAGE_GENERATION) ?: true
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.models.AIChatModel
 import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
@@ -30,24 +31,105 @@ import com.duckduckgo.duckchat.impl.models.ModelState
 import com.duckduckgo.duckchat.impl.models.Tool
 import com.duckduckgo.duckchat.impl.models.UserTier
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
+import com.duckduckgo.duckchat.store.impl.DuckAiChat
+import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import logcat.logcat
 import javax.inject.Inject
 
 data class ModelSection(@StringRes val headerRes: Int?, val models: List<AIChatModel>)
 
+/** Emitted when the user picks a model during the FE recovery model-change flow. */
+sealed class PickerModelChange {
+    data class ChangeModel(val modelId: String) : PickerModelChange()
+}
+
 @ContributesViewModel(ViewScope::class)
 class ModelPickerViewModel @Inject constructor(
     private val modelManager: DuckAiModelManager,
     private val duckChatPixels: DuckChatPixels,
+    private val nativeInputStateProvider: NativeInputStateProvider,
+    private val duckAiChatStore: DuckAiChatStore,
 ) : ViewModel() {
 
     val state: StateFlow<ModelState> = modelManager.modelState
+
+    private val currentChat = MutableStateFlow<DuckAiChat?>(null)
+
+    private var modelChangeMode: Boolean = false
+
+    // The model picked during the current recovery flow. Display-only: it drives the chip and the
+    // picker's selected tick immediately, without waiting for the FE to sync the chat's model back
+    // to native storage. Cleared when the recovery window ends.
+    private val recoverySelectedModelId = MutableStateFlow<String?>(null)
+
+    init {
+        viewModelScope.launch {
+            // collectLatest: cancel in-flight lookup on chatId flip to avoid stale currentChat.
+            nativeInputStateProvider.state
+                .map { it.chatId }
+                .distinctUntilChanged()
+                .collectLatest { chatId ->
+                    currentChat.value = if (chatId == null) null else duckAiChatStore.getChatById(chatId)
+                }
+        }
+        viewModelScope.launch {
+            nativeInputStateProvider.state.collect { state ->
+                modelChangeMode = state.modelChangeMode
+                if (!state.modelChangeMode) recoverySelectedModelId.value = null
+            }
+        }
+    }
+
+    /**
+     * Chat-aware chip label: in an ongoing chat (chatId set) shows that chat's model short name,
+     * falling back to the global selection when the chat's model isn't in the list (e.g. lost
+     * access). For a new chat (chatId null) it shows the global selection.
+     */
+    val chipLabel: StateFlow<String?> = combine(
+        modelManager.modelState,
+        nativeInputStateProvider.state,
+        currentChat,
+        recoverySelectedModelId,
+    ) { modelState, nativeState, chat, recoveryId ->
+        // A just-picked recovery model wins (only for display, before the chat's model syncs back).
+        val recoveryShortName = recoveryId?.let { id -> modelState.models.firstOrNull { it.id == id }?.shortName }
+        if (recoveryShortName != null) return@combine recoveryShortName
+        val activeChat = chat?.takeIf { it.chatId == nativeState.chatId }
+        val chatShortName = activeChat?.let { c -> modelState.models.firstOrNull { it.id == c.model }?.shortName }
+        chatShortName ?: modelState.selectedModelShortName
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = modelManager.modelState.value.selectedModelShortName,
+    )
+
+    /** True once a model was picked during the current recovery window (set synchronously in onModelTapped). */
+    fun hasPendingRecoverySelection(): Boolean = recoverySelectedModelId.value != null
+
+    /**
+     * Model id the picker should mark with the selected tick: prioritizes the recovery model if any,
+     * then the active chat's model during recovery, then
+     * the global selection (normal new-chat behaviour).
+     */
+    fun selectedModelIdForMenu(): String? {
+        recoverySelectedModelId.value?.let { return it }
+        val chat = currentChat.value
+        if (modelChangeMode && chat != null) return chat.model
+        return modelManager.modelState.value.selectedModelId
+    }
 
     var menuShowing = false
 
@@ -68,12 +150,23 @@ class ModelPickerViewModel @Inject constructor(
     private val command = Channel<UpsellCommand>(capacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
     val commands: Flow<UpsellCommand> = command.receiveAsFlow()
 
+    private val modelChangeChannel = Channel<PickerModelChange>(capacity = 1, onBufferOverflow = BufferOverflow.DROP_OLDEST)
+    val modelChanges: Flow<PickerModelChange> = modelChangeChannel.receiveAsFlow()
+
     fun onModelTapped(model: AIChatModel, surface: PickerSurface) {
         if (model.isAccessible) {
-            if (model.id != modelManager.getSelectedModelId()) {
-                duckChatPixels.fireModelSelected(model.id)
+            if (modelChangeMode) {
+                // FE recovery flow: report the chosen model to the FE instead of changing the
+                // global default. FE owns the chat's model; native storage syncs back. Show the
+                // pick immediately on the chip + tick rather than waiting for that sync.
+                recoverySelectedModelId.value = model.id
+                modelChangeChannel.trySend(PickerModelChange.ChangeModel(model.id))
+            } else {
+                if (model.id != modelManager.getSelectedModelId()) {
+                    duckChatPixels.fireModelSelected(model.id)
+                }
+                viewModelScope.launch { modelManager.selectModel(model) }
             }
-            viewModelScope.launch { modelManager.selectModel(model) }
             return
         }
         val userTier = modelManager.modelState.value.userTier

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
@@ -170,6 +170,10 @@ class ModelPickerViewModel @Inject constructor(
                 // FE recovery flow: report the chosen model to the FE instead of changing the
                 // global default. FE owns the chat's model; native storage syncs back. Show the
                 // pick immediately on the chip + tick rather than waiting for that sync.
+                // Fire the same selection pixel as the normal flow (skip a re-tap of the same pick).
+                if (model.id != recoverySelectedModelId.value) {
+                    duckChatPixels.fireModelSelected(model.id)
+                }
                 recoverySelectedModelId.value = model.id
                 modelChangeChannel.trySend(PickerModelChange.ChangeModel(model.id))
             } else {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -68,10 +68,12 @@ import com.google.android.material.tabs.TabLayout
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import logcat.logcat
@@ -92,6 +94,9 @@ interface NativeInputWidget {
     var onImageClick: (() -> Unit)?
     var onPaidTierChanged: ((Boolean) -> Unit)?
     var onAttachmentChooserStateChanged: ((Boolean) -> Unit)?
+
+    /** Fired when the user picks a model in the model-change flow (→ submitChangeModelAction). */
+    var onChangeModelSubmitted: ((modelId: String) -> Unit)?
     val isModelMenuVisible: Boolean
 
     fun onBackPressed()
@@ -119,6 +124,7 @@ interface NativeInputWidget {
     fun getResolvedReasoningEffort(): String?
     fun getSelectedTool(): String?
     fun clearSelectedTool()
+    fun onPromptSubmitted()
     fun setModelPickerEnabled(enabled: Boolean)
 
     /**
@@ -213,6 +219,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private var modelPickerEnabledSource: Flow<Boolean>? = null
     private var chatIdJob: Job? = null
     private var chatIdSource: Flow<String?>? = null
+    private var submitEnabledJob: Job? = null
+    private var openModelPickerJob: Job? = null
+    private var submitAllowed: Boolean = true
     private var modelPickerView: ModelPicker? = null
     private var optionsView: OptionsView? = null
     private var chatSuggestionsUserEnabled: Boolean = true
@@ -227,6 +236,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private var voiceChatAvailable: Boolean = false
     private var widgetRoot: View? = null
     override var onStopTapped: (() -> Unit)? = null
+    override var onChangeModelSubmitted: ((modelId: String) -> Unit)? = null
     override var onImageClick: (() -> Unit)? = null
     override var onVoiceSearchClick: (() -> Unit)? = null
         set(value) {
@@ -293,6 +303,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
         observeChatState()
         observeChatSuggestionsEnabled()
         observeNativeInputState()
+        observeSubmitEnabled()
+        observeOpenModelPicker()
         bindLeadingFireButtonClick()
         if (onPaidTierChanged != null) observeTier()
     }
@@ -350,9 +362,13 @@ class NativeInputModeWidget @JvmOverloads constructor(
                 }
             }
             launch {
-                viewModel.modelPickerEnabled.collect { enabled ->
-                    modelPickerView?.setPickerEnabled(enabled)
-                }
+                // Chip is enabled when new chat OR during the FE recovery flow (changing models).
+                combine(
+                    viewModel.modelPickerEnabled,
+                    viewModel.modelChangeMode,
+                ) { base, inRecovery -> base || inRecovery }
+                    .distinctUntilChanged()
+                    .collect { enabled -> modelPickerView?.setPickerEnabled(enabled) }
             }
         }
     }
@@ -367,10 +383,16 @@ class NativeInputModeWidget @JvmOverloads constructor(
         }
         (pluginView as? ModelPicker)?.let { picker ->
             picker.onMenuShown = { isModelMenuVisible = true }
-            picker.onMenuDismissed = { isModelMenuVisible = false }
+            picker.onMenuDismissed = {
+                isModelMenuVisible = false
+                // FE recovery: dismissing without picking a model reverts the change window so the
+                // chip hides again (nothing changed). A selection keeps the chip until submit.
+                if (!picker.hasPendingRecoverySelection()) viewModel.exitModelChangeMode()
+            }
             picker.onModelSelected = {
                 optionsView?.updateCapabilitiesFrom(picker)
             }
+            picker.onChangeModelSubmitted = { modelId -> onChangeModelSubmitted?.invoke(modelId) }
         }
     }
 
@@ -400,6 +422,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
         modelPickerEnabledJob = null
         chatIdJob?.cancel()
         chatIdJob = null
+        submitEnabledJob?.cancel()
+        submitEnabledJob = null
+        openModelPickerJob?.cancel()
+        openModelPickerJob = null
         modelPickerView = null
         optionsView = null
         widgetRoot = null
@@ -551,7 +577,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val visible = isChatTabSelected() && hasContent
         submitButtons?.setSendButtonVisible(visible)
         if (!isStreaming) {
-            submitButtons?.setSendButtonEnabled(hasContent && !attachmentLimitExceeded)
+            submitButtons?.setSendButtonEnabled(submitAllowed && hasContent && !attachmentLimitExceeded)
         }
     }
 
@@ -929,6 +955,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
         optionsView?.clearSelection()
     }
 
+    override fun onPromptSubmitted() {
+        viewModel.onPromptSubmitted()
+    }
+
     override fun setModelPickerEnabled(enabled: Boolean) {
         viewModel.setModelPickerEnabled(enabled)
     }
@@ -1141,6 +1171,35 @@ class NativeInputModeWidget @JvmOverloads constructor(
         chatSuggestionsSettingJob = viewModel.chatSuggestionsUserEnabled
             .onEach { enabled -> chatSuggestionsUserEnabled = enabled }
             .launchIn(findViewTreeLifecycleOwner()?.lifecycleScope ?: return)
+    }
+
+    // FE recovery: force-disable the submit button while the active chat's model is unavailable.
+    private fun observeSubmitEnabled() {
+        submitEnabledJob?.cancel()
+        submitEnabledJob = viewModel.submitEnabled
+            .onEach { enabled ->
+                submitAllowed = enabled
+                updateSendButtonVisibility()
+            }
+            .launchIn(findViewTreeLifecycleOwner()?.lifecycleScope ?: return)
+    }
+
+    // FE recovery "Switch Model": open the picker on every event (not on the modelChangeMode flag
+    // transition), so a repeated tap re-opens the picker after it was dismissed. The chip is shown
+    // via the modelChangeMode combine in setupPlugins; openPicker() waits for that layout pass.
+    private fun observeOpenModelPicker() {
+        openModelPickerJob?.cancel()
+        val scope = findViewTreeLifecycleOwner()?.lifecycleScope
+        openModelPickerJob = viewModel.showModelPickerEvents
+            .onEach {
+                // The picker chip lives in the bottom row, which is only laid out while the input is
+                // focused (updateBottomRowVisibility). On an ongoing chat opened from history the
+                // input is unfocused, so the chip is GONE and openPicker()'s doOnLayout would never
+                // fire. Request focus first to expand the row, then open the picker.
+                requestInputFocus()
+                modelPickerView?.openPicker()
+            }
+            .launchIn(scope ?: return)
     }
 
     private fun observeNativeInputState() {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -25,6 +25,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.Lifecycle.State.CREATED
 import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
@@ -1916,6 +1917,15 @@ class RealDuckChatTest {
         coroutineRule.testScope.advanceUntilIdle()
 
         assertFalse(testee.isChatHistoryAvailable())
+    }
+
+    @Test
+    fun whenRequestShowModelPickerThenEventEmittedWithTabId() = runTest {
+        testee.showModelPickerEvents.test {
+            testee.requestShowModelPicker("tab-1")
+            assertEquals("tab-1", awaitItem())
+            cancelAndConsumeRemainingEvents()
+        }
     }
 
     private suspend fun enableChatHistoryFlags() {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
@@ -20,6 +20,8 @@ import android.annotation.SuppressLint
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
 import com.duckduckgo.duckchat.impl.ChatState
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.ReportMetric.USER_DID_CREATE_NEW_CHAT
@@ -52,6 +54,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -77,6 +80,7 @@ class RealDuckChatJSHelperTest {
         FakeFeatureToggleFactory.create(DuckChatFeature::class.java)
     private val mockVoiceSessionStateManager: VoiceSessionStateManager = mock()
     private val mockLimitsHandler: LimitsHandler = mock()
+    private val mockNativeInputStatePublisher: NativeInputStatePublisher = mock()
     private val testee = RealDuckChatJSHelper(
         duckChat = mockDuckChat,
         duckChatPixels = mockDuckChatPixels,
@@ -89,6 +93,7 @@ class RealDuckChatJSHelperTest {
         duckChatFeature = mockDuckChatFeature,
         voiceSessionStateManager = mockVoiceSessionStateManager,
         limitsHandler = mockLimitsHandler,
+        nativeInputStatePublisher = mockNativeInputStatePublisher,
     )
     private val viewModel =
         object {
@@ -1098,6 +1103,37 @@ class RealDuckChatJSHelperTest {
         )
 
         verify(mockDuckChat).updateChatState(ChatState.SHOW)
+    }
+
+    @Test
+    fun whenDisableChatInputThenSubmitDisabledForTab() = runTest {
+        assertNull(
+            testee.processJsCallbackMessage("aiChat", "disableChatInput", "123", null, tabId = "tab-1"),
+        )
+
+        val captor = argumentCaptor<(NativeInputState) -> NativeInputState>()
+        verify(mockNativeInputStatePublisher).update(eq("tab-1"), captor.capture())
+        assertFalse(captor.firstValue.invoke(NativeInputState.zero()).submitEnabled)
+    }
+
+    @Test
+    fun whenEnableChatInputThenSubmitEnabledForTab() = runTest {
+        assertNull(
+            testee.processJsCallbackMessage("aiChat", "enableChatInput", "123", null, tabId = "tab-1"),
+        )
+
+        val captor = argumentCaptor<(NativeInputState) -> NativeInputState>()
+        verify(mockNativeInputStatePublisher).update(eq("tab-1"), captor.capture())
+        assertTrue(captor.firstValue.invoke(NativeInputState.zero().copy(submitEnabled = false)).submitEnabled)
+    }
+
+    @Test
+    fun whenShowModelPickerThenRequestShowModelPickerForTab() = runTest {
+        assertNull(
+            testee.processJsCallbackMessage("aiChat", "showModelPicker", "123", null, tabId = "tab-1"),
+        )
+
+        verify(mockDuckChat).requestShowModelPicker("tab-1")
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/DuckChatContentScopeJsMessageHandlerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/DuckChatContentScopeJsMessageHandlerTest.kt
@@ -42,26 +42,32 @@ class DuckChatContentScopeJsMessageHandlerTest {
 
     @Test
     fun `only contains valid methods`() {
-        val methods = handler.methods
-        assertTrue(methods.size == 18)
-        assertTrue(methods[0] == "getAIChatNativeHandoffData")
-        assertTrue(methods[1] == "getAIChatNativeConfigValues")
-        assertTrue(methods[2] == "openAIChat")
-        assertTrue(methods[3] == "closeAIChat")
-        assertTrue(methods[4] == "openAIChatSettings")
-        assertTrue(methods[5] == "responseState")
-        assertTrue(methods[6] == "hideChatInput")
-        assertTrue(methods[7] == "showChatInput")
-        assertTrue(methods[8] == "reportMetric")
-        assertTrue(methods[9] == "openKeyboard")
-        assertTrue(methods[10] == "getAIChatPageContext")
-        assertTrue(methods[11] == "togglePageContextTelemetry")
-        assertTrue(methods[12] == "submitAIChatPageContext")
-        assertTrue(methods[13] == "userDidAcceptTermsAndConditions")
-        assertTrue(methods[14] == "getAIChatNativePrompt")
-        assertTrue(methods[15] == "voiceSessionStarted")
-        assertTrue(methods[16] == "voiceSessionEnded")
-        assertTrue(methods[17] == "responseReceived")
+        val expected = listOf(
+            "getAIChatNativeHandoffData",
+            "getAIChatNativeConfigValues",
+            "openAIChat",
+            "closeAIChat",
+            "openAIChatSettings",
+            "responseState",
+            "hideChatInput",
+            "showChatInput",
+            "reportMetric",
+            "openKeyboard",
+            "getAIChatPageContext",
+            "togglePageContextTelemetry",
+            "submitAIChatPageContext",
+            "userDidAcceptTermsAndConditions",
+            "getAIChatNativePrompt",
+            "voiceSessionStarted",
+            "voiceSessionEnded",
+            "responseReceived",
+            "showModelPicker",
+            "disableChatInput",
+            "enableChatInput",
+        )
+        // assert exact membership (size guards against accidental add/remove).
+        assertEquals(expected.size, handler.methods.size)
+        assertTrue(handler.methods.containsAll(expected))
     }
 
     private val callback = object : JsMessageCallback() {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -25,8 +25,10 @@ import com.duckduckgo.duckchat.impl.ChatState
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 
@@ -159,6 +161,14 @@ class FakeDuckChatInternal(
     }
 
     override val chatState: StateFlow<ChatState> = _chatState
+
+    private val _showModelPickerEvents = MutableSharedFlow<String>(extraBufferCapacity = 1)
+
+    override fun requestShowModelPicker(tabId: String) {
+        _showModelPickerEvents.tryEmit(tabId)
+    }
+
+    override val showModelPickerEvents: Flow<String> = _showModelPickerEvents.asSharedFlow()
 
     override fun isImageUploadEnabled(): Boolean = false
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
@@ -289,6 +289,17 @@ class ModelPickerViewModelTest {
     }
 
     @Test
+    fun whenAccessibleModelTappedInModelChangeModeThenModelSelectedPixelFired() = runTest {
+        nativeInputState.value = nativeInputState.value.copy(chatId = "c1", modelChangeMode = true)
+        advanceUntilIdle()
+        val model = freeModel(id = "new-model", shortName = "New")
+
+        testee.onModelTapped(model, PickerSurface.MODEL_PICKER_ADDRESS_BAR)
+
+        verify(duckChatPixels).fireModelSelected("new-model")
+    }
+
+    @Test
     fun whenAccessibleModelTappedNotInModelChangeModeThenSelectModelCalled() = runTest {
         nativeInputState.value = nativeInputState.value.copy(chatId = null, modelChangeMode = false)
         advanceUntilIdle()

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
@@ -557,6 +557,48 @@ class ModelPickerViewModelTest {
     }
 
     @Test
+    fun whenOngoingChatThenCapabilitiesReflectChatModelNotGlobal() = runTest {
+        stateFlow.value = ModelState(
+            models = listOf(
+                freeModel(id = "global-model", shortName = "Global", supportedTools = emptyList()),
+                freeModel(id = "chat-model", shortName = "Chat", supportedTools = listOf(Tool.IMAGE_GENERATION)),
+            ),
+            selectedModelId = "global-model",
+            selectedModelShortName = "Global",
+        )
+        whenever(duckAiChatStore.getChatById("c1")).thenReturn(
+            DuckAiChat(chatId = "c1", title = "t", model = "chat-model", lastEdit = "now", pinned = false),
+        )
+        nativeInputState.value = nativeInputState.value.copy(chatId = "c1")
+        advanceUntilIdle()
+
+        assertEquals("chat-model", testee.getSelectedModel()?.id)
+        assertTrue(testee.isImageGenerationSupported())
+    }
+
+    @Test
+    fun whenRecoveryModelPickedThenCapabilitiesReflectRecoveryModel() = runTest {
+        val recoveryModel = freeModel(id = "recovery-model", shortName = "Recovery", supportedTools = listOf(Tool.WEB_SEARCH))
+        stateFlow.value = ModelState(
+            models = listOf(
+                freeModel(id = "global-model", shortName = "Global", supportedTools = listOf(Tool.IMAGE_GENERATION)),
+                recoveryModel,
+            ),
+            selectedModelId = "global-model",
+            selectedModelShortName = "Global",
+        )
+        nativeInputState.value = nativeInputState.value.copy(chatId = "c1", modelChangeMode = true)
+        advanceUntilIdle()
+
+        testee.onModelTapped(recoveryModel, PickerSurface.MODEL_PICKER_ADDRESS_BAR)
+        advanceUntilIdle()
+
+        assertEquals("recovery-model", testee.getSelectedModel()?.id)
+        assertTrue(testee.isWebSearchSupported())
+        assertFalse(testee.isImageGenerationSupported())
+    }
+
+    @Test
     fun whenOngoingChatThenChipLabelIsChatModelShortName() = runTest {
         stateFlow.value = ModelState(
             models = listOf(freeModel(id = "chat-model", shortName = "Chat Model")),

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
@@ -18,6 +18,8 @@ package com.duckduckgo.duckchat.impl.ui
 
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.models.AIChatModel
 import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
@@ -27,10 +29,14 @@ import com.duckduckgo.duckchat.impl.models.Tool
 import com.duckduckgo.duckchat.impl.models.UserTier
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.ModelPickerViewModel
+import com.duckduckgo.duckchat.impl.ui.nativeinput.views.PickerModelChange
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.PickerSurface
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.UpsellCommand
+import com.duckduckgo.duckchat.store.impl.DuckAiChat
+import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -56,13 +62,23 @@ class ModelPickerViewModelTest {
     private val modelManager: DuckAiModelManager = mock()
     private val duckChatPixels: DuckChatPixels = mock()
     private val stateFlow = MutableStateFlow(ModelState())
+    private val nativeInputState = MutableStateFlow(NativeInputState.zero())
+    private val nativeInputStateProvider: NativeInputStateProvider = mock<NativeInputStateProvider>().also {
+        whenever(it.state).thenReturn(nativeInputState)
+    }
+    private val duckAiChatStore: DuckAiChatStore = mock()
 
     private lateinit var testee: ModelPickerViewModel
 
     @Before
     fun setUp() {
         whenever(modelManager.modelState).thenReturn(stateFlow)
-        testee = ModelPickerViewModel(modelManager, duckChatPixels)
+        testee = ModelPickerViewModel(
+            modelManager = modelManager,
+            duckChatPixels = duckChatPixels,
+            nativeInputStateProvider = nativeInputStateProvider,
+            duckAiChatStore = duckAiChatStore,
+        )
     }
 
     @Test
@@ -256,6 +272,32 @@ class ModelPickerViewModelTest {
             flowType = "purchase",
         )
         verify(duckChatPixels, never()).fireModelSelected(any())
+    }
+
+    @Test
+    fun whenAccessibleModelTappedInModelChangeModeThenChangeModelEmittedAndSelectModelNotCalled() = runTest {
+        nativeInputState.value = nativeInputState.value.copy(chatId = "c1", modelChangeMode = true)
+        advanceUntilIdle()
+        val model = freeModel(id = "new-model", shortName = "New")
+
+        testee.modelChanges.test {
+            testee.onModelTapped(model, PickerSurface.MODEL_PICKER_ADDRESS_BAR)
+            assertEquals(PickerModelChange.ChangeModel("new-model"), awaitItem())
+            cancelAndConsumeRemainingEvents()
+        }
+        verify(modelManager, never()).selectModel(any())
+    }
+
+    @Test
+    fun whenAccessibleModelTappedNotInModelChangeModeThenSelectModelCalled() = runTest {
+        nativeInputState.value = nativeInputState.value.copy(chatId = null, modelChangeMode = false)
+        advanceUntilIdle()
+        val model = freeModel(id = "new-model", shortName = "New")
+
+        testee.onModelTapped(model, PickerSurface.MODEL_PICKER_ADDRESS_BAR)
+        advanceUntilIdle()
+
+        verify(modelManager).selectModel(model)
     }
 
     @Test
@@ -512,6 +554,156 @@ class ModelPickerViewModelTest {
         stateFlow.value = ModelState(models = emptyList(), selectedModelId = null)
 
         assertTrue(testee.isWebSearchSupported())
+    }
+
+    @Test
+    fun whenOngoingChatThenChipLabelIsChatModelShortName() = runTest {
+        stateFlow.value = ModelState(
+            models = listOf(freeModel(id = "chat-model", shortName = "Chat Model")),
+            selectedModelId = "global-model",
+            selectedModelShortName = "Global Model",
+        )
+        whenever(duckAiChatStore.getChatById("c1")).thenReturn(
+            DuckAiChat(chatId = "c1", title = "t", model = "chat-model", lastEdit = "now", pinned = false),
+        )
+        nativeInputState.value = nativeInputState.value.copy(chatId = "c1")
+        advanceUntilIdle()
+
+        assertEquals("Chat Model", testee.chipLabel.value)
+    }
+
+    @Test
+    fun whenNewChatThenChipLabelIsGlobalShortName() = runTest {
+        stateFlow.value = ModelState(
+            models = listOf(freeModel(id = "global-model", shortName = "Global Model")),
+            selectedModelId = "global-model",
+            selectedModelShortName = "Global Model",
+        )
+        nativeInputState.value = nativeInputState.value.copy(chatId = null)
+        advanceUntilIdle()
+
+        assertEquals("Global Model", testee.chipLabel.value)
+    }
+
+    @Test
+    fun whenChatModelNotInListThenChipLabelFallsBackToGlobal() = runTest {
+        stateFlow.value = ModelState(
+            models = listOf(freeModel(id = "global-model", shortName = "Global Model")),
+            selectedModelId = "global-model",
+            selectedModelShortName = "Global Model",
+        )
+        whenever(duckAiChatStore.getChatById("c1")).thenReturn(
+            DuckAiChat(chatId = "c1", title = "t", model = "lost-access-model", lastEdit = "now", pinned = false),
+        )
+        nativeInputState.value = nativeInputState.value.copy(chatId = "c1")
+        advanceUntilIdle()
+
+        assertEquals("Global Model", testee.chipLabel.value)
+    }
+
+    @Test
+    fun whenModelPickedInRecoveryThenChipLabelShowsPickedModelImmediately() = runTest {
+        stateFlow.value = ModelState(
+            models = listOf(freeModel(id = "new-model", shortName = "New Model")),
+            selectedModelShortName = "Global Model",
+        )
+        nativeInputState.value = nativeInputState.value.copy(chatId = "c1", modelChangeMode = true)
+        advanceUntilIdle()
+
+        testee.onModelTapped(freeModel(id = "new-model", shortName = "New Model"), PickerSurface.MODEL_PICKER_ADDRESS_BAR)
+        advanceUntilIdle()
+
+        assertEquals("New Model", testee.chipLabel.value)
+    }
+
+    @Test
+    fun whenRecoveryEndsThenChipLabelRevertsFromPickedModel() = runTest {
+        stateFlow.value = ModelState(
+            models = listOf(freeModel(id = "new-model", shortName = "New Model")),
+            selectedModelShortName = "Global Model",
+        )
+        nativeInputState.value = nativeInputState.value.copy(chatId = null, modelChangeMode = true)
+        advanceUntilIdle()
+        testee.onModelTapped(freeModel(id = "new-model", shortName = "New Model"), PickerSurface.MODEL_PICKER_ADDRESS_BAR)
+        advanceUntilIdle()
+        assertEquals("New Model", testee.chipLabel.value)
+
+        nativeInputState.value = nativeInputState.value.copy(modelChangeMode = false)
+        advanceUntilIdle()
+
+        assertEquals("Global Model", testee.chipLabel.value)
+    }
+
+    @Test
+    fun whenNoRecoveryPickThenHasPendingRecoverySelectionFalse() = runTest {
+        nativeInputState.value = nativeInputState.value.copy(chatId = "c1", modelChangeMode = true)
+        advanceUntilIdle()
+
+        assertFalse(testee.hasPendingRecoverySelection())
+    }
+
+    @Test
+    fun whenModelPickedInRecoveryThenHasPendingRecoverySelectionTrue() = runTest {
+        stateFlow.value = ModelState(models = listOf(freeModel(id = "new-model")))
+        nativeInputState.value = nativeInputState.value.copy(chatId = "c1", modelChangeMode = true)
+        advanceUntilIdle()
+
+        testee.onModelTapped(freeModel(id = "new-model"), PickerSurface.MODEL_PICKER_ADDRESS_BAR)
+
+        assertTrue(testee.hasPendingRecoverySelection())
+    }
+
+    @Test
+    fun whenRecoveryEndsThenHasPendingRecoverySelectionFalse() = runTest {
+        stateFlow.value = ModelState(models = listOf(freeModel(id = "new-model")))
+        nativeInputState.value = nativeInputState.value.copy(chatId = "c1", modelChangeMode = true)
+        advanceUntilIdle()
+        testee.onModelTapped(freeModel(id = "new-model"), PickerSurface.MODEL_PICKER_ADDRESS_BAR)
+        assertTrue(testee.hasPendingRecoverySelection())
+
+        nativeInputState.value = nativeInputState.value.copy(modelChangeMode = false)
+        advanceUntilIdle()
+
+        assertFalse(testee.hasPendingRecoverySelection())
+    }
+
+    @Test
+    fun whenModelPickedInRecoveryThenSelectedModelIdForMenuIsPickedModel() = runTest {
+        stateFlow.value = ModelState(models = listOf(freeModel(id = "new-model")))
+        nativeInputState.value = nativeInputState.value.copy(chatId = "c1", modelChangeMode = true)
+        advanceUntilIdle()
+
+        testee.onModelTapped(freeModel(id = "new-model"), PickerSurface.MODEL_PICKER_ADDRESS_BAR)
+        advanceUntilIdle()
+
+        assertEquals("new-model", testee.selectedModelIdForMenu())
+    }
+
+    @Test
+    fun whenInRecoveryAndNoPickThenSelectedModelIdForMenuIsChatModelNotGlobal() = runTest {
+        stateFlow.value = ModelState(
+            models = listOf(freeModel(id = "global-model")),
+            selectedModelId = "global-model",
+        )
+        whenever(duckAiChatStore.getChatById("c1")).thenReturn(
+            DuckAiChat(chatId = "c1", title = "t", model = "lost-access-model", lastEdit = "now", pinned = false),
+        )
+        nativeInputState.value = nativeInputState.value.copy(chatId = "c1", modelChangeMode = true)
+        advanceUntilIdle()
+
+        assertEquals("lost-access-model", testee.selectedModelIdForMenu())
+    }
+
+    @Test
+    fun whenNotInRecoveryThenSelectedModelIdForMenuIsGlobal() = runTest {
+        stateFlow.value = ModelState(
+            models = listOf(freeModel(id = "global-model")),
+            selectedModelId = "global-model",
+        )
+        nativeInputState.value = nativeInputState.value.copy(chatId = null, modelChangeMode = false)
+        advanceUntilIdle()
+
+        assertEquals("global-model", testee.selectedModelIdForMenu())
     }
 
     private fun freeModel(

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -63,6 +63,7 @@ import com.duckduckgo.subscriptions.api.Product
 import com.duckduckgo.subscriptions.api.Subscriptions
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
@@ -127,6 +128,7 @@ class NativeInputModeWidgetViewModelTest {
     private val chatStateFlow = MutableStateFlow(ChatState.READY)
     private val chatSuggestionsUserEnabledFlow = MutableStateFlow(true)
     private val entitlementsFlow = MutableStateFlow<List<Product>>(emptyList())
+    private val showModelPickerEvents = MutableSharedFlow<String>(extraBufferCapacity = 1)
 
     private var fakePlugins: List<NativeInputPlugin> = emptyList()
     private val fakePluginPoint = object : ActivePluginPoint<NativeInputPlugin> {
@@ -142,6 +144,7 @@ class NativeInputModeWidgetViewModelTest {
         whenever(duckChatInternal.observeInputScreenUserSettingEnabled()).thenReturn(inputScreenUserSettingFlow)
         whenever(duckChatInternal.observeChatSuggestionsUserSettingEnabled()).thenReturn(chatSuggestionsUserEnabledFlow)
         whenever(duckChatInternal.chatState).thenReturn(chatStateFlow)
+        whenever(duckChatInternal.showModelPickerEvents).thenReturn(showModelPickerEvents)
         whenever(subscriptions.getEntitlementStatus()).thenReturn(entitlementsFlow)
         whenever(autoCompleteFactory.create(any())).thenReturn(autoComplete)
         whenever(autoCompleteSettings.autoCompleteSuggestionsEnabled).thenReturn(false)
@@ -721,6 +724,102 @@ class NativeInputModeWidgetViewModelTest {
         advanceUntilIdle()
 
         assertNull(viewModel.getSelectedModelId())
+    }
+
+    @Test
+    fun whenShowModelPickerEventThenModelChangeModeSetTrueOnActiveTab() = runTest {
+        val viewModel = createViewModel()
+        viewModel.configure(tabId = "tab-A", isDuckAiMode = true, isBottom = false)
+        advanceUntilIdle()
+
+        showModelPickerEvents.tryEmit("tab-A")
+        advanceUntilIdle()
+
+        assertTrue(nativeInputStateProvider.stateForTab("tab-A").value.modelChangeMode)
+    }
+
+    @Test
+    fun whenShowModelPickerEventForOtherTabThenModelChangeModeNotSet() = runTest {
+        val viewModel = createViewModel()
+        viewModel.configure(tabId = "tab-A", isDuckAiMode = true, isBottom = false)
+        advanceUntilIdle()
+
+        showModelPickerEvents.tryEmit("tab-B")
+        advanceUntilIdle()
+
+        assertFalse(nativeInputStateProvider.stateForTab("tab-A").value.modelChangeMode)
+    }
+
+    @Test
+    fun whenChatIdChangesThenModelChangeModeCleared() = runTest {
+        val viewModel = createViewModel()
+        viewModel.configure(tabId = "tab-A", isDuckAiMode = true, isBottom = false)
+        advanceUntilIdle()
+        showModelPickerEvents.tryEmit("tab-A")
+        advanceUntilIdle()
+        assertTrue(nativeInputStateProvider.stateForTab("tab-A").value.modelChangeMode)
+
+        viewModel.setActiveChatId("new-chat")
+        advanceUntilIdle()
+
+        assertFalse(nativeInputStateProvider.stateForTab("tab-A").value.modelChangeMode)
+    }
+
+    @Test
+    fun whenPromptSubmittedThenModelChangeModeClearedOnActiveTab() = runTest {
+        val viewModel = createViewModel()
+        viewModel.configure(tabId = "tab-A", isDuckAiMode = true, isBottom = false)
+        advanceUntilIdle()
+        showModelPickerEvents.tryEmit("tab-A")
+        advanceUntilIdle()
+
+        viewModel.onPromptSubmitted()
+
+        assertFalse(nativeInputStateProvider.stateForTab("tab-A").value.modelChangeMode)
+    }
+
+    @Test
+    fun whenExitModelChangeModeThenModelChangeModeClearedOnActiveTab() = runTest {
+        val viewModel = createViewModel()
+        viewModel.configure(tabId = "tab-A", isDuckAiMode = true, isBottom = false)
+        advanceUntilIdle()
+        showModelPickerEvents.tryEmit("tab-A")
+        advanceUntilIdle()
+
+        viewModel.exitModelChangeMode()
+
+        assertFalse(nativeInputStateProvider.stateForTab("tab-A").value.modelChangeMode)
+    }
+
+    @Test
+    fun whenChatIdChangesThenSubmitEnabledResetsToTrue() = runTest {
+        val viewModel = createViewModel()
+        viewModel.configure(tabId = "tab-A", isDuckAiMode = true, isBottom = false)
+        viewModel.setActiveChatId("chat-X")
+        advanceUntilIdle()
+        // Simulate the FE having disabled submit for the previous (unsupported-model) chat.
+        nativeInputStatePublisher.update("tab-A") { it.copy(submitEnabled = false) }
+
+        viewModel.setActiveChatId("new-chat")
+        advanceUntilIdle()
+
+        assertTrue(nativeInputStateProvider.stateForTab("tab-A").value.submitEnabled)
+    }
+
+    @Test
+    fun whenSameChatIdReappliedThenSubmitEnabledPreserved() = runTest {
+        val viewModel = createViewModel()
+        viewModel.configure(tabId = "tab-A", isDuckAiMode = true, isBottom = false)
+        viewModel.setActiveChatId("chat-X")
+        advanceUntilIdle()
+        // FE disabled submit for chat-X (unsupported model).
+        nativeInputStatePublisher.update("tab-A") { it.copy(submitEnabled = false) }
+
+        // Re-applying the same chatId (e.g. tab re-selection / widget re-attach) must not re-enable.
+        viewModel.setActiveChatId("chat-X")
+        advanceUntilIdle()
+
+        assertFalse(nativeInputStateProvider.stateForTab("tab-A").value.submitEnabled)
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1215535715356706?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1212810093780571/task/1215708562820722?focus=true

### Description

When an ongoing Duck.ai chat's selected model is no longer available to the user (subscription lapsed, model retired, access lost), the web frontend (FE) shows a recovery banner with two CTAs: **Activate Subscription** and **Switch Model**. With `native-input` enabled, the native Unified Input owns the submit button and the model picker, so the FE can no longer drive these itself, it delegates to native over the JS bridge.

This PR wires native to react to those FE bridge messages:

- **`disableChatInput` / `enableChatInput`**: disable/enable the native submit button for that chat's tab.
- **`showModelPicker`**: open the native model picker on demand (the "Switch Model" CTA).
- **`submitChangeModelAction(modelId)`**: native reports back the model the user picked; the FE owns the chat's model and applies it.

All recovery state is **per-tab/per-chat** so a disabled input or an open picker in one chat can't leak to another tab or chat.

**Scope: Unified Input only.** The contextual sheet is out of scope. "Activate Subscription" remains an FE-driven action (native is not involved); native only handles the three bridge messages above.

### High-level changes
- Native reacts to the three FE recovery bridge messages: disable/enable the submit button, open the model picker, and report the user's picked model back to the FE.
- The model picker is now **chat-aware**: its chip and selected indicator reflect the current chat's model (or the just-picked one during recovery), not only the global selection.
- During recovery, picking a model is reported to the FE for that chat and does **not** change the user's global default.
- The submit button now visibly greys out when disabled.
- The picker opens reliably from the recovery banner even when the input isn't focused (e.g. a chat opened from history).

### Known limitations

- After a recovery model switch, native may pass a model id that doesn't match the recovered model on the *next* prompt. This is harmless today: the FE ignores the per-prompt model id for ongoing chats and uses the chat's own model (which it set when it received the recovery pick). It is a pre-existing behaviour, not introduced by this PR. We need to revisit this if we ever start submitting per chat model ID.


### Steps to test this PR

_Prerequisites for testing_

- [ ] Use an **internal build** with `native-input` enabled.
- [ ] To reproduce an unavailable model: open/resume an ongoing chat whose stored model the current account can't access (e.g. a Plus/Pro model on a Free account, or after signing out). The FE should render the recovery banner.

_Happy path: Switch Model recovery_
- [ ] Open an ongoing chat whose model is unavailable for the current account → FE recovery banner shows.
- [ ] Confirm the native **submit button is disabled** (greyed/non-tappable) with text in the input.
- [ ] Tap **Switch Model** → the **native model picker opens**, positioned correctly over the chip.
- [ ] Confirm the picker's selected **tick** is on the chat's (now-unavailable) model, not the global default.
- [ ] Pick a supported model → the **chip label updates** to the picked model, the **submit button re-enables**, and the FE hides the banner confirming receipt of the message.
- [ ] Submit a prompt → recovery ends, chat continues with new model, subsequent behaviour is normal.

_Activate Subscription CTA (FE-owned)_
- [ ] Tap **Activate Subscription** →. Confirm native handles it correctly (existing behaviour).

_Dismiss picker without picking_
- [ ] Trigger recovery, tap **Switch Model**, then dismiss the picker **without** selecting a model by tapping outside.
- [ ] Confirm recovery mode ends (chip returns to normal enabled/disabled state) but the **submit button stays disabled** (the model is still unavailable — FE hasn't enabled it).
- [ ] Tap Switch Model again → picker reopens correctly; pick a model → resolves as in the happy path.

_Per-tab isolation_
- [ ] In tab A, trigger recovery (submit disabled / picker openable). Switch to tab B (a normal new chat or NTP).
- [ ] Confirm tab B's **submit button is enabled** and its picker behaves normally (changing the model in B changes the global default, no recovery routing).
- [ ] Return to tab A → its recovery state is intact (still disabled / still routes picks to the FE).

_Chat change_
- [ ] In a tab in recovery, navigate to a **different chat** (or start a new chat) → submit re-enables and recovery clears.
- [ ] Re-open the **same** ongoing chat while it's still unavailable → submit returns to disabled.

_NTP _
- [ ] Trigger recovery in a tab, then **open a brand-new tab** → the new tab's submit button must be **enabled**.

_Recovery pick doesn't change the global default_
- [ ] Start a chat on any model.
- [ ] Switch to an ongoing chat that used a model no longer available.
- [ ] Complete a recovery pick in an ongoing chat. Then start a **new chat** (NTP / fresh input) → it should use the **previous global default model**, not the model just picked for recovery.

_Normal (non-recovery) picker behaviour unaffected_
- [ ] In a new chat (not in recovery), open the picker and pick a model → it selects normally (global default updates), submit behaves as before



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches native↔web bridge, per-tab input state, and model-picker routing for ongoing chats; scope is Duck.ai unified input only with solid test coverage, but regressions in normal picker/submit behavior are possible.
> 
> **Overview**
> When the Duck.ai web UI hits an **unavailable model** on an ongoing chat, it can no longer drive submit or the model picker; this PR wires **native unified input** to the FE recovery bridge so Android owns those controls per tab.
> 
> **Bridge handling:** New JS methods `disableChatInput`, `enableChatInput`, and `showModelPicker` update per-tab `submitEnabled` / open the picker via `requestShowModelPicker` + tab-scoped events. User picks in recovery emit **`submitChangeModelAction`** (`modelId`, `platform: android`) from `BrowserTabFragment` instead of changing the global default.
> 
> **Recovery UX:** `NativeInputState` gains `modelChangeMode` and `submitEnabled`. During recovery the picker stays usable, taps route to the FE, chip/tick/capabilities follow the **chat or just-picked** model (`ModelPickerViewModel` + widget observers), submit greys out when disabled, and `openPicker()` requests focus so the menu works from history/unfocused chats. Recovery clears on prompt submit, chat change, or picker dismiss without a selection.
> 
> **Tests** cover JS helper, picker VM, widget VM, and `showModelPickerEvents`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52c7026fe877871833fe1ca7022ac6a05af2479e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->