### PR TITLE
Set Duck Player to Never for new users

### DIFF
--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/duckplayer/RealDuckPlayer.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/duckplayer/RealDuckPlayer.kt
@@ -42,8 +42,6 @@ import com.duckduckgo.adblocking.api.duckplayer.PrivatePlayerMode.Disabled
 import com.duckduckgo.adblocking.api.duckplayer.PrivatePlayerMode.Enabled
 import com.duckduckgo.adblocking.api.duckplayer.YOUTUBE_HOST
 import com.duckduckgo.adblocking.api.duckplayer.YOUTUBE_MOBILE_HOST
-import com.duckduckgo.adblocking.impl.domain.AdBlockingState
-import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
 import com.duckduckgo.adblocking.impl.duckplayer.DuckPlayerPixelName.DUCK_PLAYER_DAILY_UNIQUE_VIEW
 import com.duckduckgo.adblocking.impl.duckplayer.DuckPlayerPixelName.DUCK_PLAYER_NEWTAB_SETTING_OFF
 import com.duckduckgo.adblocking.impl.duckplayer.DuckPlayerPixelName.DUCK_PLAYER_NEWTAB_SETTING_ON
@@ -56,10 +54,12 @@ import com.duckduckgo.adblocking.impl.duckplayer.DuckPlayerPixelName.DUCK_PLAYER
 import com.duckduckgo.adblocking.impl.duckplayer.DuckPlayerPixelName.DUCK_PLAYER_WATCH_ON_YOUTUBE
 import com.duckduckgo.adblocking.impl.duckplayer.ui.DuckPlayerPrimeBottomSheet
 import com.duckduckgo.adblocking.impl.duckplayer.ui.DuckPlayerPrimeDialogFragment
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.di.IsMainProcess
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.UrlScheme.Companion.duck
 import com.duckduckgo.common.utils.UrlScheme.Companion.https
