### PR TITLE
PIR: Add missing action types to PIR error pixel definitions

### DIFF
--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -111,7 +111,9 @@
                     "emailConfirmation",
                     "getCaptchaInfo",
                     "solveCaptcha",
-                    "condition"
+                    "condition",
+                    "getEmailData",
+                    "generateEmail"
                 ]
             },
             {
@@ -369,7 +371,9 @@
                     "emailConfirmation",
                     "getCaptchaInfo",
                     "solveCaptcha",
-                    "condition"
+                    "condition",
+                    "getEmailData",
+                    "generateEmail"
                 ]
             }
         ]
@@ -527,7 +531,9 @@
                     "emailConfirmation",
                     "getCaptchaInfo",
                     "solveCaptcha",
-                    "condition"
+                    "condition",
+                    "getEmailData",
+                    "generateEmail"
                 ]
             },
             {
@@ -610,7 +616,9 @@
                     "emailConfirmation",
                     "getCaptchaInfo",
                     "solveCaptcha",
-                    "condition"
+                    "condition",
+                    "getEmailData",
+                    "generateEmail"
                 ]
             },
             {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1215708696281931?focus=true
Tech Design URL (if applicable): N/A

### Description
Updates the allowed values for `action_type` field to include the two new email flexibility actions

### Steps to test this PR
N/A

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only analytics definition changes with no runtime or security impact.
> 
> **Overview**
> Extends the **`action_type`** allowed values on four PIR analytics pixels in `personal_information_removal.json5` to include **`getEmailData`** and **`generateEmail`**, matching the new email-flexibility broker runner actions.
> 
> The update applies to opt-out failure (`m_dbp_optout_process_failure`), scan stage (`m_dbp_scan_stage`), and scan completion pixels for no-results and error (`m_dbp_search_stage_main_status_no_results`, `m_dbp_search_stage_main_status_error`), so failures and terminal scan states can report the correct action type instead of falling outside the schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4fd7cc66b1c6529e479986020a3551340e4b41c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->