### PR TITLE
Show + button in split omnibar Duck.ai chats

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
@@ -23,6 +23,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.ViewOutlineProvider
 import android.widget.TextView
+import androidx.annotation.VisibleForTesting
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.view.updateLayoutParams
 import com.duckduckgo.app.browser.R
@@ -96,14 +97,22 @@ class RealNativeInputOmnibarController(
         }
     }
 
-    private fun showOmnibarButtons(omnibarView: View) {
-        omnibarView.findViewById<View?>(R.id.fireIconMenu)?.show()
+    @VisibleForTesting
+    internal fun showOmnibarButtons(omnibarView: View) {
+        // Only reached for a Duck.ai chat in split mode with native input enabled. The leading slot
+        // shows the "+" (new chat), never the fire button — fire already lives next to the native
+        // input field at the bottom, so showing it here too would duplicate it. Mirrors the fire→+
+        // swap the OmnibarLayout applies via shouldShowPlusIcon in non-split positions.
+        omnibarView.findViewById<View?>(R.id.fireIconMenu)?.gone()
+        omnibarView.findViewById<View?>(R.id.plusIconMenu)?.show()
         omnibarView.findViewById<View?>(R.id.tabsMenu)?.show()
         omnibarView.findViewById<View?>(R.id.browserMenu)?.show()
     }
 
-    private fun hideOmnibarButtons(omnibarView: View) {
+    @VisibleForTesting
+    internal fun hideOmnibarButtons(omnibarView: View) {
         omnibarView.findViewById<View?>(R.id.fireIconMenu)?.gone()
+        omnibarView.findViewById<View?>(R.id.plusIconMenu)?.gone()
         omnibarView.findViewById<View?>(R.id.tabsMenu)?.gone()
         omnibarView.findViewById<View?>(R.id.browserMenu)?.gone()
     }

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputOmnibarControllerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputOmnibarControllerTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.nativeinput
+
+import android.content.Context
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.app.browser.omnibar.Omnibar
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+
+@RunWith(AndroidJUnit4::class)
+class RealNativeInputOmnibarControllerTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val omnibar: Omnibar = mock()
+    private val rootView: ViewGroup = mock()
+
+    private val testee = RealNativeInputOmnibarController(omnibar, rootView)
+
+    private val fireIconMenu = View(context).apply { id = R.id.fireIconMenu }
+    private val plusIconMenu = View(context).apply { id = R.id.plusIconMenu }
+    private val tabsMenu = View(context).apply { id = R.id.tabsMenu }
+    private val browserMenu = View(context).apply { id = R.id.browserMenu }
+
+    private val omnibarView = FrameLayout(context).apply {
+        addView(fireIconMenu)
+        addView(plusIconMenu)
+        addView(tabsMenu)
+        addView(browserMenu)
+    }
+
+    @Test
+    fun whenShowingOmnibarButtonsThenPlusIconShownAndFireIconHidden() {
+        // Duck.ai chat in split mode: the leading slot is the "+" (new chat), never the fire
+        // button, which already lives next to the native input field at the bottom.
+        fireIconMenu.visibility = View.VISIBLE
+        plusIconMenu.visibility = View.GONE
+
+        testee.showOmnibarButtons(omnibarView)
+
+        assertEquals(View.VISIBLE, plusIconMenu.visibility)
+        assertEquals(View.GONE, fireIconMenu.visibility)
+        assertEquals(View.VISIBLE, tabsMenu.visibility)
+        assertEquals(View.VISIBLE, browserMenu.visibility)
+    }
+
+    @Test
+    fun whenHidingOmnibarButtonsThenPlusAndFireAndMenusHidden() {
+        fireIconMenu.visibility = View.VISIBLE
+        plusIconMenu.visibility = View.VISIBLE
+        tabsMenu.visibility = View.VISIBLE
+        browserMenu.visibility = View.VISIBLE
+
+        testee.hideOmnibarButtons(omnibarView)
+
+        assertEquals(View.GONE, plusIconMenu.visibility)
+        assertEquals(View.GONE, fireIconMenu.visibility)
+        assertEquals(View.GONE, tabsMenu.visibility)
+        assertEquals(View.GONE, browserMenu.visibility)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1215718259124145

### Description

In a Duck.ai chat with the address bar set to the **split** position (native input enabled), the top toolbar showed the **fire button** instead of the **+** (new chat) button — duplicating the fire button that already sits next to the bottom native input field.

In split mode the omnibar ViewModel keeps the top fire/+ slot hidden (`showFireIcon = false`), so `NativeInputOmnibarController` re-shows the toolbar buttons directly via `findViewById` when a Duck.ai chat is opened. That workaround hard-coded `fireIconMenu`, bypassing the fire→+ swap that `OmnibarLayout` applies through `shouldShowPlusIcon` for Duck.ai + native input in the non-split positions.

Fix: `showOmnibarButtons` now shows the `+` icon (and hides fire) when restoring the split top toolbar, and `hideOmnibarButtons` also hides the `+` so it does not linger when returning to browser mode.

### Steps to test this PR

_Split omnibar + Duck.ai_
- [x] Internal build. Settings → Appearance → Address Bar Position → **Split**
- [x] Open a Duck.ai chat (type in the input field, switch to the Duck.ai tab, submit)
- [x] Confirm the top toolbar shows the **+** button (next to tabs and the menu), **not** a fire button
- [x] Confirm the fire button is at the **bottom**, next to the native input field
- [x] Close the chat back to the browser — confirm the **+** does not linger in the top bar (fire button stays in the bottom nav bar)

### UI changes
| Before  | After |
| ------ | ----- |
| Top toolbar showed the fire button (duplicate of the bottom one) | Top toolbar shows the `+` (new chat) button |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized omnibar visibility tweak for split Duck.ai; no auth, data, or API changes.
> 
> **Overview**
> Fixes **split address bar + Duck.ai + native input**, where `NativeInputOmnibarController` re-shows the top toolbar via `findViewById` and previously restored **`fireIconMenu`**, duplicating the fire control already at the bottom input.
> 
> **`showOmnibarButtons`** now hides fire and shows **`plusIconMenu`** (new chat), matching the fire→+ behavior `OmnibarLayout` applies via **`shouldShowPlusIcon`**. **`hideOmnibarButtons`** also hides the + so it does not stick after leaving Duck.ai. Both helpers are **`@VisibleForTesting`** **`internal`** for unit tests.
> 
> Adds **`RealNativeInputOmnibarControllerTest`** to assert visibility for show/hide of +, fire, tabs, and menu.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a28db7aa9c0808c4aa5150e42c55605b5caecf05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->