### PR TITLE
Android/Duckai/Contextual: Add new menu for chats

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -42,6 +42,7 @@ import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebSettings
 import android.webkit.WebView
+import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.activity.OnBackPressedCallback
 import androidx.annotation.AnyThread
@@ -751,25 +752,20 @@ class DuckChatContextualFragment :
             popup.onMenuItemClicked(newChatRow) { viewModel.onNewChatRequested() }
         }
 
-        val rowIds = listOf(
-            R.id.contextualChatsPopupRow1,
-            R.id.contextualChatsPopupRow2,
-            R.id.contextualChatsPopupRow3,
-            R.id.contextualChatsPopupRow4,
-            R.id.contextualChatsPopupRow5,
-        )
-        rowIds.forEachIndexed { index, id ->
-            val row = content.findViewById<PopupMenuItemView>(id)
-            val chat = recentChats.getOrNull(index)
-            if (chat == null) {
-                row.visibility = View.GONE
-            } else {
-                row.visibility = View.VISIBLE
-                row.setPrimaryText(chat.displayTitle)
-                row.setLeadingIconResource(chat.type.iconRes(chat.pinned))
-                row.applyMaxLines(MAX_CHAT_TITLE_LINES)
-                popup.onMenuItemClicked(row) { viewModel.onRecentChatClicked(chat.chatId) }
+        val recentContainer = content.findViewById<LinearLayout>(R.id.contextualChatsPopupRecentContainer)
+        recentContainer.removeAllViews()
+        recentChats.forEach { chat ->
+            val row = PopupMenuItemView(requireContext()).apply {
+                layoutParams = LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT,
+                )
+                setPrimaryText(chat.displayTitle)
+                setLeadingIconResource(chat.type.iconRes(chat.pinned))
+                applyMaxLines(MAX_CHAT_TITLE_LINES)
             }
+            popup.onMenuItemClicked(row) { viewModel.onRecentChatClicked(chat.chatId) }
+            recentContainer.addView(row)
         }
 
         val viewAllRow = content.findViewById<PopupMenuItemView>(R.id.contextualChatsPopupViewAll)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -740,7 +740,11 @@ class DuckChatContextualFragment :
 
     private fun showChatsPopup(showNewChatHeader: Boolean, recentChats: List<ChatHistoryItem>) {
         logcat { "Duck.ai Contextual: showChatsPopup header=$showNewChatHeader chats=${recentChats.size}" }
-        val popup = PopupMenu(layoutInflater, R.layout.popup_contextual_chats_menu)
+        val popup = PopupMenu(
+            layoutInflater = layoutInflater,
+            resourceId = R.layout.popup_contextual_chats_menu,
+            width = resources.getDimensionPixelSize(R.dimen.contextualChatsPopupMenuWidth),
+        )
         val content = popup.contentView
 
         val newChatRow = content.findViewById<PopupMenuItemView>(R.id.contextualChatsPopupNewChat)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -28,6 +28,7 @@ import android.os.Environment
 import android.os.Message
 import android.provider.MediaStore
 import android.text.Editable
+import android.text.TextUtils
 import android.text.TextWatcher
 import android.view.KeyEvent
 import android.view.MotionEvent
@@ -764,6 +765,8 @@ class DuckChatContextualFragment :
                 )
                 setPrimaryText(chat.displayTitle)
                 setLeadingIconResource(chat.type.iconRes(chat.pinned))
+                setPrimaryTextMaxLines(MAX_CHAT_TITLE_LINES)
+                setPrimaryTextEllipsize(TextUtils.TruncateAt.END)
             }
             popup.onMenuItemClicked(row) { viewModel.onRecentChatClicked(chat.chatId) }
             recentContainer.addView(row)
@@ -1083,7 +1086,7 @@ class DuckChatContextualFragment :
     }
 
     companion object {
-        private const val MAX_CHAT_TITLE_LINES = 3
+        private const val MAX_CHAT_TITLE_LINES = 1
         private const val PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE = 200
         private const val CUSTOM_UA =
             "Mozilla/5.0 (Linux; Android 16) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/124.0.0.0 Mobile DuckDuckGo/5 Safari/537.36"

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -59,6 +59,8 @@ import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.browsermode.api.WebViewModeInitializer
 import com.duckduckgo.common.ui.DuckDuckGoFragment
+import com.duckduckgo.common.ui.menu.PopupMenu
+import com.duckduckgo.common.ui.view.PopupMenuItemView
 import com.duckduckgo.common.ui.view.dialog.ActionBottomSheetDialog
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.makeSnackbarWithNoBottomInset
@@ -76,6 +78,7 @@ import com.duckduckgo.downloads.api.DownloadConfirmationDialogListener
 import com.duckduckgo.downloads.api.DownloadStateListener
 import com.duckduckgo.downloads.api.DownloadsFileActions
 import com.duckduckgo.downloads.api.FileDownloader
+import com.duckduckgo.duckchat.api.DuckChatHistoryNoParams
 import com.duckduckgo.duckchat.api.viewmodel.DuckChatSharedViewModel
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.R
@@ -84,6 +87,7 @@ import com.duckduckgo.duckchat.impl.feature.AIChatDownloadFeature
 import com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper
 import com.duckduckgo.duckchat.impl.helper.Mode
 import com.duckduckgo.duckchat.impl.helper.RealDuckChatJSHelper
+import com.duckduckgo.duckchat.impl.history.ChatHistoryItem
 import com.duckduckgo.duckchat.impl.ui.DuckChatWebViewClient
 import com.duckduckgo.duckchat.impl.ui.filechooser.FileChooserIntentBuilder
 import com.duckduckgo.duckchat.impl.ui.filechooser.capture.camera.CameraHardwareChecker
@@ -497,7 +501,7 @@ class DuckChatContextualFragment :
         }
         binding.contextualNewChat.setOnClickListener {
             hideKeyboard(binding.inputField)
-            viewModel.onNewChatRequested()
+            viewModel.onChatsIconClicked()
         }
         binding.contextualFire.setOnClickListener {
             viewModel.onFireButtonClicked()
@@ -613,6 +617,20 @@ class DuckChatContextualFragment :
                     is DuckChatContextualViewModel.Command.ShowFireConfirmation -> {
                         showFireConfirmationDialog()
                     }
+
+                    is DuckChatContextualViewModel.Command.ShowChatsPopup -> {
+                        showChatsPopup(command.showNewChatHeader, command.recentChats)
+                    }
+
+                    is DuckChatContextualViewModel.Command.OpenChatUrl -> {
+                        viewModel.onContextualClose()
+                        startActivity(browserNav.openInNewTab(requireContext(), command.url, command.sourceTabId))
+                    }
+
+                    is DuckChatContextualViewModel.Command.LaunchChatHistory -> {
+                        viewModel.onContextualClose()
+                        globalActivityStarter.start(requireContext(), DuckChatHistoryNoParams)
+                    }
                 }
             }.launchIn(lifecycleScope)
 
