### PR TITLE
Fix the "create asana task" script

### DIFF
--- a/.github/workflows/release_orchestrator.yml
+++ b/.github/workflows/release_orchestrator.yml
@@ -9,14 +9,7 @@ on:
         default: 'PLACEHOLDER'
 
 jobs:
-  create-release-tag:
-    uses: ./.github/workflows/release_create_tag.yml
-    with:
-      app-version: ${{ inputs.app-version }}
-    secrets: inherit
-
   create-asana-release-task:
-    needs: create-release-tag
     uses: ./.github/workflows/release_create_task.yml
     with:
       app-version: ${{ inputs.app-version }}

--- a/.github/workflows/release_orchestrator.yml
+++ b/.github/workflows/release_orchestrator.yml
@@ -9,7 +9,14 @@ on:
         default: 'PLACEHOLDER'
 
 jobs:
+  create-release-tag:
+    uses: ./.github/workflows/release_create_tag.yml
+    with:
+      app-version: ${{ inputs.app-version }}
+    secrets: inherit
+
   create-asana-release-task:
+    needs: create-release-tag
     uses: ./.github/workflows/release_create_task.yml
     with:
       app-version: ${{ inputs.app-version }}

--- a/scripts/release/asana_release_utils.py
+++ b/scripts/release/asana_release_utils.py
@@ -135,5 +135,28 @@ def extract_task_id_from_url(url: str) -> str:
     # If the last part is 'f', get the previous part
     if task_id == 'f':
         task_id = parts[-2]
-    
+
+    return task_id
+
+
+def resolve_task_id(link: AsanaTaskLink) -> str | None:
+    """
+    Safely resolve an Asana task ID from a link.
+
+    Returns None (and logs) for a missing or malformed URL, so a single bad
+    link never aborts the workflow.
+    """
+    if not link.url:
+        return None
+
+    try:
+        task_id = extract_task_id_from_url(link.url)
+    except Exception as e:
+        log(f"Skipping malformed Asana URL '{link.url}': {e}")
+        return None
+
+    if not task_id:
+        log(f"Skipping Asana URL with no task ID: {link.url}")
+        return None
+
     return task_id

--- a/scripts/release/create-asana-internal-release.py
+++ b/scripts/release/create-asana-internal-release.py
@@ -12,7 +12,7 @@ from asana_release_utils import (
     log,
     get_commits_between,
     extract_asana_task_links,
-    extract_task_id_from_url,
+    resolve_task_id,
 )
 
 
