### PR TITLE
Fix state issue/race condition with native input

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -135,6 +135,7 @@ class RealNativeInputManager @Inject constructor(
     private lateinit var layoutCoordinator: NativeInputLayoutCoordinator
     private var isNativeInputFieldEnabled: Boolean = false
     private var isExiting: Boolean = false
+    private var isHidingWidget: Boolean = false
     private var isPickingImage: Boolean = false
     private var duckAiToolbarHidden: Boolean = false
     private var floatingSubmitContainer: View? = null
@@ -270,17 +271,31 @@ class RealNativeInputManager @Inject constructor(
 
         val widgetCard = rootView.findViewById<View?>(R.id.inputModeWidgetCard)
         if (widgetCard != null) {
+            if (isHidingWidget) return
+            isHidingWidget = true
             (widgetCard as? MaterialCardView)?.cardElevation = 0f
             widgetCard.animate()
                 .alpha(0f)
                 .setDuration(FADE_OUT_DURATION_MS)
                 .withEndAction {
                     widgetCard.alpha = 1f
-                    removeWidget()
+                    if (isHidingWidget) {
+                        isHidingWidget = false
+                        removeWidget()
+                    }
                 }
                 .start()
         } else {
             removeWidget()
+        }
+    }
+
+    private fun cancelPendingHide() {
+        if (!isHidingWidget) return
+        isHidingWidget = false
+        rootView.findViewById<View?>(R.id.inputModeWidgetCard)?.let { card ->
+            card.animate().cancel()
+            card.alpha = 1f
         }
     }
 
@@ -364,8 +379,9 @@ class RealNativeInputManager @Inject constructor(
     ) {
         if (!isNativeInputFieldEnabled) return
 
-        if (omnibarController.isDuckAiMode() && rootView.findViewById<View?>(R.id.inputModeWidget) != null) return
+        if (omnibarController.isDuckAiMode() && rootView.findViewById<View?>(R.id.inputModeWidget) != null && !isHidingWidget) return
 
+        cancelPendingHide()
         animator.cancelAnimation()
         isExiting = false
         if (omnibarController.isDuckAiMode()) {
@@ -524,6 +540,7 @@ class RealNativeInputManager @Inject constructor(
             floatingSubmitContainer = null
         }
         if (removed) widgetRoot = null
+        isHidingWidget = false
         duckAiToolbarHidden = false
         // Drop Fragment-scoped callback closures so they don't outlive the widget.
         lastCallbacks = null


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1215720267975931?focus=true
Tech Design URL (if applicable): 

### Description

- Adds a flag to prevent the omnibar state from getting out of sync when animating

### Steps to test this PR

- [ ] Focus the and unfocus the input several times
- [ ] Verify that the state is consistent 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches omnibar/native input lifecycle and Duck AI show paths where rapid open/close could previously corrupt state; scope is localized to `NativeInputManager.kt` with no auth or data changes.
> 
> **Overview**
> Fixes a **race between closing and reopening** the native input widget when hide uses a fade-out animation and `removeWidget()` runs in the animation end callback.
> 
> Adds an **`isHidingWidget`** flag so `onHide()` does not stack duplicate fades, the end action only calls **`removeWidget()`** if hide was not cancelled, and **`removeWidget()`** clears the flag. **`cancelPendingHide()`** cancels the in-flight fade and restores alpha when **`showNativeInput()`** runs again.
> 
> In Duck AI mode, **`showNativeInput()`** no longer bails out just because a widget view is still present **while a hide is in progress**, so reopening during the fade-out teardown works instead of leaving bad UI state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 600e4d8ed2827dc36aa76774042a4458d02a5cdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->