@@ -666,13 +684,21 @@ class DuckChatContextualFragment :
         binding.contextualPromptQuickAction.setCompoundDrawablesRelativeWithIntrinsicBounds(viewState.quickActionState.iconResId, 0, 0, 0)
         binding.inputField.setHint(viewState.chatHintResId)
 
+        if (viewState.showChatsIcon) {
+            binding.contextualNewChat.setImageResource(com.duckduckgo.mobile.android.R.drawable.ic_chats_24)
+        }
+
         when (viewState.sheetMode) {
             DuckChatContextualViewModel.SheetMode.INPUT -> {
                 binding.contextualModeNativeContent.show()
                 binding.contextualWebviewContainer.gone()
                 contextualNativeInputManager.onInputMode()
 
-                binding.contextualNewChat.gone()
+                if (viewState.showChatsIcon) {
+                    binding.contextualNewChat.show()
+                } else {
+                    binding.contextualNewChat.gone()
+                }
                 binding.contextualFire.gone()
 
                 renderPageContext(viewState.contextTitle, viewState.contextUrl, viewState.tabId)
@@ -707,6 +733,50 @@ class DuckChatContextualFragment :
 
     private fun showFireConfirmationDialog() {
         duckChatSharedViewModel.onContextualFireButtonClicked()
+    }
+
+    private fun showChatsPopup(showNewChatHeader: Boolean, recentChats: List<ChatHistoryItem>) {
+        logcat { "Duck.ai Contextual: showChatsPopup header=$showNewChatHeader chats=${recentChats.size}" }
+        val popup = PopupMenu(layoutInflater, R.layout.popup_contextual_chats_menu)
+        val content = popup.contentView
+
+        val newChatRow = content.findViewById<PopupMenuItemView>(R.id.contextualChatsPopupNewChat)
+        val headerDivider = content.findViewById<View>(R.id.contextualChatsPopupHeaderDivider)
+        newChatRow.visibility = if (showNewChatHeader) View.VISIBLE else View.GONE
+        headerDivider.visibility = if (showNewChatHeader) View.VISIBLE else View.GONE
+        if (showNewChatHeader) {
+            popup.onMenuItemClicked(newChatRow) { viewModel.onNewChatRequested() }
+        }
+
+        val rowIds = listOf(
+            R.id.contextualChatsPopupRow1,
+            R.id.contextualChatsPopupRow2,
+            R.id.contextualChatsPopupRow3,
+            R.id.contextualChatsPopupRow4,
+            R.id.contextualChatsPopupRow5,
+        )
+        rowIds.forEachIndexed { index, id ->
+            val row = content.findViewById<PopupMenuItemView>(id)
+            val chat = recentChats.getOrNull(index)
+            if (chat == null) {
+                row.visibility = View.GONE
+            } else {
+                row.visibility = View.VISIBLE
+                row.setPrimaryText(chat.displayTitle)
+                popup.onMenuItemClicked(row) { viewModel.onRecentChatClicked(chat.chatId) }
+            }
+        }
+
+        val viewAllRow = content.findViewById<PopupMenuItemView>(R.id.contextualChatsPopupViewAll)
+        val footerDivider = content.findViewById<View>(R.id.contextualChatsPopupFooterDivider)
+        val showFooter = recentChats.isNotEmpty()
+        viewAllRow.visibility = if (showFooter) View.VISIBLE else View.GONE
+        footerDivider.visibility = if (showFooter) View.VISIBLE else View.GONE
+        if (showFooter) {
+            popup.onMenuItemClicked(viewAllRow) { viewModel.onViewAllChatsClicked() }
+        }
+
+        popup.showAnchoredView(requireActivity(), binding.root, binding.contextualNewChat)
     }
 
     private fun observeSubscriptionEventDataChannel() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -28,6 +28,7 @@ import android.os.Environment
 import android.os.Message
 import android.provider.MediaStore
 import android.text.Editable
+import android.text.TextUtils
 import android.text.TextWatcher
 import android.view.KeyEvent
 import android.view.MotionEvent
@@ -743,6 +744,7 @@ class DuckChatContextualFragment :
 
         val newChatRow = content.findViewById<PopupMenuItemView>(R.id.contextualChatsPopupNewChat)
         val headerDivider = content.findViewById<View>(R.id.contextualChatsPopupHeaderDivider)
+        newChatRow.applyMaxLines(MAX_CHAT_TITLE_LINES)
         newChatRow.visibility = if (showNewChatHeader) View.VISIBLE else View.GONE
         headerDivider.visibility = if (showNewChatHeader) View.VISIBLE else View.GONE
         if (showNewChatHeader) {
@@ -765,6 +767,7 @@ class DuckChatContextualFragment :
                 row.visibility = View.VISIBLE
                 row.setPrimaryText(chat.displayTitle)
                 row.setLeadingIconResource(chat.type.iconRes(chat.pinned))
+                row.applyMaxLines(MAX_CHAT_TITLE_LINES)
                 popup.onMenuItemClicked(row) { viewModel.onRecentChatClicked(chat.chatId) }
             }
         }
@@ -772,6 +775,7 @@ class DuckChatContextualFragment :
         val viewAllRow = content.findViewById<PopupMenuItemView>(R.id.contextualChatsPopupViewAll)
         val footerDivider = content.findViewById<View>(R.id.contextualChatsPopupFooterDivider)
         val showFooter = recentChats.isNotEmpty()
+        viewAllRow.applyMaxLines(MAX_CHAT_TITLE_LINES)
         viewAllRow.visibility = if (showFooter) View.VISIBLE else View.GONE
         footerDivider.visibility = if (showFooter) View.VISIBLE else View.GONE
         if (showFooter) {
@@ -779,6 +783,13 @@ class DuckChatContextualFragment :
         }
 
         popup.showAnchoredView(requireActivity(), binding.root, binding.contextualNewChat)
+    }
+
+    private fun PopupMenuItemView.applyMaxLines(maxLines: Int) {
+        findViewById<TextView>(com.duckduckgo.mobile.android.R.id.label)?.apply {
+            this.maxLines = maxLines
+            ellipsize = TextUtils.TruncateAt.END
+        }
     }
 
     private fun observeSubscriptionEventDataChannel() {
@@ -1083,6 +1094,7 @@ class DuckChatContextualFragment :
     }
 
     companion object {
+        private const val MAX_CHAT_TITLE_LINES = 3
         private const val PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE = 200
         private const val CUSTOM_UA =
             "Mozilla/5.0 (Linux; Android 16) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/124.0.0.0 Mobile DuckDuckGo/5 Safari/537.36"

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -28,7 +28,6 @@ import android.os.Environment
 import android.os.Message
 import android.provider.MediaStore
 import android.text.Editable
-import android.text.TextUtils
 import android.text.TextWatcher
 import android.view.KeyEvent
 import android.view.MotionEvent
@@ -749,7 +748,6 @@ class DuckChatContextualFragment :
 
         val newChatRow = content.findViewById<PopupMenuItemView>(R.id.contextualChatsPopupNewChat)
         val headerDivider = content.findViewById<View>(R.id.contextualChatsPopupHeaderDivider)
-        newChatRow.applyMaxLines(MAX_CHAT_TITLE_LINES)
         newChatRow.visibility = if (showNewChatHeader) View.VISIBLE else View.GONE
         headerDivider.visibility = if (showNewChatHeader) View.VISIBLE else View.GONE
         if (showNewChatHeader) {
@@ -766,7 +764,6 @@ class DuckChatContextualFragment :
                 )
                 setPrimaryText(chat.displayTitle)
                 setLeadingIconResource(chat.type.iconRes(chat.pinned))
-                applyMaxLines(MAX_CHAT_TITLE_LINES)
             }
             popup.onMenuItemClicked(row) { viewModel.onRecentChatClicked(chat.chatId) }
             recentContainer.addView(row)