@@ -69,10 +69,8 @@ import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -121,7 +119,8 @@ class RealDuckPlayer @Inject constructor(
     private val duckPlayerLocalFilesPath: DuckPlayerLocalFilesPath,
     private val mimeTypeMap: MimeTypeMap,
     private val dispatchers: DispatcherProvider,
-    private val adBlockingStatusChecker: AdBlockingStatusChecker,
+    private val adBlockingExtensionFeature: AdBlockingExtensionFeature,
+    private val appBuildConfig: AppBuildConfig,
     @IsMainProcess private val isMainProcess: Boolean,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) : DuckPlayerInternal, PrivacyConfigCallbackPlugin {
@@ -135,11 +134,38 @@ class RealDuckPlayer @Inject constructor(
     init {
         if (isMainProcess) {
             loadToMemory()
+            appCoroutineScope.launch {
+                combine(
+                    duckPlayerFeatureRepository.observeUserPreferences(),
+                    adBlockingExtensionFeature.self().enabled(),
+                    adBlockingExtensionFeature.enabledByDefault().enabled(),
+                    ::Triple,
+                ).collect { (stored, selfEnabled, enabledByDefault) ->
+                    applyAdBlockingRolloutDefaultIfEligible(stored, selfEnabled, enabledByDefault)
+                }
+            }
         }
     }
 
     override fun onPrivacyConfigDownloaded() {
         loadToMemory()
+    }
+
+    private suspend fun applyAdBlockingRolloutDefaultIfEligible(
+        stored: StoredUserPreferences,
+        selfEnabled: Boolean,
+        enabledByDefault: Boolean,
+    ) {
+        if (!appBuildConfig.isNewInstall()) return
+        if (stored.privatePlayerMode != null) return
+        if (!selfEnabled) return
+        if (!enabledByDefault) return
+        duckPlayerFeatureRepository.setUserPreferences(
+            UserPreferences(
+                overlayInteracted = stored.overlayInteracted,
+                privatePlayerMode = Disabled,
+            ),
+        )
     }
 
     override fun getDuckPlayerState(): DuckPlayerState {
@@ -181,16 +207,10 @@ class RealDuckPlayer @Inject constructor(
     }
 
     override fun getUserPreferences(): UserPreferences {
-        val defaultPlayerMode =
-            if (adBlockingStatusChecker.isShownInSettings() && adBlockingStatusChecker.currentState() is AdBlockingState.Enabled) {
-                Disabled
-            } else {
-                AlwaysAsk
-            }
         val stored = duckPlayerFeatureRepository.getUserPreferences()
         return UserPreferences(
             overlayInteracted = stored.overlayInteracted,
-            privatePlayerMode = stored.privatePlayerMode ?: defaultPlayerMode,
+            privatePlayerMode = stored.privatePlayerMode ?: AlwaysAsk,
         )
     }
 
@@ -212,19 +232,9 @@ class RealDuckPlayer @Inject constructor(
         shouldForceYTNavigation = false
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     override fun observeUserPreferences(): Flow<UserPreferences> {
-        return combine(
-            adBlockingStatusChecker.isShownInSettingsFlow(),
-            adBlockingStatusChecker.observeState(),
-        ) { isShownInSettings, currentState ->
-            isShownInSettings && currentState is AdBlockingState.Enabled
-        }
-            .flatMapLatest { consentGated ->
-                val defaultPlayerMode = if (consentGated) Disabled else AlwaysAsk
-                duckPlayerFeatureRepository.observeUserPreferences()
-                    .map { UserPreferences(it.overlayInteracted, it.privatePlayerMode ?: defaultPlayerMode) }
-            }
+        return duckPlayerFeatureRepository.observeUserPreferences()
+            .map { UserPreferences(it.overlayInteracted, it.privatePlayerMode ?: AlwaysAsk) }
     }
 
     override suspend fun sendDuckPlayerPixel(

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/duckplayer/RealDuckPlayerTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/duckplayer/RealDuckPlayerTest.kt
@@ -33,9 +33,6 @@ import com.duckduckgo.adblocking.api.duckplayer.DuckPlayer.UserPreferences
 import com.duckduckgo.adblocking.api.duckplayer.PrivatePlayerMode.AlwaysAsk
 import com.duckduckgo.adblocking.api.duckplayer.PrivatePlayerMode.Disabled
 import com.duckduckgo.adblocking.api.duckplayer.PrivatePlayerMode.Enabled
-import com.duckduckgo.adblocking.impl.domain.AdBlockingState
-import com.duckduckgo.adblocking.impl.domain.AdBlockingState.Enabled.UserEnabled
-import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
 import com.duckduckgo.adblocking.impl.duckplayer.DuckPlayerPixelName.DUCK_PLAYER_DAILY_UNIQUE_VIEW
 import com.duckduckgo.adblocking.impl.duckplayer.DuckPlayerPixelName.DUCK_PLAYER_NEWTAB_SETTING_OFF
 import com.duckduckgo.adblocking.impl.duckplayer.DuckPlayerPixelName.DUCK_PLAYER_NEWTAB_SETTING_ON
@@ -45,17 +42,22 @@ import com.duckduckgo.adblocking.impl.duckplayer.DuckPlayerPixelName.DUCK_PLAYER
 import com.duckduckgo.adblocking.impl.duckplayer.DuckPlayerPixelName.DUCK_PLAYER_VIEW_FROM_YOUTUBE_AUTOMATIC
 import com.duckduckgo.adblocking.impl.duckplayer.DuckPlayerPixelName.DUCK_PLAYER_VIEW_FROM_YOUTUBE_MAIN_OVERLAY
 import com.duckduckgo.adblocking.impl.duckplayer.DuckPlayerPixelName.DUCK_PLAYER_WATCH_ON_YOUTUBE
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.UrlScheme.Companion.duck
 import com.duckduckgo.common.utils.UrlScheme.Companion.https
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -68,6 +70,7 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
+import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.never
 import org.mockito.kotlin.whenever
 import java.io.InputStream
@@ -86,7 +89,13 @@ class RealDuckPlayerTest {
     private val mockDuckPlayerLocalFilesPath: DuckPlayerLocalFilesPath = mock()
     private val mimeType: MimeTypeMap = mock()
     private val dispatcherProvider = coroutineRule.testDispatcherProvider
-    private val mockAdBlockingStatusChecker: AdBlockingStatusChecker = mock()
+    private val adBlockingExtensionFeature = FakeFeatureToggleFactory.create(AdBlockingExtensionFeature::class.java)
+    private val mockAppBuildConfig: AppBuildConfig = mock()
+    private val storedUserPreferencesFlow = MutableStateFlow(StoredUserPreferences(false, null))
+
+    init {
+        whenever(mockDuckPlayerFeatureRepository.observeUserPreferences()).thenReturn(storedUserPreferencesFlow)
+    }
 
     private val testee = RealDuckPlayer(
         mockDuckPlayerFeatureRepository,
@@ -95,7 +104,8 @@ class RealDuckPlayerTest {
         mockDuckPlayerLocalFilesPath,
         mimeType,
         dispatcherProvider,
-        mockAdBlockingStatusChecker,
+        adBlockingExtensionFeature,
+        mockAppBuildConfig,
         true,
         coroutineRule.testScope,
     )
@@ -103,10 +113,9 @@ class RealDuckPlayerTest {
     @Before
     fun setup() = runTest {
         setFeatureToggle(true)
-        whenever(mockAdBlockingStatusChecker.isShownInSettings()).thenReturn(false)
-        whenever(mockAdBlockingStatusChecker.isShownInSettingsFlow()).thenReturn(flowOf(false))
-        whenever(mockAdBlockingStatusChecker.currentState()).thenReturn(AdBlockingState.Disabled)
-        whenever(mockAdBlockingStatusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled))
+        whenever(mockAppBuildConfig.isNewInstall()).thenReturn(false)
+        whenever(mockDuckPlayerFeatureRepository.getUserPreferences())
+            .thenReturn(StoredUserPreferences(false, null))
         whenever(mockDuckPlayerFeatureRepository.getDuckPlayerDisabledHelpPageLink())
             .thenReturn(null)
         whenever(mockDuckPlayerFeatureRepository.getVideoIDQueryParam()).thenReturn("v")
@@ -208,6 +217,59 @@ class RealDuckPlayerTest {
 
     //endregion
 
+    // region ad-blocking rollout default (driven by combine() in init)
+    @Test
+    fun whenNotNewInstall_combineDoesNotPersistRolloutDefault() = runTest {
+        whenever(mockAppBuildConfig.isNewInstall()).thenReturn(false)
+        adBlockingExtensionFeature.self().setRawStoredState(State(true))
+        adBlockingExtensionFeature.enabledByDefault().setRawStoredState(State(true))
+
+        verify(mockDuckPlayerFeatureRepository, never()).setUserPreferences(any())
+    }
+
+    @Test
+    fun whenNewInstallAndEnabledByDefaultOff_combineDoesNotPersistRolloutDefault() = runTest {
+        whenever(mockAppBuildConfig.isNewInstall()).thenReturn(true)
+        adBlockingExtensionFeature.self().setRawStoredState(State(true))
+        adBlockingExtensionFeature.enabledByDefault().setRawStoredState(State(false))
+
+        verify(mockDuckPlayerFeatureRepository, never()).setUserPreferences(any())
+    }
+
+    @Test
+    fun whenNewInstallAndKillSwitchOff_combineDoesNotPersistRolloutDefault() = runTest {
+        whenever(mockAppBuildConfig.isNewInstall()).thenReturn(true)
+        adBlockingExtensionFeature.self().setRawStoredState(State(false))
+        adBlockingExtensionFeature.enabledByDefault().setRawStoredState(State(true))
+
+        verify(mockDuckPlayerFeatureRepository, never()).setUserPreferences(any())
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun whenNewInstallAndRolloutOnAndNoStoredMode_combinePersistsDisabled() = runTest {
+        whenever(mockAppBuildConfig.isNewInstall()).thenReturn(true)
+        storedUserPreferencesFlow.value = StoredUserPreferences(true, null)
+        adBlockingExtensionFeature.self().setRawStoredState(State(true))
+        adBlockingExtensionFeature.enabledByDefault().setRawStoredState(State(true))
+        advanceUntilIdle()
+
+        // atLeastOnce because the mocked repo doesn't propagate the write back through
+        // observeUserPreferences(); in prod the datastore re-emission flips the null-guard.
+        verify(mockDuckPlayerFeatureRepository, atLeastOnce()).setUserPreferences(UserPreferences(true, Disabled))
+    }
+
+    @Test
+    fun whenNewInstallAndRolloutOnButStoredModeAlreadySet_combineDoesNotOverwrite() = runTest {
+        whenever(mockAppBuildConfig.isNewInstall()).thenReturn(true)
+        storedUserPreferencesFlow.value = StoredUserPreferences(false, AlwaysAsk)
+        adBlockingExtensionFeature.self().setRawStoredState(State(true))
+        adBlockingExtensionFeature.enabledByDefault().setRawStoredState(State(true))
+
+        verify(mockDuckPlayerFeatureRepository, never()).setUserPreferences(any())
+    }
+    //endregion
+
     //region getUserPreferences
 
     @Test
@@ -239,8 +301,6 @@ class RealDuckPlayerTest {
 
     @Test
     fun whenStoredPlayerModeSetThenGetUserPreferencesKeepsItOverDefault() = runTest {
-        whenever(mockAdBlockingStatusChecker.isShownInSettings()).thenReturn(true)
-        whenever(mockAdBlockingStatusChecker.currentState()).thenReturn(UserEnabled)
         whenever(mockDuckPlayerFeatureRepository.getUserPreferences()).thenReturn(StoredUserPreferences(false, Enabled))
 
         val result = testee.getUserPreferences()
@@ -249,42 +309,7 @@ class RealDuckPlayerTest {
     }
 
     @Test
-    fun whenAdBlockingShownInSettingsAndUserEnabledAndNoStoredModeThenGetUserPreferencesDefaultsToDisabled() = runTest {
-        whenever(mockAdBlockingStatusChecker.isShownInSettings()).thenReturn(true)
-        whenever(mockAdBlockingStatusChecker.currentState()).thenReturn(UserEnabled)
-        whenever(mockDuckPlayerFeatureRepository.getUserPreferences()).thenReturn(StoredUserPreferences(false, null))
-
-        val result = testee.getUserPreferences()
-
-        assertEquals(Disabled, result.privatePlayerMode)
-    }
-
-    @Test
-    fun whenAdBlockingShownInSettingsButUserNotEnabledAndNoStoredModeThenGetUserPreferencesDefaultsToAlwaysAsk() = runTest {
-        whenever(mockAdBlockingStatusChecker.isShownInSettings()).thenReturn(true)
-        whenever(mockAdBlockingStatusChecker.currentState()).thenReturn(AdBlockingState.Disabled)
-        whenever(mockDuckPlayerFeatureRepository.getUserPreferences()).thenReturn(StoredUserPreferences(false, null))
-
-        val result = testee.getUserPreferences()
-
-        assertEquals(AlwaysAsk, result.privatePlayerMode)
-    }
-
-    @Test
-    fun whenAdBlockingNotShownInSettingsAndNoStoredModeThenGetUserPreferencesDefaultsToAlwaysAsk() = runTest {
-        whenever(mockAdBlockingStatusChecker.isShownInSettings()).thenReturn(false)
-        whenever(mockAdBlockingStatusChecker.currentState()).thenReturn(UserEnabled)
-        whenever(mockDuckPlayerFeatureRepository.getUserPreferences()).thenReturn(StoredUserPreferences(false, null))
-
-        val result = testee.getUserPreferences()
-
-        assertEquals(AlwaysAsk, result.privatePlayerMode)
-    }
-
-    @Test
-    fun whenAdBlockingStateUninitializedAndNoStoredModeThenGetUserPreferencesDefaultsToAlwaysAsk() = runTest {
-        whenever(mockAdBlockingStatusChecker.isShownInSettings()).thenReturn(true)
-        whenever(mockAdBlockingStatusChecker.currentState()).thenReturn(AdBlockingState.Uninitialized)
+    fun whenNoStoredModeThenGetUserPreferencesDefaultsToAlwaysAsk() = runTest {
         whenever(mockDuckPlayerFeatureRepository.getUserPreferences()).thenReturn(StoredUserPreferences(false, null))
 
         val result = testee.getUserPreferences()
@@ -334,8 +359,6 @@ class RealDuckPlayerTest {
 
     @Test
     fun whenStoredPlayerModeSetThenObserveUserPreferencesKeepsItOverDefault() = runTest {
-        whenever(mockAdBlockingStatusChecker.isShownInSettingsFlow()).thenReturn(flowOf(true))
-        whenever(mockAdBlockingStatusChecker.observeState()).thenReturn(flowOf(UserEnabled))
         whenever(mockDuckPlayerFeatureRepository.observeUserPreferences()).thenReturn(flowOf(StoredUserPreferences(false, Enabled)))
 
         val result = testee.observeUserPreferences().first()
@@ -344,42 +367,7 @@ class RealDuckPlayerTest {
     }
 
     @Test
-    fun whenAdBlockingShownInSettingsAndUserEnabledAndNoStoredModeThenObserveUserPreferencesDefaultsToDisabled() = runTest {
-        whenever(mockAdBlockingStatusChecker.isShownInSettingsFlow()).thenReturn(flowOf(true))
-        whenever(mockAdBlockingStatusChecker.observeState()).thenReturn(flowOf(UserEnabled))
-        whenever(mockDuckPlayerFeatureRepository.observeUserPreferences()).thenReturn(flowOf(StoredUserPreferences(false, null)))
-
-        val result = testee.observeUserPreferences().first()
-
-        assertEquals(Disabled, result.privatePlayerMode)
-    }
-
-    @Test
-    fun whenAdBlockingShownInSettingsButUserNotEnabledAndNoStoredModeThenObserveUserPreferencesDefaultsToAlwaysAsk() = runTest {
-        whenever(mockAdBlockingStatusChecker.isShownInSettingsFlow()).thenReturn(flowOf(true))
-        whenever(mockAdBlockingStatusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled))
-        whenever(mockDuckPlayerFeatureRepository.observeUserPreferences()).thenReturn(flowOf(StoredUserPreferences(false, null)))
-
-        val result = testee.observeUserPreferences().first()
-
-        assertEquals(AlwaysAsk, result.privatePlayerMode)
-    }
-
-    @Test
-    fun whenAdBlockingNotShownInSettingsButUserEnabledAndNoStoredModeThenObserveUserPreferencesDefaultsToAlwaysAsk() = runTest {
-        whenever(mockAdBlockingStatusChecker.isShownInSettingsFlow()).thenReturn(flowOf(false))
-        whenever(mockAdBlockingStatusChecker.observeState()).thenReturn(flowOf(UserEnabled))
-        whenever(mockDuckPlayerFeatureRepository.observeUserPreferences()).thenReturn(flowOf(StoredUserPreferences(false, null)))
-
-        val result = testee.observeUserPreferences().first()
-
-        assertEquals(AlwaysAsk, result.privatePlayerMode)
-    }
-
-    @Test
-    fun whenAdBlockingNotShownInSettingsAndNoStoredModeThenObserveUserPreferencesDefaultsToAlwaysAsk() = runTest {
-        whenever(mockAdBlockingStatusChecker.isShownInSettingsFlow()).thenReturn(flowOf(false))
-        whenever(mockAdBlockingStatusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled))
+    fun whenNoStoredModeThenObserveUserPreferencesDefaultsToAlwaysAsk() = runTest {
         whenever(mockDuckPlayerFeatureRepository.observeUserPreferences()).thenReturn(flowOf(StoredUserPreferences(false, null)))
 
         val result = testee.observeUserPreferences().first()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215652881336097?focus=true 
Tech Design URL (if applicable): 

> [!IMPORTANT]
> If `version.properties` is lower than `5.283.1.6`, update it to `5.284.0`, otherwise, Ad Blocking will be off

### Description
Set Duck Player to Never for new users

### Steps to test this PR

_Feature disabled, new user > Ask Every Time_
- [x] Fresh install the app
- [x] Complete the onboarding
- [x] Open Duck Player settings
- [x] Check state is `Ask Every Time`

_Feature enabled, disabled by default, new user > Ask Every Time_
- [x] Apply _Patch 1 ad blocking enabled and disabled by default_
- [x] Fresh install the app
- [x] Complete the onboarding
- [x] Open YouTube Ad Blocking > Duck Player settings
- [x] Check state is `Ask Every Time`

_Feature enabled, enabled by default, existing user > Ask Every Time_
- [x] Install the app from develop
- [x] Complete the onboarding
- [x] Switch to this branch
- [x] Apply _Patch 2: ad blocking enabled and enabled by default_
- [x] Fresh install the app
- [x] Complete the onboarding
- [x] Open YouTube Ad Blocking > Duck Player settings
- [x] Check state is `Never`

_Feature enabled, enabled by default, new user > Never_
- [x] Apply _Patch 2: ad blocking enabled and enabled by default_
- [x] Fresh install the app
- [x] Complete the onboarding
- [x] Open YouTube Ad Blocking > Duck Player settings
- [x] Check state is `Never`
 


### UI changes
n/a

### Patches
_Patch 1 ad blocking enabled and disabled by default_
```
Subject: [PATCH] ad blocking enabled and disabled by default
---
Index: privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt
--- a/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt	(revision d85af13fffb7404a41cbe6a1ba587521ca6d9af4)
+++ b/privacy-config/privacy-config-api/src/main/java/com/duckduckgo/privacy/config/api/PrivacyFeatureName.kt	(date 1781614366554)
@@ -29,4 +29,4 @@
     TrackingParametersFeatureName("trackingParameters"),
 }
 
-const val PRIVACY_REMOTE_CONFIG_URL = "https://staticcdn.duckduckgo.com/trackerblocking/config/v5/android-config.json"
+const val PRIVACY_REMOTE_CONFIG_URL = "https://gist.githubusercontent.com/CrisBarreiro/91d53b9f9411079f57d13bcbe02c3750/raw/2729c8de3c1090cb967a2fabc283a381d87961e2/android-config.json"
```

[ _Patch 2: ad blocking enabled and enabled by default_
](https://app.asana.com/app/asana/-/get_asset?asset_id=1215757468500059)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes first-run defaults and YouTube navigation behavior for new users under remote-config rollout; existing users with stored prefs are mostly unchanged, but the new init-time write depends on toggle timing.
> 
> **Overview**
> **Duck Player** no longer ties default private-player mode to live ad-blocking consent via `AdBlockingStatusChecker`. When preferences are unset, **`getUserPreferences`** and **`observeUserPreferences`** now always surface **`AlwaysAsk`** instead of sometimes defaulting to **`Disabled`**.
> 
> For **fresh installs only**, `RealDuckPlayer` watches stored preferences plus **`AdBlockingExtensionFeature`** (`self` and **`enabledByDefault`**) and **persists `Disabled` (Never)** once when the user has no stored mode and the extension rollout is on with enabled-by-default—without overwriting an existing choice.
> 
> Tests swap the status-checker mocks for feature toggles and **`AppBuildConfig`**, and add coverage for the rollout persistence guards.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09f388e4458ff9e05b7c243b1b539f9fabb93d31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->