### PR TITLE
Duck.ai on custom tabs UI

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2463,6 +2463,10 @@ class BrowserTabFragment :
         (activity as? CustomTabActivity)?.finishAndRemoveTask()
     }
 
+    private fun finishCustomTab() {
+        (activity as? CustomTabActivity)?.finish()
+    }
+
     private fun onBypassMaliciousWarning(
         url: Uri,
         feed: Feed,
@@ -2935,6 +2939,7 @@ class BrowserTabFragment :
             is Command.HideWarningMaliciousSite -> hideMaliciousWarning(it.canGoBack)
             is Command.EscapeMaliciousSite -> onEscapeMaliciousSite()
             is Command.CloseCustomTab -> closeCustomTab()
+            is Command.FinishCustomTab -> finishCustomTab()
             is Command.BypassMaliciousSiteWarning -> onBypassMaliciousWarning(it.url, it.feed)
             is OpenBrokenSiteLearnMore -> openBrokenSiteLearnMore(it.url)
             is ReportBrokenSiteError -> openBrokenSiteReportError(it.url)

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -96,6 +96,7 @@ import com.duckduckgo.app.browser.commands.Command.EscapeMaliciousSite
 import com.duckduckgo.app.browser.commands.Command.ExtractSerpLogo
 import com.duckduckgo.app.browser.commands.Command.ExtractUrlFromCloakedAmpLink
 import com.duckduckgo.app.browser.commands.Command.FindInPageCommand
+import com.duckduckgo.app.browser.commands.Command.FinishCustomTab
 import com.duckduckgo.app.browser.commands.Command.GenerateWebViewPreviewImage
 import com.duckduckgo.app.browser.commands.Command.HandleNonHttpAppLink
 import com.duckduckgo.app.browser.commands.Command.HideBrokenSitePromptCta
@@ -1481,12 +1482,7 @@ class BrowserTabViewModel @Inject constructor(
             is ShouldLaunchDuckChatLink -> {
                 runCatching {
                     logcat { "Duck.ai: ShouldLaunchDuckChatLink $urlToNavigate" }
-                    val queryParameter = urlToNavigate.toUri().getQueryParameter(QUERY)
-                    if (queryParameter != null) {
-                        duckChat.openDuckChatWithPrefill(queryParameter)
-                    } else {
-                        duckChat.openDuckChat()
-                    }
+                    openDuckChatForUrl(urlToNavigate.toUri())
                     return
                 }
             }
@@ -3773,6 +3769,26 @@ class BrowserTabViewModel @Inject constructor(
 
     override fun openLinkInNewTab(uri: Uri) {
         command.value = OpenInNewTab(uri.toString(), tabId)
+    }
+
+    override fun handleDuckChatUrlInCustomTab(uri: Uri): Boolean {
+        if (!isCustomTabScreen) return false
+        if (!androidBrowserConfig.redirectDuckAiLinksFromCustomTab().isEnabled()) return false
+
+        openDuckChatForUrl(uri)
+        // Finish only the custom tab activity (not the whole task) so we don't tear down the Duck Chat
+        // host activity, which the singleTask BrowserActivity may launch into the same task.
+        command.value = FinishCustomTab
+        return true
+    }
+
+    private fun openDuckChatForUrl(uri: Uri) {
+        val queryParameter = uri.getQueryParameter(QUERY)
+        if (queryParameter != null) {
+            duckChat.openDuckChatWithPrefill(queryParameter)
+        } else {
+            duckChat.openDuckChat()
+        }
     }
 
     override fun recoverFromRenderProcessGone() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -234,6 +234,11 @@ class BrowserWebViewClient @Inject constructor(
                 return false
             }
 
+            // Redirect duck.ai links out of a custom tab into the Duck Chat experience instead of loading them in the custom tab.
+            if (isForMainFrame && duckChat.isDuckChatUrl(url) && webViewClientListener?.handleDuckChatUrlInCustomTab(url) == true) {
+                return true
+            }
+
             return when (val urlType = specialUrlDetector.determineType(initiatingUrl = webView.originalUrl, uri = url)) {
                 is SpecialUrlDetector.UrlType.ShouldLaunchSubscriptionLink -> {
                     subscriptions.launchSubscription(webView.context, url)

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
@@ -93,6 +93,13 @@ interface WebViewClientListener {
 
     fun openLinkInNewTab(uri: Uri)
 
+    /**
+     * Called for a main-frame duck.ai navigation. When the page is shown inside a custom tab, the
+     * implementation opens the Duck Chat experience, closes the custom tab, and returns `true` so
+     * the navigation is not loaded in the custom tab. Returns `false` otherwise (let navigation proceed).
+     */
+    fun handleDuckChatUrlInCustomTab(uri: Uri): Boolean
+
     fun recoverFromRenderProcessGone()
 
     fun requiresAuthentication(request: BasicAuthenticationRequest)

--- a/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
@@ -480,6 +480,13 @@ sealed class Command {
 
     data object CloseCustomTab : Command()
 
+    /**
+     * Finishes only the [CustomTabActivity] (not the whole task). Used when the custom tab is being
+     * dismissed while another activity (e.g. the Duck Chat host) is being launched into the same task,
+     * where [CloseCustomTab]'s `finishAndRemoveTask()` would tear down that activity too.
+     */
+    data object FinishCustomTab : Command()
+
     data class LaunchPopupMenu(val anchorToNavigationBar: Boolean) : Command()
 
     data class ShowAutoconsentAnimation(

--- a/app/src/main/java/com/duckduckgo/app/dispatchers/IntentDispatcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/dispatchers/IntentDispatcherViewModel.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.dispatchers
 
 import android.content.Intent
 import androidx.browser.customtabs.CustomTabsIntent
+import androidx.core.net.toUri
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.adblocking.api.duckplayer.DuckPlayerSettingsNoParams
@@ -30,6 +31,7 @@ import com.duckduckgo.autofill.api.emailprotection.EmailProtectionLinkVerifier
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.customtabs.api.CustomTabDetector
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
 import com.duckduckgo.sync.api.setup.SyncUrlIdentifier
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -46,6 +48,7 @@ class IntentDispatcherViewModel @Inject constructor(
     private val emailProtectionLinkVerifier: EmailProtectionLinkVerifier,
     private val duckDuckGoUrlDetector: DuckDuckGoUrlDetector,
     private val syncUrlIdentifier: SyncUrlIdentifier,
+    private val duckChat: DuckChat,
     private val appBuildConfig: AppBuildConfig,
 ) : ViewModel() {
 
@@ -83,9 +86,9 @@ class IntentDispatcherViewModel @Inject constructor(
 
                 val isEmailProtectionLink = emailProtectionLinkVerifier.shouldDelegateToInContextView(intentText, true)
                 val isDuckDuckGoUrl = intentText?.let { duckDuckGoUrlDetector.isDuckDuckGoUrl(it) } ?: false
-
+                val isDuckAiUrl = intentText?.let { duckChat.isDuckChatUrl(it.toUri()) } ?: false
                 val isSyncPairingUrl = syncUrlIdentifier.shouldDelegateToSyncSetup(intentText)
-                val customTabRequested = hasSession && !isEmailProtectionLink && !isDuckDuckGoUrl && !isSyncPairingUrl
+                val customTabRequested = hasSession && !isEmailProtectionLink && !isDuckDuckGoUrl && !isSyncPairingUrl && !isDuckAiUrl
 
                 logcat { "Intent $intent received. Has extra session=$hasSession. Intent text=$intentText. Toolbar color=$toolbarColor" }
 

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -375,4 +375,14 @@ interface AndroidBrowserConfigFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun pdfViewer(): Toggle
+
+    /**
+     * Controls whether duck.ai links tapped inside a custom tab are redirected out of the custom
+     * tab into the Duck Chat experience (closing the custom tab) instead of loading in the custom tab.
+     * @return `true` when the remote config has the global "redirectDuckAiLinksFromCustomTab" androidBrowserConfig
+     * sub-feature flag enabled
+     * If the remote feature is not present defaults to `true`
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun redirectDuckAiLinksFromCustomTab(): Toggle
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -5556,6 +5556,54 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenHandleDuckChatUrlInCustomTabWithQueryAndFeatureEnabledThenOpenDuckChatWithPrefillAndCloseCustomTabAndReturnTrue() = runTest {
+        fakeAndroidConfigBrowserFeature.redirectDuckAiLinksFromCustomTab().setRawStoredState(State(enable = true))
+        testee.setIsCustomTab(true)
+
+        val handled = testee.handleDuckChatUrlInCustomTab("https://duck.ai/?q=hello".toUri())
+
+        assertTrue(handled)
+        verify(mockDuckChat).openDuckChatWithPrefill("hello")
+        assertTrue(captureCommands().allValues.contains(Command.FinishCustomTab))
+    }
+
+    @Test
+    fun whenHandleDuckChatUrlInCustomTabWithoutQueryAndFeatureEnabledThenOpenDuckChatAndCloseCustomTabAndReturnTrue() = runTest {
+        fakeAndroidConfigBrowserFeature.redirectDuckAiLinksFromCustomTab().setRawStoredState(State(enable = true))
+        testee.setIsCustomTab(true)
+
+        val handled = testee.handleDuckChatUrlInCustomTab("https://duck.ai/".toUri())
+
+        assertTrue(handled)
+        verify(mockDuckChat).openDuckChat()
+        assertTrue(captureCommands().allValues.contains(Command.FinishCustomTab))
+    }
+
+    @Test
+    fun whenHandleDuckChatUrlInCustomTabButNotCustomTabThenReturnFalseAndDoNotOpenDuckChat() = runTest {
+        fakeAndroidConfigBrowserFeature.redirectDuckAiLinksFromCustomTab().setRawStoredState(State(enable = true))
+        testee.setIsCustomTab(false)
+
+        val handled = testee.handleDuckChatUrlInCustomTab("https://duck.ai/?q=hello".toUri())
+
+        assertFalse(handled)
+        verify(mockDuckChat, never()).openDuckChat()
+        verify(mockDuckChat, never()).openDuckChatWithPrefill(any())
+    }
+
+    @Test
+    fun whenHandleDuckChatUrlInCustomTabButFeatureDisabledThenReturnFalseAndDoNotOpenDuckChat() = runTest {
+        fakeAndroidConfigBrowserFeature.redirectDuckAiLinksFromCustomTab().setRawStoredState(State(enable = false))
+        testee.setIsCustomTab(true)
+
+        val handled = testee.handleDuckChatUrlInCustomTab("https://duck.ai/?q=hello".toUri())
+
+        assertFalse(handled)
+        verify(mockDuckChat, never()).openDuckChat()
+        verify(mockDuckChat, never()).openDuckChatWithPrefill(any())
+    }
+
+    @Test
     fun whenHandleNewTabIfEmptyUrlAndNonNoNavigationStateThenThenDoNotSetOmnibarText() {
         loadUrl("url")
         testee.handleNewTabIfEmptyUrl()

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -566,6 +566,50 @@ class BrowserWebViewClientTest {
     }
 
     @Test
+    fun whenMainFrameDuckChatUrlAndListenerHandlesInCustomTabThenReturnTrueAndDoNotClassify() {
+        val url = "https://duck.ai/?q=example".toUri()
+        whenever(webResourceRequest.isForMainFrame).thenReturn(true)
+        whenever(webResourceRequest.url).thenReturn(url)
+        whenever(mockDuckChat.isDuckChatUrl(url)).thenReturn(true)
+        whenever(listener.handleDuckChatUrlInCustomTab(url)).thenReturn(true)
+
+        assertTrue(testee.shouldOverrideUrlLoading(webView, webResourceRequest))
+
+        verify(listener).handleDuckChatUrlInCustomTab(url)
+        verifyNoInteractions(specialUrlDetector)
+    }
+
+    @Test
+    fun whenMainFrameDuckChatUrlButListenerDoesNotHandleThenFallThroughToClassification() {
+        val url = "https://duck.ai/?q=example".toUri()
+        whenever(webResourceRequest.isForMainFrame).thenReturn(true)
+        whenever(webResourceRequest.url).thenReturn(url)
+        whenever(mockDuckChat.isDuckChatUrl(url)).thenReturn(true)
+        whenever(listener.handleDuckChatUrlInCustomTab(url)).thenReturn(false)
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
+            .thenReturn(SpecialUrlDetector.UrlType.Web(url.toString()))
+
+        assertFalse(testee.shouldOverrideUrlLoading(webView, webResourceRequest))
+
+        verify(listener).handleDuckChatUrlInCustomTab(url)
+        verify(specialUrlDetector).determineType(initiatingUrl = any(), uri = any())
+    }
+
+    @Test
+    fun whenSubFrameDuckChatUrlThenListenerNotConsultedForCustomTabRedirect() {
+        val url = "https://duck.ai/?q=example".toUri()
+        whenever(webResourceRequest.isForMainFrame).thenReturn(false)
+        whenever(webResourceRequest.url).thenReturn(url)
+        whenever(mockDuckChat.isDuckChatUrl(url)).thenReturn(true)
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any()))
+            .thenReturn(SpecialUrlDetector.UrlType.Web(url.toString()))
+
+        testee.shouldOverrideUrlLoading(webView, webResourceRequest)
+
+        verify(listener, never()).handleDuckChatUrlInCustomTab(any())
+    }
+
+    @Test
     fun whenShouldOverrideWithShouldNavigateToDuckPlayerSetOriginToSerpAuto() =
         runTest {
             val urlType = SpecialUrlDetector.UrlType.ShouldLaunchDuckPlayerLink("duck://player/1234".toUri())

--- a/app/src/test/java/com/duckduckgo/app/dispatchers/IntentDispatcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/dispatchers/IntentDispatcherViewModelTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.dispatchers
 import android.content.Intent
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
+import androidx.core.net.toUri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import com.duckduckgo.adblocking.api.duckplayer.DuckPlayerSettingsNoParams
@@ -29,6 +30,7 @@ import com.duckduckgo.appbuildconfig.api.BuildFlavor
 import com.duckduckgo.autofill.api.emailprotection.EmailProtectionLinkVerifier
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.customtabs.api.CustomTabDetector
+import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.sync.api.setup.SyncUrlIdentifier
 import com.duckduckgo.sync.impl.ui.qrcode.SyncBarcodeUrl
 import kotlinx.coroutines.test.runTest
@@ -56,6 +58,7 @@ class IntentDispatcherViewModelTest {
     private val emailProtectionLinkVerifier: EmailProtectionLinkVerifier = mock()
     private val duckDuckGoUrlDetector: DuckDuckGoUrlDetector = mock()
     private val syncUrlIdentifier: SyncUrlIdentifier = mock()
+    private val duckChat: DuckChat = mock()
     private val mockAppBuildConfig: AppBuildConfig = mock()
 
     private lateinit var testee: IntentDispatcherViewModel
@@ -68,6 +71,7 @@ class IntentDispatcherViewModelTest {
             emailProtectionLinkVerifier = emailProtectionLinkVerifier,
             duckDuckGoUrlDetector = duckDuckGoUrlDetector,
             syncUrlIdentifier = syncUrlIdentifier,
+            duckChat = duckChat,
             appBuildConfig = mockAppBuildConfig,
         )
 
@@ -226,6 +230,37 @@ class IntentDispatcherViewModelTest {
         testee.viewState.test {
             val state = awaitItem()
             assertFalse(state.customTabRequested)
+        }
+    }
+
+    @Test
+    fun `when Intent received with session and intent text is a duck ai url then custom tab is not requested`() = runTest {
+        val text = "https://duck.ai/?q=hello"
+        configureHasSession(true)
+        whenever(mockIntent.intentText).thenReturn(text)
+        whenever(duckChat.isDuckChatUrl(text.toUri())).thenReturn(true)
+
+        testee.onIntentReceived(mockIntent, isExternal = false)
+
+        testee.viewState.test {
+            val state = awaitItem()
+            assertFalse(state.customTabRequested)
+            assertEquals(text, state.intentText)
+        }
+    }
+
+    @Test
+    fun `when Intent received with session and intent text is not a duck ai url then custom tab is requested`() = runTest {
+        val text = "https://example.com"
+        configureHasSession(true)
+        whenever(mockIntent.intentText).thenReturn(text)
+        whenever(duckChat.isDuckChatUrl(text.toUri())).thenReturn(false)
+
+        testee.onIntentReceived(mockIntent, isExternal = false)
+
+        testee.viewState.test {
+            val state = awaitItem()
+            assertTrue(state.customTabRequested)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1215730567218052?focus=true
Tech Design URL (if applicable): N/A

### Description
Implement redirect for duck.ai links in custom tabs to Duck Chat experience.

### Steps to test this PR

_Feature_ _1:_ _Open_ _duck.ai_ 

- [x]  Install from this branch
- [x]  Skip onboarding, make DDG default browser
- [x]  Tap on https://duck.ai from an email
- [x]  Notice Duck.ai does not open in Custom Tab

Feature 2: Open Reddit and open duck.ai from there

- [x]  Install from this branch
- [x]  Skip onboarding, make DDG default browser
- [x]  Tap on https://www.reddit.com/r/duckduckgo/comments/1u3uk82/duckai_usage_decrease_for_pro_subscription/ from an email
- [x]  Notice the page loads in a Custom Tab
- [x]  Tap on the duck.ai link in the page
- [x]  Notice Duck.ai does not open in Custom Tab



### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 6e97328a27c49da6f968dcb70349a6efd0641d86. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->