### PR TITLE
Fix unified input Maestro flows for new labels

### DIFF
--- a/.maestro/shared/accept_duckai_agreement.yaml
+++ b/.maestro/shared/accept_duckai_agreement.yaml
@@ -5,12 +5,12 @@ appId: com.duckduckgo.mobile.android
 #
 - extendedWaitUntil:
     visible:
-      text: ".*Agree.*"
+      text: ".*(Agree|Continue).*"
     timeout: 10000
     optional: true
 
 - tapOn:
-    text: ".*Agree.*"
+    text: ".*(Agree|Continue).*"
     optional: true
 
 # Dismiss the "Your recent chats live here!" tooltip if it appears. This is a

--- a/.maestro/unified_input_screen/shared/flow_duckai_model_reasoning.yaml
+++ b/.maestro/unified_input_screen/shared/flow_duckai_model_reasoning.yaml
@@ -26,12 +26,14 @@ appId: com.duckduckgo.mobile.android
 - tapOn:
     id: "modelPickerChip"
 - assertVisible:
-    text: "GPT-4o mini"
+    text: "Claude Haiku 2.5"
 
-# pick GPT-4o mini and assert the chip text changes to "4o-mini"
-- tapOn: "GPT-4o mini"
-- assertVisible:
-    text: "4o-mini"
+# pick Claude Haiku 2.5 and assert the chip updated away from the default
+# (the chip short name is backend-driven, so assert it's no longer "GPT-5"
+# rather than hardcoding Haiku's truncated label)
+- tapOn: "Claude Haiku 2.5"
+- assertNotVisible:
+    text: "GPT-5"
     childOf:
       id: "modelPickerChip"
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1215746473639356
Tech Design URL (if applicable):

### Description

Two unified-input Maestro flows started failing because duck.ai copy/config changed:

- The duck.ai agreement prompt now shows a **Continue** CTA instead of **Agree**.
- The Duck.ai model picker now offers **Claude Haiku 2.5** where it used to list **GPT-4o mini**.

Changes:

- `accept_duckai_agreement.yaml` — match either label via a regex alternation (`.*(Agree|Continue).*`) on both the wait and the tap, so the shared agreement step stays green whichever CTA the WebView renders. Both steps remain `optional`.
- `flow_duckai_model_reasoning.yaml` — assert/select **Claude Haiku 2.5** instead of **GPT-4o mini**. The model chip's short name is backend/remote-config driven (it isn't in the repo and isn't a simple truncation), so rather than hardcoding Haiku's chip label we now assert the chip moved off the default **GPT-5** after selecting the new model. The rest of the flow (switching back to GPT-5 mini, exercising the reasoning picker) is unchanged.

### Steps to test this PR

_UnifiedInput: change duck.ai model and reasoning effort × omnibar positions_
- [ ] Run `flow_duckai_model_reasoning.yaml` across the omnibar positions and confirm it passes against a build serving the current model catalog (picker lists "Claude Haiku 2.5"; chip leaves "GPT-5" after selection).

_duck.ai agreement_
- [ ] Run a unified-input flow that hits `accept_duckai_agreement.yaml` on a fresh profile and confirm the agreement is accepted whether the CTA reads "Agree" or "Continue".

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |
