### PR TITLE
Revert "Fix state issue/race condition with native input (#8886)"

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -137,7 +137,6 @@ class RealNativeInputManager @Inject constructor(
     private lateinit var layoutCoordinator: NativeInputLayoutCoordinator
     private var isNativeInputFieldEnabled: Boolean = false
     private var isExiting: Boolean = false
-    private var isHidingWidget: Boolean = false
     private var isPickingImage: Boolean = false
     private var duckAiToolbarHidden: Boolean = false
     private var floatingSubmitContainer: View? = null
@@ -273,31 +272,17 @@ class RealNativeInputManager @Inject constructor(
 
         val widgetCard = rootView.findViewById<View?>(R.id.inputModeWidgetCard)
         if (widgetCard != null) {
-            if (isHidingWidget) return
-            isHidingWidget = true
             (widgetCard as? MaterialCardView)?.cardElevation = 0f
             widgetCard.animate()
                 .alpha(0f)
                 .setDuration(FADE_OUT_DURATION_MS)
                 .withEndAction {
                     widgetCard.alpha = 1f
-                    if (isHidingWidget) {
-                        isHidingWidget = false
-                        removeWidget()
-                    }
+                    removeWidget()
                 }
                 .start()
         } else {
             removeWidget()
-        }
-    }
-
-    private fun cancelPendingHide() {
-        if (!isHidingWidget) return
-        isHidingWidget = false
-        rootView.findViewById<View?>(R.id.inputModeWidgetCard)?.let { card ->
-            card.animate().cancel()
-            card.alpha = 1f
         }
     }
 
@@ -381,9 +366,8 @@ class RealNativeInputManager @Inject constructor(
     ) {
         if (!isNativeInputFieldEnabled) return
 
-        if (omnibarController.isDuckAiMode() && rootView.findViewById<View?>(R.id.inputModeWidget) != null && !isHidingWidget) return
+        if (omnibarController.isDuckAiMode() && rootView.findViewById<View?>(R.id.inputModeWidget) != null) return
 
-        cancelPendingHide()
         animator.cancelAnimation()
         isExiting = false
         if (omnibarController.isDuckAiMode()) {
@@ -544,7 +528,6 @@ class RealNativeInputManager @Inject constructor(
             floatingSubmitContainer = null
         }
         if (removed) widgetRoot = null
-        isHidingWidget = false
         duckAiToolbarHidden = false
         // Drop Fragment-scoped callback closures so they don't outlive the widget.
         lastCallbacks = null


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1215746473639362?focus=true
Tech Design URL (if applicable): 

### Description

- This fix introduced other issues, reverting

### Steps to test this PR

- [ ] Submit a Duck.ai chat
- [ ] Go back
- [ ] Verify the state of the omnibar is correct

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Restores prior timing bugs around rapid show/hide of the native input widget in Duck.ai mode, where overlapping animations could leave UI in a lot leave stale views or skip re-show.
> 
> **Overview**
> **Reverts** the native input hide/show coordination added in #8886 by stripping the `isHidingWidget` flag and `cancelPendingHide()` from `NativeInputManager`.
> 
> Widget teardown on hide again always runs `removeWidget()` when the fade-out animation finishes, with no guard against overlapping hide animations or cancellation when `showNativeInput` runs mid-hide. Duck.ai early-return in `showNativeInput` no longer treats an in-progress hide as “widget still present,” and reopening no longer cancels a pending fade before tearing down and re-attaching the widget.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcdbd4df5447966ea2b6f453625d51a9b7626e00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->