@@ -775,7 +772,6 @@ class DuckChatContextualFragment :
         val viewAllRow = content.findViewById<PopupMenuItemView>(R.id.contextualChatsPopupViewAll)
         val footerDivider = content.findViewById<View>(R.id.contextualChatsPopupFooterDivider)
         val showFooter = recentChats.isNotEmpty()
-        viewAllRow.applyMaxLines(MAX_CHAT_TITLE_LINES)
         viewAllRow.visibility = if (showFooter) View.VISIBLE else View.GONE
         footerDivider.visibility = if (showFooter) View.VISIBLE else View.GONE
         if (showFooter) {
@@ -783,13 +779,6 @@ class DuckChatContextualFragment :
         }
 
         popup.showAnchoredView(requireActivity(), binding.root, binding.contextualNewChat)
-    }
-
-    private fun PopupMenuItemView.applyMaxLines(maxLines: Int) {
-        findViewById<TextView>(com.duckduckgo.mobile.android.R.id.label)?.apply {
-            this.maxLines = maxLines
-            ellipsize = TextUtils.TruncateAt.END
-        }
     }
 
     private fun observeSubscriptionEventDataChannel() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -88,6 +88,7 @@ import com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper
 import com.duckduckgo.duckchat.impl.helper.Mode
 import com.duckduckgo.duckchat.impl.helper.RealDuckChatJSHelper
 import com.duckduckgo.duckchat.impl.history.ChatHistoryItem
+import com.duckduckgo.duckchat.impl.models.iconRes
 import com.duckduckgo.duckchat.impl.ui.DuckChatWebViewClient
 import com.duckduckgo.duckchat.impl.ui.filechooser.FileChooserIntentBuilder
 import com.duckduckgo.duckchat.impl.ui.filechooser.capture.camera.CameraHardwareChecker
@@ -763,6 +764,7 @@ class DuckChatContextualFragment :
             } else {
                 row.visibility = View.VISIBLE
                 row.setPrimaryText(chat.displayTitle)
+                row.setLeadingIconResource(chat.type.iconRes(chat.pinned))
                 popup.onMenuItemClicked(row) { viewModel.onRecentChatClicked(chat.chatId) }
             }
         }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -47,9 +47,9 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
@@ -192,8 +192,14 @@ class DuckChatContextualViewModel @Inject constructor(
     }
 
     private fun observeRecentChats() {
-        chatHistoryRepository.observeChats()
-            .map { chats -> chats.sortedByDescending { it.lastEditMillis }.take(MAX_RECENT_CHATS) }
+        combine(chatHistoryRepository.observeChats(), _chatId) { chats, currentChatId ->
+            chats
+                .asSequence()
+                .filterNot { it.chatId == currentChatId }
+                .sortedByDescending { it.lastEditMillis }
+                .take(MAX_RECENT_CHATS)
+                .toList()
+        }
             .flowOn(dispatchers.io())
             .onEach { recent -> _viewState.update { it.copy(recentChats = recent) } }
             .launchIn(viewModelScope)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -187,8 +187,40 @@ class DuckChatContextualViewModel @Inject constructor(
             }
             if (isContextualSheetImprovementsEnabled) {
                 observeRecentChats()
+                observeCurrentChatDeletion()
             }
         }
