### PR TITLE
PopupMenuItemView: Allow setting maxlines and truncate

### DIFF
--- a/android-design-system/design-system-internal/src/main/res/layout/component_popup_menu_item.xml
+++ b/android-design-system/design-system-internal/src/main/res/layout/component_popup_menu_item.xml
@@ -43,5 +43,12 @@
         android:layout_height="wrap_content"
         app:primaryText="With trailing icon"
         app:trailingIcon="@drawable/ic_bookmark_16"/>
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:primaryText="Max lines should only be 1 and with ellipsize text Lorem ipsum dolor sit amet consectetur adipiscing elit. Sit amet consectetur adipiscing elit quisque faucibus ex. Adipiscing elit quisque faucibus ex sapien vitae pellentesque."
+        app:trailingIcon="@drawable/ic_bookmark_16"
+        app:primaryTextMaxLines="1"
+        app:primaryTextEllipsize="end"/>
 
 </LinearLayout>

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/PopupMenuItemView.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/PopupMenuItemView.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.drawable.Drawable
 import android.text.SpannableString
+import android.text.TextUtils.TruncateAt
 import android.text.style.ForegroundColorSpan
 import android.util.AttributeSet
 import android.widget.LinearLayout
@@ -76,6 +77,22 @@ constructor(
                 setTrailingIconVisibility(false)
             }
 
+            if (hasValue(R.styleable.PopupMenuItemView_primaryTextMaxLines)) {
+                setPrimaryTextMaxLines(getInt(R.styleable.PopupMenuItemView_primaryTextMaxLines, 1))
+            }
+
+            if (hasValue(R.styleable.PopupMenuItemView_primaryTextEllipsize)) {
+                setPrimaryTextEllipsize(
+                    when (getInt(R.styleable.PopupMenuItemView_primaryTextEllipsize, 0)) {
+                        1 -> TruncateAt.START
+                        2 -> TruncateAt.MIDDLE
+                        3 -> TruncateAt.END
+                        4 -> TruncateAt.MARQUEE
+                        else -> null
+                    },
+                )
+            }
+
             binding.label.text = getString(R.styleable.PopupMenuItemView_primaryText) ?: ""
             updateContentDescription()
             recycle()
@@ -94,6 +111,14 @@ constructor(
     fun setPrimaryText(label: () -> String) {
         binding.label.text = label()
         updateContentDescription()
+    }
+
+    fun setPrimaryTextMaxLines(maxLines: Int) {
+        binding.label.maxLines = maxLines
+    }
+
+    fun setPrimaryTextEllipsize(ellipsize: TruncateAt?) {
+        binding.label.ellipsize = ellipsize
     }
 
     fun setPrimaryTextType(type: PopupMenuItemType) {

--- a/android-design-system/design-system/src/main/res/values/attrs-menu-item.xml
+++ b/android-design-system/design-system/src/main/res/values/attrs-menu-item.xml
@@ -35,6 +35,14 @@
         <attr name="leadingIcon" />
         <attr name="leadingIconTint" />
         <attr name="trailingIcon" />
+        <attr name="primaryTextMaxLines" format="integer" />
+        <attr name="primaryTextEllipsize">
+            <enum name="none" value="0" />
+            <enum name="start" value="1" />
+            <enum name="middle" value="2" />
+            <enum name="end" value="3" />
+            <enum name="marquee" value="4" />
+        </attr>
     </declare-styleable>
 
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202857801505092/task/1215747562755683?focus=true
Tech Design URL (if applicable): 

### Description
Adds support for `primaryTextMaxLines` and `PrimaryTextEllipsize`.

### Steps to test this PR
QA-optional



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional presentation-only API on a design-system menu item; no auth, data, or behavior changes beyond text layout defaults when attrs are set.
> 
> **Overview**
> **`PopupMenuItemView`** can now clamp and truncate long primary labels via new **`primaryTextMaxLines`** and **`primaryTextEllipsize`** XML attributes (ellipsize modes: none, start, middle, end, marquee).
> 
> The view reads those attrs in its constructor and exposes **`setPrimaryTextMaxLines`** / **`setPrimaryTextEllipsize`** for programmatic use. The internal component layout adds a sample row (single line + end ellipsize with a trailing icon) to demonstrate the behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3cf6bf8c3d09bb71c3cb3443fde5f93d1d63433. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->