@@ -30,18 +30,8 @@ def create_asana_task(client: asana.ApiClient,
     for link in task_links:
         # Use an explicit href link instead of a data-asana-gid anchor so the
         # request does not fail if Asana cannot auto-resolve an object ID.
-        task_link = "no task"
-        if link.url:
-            try:
-                task_id = extract_task_id_from_url(link.url)
-            except Exception as e:
-                log(f"Skipping malformed Asana URL '{link.url}': {e}")
-                task_id = None
-
-            if task_id:
-                task_link = f'<a href="https://app.asana.com/0/0/{task_id}/f">{task_id}</a>'
-            else:
-                log(f"Skipping Asana URL with no task ID: {link.url}")
+        task_id = resolve_task_id(link)
+        task_link = f'<a href="{link.url}">{task_id}</a>' if task_id else "no task"
 
         commit_url = f"https://github.com/duckduckgo/Android/commit/{link.commit_hash}"
         description += f"- {task_link} - <a href=\"{commit_url}\">{link.commit_hash[:9]}</a>\n"

--- a/scripts/release/create-asana-internal-release.py
+++ b/scripts/release/create-asana-internal-release.py
@@ -28,10 +28,21 @@ def create_asana_task(client: asana.ApiClient,
     description = "<body>"
     description += "<h2>Included Tasks</h2>"
     for link in task_links:
+        # Use an explicit href link instead of a data-asana-gid anchor so the
+        # request does not fail if Asana cannot auto-resolve an object ID.
+        task_link = "no task"
         if link.url:
-            task_link = f"<a data-asana-gid=\"{extract_task_id_from_url(link.url)}\"/>"
-        else:
-            task_link = "no task"
+            try:
+                task_id = extract_task_id_from_url(link.url)
+            except Exception as e:
+                log(f"Skipping malformed Asana URL '{link.url}': {e}")
+                task_id = None
+
+            if task_id:
+                task_link = f'<a href="https://app.asana.com/0/0/{task_id}/f">{task_id}</a>'
+            else:
+                log(f"Skipping Asana URL with no task ID: {link.url}")
+
         commit_url = f"https://github.com/duckduckgo/Android/commit/{link.commit_hash}"
         description += f"- {task_link} - <a href=\"{commit_url}\">{link.commit_hash[:9]}</a>\n"
     

--- a/scripts/release/create-asana-public-release.py
+++ b/scripts/release/create-asana-public-release.py
@@ -32,15 +32,14 @@ def wait_for_job(client: asana.ApiClient, job_gid: str, timeout: int = 30, inter
     raise TimeoutError(f"Job {job_gid} did not complete within {timeout}s")
 
 
-def build_release_task_links_html(task_links: List[AsanaTaskLink]) -> str:
+def iter_valid_task_ids(task_links: List[AsanaTaskLink]):
     """
-    Build HTML list items for release task notes.
+    Yield resolvable Asana task IDs from the given links.
 
-    Use explicit href links instead of data-asana-gid anchors so the request
-    does not fail if Asana cannot auto-resolve an object ID.
+    Links with no URL, a malformed URL, or no extractable task ID are skipped
+    (and logged) instead of raising, so a single bad URL never aborts the
+    workflow.
     """
-    items = []
-
     for link in task_links:
         if not link.url:
             continue
@@ -55,9 +54,20 @@ def build_release_task_links_html(task_links: List[AsanaTaskLink]) -> str:
             log(f"Skipping Asana URL with no task ID: {link.url}")
             continue
 
-        items.append(
-            f'<li><a href="https://app.asana.com/0/0/{task_id}/f">{task_id}</a></li>'
-        )
+        yield task_id
+
+
+def build_release_task_links_html(task_links: List[AsanaTaskLink]) -> str:
+    """
+    Build HTML list items for release task notes.
+
+    Use explicit href links instead of data-asana-gid anchors so the request
+    does not fail if Asana cannot auto-resolve an object ID.
+    """
+    items = [
+        f'<li><a href="https://app.asana.com/0/0/{task_id}/f">{task_id}</a></li>'
+        for task_id in iter_valid_task_ids(task_links)
+    ]
 
     return "".join(items)
 
@@ -169,14 +179,12 @@ def tag_tasks(client: asana.ApiClient, workspace_id: str, task_links: List[Asana
     tasks_api = asana.TasksApi(client)
 
     tagged_count = 0
-    for link in task_links:
-        if link.url:
-            task_id = extract_task_id_from_url(link.url)
-            try:
-                tasks_api.add_tag_for_task({"data": {"tag": tag_id}}, task_id)
-                tagged_count += 1
-            except Exception as e:
-                log(f"Error tagging task {task_id}: {e}")
+    for task_id in iter_valid_task_ids(task_links):
+        try:
+            tasks_api.add_tag_for_task({"data": {"tag": tag_id}}, task_id)
+            tagged_count += 1
+        except Exception as e:
+            log(f"Error tagging task {task_id}: {e}")
 
     log(f"Tagged {tagged_count} tasks with '{tag_name}'")
 
@@ -190,14 +198,12 @@ def remove_tasks_from_project(client: asana.ApiClient, task_links: List[AsanaTas
     tasks_api = asana.TasksApi(client)
 
     removed_count = 0
-    for link in task_links:
-        if link.url:
-            task_id = extract_task_id_from_url(link.url)
-            try:
-                tasks_api.remove_project_for_task({"data": {"project": project_id}}, task_id)
-                removed_count += 1
-            except Exception as e:
-                log(f"Error removing task {task_id} from project: {e}")
+    for task_id in iter_valid_task_ids(task_links):
+        try:
+            tasks_api.remove_project_for_task({"data": {"project": project_id}}, task_id)
+            removed_count += 1
+        except Exception as e:
+            log(f"Error removing task {task_id} from project: {e}")
 
     log(f"Removed {removed_count} tasks from project")
 

--- a/scripts/release/create-asana-public-release.py
+++ b/scripts/release/create-asana-public-release.py
@@ -12,7 +12,7 @@ from asana_release_utils import (
     log,
     get_commits_between,
     extract_asana_task_links,
-    extract_task_id_from_url,
+    resolve_task_id,
     get_public_release_tag_before,
 )
 
@@ -41,20 +41,9 @@ def iter_valid_task_ids(task_links: List[AsanaTaskLink]):
     workflow.
     """
     for link in task_links:
-        if not link.url:
-            continue
-
-        try:
-            task_id = extract_task_id_from_url(link.url)
-        except Exception as e:
-            log(f"Skipping malformed Asana URL '{link.url}': {e}")
-            continue
-
-        if not task_id:
-            log(f"Skipping Asana URL with no task ID: {link.url}")
-            continue
-
-        yield task_id
+        task_id = resolve_task_id(link)
+        if task_id:
+            yield task_id
 
 
 def build_release_task_links_html(task_links: List[AsanaTaskLink]) -> str:
@@ -65,8 +54,9 @@ def build_release_task_links_html(task_links: List[AsanaTaskLink]) -> str:
     does not fail if Asana cannot auto-resolve an object ID.
     """
     items = [
-        f'<li><a href="https://app.asana.com/0/0/{task_id}/f">{task_id}</a></li>'
-        for task_id in iter_valid_task_ids(task_links)
+        f'<li><a href="{link.url}">{task_id}</a></li>'
+        for link in task_links
+        if (task_id := resolve_task_id(link))
     ]
 
     return "".join(items)

--- a/scripts/release/create-asana-public-release.py
+++ b/scripts/release/create-asana-public-release.py
@@ -32,6 +32,36 @@ def wait_for_job(client: asana.ApiClient, job_gid: str, timeout: int = 30, inter
     raise TimeoutError(f"Job {job_gid} did not complete within {timeout}s")
 
 
+def build_release_task_links_html(task_links: List[AsanaTaskLink]) -> str:
+    """
+    Build HTML list items for release task notes.
+
+    Use explicit href links instead of data-asana-gid anchors so the request
+    does not fail if Asana cannot auto-resolve an object ID.
+    """
+    items = []
+
+    for link in task_links:
+        if not link.url:
+            continue
+
+        try:
+            task_id = extract_task_id_from_url(link.url)
+        except Exception as e:
+            log(f"Skipping malformed Asana URL '{link.url}': {e}")
+            continue
+
+        if not task_id:
+            log(f"Skipping Asana URL with no task ID: {link.url}")
+            continue
+
+        items.append(
+            f'<li><a href="https://app.asana.com/0/0/{task_id}/f">{task_id}</a></li>'
+        )
+
+    return "".join(items)
+
+
 def create_asana_release_task(client: asana.ApiClient,
                               workspace_id: str,
                               release_tag: str,
@@ -72,11 +102,7 @@ def create_asana_release_task(client: asana.ApiClient,
     current_notes = task.get('html_notes', '')
 
     # Build the task links bullet points
-    task_links_html = ""
-    for link in task_links:
-        if link.url:
-            task_id = extract_task_id_from_url(link.url)
-            task_links_html += f'<li><a data-asana-gid="{task_id}"/></li>'
+    task_links_html = build_release_task_links_html(task_links)
 
     # Replace the placeholder section with actual task links using regex to handle newlines
     placeholder_pattern = r"<strong>This release includes:</strong>\s*<ul><li>Add Asana tasks in release here and tag them with release number e\.g android-release-5\.9\.0</li></ul>"
@@ -188,17 +214,17 @@ def main():
     parser.add_argument('--template-task-id', required=True, help='Asana template task ID to duplicate')
 
     args = parser.parse_args()
-    
+
     try:
         # Get environment variables
         asana_api_key = os.getenv(args.asana_api_key_env_var)
-        
+
         # Validate environment variables
         if not asana_api_key:
             log("Error: Missing required environment variable")
             log(f"Please set {args.asana_api_key_env_var}")
             return 1
-    
+
         configuration = asana.Configuration()
         configuration.access_token = asana_api_key
         client = asana.ApiClient(configuration)
@@ -207,13 +233,13 @@ def main():
         if not start_tag:
             log(f"Error: No previous public release tag found before {args.tag}")
             return 1
-        
+
         log(f"Using tag {start_tag} as start commit")
         log(f"Using tag {args.tag} as end commit")
-        
+
         # Get commits between the tags
         commits = get_commits_between(args.android_repo_path, start_tag, args.tag)
-        
+
         log(f"Extracting task links from {len(commits)} commits")
         # Extract Asana task links from commit messages
         task_links = extract_asana_task_links(commits, args.trigger_phrase)
@@ -242,10 +268,10 @@ def main():
         remove_tasks_from_project(client, task_links, args.asana_project_id)
 
         task_url = f"https://app.asana.com/1/{args.asana_workspace_id}/project/{args.asana_project_id}/task/{task_id}"
-        print(task_url) # Only the URL is ever printed to stdout
+        print(task_url)  # Only the URL is ever printed to stdout
 
         return 0
-        
+
     except Exception as e:
         import traceback
         log(f"Unexpected error: {e}")

--- a/scripts/release/test_asana_release_utils.py
+++ b/scripts/release/test_asana_release_utils.py
@@ -8,6 +8,7 @@ from asana_release_utils import (
     get_latest_public_release_tag,
     get_public_release_tag_before,
     extract_asana_task_links,
+    resolve_task_id,
     _build_flexible_prefix_pattern,
     AsanaTaskLink,
 )
@@ -199,6 +200,34 @@ class TestExtractAsanaTaskLinks:
         commits = [_fake_commit("ppp", message)]
         result = extract_asana_task_links(commits, STANDARD_PREFIX)
         assert result[0].url == "https://app.asana.com/0/123/456"
+
+
+# --- resolve_task_id ---
+
+
+class TestResolveTaskId:
+    def test_resolves_id_from_valid_url(self):
+        link = AsanaTaskLink(url="https://app.asana.com/0/123/456", commit_hash="aaa")
+        assert resolve_task_id(link) == "456"
+
+    def test_resolves_id_from_new_style_url(self):
+        url = "https://app.asana.com/1/137249556945/project/1209107918776641/task/1210066941136479?focus=true"
+        link = AsanaTaskLink(url=url, commit_hash="bbb")
+        assert resolve_task_id(link) == "1210066941136479"
+
+    def test_returns_none_when_no_url(self):
+        link = AsanaTaskLink(url=None, commit_hash="ccc")
+        assert resolve_task_id(link) is None
+
+    @patch("asana_release_utils.extract_task_id_from_url", side_effect=IndexError("boom"))
+    def test_returns_none_on_malformed_url(self, _mock_extract):
+        link = AsanaTaskLink(url="https://app.asana.com/", commit_hash="ddd")
+        assert resolve_task_id(link) is None
+
+    @patch("asana_release_utils.extract_task_id_from_url", return_value="")
+    def test_returns_none_when_extracted_id_is_empty(self, _mock_extract):
+        link = AsanaTaskLink(url="https://app.asana.com/0/0", commit_hash="eee")
+        assert resolve_task_id(link) is None
 
 
 # --- _build_flexible_prefix_pattern ---


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1215767831573327?focus=true

### Description

The PR fixes the Release Orchestrator workflow script. It replaces the `<a data-asana-gid="..."/>` anchor (which relied on Asana auto-resolving the task GID server-side and failed the entire request when it couldn't when it found a private task), with an explicit `<a href="https://app.asana.com/0/0/{task_id}/f">` link that points directly at the task, so no server-side resolution is needed. It also wraps the ID extraction in error handling, so a malformed or empty URL now logs a warning and falls back to "no task" instead of crashing task creation.

### Steps to test this PR

The script was [already verified as working](https://github.com/duckduckgo/Android/actions/runs/27635020475).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to release automation scripts under `scripts/release/` with added tests; no app runtime or auth paths are touched.
> 
> **Overview**
> Hardens the Release notes **Release Orchestrator** Asana scripts so release task creation no longer fails when a commit link is bad or Asana cannot resolve a task GID.
> 
> Adds **`resolve_task_id`** in `asana_release_utils.py` to wrap URL parsing: missing, malformed, or empty task IDs are logged and skipped instead of aborting the workflow. Internal and public release scripts now build task links with explicit **`<a href="...">`** anchors (task ID as link text) instead of **`data-asana-gid`** placeholders that could fail the whole API request (e.g. private tasks). The public release script centralizes valid IDs via **`iter_valid_task_ids`** and **`build_release_task_links_html`**, and uses the same safe resolution for tagging and removing tasks from the release board. Unit tests cover **`resolve_task_id`** behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0fd3138181c442666d543f3ae5558375de162a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->