### PR TITLE
Fix failing Duck Player tests

### DIFF
--- a/.github/workflows/e2e-duckplayer.yml
+++ b/.github/workflows/e2e-duckplayer.yml
@@ -55,6 +55,7 @@ jobs:
           asana_project_id: ${{ secrets.DUCK_PLAYER_AOR_PROJECT_ID }}
           asana_section_id: ${{ secrets.DUCK_PLAYER_AOR_INCOMING_ID }}
           test_suite_name: Duck Player
+          maestro_api_level: 34
 
       - name: Create Asana task when workflow failed
         if: ${{ failure() && github.event_name != 'workflow_dispatch' && steps.maestro-cloud-asana.outputs.flow_summary_status != 'failure'}}

--- a/.maestro/duckplayer/patches/ad_blocking_enabled_patch.json
+++ b/.maestro/duckplayer/patches/ad_blocking_enabled_patch.json
@@ -3,5 +3,10 @@
     "op": "replace",
     "path": "/features/adBlockingExtension/state",
     "value": "enabled"
+  },
+  {
+    "op": "replace",
+    "path": "/features/adBlockingExtension/minSupportedVersion",
+    "value": 0
   }
 ]


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1210626814037951/task/1215651271606906?focus=true
Tech Design URL (if applicable): 

### Description
* Update patch to specify minSupportedVersion (otherwise, flag will still be disabled due to minSupportedVersion in RC)
* Run standalone e2e-duckplayer tests on API 34

### Steps to test this PR

_Feature 1_
- [x] Check [workflow](https://github.com/duckduckgo/Android/actions/runs/27537115654) passes 

### UI changes
n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only CI workflow and Maestro config patch JSON change; no production app logic.
> 
> **Overview**
> Targets two CI/test setup tweaks so Duck Player Maestro runs stop failing.
> 
> The **Duck Player** workflow now passes **`maestro_api_level: 34`** into the Maestro Cloud reporter (instead of the action default **35**), pinning the emulator API level for those flows.
> 
> The assemble **`config_patches`** file gains a second patch that sets **`adBlockingExtension/minSupportedVersion`** to **`0`**, in addition to forcing ad blocking **enabled**, so the internal APK built for these tests does not skip ad blocking due to a minimum-version gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ff78c8bf3308d8a2721725b1e2ea46921397fb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->