### PR TITLE
Update action-pr-opened towards being a required check

### DIFF
--- a/.github/workflows/action-pr-opened.yaml
+++ b/.github/workflows/action-pr-opened.yaml
@@ -2,7 +2,7 @@ name: 'Pull Request opened -> Comment on task and add it to Android Release Boar
 
 on:
   pull_request:
-    types: [opened, reopened, edited, ready_for_review]
+    types: [opened, reopened, edited, synchronize, ready_for_review]
 
 jobs:
   process-internal-pr:
@@ -10,23 +10,23 @@ jobs:
     permissions:
       issues: write
     steps:
+      - name: Find Asana Task ID
+        if: ${{ github.event.pull_request.base.ref == github.event.repository.default_branch }}
+        id: find-asana-task
+        uses: duckduckgo/native-github-asana-sync@v2.0
+        with:
+          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          trigger-phrase: ${{ vars.ASANA_TASK_TRIGGER_PHRASE }}
+          action: 'find-asana-task-id'
+
       - name: Add comment with PR link in Asana task
         if: ${{ github.actor == github.event.pull_request.user.login && ( github.event.action == 'opened' || github.event.action == 'reopened') }}
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          trigger-phrase: "Task/Issue URL:"
+          trigger-phrase: ${{ vars.ASANA_TASK_TRIGGER_PHRASE }}
           action: 'add-asana-comment'
           is-pinned: true
-
-      - name: Find Asana Task ID
-        if: ${{ github.event.pull_request.base.ref == 'develop' }}
-        id: find-asana-task
-        uses: duckduckgo/native-github-asana-sync@v2.0
-        with:
-          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          trigger-phrase: "Task/Issue URL:"
-          action: 'find-asana-task-id'
 
       - name: Add task to Asana project section
         if: ${{ steps.find-asana-task.outcome == 'success' && steps.find-asana-task.outputs.asanaTaskId != '' }}

--- a/.github/workflows/action-pr-opened.yaml
+++ b/.github/workflows/action-pr-opened.yaml
@@ -20,6 +20,7 @@ jobs:
           action: 'find-asana-task-id'
 
       - name: Add comment with PR link in Asana task
+        continue-on-error: true
         if: ${{ github.actor == github.event.pull_request.user.login && ( github.event.action == 'opened' || github.event.action == 'reopened') }}
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211760946270935/task/1214059966316154?focus=true
Tech Design URL (if applicable): 

### Description
Make `action-pr-opened` more resilient so that it can be converted into a required check
* Also run on `synchronize`
* Short-cirtcuit on task URL not found
* Rely on variable for trigger-phrase 
* Use default branch reference instead of hard-coding develop
* Allow execution to continue if posting comment failed

### Steps to test this PR
n/a

### UI changes
n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only changes to Asana sync ordering and failure handling; no application or security-sensitive runtime code.
> 
> **Overview**
> Prepares the **Pull Request opened** workflow so it can be used as a **required GitHub check** without failing PRs that lack Asana linkage.
> 
> The workflow now runs on **`synchronize`** (new commits on the PR) in addition to open/reopen/edit/ready_for_review. **Find Asana Task ID** runs first when the PR targets the repo **default branch** (replacing a hardcoded `develop` check). The Asana **trigger phrase** is read from **`vars.ASANA_TASK_TRIGGER_PHRASE`** instead of a fixed string. **Add comment** is moved after the find step, limited to **opened/reopened**, and uses **`continue-on-error: true`** so a missing or invalid task link does not fail the job. Adding the task to the release board still depends on a successful find with a non-empty task id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3483a4c25b4cfc8b21211a6cf0ed32ab54df8b2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->