### PR TITLE
Fix last used toggle bug

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1388,7 +1388,7 @@ class BrowserTabFragment :
     private fun configureInputScreenLauncher() {
         omnibar.configureInputScreenLaunchListener { query ->
             if (!nativeInputManager.isNativeInputEnabled()) {
-                launchInputScreen(query)
+                launchInputScreen(query, isNewTab = omnibar.viewMode == NewTab)
             } else {
                 removeDuckChatContextualSheet()
                 showNativeInput(query)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1215751567544070?focus=true
Tech Design URL (if applicable): 

### Description

- Fixes a bug where the last used mode was not remembered when opening the input screen from NTP

### Steps to test this PR

_with the native input enabled and toggle behavior set to “Last Used"_
- [ ] Toggle to duck.ai and submit query
- [ ] Open a new tab and focus the input
- [ ] Verify that Duck.ai selected by default

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-parameter wiring fix on an existing launch path; no new APIs or broad refactors.
> 
> **Overview**
> Fixes incorrect **last-used toggle** behavior when opening the input screen from the omnibar on the new tab page.
> 
> When native input is disabled, omnibar launches now pass **`isNewTab = (omnibar.viewMode == NewTab)`** into `launchInputScreen`, which forwards the flag on `InputScreenActivityParams`. Previously this path always used the default `isNewTab = false`, unlike the explicit `Command.LaunchInputScreen` flow that already sets `isNewTab = true`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1815f548d92f910d327c213da52e82ed7e43a611. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->