+    }
+
+    // Last chat id we confirmed exists in history. A brand-new chat sets _chatId (from the loaded
+    // URL) before it is persisted, so "absent from history" only means "deleted" once we've actually
+    // seen it present — this field is what distinguishes the two.
+    private var lastSeenChatId: String? = null
+
+    private fun observeCurrentChatDeletion() {
+        combine(chatHistoryRepository.observeChats(), _chatId) { chats, currentChatId ->
+            currentChatId to chats.any { it.chatId == currentChatId }
+        }
+            .flowOn(dispatchers.io())
+            .onEach { (currentChatId, isPresent) ->
+                if (isPresent) {
+                    lastSeenChatId = currentChatId
+                } else if (currentChatId != null && currentChatId == lastSeenChatId && _viewState.value.sheetMode == SheetMode.WEBVIEW) {
+                    // A chat we had seen in history is now gone -> deleted elsewhere. Clear
+                    // synchronously so repeat emissions for the same id don't retrigger before the
+                    // reset propagates to _chatId/sheetMode.
+                    lastSeenChatId = null
+                    handleLoadedChatDeleted()
+                }
+            }
+            .launchIn(viewModelScope)
+    }
+
+    private fun handleLoadedChatDeleted() {
+        logcat { "Duck.ai Contextual: loaded chat deleted elsewhere, resetting sheet" }
+        // Reset session/state but leave the sheet position untouched (sheetState = null):
+        // if visible it swaps to INPUT in place; if hidden it stays hidden and opens fresh next time.
+        renderNewChatState(sheetState = null)
     }
 
     private fun observeRecentChats() {
@@ -821,7 +853,9 @@ class DuckChatContextualViewModel @Inject constructor(
         renderNewChatState(sheetState = BottomSheetBehavior.STATE_HIDDEN)
     }
 
-    private fun renderNewChatState(sheetState: Int = BottomSheetBehavior.STATE_HALF_EXPANDED) {
+    // sheetState == null leaves the bottom sheet position untouched (used when resetting after the
+    // loaded chat is deleted elsewhere, so we don't pop a dismissed sheet back open).
+    private fun renderNewChatState(sheetState: Int? = BottomSheetBehavior.STATE_HALF_EXPANDED) {
         viewModelScope.launch(dispatchers.io()) {
             val currentTabId = _viewState.value.tabId
             if (currentTabId.isNotBlank()) {
@@ -842,14 +876,14 @@ class DuckChatContextualViewModel @Inject constructor(
                             quickActionState = resetQuickActionState,
                         )
                     }
-                    commandChannel.trySend(Command.ChangeSheetState(sheetState))
+                    sheetState?.let { commandChannel.trySend(Command.ChangeSheetState(it)) }
 
                     val subscriptionEvent = duckChatJSHelper.onNativeAction(NativeAction.NEW_CHAT)
                     _subscriptionEventDataChannel.trySend(subscriptionEvent)
                 }
             }
         }
-        if (sheetState != BottomSheetBehavior.STATE_HIDDEN) {
+        if (sheetState == BottomSheetBehavior.STATE_HALF_EXPANDED) {
             duckChatPixels.reportContextualPlaceholderContextShown()
         }
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -782,7 +782,7 @@ class DuckChatContextualViewModel @Inject constructor(
             return
         }
         if (state.recentChats.isEmpty()) {
-            onNewChatRequested()
+            onViewAllChatsClicked()
         } else {
             commandChannel.trySend(
                 Command.ShowChatsPopup(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -34,6 +34,8 @@ import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper
 import com.duckduckgo.duckchat.impl.helper.NativeAction
 import com.duckduckgo.duckchat.impl.helper.RealDuckChatJSHelper
+import com.duckduckgo.duckchat.impl.history.ChatHistoryItem
+import com.duckduckgo.duckchat.impl.history.ChatHistoryRepository
 import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.store.DuckChatContextualDataStore
@@ -45,6 +47,10 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -68,6 +74,7 @@ class DuckChatContextualViewModel @Inject constructor(
     private val featureTogglesInventory: FeatureTogglesInventory,
     private val modelManager: DuckAiModelManager,
     private val contextualNativeInputManager: ContextualNativeInputManager,
+    private val chatHistoryRepository: ChatHistoryRepository,
     private val context: Context,
 ) : ViewModel() {
 
@@ -122,6 +129,15 @@ class DuckChatContextualViewModel @Inject constructor(
         ) : Command()
         data object RequestPageContext : Command()
         data object ShowFireConfirmation : Command()
+        data class ShowChatsPopup(
+            val showNewChatHeader: Boolean,
+            val recentChats: List<ChatHistoryItem>,
+        ) : Command()
+        data class OpenChatUrl(
+            val url: String,
+            val sourceTabId: String,
+        ) : Command()
+        data object LaunchChatHistory : Command()
     }
 
     private val _viewState: MutableStateFlow<ViewState> =
@@ -166,9 +182,21 @@ class DuckChatContextualViewModel @Inject constructor(
                     isFireButtonEnabled = duckChatFeature.contextualFireButton().isEnabled() && isSingleTabFireEnabled,
                     quickActionState = initialQuickActionState,
                     chatHintResId = chatHintResId,
+                    showChatsIcon = isContextualSheetImprovementsEnabled,
                 )
             }
+            if (isContextualSheetImprovementsEnabled) {
+                observeRecentChats()
+            }
         }
+    }
+
+    private fun observeRecentChats() {
+        chatHistoryRepository.observeChats()
+            .map { chats -> chats.sortedByDescending { it.lastEditMillis }.take(MAX_RECENT_CHATS) }
+            .flowOn(dispatchers.io())
+            .onEach { recent -> _viewState.update { it.copy(recentChats = recent) } }
+            .launchIn(viewModelScope)
     }
 
     data class ViewState(
@@ -184,6 +212,9 @@ class DuckChatContextualViewModel @Inject constructor(
         val isFireButtonEnabled: Boolean = false,
         val quickActionState: QuickActionState = QuickActionState.LEGACY_SUMMARIZE,
         @StringRes val chatHintResId: Int = R.string.input_screen_chat_hint,
+        // When true, the legacy "+" icon is replaced by the chats icon and shown regardless of sheet mode.
+        val showChatsIcon: Boolean = false,
+        val recentChats: List<ChatHistoryItem> = emptyList(),
     )
 
     fun onSheetReopened() {
@@ -740,6 +771,38 @@ class DuckChatContextualViewModel @Inject constructor(
         duckChatPixels.reportContextualSheetNewChat()
     }
 
+    fun onChatsIconClicked() {
+        val state = _viewState.value
+        logcat {
+            "Duck.ai Contextual: onChatsIconClicked improvementsEnabled=$isContextualSheetImprovementsEnabled " +
+                "recentChats=${state.recentChats.size} sheetMode=${state.sheetMode}"
+        }
+        if (!isContextualSheetImprovementsEnabled) {
+            onNewChatRequested()
+            return
+        }
+        if (state.recentChats.isEmpty()) {
+            onNewChatRequested()
+        } else {
+            commandChannel.trySend(
+                Command.ShowChatsPopup(
+                    showNewChatHeader = state.sheetMode == SheetMode.WEBVIEW,
+                    recentChats = state.recentChats,
+                ),
+            )
+        }
+    }
+
+    fun onRecentChatClicked(chatId: String) {
+        val url = duckChatInternal.buildChatUrl(chatId)
+        val sourceTabId = _viewState.value.tabId
+        commandChannel.trySend(Command.OpenChatUrl(url = url, sourceTabId = sourceTabId))
+    }
+
+    fun onViewAllChatsClicked() {
+        commandChannel.trySend(Command.LaunchChatHistory)
+    }
+
     fun onFireButtonClicked() {
         duckChatPixels.reportContextualFireButtonTapped()
         viewModelScope.launch {
@@ -827,5 +890,9 @@ class DuckChatContextualViewModel @Inject constructor(
                 commandChannel.trySend(Command.RequestPageContext)
             }
         }
+    }
+
+    companion object {
+        const val MAX_RECENT_CHATS = 5
     }
 }

--- a/duckchat/duckchat-impl/src/main/res/layout/popup_contextual_chats_menu.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/popup_contextual_chats_menu.xml
@@ -79,6 +79,7 @@
         android:id="@+id/contextualChatsPopupViewAll"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        app:leadingIcon="@drawable/ic_open_in_24"
         app:primaryText="@string/duckAiChatHistoryViewAllChats" />
 
 </LinearLayout>

--- a/duckchat/duckchat-impl/src/main/res/layout/popup_contextual_chats_menu.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/popup_contextual_chats_menu.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/popup_menu_bg"
+    android:orientation="vertical">
+
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
+        android:id="@+id/contextualChatsPopupNewChat"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:leadingIcon="@drawable/ic_compose_24"
+        app:primaryText="@string/chatMenuPopupNewChat" />
+
+    <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+        android:id="@+id/contextualChatsPopupHeaderDivider"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:defaultPadding="false" />
+
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
+        android:id="@+id/contextualChatsPopupRow1"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:primaryText="@string/duck_ai_chat_history_untitled" />
+
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
+        android:id="@+id/contextualChatsPopupRow2"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:primaryText="@string/duck_ai_chat_history_untitled" />
+
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
+        android:id="@+id/contextualChatsPopupRow3"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:primaryText="@string/duck_ai_chat_history_untitled" />
+
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
+        android:id="@+id/contextualChatsPopupRow4"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:primaryText="@string/duck_ai_chat_history_untitled" />
+
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
+        android:id="@+id/contextualChatsPopupRow5"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:primaryText="@string/duck_ai_chat_history_untitled" />
+
+    <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+        android:id="@+id/contextualChatsPopupFooterDivider"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:defaultPadding="false" />
+
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
+        android:id="@+id/contextualChatsPopupViewAll"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:primaryText="@string/duckAiChatHistoryViewAllChats" />
+
+</LinearLayout>

--- a/duckchat/duckchat-impl/src/main/res/layout/popup_contextual_chats_menu.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/popup_contextual_chats_menu.xml
@@ -34,6 +34,12 @@
         android:layout_height="wrap_content"
         app:defaultPadding="false" />
 
+    <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+        android:id="@+id/contextualChatsPopupRecentHeader"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:primaryText="@string/contextualSheetChatsPopupRecentSection" />
+
     <com.duckduckgo.common.ui.view.PopupMenuItemView
         android:id="@+id/contextualChatsPopupRow1"
         android:layout_width="match_parent"

--- a/duckchat/duckchat-impl/src/main/res/layout/popup_contextual_chats_menu.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/popup_contextual_chats_menu.xml
@@ -40,40 +40,11 @@
         android:layout_height="wrap_content"
         app:primaryText="@string/contextualSheetChatsPopupRecentSection" />
 
-    <com.duckduckgo.common.ui.view.PopupMenuItemView
-        android:id="@+id/contextualChatsPopupRow1"
+    <LinearLayout
+        android:id="@+id/contextualChatsPopupRecentContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:visibility="gone"
-        app:primaryText="@string/duck_ai_chat_history_untitled" />
-
-    <com.duckduckgo.common.ui.view.PopupMenuItemView
-        android:id="@+id/contextualChatsPopupRow2"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        app:primaryText="@string/duck_ai_chat_history_untitled" />
-
-    <com.duckduckgo.common.ui.view.PopupMenuItemView
-        android:id="@+id/contextualChatsPopupRow3"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        app:primaryText="@string/duck_ai_chat_history_untitled" />
-
-    <com.duckduckgo.common.ui.view.PopupMenuItemView
-        android:id="@+id/contextualChatsPopupRow4"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        app:primaryText="@string/duck_ai_chat_history_untitled" />
-
-    <com.duckduckgo.common.ui.view.PopupMenuItemView
-        android:id="@+id/contextualChatsPopupRow5"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        app:primaryText="@string/duck_ai_chat_history_untitled" />
+        android:orientation="vertical" />
 
     <com.duckduckgo.common.ui.view.divider.HorizontalDivider
         android:id="@+id/contextualChatsPopupFooterDivider"

--- a/duckchat/duckchat-impl/src/main/res/values/dimens.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/dimens.xml
@@ -37,6 +37,9 @@
     <dimen name="nativeInputMenuWidth">260dp</dimen>
     <dimen name="nativeInputButtonSize">36dp</dimen>
 
+    <!-- Width of the contextual sheet "recent chats" popup menu. Wider than the default popupMenuWidth (200dp) to fit chat titles. -->
+    <dimen name="contextualChatsPopupMenuWidth">280dp</dimen>
+
     <!-- Reasoning Mode Picker -->
     <dimen name="reasoningModePickerMenuWidth">220dp</dimen>
 

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -77,4 +77,5 @@
 
     <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
     <string name="contextualSheetImprovedHint">Ask anything privately</string>
+    <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Recent chats</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -124,7 +124,6 @@
 
     <!-- Duck AI Chat Suggestions -->
     <string name="duckAiChatHistoryViewAllChats">View All Chats</string>
-    <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Recent chats</string>
 
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Chats</string>

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -124,6 +124,7 @@
 
     <!-- Duck AI Chat Suggestions -->
     <string name="duckAiChatHistoryViewAllChats">View All Chats</string>
+    <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Recent chats</string>
 
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Chats</string>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -27,6 +27,9 @@ import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper
 import com.duckduckgo.duckchat.impl.helper.NativeAction
 import com.duckduckgo.duckchat.impl.helper.RealDuckChatJSHelper
+import com.duckduckgo.duckchat.impl.history.ChatHistoryItem
+import com.duckduckgo.duckchat.impl.history.ChatHistoryRepository
+import com.duckduckgo.duckchat.impl.models.ChatType
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.store.DuckChatContextualDataStore
 import com.duckduckgo.feature.toggles.api.FeatureTogglesInventory
@@ -76,6 +79,8 @@ class DuckChatContextualViewModelTest {
     private val featureTogglesInventory: FeatureTogglesInventory = mock()
     private val modelManager: com.duckduckgo.duckchat.impl.models.DuckAiModelManager = mock()
     private val contextualNativeInputManager: ContextualNativeInputManager = mock()
+    private val chatHistoryRepository: ChatHistoryRepository = mock()
+    private val recentChatsFlow = MutableStateFlow<List<ChatHistoryItem>>(emptyList())
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val singleTabFireDialogToggle: Toggle = mock()
     private val singleTabFireDialogFeatureName: Toggle.FeatureName = Toggle.FeatureName(
@@ -92,6 +97,7 @@ class DuckChatContextualViewModelTest {
         whenever(singleTabFireDialogToggle.featureName()).thenReturn(singleTabFireDialogFeatureName)
         whenever(singleTabFireDialogToggle.isEnabled()).thenReturn(false)
         runBlocking { whenever(featureTogglesInventory.getAllTogglesForParent("androidBrowserConfig")) }.thenReturn(listOf(singleTabFireDialogToggle))
+        whenever(chatHistoryRepository.observeChats()).thenReturn(recentChatsFlow)
         whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(true)
         whenever(
             duckChatJSHelper.onNativeAction(NativeAction.NEW_CHAT),
@@ -385,6 +391,7 @@ class DuckChatContextualViewModelTest {
                     featureTogglesInventory = featureTogglesInventory,
                     modelManager = modelManager,
                     contextualNativeInputManager = contextualNativeInputManager,
+                    chatHistoryRepository = chatHistoryRepository,
                     context = context,
                 )
 
@@ -795,6 +802,7 @@ class DuckChatContextualViewModelTest {
                     featureTogglesInventory = featureTogglesInventory,
                     modelManager = modelManager,
                     contextualNativeInputManager = contextualNativeInputManager,
+                    chatHistoryRepository = chatHistoryRepository,
                     context = context,
                 )
 
@@ -834,6 +842,7 @@ class DuckChatContextualViewModelTest {
                     featureTogglesInventory = featureTogglesInventory,
                     modelManager = modelManager,
                     contextualNativeInputManager = contextualNativeInputManager,
+                    chatHistoryRepository = chatHistoryRepository,
                     context = context,
                 )
 
@@ -1880,6 +1889,144 @@ class DuckChatContextualViewModelTest {
         }
     }
 
+    @Test
+    fun `when chats icon clicked and improvements disabled then new chat is requested`() = runTest {
+        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(false)
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+
+        testee.onChatsIconClicked()
+
+        verify(duckChatPixels).reportContextualSheetNewChat()
+    }
+
+    @Test
+    fun `when chats icon clicked with no recent chats then new chat is requested`() = runTest {
+        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        recentChatsFlow.value = emptyList()
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+
+        testee.onChatsIconClicked()
+
+        verify(duckChatPixels).reportContextualSheetNewChat()
+    }
+
+    @Test
+    fun `when chats icon clicked with recent chats in INPUT mode then ShowChatsPopup command emitted without new chat header`() = runTest {
+        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        recentChatsFlow.value = listOf(fakeChat("c1", "Chat 1", 100L))
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+
+        testee.commands.test {
+            expectMostRecentItem() // drain onSheetOpened
+            testee.onChatsIconClicked()
+
+            val command = awaitItem() as DuckChatContextualViewModel.Command.ShowChatsPopup
+            assertFalse(command.showNewChatHeader)
+            assertEquals(1, command.recentChats.size)
+            assertEquals("c1", command.recentChats[0].chatId)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when chats icon clicked with recent chats in WEBVIEW mode then ShowChatsPopup command includes new chat header`() = runTest {
+        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        recentChatsFlow.value = listOf(fakeChat("c1", "Chat 1", 100L))
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+        testee.onPromptSent("hello") // transitions to WEBVIEW
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.commands.test {
+            testee.onChatsIconClicked()
+
+            val command = expectMostRecentItem() as DuckChatContextualViewModel.Command.ShowChatsPopup
+            assertTrue(command.showNewChatHeader)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when recent chats updates then view state is capped at 5 sorted by lastEdit desc`() = runTest {
+        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        recentChatsFlow.value = listOf(
+            fakeChat("a", "A", 1L),
+            fakeChat("b", "B", 5L),
+            fakeChat("c", "C", 3L),
+            fakeChat("d", "D", 7L),
+            fakeChat("e", "E", 2L),
+            fakeChat("f", "F", 6L),
+            fakeChat("g", "G", 4L),
+        )
+        val testee = buildViewModel()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        val ids = testee.viewState.value.recentChats.map { it.chatId }
+        assertEquals(listOf("d", "f", "b", "g", "c"), ids)
+    }
+
+    @Test
+    fun `when recent chat clicked then OpenChatUrl command emitted with built url`() = runTest {
+        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        whenever(duckChatInternal.buildChatUrl("c1")).thenReturn("https://duckduckgo.com/?chat_id=c1")
+        recentChatsFlow.value = listOf(fakeChat("c1", "Chat 1", 100L))
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+
+        testee.commands.test {
+            expectMostRecentItem()
+            testee.onRecentChatClicked("c1")
+
+            val command = awaitItem() as DuckChatContextualViewModel.Command.OpenChatUrl
+            assertEquals("https://duckduckgo.com/?chat_id=c1", command.url)
+            assertEquals("tab-1", command.sourceTabId)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when view all chats clicked then LaunchChatHistory command emitted`() = runTest {
+        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        val testee = buildViewModel()
+
+        testee.commands.test {
+            testee.onViewAllChatsClicked()
+            assertTrue(awaitItem() is DuckChatContextualViewModel.Command.LaunchChatHistory)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when improvements enabled then showChatsIcon is true`() = runTest {
+        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        val testee = buildViewModel()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(testee.viewState.value.showChatsIcon)
+    }
+
+    @Test
+    fun `when improvements disabled then showChatsIcon is false`() = runTest {
+        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(false)
+        val testee = buildViewModel()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        assertFalse(testee.viewState.value.showChatsIcon)
+    }
+
+    private fun fakeChat(id: String, title: String, lastEditMillis: Long): ChatHistoryItem =
+        ChatHistoryItem(
+            chatId = id,
+            displayTitle = title,
+            type = ChatType.Discussion,
+            model = "",
+            pinned = false,
+            lastEditMillis = lastEditMillis,
+        )
+
     private fun buildViewModel() = DuckChatContextualViewModel(
         dispatchers = coroutineRule.testDispatcherProvider,
         duckChat = duckChat,
@@ -1893,6 +2040,7 @@ class DuckChatContextualViewModelTest {
         featureTogglesInventory = featureTogglesInventory,
         modelManager = modelManager,
         contextualNativeInputManager = contextualNativeInputManager,
+        chatHistoryRepository = chatHistoryRepository,
         context = context,
     )
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -1954,6 +1954,24 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
+    fun `when current chat is loaded then it is excluded from recent chats`() = runTest {
+        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        recentChatsFlow.value = listOf(
+            fakeChat("current", "Current chat", 10L),
+            fakeChat("a", "A", 5L),
+            fakeChat("b", "B", 3L),
+        )
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+        testee.onPromptSent("hi") // moves into WEBVIEW; onChatPageLoaded below sets chatId
+        testee.onChatPageLoaded("https://duckduckgo.com/?chatID=current")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        val ids = testee.viewState.value.recentChats.map { it.chatId }
+        assertEquals(listOf("a", "b"), ids)
+    }
+
+    @Test
     fun `when recent chats updates then view state is capped at 5 sorted by lastEdit desc`() = runTest {
         whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         recentChatsFlow.value = listOf(

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -2039,6 +2039,123 @@ class DuckChatContextualViewModelTest {
         assertFalse(testee.viewState.value.showChatsIcon)
     }
 
+    @Test
+    fun `when loaded chat deleted elsewhere then sheet resets to input without forcing sheet open`() = runTest {
+        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        recentChatsFlow.value = listOf(fakeChat("current", "Current", 10L), fakeChat("a", "A", 5L))
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+        testee.onPromptSent("hi")
+        testee.onChatPageLoaded("https://duckduckgo.com/?chatID=current")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals("current", testee.chatId.value)
+
+        testee.commands.test {
+            expectMostRecentItem() // drain setup commands
+            recentChatsFlow.value = listOf(fakeChat("a", "A", 5L)) // current chat deleted elsewhere
+            coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+            expectNoEvents() // no ChangeSheetState command -> sheet position untouched
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        assertEquals(DuckChatContextualViewModel.SheetMode.INPUT, testee.viewState.value.sheetMode)
+        assertNull(testee.chatId.value)
+        assertNull(contextualDataStore.getTabChatUrl("tab-1"))
+        verify(duckChatJSHelper).onNativeAction(NativeAction.NEW_CHAT)
+    }
+
+    @Test
+    fun `when brand new chat not yet persisted then sheet is not reset`() = runTest {
+        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        recentChatsFlow.value = emptyList()
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+        testee.onPromptSent("hi")
+        testee.onChatPageLoaded("https://duckduckgo.com/?chatID=new")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        // List changes but never contained the new chat -> it was never seen, so do not treat as deletion.
+        recentChatsFlow.value = listOf(fakeChat("unrelated", "Unrelated", 1L))
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(DuckChatContextualViewModel.SheetMode.WEBVIEW, testee.viewState.value.sheetMode)
+        assertEquals("new", testee.chatId.value)
+        verify(duckChatJSHelper, never()).onNativeAction(NativeAction.NEW_CHAT)
+    }
+
+    @Test
+    fun `when a different chat is deleted then loaded chat sheet is not reset`() = runTest {
+        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        recentChatsFlow.value = listOf(fakeChat("current", "Current", 10L), fakeChat("other", "Other", 5L))
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+        testee.onPromptSent("hi")
+        testee.onChatPageLoaded("https://duckduckgo.com/?chatID=current")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        recentChatsFlow.value = listOf(fakeChat("current", "Current", 10L)) // a different chat deleted
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(DuckChatContextualViewModel.SheetMode.WEBVIEW, testee.viewState.value.sheetMode)
+        assertEquals("current", testee.chatId.value)
+    }
+
+    @Test
+    fun `when all chats deleted while a chat is loaded then sheet resets to input`() = runTest {
+        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        recentChatsFlow.value = listOf(fakeChat("current", "Current", 10L))
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+        testee.onPromptSent("hi")
+        testee.onChatPageLoaded("https://duckduckgo.com/?chatID=current")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        recentChatsFlow.value = emptyList() // e.g. clear-all / fire button
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(DuckChatContextualViewModel.SheetMode.INPUT, testee.viewState.value.sheetMode)
+        assertNull(testee.chatId.value)
+        assertNull(contextualDataStore.getTabChatUrl("tab-1"))
+    }
+
+    @Test
+    fun `when chat history keeps updating after a deletion then sheet is reset only once`() = runTest {
+        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        recentChatsFlow.value = listOf(fakeChat("current", "Current", 10L))
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+        testee.onPromptSent("hi")
+        testee.onChatPageLoaded("https://duckduckgo.com/?chatID=current")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        recentChatsFlow.value = emptyList() // loaded chat deleted -> reset
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        // Further history emissions that still lack the (now cleared) chat must not retrigger the reset.
+        recentChatsFlow.value = listOf(fakeChat("unrelated", "Unrelated", 1L))
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(DuckChatContextualViewModel.SheetMode.INPUT, testee.viewState.value.sheetMode)
+        verify(duckChatJSHelper, times(1)).onNativeAction(NativeAction.NEW_CHAT)
+    }
+
+    @Test
+    fun `when improvements disabled and loaded chat deleted then sheet is not reset`() = runTest {
+        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(false)
+        recentChatsFlow.value = listOf(fakeChat("current", "Current", 10L))
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+        testee.onPromptSent("hi")
+        testee.onChatPageLoaded("https://duckduckgo.com/?chatID=current")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        recentChatsFlow.value = emptyList()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        // Deletion observation is gated behind contextualSheetImprovements, so nothing resets when it is off.
+        assertEquals(DuckChatContextualViewModel.SheetMode.WEBVIEW, testee.viewState.value.sheetMode)
+        assertEquals("current", testee.chatId.value)
+    }
+
     private fun fakeChat(id: String, title: String, lastEditMillis: Long): ChatHistoryItem =
         ChatHistoryItem(
             chatId = id,

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -1901,15 +1901,19 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
-    fun `when chats icon clicked with no recent chats then new chat is requested`() = runTest {
+    fun `when chats icon clicked with no recent chats then chat history is launched`() = runTest {
         whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         recentChatsFlow.value = emptyList()
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
 
-        testee.onChatsIconClicked()
+        testee.commands.test {
+            expectMostRecentItem() // drain onSheetOpened commands
+            testee.onChatsIconClicked()
 
-        verify(duckChatPixels).reportContextualSheetNewChat()
+            assertTrue(awaitItem() is DuckChatContextualViewModel.Command.LaunchChatHistory)
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671677432066/task/1215444384395010?focus=true
Tech Design URL (if applicable): 

### Description
See https://app.asana.com/1/137249556945/project/1208671677432066/task/1215444384395010?focus=true 

### Steps to test this PR

_contextualSheetImprovements OFF_
- [x] Open a new tab and open an article in cnn.com
- [x] Select contextual menu icon
- [x] Verify for the initial state only has the full screen and x icons.
- [x] Select Summarize This Page and press send
- [x] Verify new chat icon is shown
- [x] Select new chat icon
- [x] Verify contextual sheet is reset

_contextualSheetImprovements ON, user with NO recent chats_
- [x] Open a new tab and open an NEW article in cnn.com
- [x] Select contextual menu icon
- [x] Verify chats icon is visible next to full screen icon
- [x] Click on chats icon
- [x] Verify chat history page is opened
- [x] Repeat first and second step
- [x] Select ask about page
- [x] Select summarize page
- [x] Verify chats icon is still visible next to full screen icon
- [x] Click on chats icon
- [x] Verify chat history page is opened

_contextualSheetImprovements ON, user with recent chats_
- [x] Start at least 2 more duck ai session
- [x] Open a new tab and open an NEW article in cnn.com
- [x] Select contextual menu icon
- [x] Verify chats icon is visible next to full screen icon
- [x] Click on chats icon
- [x] Verify menu opens
- [x] Verify menu shows ALL recent chats (max 5 only)
- [x] Click on a chat
- [x] Verify it opens on a new tab
- [x] Re-open contextual sheet again
- [x] Select ask about page
- [x] Select summarize page
- [x] Verify chats icon is still visible next to full screen icon
- [x] Click on chats icon
- [x] Verify menu opens
- [x] Select “View All Chats"
- [x] Verify chat history page opens
- [x] Start more duck ai sessions (more than 5)
- [x] Open contextual sheet again and press chats icon
- [x] Verify only 5 most recent chats are shown

### UI changes
Before:
https://github.com/user-attachments/assets/3d54c3b2-8c4b-4027-8ca2-c632ef83360b

After:
https://github.com/user-attachments/assets/357b595c-60ce-4812-827a-5cb8acb64251
https://github.com/user-attachments/assets/95a5bed9-de65-4654-9270-8903b1cbb7a7
https://github.com/user-attachments/assets/3ee83bab-b340-4f42-8f5c-760ebc4df279



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes contextual sheet UX and tab/navigation flows behind a flag, with non-trivial chat-deletion sync logic; mitigated by broad unit tests and unchanged behavior when the flag is off.
> 
> **Overview**
> With **`contextualSheetImprovements`**, the contextual Duck.ai sheet swaps the legacy new-chat control for a **chats icon** (visible in input mode too) and wires it to **`ChatHistoryRepository`**.
> 
> Tapping chats keeps legacy behavior when the flag is off (still starts a new chat). When the flag is on, **no recent history** opens full chat history; **with recents** shows a new **`popup_contextual_chats_menu`** (optional New Chat in WEBVIEW, up to five other chats excluding the current one, View All). Selections **open a chat in a new browser tab** or **launch chat history**, and the sheet closes first.
> 
> The ViewModel adds **`observeRecentChats`**, popup/open/history commands, and **`observeCurrentChatDeletion`** so if the loaded chat disappears from history after it was seen, the sheet resets to input **without changing bottom-sheet visibility** (`renderNewChatState(sheetState = null)`). **`DuckChatContextualViewModelTest`** covers menu flows, caps/sorting, and deletion edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7785857d1231be6d864b77d2a22c2e67fa0bc35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->