### PR TITLE
PIR: Update constraints for PIR scheduled worker

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/brokers/PirDataUpdateObserver.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/brokers/PirDataUpdateObserver.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.pir.impl.PirFeatureDataCleaner
 import com.duckduckgo.pir.impl.checker.PirEligibility
 import com.duckduckgo.pir.impl.checker.PirWorkHandler
 import com.duckduckgo.pir.impl.pixels.PirPixelSender
+import com.duckduckgo.pir.impl.scan.PirScanScheduler
 import com.duckduckgo.pir.impl.store.PirRepository
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent.CancellationReason
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -48,6 +49,7 @@ class PirDataUpdateObserver @Inject constructor(
     private val pirRepository: PirRepository,
     private val currentTimeProvider: CurrentTimeProvider,
     private val pirPixelSender: PirPixelSender,
+    private val pirScanScheduler: PirScanScheduler,
 ) : MainProcessLifecycleObserver {
     override fun onCreate(owner: LifecycleOwner) {
         coroutineScope.launch(dispatcherProvider.io()) {
@@ -69,6 +71,12 @@ class PirDataUpdateObserver @Inject constructor(
                                 logcat { "PIR-update: Update successfully completed." }
                             } else {
                                 logcat { "PIR-update: Failed to complete." }
+                            }
+
+                            // Re-apply the periodic scan schedule so changes to the interval/constraints
+                            // (e.g. after an app update) are picked up by already-enrolled users
+                            if (pirRepository.getValidUserProfileQueries().isNotEmpty()) {
+                                pirScanScheduler.reschedulePirScans()
                             }
                         }
 

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirJobConstants.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirJobConstants.kt
@@ -20,7 +20,7 @@ object PirJobConstants {
     const val DBP_INITIAL_URL = "dbp://blank"
     const val RECOVERY_URL = "https://duckduckgo.com/"
     const val MAX_DETACHED_WEBVIEW_COUNT = 20
-    const val SCHEDULED_SCAN_INTERVAL_HOURS = 12L
+    const val SCHEDULED_SCAN_INTERVAL_HOURS = 4L
     const val EMAIL_CONFIRMATION_INTERVAL_HOURS = 8L
     const val CUSTOM_PIXEL_INTERVAL_HOURS = 5L
     const val BG_STATS_REPORT_INTERVAL_HOURS = 24L

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scan/PirScanScheduler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scan/PirScanScheduler.kt
@@ -56,6 +56,12 @@ import javax.inject.Inject
 interface PirScanScheduler {
     fun scheduleScans()
 
+    /**
+     * Re-applies the scheduled scan work spec (interval / constraints) to the already-enqueued
+     * periodic scan so that changes are picked up by already-enrolled users after an app update.
+     */
+    fun reschedulePirScans()
+
     fun cancelScheduledScans(context: Context)
 }
 
@@ -77,7 +83,26 @@ class RealPirScanScheduler @Inject constructor(
         scheduleBackgroundScanStats()
     }
 
+    override fun reschedulePirScans() {
+        logcat { "PIR-SCHEDULED: Re-applying scheduled scan work spec appId: ${appBuildConfig.applicationId}" }
+        enqueueScheduledScanWork()
+    }
+
     private fun schedulePirScans() {
+        pirPixelSender.reportScheduledScanScheduled()
+        coroutineScope.launch {
+            eventsRepository.saveEventLog(
+                PirEventLog(
+                    eventTimeInMillis = currentTimeProvider.currentTimeMillis(),
+                    eventType = EventType.SCHEDULED_SCAN_SCHEDULED,
+                ),
+            )
+        }
+
+        enqueueScheduledScanWork()
+    }
+
+    private fun enqueueScheduledScanWork() {
         val constraints =
             Constraints
                 .Builder()
@@ -94,16 +119,6 @@ class RealPirScanScheduler @Inject constructor(
                 .setConstraints(constraints)
                 .setInitialDelay(SCHEDULED_SCAN_INTERVAL_HOURS, TimeUnit.HOURS)
                 .build()
-
-        pirPixelSender.reportScheduledScanScheduled()
-        coroutineScope.launch {
-            eventsRepository.saveEventLog(
-                PirEventLog(
-                    eventTimeInMillis = currentTimeProvider.currentTimeMillis(),
-                    eventType = EventType.SCHEDULED_SCAN_SCHEDULED,
-                ),
-            )
-        }
 
         workManager.enqueueUniquePeriodicWork(
             TAG_SCHEDULED_SCAN,

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scan/PirScanScheduler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scan/PirScanScheduler.kt
@@ -81,7 +81,6 @@ class RealPirScanScheduler @Inject constructor(
         val constraints =
             Constraints
                 .Builder()
-                .setRequiresCharging(true)
                 .setRequiredNetworkType(NetworkType.CONNECTED)
                 .build()
 

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/brokers/PirDataUpdateObserverTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/brokers/PirDataUpdateObserverTest.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.pir.impl.checker.DisabledReason
 import com.duckduckgo.pir.impl.checker.PirEligibility
 import com.duckduckgo.pir.impl.checker.PirWorkHandler
 import com.duckduckgo.pir.impl.pixels.PirPixelSender
+import com.duckduckgo.pir.impl.scan.PirScanScheduler
 import com.duckduckgo.pir.impl.store.PirRepository
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent.CancellationReason
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -52,6 +53,7 @@ class PirDataUpdateObserverTest {
     private val pirRepository: PirRepository = mock()
     private val currentTimeProvider: CurrentTimeProvider = mock()
     private val pirPixelSender: PirPixelSender = mock()
+    private val pirScanScheduler: PirScanScheduler = mock()
     private val canRunPirFlow = MutableStateFlow<PirEligibility>(PirEligibility.Disabled(DisabledReason.FEATURE_DISABLED))
 
     private lateinit var pirDataUpdateObserver: PirDataUpdateObserver
@@ -61,6 +63,7 @@ class PirDataUpdateObserverTest {
         lifecycleOwner = TestLifecycleOwner(initialState = INITIALIZED)
         whenever(pirWorkHandler.canRunPir()).thenReturn(canRunPirFlow)
         whenever(pirRepository.getFeatureReceivedMs()).thenReturn(0L)
+        whenever(pirRepository.getValidUserProfileQueries()).thenReturn(emptyList())
         whenever(currentTimeProvider.currentTimeMillis()).thenReturn(1000L)
 
         pirDataUpdateObserver = PirDataUpdateObserver(
@@ -72,6 +75,7 @@ class PirDataUpdateObserverTest {
             pirRepository = pirRepository,
             currentTimeProvider = currentTimeProvider,
             pirPixelSender = pirPixelSender,
+            pirScanScheduler = pirScanScheduler,
         )
     }
 
@@ -151,6 +155,38 @@ class PirDataUpdateObserverTest {
         verify(brokerJsonUpdater).update()
         verify(pirWorkHandler, never()).cancelWork(any())
         verifyNoInteractions(pirFeatureDataCleaner)
+    }
+
+    @Test
+    fun whenPirEnabledAndValidProfileExistsThenReschedulesScans() = runTest {
+        whenever(brokerJsonUpdater.update()).thenReturn(true)
+        whenever(pirRepository.getValidUserProfileQueries()).thenReturn(listOf(mock()))
+        canRunPirFlow.value = PirEligibility.Enabled
+
+        pirDataUpdateObserver.onCreate(lifecycleOwner)
+
+        verify(pirScanScheduler).reschedulePirScans()
+    }
+
+    @Test
+    fun whenPirEnabledButNoValidProfileThenDoesNotRescheduleScans() = runTest {
+        whenever(brokerJsonUpdater.update()).thenReturn(true)
+        whenever(pirRepository.getValidUserProfileQueries()).thenReturn(emptyList())
+        canRunPirFlow.value = PirEligibility.Enabled
+
+        pirDataUpdateObserver.onCreate(lifecycleOwner)
+
+        verify(pirScanScheduler, never()).reschedulePirScans()
+    }
+
+    @Test
+    fun whenPirDisabledThenDoesNotRescheduleScans() = runTest {
+        whenever(pirRepository.getValidUserProfileQueries()).thenReturn(listOf(mock()))
+
+        pirDataUpdateObserver.onCreate(lifecycleOwner)
+        canRunPirFlow.value = PirEligibility.Disabled(DisabledReason.FEATURE_DISABLED)
+
+        verify(pirScanScheduler, never()).reschedulePirScans()
     }
 
     @Test

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scan/RealPirScanSchedulerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scan/RealPirScanSchedulerTest.kt
@@ -42,6 +42,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -298,6 +299,44 @@ class RealPirScanSchedulerTest {
             any(),
             any<PeriodicWorkRequest>(),
         )
+    }
+
+    @Test
+    fun whenReschedulePirScansThenSchedulesScheduledScanWorkerWithUpdatePolicy() {
+        testee.reschedulePirScans()
+
+        verify(mockWorkManager).enqueueUniquePeriodicWork(
+            eq(PirScheduledScanRemoteWorker.TAG_SCHEDULED_SCAN),
+            eq(ExistingPeriodicWorkPolicy.UPDATE),
+            any<PeriodicWorkRequest>(),
+        )
+    }
+
+    @Test
+    fun whenReschedulePirScansThenOnlySchedulesScheduledScanWorker() {
+        testee.reschedulePirScans()
+
+        verify(mockWorkManager, times(1)).enqueueUniquePeriodicWork(
+            any(),
+            any(),
+            any<PeriodicWorkRequest>(),
+        )
+    }
+
+    @Test
+    fun whenReschedulePirScansThenDoesNotReportScheduledScanPixel() {
+        testee.reschedulePirScans()
+
+        verify(mockPirPixelSender, never()).reportScheduledScanScheduled()
+    }
+
+    @Test
+    fun whenReschedulePirScansThenDoesNotSaveEventLog() = runTest {
+        testee.reschedulePirScans()
+
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        verify(mockEventsRepository, never()).saveEventLog(any())
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1215635670621416?focus=true
Tech Design URL (if applicable): N/A

### Description
Updated the scheduled background scan constraints to no longer require that the device is charging and increase the run period from 12h to 4h.

### Steps to test this PR
N/A

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> More frequent background PIR scans and looser WorkManager constraints increase background network/workload; rollout path touches enrolled users via lifecycle observer.
> 
> **Overview**
> **PIR scheduled background scans** now run every **4 hours** (was 12) and no longer require the device to be charging—only a connected network.
> 
> To roll this out to users who already had periodic work enqueued, **`reschedulePirScans()`** re-applies the scan WorkManager spec with `ExistingPeriodicWorkPolicy.UPDATE` without firing the “scheduled scan” pixel or event log. **`PirDataUpdateObserver`** calls that when PIR is enabled and the user has at least one valid profile query (e.g. after an app update).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13cdfbd97d32d025df19b4e80124f340b7cbd0d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->