### PR TITLE
Fix app startup ANRs

### DIFF
--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorker.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorker.kt
@@ -105,12 +105,13 @@ class ScriptletDownloadWorkerScheduler @Inject constructor(
     private val configProvider: AdBlockingExtensionConfigProvider,
     private val feature: AdBlockingExtensionFeature,
     @AppCoroutineScope private val appScope: CoroutineScope,
+    private val dispatchers: DispatcherProvider,
 ) : MainProcessLifecycleObserver {
 
     private val settingsAdapter by lazy { buildJsonAdapter() }
 
     override fun onCreate(owner: LifecycleOwner) {
-        appScope.launch {
+        appScope.launch(dispatchers.io()) {
             combine(
                 feature.self().enabled(),
                 feature.enableContingencyMode().enabled(),

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionConfigProvider.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionConfigProvider.kt
@@ -16,6 +16,8 @@
 
 package com.duckduckgo.adblocking.impl.remoteconfig
 
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
 import com.squareup.anvil.annotations.ContributesBinding
@@ -25,9 +27,11 @@ import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dagger.SingleInstanceIn
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import logcat.LogPriority.WARN
 import logcat.asLog
 import logcat.logcat
@@ -56,20 +60,22 @@ interface AdBlockingExtensionConfigProvider {
 @ContributesMultibinding(scope = AppScope::class, boundType = PrivacyConfigCallbackPlugin::class)
 class RealAdBlockingExtensionConfigProvider @Inject constructor(
     private val feature: AdBlockingExtensionFeature,
+    @AppCoroutineScope private val appScope: CoroutineScope,
+    private val dispatchers: DispatcherProvider,
 ) : AdBlockingExtensionConfigProvider, PrivacyConfigCallbackPlugin {
 
     private val settingsAdapter by lazy { buildJsonAdapter() }
     private val scriptletsFlow = MutableStateFlow<AdBlockingExtensionSettings?>(null)
 
     init {
-        refresh()
+        appScope.launch(dispatchers.io()) { refresh() }
     }
 
     override val scriptletsSettings: StateFlow<AdBlockingExtensionSettings?> = scriptletsFlow.asStateFlow()
 
     override fun onPrivacyConfigDownloaded() {
         logcat { "onPrivacyConfigDownloaded" }
-        refresh()
+        appScope.launch(dispatchers.io()) { refresh() }
     }
 
     private fun refresh() {

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionConfigProvider.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionConfigProvider.kt
@@ -16,7 +16,9 @@
 
 package com.duckduckgo.adblocking.impl.remoteconfig
 
+import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
@@ -28,6 +30,8 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -58,28 +62,35 @@ interface AdBlockingExtensionConfigProvider {
 @SingleInstanceIn(AppScope::class)
 @ContributesBinding(scope = AppScope::class, boundType = AdBlockingExtensionConfigProvider::class)
 @ContributesMultibinding(scope = AppScope::class, boundType = PrivacyConfigCallbackPlugin::class)
+@ContributesMultibinding(scope = AppScope::class, boundType = MainProcessLifecycleObserver::class)
 class RealAdBlockingExtensionConfigProvider @Inject constructor(
     private val feature: AdBlockingExtensionFeature,
     @AppCoroutineScope private val appScope: CoroutineScope,
     private val dispatchers: DispatcherProvider,
-) : AdBlockingExtensionConfigProvider, PrivacyConfigCallbackPlugin {
+) : AdBlockingExtensionConfigProvider, PrivacyConfigCallbackPlugin, MainProcessLifecycleObserver {
 
     private val settingsAdapter by lazy { buildJsonAdapter() }
     private val scriptletsFlow = MutableStateFlow<AdBlockingExtensionSettings?>(null)
-
-    init {
-        appScope.launch(dispatchers.io()) { refresh() }
-    }
+    private var refreshJob: Job? = null
 
     override val scriptletsSettings: StateFlow<AdBlockingExtensionSettings?> = scriptletsFlow.asStateFlow()
 
+    override fun onCreate(owner: LifecycleOwner) {
+        refresh()
+    }
+
     override fun onPrivacyConfigDownloaded() {
         logcat { "onPrivacyConfigDownloaded" }
-        appScope.launch(dispatchers.io()) { refresh() }
+        refresh()
     }
 
     private fun refresh() {
-        scriptletsFlow.value = parseSettings()
+        refreshJob?.cancel()
+        refreshJob = appScope.launch(dispatchers.io()) {
+            val parsed = parseSettings()
+            ensureActive()
+            scriptletsFlow.value = parsed
+        }
     }
 
     private fun parseSettings(): AdBlockingExtensionSettings? {

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionConfigProviderTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionConfigProviderTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.adblocking.impl
 
 import android.annotation.SuppressLint
+import androidx.lifecycle.LifecycleOwner
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
@@ -32,6 +33,7 @@ import org.junit.Assert.assertNull
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
 
 @SuppressLint("DenyListedApi") // setRawStoredState
 @RunWith(AndroidJUnit4::class)
@@ -41,6 +43,7 @@ class AdBlockingExtensionConfigProviderTest {
     val coroutineRule = CoroutineTestRule()
 
     private val feature = FakeFeatureToggleFactory.create(AdBlockingExtensionFeature::class.java)
+    private val lifecycleOwner: LifecycleOwner = mock()
     private val provider = RealAdBlockingExtensionConfigProvider(feature, coroutineRule.testScope, coroutineRule.testDispatcherProvider)
 
     private val validSettingsJson = """
@@ -108,9 +111,10 @@ class AdBlockingExtensionConfigProviderTest {
     }
 
     @Test
-    fun whenSettingsAreValidAtConstructionThenScriptletsSettingsEmitsInitialValue() = runTest {
+    fun whenSettingsAreValidAtOnCreateThenScriptletsSettingsEmitsInitialValue() = runTest {
         feature.self().setRawStoredState(Toggle.State(remoteEnableState = true, settings = validSettingsJson))
         val freshProvider = RealAdBlockingExtensionConfigProvider(feature, coroutineRule.testScope, coroutineRule.testDispatcherProvider)
+        freshProvider.onCreate(lifecycleOwner)
 
         freshProvider.scriptletsSettings.filterNotNull().test {
             assertEquals("2026.3.9", awaitItem().version)
@@ -122,6 +126,7 @@ class AdBlockingExtensionConfigProviderTest {
     fun whenOnPrivacyConfigDownloadedFiresAfterSettingsChangeThenScriptletsSettingsEmitsNewValue() = runTest {
         feature.self().setRawStoredState(Toggle.State(remoteEnableState = true, settings = validSettingsJson))
         val freshProvider = RealAdBlockingExtensionConfigProvider(feature, coroutineRule.testScope, coroutineRule.testDispatcherProvider)
+        freshProvider.onCreate(lifecycleOwner)
 
         freshProvider.scriptletsSettings.filterNotNull().test {
             assertEquals("2026.3.9", awaitItem().version)
@@ -139,6 +144,7 @@ class AdBlockingExtensionConfigProviderTest {
     fun whenOnPrivacyConfigDownloadedFiresWithUnchangedSettingsThenScriptletsSettingsDoesNotEmitDuplicates() = runTest {
         feature.self().setRawStoredState(Toggle.State(remoteEnableState = true, settings = validSettingsJson))
         val freshProvider = RealAdBlockingExtensionConfigProvider(feature, coroutineRule.testScope, coroutineRule.testDispatcherProvider)
+        freshProvider.onCreate(lifecycleOwner)
 
         freshProvider.scriptletsSettings.filterNotNull().test {
             assertEquals("2026.3.9", awaitItem().version)

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionConfigProviderTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionConfigProviderTest.kt
@@ -22,12 +22,14 @@ import app.cash.turbine.test
 import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
 import com.duckduckgo.adblocking.impl.remoteconfig.RealAdBlockingExtensionConfigProvider
 import com.duckduckgo.adblocking.impl.remoteconfig.ScriptletEntry
+import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -35,8 +37,11 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class AdBlockingExtensionConfigProviderTest {
 
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
     private val feature = FakeFeatureToggleFactory.create(AdBlockingExtensionFeature::class.java)
-    private val provider = RealAdBlockingExtensionConfigProvider(feature)
+    private val provider = RealAdBlockingExtensionConfigProvider(feature, coroutineRule.testScope, coroutineRule.testDispatcherProvider)
 
     private val validSettingsJson = """
         {
@@ -105,7 +110,7 @@ class AdBlockingExtensionConfigProviderTest {
     @Test
     fun whenSettingsAreValidAtConstructionThenScriptletsSettingsEmitsInitialValue() = runTest {
         feature.self().setRawStoredState(Toggle.State(remoteEnableState = true, settings = validSettingsJson))
-        val freshProvider = RealAdBlockingExtensionConfigProvider(feature)
+        val freshProvider = RealAdBlockingExtensionConfigProvider(feature, coroutineRule.testScope, coroutineRule.testDispatcherProvider)
 
         freshProvider.scriptletsSettings.filterNotNull().test {
             assertEquals("2026.3.9", awaitItem().version)
@@ -116,7 +121,7 @@ class AdBlockingExtensionConfigProviderTest {
     @Test
     fun whenOnPrivacyConfigDownloadedFiresAfterSettingsChangeThenScriptletsSettingsEmitsNewValue() = runTest {
         feature.self().setRawStoredState(Toggle.State(remoteEnableState = true, settings = validSettingsJson))
-        val freshProvider = RealAdBlockingExtensionConfigProvider(feature)
+        val freshProvider = RealAdBlockingExtensionConfigProvider(feature, coroutineRule.testScope, coroutineRule.testDispatcherProvider)
 
         freshProvider.scriptletsSettings.filterNotNull().test {
             assertEquals("2026.3.9", awaitItem().version)
@@ -133,7 +138,7 @@ class AdBlockingExtensionConfigProviderTest {
     @Test
     fun whenOnPrivacyConfigDownloadedFiresWithUnchangedSettingsThenScriptletsSettingsDoesNotEmitDuplicates() = runTest {
         feature.self().setRawStoredState(Toggle.State(remoteEnableState = true, settings = validSettingsJson))
-        val freshProvider = RealAdBlockingExtensionConfigProvider(feature)
+        val freshProvider = RealAdBlockingExtensionConfigProvider(feature, coroutineRule.testScope, coroutineRule.testDispatcherProvider)
 
         freshProvider.scriptletsSettings.filterNotNull().test {
             assertEquals("2026.3.9", awaitItem().version)

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorkerSchedulerTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ScriptletDownloadWorkerSchedulerTest.kt
@@ -23,13 +23,11 @@ import androidx.work.WorkManager
 import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionConfigProvider
 import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
 import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionSettings
+import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.Toggle
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import org.junit.After
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
@@ -42,6 +40,9 @@ import org.mockito.kotlin.verify
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
 class ScriptletDownloadWorkerSchedulerTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
 
     private val workManager: WorkManager = mock()
 
@@ -63,21 +64,16 @@ class ScriptletDownloadWorkerSchedulerTest {
         on { scriptletsSettings } doReturn settingsFlow
     }
     private val lifecycleOwner: LifecycleOwner = mock()
-    private val testScope = CoroutineScope(UnconfinedTestDispatcher())
 
     private val scriptletsSettings = AdBlockingExtensionSettings(version = "2026.5.14", scriptlets = emptyMap())
-
-    @After
-    fun tearDown() {
-        testScope.cancel()
-    }
 
     private fun startScheduler() {
         ScriptletDownloadWorkerScheduler(
             workManager = workManager,
             configProvider = configProvider,
             feature = feature,
-            appScope = testScope,
+            appScope = coroutineRule.testScope,
+            dispatchers = coroutineRule.testDispatcherProvider,
         ).onCreate(lifecycleOwner)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1215718265244661?focus=true 
Tech Design URL (if applicable): 

### Description
Fixes ANRs caused by building a moshi adapter on the main thread during app init 

### Steps to test this PR
qa-optional


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Threading-only change for startup and config refresh with the same parsing logic; risk is mainly timing of when `scriptletsSettings` first emits relative to other startup observers.
> 
> **Overview**
> Moves **ad-blocking extension settings parsing** off the main thread during app startup to address ANRs from building Moshi adapters and parsing JSON on init.
> 
> `RealAdBlockingExtensionConfigProvider` no longer refreshes in its constructor; it implements `MainProcessLifecycleObserver` and kicks off `refresh()` from `onCreate`, with parsing on `dispatchers.io()` and in-flight work cancelled when privacy config updates arrive again. `ScriptletDownloadWorkerScheduler` now starts its `combine`/`collect` loop on the IO dispatcher as well.
> 
> Unit tests were updated to trigger `onCreate`, inject test coroutine scopes/dispatchers, and use `CoroutineTestRule` instead of ad-hoc test scopes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6f96314e3b599beae5e825a191a07d336714729. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->