### PR TITLE
Sync v2: Handle Abort and Errors + final error copies

### DIFF
--- a/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -1,0 +1,319 @@
+{
+    "sync_setup_barcode_screen_shown": {
+        "description": "The sync setup barcode (QR) screen was shown to the user",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow the screen belongs to",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_manual_code_entry_screen_shown": {
+        "description": "The sync setup manual code entry screen was shown to the user",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow the screen belongs to",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_barcode_scanner_success": {
+        "description": "A scanned sync code was recognized successfully",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow the scan belongs to",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "code_version",
+                "type": "string",
+                "description": "Protocol version of the code that was scanned",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "code_type",
+                "type": "string",
+                "description": "Kind of recognized code. Sent on the v2 path only",
+                "enum": ["recovery", "linking"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_manual_code_entered_success": {
+        "description": "A manually entered/pasted sync code was recognized successfully",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow the code entry belongs to",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "code_version",
+                "type": "string",
+                "description": "Protocol version of the code that was entered",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "code_type",
+                "type": "string",
+                "description": "Kind of recognized code. Sent on the v2 path only",
+                "enum": ["recovery", "linking"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_barcode_scanner_failed": {
+        "description": "A scanned sync code could not be parsed/recognized",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow the scan belongs to",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_manual_code_entered_failed": {
+        "description": "A manually entered/pasted sync code could not be parsed/recognized",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow the code entry belongs to",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_ended_successful": {
+        "description": "Sync setup completed successfully (recovery-code login or device pairing). For a v2 pairing the host reports it after sending the recovery code, the joiner after login",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow completed",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            },
+            {
+                "key": "path",
+                "type": "string",
+                "description": "Whether the v2 setup was a recovery-code login or a device pairing. Sent on the v2 path only",
+                "enum": ["recovery", "pairing"]
+            },
+            {
+                "key": "my_role",
+                "type": "string",
+                "description": "This device's elected role in a v2 pairing. Sent for v2 pairings only",
+                "enum": ["host", "joiner"]
+            },
+            {
+                "key": "peer_kind",
+                "type": "string",
+                "description": "The peer device's credential kind in a v2 pairing. Sent for v2 pairings only",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_ended_failed": {
+        "description": "A v2 sync setup that started (code recognized) failed with an error, not a user cancellation",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Why the v2 setup failed, aligned with the error codes we handle",
+                "enum": [
+                    "needs_upgrade",
+                    "already_upgraded",
+                    "invalid_credentials",
+                    "pairing_unavailable",
+                    "protocol_error",
+                    "transport_failure",
+                    "unexpected_failure"
+                ]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on. Always v2 for this pixel",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            },
+            {
+                "key": "path",
+                "type": "string",
+                "description": "Whether the failed setup was a recovery-code login or a device pairing. Best-effort, omitted when unknown",
+                "enum": ["recovery", "pairing"]
+            },
+            {
+                "key": "my_role",
+                "type": "string",
+                "description": "This device's elected role in a v2 pairing. Best-effort, omitted when unknown",
+                "enum": ["host", "joiner"]
+            },
+            {
+                "key": "peer_kind",
+                "type": "string",
+                "description": "The peer device's credential kind in a v2 pairing. Best-effort, omitted when unknown",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    },
+    "sync_setup_ended_abandoned": {
+        "description": "Sync setup was cancelled by the user (back navigation or denying the sync confirmation prompt)",
+        "owners": ["CDRussell"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow was cancelled",
+                "enum": ["connect", "exchange"]
+            },
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Why the setup was cancelled, based on the v2 protocol state at cancellation",
+                "enum": ["scanning_cancelled", "sync_confirmation_denied", "cancelled_before_finished"]
+            },
+            {
+                "key": "flow_version",
+                "type": "string",
+                "description": "Which sync setup protocol stack the device is on (v2 when canUseV2ConnectFlow is enabled)",
+                "enum": ["v1", "v2"]
+            },
+            {
+                "key": "my_kind",
+                "type": "string",
+                "description": "This device's credential kind. Always ddg for the native client",
+                "enum": ["ddg", "3party"]
+            }
+        ]
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ProtectedKeyManager.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ProtectedKeyManager.kt
@@ -25,9 +25,6 @@ import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
 import com.duckduckgo.sync.store.SyncStore
 import com.squareup.anvil.annotations.ContributesBinding
-import com.squareup.moshi.JsonAdapter
-import com.squareup.moshi.Moshi
-import com.squareup.moshi.Types
 import dagger.SingleInstanceIn
 import logcat.LogPriority.ERROR
 import logcat.logcat
@@ -45,11 +42,12 @@ interface ProtectedKeyManager {
      * Generates an RSA keypair for [purpose] (e.g. "ai_chats"), libsodium-encrypts the private key
      * with the account secret key, and POSTs the entry via /sync/keys/.../set-if-absent.
      *
-     * Returns the created [ProtectedKeyEntry] (the locally-generated, ddg-wrapped key) on success so
-     * callers can use it without a read-after-write GET /keys round-trip (which can lag right after
-     * the write). No-op success semantics for set-if-absent: in the newly-created case (the only case
-     * the 3party-extend caller hits, since it generates only when no keys exist) the returned entry is
-     * authoritative.
+     * Returns the authoritative [ProtectedKeyEntry] taken from the server's response. In the
+     * we-wrote-it case the returned entry equals the one we POSTed; in the race-loser case the
+     * server's `set-if-absent` returns its pre-existing entry instead, and we surface that so
+     * the caller reflects the truth on the server rather than the local key we minted.
+     *
+     * Returns the entry for [purpose] only — not all keys for the account.
      */
     fun create(purpose: String): Result<ProtectedKeyEntry>
 }
@@ -104,39 +102,26 @@ class RealProtectedKeyManager @Inject constructor(
             publicKey = RsaJwk(n = n, e = e),
         )
 
-        return when (val result = syncApi.setProtectedKeyIfAbsent(token, purpose, key)) {
+        return when (val result = syncApi.setProtectedKeyIfAbsent(token, purpose, listOf(key))) {
             is Success -> {
-                logcat { "Sync-ScopedToken: protected key for $purpose created (kid=$kid)" }
-                // Per the Access Credentials TD, the local cache should mirror what's on the
-                // server after every mutation. Append the new entry so callers don't have to
-                // re-hit /sync/keys to find it.
-                cacheLocalProtectedKey(key)
-                Success(key)
+                val entry = result.data.firstOrNull { it.purpose == purpose && it.encryptedWith == CREDENTIAL_ID_DDG }
+                    ?: return Error(reason = "CreateProtectedKey: server response missing created key for $purpose")
+                if (entry.kid != kid) {
+                    // Server returned a pre-existing entry — another device created the key for this
+                    // purpose between our (implicit) check and our POST. The server's entry wins.
+                    logcat {
+                        "Sync-ScopedToken: protected key for $purpose already existed on server " +
+                            "(server kid=${entry.kid}, our kid=$kid) — adopting server entry"
+                    }
+                } else {
+                    logcat { "Sync-ScopedToken: protected key for $purpose created (kid=$kid)" }
+                }
+                Success(entry)
             }
             is Error -> {
                 logcat(ERROR) { "Sync-ScopedToken: failed to create protected key: ${result.reason}" }
                 result
             }
         }
-    }
-
-    private fun cacheLocalProtectedKey(newEntry: ProtectedKeyEntry) {
-        val existing = syncStore.protectedKeysJson
-            ?.let { runCatching { protectedKeysAdapter.fromJson(it) }.getOrNull() }
-            ?: emptyList()
-        // De-dup on kid in case the same key is re-created (shouldn't happen but defensive).
-        val merged = existing.filterNot { it.kid == newEntry.kid } + newEntry
-        // Best-effort cache: the key was already created on the server and is returned to the caller,
-        // so a serialization failure here must not fail create().
-        runCatching { protectedKeysAdapter.toJson(merged) }
-            .onSuccess { syncStore.protectedKeysJson = it }
-            .onFailure { logcat(ERROR) { "Sync-ScopedToken: failed to serialize protected keys cache: ${it.message}" } }
-    }
-
-    private companion object {
-        private val protectedKeysAdapter: JsonAdapter<List<ProtectedKeyEntry>> =
-            Moshi.Builder().build().adapter(
-                Types.newParameterizedType(List::class.java, ProtectedKeyEntry::class.java),
-            )
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
@@ -19,6 +19,12 @@ package com.duckduckgo.sync.impl
 import android.util.Base64
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN
+import com.duckduckgo.sync.impl.AccountErrorCodes.NEGOTIATION_ABORTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.NO_RECOVERY_CODE
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_UNAVAILABLE
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
@@ -119,28 +125,32 @@ class RealSyncCodeDispatcher @Inject constructor(
                 DispatchOutcome.HostConfirmationRequested(peerName = runner.peerName)
             ExchangeV2State.Host.Done -> DispatchOutcome.LoggedIn
             ExchangeV2State.Host.Aborted -> when (event.localTrigger) {
-                LocalTrigger.UserDeniedHost -> DispatchOutcome.Failed("user_denied")
-                LocalTrigger.HostUnavailable -> DispatchOutcome.Failed("host_unavailable")
-                else -> DispatchOutcome.Failed("host_aborted")
+                LocalTrigger.UserDeniedHost -> DispatchOutcome.Failed("user_denied", PAIRING_CANCELLED.code)
+                LocalTrigger.HostUnavailable -> DispatchOutcome.Failed("host_unavailable", PAIRING_UNAVAILABLE.code)
+                else -> DispatchOutcome.Failed("host_aborted", NEGOTIATION_ABORTED.code)
             }
             ExchangeV2State.SameAccountAbort -> DispatchOutcome.AlreadyConnected
             ExchangeV2State.Joiner.Done -> {
                 val received = (event.trigger as? ExchangeV2Message.RecoveryCodeResponse)?.recoveryCode
                 if (received.isNullOrBlank()) {
-                    DispatchOutcome.Failed("Pairing completed without a recovery code")
+                    DispatchOutcome.Failed("Pairing completed without a recovery code", NO_RECOVERY_CODE.code)
                 } else {
                     loginWithV2RecoveryCode(received)
                 }
             }
-            ExchangeV2State.Joiner.AbortedByHost -> {
-                val msgType = event.trigger?.messageType ?: "abort"
-                DispatchOutcome.Failed("Pairing aborted by peer ($msgType)")
+            ExchangeV2State.Joiner.AbortedByHost -> when (event.trigger) {
+                is ExchangeV2Message.RecoveryCodeDenied ->
+                    DispatchOutcome.Failed("Pairing declined by peer", PAIRING_REJECTED.code)
+                is ExchangeV2Message.RecoveryCodeUnavailable ->
+                    DispatchOutcome.Failed("Peer has no recovery code", PAIRING_UNAVAILABLE.code)
+                // AbortedByHost is only reachable via those two host messages; default defensively to rejected.
+                else -> DispatchOutcome.Failed("Pairing aborted by peer", PAIRING_REJECTED.code)
             }
-            ExchangeV2State.Joiner.AbortedLocal -> DispatchOutcome.Failed("Pairing cancelled on this device")
-            ExchangeV2State.Aborted -> DispatchOutcome.Failed("negotiation_aborted")
+            ExchangeV2State.Joiner.AbortedLocal -> DispatchOutcome.Failed("Pairing cancelled on this device", PAIRING_CANCELLED.code)
+            ExchangeV2State.Aborted -> DispatchOutcome.Failed("negotiation_aborted", NEGOTIATION_ABORTED.code)
             else -> null
         }
-        is ExchangeV2Event.SessionError -> DispatchOutcome.Failed(event.message)
+        is ExchangeV2Event.SessionError -> DispatchOutcome.Failed(event.message, PAIRING_FAILED.code)
         else -> null
     }
 
@@ -301,22 +311,26 @@ class RealSyncCodeDispatcher @Inject constructor(
             ExchangeV2State.Joiner.Done -> {
                 val received = (event.trigger as? ExchangeV2Message.RecoveryCodeResponse)?.recoveryCode
                 if (received.isNullOrBlank()) {
-                    DispatchOutcome.Failed("Pairing completed without a recovery code")
+                    DispatchOutcome.Failed("Pairing completed without a recovery code", NO_RECOVERY_CODE.code)
                 } else {
                     loginWithV2RecoveryCode(received)
                 }
             }
-            ExchangeV2State.Joiner.AbortedByHost -> {
-                val msgType = event.trigger?.messageType ?: "abort"
-                DispatchOutcome.Failed("Pairing aborted by peer ($msgType)")
+            ExchangeV2State.Joiner.AbortedByHost -> when (event.trigger) {
+                is ExchangeV2Message.RecoveryCodeDenied ->
+                    DispatchOutcome.Failed("Pairing declined by peer", PAIRING_REJECTED.code)
+                is ExchangeV2Message.RecoveryCodeUnavailable ->
+                    DispatchOutcome.Failed("Peer has no recovery code", PAIRING_UNAVAILABLE.code)
+                // AbortedByHost is only reachable via those two host messages; default defensively to rejected.
+                else -> DispatchOutcome.Failed("Pairing aborted by peer", PAIRING_REJECTED.code)
             }
-            ExchangeV2State.Joiner.AbortedLocal -> DispatchOutcome.Failed("Pairing cancelled on this device")
-            ExchangeV2State.Host.Aborted -> DispatchOutcome.Failed("Pairing aborted")
+            ExchangeV2State.Joiner.AbortedLocal -> DispatchOutcome.Failed("Pairing cancelled on this device", PAIRING_CANCELLED.code)
+            ExchangeV2State.Host.Aborted -> DispatchOutcome.Failed("Pairing aborted", NEGOTIATION_ABORTED.code)
             // Per spec §"Same-account case": not an abort; both devices share an account already.
             ExchangeV2State.SameAccountAbort -> DispatchOutcome.AlreadyConnected
             // Elected Host and shared a recovery code — success from this device's perspective.
             ExchangeV2State.Host.Done -> DispatchOutcome.LoggedIn
-            ExchangeV2State.Aborted -> DispatchOutcome.Failed("negotiation_aborted")
+            ExchangeV2State.Aborted -> DispatchOutcome.Failed("negotiation_aborted", NEGOTIATION_ABORTED.code)
             else -> null
         }
         is ExchangeV2Event.SessionError -> {
@@ -324,7 +338,7 @@ class RealSyncCodeDispatcher @Inject constructor(
             if (match != null) {
                 DispatchOutcome.UpgradeRequired(codeMajor = match.groupValues[1].toIntOrNull() ?: -1)
             } else {
-                DispatchOutcome.Failed(event.message)
+                DispatchOutcome.Failed(event.message, PAIRING_FAILED.code)
             }
         }
         else -> null

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
@@ -333,8 +333,6 @@ class RealSyncCodeDispatcher @Inject constructor(
         else -> null
     }
 
-    /** A version-too-new SessionError (peer needs a higher protocol major) becomes an upgrade
-     *  prompt; anything else is a generic failure. Shared so the Present/Scanner mappers can't drift. */
     private fun sessionErrorToOutcome(message: String): DispatchOutcome {
         val match = VERSION_TOO_NEW_REGEX.find(message)
         return if (match != null) {
@@ -344,9 +342,6 @@ class RealSyncCodeDispatcher @Inject constructor(
         }
     }
 
-    /** Host abort reason → outcome: user-denied vs host-can't-share carry distinct codes
-     *  (spec: recovery_code_denied vs recovery_code_unavailable). Shared so the Present/Scanner
-     *  mappers can't drift. */
     private fun hostAbortedToOutcome(localTrigger: LocalTrigger?): DispatchOutcome = when (localTrigger) {
         LocalTrigger.UserDeniedHost -> DispatchOutcome.Failed("user_denied", PAIRING_CANCELLED.code)
         LocalTrigger.HostUnavailable -> DispatchOutcome.Failed("host_unavailable", PAIRING_UNAVAILABLE.code)

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
@@ -124,11 +124,7 @@ class RealSyncCodeDispatcher @Inject constructor(
             ExchangeV2State.Host.Confirming ->
                 DispatchOutcome.HostConfirmationRequested(peerName = runner.peerName)
             ExchangeV2State.Host.Done -> DispatchOutcome.LoggedIn
-            ExchangeV2State.Host.Aborted -> when (event.localTrigger) {
-                LocalTrigger.UserDeniedHost -> DispatchOutcome.Failed("user_denied", PAIRING_CANCELLED.code)
-                LocalTrigger.HostUnavailable -> DispatchOutcome.Failed("host_unavailable", PAIRING_UNAVAILABLE.code)
-                else -> DispatchOutcome.Failed("host_aborted", NEGOTIATION_ABORTED.code)
-            }
+            ExchangeV2State.Host.Aborted -> hostAbortedToOutcome(event.localTrigger)
             ExchangeV2State.SameAccountAbort -> DispatchOutcome.AlreadyConnected
             ExchangeV2State.Joiner.Done -> {
                 val received = (event.trigger as? ExchangeV2Message.RecoveryCodeResponse)?.recoveryCode
@@ -325,7 +321,7 @@ class RealSyncCodeDispatcher @Inject constructor(
                 else -> DispatchOutcome.Failed("Pairing aborted by peer", PAIRING_REJECTED.code)
             }
             ExchangeV2State.Joiner.AbortedLocal -> DispatchOutcome.Failed("Pairing cancelled on this device", PAIRING_CANCELLED.code)
-            ExchangeV2State.Host.Aborted -> DispatchOutcome.Failed("Pairing aborted", NEGOTIATION_ABORTED.code)
+            ExchangeV2State.Host.Aborted -> hostAbortedToOutcome(event.localTrigger)
             // Per spec §"Same-account case": not an abort; both devices share an account already.
             ExchangeV2State.SameAccountAbort -> DispatchOutcome.AlreadyConnected
             // Elected Host and shared a recovery code — success from this device's perspective.
@@ -346,6 +342,15 @@ class RealSyncCodeDispatcher @Inject constructor(
         } else {
             DispatchOutcome.Failed(message, PAIRING_FAILED.code)
         }
+    }
+
+    /** Host abort reason → outcome: user-denied vs host-can't-share carry distinct codes
+     *  (spec: recovery_code_denied vs recovery_code_unavailable). Shared so the Present/Scanner
+     *  mappers can't drift. */
+    private fun hostAbortedToOutcome(localTrigger: LocalTrigger?): DispatchOutcome = when (localTrigger) {
+        LocalTrigger.UserDeniedHost -> DispatchOutcome.Failed("user_denied", PAIRING_CANCELLED.code)
+        LocalTrigger.HostUnavailable -> DispatchOutcome.Failed("host_unavailable", PAIRING_UNAVAILABLE.code)
+        else -> DispatchOutcome.Failed("host_aborted", NEGOTIATION_ABORTED.code)
     }
 
     /**

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
@@ -150,7 +150,7 @@ class RealSyncCodeDispatcher @Inject constructor(
             ExchangeV2State.Aborted -> DispatchOutcome.Failed("negotiation_aborted", NEGOTIATION_ABORTED.code)
             else -> null
         }
-        is ExchangeV2Event.SessionError -> DispatchOutcome.Failed(event.message, PAIRING_FAILED.code)
+        is ExchangeV2Event.SessionError -> sessionErrorToOutcome(event.message)
         else -> null
     }
 
@@ -333,15 +333,19 @@ class RealSyncCodeDispatcher @Inject constructor(
             ExchangeV2State.Aborted -> DispatchOutcome.Failed("negotiation_aborted", NEGOTIATION_ABORTED.code)
             else -> null
         }
-        is ExchangeV2Event.SessionError -> {
-            val match = VERSION_TOO_NEW_REGEX.find(event.message)
-            if (match != null) {
-                DispatchOutcome.UpgradeRequired(codeMajor = match.groupValues[1].toIntOrNull() ?: -1)
-            } else {
-                DispatchOutcome.Failed(event.message, PAIRING_FAILED.code)
-            }
-        }
+        is ExchangeV2Event.SessionError -> sessionErrorToOutcome(event.message)
         else -> null
+    }
+
+    /** A version-too-new SessionError (peer needs a higher protocol major) becomes an upgrade
+     *  prompt; anything else is a generic failure. Shared so the Present/Scanner mappers can't drift. */
+    private fun sessionErrorToOutcome(message: String): DispatchOutcome {
+        val match = VERSION_TOO_NEW_REGEX.find(message)
+        return if (match != null) {
+            DispatchOutcome.UpgradeRequired(codeMajor = match.groupValues[1].toIntOrNull() ?: -1)
+        } else {
+            DispatchOutcome.Failed(message, PAIRING_FAILED.code)
+        }
     }
 
     /**

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
@@ -32,12 +32,16 @@ import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
 import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.moshi.Moshi
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.transformWhile
 import logcat.logcat
@@ -83,6 +87,9 @@ class RealSyncCodeDispatcher @Inject constructor(
         logcat { "$TAG: V2 Presenter starting runner.startPresent (scoped to events since $sessionStartMs)" }
         runner.startPresent()
         var ownChannelId: String? = null
+        // Snapshot the peer kind while the session is live; the runner clears it on terminal teardown,
+        // so by the time we map the terminal event runner.peerKind is already null.
+        var peerKind: PeerKind? = null
         emitAll(
             runner.eventsSince(sessionStartMs)
                 .transformWhile { event ->
@@ -96,7 +103,9 @@ class RealSyncCodeDispatcher @Inject constructor(
                             return@transformWhile false
                         }
                     }
-                    val outcome = mapV2PresentEventToOutcome(event) ?: return@transformWhile true
+                    runner.peerKind.toPeerKind()?.let { peerKind = it }
+                    val outcome = (mapV2PresentEventToOutcome(event, peerKind) ?: return@transformWhile true)
+                        .withFailureContext(SetupPath.PAIRING, roleFromTerminalState(event), peerKind)
                     emit(outcome)
                     !outcome.isTerminal()
                 },
@@ -116,14 +125,14 @@ class RealSyncCodeDispatcher @Inject constructor(
      * or null for intermediate events the caller should ignore. Both Host and Joiner roles are
      * reachable here; mirrors [mapV2LinkingEventToOutcome] (login on Joiner.Done, preserve abort reason).
      */
-    private fun mapV2PresentEventToOutcome(event: ExchangeV2Event): DispatchOutcome? = when (event) {
+    private fun mapV2PresentEventToOutcome(event: ExchangeV2Event, peerKind: PeerKind?): DispatchOutcome? = when (event) {
         is ExchangeV2Event.SessionStarted -> event.linkingCode?.let { DispatchOutcome.LinkingCodeReady(it) }
         is ExchangeV2Event.Transition -> when (event.to) {
             ExchangeV2State.Joiner.Confirming ->
-                DispatchOutcome.JoinerConfirmationRequested(peerName = runner.peerName)
+                DispatchOutcome.JoinerConfirmationRequested(peerName = runner.peerName, peerKind = peerKind)
             ExchangeV2State.Host.Confirming ->
-                DispatchOutcome.HostConfirmationRequested(peerName = runner.peerName)
-            ExchangeV2State.Host.Done -> DispatchOutcome.LoggedIn
+                DispatchOutcome.HostConfirmationRequested(peerName = runner.peerName, peerKind = peerKind)
+            ExchangeV2State.Host.Done -> DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST, peerKind)
             ExchangeV2State.Host.Aborted -> hostAbortedToOutcome(event.localTrigger)
             ExchangeV2State.SameAccountAbort -> DispatchOutcome.AlreadyConnected
             ExchangeV2State.Joiner.Done -> {
@@ -131,7 +140,7 @@ class RealSyncCodeDispatcher @Inject constructor(
                 if (received.isNullOrBlank()) {
                     DispatchOutcome.Failed("Pairing completed without a recovery code", NO_RECOVERY_CODE.code)
                 } else {
-                    loginWithV2RecoveryCode(received)
+                    loginWithV2RecoveryCode(received, peerKind)
                 }
             }
             ExchangeV2State.Joiner.AbortedByHost -> when (event.trigger) {
@@ -147,6 +156,11 @@ class RealSyncCodeDispatcher @Inject constructor(
         }
         is ExchangeV2Event.SessionError -> sessionErrorToOutcome(event.message)
         else -> null
+    }
+
+    override fun isV2ExchangeUnderway(): Boolean = when (runner.currentState) {
+        null, ExchangeV2State.Bootstrapped -> false
+        else -> true
     }
 
     override fun route(pastedCode: String): RouteDecision {
@@ -165,12 +179,12 @@ class RealSyncCodeDispatcher @Inject constructor(
         return when (parsed) {
             is ExchangeV2CodeParseResult.LinkingV2 -> {
                 logcat { "$TAG: routing → V2 LinkingV2 (runner.startScan)" }
-                RouteDecision.V2InProgress(driveV2Linking(pastedCode))
+                RouteDecision.V2InProgress(SyncCodeType.LINKING, driveV2Linking(pastedCode))
             }
             is ExchangeV2CodeParseResult.RecoveryCode -> {
                 val cid = parsed.rawJson.optString("cid", "ddg")
                 logcat { "$TAG: routing → V2 RecoveryCode (cid=$cid)" }
-                RouteDecision.V2InProgress(driveV2Recovery(parsed, cid))
+                RouteDecision.V2InProgress(SyncCodeType.RECOVERY, driveV2Recovery(parsed, cid))
             }
             ExchangeV2CodeParseResult.LinkingV1,
             ExchangeV2CodeParseResult.Unknown,
@@ -210,6 +224,7 @@ class RealSyncCodeDispatcher @Inject constructor(
                 emit(
                     syncAccountRepository.processCode(authCode, existingDeviceId = null).toOutcome(
                         label = "v2 recovery (ddg)",
+                        path = SetupPath.RECOVERY,
                         codeForAccountSwitch = encodeV1RecoveryCodeAsB64(userId = userId, secret = primaryKey),
                     ),
                 )
@@ -233,14 +248,18 @@ class RealSyncCodeDispatcher @Inject constructor(
                     Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP,
                 )
                 logcat { "$TAG: v2 recovery (3party) → joinAccountFromThirdPartyRecoveryCode" }
-                emit(syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(b64).toOutcome(label = "v2 recovery (3party)"))
+                emit(
+                    syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(
+                        b64,
+                    ).toOutcome(label = "v2 recovery (3party)", path = SetupPath.RECOVERY),
+                )
             }
             else -> {
                 logcat { "$TAG: v2 recovery: unknown cid='$cid'" }
                 emit(DispatchOutcome.Failed("Unknown v2 credential type: $cid"))
             }
         }
-    }
+    }.map { it.withFailureContext(SetupPath.RECOVERY, myRole = null, peerKind = null) }
 
     /**
      * V2 LinkingV2 (`code2=…`) scanner side. Starts [ExchangeV2Runner.startScan] and maps its
@@ -253,6 +272,9 @@ class RealSyncCodeDispatcher @Inject constructor(
         logcat { "$TAG: V2 LinkingV2 starting runner.startScan (scoped to events since $sessionStartMs)" }
         runner.startScan(pastedCode)
         var ownChannelId: String? = null
+        // Snapshot the peer kind while the session is live (see presentV2): the runner clears it on
+        // terminal teardown, before we map the terminal event.
+        var peerKind: PeerKind? = null
         emitAll(
             runner.eventsSince(sessionStartMs)
                 .transformWhile { event ->
@@ -266,7 +288,9 @@ class RealSyncCodeDispatcher @Inject constructor(
                             return@transformWhile false
                         }
                     }
-                    val outcome = mapV2LinkingEventToOutcome(event) ?: return@transformWhile true
+                    runner.peerKind.toPeerKind()?.let { peerKind = it }
+                    val outcome = (mapV2LinkingEventToOutcome(event, peerKind) ?: return@transformWhile true)
+                        .withFailureContext(SetupPath.PAIRING, roleFromTerminalState(event), peerKind)
                     emit(outcome)
                     !outcome.isTerminal()
                 },
@@ -297,18 +321,18 @@ class RealSyncCodeDispatcher @Inject constructor(
      * Translate one runner event into a terminal [DispatchOutcome] for the v2 scanner flow,
      * or null for intermediate events the caller should ignore.
      */
-    private fun mapV2LinkingEventToOutcome(event: ExchangeV2Event): DispatchOutcome? = when (event) {
+    private fun mapV2LinkingEventToOutcome(event: ExchangeV2Event, peerKind: PeerKind?): DispatchOutcome? = when (event) {
         is ExchangeV2Event.Transition -> when (event.to) {
             ExchangeV2State.Joiner.Confirming ->
-                DispatchOutcome.JoinerConfirmationRequested(peerName = runner.peerName)
+                DispatchOutcome.JoinerConfirmationRequested(peerName = runner.peerName, peerKind = peerKind)
             ExchangeV2State.Host.Confirming ->
-                DispatchOutcome.HostConfirmationRequested(peerName = runner.peerName)
+                DispatchOutcome.HostConfirmationRequested(peerName = runner.peerName, peerKind = peerKind)
             ExchangeV2State.Joiner.Done -> {
                 val received = (event.trigger as? ExchangeV2Message.RecoveryCodeResponse)?.recoveryCode
                 if (received.isNullOrBlank()) {
                     DispatchOutcome.Failed("Pairing completed without a recovery code", NO_RECOVERY_CODE.code)
                 } else {
-                    loginWithV2RecoveryCode(received)
+                    loginWithV2RecoveryCode(received, peerKind)
                 }
             }
             ExchangeV2State.Joiner.AbortedByHost -> when (event.trigger) {
@@ -323,7 +347,7 @@ class RealSyncCodeDispatcher @Inject constructor(
             // Per spec §"Same-account case": not an abort; both devices share an account already.
             ExchangeV2State.SameAccountAbort -> DispatchOutcome.AlreadyConnected
             // Elected Host and shared a recovery code — success from this device's perspective.
-            ExchangeV2State.Host.Done -> DispatchOutcome.LoggedIn
+            ExchangeV2State.Host.Done -> DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST, peerKind)
             ExchangeV2State.Aborted -> DispatchOutcome.Failed("negotiation_aborted", NEGOTIATION_ABORTED.code)
             else -> null
         }
@@ -352,23 +376,32 @@ class RealSyncCodeDispatcher @Inject constructor(
      * cid=ddg logs in directly; cid=3party upgrades the account via
      * [SyncAccountRepository.joinAccountFromThirdPartyRecoveryCode].
      */
-    private fun loginWithV2RecoveryCode(b64: String): DispatchOutcome {
+    private fun loginWithV2RecoveryCode(b64: String, peerKind: PeerKind?): DispatchOutcome {
         val parsed = decodeV2Recovery(b64) ?: return DispatchOutcome.Failed("Couldn't parse received recovery code as v2.0")
         return when (parsed.cid) {
             CID_DDG -> {
                 val primaryKey = v2SecretToV1PrimaryKey(parsed.secret)
                     ?: return DispatchOutcome.Failed("Received recovery code has a malformed secret")
                 val recovery = SyncAuthCode.Recovery(RecoveryCode(primaryKey = primaryKey, userId = parsed.userId))
+                logcat { "$TAG: v2 LinkingV2 received ddg code → $recovery" }
                 syncAccountRepository.processCode(recovery, existingDeviceId = null)
                     .toOutcome(
                         label = "v2 LinkingV2 login (ddg)",
+                        path = SetupPath.PAIRING,
+                        myRole = SetupRole.JOINER,
+                        peerKind = peerKind,
                         codeForAccountSwitch = encodeV1RecoveryCodeAsB64(userId = parsed.userId, secret = primaryKey),
                     )
             }
             CID_3PARTY -> {
                 logcat { "$TAG: v2 LinkingV2 received 3party code → joinAccountFromThirdPartyRecoveryCode" }
                 syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(b64)
-                    .toOutcome(label = "v2 LinkingV2 login (3party upgrade)")
+                    .toOutcome(
+                        label = "v2 LinkingV2 login (3party upgrade)",
+                        path = SetupPath.PAIRING,
+                        myRole = SetupRole.JOINER,
+                        peerKind = peerKind,
+                    )
             }
             else -> DispatchOutcome.Failed("Received unknown credential type '${parsed.cid}' over v2 linking")
         }
@@ -411,13 +444,45 @@ class RealSyncCodeDispatcher @Inject constructor(
      * [codeForAccountSwitch] must be a v1 b64 shape [SyncAccountRepository.parseSyncAuthCode] can
      * re-parse, so v2 callers convert first (see [encodeV1RecoveryCodeAsB64]).
      */
+    /** Map the runner's raw peer credential id ("ddg"/"3party") to the telemetry [PeerKind], or null. */
+    private fun String?.toPeerKind(): PeerKind? = when (this) {
+        CID_DDG -> PeerKind.DDG
+        CID_3PARTY -> PeerKind.THIRD_PARTY
+        else -> null
+    }
+
+    /** Elected role implied by a terminal transition's target state, for "Setup failed" telemetry. */
+    private fun roleFromTerminalState(event: ExchangeV2Event): SetupRole? =
+        when ((event as? ExchangeV2Event.Transition)?.to) {
+            is ExchangeV2State.Host -> SetupRole.HOST
+            is ExchangeV2State.Joiner -> SetupRole.JOINER
+            else -> null
+        }
+
+    /**
+     * Attach best-effort failure telemetry ([path]/[myRole]/[peerKind]) to a terminal error outcome.
+     * No-op for non-error outcomes, so a [DispatchOutcome.LoggedIn] keeps the context set at its source.
+     */
+    private fun DispatchOutcome.withFailureContext(
+        path: SetupPath,
+        myRole: SetupRole?,
+        peerKind: PeerKind?,
+    ): DispatchOutcome = when (this) {
+        is DispatchOutcome.Failed -> copy(path = path, myRole = myRole, peerKind = peerKind)
+        is DispatchOutcome.UpgradeRequired -> copy(path = path, myRole = myRole, peerKind = peerKind)
+        else -> this
+    }
+
     private fun Result<Boolean>.toOutcome(
         label: String,
+        path: SetupPath,
+        myRole: SetupRole? = null,
+        peerKind: PeerKind? = null,
         codeForAccountSwitch: String? = null,
     ): DispatchOutcome = when (this) {
         is Result.Success -> {
             logcat { "$TAG: $label → success" }
-            DispatchOutcome.LoggedIn
+            DispatchOutcome.LoggedIn(path, myRole, peerKind)
         }
         is Result.Error -> {
             logcat { "$TAG: $label → error: $reason (code=$code)" }
@@ -426,7 +491,7 @@ class RealSyncCodeDispatcher @Inject constructor(
                 when (val switched = syncAccountRepository.logoutAndJoinNewAccount(codeForAccountSwitch)) {
                     is Result.Success -> {
                         logcat { "$TAG: $label → logout+rejoin success" }
-                        DispatchOutcome.LoggedIn
+                        DispatchOutcome.LoggedIn(path, myRole, peerKind)
                     }
                     is Result.Error -> {
                         logcat { "$TAG: $label → logout+rejoin failed: ${switched.reason} (code=${switched.code})" }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
@@ -139,7 +139,6 @@ class RealSyncCodeDispatcher @Inject constructor(
                     DispatchOutcome.Failed("Pairing declined by peer", PAIRING_REJECTED.code)
                 is ExchangeV2Message.RecoveryCodeUnavailable ->
                     DispatchOutcome.Failed("Peer has no recovery code", PAIRING_UNAVAILABLE.code)
-                // AbortedByHost is only reachable via those two host messages; default defensively to rejected.
                 else -> DispatchOutcome.Failed("Pairing aborted by peer", PAIRING_REJECTED.code)
             }
             ExchangeV2State.Joiner.AbortedLocal -> DispatchOutcome.Failed("Pairing cancelled on this device", PAIRING_CANCELLED.code)
@@ -317,7 +316,6 @@ class RealSyncCodeDispatcher @Inject constructor(
                     DispatchOutcome.Failed("Pairing declined by peer", PAIRING_REJECTED.code)
                 is ExchangeV2Message.RecoveryCodeUnavailable ->
                     DispatchOutcome.Failed("Peer has no recovery code", PAIRING_UNAVAILABLE.code)
-                // AbortedByHost is only reachable via those two host messages; default defensively to rejected.
                 else -> DispatchOutcome.Failed("Pairing aborted by peer", PAIRING_REJECTED.code)
             }
             ExchangeV2State.Joiner.AbortedLocal -> DispatchOutcome.Failed("Pairing cancelled on this device", PAIRING_CANCELLED.code)

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
@@ -1575,6 +1575,7 @@ enum class AccountErrorCodes(val code: Int) {
     INVALID_CODE(55),
     EXCHANGE_FAILED(56),
     THIRD_PARTY_ALREADY_UPGRADED(57),
+
     // v2 pairing aborts (each a distinct, structured terminal — see RealSyncCodeDispatcher mappers).
     PAIRING_REJECTED(58),
     PAIRING_UNAVAILABLE(59),

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
@@ -1575,8 +1575,6 @@ enum class AccountErrorCodes(val code: Int) {
     INVALID_CODE(55),
     EXCHANGE_FAILED(56),
     THIRD_PARTY_ALREADY_UPGRADED(57),
-
-    // v2 pairing aborts (each a distinct, structured terminal — see RealSyncCodeDispatcher mappers).
     PAIRING_REJECTED(58),
     PAIRING_UNAVAILABLE(59),
     PAIRING_CANCELLED(60),

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
@@ -678,12 +678,12 @@ class AppSyncAccountRepository @Inject constructor(
         // SP travels in the recovery code as base64url; nativeLib + hkdfDerive* helpers expect
         // standard base64. Compute once at the boundary, reuse for all derivations.
         val spStandardB64 = kotlin.runCatching { base64UrlStringToStandardBase64(parsed.secret) }
-            .getOrElse { return Error(reason = "Upgrade: failed to decode SP: ${it.message}") }
+            .getOrElse { return Error(reason = "Upgrade: failed to decode SP") }
         val hkdfSalt = parsed.userId.toByteArray(Charsets.UTF_8)
 
         // SP-derived MEK: used to decrypt FE-written (JWE) keys we received from /sync/login.
         val spMek = kotlin.runCatching { syncJweCrypto.hkdfDeriveBytes(spStandardB64, hkdfSalt, "Main Key", 32) }
-            .getOrElse { return Error(reason = "Upgrade: failed to derive SP MEK: ${it.message}") }
+            .getOrElse { return Error(reason = "Upgrade: failed to derive SP MEK") }
 
         // Fresh DDG credential generated locally. nativeLib.generateAccountKeys returns a tuple
         // where `primaryKey` is the new account's MP (the seed for all spec-side derivations) and
@@ -699,14 +699,14 @@ class AppSyncAccountRepository @Inject constructor(
         // DDG's MEK?", this is HKDF(MP, salt=user_id, info="Main Key", 32 bytes) imported as
         // AES-GCM-256. Pinned against the TD's test3 vector in SyncJweCryptoTdVectorsTest.
         val ddgMek = kotlin.runCatching { syncJweCrypto.hkdfDeriveBytes(newDdgKeys.primaryKey, hkdfSalt, "Main Key", 32) }
-            .getOrElse { return Error(reason = "Upgrade: failed to derive DDG MEK: ${it.message}") }
+            .getOrElse { return Error(reason = "Upgrade: failed to derive DDG MEK") }
 
         // encrypted_3party_credential: JWE compact (alg=dir, enc=A256GCM, kid="ddg") of the SP
         // base64url STRING (matches the reverse direction in createThirdPartyCredential, which
         // encrypts the base64url SP string — not the raw SP bytes — so the wire is symmetrical).
         val encryptedThreePartyCredential = kotlin.runCatching {
             syncJweCrypto.jweEncryptSymmetric(parsed.secret.toByteArray(Charsets.UTF_8), ddgMek, kid = CREDENTIAL_ID_DDG)
-        }.getOrElse { return Error(reason = "Upgrade: failed to encrypt encrypted_3party_credential: ${it.message}") }
+        }.getOrElse { return Error(reason = "Upgrade: failed to encrypt encrypted_3party_credential") }
 
         // Re-wrap each FE-written key from /sync/login. Decrypt via JWE using SP MEK, then
         // re-encrypt with libsodium-secretbox using the new DDG secretKey, matching the Native
@@ -873,8 +873,6 @@ class AppSyncAccountRepository @Inject constructor(
         // pre-upgrade until this block runs.
         val spStandardB64 = kotlin.runCatching { base64UrlStringToStandardBase64(parsed.secret) }
             .getOrElse { return Error(reason = "JoinFrom3party: failed to decode SP: ${it.message}") }
-        val protectedKeysJson = kotlin.runCatching { Adapters.protectedKeysAdapter.toJson(upgradePackage.rewrappedKeys) }
-            .getOrElse { return Error(reason = "JoinFrom3party: failed to serialize protected keys: ${it.message}") }
         syncStore.storeCredentials(
             userId = parsed.userId,
             deviceId = deviceId,
@@ -885,7 +883,6 @@ class AppSyncAccountRepository @Inject constructor(
         )
         syncStore.credentialId = CREDENTIAL_ID_DDG
         syncStore.scopedPassword = ScopedPassword(spStandardB64)
-        syncStore.protectedKeysJson = protectedKeysJson
 
         logcat { "Sync-ScopedToken: 3party→ddg upgrade complete; account joined as ddg" }
 
@@ -1354,10 +1351,6 @@ class AppSyncAccountRepository @Inject constructor(
                     }
                     result.data.keys?.let { keys ->
                         logcat { "Sync-ScopedToken: ${keys.size} protected key(s) in response" }
-                        val ddgKeys = keys.filter { it.encryptedWith == CREDENTIAL_ID_DDG }
-                        runCatching { Adapters.protectedKeysAdapter.toJson(ddgKeys) }
-                            .onSuccess { syncStore.protectedKeysJson = it }
-                            .onFailure { logcat(ERROR) { "Sync-ScopedToken: failed to serialize protected keys from login: ${it.message}" } }
                     }
                 }
 
@@ -1458,8 +1451,6 @@ class AppSyncAccountRepository @Inject constructor(
 
             val invitationCodeAdapter: JsonAdapter<InvitationCodeWrapper> = moshi.adapter(InvitationCodeWrapper::class.java)
             val invitedDeviceAdapter: JsonAdapter<InvitedDeviceDetails> = moshi.adapter(InvitedDeviceDetails::class.java)
-            val protectedKeysAdapter: JsonAdapter<List<ProtectedKeyEntry>> =
-                moshi.adapter(Types.newParameterizedType(List::class.java, ProtectedKeyEntry::class.java))
         }
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
@@ -1575,6 +1575,13 @@ enum class AccountErrorCodes(val code: Int) {
     INVALID_CODE(55),
     EXCHANGE_FAILED(56),
     THIRD_PARTY_ALREADY_UPGRADED(57),
+    // v2 pairing aborts (each a distinct, structured terminal — see RealSyncCodeDispatcher mappers).
+    PAIRING_REJECTED(58),
+    PAIRING_UNAVAILABLE(59),
+    PAIRING_CANCELLED(60),
+    NEGOTIATION_ABORTED(61),
+    NO_RECOVERY_CODE(62),
+    PAIRING_FAILED(63),
 }
 
 sealed interface SyncAuthCode {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncCodeDispatcher.kt
@@ -16,6 +16,9 @@
 
 package com.duckduckgo.sync.impl
 
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -63,6 +66,12 @@ interface SyncCodeDispatcher {
      * Host or Joiner. Cancelling the collecting coroutine cancels the underlying runner session.
      */
     fun presentV2(): Flow<DispatchOutcome>
+
+    /**
+     * Whether a v2 exchange has engaged a peer and is mid-protocol (past Bootstrapped, before a
+     * terminal).
+     */
+    fun isV2ExchangeUnderway(): Boolean
 }
 
 sealed interface RouteDecision {
@@ -70,11 +79,17 @@ sealed interface RouteDecision {
     data class Legacy(val authCode: SyncAuthCode) : RouteDecision
 
     /**
-     * Dispatcher owns the work. [outcomes] is a cold Flow that drives the v2 work when collected
-     * (see [DispatchOutcome] for the emitted sequence). Cancelling the collector cancels the work.
+     * Dispatcher owns the work. [codeType] is the kind of v2 code that was recognized.
+     * [outcomes] is a cold Flow that drives the v2 work when collected (see [DispatchOutcome] for the
+     * emitted sequence). Cancelling the collector cancels the work.
      */
-    data class V2InProgress(val outcomes: Flow<DispatchOutcome>) : RouteDecision
+    data class V2InProgress(
+        val codeType: SyncCodeType,
+        val outcomes: Flow<DispatchOutcome>,
+    ) : RouteDecision
 }
+
+enum class SyncCodeType { RECOVERY, LINKING }
 
 /**
  * Outcomes emitted by a v2-owned dispatch, used by both [SyncCodeDispatcher.route] (Scanner) and
@@ -99,13 +114,13 @@ sealed interface DispatchOutcome {
      * SM reached Joiner.Confirming. Caller must prompt the user ("Sync your data with [peerName]?")
      * then call [SyncCodeDispatcher.confirmJoiner] or [SyncCodeDispatcher.denyJoiner] to resume.
      */
-    data class JoinerConfirmationRequested(val peerName: String?) : DispatchOutcome
+    data class JoinerConfirmationRequested(val peerName: String?, val peerKind: PeerKind? = null) : DispatchOutcome
 
     /**
      * SM reached Host.Confirming. Caller must prompt the user ("Allow [peerName] to join your
      * sync & backup?") then call [SyncCodeDispatcher.confirmHost] or [SyncCodeDispatcher.denyHost].
      */
-    data class HostConfirmationRequested(val peerName: String?) : DispatchOutcome
+    data class HostConfirmationRequested(val peerName: String?, val peerKind: PeerKind? = null) : DispatchOutcome
 
     /**
      * Emitted once per [SyncCodeDispatcher.presentV2] session, before any confirmation or
@@ -114,8 +129,16 @@ sealed interface DispatchOutcome {
      */
     data class LinkingCodeReady(val linkingCode: String) : DispatchOutcome
 
-    /** Terminal — login completed (recovery code applied; account state updated). */
-    data object LoggedIn : DispatchOutcome
+    /**
+     * Terminal — login completed (recovery code applied; account state updated). Carries telemetry
+     * for the "Setup success" pixel: [path] (recovery vs pairing) and, for a pairing, the elected
+     * [myRole] and the [peerKind]. [myRole]/[peerKind] are null for recovery.
+     */
+    data class LoggedIn(
+        val path: SetupPath,
+        val myRole: SetupRole? = null,
+        val peerKind: PeerKind? = null,
+    ) : DispatchOutcome
 
     /**
      * Terminal — peer and this device are already on the same account. Per spec §"Same-account
@@ -123,16 +146,29 @@ sealed interface DispatchOutcome {
      */
     data object AlreadyConnected : DispatchOutcome
 
-    /** Terminal — the pasted code requires a protocol major version higher than this app supports. */
-    data class UpgradeRequired(val codeMajor: Int) : DispatchOutcome
+    /**
+     * Terminal — the pasted code requires a protocol major version higher than this app supports.
+     * [path]/[myRole]/[peerKind] are best-effort telemetry for the "Setup failed" pixel (see [Failed]).
+     */
+    data class UpgradeRequired(
+        val codeMajor: Int,
+        val path: SetupPath? = null,
+        val myRole: SetupRole? = null,
+        val peerKind: PeerKind? = null,
+    ) : DispatchOutcome
 
     /**
      * Terminal — transport error, missing credentials on this device, BE rejection, denial, etc.
      * [code] carries the originating [AccountErrorCodes] code (defaults to GENERIC_ERROR) so callers
      * can map specific failures (e.g. THIRD_PARTY_ALREADY_UPGRADED) to user-facing copy.
+     * [path]/[myRole]/[peerKind] are best-effort telemetry for the "Setup failed" pixel: [path] is the
+     * flow kind, and [myRole]/[peerKind] are populated when known at the point of failure.
      */
     data class Failed(
         val reason: String,
         val code: Int = AccountErrorCodes.GENERIC_ERROR.code,
+        val path: SetupPath? = null,
+        val myRole: SetupRole? = null,
+        val peerKind: PeerKind? = null,
     ) : DispatchOutcome
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncService.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncService.kt
@@ -141,7 +141,7 @@ interface SyncService {
         @Header("Authorization") token: String,
         @Path("purpose") purpose: String,
         @Body request: SetProtectedKeyIfAbsentRequest,
-    ): Call<Void>
+    ): Call<ProtectedKeysResponse>
 
     @GET("$SYNC_PROD_ENVIRONMENT_URL/sync/access-credentials")
     fun getAccessCredentials(
@@ -283,7 +283,7 @@ data class ProtectedKeysResponse(
 
 /** Body for POST /sync/keys/purpose/{purpose}/set-if-absent — adds a protected key only if no key exists for that purpose. */
 data class SetProtectedKeyIfAbsentRequest(
-    val key: ProtectedKeyEntry,
+    val keys: List<ProtectedKeyEntry>,
 )
 
 data class AccessCredentialsResponse(

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
@@ -120,7 +120,7 @@ interface SyncApi {
     fun getProtectedKeys(token: String): Result<List<ProtectedKeyEntry>>
 
     /** Atomically claim [purpose] with [key] or no-op if one already exists. */
-    fun setProtectedKeyIfAbsent(token: String, purpose: String, key: ProtectedKeyEntry): Result<Boolean>
+    fun setProtectedKeyIfAbsent(token: String, purpose: String, keys: List<ProtectedKeyEntry>): Result<List<ProtectedKeyEntry>>
 
     fun getAccessCredentials(token: String): Result<List<AccessCredentialEntry>>
 
@@ -539,16 +539,17 @@ class SyncServiceRemote @Inject constructor(
         }
     }
 
-    override fun setProtectedKeyIfAbsent(token: String, purpose: String, key: ProtectedKeyEntry): Result<Boolean> {
+    override fun setProtectedKeyIfAbsent(token: String, purpose: String, keys: List<ProtectedKeyEntry>): Result<List<ProtectedKeyEntry>> {
         val response = runCatching {
-            val call = syncService.setProtectedKeyIfAbsent("Bearer $token", purpose, SetProtectedKeyIfAbsentRequest(key))
+            val call = syncService.setProtectedKeyIfAbsent("Bearer $token", purpose, SetProtectedKeyIfAbsentRequest(keys))
             call.execute()
         }.getOrElse { throwable ->
             return Result.Error(reason = throwable.message.toString())
         }
 
         return onSuccess(response) {
-            Result.Success(true)
+            val keys = response.body()?.keys ?: emptyList()
+            Result.Success(keys)
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ThirdPartyCredentialManager.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ThirdPartyCredentialManager.kt
@@ -233,10 +233,12 @@ class RealThirdPartyCredentialManager @Inject constructor(
             }
         }
 
-        if (ddgKeys.isEmpty()) {
-            logcat { "Sync-ScopedToken: no ddg protected keys; generating $SYNC_SCOPE_AI_CHATS key before 3party extend" }
-            ddgKeys = when (val gen = protectedKeyManager.create(SYNC_SCOPE_AI_CHATS)) {
-                is Success -> listOf(gen.data)
+        // We ensure ai_chats (the scope's required purpose) exists, then re-wrap every
+        // ddg-wrapped key — preserving any other purposes already on the account.
+        if (ddgKeys.none { it.purpose == SYNC_SCOPE_AI_CHATS }) {
+            logcat { "Sync-ScopedToken: no ddg $SYNC_SCOPE_AI_CHATS key; generating before 3party extend" }
+            when (val gen = protectedKeyManager.create(SYNC_SCOPE_AI_CHATS)) {
+                is Success -> ddgKeys = ddgKeys + gen.data
                 is Error -> {
                     logcat(ERROR) { "Sync-ScopedToken: failed to generate $SYNC_SCOPE_AI_CHATS protected key: ${gen.reason}" }
                     return Error(code = gen.code, reason = "CreateThirdPartyCredential: generate $SYNC_SCOPE_AI_CHATS key failed: ${gen.reason}")

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -81,6 +81,9 @@ interface ExchangeV2Runner {
     /** Peer device's human-readable name, learned from `recovery_code_available` / `recovery_code_request`. */
     val peerName: String?
 
+    /** Peer device's credential kind ("ddg" / "3party"), learned during role election. Null before then. */
+    val peerKind: String?
+
     fun startScan(pastedUrl: String)
 
     fun startPresent()
@@ -134,7 +137,7 @@ class RealExchangeV2Runner @Inject constructor(
 
     @Volatile private var peerPublicKey: String? = null
 
-    @Volatile private var peerKind: String? = null
+    @Volatile private var _peerKind: String? = null
 
     @Volatile private var peerUserId: String? = null
 
@@ -160,6 +163,7 @@ class RealExchangeV2Runner @Inject constructor(
     override val linkingCode: String? get() = _linkingCode
     override val canStartAsPresenter: Boolean get() = true
     override val peerName: String? get() = _peerName
+    override val peerKind: String? get() = _peerKind
 
     // -----------------------------------------------------------------------
     // Entry points
@@ -251,7 +255,7 @@ class RealExchangeV2Runner @Inject constructor(
                     if (r.code == HTTP_CONFLICT) {
                         logcat { "Sync-ExchangeV2: channel_id $candidate already taken, retrying (${attempt + 1}/$MAX_CHANNEL_CREATE_RETRIES)" }
                     } else {
-                        emitSessionError("Failed to create channel: ${r.reason}")
+                        emitSessionError("Failed to create channel")
                         return null
                     }
                 }
@@ -302,7 +306,7 @@ class RealExchangeV2Runner @Inject constructor(
         ownKeyPair = null
         peerChannelId = null
         peerPublicKey = null
-        peerKind = null
+        _peerKind = null
         peerUserId = null
         _peerName = null
         _linkingCode = null
@@ -463,12 +467,12 @@ class RealExchangeV2Runner @Inject constructor(
                 peerPublicKey = message.publicKey
             }
             is ExchangeV2Message.RecoveryCodeAvailable -> {
-                peerKind = message.kind
+                _peerKind = message.kind
                 peerUserId = message.userId
                 _peerName = message.name
             }
             is ExchangeV2Message.RecoveryCodeRequest -> {
-                peerKind = message.kind
+                _peerKind = message.kind
                 peerUserId = null
                 _peerName = message.name
             }
@@ -501,12 +505,12 @@ class RealExchangeV2Runner @Inject constructor(
      */
     private fun autoElectRoleLocked(sm: ExchangeV2StateMachine) {
         val elected = electRole() ?: run {
-            logcat { "Sync-ExchangeV2: cannot auto-elect role yet (role=${_pairingRole}, peerKind=$peerKind)" }
+            logcat { "Sync-ExchangeV2: cannot auto-elect role yet (role=${_pairingRole}, peerKind=$_peerKind)" }
             return
         }
         logcat {
             "Sync-ExchangeV2: auto-electing $elected " +
-                "(own role=${_pairingRole}, own userId=${syncStore.userId}, peer kind=$peerKind, peer userId=$peerUserId)"
+                "(own role=${_pairingRole}, own userId=${syncStore.userId}, peer kind=$_peerKind, peer userId=$peerUserId)"
         }
         val electResult = sm.localTrigger(LocalTrigger.RoleElected(elected))
         emit(electResult.event)
@@ -527,7 +531,7 @@ class RealExchangeV2Runner @Inject constructor(
     private fun electRole(): Role? {
         val ownRole = _pairingRole ?: return null
         val ownUserId = syncStore.userId
-        val pKind = peerKind ?: return null
+        val pKind = _peerKind ?: return null
         val pUserId = peerUserId
         return when {
             ownUserId != null && pUserId == null -> Role.Host
@@ -642,7 +646,7 @@ class RealExchangeV2Runner @Inject constructor(
         // REVIEW: likely unreachable under eager-send ordering — confirm against the ordering spec
         // (Unified Algorithm 1214739740392701) and delete if dead.
         val sm = session ?: return
-        if (sm.currentState == ExchangeV2State.Negotiating && peerKind != null) {
+        if (sm.currentState == ExchangeV2State.Negotiating && _peerKind != null) {
             autoElectRoleLocked(sm)
         }
     }
@@ -661,11 +665,11 @@ class RealExchangeV2Runner @Inject constructor(
         // failure falls through to recovery_code_unavailable below.
         // peerKind is set during role election; reaching Host.Sending without it means something
         // upstream is broken — bail rather than silently assuming ddg.
-        val codeResult = when (peerKind) {
+        val codeResult = when (_peerKind) {
             "ddg" -> provisionForDdgPeer()
             "3party" -> provisionForThirdPartyPeer()
             null -> Result.Error(reason = "Host.Sending reached without a known peer kind")
-            else -> Result.Error(reason = "Unsupported peer kind '$peerKind'")
+            else -> Result.Error(reason = "Unsupported peer kind '$_peerKind'")
         }
         return when (codeResult) {
             is Result.Success -> {
@@ -678,7 +682,7 @@ class RealExchangeV2Runner @Inject constructor(
                 sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.RecoveryCodeResponse(json, recoveryCode))
             }
             is Result.Error -> {
-                logcat(ERROR) { "Sync-ExchangeV2: recovery code unavailable for peerKind=$peerKind: ${codeResult.reason}" }
+                logcat(ERROR) { "Sync-ExchangeV2: recovery code unavailable for peerKind=$_peerKind: ${codeResult.reason}" }
                 val json = """{"type":"recovery_code_unavailable"}"""
                 sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.RecoveryCodeUnavailable(json))
                 emitSessionError("Couldn't generate a recovery code: ${codeResult.reason}")
@@ -739,7 +743,7 @@ class RealExchangeV2Runner @Inject constructor(
                 true
             }
             is Result.Error -> {
-                emitSessionError("Failed to send ${outboundMessage.messageType}: ${r.reason}")
+                emitSessionError("Failed to send message to peer over channel")
                 false
             }
         }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixelParamRemovalPlugin.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixelParamRemovalPlugin.kt
@@ -57,6 +57,7 @@ class SyncPixelParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugi
             SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_SUCCESS.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_SETUP_ENDED_ABANDONED.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_SETUP_ENDED_SUCCESS.pixelName to PixelParameter.removeAtb(),
+            SyncPixelName.SYNC_SETUP_ENDED_FAILED.pixelName to PixelParameter.removeAtb(),
 
             SyncPixelName.SYNC_AUTO_RESTORE_TOGGLE_SHOWN.pixelName to PixelParameter.removeAtb(),
             SyncPixelName.SYNC_AUTO_RESTORE_TOGGLE_OPTED_OUT.pixelName to PixelParameter.removeAtb(),

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -26,14 +26,32 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.sync.api.engine.DeletableType
 import com.duckduckgo.sync.api.engine.SyncFeatureType
 import com.duckduckgo.sync.impl.API_CODE
+import com.duckduckgo.sync.impl.AccountErrorCodes
+import com.duckduckgo.sync.impl.DispatchOutcome
 import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.SyncCodeType
+import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_DAILY
 import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_DAILY_SUCCESS_RATE_PIXEL
 import com.duckduckgo.sync.impl.pixels.SyncPixelName.SYNC_OBJECT_LIMIT_EXCEEDED_DAILY
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.CONNECTED_DEVICES_WHEN_DELETING
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_FEATURE_PROMOTION_SOURCE
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_CODE_TYPE
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_CODE_VERSION
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_FLOW_VERSION
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_MY_KIND
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_MY_ROLE
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_PATH
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_PEER_KIND
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_REASON
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupFailureReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
 import com.duckduckgo.sync.impl.stats.SyncStatsRepository
 import com.duckduckgo.sync.store.SharedPrefsProvider
 import com.squareup.anvil.annotations.ContributesBinding
@@ -98,18 +116,80 @@ interface SyncPixels {
     fun fireUserSwitchedLoginError()
     fun fireTimeoutOnDeepLinkSetup()
     fun fireSyncBarcodeScreenShown(screenType: ScreenType)
-    fun fireSyncSetupFinishedSuccessfully(screenType: ScreenType)
-    fun fireSyncSetupAbandoned(screenType: ScreenType)
+    fun fireSyncSetupFinishedSuccessfully(
+        screenType: ScreenType,
+        path: SetupPath? = null,
+        myRole: SetupRole? = null,
+        peerKind: PeerKind? = null,
+    )
+    fun fireSyncSetupAbandoned(screenType: ScreenType, reason: CancellationReason? = null)
     fun fireSyncSetupManualCodeScreenShown(screenType: ScreenType)
-    fun fireSyncSetupCodePastedParseSuccess(screenType: ScreenType)
+    fun fireSyncSetupCodePastedParseSuccess(screenType: ScreenType, codeVersion: CodeVersion, codeType: SyncCodeType? = null)
     fun fireSyncSetupCodePastedParseFailure(screenType: ScreenType)
     fun fireSyncSetupCodeCopiedToClipboard(screenType: ScreenType)
     fun fireBarcodeScannerParseError(screenType: ScreenType)
-    fun fireBarcodeScannerParseSuccess(screenType: ScreenType)
+    fun fireBarcodeScannerParseSuccess(screenType: ScreenType, codeVersion: CodeVersion, codeType: SyncCodeType? = null)
+
+    /**
+     * "Setup failed" — a v2 setup that started (code recognized) then failed with an error (not a
+     * user cancellation). [path]/[myRole]/[peerKind] are best-effort and omitted when unknown.
+     */
+    fun fireSyncSetupFailed(
+        reason: SetupFailureReason,
+        path: SetupPath? = null,
+        myRole: SetupRole? = null,
+        peerKind: PeerKind? = null,
+    )
 
     enum class ScreenType(val value: String) {
         SYNC_CONNECT("connect"),
         SYNC_EXCHANGE("exchange"),
+    }
+
+    /** Protocol version of the code that was scanned/pasted, per the "Code recognized" telemetry. */
+    enum class CodeVersion(val value: String) {
+        V1("v1"),
+        V2("v2"),
+    }
+
+    /** Whether a successful setup was a recovery-code login or a device pairing. v2 only. */
+    enum class SetupPath(val value: String) {
+        RECOVERY("recovery"),
+        PAIRING("pairing"),
+    }
+
+    /** This device's elected role in a v2 pairing. */
+    enum class SetupRole(val value: String) {
+        HOST("host"),
+        JOINER("joiner"),
+    }
+
+    /** The peer device's credential kind in a v2 pairing. */
+    enum class PeerKind(val value: String) {
+        DDG("ddg"),
+        THIRD_PARTY("3party"),
+    }
+
+    /**
+     * Why a setup was cancelled, per the "Cancellation" telemetry. Based on the v2 protocol state at
+     * the moment of cancellation: [SCANNING_CANCELLED] before the exchange engages a peer,
+     * [CANCELLED_BEFORE_FINISHED] mid-exchange, [CONFIRMATION_DENIED] when this device denied the prompt.
+     */
+    enum class CancellationReason(val value: String) {
+        SCANNING_CANCELLED("scanning_cancelled"),
+        CONFIRMATION_DENIED("sync_confirmation_denied"),
+        CANCELLED_BEFORE_FINISHED("cancelled_before_finished"),
+    }
+
+    /** Why a v2 setup failed, per the "Setup failed" telemetry. Aligned with the error codes we handle. */
+    enum class SetupFailureReason(val value: String) {
+        NEEDS_UPGRADE("needs_upgrade"),
+        ALREADY_UPGRADED("already_upgraded"),
+        INVALID_CREDENTIALS("invalid_credentials"),
+        PAIRING_UNAVAILABLE("pairing_unavailable"),
+        PROTOCOL_ERROR("protocol_error"),
+        TRANSPORT_FAILURE("transport_failure"),
+        UNEXPECTED_FAILURE("unexpected_failure"),
     }
     fun fireSetupDeepLinkFlowStarted()
     fun fireSetupDeepLinkFlowSuccess()
@@ -145,10 +225,62 @@ class RealSyncPixels @Inject constructor(
     private val pixel: Pixel,
     private val statsRepository: SyncStatsRepository,
     private val sharedPrefsProvider: SharedPrefsProvider,
+    private val syncFeature: SyncFeature,
 ) : SyncPixels {
 
     private val preferences: SharedPreferences by lazy {
         sharedPrefsProvider.getSharedPrefs(SYNC_PIXELS_PREF_FILE)
+    }
+
+    /**
+     * Common metadata describing the setup flow this device is opening:
+     * - [SYNC_SETUP_FLOW_VERSION]: "v2" when the device is on the v2 connect/exchange stack
+     *   ([SyncFeature.canUseV2ConnectFlow]), "v1" otherwise. Independent of which code version is
+     *   actually displayed (that is gated separately by [SyncFeature.canShowV2ConnectCode]).
+     * - [SYNC_SETUP_MY_KIND]: always "ddg" — this is the native DuckDuckGo client.
+     */
+    private fun setupFlowMetadata(): Map<String, String> = mapOf(
+        SYNC_SETUP_FLOW_VERSION to if (syncFeature.canUseV2ConnectFlow().isEnabled()) FLOW_VERSION_V2 else FLOW_VERSION_V1,
+        SYNC_SETUP_MY_KIND to MY_KIND_DDG,
+    )
+
+    /**
+     * Params for the "Code recognized" pixels (scanner/manual-entry success): the screen [source],
+     * the recognized [codeVersion] (what was scanned/pasted), the common [setupFlowMetadata]
+     * (flow_version + my_kind), and — only when known — the [codeType]. The legacy/v1 path does not
+     * report a code type, so [codeType] is omitted there; the v2 path always supplies it.
+     */
+    private fun recognizedCodeParams(
+        screenType: ScreenType,
+        codeVersion: CodeVersion,
+        codeType: SyncCodeType?,
+    ): Map<String, String> = buildMap {
+        put(SYNC_SETUP_SCREEN_TYPE, screenType.value)
+        put(SYNC_SETUP_CODE_VERSION, codeVersion.value)
+        when (codeType) {
+            SyncCodeType.RECOVERY -> put(SYNC_SETUP_CODE_TYPE, CODE_TYPE_RECOVERY)
+            SyncCodeType.LINKING -> put(SYNC_SETUP_CODE_TYPE, CODE_TYPE_LINKING)
+            null -> {}
+        }
+        putAll(setupFlowMetadata())
+    }
+
+    /**
+     * Params for the "Setup success" pixel: the screen [source], the common [setupFlowMetadata]
+     * (flow_version + my_kind), and — v2 only — the [path] (recovery/pairing) plus, for pairing, the
+     * elected [myRole] and the [peerKind]. Each is omitted when null.
+     */
+    private fun setupSuccessParams(
+        screenType: ScreenType,
+        path: SetupPath?,
+        myRole: SetupRole?,
+        peerKind: PeerKind?,
+    ): Map<String, String> = buildMap {
+        put(SYNC_SETUP_SCREEN_TYPE, screenType.value)
+        if (path != null) put(SYNC_SETUP_PATH, path.value)
+        if (myRole != null) put(SYNC_SETUP_MY_ROLE, myRole.value)
+        if (peerKind != null) put(SYNC_SETUP_PEER_KIND, peerKind.value)
+        putAll(setupFlowMetadata())
     }
 
     override fun fireDailyPixel() {
@@ -378,32 +510,57 @@ class RealSyncPixels @Inject constructor(
     }
 
     override fun fireSyncBarcodeScreenShown(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value) + setupFlowMetadata()
         pixel.fire(SyncPixelName.SYNC_SETUP_BARCODE_SCREEN_SHOWN, parameters = params)
     }
 
-    override fun fireSyncSetupAbandoned(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+    override fun fireSyncSetupAbandoned(screenType: ScreenType, reason: CancellationReason?) {
+        val params = buildMap {
+            put(SYNC_SETUP_SCREEN_TYPE, screenType.value)
+            if (reason != null) put(SYNC_SETUP_REASON, reason.value)
+            putAll(setupFlowMetadata())
+        }
         pixel.fire(SyncPixelName.SYNC_SETUP_ENDED_ABANDONED, parameters = params)
     }
 
-    override fun fireSyncSetupFinishedSuccessfully(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+    override fun fireSyncSetupFinishedSuccessfully(
+        screenType: ScreenType,
+        path: SetupPath?,
+        myRole: SetupRole?,
+        peerKind: PeerKind?,
+    ) {
+        val params = setupSuccessParams(screenType, path, myRole, peerKind)
         pixel.fire(SyncPixelName.SYNC_SETUP_ENDED_SUCCESS, parameters = params)
     }
 
+    override fun fireSyncSetupFailed(
+        reason: SetupFailureReason,
+        path: SetupPath?,
+        myRole: SetupRole?,
+        peerKind: PeerKind?,
+    ) {
+        val params = buildMap {
+            put(SYNC_SETUP_REASON, reason.value)
+            if (path != null) put(SYNC_SETUP_PATH, path.value)
+            if (myRole != null) put(SYNC_SETUP_MY_ROLE, myRole.value)
+            if (peerKind != null) put(SYNC_SETUP_PEER_KIND, peerKind.value)
+            putAll(setupFlowMetadata())
+        }
+        pixel.fire(SyncPixelName.SYNC_SETUP_ENDED_FAILED, parameters = params)
+    }
+
     override fun fireSyncSetupManualCodeScreenShown(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value) + setupFlowMetadata()
         pixel.fire(SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTRY_SCREEN_SHOWN, parameters = params)
     }
 
-    override fun fireSyncSetupCodePastedParseSuccess(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+    override fun fireSyncSetupCodePastedParseSuccess(screenType: ScreenType, codeVersion: CodeVersion, codeType: SyncCodeType?) {
+        val params = recognizedCodeParams(screenType, codeVersion, codeType)
         pixel.fire(SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_SUCCESS, parameters = params)
     }
 
     override fun fireSyncSetupCodePastedParseFailure(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value) + setupFlowMetadata()
         pixel.fire(SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_FAILED, parameters = params)
     }
 
@@ -412,13 +569,13 @@ class RealSyncPixels @Inject constructor(
         pixel.fire(SyncPixelName.SYNC_SETUP_BARCODE_CODE_COPIED, parameters = params)
     }
 
-    override fun fireBarcodeScannerParseSuccess(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+    override fun fireBarcodeScannerParseSuccess(screenType: ScreenType, codeVersion: CodeVersion, codeType: SyncCodeType?) {
+        val params = recognizedCodeParams(screenType, codeVersion, codeType)
         pixel.fire(SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_SUCCESS, parameters = params)
     }
 
     override fun fireBarcodeScannerParseError(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value)
+        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value) + setupFlowMetadata()
         pixel.fire(SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_FAILED, parameters = params)
     }
 
@@ -506,6 +663,11 @@ class RealSyncPixels @Inject constructor(
 
     companion object {
         private const val SYNC_PIXELS_PREF_FILE = "com.duckduckgo.sync.pixels.v1"
+        private const val FLOW_VERSION_V1 = "v1"
+        private const val FLOW_VERSION_V2 = "v2"
+        private const val MY_KIND_DDG = "ddg"
+        private const val CODE_TYPE_RECOVERY = "recovery"
+        private const val CODE_TYPE_LINKING = "linking"
     }
 }
 
@@ -573,6 +735,7 @@ enum class SyncPixelName(override val pixelName: String) : Pixel.PixelName {
     SYNC_SETUP_MANUAL_CODE_ENTERED_FAILED("sync_setup_manual_code_entered_failed"),
     SYNC_SETUP_ENDED_ABANDONED("sync_setup_ended_abandoned"),
     SYNC_SETUP_ENDED_SUCCESS("sync_setup_ended_successful"),
+    SYNC_SETUP_ENDED_FAILED("sync_setup_ended_failed"),
     SYNC_USER_CONFIRMED_TO_TURN_OFF_SYNC("sync_disabled"),
     SYNC_USER_CONFIRMED_TO_TURN_OFF_SYNC_AND_DELETE("sync_disabledanddeleted"),
     SYNC_SETUP_PROMO_BOOKMARK_ADDED_DIALOG_SHOWN("sync_setup_promo_bookmark_added_dialog_shown"),
@@ -615,6 +778,14 @@ object SyncPixelParameters {
     const val SYNC_FEATURE_PROMOTION_SOURCE = "source"
     const val GET_OTHER_DEVICES_SCREEN_LAUNCH_SOURCE = "source"
     const val SYNC_SETUP_SCREEN_TYPE = "source"
+    const val SYNC_SETUP_FLOW_VERSION = "flow_version"
+    const val SYNC_SETUP_MY_KIND = "my_kind"
+    const val SYNC_SETUP_CODE_VERSION = "code_version"
+    const val SYNC_SETUP_CODE_TYPE = "code_type"
+    const val SYNC_SETUP_PATH = "path"
+    const val SYNC_SETUP_MY_ROLE = "my_role"
+    const val SYNC_SETUP_PEER_KIND = "peer_kind"
+    const val SYNC_SETUP_REASON = "reason"
     const val CONNECTED_DEVICES_WHEN_DELETING = "connected_devices"
 
     const val AUTO_RESTORE_SOURCE = "source"
@@ -642,5 +813,55 @@ object SyncPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
             SyncPixelName.SYNC_RESCOPE_TOKEN_FAILURE.pixelName to removeAtb(),
             SyncPixelName.SYNC_AI_CHAT_ACTIVE.pixelName to removeAtb(),
         )
+    }
+}
+
+/**
+ * Maps a v2 [com.duckduckgo.sync.impl.DispatchOutcome.Failed] error code to the "Setup failed"
+ * telemetry [SetupFailureReason], aligned with the error codes we already handle. Cancellation codes
+ * (`PAIRING_CANCELLED`, `PAIRING_REJECTED`) are excluded by the caller, so they fall to the catch-all.
+ */
+internal fun Int.toSetupFailureReason(): SetupFailureReason = when (this) {
+    AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED.code -> SetupFailureReason.ALREADY_UPGRADED
+    AccountErrorCodes.LOGIN_FAILED.code,
+    AccountErrorCodes.INVALID_CODE.code,
+    AccountErrorCodes.EXCHANGE_FAILED.code,
+    -> SetupFailureReason.INVALID_CREDENTIALS
+    AccountErrorCodes.PAIRING_UNAVAILABLE.code -> SetupFailureReason.PAIRING_UNAVAILABLE
+    AccountErrorCodes.NEGOTIATION_ABORTED.code,
+    AccountErrorCodes.NO_RECOVERY_CODE.code,
+    -> SetupFailureReason.PROTOCOL_ERROR
+    AccountErrorCodes.PAIRING_FAILED.code -> SetupFailureReason.TRANSPORT_FAILURE
+    else -> SetupFailureReason.UNEXPECTED_FAILURE
+}
+
+/**
+ * Fire the "Setup failed" pixel for a v2 error [outcome]. No-op for non-error outcomes. User
+ * cancellations (`PAIRING_CANCELLED`, `PAIRING_REJECTED`) are intentionally skipped — they are not
+ * setup errors (the latter pending the cancellation-telemetry follow-up).
+ */
+
+internal fun SyncPixels.fireSetupFailed(outcome: DispatchOutcome) {
+    when (outcome) {
+        is DispatchOutcome.UpgradeRequired ->
+            fireSyncSetupFailed(SetupFailureReason.NEEDS_UPGRADE, outcome.path, outcome.myRole, outcome.peerKind)
+        is DispatchOutcome.Failed -> {
+            if (outcome.code == AccountErrorCodes.PAIRING_CANCELLED.code || outcome.code == AccountErrorCodes.PAIRING_REJECTED.code) {
+                return
+            }
+            fireSyncSetupFailed(outcome.code.toSetupFailureReason(), outcome.path, outcome.myRole, outcome.peerKind)
+        }
+        else -> {}
+    }
+}
+
+/**
+ * Fire the "Cancellation" pixel (sync_setup_ended_abandoned) when a v2 outcome is this device's own
+ * confirmation denial ([AccountErrorCodes.PAIRING_CANCELLED]). Peer denials (`PAIRING_REJECTED`) are
+ * intentionally ignored — the peer reports its own cancel. No-op for any other outcome.
+ */
+internal fun SyncPixels.fireSetupCancelledIfDenied(outcome: DispatchOutcome, screenType: SyncPixels.ScreenType) {
+    if (outcome is DispatchOutcome.Failed && outcome.code == AccountErrorCodes.PAIRING_CANCELLED.code) {
+        fireSyncSetupAbandoned(screenType, CancellationReason.CONFIRMATION_DENIED)
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.databinding.ActivityEnterCodeBinding
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState.Idle
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState.Loading
@@ -122,8 +123,8 @@ class EnterCodeActivity : DuckDuckGoActivity() {
                 setResult(RESULT_OK, resultIntent)
                 finish()
             }
-            is Command.AskJoinerConfirmation -> askJoinerConfirmation(command.peerName)
-            is Command.AskHostConfirmation -> askHostConfirmation(command.peerName)
+            is Command.AskJoinerConfirmation -> askJoinerConfirmation(command.peerName, command.peerKind)
+            is Command.AskHostConfirmation -> askHostConfirmation(command.peerName, command.peerKind)
             Command.FinishWithError -> {
                 setResult(RESULT_CANCELED)
                 finish()
@@ -131,15 +132,10 @@ class EnterCodeActivity : DuckDuckGoActivity() {
         }
     }
 
-    private fun askJoinerConfirmation(peerName: String?) {
-        val message = if (peerName.isNullOrBlank()) {
-            getString(R.string.sync_v2_joiner_confirmation_message_unknown_peer)
-        } else {
-            getString(R.string.sync_v2_joiner_confirmation_message, peerName)
-        }
+    private fun askJoinerConfirmation(peerName: String?, peerKind: PeerKind?) {
         TextAlertDialogBuilder(this)
             .setTitle(R.string.sync_v2_joiner_confirmation_title)
-            .setMessage(message)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
             .setPositiveButton(R.string.sync_v2_joiner_confirmation_positive)
             .setNegativeButton(R.string.sync_v2_joiner_confirmation_negative)
             .addEventListener(
@@ -150,15 +146,10 @@ class EnterCodeActivity : DuckDuckGoActivity() {
             ).show()
     }
 
-    private fun askHostConfirmation(peerName: String?) {
-        val message = if (peerName.isNullOrBlank()) {
-            getString(R.string.sync_v2_host_confirmation_message_unknown_peer)
-        } else {
-            getString(R.string.sync_v2_host_confirmation_message, peerName)
-        }
+    private fun askHostConfirmation(peerName: String?, peerKind: PeerKind?) {
         TextAlertDialogBuilder(this)
             .setTitle(R.string.sync_v2_host_confirmation_title)
-            .setMessage(message)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
             .setPositiveButton(R.string.sync_v2_host_confirmation_positive)
             .setNegativeButton(R.string.sync_v2_host_confirmation_negative)
             .addEventListener(

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
@@ -171,8 +171,8 @@ class EnterCodeActivity : DuckDuckGoActivity() {
 
     private fun showError(it: ShowError) {
         TextAlertDialogBuilder(this)
-            .setTitle(it.title)
-            .setMessage(if (it.reason.isBlank()) getString(it.message) else getString(it.message) + "\n" + it.reason)
+            .setTitle(R.string.sync_dialog_error_title)
+            .setMessage(getString(it.message) + "\n" + it.reason)
             .setPositiveButton(R.string.sync_dialog_error_ok)
             .addEventListener(
                 object : TextAlertDialogBuilder.EventListener() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
@@ -113,6 +113,8 @@ class EnterCodeActivity : DuckDuckGoActivity() {
                 showError(command)
             }
 
+            is Command.ShowV2Error -> showV2PairingError(command.content) { viewModel.onErrorDialogDismissed() }
+
             is AskToSwitchAccount -> askUserToSwitchAccount(command)
             SwitchAccountSuccess -> {
                 val resultIntent = Intent()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
@@ -122,6 +122,7 @@ class EnterCodeActivity : DuckDuckGoActivity() {
             }
             is Command.AskJoinerConfirmation -> askJoinerConfirmation(command.peerName)
             is Command.AskHostConfirmation -> askHostConfirmation(command.peerName)
+            is Command.ShowAlreadyConnected -> showAlreadyConnected()
         }
     }
 
@@ -159,6 +160,20 @@ class EnterCodeActivity : DuckDuckGoActivity() {
                 object : TextAlertDialogBuilder.EventListener() {
                     override fun onPositiveButtonClicked() { viewModel.onHostConfirmed() }
                     override fun onNegativeButtonClicked() { viewModel.onHostDenied() }
+                },
+            ).show()
+    }
+
+    private fun showAlreadyConnected() {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_already_paired_title)
+            .setMessage(R.string.sync_v2_already_paired_message)
+            .setPositiveButton(R.string.sync_dialog_error_ok)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() {
+                        viewModel.onAlreadyConnectedAcknowledged()
+                    }
                 },
             ).show()
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
@@ -165,8 +165,8 @@ class EnterCodeActivity : DuckDuckGoActivity() {
 
     private fun showError(it: ShowError) {
         TextAlertDialogBuilder(this)
-            .setTitle(R.string.sync_dialog_error_title)
-            .setMessage(getString(it.message) + "\n" + it.reason)
+            .setTitle(it.title)
+            .setMessage(if (it.reason.isBlank()) getString(it.message) else getString(it.message) + "\n" + it.reason)
             .setPositiveButton(R.string.sync_dialog_error_ok)
             .addEventListener(
                 object : TextAlertDialogBuilder.EventListener() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
@@ -122,7 +122,10 @@ class EnterCodeActivity : DuckDuckGoActivity() {
             }
             is Command.AskJoinerConfirmation -> askJoinerConfirmation(command.peerName)
             is Command.AskHostConfirmation -> askHostConfirmation(command.peerName)
-            is Command.ShowAlreadyConnected -> showAlreadyConnected()
+            Command.FinishWithError -> {
+                setResult(RESULT_CANCELED)
+                finish()
+            }
         }
     }
 
@@ -164,20 +167,6 @@ class EnterCodeActivity : DuckDuckGoActivity() {
             ).show()
     }
 
-    private fun showAlreadyConnected() {
-        TextAlertDialogBuilder(this)
-            .setTitle(R.string.sync_v2_already_paired_title)
-            .setMessage(R.string.sync_v2_already_paired_message)
-            .setPositiveButton(R.string.sync_dialog_error_ok)
-            .addEventListener(
-                object : TextAlertDialogBuilder.EventListener() {
-                    override fun onPositiveButtonClicked() {
-                        viewModel.onAlreadyConnectedAcknowledged()
-                    }
-                },
-            ).show()
-    }
-
     private fun showError(it: ShowError) {
         TextAlertDialogBuilder(this)
             .setTitle(it.title)
@@ -185,8 +174,7 @@ class EnterCodeActivity : DuckDuckGoActivity() {
             .setPositiveButton(R.string.sync_dialog_error_ok)
             .addEventListener(
                 object : TextAlertDialogBuilder.EventListener() {
-                    override fun onPositiveButtonClicked() {
-                    }
+                    override fun onPositiveButtonClicked() { viewModel.onErrorDialogDismissed() }
                 },
             ).show()
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
@@ -136,7 +136,7 @@ class EnterCodeViewModel @Inject constructor(
             }
             is RouteDecision.V2InProgress -> {
                 logcat { "Sync-CodeDispatch: EnterCodeViewModel observing V2InProgress" }
-                decision.outcomes.collect { outcome -> handleV2Outcome(outcome, previousPrimaryKey, pastedCode) }
+                decision.outcomes.collect { outcome -> handleV2Outcome(outcome, previousPrimaryKey) }
             }
         }
     }
@@ -145,7 +145,6 @@ class EnterCodeViewModel @Inject constructor(
     private suspend fun handleV2Outcome(
         outcome: DispatchOutcome,
         previousPrimaryKey: String,
-        pastedCode: String,
     ) {
         when (outcome) {
             is DispatchOutcome.LoggedIn -> onLoginSuccess(previousPrimaryKey)
@@ -158,7 +157,13 @@ class EnterCodeViewModel @Inject constructor(
                     reason = "Code requires protocol v${outcome.codeMajor}",
                 ),
             )
-            is DispatchOutcome.Failed -> processError(Error(code = outcome.code, reason = outcome.reason), pastedCode)
+            is DispatchOutcome.Failed -> {
+                // v2 failures must always surface a visible error — never the v1 processError catch-all
+                // (else -> null) which silently no-ops an unrecognised code, and never the v1
+                // AskToSwitchAccount dialog (v2 switches transparently in the dispatcher).
+                viewState.value = viewState.value.copy(authState = AuthState.Idle)
+                command.send(ShowError(message = outcome.code.toV2PairingErrorMessage(), reason = outcome.reason))
+            }
             is DispatchOutcome.JoinerConfirmationRequested ->
                 command.send(Command.AskJoinerConfirmation(outcome.peerName))
             is DispatchOutcome.HostConfirmationRequested ->

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
@@ -94,11 +94,7 @@ class EnterCodeViewModel @Inject constructor(
     sealed class Command {
         data object LoginSuccess : Command()
         data class AskToSwitchAccount(val encodedStringCode: String) : Command()
-        data class ShowError(
-            @StringRes val message: Int,
-            val reason: String = "",
-            @StringRes val title: Int = R.string.sync_dialog_error_title,
-        ) : Command()
+        data class ShowError(@StringRes val message: Int, val reason: String = "") : Command()
         data object SwitchAccountSuccess : Command()
 
         /** v2 §"Exchange Confirmations": prompt user "Sync your data with [peerName]?". */

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
@@ -77,7 +77,6 @@ class EnterCodeViewModel @Inject constructor(
 
     private val viewState = MutableStateFlow(ViewState())
     private var codeType: Code = Code.RECOVERY_CODE
-    private var alreadyConnectedPreviousPrimaryKey: String = ""
 
     fun viewState(): Flow<ViewState> = viewState
 
@@ -108,8 +107,8 @@ class EnterCodeViewModel @Inject constructor(
         /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
         data class AskHostConfirmation(val peerName: String?) : Command()
 
-        /** v2 §"Same-account case": inform the user then land connected on OK. */
-        data object ShowAlreadyConnected : Command()
+        /** Dismiss the dialog and close the flow with RESULT_CANCELED */
+        data object FinishWithError : Command()
     }
 
     fun onPasteCodeClicked() {
@@ -157,16 +156,15 @@ class EnterCodeViewModel @Inject constructor(
         when (outcome) {
             is DispatchOutcome.LoggedIn -> onLoginSuccess(previousPrimaryKey)
             is DispatchOutcome.AlreadyConnected -> {
-                alreadyConnectedPreviousPrimaryKey = previousPrimaryKey
                 viewState.value = viewState.value.copy(authState = AuthState.Idle)
-                command.send(Command.ShowAlreadyConnected)
+                command.send(ShowError(message = v2AlreadyPairedError.message, title = v2AlreadyPairedError.title))
             }
             is DispatchOutcome.UpgradeRequired -> {
+                viewState.value = viewState.value.copy(authState = AuthState.Idle)
                 logcat { "Sync v2: upgrade required, peer needs protocol v${outcome.codeMajor}" }
                 command.send(ShowError(message = v2UpgradeRequiredError.message, title = v2UpgradeRequiredError.title))
             }
             is DispatchOutcome.Failed -> {
-                // Always surface v2 failures via the mapper; bypass the v1 catch-all (silent no-op) and AskToSwitchAccount.
                 viewState.value = viewState.value.copy(authState = AuthState.Idle)
                 val content = outcome.code.toV2PairingError()
                 command.send(ShowError(message = content.message, title = content.title))
@@ -184,9 +182,9 @@ class EnterCodeViewModel @Inject constructor(
     fun onHostConfirmed() { codeDispatcher.confirmHost() }
     fun onHostDenied() { codeDispatcher.denyHost() }
 
-    fun onAlreadyConnectedAcknowledged() {
+    fun onErrorDialogDismissed() {
         viewModelScope.launch(dispatchers.io()) {
-            onLoginSuccess(alreadyConnectedPreviousPrimaryKey)
+            command.send(Command.FinishWithError)
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
@@ -77,6 +77,7 @@ class EnterCodeViewModel @Inject constructor(
 
     private val viewState = MutableStateFlow(ViewState())
     private var codeType: Code = Code.RECOVERY_CODE
+    private var alreadyConnectedPreviousPrimaryKey: String = ""
 
     fun viewState(): Flow<ViewState> = viewState
 
@@ -106,6 +107,9 @@ class EnterCodeViewModel @Inject constructor(
 
         /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
         data class AskHostConfirmation(val peerName: String?) : Command()
+
+        /** v2 §"Same-account case": inform the user then land connected on OK. */
+        data object ShowAlreadyConnected : Command()
     }
 
     fun onPasteCodeClicked() {
@@ -152,8 +156,11 @@ class EnterCodeViewModel @Inject constructor(
     ) {
         when (outcome) {
             is DispatchOutcome.LoggedIn -> onLoginSuccess(previousPrimaryKey)
-            // Spec §"Same-account case": friendly finish, no account change. Surface as success.
-            is DispatchOutcome.AlreadyConnected -> onLoginSuccess(previousPrimaryKey)
+            is DispatchOutcome.AlreadyConnected -> {
+                alreadyConnectedPreviousPrimaryKey = previousPrimaryKey
+                viewState.value = viewState.value.copy(authState = AuthState.Idle)
+                command.send(Command.ShowAlreadyConnected)
+            }
             is DispatchOutcome.UpgradeRequired -> {
                 logcat { "Sync v2: upgrade required, peer needs protocol v${outcome.codeMajor}" }
                 command.send(ShowError(message = v2UpgradeRequiredError.message, title = v2UpgradeRequiredError.title))
@@ -176,6 +183,12 @@ class EnterCodeViewModel @Inject constructor(
     fun onJoinerDenied() { codeDispatcher.denyJoiner() }
     fun onHostConfirmed() { codeDispatcher.confirmHost() }
     fun onHostDenied() { codeDispatcher.denyHost() }
+
+    fun onAlreadyConnectedAcknowledged() {
+        viewModelScope.launch(dispatchers.io()) {
+            onLoginSuccess(alreadyConnectedPreviousPrimaryKey)
+        }
+    }
 
     private suspend fun onLoginSuccess(previousPrimaryKey: String) {
         val postProcessCodePK = syncAccountRepository.getAccountInfo().primaryKey

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
@@ -111,7 +111,7 @@ class EnterCodeViewModel @Inject constructor(
         data object FinishWithError : Command()
 
         /** v2 pairing terminal-outcome dialog: title-primary copy, optional message, "Got It" button. */
-        data class ShowV2Error(val content: V2PairingErrorContent) : Command()
+        internal data class ShowV2Error(val content: V2PairingErrorContent) : Command()
     }
 
     fun onPasteCodeClicked() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
@@ -158,9 +158,7 @@ class EnterCodeViewModel @Inject constructor(
                 ),
             )
             is DispatchOutcome.Failed -> {
-                // v2 failures must always surface a visible error — never the v1 processError catch-all
-                // (else -> null) which silently no-ops an unrecognised code, and never the v1
-                // AskToSwitchAccount dialog (v2 switches transparently in the dispatcher).
+                // Always surface v2 failures via the helper; bypass the v1 catch-all (silent no-op) and AskToSwitchAccount.
                 viewState.value = viewState.value.copy(authState = AuthState.Idle)
                 command.send(ShowError(message = outcome.code.toV2PairingErrorMessage(), reason = outcome.reason))
             }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
@@ -154,13 +154,10 @@ class EnterCodeViewModel @Inject constructor(
             is DispatchOutcome.LoggedIn -> onLoginSuccess(previousPrimaryKey)
             // Spec §"Same-account case": friendly finish, no account change. Surface as success.
             is DispatchOutcome.AlreadyConnected -> onLoginSuccess(previousPrimaryKey)
-            // Peer needs a newer protocol major — show a visible "please update" error. (follow-up: 1215484651575360)
-            is DispatchOutcome.UpgradeRequired -> command.send(
-                Command.ShowError(
-                    message = R.string.sync_flows_disabled_new_version,
-                    reason = "Code requires protocol v${outcome.codeMajor}",
-                ),
-            )
+            is DispatchOutcome.UpgradeRequired -> {
+                logcat { "Sync v2: upgrade required, peer needs protocol v${outcome.codeMajor}" }
+                command.send(ShowError(message = v2UpgradeRequiredError.message, title = v2UpgradeRequiredError.title))
+            }
             is DispatchOutcome.Failed -> {
                 // Always surface v2 failures via the mapper; bypass the v1 catch-all (silent no-op) and AskToSwitchAccount.
                 viewState.value = viewState.value.copy(authState = AuthState.Idle)

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
@@ -103,10 +103,7 @@ class EnterCodeViewModel @Inject constructor(
         /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
         data class AskHostConfirmation(val peerName: String?) : Command()
 
-        /** Dismiss the dialog and close the flow with RESULT_CANCELED */
         data object FinishWithError : Command()
-
-        /** v2 pairing terminal-outcome dialog: title-primary copy, optional message, "Got It" button. */
         internal data class ShowV2Error(val content: V2PairingErrorContent) : Command()
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
@@ -109,6 +109,9 @@ class EnterCodeViewModel @Inject constructor(
 
         /** Dismiss the dialog and close the flow with RESULT_CANCELED */
         data object FinishWithError : Command()
+
+        /** v2 pairing terminal-outcome dialog: title-primary copy, optional message, "Got It" button. */
+        data class ShowV2Error(val content: V2PairingErrorContent) : Command()
     }
 
     fun onPasteCodeClicked() {
@@ -157,17 +160,16 @@ class EnterCodeViewModel @Inject constructor(
             is DispatchOutcome.LoggedIn -> onLoginSuccess(previousPrimaryKey)
             is DispatchOutcome.AlreadyConnected -> {
                 viewState.value = viewState.value.copy(authState = AuthState.Idle)
-                command.send(ShowError(message = v2AlreadyPairedError.message, title = v2AlreadyPairedError.title))
+                command.send(Command.ShowV2Error(v2AlreadyPairedError))
             }
             is DispatchOutcome.UpgradeRequired -> {
                 viewState.value = viewState.value.copy(authState = AuthState.Idle)
                 logcat { "Sync v2: upgrade required, peer needs protocol v${outcome.codeMajor}" }
-                command.send(ShowError(message = v2UpgradeRequiredError.message, title = v2UpgradeRequiredError.title))
+                command.send(Command.ShowV2Error(v2UpgradeRequiredError))
             }
             is DispatchOutcome.Failed -> {
                 viewState.value = viewState.value.copy(authState = AuthState.Idle)
-                val content = outcome.code.toV2PairingError()
-                command.send(ShowError(message = content.message, title = content.title))
+                command.send(Command.ShowV2Error(outcome.code.toV2PairingError()))
             }
             is DispatchOutcome.JoinerConfirmationRequested ->
                 command.send(Command.AskJoinerConfirmation(outcome.peerName))

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
@@ -94,7 +94,11 @@ class EnterCodeViewModel @Inject constructor(
     sealed class Command {
         data object LoginSuccess : Command()
         data class AskToSwitchAccount(val encodedStringCode: String) : Command()
-        data class ShowError(@StringRes val message: Int, val reason: String = "") : Command()
+        data class ShowError(
+            @StringRes val message: Int,
+            val reason: String = "",
+            @StringRes val title: Int = R.string.sync_dialog_error_title,
+        ) : Command()
         data object SwitchAccountSuccess : Command()
 
         /** v2 §"Exchange Confirmations": prompt user "Sync your data with [peerName]?". */

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
@@ -44,7 +44,12 @@ import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.onFailure
 import com.duckduckgo.sync.impl.onSuccess
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
+import com.duckduckgo.sync.impl.pixels.fireSetupFailed
 import com.duckduckgo.sync.impl.ui.EnterCodeActivity.Companion.Code
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.AskToSwitchAccount
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.LoginSuccess
@@ -98,10 +103,10 @@ class EnterCodeViewModel @Inject constructor(
         data object SwitchAccountSuccess : Command()
 
         /** v2 §"Exchange Confirmations": prompt user "Sync your data with [peerName]?". */
-        data class AskJoinerConfirmation(val peerName: String?) : Command()
+        data class AskJoinerConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
 
         /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
-        data class AskHostConfirmation(val peerName: String?) : Command()
+        data class AskHostConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
 
         data object FinishWithError : Command()
         internal data class ShowV2Error(val content: V2PairingErrorContent) : Command()
@@ -139,6 +144,7 @@ class EnterCodeViewModel @Inject constructor(
             }
             is RouteDecision.V2InProgress -> {
                 logcat { "Sync-CodeDispatch: EnterCodeViewModel observing V2InProgress" }
+                syncPixels.fireSyncSetupCodePastedParseSuccess(codeType.asScreenType(), CodeVersion.V2, decision.codeType)
                 decision.outcomes.collect { outcome -> handleV2Outcome(outcome, previousPrimaryKey) }
             }
         }
@@ -149,8 +155,9 @@ class EnterCodeViewModel @Inject constructor(
         outcome: DispatchOutcome,
         previousPrimaryKey: String,
     ) {
+        syncPixels.fireSetupFailed(outcome)
         when (outcome) {
-            is DispatchOutcome.LoggedIn -> onLoginSuccess(previousPrimaryKey)
+            is DispatchOutcome.LoggedIn -> onLoginSuccess(previousPrimaryKey, outcome.path, outcome.myRole, outcome.peerKind)
             is DispatchOutcome.AlreadyConnected -> {
                 viewState.value = viewState.value.copy(authState = AuthState.Idle)
                 command.send(Command.ShowV2Error(v2AlreadyPairedError))
@@ -165,9 +172,9 @@ class EnterCodeViewModel @Inject constructor(
                 command.send(Command.ShowV2Error(outcome.code.toV2PairingError()))
             }
             is DispatchOutcome.JoinerConfirmationRequested ->
-                command.send(Command.AskJoinerConfirmation(outcome.peerName))
+                command.send(Command.AskJoinerConfirmation(outcome.peerName, outcome.peerKind))
             is DispatchOutcome.HostConfirmationRequested ->
-                command.send(Command.AskHostConfirmation(outcome.peerName))
+                command.send(Command.AskHostConfirmation(outcome.peerName, outcome.peerKind))
             is DispatchOutcome.LinkingCodeReady -> {} // No-op; used only by presentV2() flow
         }
     }
@@ -183,7 +190,12 @@ class EnterCodeViewModel @Inject constructor(
         }
     }
 
-    private suspend fun onLoginSuccess(previousPrimaryKey: String) {
+    private suspend fun onLoginSuccess(
+        previousPrimaryKey: String,
+        path: SetupPath? = null,
+        myRole: SetupRole? = null,
+        peerKind: PeerKind? = null,
+    ) {
         val postProcessCodePK = syncAccountRepository.getAccountInfo().primaryKey
         val userSwitchedAccount = previousPrimaryKey.isNotBlank() && previousPrimaryKey != postProcessCodePK
         val commandSuccess = if (userSwitchedAccount) {
@@ -192,6 +204,9 @@ class EnterCodeViewModel @Inject constructor(
         } else {
             LoginSuccess
         }
+        // Owns the "Setup success" pixel for codes entered here; the launching screen fires only its
+        // login pixel on the result, so this does not double-count.
+        syncPixels.fireSyncSetupFinishedSuccessfully(codeType.asScreenType(), path, myRole, peerKind)
         command.send(commandSuccess)
     }
 
@@ -302,7 +317,7 @@ class EnterCodeViewModel @Inject constructor(
     private fun SyncAuthCode.onCodePasted() {
         when (this) {
             is SyncAuthCode.Unknown -> syncPixels.fireSyncSetupCodePastedParseFailure(codeType.asScreenType())
-            else -> syncPixels.fireSyncSetupCodePastedParseSuccess(codeType.asScreenType())
+            else -> syncPixels.fireSyncSetupCodePastedParseSuccess(codeType.asScreenType(), CodeVersion.V1)
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
@@ -162,9 +162,10 @@ class EnterCodeViewModel @Inject constructor(
                 ),
             )
             is DispatchOutcome.Failed -> {
-                // Always surface v2 failures via the helper; bypass the v1 catch-all (silent no-op) and AskToSwitchAccount.
+                // Always surface v2 failures via the mapper; bypass the v1 catch-all (silent no-op) and AskToSwitchAccount.
                 viewState.value = viewState.value.copy(authState = AuthState.Idle)
-                command.send(ShowError(message = outcome.code.toV2PairingErrorMessage(), reason = outcome.reason))
+                val content = outcome.code.toV2PairingError()
+                command.send(ShowError(message = content.message, title = content.title))
             }
             is DispatchOutcome.JoinerConfirmationRequested ->
                 command.send(Command.AskJoinerConfirmation(outcome.peerName))

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectActivity.kt
@@ -37,6 +37,7 @@ import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.databinding.ActivityConnectSyncBinding
 import com.duckduckgo.sync.impl.databinding.ActivityConnectSyncNewBinding
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.ui.EnterCodeActivity.Companion.Code.CONNECT_CODE
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.AskHostConfirmation
@@ -170,8 +171,8 @@ class SyncConnectActivity : DuckDuckGoActivity() {
             is ShowMessage -> Snackbar.make(binding.root, it.messageId, Snackbar.LENGTH_SHORT).show()
             is ShowError -> showError(it)
             is Command.ShowV2Error -> showV2PairingError(it.content) { viewModel.onErrorDialogDismissed() }
-            is AskJoinerConfirmation -> askJoinerConfirmation(it.peerName)
-            is AskHostConfirmation -> askHostConfirmation(it.peerName)
+            is AskJoinerConfirmation -> askJoinerConfirmation(it.peerName, it.peerKind)
+            is AskHostConfirmation -> askHostConfirmation(it.peerName, it.peerKind)
         }
     }
 
@@ -198,15 +199,10 @@ class SyncConnectActivity : DuckDuckGoActivity() {
             ).show()
     }
 
-    private fun askJoinerConfirmation(peerName: String?) {
-        val message = if (peerName.isNullOrBlank()) {
-            getString(R.string.sync_v2_joiner_confirmation_message_unknown_peer)
-        } else {
-            getString(R.string.sync_v2_joiner_confirmation_message, peerName)
-        }
+    private fun askJoinerConfirmation(peerName: String?, peerKind: PeerKind?) {
         TextAlertDialogBuilder(this)
             .setTitle(R.string.sync_v2_joiner_confirmation_title)
-            .setMessage(message)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
             .setPositiveButton(R.string.sync_v2_joiner_confirmation_positive)
             .setNegativeButton(R.string.sync_v2_joiner_confirmation_negative)
             .addEventListener(
@@ -217,15 +213,10 @@ class SyncConnectActivity : DuckDuckGoActivity() {
             ).show()
     }
 
-    private fun askHostConfirmation(peerName: String?) {
-        val message = if (peerName.isNullOrBlank()) {
-            getString(R.string.sync_v2_host_confirmation_message_unknown_peer)
-        } else {
-            getString(R.string.sync_v2_host_confirmation_message, peerName)
-        }
+    private fun askHostConfirmation(peerName: String?, peerKind: PeerKind?) {
         TextAlertDialogBuilder(this)
             .setTitle(R.string.sync_v2_host_confirmation_title)
-            .setMessage(message)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
             .setPositiveButton(R.string.sync_v2_host_confirmation_positive)
             .setNegativeButton(R.string.sync_v2_host_confirmation_negative)
             .addEventListener(

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectActivity.kt
@@ -171,7 +171,6 @@ class SyncConnectActivity : DuckDuckGoActivity() {
             is ShowError -> showError(it)
             is AskJoinerConfirmation -> askJoinerConfirmation(it.peerName)
             is AskHostConfirmation -> askHostConfirmation(it.peerName)
-            is Command.ShowAlreadyConnected -> showAlreadyConnected()
         }
     }
 
@@ -182,20 +181,6 @@ class SyncConnectActivity : DuckDuckGoActivity() {
                 viewModel.onReadTextCodeClicked()
             }
         }
-    }
-
-    private fun showAlreadyConnected() {
-        TextAlertDialogBuilder(this)
-            .setTitle(R.string.sync_v2_already_paired_title)
-            .setMessage(R.string.sync_v2_already_paired_message)
-            .setPositiveButton(R.string.sync_dialog_error_ok)
-            .addEventListener(
-                object : TextAlertDialogBuilder.EventListener() {
-                    override fun onPositiveButtonClicked() {
-                        viewModel.onAlreadyConnectedAcknowledged()
-                    }
-                },
-            ).show()
     }
 
     private fun showError(it: ShowError) {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectActivity.kt
@@ -185,8 +185,8 @@ class SyncConnectActivity : DuckDuckGoActivity() {
 
     private fun showError(it: ShowError) {
         TextAlertDialogBuilder(this)
-            .setTitle(R.string.sync_dialog_error_title)
-            .setMessage(getString(it.message) + "\n" + it.reason)
+            .setTitle(it.title)
+            .setMessage(if (it.reason.isBlank()) getString(it.message) else getString(it.message) + "\n" + it.reason)
             .setPositiveButton(R.string.sync_dialog_error_ok)
             .addEventListener(
                 object : TextAlertDialogBuilder.EventListener() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectActivity.kt
@@ -169,6 +169,7 @@ class SyncConnectActivity : DuckDuckGoActivity() {
 
             is ShowMessage -> Snackbar.make(binding.root, it.messageId, Snackbar.LENGTH_SHORT).show()
             is ShowError -> showError(it)
+            is Command.ShowV2Error -> showV2PairingError(it.content) { viewModel.onErrorDialogDismissed() }
             is AskJoinerConfirmation -> askJoinerConfirmation(it.peerName)
             is AskHostConfirmation -> askHostConfirmation(it.peerName)
         }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectActivity.kt
@@ -186,8 +186,8 @@ class SyncConnectActivity : DuckDuckGoActivity() {
 
     private fun showError(it: ShowError) {
         TextAlertDialogBuilder(this)
-            .setTitle(it.title)
-            .setMessage(if (it.reason.isBlank()) getString(it.message) else getString(it.message) + "\n" + it.reason)
+            .setTitle(R.string.sync_dialog_error_title)
+            .setMessage(getString(it.message) + "\n" + it.reason)
             .setPositiveButton(R.string.sync_dialog_error_ok)
             .addEventListener(
                 object : TextAlertDialogBuilder.EventListener() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectActivity.kt
@@ -171,6 +171,7 @@ class SyncConnectActivity : DuckDuckGoActivity() {
             is ShowError -> showError(it)
             is AskJoinerConfirmation -> askJoinerConfirmation(it.peerName)
             is AskHostConfirmation -> askHostConfirmation(it.peerName)
+            is Command.ShowAlreadyConnected -> showAlreadyConnected()
         }
     }
 
@@ -181,6 +182,20 @@ class SyncConnectActivity : DuckDuckGoActivity() {
                 viewModel.onReadTextCodeClicked()
             }
         }
+    }
+
+    private fun showAlreadyConnected() {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_already_paired_title)
+            .setMessage(R.string.sync_v2_already_paired_message)
+            .setPositiveButton(R.string.sync_dialog_error_ok)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() {
+                        viewModel.onAlreadyConnectedAcknowledged()
+                    }
+                },
+            ).show()
     }
 
     private fun showError(it: ShowError) {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
@@ -235,7 +235,11 @@ class SyncConnectViewModel @Inject constructor(
         data object LoginSuccess : Command()
         data class ShowMessage(val messageId: Int) : Command()
         data object FinishWithError : Command()
-        data class ShowError(@StringRes val message: Int, val reason: String = "") : Command()
+        data class ShowError(
+            @StringRes val message: Int,
+            val reason: String = "",
+            @StringRes val title: Int = R.string.sync_dialog_error_title,
+        ) : Command()
 
         /** v2 §"Exchange Confirmations": prompt user "Sync your data with [peerName]?". */
         data class AskJoinerConfirmation(val peerName: String?) : Command()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
@@ -147,7 +147,8 @@ class SyncConnectViewModel @Inject constructor(
                 fireLoginPixels()
                 command.send(LoginSuccess)
             }
-            is DispatchOutcome.AlreadyConnected -> command.send(Command.ShowAlreadyConnected)
+            is DispatchOutcome.AlreadyConnected ->
+                command.send(ShowError(message = v2AlreadyPairedError.message, title = v2AlreadyPairedError.title))
             is DispatchOutcome.UpgradeRequired -> {
                 logcat { "Sync v2: upgrade required, peer needs protocol v${outcome.codeMajor}" }
                 command.send(ShowError(message = v2UpgradeRequiredError.message, title = v2UpgradeRequiredError.title))
@@ -210,13 +211,6 @@ class SyncConnectViewModel @Inject constructor(
         }
     }
 
-    fun onAlreadyConnectedAcknowledged() {
-        viewModelScope.launch(dispatchers.io()) {
-            fireLoginPixels()
-            command.send(LoginSuccess)
-        }
-    }
-
     fun onCopyCodeClicked() {
         viewModelScope.launch(dispatchers.io()) {
             val v2Code = v2LinkingCode
@@ -255,9 +249,6 @@ class SyncConnectViewModel @Inject constructor(
 
         /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
         data class AskHostConfirmation(val peerName: String?) : Command()
-
-        /** v2 §"Same-account case": inform the user then land connected on OK. */
-        data object ShowAlreadyConnected : Command()
     }
 
     fun onReadTextCodeClicked() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
@@ -148,15 +148,13 @@ class SyncConnectViewModel @Inject constructor(
                 command.send(LoginSuccess)
             }
             is DispatchOutcome.AlreadyConnected ->
-                command.send(ShowError(message = v2AlreadyPairedError.message, title = v2AlreadyPairedError.title))
+                command.send(Command.ShowV2Error(v2AlreadyPairedError))
             is DispatchOutcome.UpgradeRequired -> {
                 logcat { "Sync v2: upgrade required, peer needs protocol v${outcome.codeMajor}" }
-                command.send(ShowError(message = v2UpgradeRequiredError.message, title = v2UpgradeRequiredError.title))
+                command.send(Command.ShowV2Error(v2UpgradeRequiredError))
             }
-            is DispatchOutcome.Failed -> {
-                val content = outcome.code.toV2PairingError()
-                command.send(ShowError(message = content.message, title = content.title))
-            }
+            is DispatchOutcome.Failed ->
+                command.send(Command.ShowV2Error(outcome.code.toV2PairingError()))
         }
     }
 
@@ -249,6 +247,9 @@ class SyncConnectViewModel @Inject constructor(
 
         /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
         data class AskHostConfirmation(val peerName: String?) : Command()
+
+        /** v2 pairing terminal-outcome dialog: title-primary copy, optional message, "Got It" button. */
+        data class ShowV2Error(val content: V2PairingErrorContent) : Command()
     }
 
     fun onReadTextCodeClicked() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
@@ -149,9 +149,10 @@ class SyncConnectViewModel @Inject constructor(
                 fireLoginPixels()
                 command.send(LoginSuccess)
             }
-            // Peer needs a newer protocol major — show the "please update" string like EnterCode/SyncLogin.
-            is DispatchOutcome.UpgradeRequired ->
-                command.send(ShowError(R.string.sync_flows_disabled_new_version, "Code requires protocol v${outcome.codeMajor}"))
+            is DispatchOutcome.UpgradeRequired -> {
+                logcat { "Sync v2: upgrade required, peer needs protocol v${outcome.codeMajor}" }
+                command.send(ShowError(message = v2UpgradeRequiredError.message, title = v2UpgradeRequiredError.title))
+            }
             is DispatchOutcome.Failed -> {
                 val content = outcome.code.toV2PairingError()
                 command.send(ShowError(message = content.message, title = content.title))

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
@@ -236,11 +236,7 @@ class SyncConnectViewModel @Inject constructor(
         data object LoginSuccess : Command()
         data class ShowMessage(val messageId: Int) : Command()
         data object FinishWithError : Command()
-        data class ShowError(
-            @StringRes val message: Int,
-            val reason: String = "",
-            @StringRes val title: Int = R.string.sync_dialog_error_title,
-        ) : Command()
+        data class ShowError(@StringRes val message: Int, val reason: String = "") : Command()
 
         /** v2 §"Exchange Confirmations": prompt user "Sync your data with [peerName]?". */
         data class AskJoinerConfirmation(val peerName: String?) : Command()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
@@ -244,7 +244,6 @@ class SyncConnectViewModel @Inject constructor(
         /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
         data class AskHostConfirmation(val peerName: String?) : Command()
 
-        /** v2 pairing terminal-outcome dialog: title-primary copy, optional message, "Got It" button. */
         internal data class ShowV2Error(val content: V2PairingErrorContent) : Command()
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
@@ -152,8 +152,10 @@ class SyncConnectViewModel @Inject constructor(
             // Peer needs a newer protocol major — show the "please update" string like EnterCode/SyncLogin.
             is DispatchOutcome.UpgradeRequired ->
                 command.send(ShowError(R.string.sync_flows_disabled_new_version, "Code requires protocol v${outcome.codeMajor}"))
-            is DispatchOutcome.Failed ->
-                command.send(ShowError(message = outcome.code.toV2PairingErrorMessage(), reason = outcome.reason))
+            is DispatchOutcome.Failed -> {
+                val content = outcome.code.toV2PairingError()
+                command.send(ShowError(message = content.message, title = content.title))
+            }
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
@@ -249,7 +249,7 @@ class SyncConnectViewModel @Inject constructor(
         data class AskHostConfirmation(val peerName: String?) : Command()
 
         /** v2 pairing terminal-outcome dialog: title-primary copy, optional message, "Got It" button. */
-        data class ShowV2Error(val content: V2PairingErrorContent) : Command()
+        internal data class ShowV2Error(val content: V2PairingErrorContent) : Command()
     }
 
     fun onReadTextCodeClicked() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
@@ -49,7 +49,12 @@ import com.duckduckgo.sync.impl.getOrNull
 import com.duckduckgo.sync.impl.onFailure
 import com.duckduckgo.sync.impl.onSuccess
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_CONNECT
+import com.duckduckgo.sync.impl.pixels.fireSetupCancelledIfDenied
+import com.duckduckgo.sync.impl.pixels.fireSetupFailed
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.FinishWithError
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.LoginSuccess
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.ReadTextCode
@@ -139,12 +144,15 @@ class SyncConnectViewModel @Inject constructor(
 
     /** Map one v2 [DispatchOutcome] onto this VM's command pipeline. Shared by the Presenter and Scanner paths. */
     private suspend fun handleV2Outcome(outcome: DispatchOutcome) {
+        syncPixels.fireSetupFailed(outcome)
+        syncPixels.fireSetupCancelledIfDenied(outcome, SYNC_CONNECT)
         when (outcome) {
             is DispatchOutcome.LinkingCodeReady -> renderV2QrCode(outcome.linkingCode)
-            is DispatchOutcome.HostConfirmationRequested -> command.send(Command.AskHostConfirmation(outcome.peerName))
-            is DispatchOutcome.JoinerConfirmationRequested -> command.send(Command.AskJoinerConfirmation(outcome.peerName))
+            is DispatchOutcome.HostConfirmationRequested -> command.send(Command.AskHostConfirmation(outcome.peerName, outcome.peerKind))
+            is DispatchOutcome.JoinerConfirmationRequested -> command.send(Command.AskJoinerConfirmation(outcome.peerName, outcome.peerKind))
             is DispatchOutcome.LoggedIn -> {
-                fireLoginPixels()
+                syncPixels.fireLoginPixel()
+                syncPixels.fireSyncSetupFinishedSuccessfully(SYNC_CONNECT, outcome.path, outcome.myRole, outcome.peerKind)
                 command.send(LoginSuccess)
             }
             is DispatchOutcome.AlreadyConnected ->
@@ -239,10 +247,10 @@ class SyncConnectViewModel @Inject constructor(
         data class ShowError(@StringRes val message: Int, val reason: String = "") : Command()
 
         /** v2 §"Exchange Confirmations": prompt user "Sync your data with [peerName]?". */
-        data class AskJoinerConfirmation(val peerName: String?) : Command()
+        data class AskJoinerConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
 
         /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
-        data class AskHostConfirmation(val peerName: String?) : Command()
+        data class AskHostConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
 
         internal data class ShowV2Error(val content: V2PairingErrorContent) : Command()
     }
@@ -276,6 +284,7 @@ class SyncConnectViewModel @Inject constructor(
                 }
                 is RouteDecision.V2InProgress -> {
                     logcat { "Sync-CodeDispatch: SyncConnectViewModel observing V2InProgress" }
+                    syncPixels.fireBarcodeScannerParseSuccess(SYNC_CONNECT, CodeVersion.V2, decision.codeType)
                     decision.outcomes.collect { handleV2Outcome(it) }
                 }
             }
@@ -287,7 +296,12 @@ class SyncConnectViewModel @Inject constructor(
     }
 
     fun onUserCancelledWithoutSyncSetup() {
-        syncPixels.fireSyncSetupAbandoned(SYNC_CONNECT)
+        val reason = if (codeDispatcher.isV2ExchangeUnderway()) {
+            CancellationReason.CANCELLED_BEFORE_FINISHED
+        } else {
+            CancellationReason.SCANNING_CANCELLED
+        }
+        syncPixels.fireSyncSetupAbandoned(SYNC_CONNECT, reason)
     }
 
     private suspend fun processError(result: Error) {
@@ -305,7 +319,9 @@ class SyncConnectViewModel @Inject constructor(
 
     fun onLoginSuccess() {
         viewModelScope.launch {
-            fireLoginPixels()
+            // Manual code entry: EnterCodeViewModel fires the "Setup success" pixel (it has the v2
+            // path/role/peer); here we only fire the login pixel to avoid double-counting.
+            syncPixels.fireLoginPixel()
             command.send(LoginSuccess)
         }
     }
@@ -323,7 +339,7 @@ class SyncConnectViewModel @Inject constructor(
     private fun SyncAuthCode.onCodeScanned() {
         when (this) {
             is Unknown -> syncPixels.fireBarcodeScannerParseError(SYNC_CONNECT)
-            else -> syncPixels.fireBarcodeScannerParseSuccess(SYNC_CONNECT)
+            else -> syncPixels.fireBarcodeScannerParseSuccess(SYNC_CONNECT, CodeVersion.V1)
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
@@ -149,9 +149,11 @@ class SyncConnectViewModel @Inject constructor(
                 fireLoginPixels()
                 command.send(LoginSuccess)
             }
-            is DispatchOutcome.UpgradeRequired,
-            is DispatchOutcome.Failed,
-            -> command.send(ShowError(R.string.sync_connect_login_error))
+            // Peer needs a newer protocol major — show the "please update" string like EnterCode/SyncLogin.
+            is DispatchOutcome.UpgradeRequired ->
+                command.send(ShowError(R.string.sync_flows_disabled_new_version, "Code requires protocol v${outcome.codeMajor}"))
+            is DispatchOutcome.Failed ->
+                command.send(ShowError(message = outcome.code.toV2PairingErrorMessage(), reason = outcome.reason))
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
@@ -143,12 +143,11 @@ class SyncConnectViewModel @Inject constructor(
             is DispatchOutcome.LinkingCodeReady -> renderV2QrCode(outcome.linkingCode)
             is DispatchOutcome.HostConfirmationRequested -> command.send(Command.AskHostConfirmation(outcome.peerName))
             is DispatchOutcome.JoinerConfirmationRequested -> command.send(Command.AskJoinerConfirmation(outcome.peerName))
-            is DispatchOutcome.LoggedIn,
-            is DispatchOutcome.AlreadyConnected,
-            -> {
+            is DispatchOutcome.LoggedIn -> {
                 fireLoginPixels()
                 command.send(LoginSuccess)
             }
+            is DispatchOutcome.AlreadyConnected -> command.send(Command.ShowAlreadyConnected)
             is DispatchOutcome.UpgradeRequired -> {
                 logcat { "Sync v2: upgrade required, peer needs protocol v${outcome.codeMajor}" }
                 command.send(ShowError(message = v2UpgradeRequiredError.message, title = v2UpgradeRequiredError.title))
@@ -211,6 +210,13 @@ class SyncConnectViewModel @Inject constructor(
         }
     }
 
+    fun onAlreadyConnectedAcknowledged() {
+        viewModelScope.launch(dispatchers.io()) {
+            fireLoginPixels()
+            command.send(LoginSuccess)
+        }
+    }
+
     fun onCopyCodeClicked() {
         viewModelScope.launch(dispatchers.io()) {
             val v2Code = v2LinkingCode
@@ -249,6 +255,9 @@ class SyncConnectViewModel @Inject constructor(
 
         /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
         data class AskHostConfirmation(val peerName: String?) : Command()
+
+        /** v2 §"Same-account case": inform the user then land connected on OK. */
+        data object ShowAlreadyConnected : Command()
     }
 
     fun onReadTextCodeClicked() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginActivity.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.databinding.ActivityLoginSyncBinding
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.ui.EnterCodeActivity.Companion.Code.RECOVERY_CODE
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command.Error
@@ -96,20 +97,15 @@ class SyncLoginActivity : DuckDuckGoActivity() {
 
             is ShowError -> showError(it)
             is Command.ShowV2Error -> showV2PairingError(it.content) { viewModel.onErrorDialogDismissed() }
-            is Command.AskJoinerConfirmation -> askJoinerConfirmation(it.peerName)
-            is Command.AskHostConfirmation -> askHostConfirmation(it.peerName)
+            is Command.AskJoinerConfirmation -> askJoinerConfirmation(it.peerName, it.peerKind)
+            is Command.AskHostConfirmation -> askHostConfirmation(it.peerName, it.peerKind)
         }
     }
 
-    private fun askJoinerConfirmation(peerName: String?) {
-        val message = if (peerName.isNullOrBlank()) {
-            getString(R.string.sync_v2_joiner_confirmation_message_unknown_peer)
-        } else {
-            getString(R.string.sync_v2_joiner_confirmation_message, peerName)
-        }
+    private fun askJoinerConfirmation(peerName: String?, peerKind: PeerKind?) {
         TextAlertDialogBuilder(this)
             .setTitle(R.string.sync_v2_joiner_confirmation_title)
-            .setMessage(message)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
             .setPositiveButton(R.string.sync_v2_joiner_confirmation_positive)
             .setNegativeButton(R.string.sync_v2_joiner_confirmation_negative)
             .addEventListener(
@@ -120,15 +116,10 @@ class SyncLoginActivity : DuckDuckGoActivity() {
             ).show()
     }
 
-    private fun askHostConfirmation(peerName: String?) {
-        val message = if (peerName.isNullOrBlank()) {
-            getString(R.string.sync_v2_host_confirmation_message_unknown_peer)
-        } else {
-            getString(R.string.sync_v2_host_confirmation_message, peerName)
-        }
+    private fun askHostConfirmation(peerName: String?, peerKind: PeerKind?) {
         TextAlertDialogBuilder(this)
             .setTitle(R.string.sync_v2_host_confirmation_title)
-            .setMessage(message)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
             .setPositiveButton(R.string.sync_v2_host_confirmation_positive)
             .setNegativeButton(R.string.sync_v2_host_confirmation_negative)
             .addEventListener(

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginActivity.kt
@@ -97,7 +97,6 @@ class SyncLoginActivity : DuckDuckGoActivity() {
             is ShowError -> showError(it)
             is Command.AskJoinerConfirmation -> askJoinerConfirmation(it.peerName)
             is Command.AskHostConfirmation -> askHostConfirmation(it.peerName)
-            is Command.ShowAlreadyConnected -> showAlreadyConnected()
         }
     }
 
@@ -146,20 +145,6 @@ class SyncLoginActivity : DuckDuckGoActivity() {
                 viewModel.onReadTextCodeClicked()
             }
         }
-    }
-
-    private fun showAlreadyConnected() {
-        TextAlertDialogBuilder(this)
-            .setTitle(R.string.sync_v2_already_paired_title)
-            .setMessage(R.string.sync_v2_already_paired_message)
-            .setPositiveButton(R.string.sync_dialog_error_ok)
-            .addEventListener(
-                object : TextAlertDialogBuilder.EventListener() {
-                    override fun onPositiveButtonClicked() {
-                        viewModel.onAlreadyConnectedAcknowledged()
-                    }
-                },
-            ).show()
     }
 
     private fun showError(it: ShowError) {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginActivity.kt
@@ -150,8 +150,8 @@ class SyncLoginActivity : DuckDuckGoActivity() {
 
     private fun showError(it: ShowError) {
         TextAlertDialogBuilder(this)
-            .setTitle(it.title)
-            .setMessage(if (it.reason.isBlank()) getString(it.message) else getString(it.message) + "\n" + it.reason)
+            .setTitle(R.string.sync_dialog_error_title)
+            .setMessage(getString(it.message) + "\n" + it.reason)
             .setPositiveButton(R.string.sync_dialog_error_ok)
             .addEventListener(
                 object : TextAlertDialogBuilder.EventListener() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginActivity.kt
@@ -97,6 +97,7 @@ class SyncLoginActivity : DuckDuckGoActivity() {
             is ShowError -> showError(it)
             is Command.AskJoinerConfirmation -> askJoinerConfirmation(it.peerName)
             is Command.AskHostConfirmation -> askHostConfirmation(it.peerName)
+            is Command.ShowAlreadyConnected -> showAlreadyConnected()
         }
     }
 
@@ -145,6 +146,20 @@ class SyncLoginActivity : DuckDuckGoActivity() {
                 viewModel.onReadTextCodeClicked()
             }
         }
+    }
+
+    private fun showAlreadyConnected() {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_already_paired_title)
+            .setMessage(R.string.sync_v2_already_paired_message)
+            .setPositiveButton(R.string.sync_dialog_error_ok)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() {
+                        viewModel.onAlreadyConnectedAcknowledged()
+                    }
+                },
+            ).show()
     }
 
     private fun showError(it: ShowError) {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginActivity.kt
@@ -149,8 +149,8 @@ class SyncLoginActivity : DuckDuckGoActivity() {
 
     private fun showError(it: ShowError) {
         TextAlertDialogBuilder(this)
-            .setTitle(R.string.sync_dialog_error_title)
-            .setMessage(getString(it.message) + "\n" + it.reason)
+            .setTitle(it.title)
+            .setMessage(if (it.reason.isBlank()) getString(it.message) else getString(it.message) + "\n" + it.reason)
             .setPositiveButton(R.string.sync_dialog_error_ok)
             .addEventListener(
                 object : TextAlertDialogBuilder.EventListener() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginActivity.kt
@@ -95,6 +95,7 @@ class SyncLoginActivity : DuckDuckGoActivity() {
             }
 
             is ShowError -> showError(it)
+            is Command.ShowV2Error -> showV2PairingError(it.content) { viewModel.onErrorDialogDismissed() }
             is Command.AskJoinerConfirmation -> askJoinerConfirmation(it.peerName)
             is Command.AskHostConfirmation -> askHostConfirmation(it.peerName)
         }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
@@ -80,9 +80,6 @@ class SyncLoginViewModel @Inject constructor(
 
         /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
         data class AskHostConfirmation(val peerName: String?) : Command()
-
-        /** v2 §"Same-account case": inform the user then land connected on OK. */
-        data object ShowAlreadyConnected : Command()
     }
 
     fun onReadTextCodeClicked() {
@@ -138,13 +135,13 @@ class SyncLoginViewModel @Inject constructor(
                 syncPixels.fireLoginPixel()
                 command.send(LoginSucess)
             }
-            is DispatchOutcome.AlreadyConnected -> command.send(Command.ShowAlreadyConnected)
+            is DispatchOutcome.AlreadyConnected ->
+                command.send(ShowError(message = v2AlreadyPairedError.message, title = v2AlreadyPairedError.title))
             is DispatchOutcome.UpgradeRequired -> {
                 logcat { "Sync v2: upgrade required, peer needs protocol v${outcome.codeMajor}" }
                 command.send(ShowError(message = v2UpgradeRequiredError.message, title = v2UpgradeRequiredError.title))
             }
             is DispatchOutcome.Failed -> {
-                // Always surface v2 failures via the mapper; bypass the v1 catch-all (silent no-op) and AskToSwitchAccount.
                 val content = outcome.code.toV2PairingError()
                 command.send(ShowError(message = content.message, title = content.title))
             }
@@ -160,12 +157,6 @@ class SyncLoginViewModel @Inject constructor(
     fun onJoinerDenied() { codeDispatcher.denyJoiner() }
     fun onHostConfirmed() { codeDispatcher.confirmHost() }
     fun onHostDenied() { codeDispatcher.denyHost() }
-
-    fun onAlreadyConnectedAcknowledged() {
-        viewModelScope.launch {
-            command.send(LoginSucess)
-        }
-    }
 
     private suspend fun processError(result: Error) {
         when (result.code) {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
@@ -140,8 +140,8 @@ class SyncLoginViewModel @Inject constructor(
                 command.send(LoginSucess)
             }
             is DispatchOutcome.UpgradeRequired -> {
-                // Peer needs a newer protocol major — show a visible "please update" error. (follow-up: 1215484651575360)
-                command.send(ShowError(message = R.string.sync_flows_disabled_new_version, reason = "Code requires protocol v${outcome.codeMajor}"))
+                logcat { "Sync v2: upgrade required, peer needs protocol v${outcome.codeMajor}" }
+                command.send(ShowError(message = v2UpgradeRequiredError.message, title = v2UpgradeRequiredError.title))
             }
             is DispatchOutcome.Failed -> {
                 // Always surface v2 failures via the mapper; bypass the v1 catch-all (silent no-op) and AskToSwitchAccount.

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
@@ -69,7 +69,11 @@ class SyncLoginViewModel @Inject constructor(
         data object ReadTextCode : Command()
         data object LoginSucess : Command()
         data object Error : Command()
-        data class ShowError(@StringRes val message: Int, val reason: String = "") : Command()
+        data class ShowError(
+            @StringRes val message: Int,
+            val reason: String = "",
+            @StringRes val title: Int = R.string.sync_dialog_error_title,
+        ) : Command()
 
         /** v2 §"Exchange Confirmations": prompt user "Sync your data with [peerName]?". */
         data class AskJoinerConfirmation(val peerName: String?) : Command()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
@@ -82,7 +82,7 @@ class SyncLoginViewModel @Inject constructor(
         data class AskHostConfirmation(val peerName: String?) : Command()
 
         /** v2 pairing terminal-outcome dialog: title-primary copy, optional message, "Got It" button. */
-        data class ShowV2Error(val content: V2PairingErrorContent) : Command()
+        internal data class ShowV2Error(val content: V2PairingErrorContent) : Command()
     }
 
     fun onReadTextCodeClicked() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
@@ -144,8 +144,9 @@ class SyncLoginViewModel @Inject constructor(
                 command.send(ShowError(message = R.string.sync_flows_disabled_new_version, reason = "Code requires protocol v${outcome.codeMajor}"))
             }
             is DispatchOutcome.Failed -> {
-                // Always surface v2 failures via the helper; bypass the v1 catch-all (silent no-op) and AskToSwitchAccount.
-                command.send(ShowError(message = outcome.code.toV2PairingErrorMessage(), reason = outcome.reason))
+                // Always surface v2 failures via the mapper; bypass the v1 catch-all (silent no-op) and AskToSwitchAccount.
+                val content = outcome.code.toV2PairingError()
+                command.send(ShowError(message = content.message, title = content.title))
             }
             is DispatchOutcome.JoinerConfirmationRequested ->
                 command.send(Command.AskJoinerConfirmation(outcome.peerName))

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
@@ -80,6 +80,9 @@ class SyncLoginViewModel @Inject constructor(
 
         /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
         data class AskHostConfirmation(val peerName: String?) : Command()
+
+        /** v2 §"Same-account case": inform the user then land connected on OK. */
+        data object ShowAlreadyConnected : Command()
     }
 
     fun onReadTextCodeClicked() {
@@ -135,10 +138,7 @@ class SyncLoginViewModel @Inject constructor(
                 syncPixels.fireLoginPixel()
                 command.send(LoginSucess)
             }
-            is DispatchOutcome.AlreadyConnected -> {
-                // Spec §"Same-account case": treat as success. No new login (account is unchanged).
-                command.send(LoginSucess)
-            }
+            is DispatchOutcome.AlreadyConnected -> command.send(Command.ShowAlreadyConnected)
             is DispatchOutcome.UpgradeRequired -> {
                 logcat { "Sync v2: upgrade required, peer needs protocol v${outcome.codeMajor}" }
                 command.send(ShowError(message = v2UpgradeRequiredError.message, title = v2UpgradeRequiredError.title))
@@ -160,6 +160,12 @@ class SyncLoginViewModel @Inject constructor(
     fun onJoinerDenied() { codeDispatcher.denyJoiner() }
     fun onHostConfirmed() { codeDispatcher.confirmHost() }
     fun onHostDenied() { codeDispatcher.denyHost() }
+
+    fun onAlreadyConnectedAcknowledged() {
+        viewModelScope.launch {
+            command.send(LoginSucess)
+        }
+    }
 
     private suspend fun processError(result: Error) {
         when (result.code) {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
@@ -77,7 +77,6 @@ class SyncLoginViewModel @Inject constructor(
         /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
         data class AskHostConfirmation(val peerName: String?) : Command()
 
-        /** v2 pairing terminal-outcome dialog: title-primary copy, optional message, "Got It" button. */
         internal data class ShowV2Error(val content: V2PairingErrorContent) : Command()
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
@@ -80,6 +80,9 @@ class SyncLoginViewModel @Inject constructor(
 
         /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
         data class AskHostConfirmation(val peerName: String?) : Command()
+
+        /** v2 pairing terminal-outcome dialog: title-primary copy, optional message, "Got It" button. */
+        data class ShowV2Error(val content: V2PairingErrorContent) : Command()
     }
 
     fun onReadTextCodeClicked() {
@@ -136,14 +139,14 @@ class SyncLoginViewModel @Inject constructor(
                 command.send(LoginSucess)
             }
             is DispatchOutcome.AlreadyConnected ->
-                command.send(ShowError(message = v2AlreadyPairedError.message, title = v2AlreadyPairedError.title))
+                command.send(Command.ShowV2Error(v2AlreadyPairedError))
             is DispatchOutcome.UpgradeRequired -> {
                 logcat { "Sync v2: upgrade required, peer needs protocol v${outcome.codeMajor}" }
-                command.send(ShowError(message = v2UpgradeRequiredError.message, title = v2UpgradeRequiredError.title))
+                command.send(Command.ShowV2Error(v2UpgradeRequiredError))
             }
             is DispatchOutcome.Failed -> {
                 val content = outcome.code.toV2PairingError()
-                command.send(ShowError(message = content.message, title = content.title))
+                command.send(Command.ShowV2Error(content))
             }
             is DispatchOutcome.JoinerConfirmationRequested ->
                 command.send(Command.AskJoinerConfirmation(outcome.peerName))

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
@@ -69,11 +69,7 @@ class SyncLoginViewModel @Inject constructor(
         data object ReadTextCode : Command()
         data object LoginSucess : Command()
         data object Error : Command()
-        data class ShowError(
-            @StringRes val message: Int,
-            val reason: String = "",
-            @StringRes val title: Int = R.string.sync_dialog_error_title,
-        ) : Command()
+        data class ShowError(@StringRes val message: Int, val reason: String = "") : Command()
 
         /** v2 §"Exchange Confirmations": prompt user "Sync your data with [peerName]?". */
         data class AskJoinerConfirmation(val peerName: String?) : Command()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
@@ -140,8 +140,7 @@ class SyncLoginViewModel @Inject constructor(
                 command.send(ShowError(message = R.string.sync_flows_disabled_new_version, reason = "Code requires protocol v${outcome.codeMajor}"))
             }
             is DispatchOutcome.Failed -> {
-                // v2 failures must always surface — bypass the v1 processError catch-all (else -> null),
-                // which would silently no-op the GENERIC/uncoded reason this used to pass.
+                // Always surface v2 failures via the helper; bypass the v1 catch-all (silent no-op) and AskToSwitchAccount.
                 command.send(ShowError(message = outcome.code.toV2PairingErrorMessage(), reason = outcome.reason))
             }
             is DispatchOutcome.JoinerConfirmationRequested ->

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
@@ -41,6 +41,8 @@ import com.duckduckgo.sync.impl.SyncCodeDispatcher
 import com.duckduckgo.sync.impl.onFailure
 import com.duckduckgo.sync.impl.onSuccess
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import com.duckduckgo.sync.impl.pixels.fireSetupFailed
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Companion.POLLING_INTERVAL_EXCHANGE_FLOW
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command.LoginSucess
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command.ReadTextCode
@@ -72,10 +74,10 @@ class SyncLoginViewModel @Inject constructor(
         data class ShowError(@StringRes val message: Int, val reason: String = "") : Command()
 
         /** v2 §"Exchange Confirmations": prompt user "Sync your data with [peerName]?". */
-        data class AskJoinerConfirmation(val peerName: String?) : Command()
+        data class AskJoinerConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
 
         /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
-        data class AskHostConfirmation(val peerName: String?) : Command()
+        data class AskHostConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
 
         internal data class ShowV2Error(val content: V2PairingErrorContent) : Command()
     }
@@ -128,6 +130,7 @@ class SyncLoginViewModel @Inject constructor(
 
     /** Map one v2 [DispatchOutcome] onto this VM's existing command pipeline. */
     private suspend fun handleV2Outcome(outcome: DispatchOutcome) {
+        syncPixels.fireSetupFailed(outcome)
         when (outcome) {
             is DispatchOutcome.LoggedIn -> {
                 syncPixels.fireLoginPixel()
@@ -144,9 +147,9 @@ class SyncLoginViewModel @Inject constructor(
                 command.send(Command.ShowV2Error(content))
             }
             is DispatchOutcome.JoinerConfirmationRequested ->
-                command.send(Command.AskJoinerConfirmation(outcome.peerName))
+                command.send(Command.AskJoinerConfirmation(outcome.peerName, outcome.peerKind))
             is DispatchOutcome.HostConfirmationRequested ->
-                command.send(Command.AskHostConfirmation(outcome.peerName))
+                command.send(Command.AskHostConfirmation(outcome.peerName, outcome.peerKind))
             is DispatchOutcome.LinkingCodeReady -> {} // No-op; used only by presentV2() flow
         }
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
@@ -140,7 +140,9 @@ class SyncLoginViewModel @Inject constructor(
                 command.send(ShowError(message = R.string.sync_flows_disabled_new_version, reason = "Code requires protocol v${outcome.codeMajor}"))
             }
             is DispatchOutcome.Failed -> {
-                processError(Error(reason = outcome.reason))
+                // v2 failures must always surface — bypass the v1 processError catch-all (else -> null),
+                // which would silently no-op the GENERIC/uncoded reason this used to pass.
+                command.send(ShowError(message = outcome.code.toV2PairingErrorMessage(), reason = outcome.reason))
             }
             is DispatchOutcome.JoinerConfirmationRequested ->
                 command.send(Command.AskJoinerConfirmation(outcome.peerName))

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncV2ConfirmationCopy.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncV2ConfirmationCopy.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui
+
+import android.content.Context
+import androidx.annotation.StringRes
+import com.duckduckgo.sync.impl.R
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+
+@StringRes
+internal fun syncV2ConfirmationMessageRes(
+    unknownPeer: Boolean,
+    peerKind: PeerKind?,
+): Int {
+    val thirdParty = peerKind == PeerKind.THIRD_PARTY
+    return when {
+        unknownPeer && thirdParty -> R.string.sync_v2_confirmation_message_unknown_peer_3p
+        unknownPeer -> R.string.sync_v2_confirmation_message_unknown_peer_ddg
+        thirdParty -> R.string.sync_v2_confirmation_message_3p
+        else -> R.string.sync_v2_confirmation_message_ddg
+    }
+}
+
+internal fun Context.syncV2ConfirmationMessage(
+    peerName: String?,
+    peerKind: PeerKind?,
+): String {
+    val res = syncV2ConfirmationMessageRes(unknownPeer = peerName.isNullOrBlank(), peerKind = peerKind)
+    return if (peerName.isNullOrBlank()) getString(res) else getString(res, peerName)
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
@@ -154,7 +154,7 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
         codeDispatcher.presentV2().collect { outcome ->
             when (outcome) {
                 is DispatchOutcome.LinkingCodeReady -> renderV2QrCode(outcome.linkingCode)
-                else -> handleV2Outcome(outcome, previousPrimaryKey, qrCode = "")
+                else -> handleV2Outcome(outcome, previousPrimaryKey)
             }
         }
     }
@@ -268,17 +268,20 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
                 }
                 is RouteDecision.V2InProgress -> {
                     logcat { "Sync-CodeDispatch: SyncWithAnotherActivityViewModel observing V2InProgress" }
-                    decision.outcomes.collect { handleV2Outcome(it, previousPrimaryKey, qrCode) }
+                    decision.outcomes.collect { handleV2Outcome(it, previousPrimaryKey) }
                 }
             }
         }
     }
 
-    /** Map one v2 [DispatchOutcome] onto this VM's existing command pipeline. */
+    /**
+     * Map one v2 [DispatchOutcome] onto this VM's command pipeline. LoggedIn mirrors v1 Connect
+     * post-success semantics: show recovery to fresh devices (no prior primary key), skip it for
+     * account-switchers.
+     */
     private suspend fun handleV2Outcome(
         outcome: DispatchOutcome,
         previousPrimaryKey: String,
-        qrCode: String,
     ) {
         // Cancel the deep-link timeout only on terminal outcomes; keep it running across confirmation prompts.
         when (outcome) {
@@ -294,7 +297,8 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
             }
             is DispatchOutcome.UpgradeRequired -> {
                 cancelTimeout()
-                emitError(Error(code = CONNECT_FAILED.code, reason = "Code requires protocol v${outcome.codeMajor}"), qrCode)
+                // Peer needs a newer protocol major — show the "please update" string like EnterCode/SyncLogin.
+                command.send(ShowError(R.string.sync_flows_disabled_new_version, "Code requires protocol v${outcome.codeMajor}"))
             }
             is DispatchOutcome.Failed -> {
                 cancelTimeout()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
@@ -227,7 +227,6 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
         /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
         data class AskHostConfirmation(val peerName: String?) : Command()
 
-        /** v2 pairing terminal-outcome dialog: title-primary copy, optional message, "Got It" button. */
         internal data class ShowV2Error(val content: V2PairingErrorContent) : Command()
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
@@ -302,9 +302,7 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
             }
             is DispatchOutcome.Failed -> {
                 cancelTimeout()
-                // Pass the dispatcher's specific code through the shared helper (was force-mapped to
-                // CONNECT_FAILED, discarding it). Always a visible error — bypasses the v1 emitError
-                // catch-all and its AskToSwitchAccount branch.
+                // Always surface v2 failures via the helper; bypass the v1 catch-all (silent no-op) and AskToSwitchAccount.
                 command.send(ShowError(message = outcome.code.toV2PairingErrorMessage(), reason = outcome.reason))
             }
             is DispatchOutcome.JoinerConfirmationRequested ->

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
@@ -298,8 +298,8 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
             }
             is DispatchOutcome.UpgradeRequired -> {
                 cancelTimeout()
-                // Peer needs a newer protocol major — show the "please update" string like EnterCode/SyncLogin.
-                command.send(ShowError(R.string.sync_flows_disabled_new_version, "Code requires protocol v${outcome.codeMajor}"))
+                logcat { "Sync v2: upgrade required, peer needs protocol v${outcome.codeMajor}" }
+                command.send(ShowError(message = v2UpgradeRequiredError.message, title = v2UpgradeRequiredError.title))
             }
             is DispatchOutcome.Failed -> {
                 cancelTimeout()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
@@ -86,7 +86,6 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
     fun commands(): Flow<Command> = command.receiveAsFlow()
 
     private var barcodeContents: AuthCode? = null
-    private var alreadyConnectedPreviousPrimaryKey: String = ""
 
     // this can be true during deep linking setup.
     // when the timeout expires, an error message will show to the user
@@ -228,9 +227,6 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
 
         /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
         data class AskHostConfirmation(val peerName: String?) : Command()
-
-        /** v2 §"Same-account case": inform the user then land connected on OK. */
-        data object ShowAlreadyConnected : Command()
     }
 
     fun onReadTextCodeClicked() {
@@ -279,11 +275,7 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
         }
     }
 
-    /**
-     * Map one v2 [DispatchOutcome] onto this VM's command pipeline. LoggedIn mirrors v1 Connect
-     * post-success semantics: show recovery to fresh devices (no prior primary key), skip it for
-     * account-switchers.
-     */
+    /** Map one v2 [DispatchOutcome] onto this VM's existing command pipeline. */
     private suspend fun handleV2Outcome(
         outcome: DispatchOutcome,
         previousPrimaryKey: String,
@@ -297,8 +289,7 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
             }
             is DispatchOutcome.AlreadyConnected -> {
                 cancelTimeout()
-                alreadyConnectedPreviousPrimaryKey = previousPrimaryKey
-                command.send(Command.ShowAlreadyConnected)
+                command.send(ShowError(message = v2AlreadyPairedError.message, title = v2AlreadyPairedError.title))
             }
             is DispatchOutcome.UpgradeRequired -> {
                 cancelTimeout()
@@ -322,12 +313,6 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
     fun onJoinerDenied() { codeDispatcher.denyJoiner() }
     fun onHostConfirmed() { codeDispatcher.confirmHost() }
     fun onHostDenied() { codeDispatcher.denyHost() }
-
-    fun onAlreadyConnectedAcknowledged() {
-        viewModelScope.launch(dispatchers.io()) {
-            onLoginSuccess(alreadyConnectedPreviousPrimaryKey, showRecovery = false)
-        }
-    }
 
     private suspend fun onLoginSuccess(previousPrimaryKey: String, showRecovery: Boolean) {
         val postProcessCodePK = syncAccountRepository.getAccountInfo().primaryKey

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
@@ -217,6 +217,7 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
         data class ShowError(
             @StringRes val message: Int,
             val reason: String = "",
+            @StringRes val title: Int = R.string.sync_dialog_error_title,
         ) : Command()
 
         data class AskToSwitchAccount(val encodedStringCode: String) : Command()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
@@ -227,6 +227,9 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
 
         /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
         data class AskHostConfirmation(val peerName: String?) : Command()
+
+        /** v2 pairing terminal-outcome dialog: title-primary copy, optional message, "Got It" button. */
+        data class ShowV2Error(val content: V2PairingErrorContent) : Command()
     }
 
     fun onReadTextCodeClicked() {
@@ -289,17 +292,16 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
             }
             is DispatchOutcome.AlreadyConnected -> {
                 cancelTimeout()
-                command.send(ShowError(message = v2AlreadyPairedError.message, title = v2AlreadyPairedError.title))
+                command.send(Command.ShowV2Error(v2AlreadyPairedError))
             }
             is DispatchOutcome.UpgradeRequired -> {
                 cancelTimeout()
                 logcat { "Sync v2: upgrade required, peer needs protocol v${outcome.codeMajor}" }
-                command.send(ShowError(message = v2UpgradeRequiredError.message, title = v2UpgradeRequiredError.title))
+                command.send(Command.ShowV2Error(v2UpgradeRequiredError))
             }
             is DispatchOutcome.Failed -> {
                 cancelTimeout()
-                val content = outcome.code.toV2PairingError()
-                command.send(ShowError(message = content.message, title = content.title))
+                command.send(Command.ShowV2Error(outcome.code.toV2PairingError()))
             }
             is DispatchOutcome.JoinerConfirmationRequested ->
                 command.send(Command.AskJoinerConfirmation(outcome.peerName))

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
@@ -217,7 +217,6 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
         data class ShowError(
             @StringRes val message: Int,
             val reason: String = "",
-            @StringRes val title: Int = R.string.sync_dialog_error_title,
         ) : Command()
 
         data class AskToSwitchAccount(val encodedStringCode: String) : Command()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
@@ -298,7 +298,10 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
             }
             is DispatchOutcome.Failed -> {
                 cancelTimeout()
-                emitError(Error(code = CONNECT_FAILED.code, reason = outcome.reason), qrCode)
+                // Pass the dispatcher's specific code through the shared helper (was force-mapped to
+                // CONNECT_FAILED, discarding it). Always a visible error — bypasses the v1 emitError
+                // catch-all and its AskToSwitchAccount branch.
+                command.send(ShowError(message = outcome.code.toV2PairingErrorMessage(), reason = outcome.reason))
             }
             is DispatchOutcome.JoinerConfirmationRequested ->
                 command.send(Command.AskJoinerConfirmation(outcome.peerName))

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
@@ -49,7 +49,14 @@ import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.onFailure
 import com.duckduckgo.sync.impl.onSuccess
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_EXCHANGE
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
+import com.duckduckgo.sync.impl.pixels.fireSetupCancelledIfDenied
+import com.duckduckgo.sync.impl.pixels.fireSetupFailed
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Companion.POLLING_INTERVAL_EXCHANGE_FLOW
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.AskToSwitchAccount
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.FinishWithError
@@ -222,10 +229,10 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
         data class AskToSwitchAccount(val encodedStringCode: String) : Command()
 
         /** v2 §"Exchange Confirmations": prompt user "Sync your data with [peerName]?". */
-        data class AskJoinerConfirmation(val peerName: String?) : Command()
+        data class AskJoinerConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
 
         /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
-        data class AskHostConfirmation(val peerName: String?) : Command()
+        data class AskHostConfirmation(val peerName: String?, val peerKind: PeerKind? = null) : Command()
 
         internal data class ShowV2Error(val content: V2PairingErrorContent) : Command()
     }
@@ -270,6 +277,9 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
                 }
                 is RouteDecision.V2InProgress -> {
                     logcat { "Sync-CodeDispatch: SyncWithAnotherActivityViewModel observing V2InProgress" }
+                    if (!isDeepLink) {
+                        syncPixels.fireBarcodeScannerParseSuccess(SYNC_EXCHANGE, CodeVersion.V2, decision.codeType)
+                    }
                     decision.outcomes.collect { handleV2Outcome(it, previousPrimaryKey) }
                 }
             }
@@ -281,12 +291,14 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
         outcome: DispatchOutcome,
         previousPrimaryKey: String,
     ) {
+        syncPixels.fireSetupFailed(outcome)
+        syncPixels.fireSetupCancelledIfDenied(outcome, SYNC_EXCHANGE)
         // Cancel the deep-link timeout only on terminal outcomes; keep it running across confirmation prompts.
         when (outcome) {
             is DispatchOutcome.LoggedIn -> {
                 cancelTimeout()
                 val showRecovery = previousPrimaryKey.isEmpty()
-                onLoginSuccess(previousPrimaryKey, showRecovery)
+                onLoginSuccess(previousPrimaryKey, showRecovery, outcome.path, outcome.myRole, outcome.peerKind)
             }
             is DispatchOutcome.AlreadyConnected -> {
                 cancelTimeout()
@@ -302,9 +314,9 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
                 command.send(Command.ShowV2Error(outcome.code.toV2PairingError()))
             }
             is DispatchOutcome.JoinerConfirmationRequested ->
-                command.send(Command.AskJoinerConfirmation(outcome.peerName))
+                command.send(Command.AskJoinerConfirmation(outcome.peerName, outcome.peerKind))
             is DispatchOutcome.HostConfirmationRequested ->
-                command.send(Command.AskHostConfirmation(outcome.peerName))
+                command.send(Command.AskHostConfirmation(outcome.peerName, outcome.peerKind))
             is DispatchOutcome.LinkingCodeReady -> {} // No-op; used only by presentV2() flow
         }
     }
@@ -314,9 +326,15 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
     fun onHostConfirmed() { codeDispatcher.confirmHost() }
     fun onHostDenied() { codeDispatcher.denyHost() }
 
-    private suspend fun onLoginSuccess(previousPrimaryKey: String, showRecovery: Boolean) {
+    private suspend fun onLoginSuccess(
+        previousPrimaryKey: String,
+        showRecovery: Boolean,
+        path: SetupPath? = null,
+        myRole: SetupRole? = null,
+        peerKind: PeerKind? = null,
+    ) {
         val postProcessCodePK = syncAccountRepository.getAccountInfo().primaryKey
-        fireLoginPixels()
+        fireLoginPixels(path, myRole, peerKind)
         val userSwitchedAccount = previousPrimaryKey.isNotBlank() && previousPrimaryKey != postProcessCodePK
         val commandSuccess = if (userSwitchedAccount) {
             syncPixels.fireUserSwitchedAccount()
@@ -327,13 +345,17 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
         command.send(commandSuccess)
     }
 
-    private fun fireLoginPixels() {
+    private fun fireLoginPixels(
+        path: SetupPath? = null,
+        myRole: SetupRole? = null,
+        peerKind: PeerKind? = null,
+    ) {
         syncPixels.fireLoginPixel()
 
         if (isDeepLink) {
             syncPixels.fireSetupDeepLinkFlowSuccess()
         } else {
-            syncPixels.fireSyncSetupFinishedSuccessfully(SYNC_EXCHANGE)
+            syncPixels.fireSyncSetupFinishedSuccessfully(SYNC_EXCHANGE, path, myRole, peerKind)
         }
     }
 
@@ -421,11 +443,12 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
             when (result) {
                 EnterCodeContractOutput.Error -> {}
                 EnterCodeContractOutput.LoginSuccess -> {
-                    fireLoginPixels()
+                    // Manual entry: EnterCodeViewModel fires "Setup success"; only fire login pixel here.
+                    syncPixels.fireLoginPixel()
                     command.send(LoginSuccess(showRecovery = true))
                 }
                 EnterCodeContractOutput.SwitchAccountSuccess -> {
-                    fireLoginPixels()
+                    syncPixels.fireLoginPixel()
                     command.send(SwitchAccountSuccess)
                 }
             }
@@ -448,7 +471,12 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
         if (isDeepLink) {
             syncPixels.fireSetupDeepLinkFlowAbandoned()
         } else {
-            syncPixels.fireSyncSetupAbandoned(SYNC_EXCHANGE)
+            val reason = if (codeDispatcher.isV2ExchangeUnderway()) {
+                CancellationReason.CANCELLED_BEFORE_FINISHED
+            } else {
+                CancellationReason.SCANNING_CANCELLED
+            }
+            syncPixels.fireSyncSetupAbandoned(SYNC_EXCHANGE, reason)
         }
     }
 
@@ -457,7 +485,7 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
 
         when (this) {
             is Unknown -> syncPixels.fireBarcodeScannerParseError(SYNC_EXCHANGE)
-            else -> syncPixels.fireBarcodeScannerParseSuccess(SYNC_EXCHANGE)
+            else -> syncPixels.fireBarcodeScannerParseSuccess(SYNC_EXCHANGE, CodeVersion.V1)
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
@@ -229,7 +229,7 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
         data class AskHostConfirmation(val peerName: String?) : Command()
 
         /** v2 pairing terminal-outcome dialog: title-primary copy, optional message, "Got It" button. */
-        data class ShowV2Error(val content: V2PairingErrorContent) : Command()
+        internal data class ShowV2Error(val content: V2PairingErrorContent) : Command()
     }
 
     fun onReadTextCodeClicked() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
@@ -303,8 +303,8 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
             }
             is DispatchOutcome.Failed -> {
                 cancelTimeout()
-                // Always surface v2 failures via the helper; bypass the v1 catch-all (silent no-op) and AskToSwitchAccount.
-                command.send(ShowError(message = outcome.code.toV2PairingErrorMessage(), reason = outcome.reason))
+                val content = outcome.code.toV2PairingError()
+                command.send(ShowError(message = content.message, title = content.title))
             }
             is DispatchOutcome.JoinerConfirmationRequested ->
                 command.send(Command.AskJoinerConfirmation(outcome.peerName))

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
@@ -86,6 +86,7 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
     fun commands(): Flow<Command> = command.receiveAsFlow()
 
     private var barcodeContents: AuthCode? = null
+    private var alreadyConnectedPreviousPrimaryKey: String = ""
 
     // this can be true during deep linking setup.
     // when the timeout expires, an error message will show to the user
@@ -227,6 +228,9 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
 
         /** v2 §"Exchange Confirmations": prompt user "Allow [peerName] to join your sync?". */
         data class AskHostConfirmation(val peerName: String?) : Command()
+
+        /** v2 §"Same-account case": inform the user then land connected on OK. */
+        data object ShowAlreadyConnected : Command()
     }
 
     fun onReadTextCodeClicked() {
@@ -293,8 +297,8 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
             }
             is DispatchOutcome.AlreadyConnected -> {
                 cancelTimeout()
-                // Spec §"Same-account case": friendly finish, no account change, no recovery screen.
-                onLoginSuccess(previousPrimaryKey, showRecovery = false)
+                alreadyConnectedPreviousPrimaryKey = previousPrimaryKey
+                command.send(Command.ShowAlreadyConnected)
             }
             is DispatchOutcome.UpgradeRequired -> {
                 cancelTimeout()
@@ -318,6 +322,12 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
     fun onJoinerDenied() { codeDispatcher.denyJoiner() }
     fun onHostConfirmed() { codeDispatcher.confirmHost() }
     fun onHostDenied() { codeDispatcher.denyHost() }
+
+    fun onAlreadyConnectedAcknowledged() {
+        viewModelScope.launch(dispatchers.io()) {
+            onLoginSuccess(alreadyConnectedPreviousPrimaryKey, showRecovery = false)
+        }
+    }
 
     private suspend fun onLoginSuccess(previousPrimaryKey: String, showRecovery: Boolean) {
         val postProcessCodePK = syncAccountRepository.getAccountInfo().primaryKey

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
@@ -156,6 +156,7 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
 
             is ShowMessage -> Snackbar.make(binding.root, it.messageId, Snackbar.LENGTH_SHORT).show()
             is ShowError -> showError(it)
+            is Command.ShowV2Error -> showV2PairingError(it.content) { viewModel.onErrorDialogDismissed() }
             is AskToSwitchAccount -> askUserToSwitchAccount(it)
             SwitchAccountSuccess -> {
                 val resultIntent = Intent()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
@@ -249,8 +249,8 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
 
     private fun showError(it: ShowError) {
         TextAlertDialogBuilder(this)
-            .setTitle(it.title)
-            .setMessage(if (it.reason.isBlank()) getString(it.message) else getString(it.message) + "\n" + it.reason)
+            .setTitle(R.string.sync_dialog_error_title)
+            .setMessage(getString(it.message) + "\n" + it.reason)
             .setPositiveButton(R.string.sync_dialog_error_ok)
             .addEventListener(
                 object : TextAlertDialogBuilder.EventListener() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.databinding.ActivityConnectSyncBinding
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.ui.EnterCodeActivity.Companion.Code.RECOVERY_CODE
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.AskToSwitchAccount
@@ -164,20 +165,15 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
                 setResult(RESULT_OK, resultIntent)
                 finish()
             }
-            is Command.AskJoinerConfirmation -> askJoinerConfirmation(it.peerName)
-            is Command.AskHostConfirmation -> askHostConfirmation(it.peerName)
+            is Command.AskJoinerConfirmation -> askJoinerConfirmation(it.peerName, it.peerKind)
+            is Command.AskHostConfirmation -> askHostConfirmation(it.peerName, it.peerKind)
         }
     }
 
-    private fun askJoinerConfirmation(peerName: String?) {
-        val message = if (peerName.isNullOrBlank()) {
-            getString(R.string.sync_v2_joiner_confirmation_message_unknown_peer)
-        } else {
-            getString(R.string.sync_v2_joiner_confirmation_message, peerName)
-        }
+    private fun askJoinerConfirmation(peerName: String?, peerKind: PeerKind?) {
         TextAlertDialogBuilder(this)
             .setTitle(R.string.sync_v2_joiner_confirmation_title)
-            .setMessage(message)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
             .setPositiveButton(R.string.sync_v2_joiner_confirmation_positive)
             .setNegativeButton(R.string.sync_v2_joiner_confirmation_negative)
             .addEventListener(
@@ -188,15 +184,10 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
             ).show()
     }
 
-    private fun askHostConfirmation(peerName: String?) {
-        val message = if (peerName.isNullOrBlank()) {
-            getString(R.string.sync_v2_host_confirmation_message_unknown_peer)
-        } else {
-            getString(R.string.sync_v2_host_confirmation_message, peerName)
-        }
+    private fun askHostConfirmation(peerName: String?, peerKind: PeerKind?) {
         TextAlertDialogBuilder(this)
             .setTitle(R.string.sync_v2_host_confirmation_title)
-            .setMessage(message)
+            .setMessage(syncV2ConfirmationMessage(peerName, peerKind))
             .setPositiveButton(R.string.sync_v2_host_confirmation_positive)
             .setNegativeButton(R.string.sync_v2_host_confirmation_negative)
             .addEventListener(

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
@@ -165,6 +165,7 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
             }
             is Command.AskJoinerConfirmation -> askJoinerConfirmation(it.peerName)
             is Command.AskHostConfirmation -> askHostConfirmation(it.peerName)
+            is Command.ShowAlreadyConnected -> showAlreadyConnected()
         }
     }
 
@@ -241,6 +242,20 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
                         if (isDeepLinkSetup()) {
                             finish()
                         }
+                    }
+                },
+            ).show()
+    }
+
+    private fun showAlreadyConnected() {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_v2_already_paired_title)
+            .setMessage(R.string.sync_v2_already_paired_message)
+            .setPositiveButton(R.string.sync_dialog_error_ok)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() {
+                        viewModel.onAlreadyConnectedAcknowledged()
                     }
                 },
             ).show()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
@@ -165,7 +165,6 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
             }
             is Command.AskJoinerConfirmation -> askJoinerConfirmation(it.peerName)
             is Command.AskHostConfirmation -> askHostConfirmation(it.peerName)
-            is Command.ShowAlreadyConnected -> showAlreadyConnected()
         }
     }
 
@@ -242,20 +241,6 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
                         if (isDeepLinkSetup()) {
                             finish()
                         }
-                    }
-                },
-            ).show()
-    }
-
-    private fun showAlreadyConnected() {
-        TextAlertDialogBuilder(this)
-            .setTitle(R.string.sync_v2_already_paired_title)
-            .setMessage(R.string.sync_v2_already_paired_message)
-            .setPositiveButton(R.string.sync_dialog_error_ok)
-            .addEventListener(
-                object : TextAlertDialogBuilder.EventListener() {
-                    override fun onPositiveButtonClicked() {
-                        viewModel.onAlreadyConnectedAcknowledged()
                     }
                 },
             ).show()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
@@ -248,8 +248,8 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
 
     private fun showError(it: ShowError) {
         TextAlertDialogBuilder(this)
-            .setTitle(R.string.sync_dialog_error_title)
-            .setMessage(getString(it.message) + "\n" + it.reason)
+            .setTitle(it.title)
+            .setMessage(if (it.reason.isBlank()) getString(it.message) else getString(it.message) + "\n" + it.reason)
             .setPositiveButton(R.string.sync_dialog_error_ok)
             .addEventListener(
                 object : TextAlertDialogBuilder.EventListener() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/V2PairingError.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/V2PairingError.kt
@@ -17,29 +17,30 @@
 package com.duckduckgo.sync.impl.ui
 
 import androidx.annotation.StringRes
-import com.duckduckgo.sync.impl.AccountErrorCodes.NEGOTIATION_ABORTED
-import com.duckduckgo.sync.impl.AccountErrorCodes.NO_RECOVERY_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
-import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
-import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_UNAVAILABLE
 import com.duckduckgo.sync.impl.R
 
+/** Title + message for a v2 pairing dialog. */
+internal data class V2PairingErrorContent(
+    @StringRes val title: Int,
+    @StringRes val message: Int,
+)
+
 /**
- * Maps a v2 pairing [com.duckduckgo.sync.impl.DispatchOutcome.Failed] error code to a user-facing
- * message resource. Single source for the v2 connect-flow ViewModels so the mapping cannot diverge
- * again (divergence was the root of the silent-hang bug, 2026-06-11). NEVER returns null — every v2
- * failure surfaces a visible error. The specific `reason` string is shown as the detail line;
- * per-code copy is a follow-up.
+ * Maps a v2 pairing [com.duckduckgo.sync.impl.DispatchOutcome.Failed] error code to dialog copy.
+ * Single source for the v2 connect-flow ViewModels so the mapping cannot diverge again (divergence
+ * was the root of the silent-hang bug, 2026-06-11). NEVER returns null. The six distinct codes
+ * intentionally collapse to three messages here; the codes survive for logs/telemetry.
  */
-@StringRes
-internal fun Int.toV2PairingErrorMessage(): Int = when (this) {
-    PAIRING_REJECTED.code,
-    PAIRING_UNAVAILABLE.code,
-    PAIRING_CANCELLED.code,
-    NEGOTIATION_ABORTED.code,
-    NO_RECOVERY_CODE.code,
-    PAIRING_FAILED.code,
-    -> R.string.sync_connect_login_error
-    else -> R.string.sync_connect_generic_error
+internal fun Int.toV2PairingError(): V2PairingErrorContent = when (this) {
+    PAIRING_REJECTED.code -> V2PairingErrorContent(R.string.sync_dialog_error_title, R.string.sync_v2_error_pairing_rejected)
+    PAIRING_CANCELLED.code -> V2PairingErrorContent(R.string.sync_dialog_error_title, R.string.sync_v2_error_pairing_canceled)
+    else -> V2PairingErrorContent(R.string.sync_dialog_error_title, R.string.sync_v2_error_pairing_failed)
 }
+
+/** Fixed copy for the non-Failed [com.duckduckgo.sync.impl.DispatchOutcome.UpgradeRequired] outcome. */
+internal val v2UpgradeRequiredError = V2PairingErrorContent(
+    title = R.string.sync_dialog_error_title,
+    message = R.string.sync_v2_error_upgrade_required,
+)

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/V2PairingError.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/V2PairingError.kt
@@ -16,38 +16,75 @@
 
 package com.duckduckgo.sync.impl.ui
 
+import android.content.Context
 import androidx.annotation.StringRes
+import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
 import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
 import com.duckduckgo.sync.impl.AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED
 import com.duckduckgo.sync.impl.R
 
-internal data class V2PairingErrorContent(
+/** Dialog copy for a v2 pairing terminal outcome. A null [message] renders a title-only dialog. */
+data class V2PairingErrorContent(
     @StringRes val title: Int,
-    @StringRes val message: Int,
+    @StringRes val message: Int?,
 )
 
 /**
  * Maps a v2 pairing [com.duckduckgo.sync.impl.DispatchOutcome.Failed] error code to dialog copy.
+ * The scenario line is the title; the message is a short supporting line or null (title-only).
  */
-internal fun Int.toV2PairingError(): V2PairingErrorContent = when (this) {
-    PAIRING_REJECTED.code -> V2PairingErrorContent(R.string.sync_dialog_error_title, R.string.sync_v2_error_pairing_rejected)
-    PAIRING_CANCELLED.code -> V2PairingErrorContent(R.string.sync_dialog_error_title, R.string.sync_v2_error_pairing_canceled)
-    THIRD_PARTY_ALREADY_UPGRADED.code -> V2PairingErrorContent(
-        R.string.sync_v2_error_pairing_failed,
-        R.string.sync_v2_error_third_party_already_upgraded,
+fun Int.toV2PairingError(): V2PairingErrorContent = when (this) {
+    PAIRING_REJECTED.code -> V2PairingErrorContent(
+        title = R.string.sync_v2_error_pairing_rejected,
+        message = R.string.sync_v2_error_try_again,
     )
-    else -> V2PairingErrorContent(R.string.sync_dialog_error_title, R.string.sync_v2_error_pairing_failed)
+    PAIRING_CANCELLED.code -> V2PairingErrorContent(
+        title = R.string.sync_v2_error_pairing_canceled,
+        message = null,
+    )
+    THIRD_PARTY_ALREADY_UPGRADED.code -> V2PairingErrorContent(
+        title = R.string.sync_v2_error_pairing_failed,
+        message = R.string.sync_v2_error_third_party_already_upgraded,
+    )
+    else -> V2PairingErrorContent(
+        title = R.string.sync_v2_error_pairing_failed,
+        message = R.string.sync_v2_error_try_again,
+    )
 }
 
-/** Fixed copy for [com.duckduckgo.sync.impl.DispatchOutcome.UpgradeRequired] outcome. */
-internal val v2UpgradeRequiredError = V2PairingErrorContent(
-    title = R.string.sync_dialog_error_title,
-    message = R.string.sync_v2_error_upgrade_required,
+/** Fixed copy for [com.duckduckgo.sync.impl.DispatchOutcome.UpgradeRequired] outcome (title-only). */
+val v2UpgradeRequiredError = V2PairingErrorContent(
+    title = R.string.sync_v2_error_upgrade_required,
+    message = null,
 )
 
 /** Fixed copy for the same-account [com.duckduckgo.sync.impl.DispatchOutcome.AlreadyConnected] outcome. */
-internal val v2AlreadyPairedError = V2PairingErrorContent(
+val v2AlreadyPairedError = V2PairingErrorContent(
     title = R.string.sync_v2_already_paired_title,
     message = R.string.sync_v2_already_paired_message,
 )
+
+/**
+ * Renders a v2 pairing error dialog: the scenario line as the title, an optional supporting
+ * [V2PairingErrorContent.message], and the shared v2 "Got It" button. A null message yields a
+ * title-only dialog (the builder hides the message view when it is empty). [onDismissed] runs on
+ * the positive-button tap, mirroring the v1 path's `viewModel.onErrorDialogDismissed()`.
+ */
+fun Context.showV2PairingError(
+    content: V2PairingErrorContent,
+    onDismissed: () -> Unit,
+) {
+    TextAlertDialogBuilder(this)
+        .setTitle(content.title)
+        .apply { content.message?.let { setMessage(it) } }
+        .setPositiveButton(R.string.sync_v2_error_got_it)
+        .addEventListener(
+            object : TextAlertDialogBuilder.EventListener() {
+                override fun onPositiveButtonClicked() {
+                    onDismissed()
+                }
+            },
+        )
+        .show()
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/V2PairingError.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/V2PairingError.kt
@@ -32,7 +32,6 @@ internal data class V2PairingErrorContent(
 
 /**
  * Maps a v2 pairing [com.duckduckgo.sync.impl.DispatchOutcome.Failed] error code to dialog copy.
- * The scenario line is the title; the message is a short supporting line or null (title-only).
  */
 internal fun Int.toV2PairingError(): V2PairingErrorContent = when (this) {
     PAIRING_REJECTED.code -> V2PairingErrorContent(
@@ -53,7 +52,7 @@ internal fun Int.toV2PairingError(): V2PairingErrorContent = when (this) {
     )
 }
 
-/** Fixed copy for [com.duckduckgo.sync.impl.DispatchOutcome.UpgradeRequired] outcome (title-only). */
+/** Fixed copy for [com.duckduckgo.sync.impl.DispatchOutcome.UpgradeRequired] */
 internal val v2UpgradeRequiredError = V2PairingErrorContent(
     title = R.string.sync_v2_error_upgrade_required,
     message = null,
@@ -67,9 +66,7 @@ internal val v2AlreadyPairedError = V2PairingErrorContent(
 
 /**
  * Renders a v2 pairing error dialog: the scenario line as the title, an optional supporting
- * [V2PairingErrorContent.message], and the shared v2 "Got It" button. A null message yields a
- * title-only dialog (the builder hides the message view when it is empty). [onDismissed] runs on
- * the positive-button tap, mirroring the v1 path's `viewModel.onErrorDialogDismissed()`.
+ * [V2PairingErrorContent.message].
  */
 internal fun Context.showV2PairingError(
     content: V2PairingErrorContent,

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/V2PairingError.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/V2PairingError.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui
+
+import androidx.annotation.StringRes
+import com.duckduckgo.sync.impl.AccountErrorCodes.NEGOTIATION_ABORTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.NO_RECOVERY_CODE
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_UNAVAILABLE
+import com.duckduckgo.sync.impl.R
+
+/**
+ * Maps a v2 pairing [com.duckduckgo.sync.impl.DispatchOutcome.Failed] error code to a user-facing
+ * message resource. Single source for the v2 connect-flow ViewModels so the mapping cannot diverge
+ * again (divergence was the root of the silent-hang bug, 2026-06-11). NEVER returns null — every v2
+ * failure surfaces a visible error. The specific `reason` string is shown as the detail line;
+ * per-code copy is a follow-up.
+ */
+@StringRes
+internal fun Int.toV2PairingErrorMessage(): Int = when (this) {
+    PAIRING_REJECTED.code,
+    PAIRING_UNAVAILABLE.code,
+    PAIRING_CANCELLED.code,
+    NEGOTIATION_ABORTED.code,
+    NO_RECOVERY_CODE.code,
+    PAIRING_FAILED.code,
+    -> R.string.sync_connect_login_error
+    else -> R.string.sync_connect_generic_error
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/V2PairingError.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/V2PairingError.kt
@@ -22,7 +22,6 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
 import com.duckduckgo.sync.impl.AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED
 import com.duckduckgo.sync.impl.R
 
-/** Title + message for a v2 pairing dialog. */
 internal data class V2PairingErrorContent(
     @StringRes val title: Int,
     @StringRes val message: Int,
@@ -30,15 +29,10 @@ internal data class V2PairingErrorContent(
 
 /**
  * Maps a v2 pairing [com.duckduckgo.sync.impl.DispatchOutcome.Failed] error code to dialog copy.
- * Single source for the v2 connect-flow ViewModels so the mapping cannot diverge again (divergence
- * was the root of the silent-hang bug, 2026-06-11). NEVER returns null. Distinct error codes
- * intentionally collapse to a small set of user messages here; the codes survive for logs/telemetry.
  */
 internal fun Int.toV2PairingError(): V2PairingErrorContent = when (this) {
     PAIRING_REJECTED.code -> V2PairingErrorContent(R.string.sync_dialog_error_title, R.string.sync_v2_error_pairing_rejected)
     PAIRING_CANCELLED.code -> V2PairingErrorContent(R.string.sync_dialog_error_title, R.string.sync_v2_error_pairing_canceled)
-    // Joined from a 3rd-party recovery code but the account already holds a ddg credential — can't re-upgrade.
-    // Title is "Sync failed." (reuses sync_v2_error_pairing_failed); the instruction is the body.
     THIRD_PARTY_ALREADY_UPGRADED.code -> V2PairingErrorContent(
         R.string.sync_v2_error_pairing_failed,
         R.string.sync_v2_error_third_party_already_upgraded,
@@ -46,8 +40,14 @@ internal fun Int.toV2PairingError(): V2PairingErrorContent = when (this) {
     else -> V2PairingErrorContent(R.string.sync_dialog_error_title, R.string.sync_v2_error_pairing_failed)
 }
 
-/** Fixed copy for the non-Failed [com.duckduckgo.sync.impl.DispatchOutcome.UpgradeRequired] outcome. */
+/** Fixed copy for [com.duckduckgo.sync.impl.DispatchOutcome.UpgradeRequired] outcome. */
 internal val v2UpgradeRequiredError = V2PairingErrorContent(
     title = R.string.sync_dialog_error_title,
     message = R.string.sync_v2_error_upgrade_required,
+)
+
+/** Fixed copy for the same-account [com.duckduckgo.sync.impl.DispatchOutcome.AlreadyConnected] outcome. */
+internal val v2AlreadyPairedError = V2PairingErrorContent(
+    title = R.string.sync_v2_already_paired_title,
+    message = R.string.sync_v2_already_paired_message,
 )

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/V2PairingError.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/V2PairingError.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.sync.impl.ui
 import androidx.annotation.StringRes
 import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
 import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED
 import com.duckduckgo.sync.impl.R
 
 /** Title + message for a v2 pairing dialog. */
@@ -30,12 +31,14 @@ internal data class V2PairingErrorContent(
 /**
  * Maps a v2 pairing [com.duckduckgo.sync.impl.DispatchOutcome.Failed] error code to dialog copy.
  * Single source for the v2 connect-flow ViewModels so the mapping cannot diverge again (divergence
- * was the root of the silent-hang bug, 2026-06-11). NEVER returns null. The six distinct codes
- * intentionally collapse to three messages here; the codes survive for logs/telemetry.
+ * was the root of the silent-hang bug, 2026-06-11). NEVER returns null. Distinct error codes
+ * intentionally collapse to a small set of user messages here; the codes survive for logs/telemetry.
  */
 internal fun Int.toV2PairingError(): V2PairingErrorContent = when (this) {
     PAIRING_REJECTED.code -> V2PairingErrorContent(R.string.sync_dialog_error_title, R.string.sync_v2_error_pairing_rejected)
     PAIRING_CANCELLED.code -> V2PairingErrorContent(R.string.sync_dialog_error_title, R.string.sync_v2_error_pairing_canceled)
+    // Joined from a 3rd-party recovery code but the account already holds a ddg credential — can't re-upgrade.
+    THIRD_PARTY_ALREADY_UPGRADED.code -> V2PairingErrorContent(R.string.sync_dialog_error_title, R.string.sync_v2_error_third_party_already_upgraded)
     else -> V2PairingErrorContent(R.string.sync_dialog_error_title, R.string.sync_v2_error_pairing_failed)
 }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/V2PairingError.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/V2PairingError.kt
@@ -38,7 +38,11 @@ internal fun Int.toV2PairingError(): V2PairingErrorContent = when (this) {
     PAIRING_REJECTED.code -> V2PairingErrorContent(R.string.sync_dialog_error_title, R.string.sync_v2_error_pairing_rejected)
     PAIRING_CANCELLED.code -> V2PairingErrorContent(R.string.sync_dialog_error_title, R.string.sync_v2_error_pairing_canceled)
     // Joined from a 3rd-party recovery code but the account already holds a ddg credential — can't re-upgrade.
-    THIRD_PARTY_ALREADY_UPGRADED.code -> V2PairingErrorContent(R.string.sync_dialog_error_title, R.string.sync_v2_error_third_party_already_upgraded)
+    // Title is "Sync failed." (reuses sync_v2_error_pairing_failed); the instruction is the body.
+    THIRD_PARTY_ALREADY_UPGRADED.code -> V2PairingErrorContent(
+        R.string.sync_v2_error_pairing_failed,
+        R.string.sync_v2_error_third_party_already_upgraded,
+    )
     else -> V2PairingErrorContent(R.string.sync_dialog_error_title, R.string.sync_v2_error_pairing_failed)
 }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/V2PairingError.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/V2PairingError.kt
@@ -25,7 +25,7 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED
 import com.duckduckgo.sync.impl.R
 
 /** Dialog copy for a v2 pairing terminal outcome. A null [message] renders a title-only dialog. */
-data class V2PairingErrorContent(
+internal data class V2PairingErrorContent(
     @StringRes val title: Int,
     @StringRes val message: Int?,
 )
@@ -34,7 +34,7 @@ data class V2PairingErrorContent(
  * Maps a v2 pairing [com.duckduckgo.sync.impl.DispatchOutcome.Failed] error code to dialog copy.
  * The scenario line is the title; the message is a short supporting line or null (title-only).
  */
-fun Int.toV2PairingError(): V2PairingErrorContent = when (this) {
+internal fun Int.toV2PairingError(): V2PairingErrorContent = when (this) {
     PAIRING_REJECTED.code -> V2PairingErrorContent(
         title = R.string.sync_v2_error_pairing_rejected,
         message = R.string.sync_v2_error_try_again,
@@ -54,13 +54,13 @@ fun Int.toV2PairingError(): V2PairingErrorContent = when (this) {
 }
 
 /** Fixed copy for [com.duckduckgo.sync.impl.DispatchOutcome.UpgradeRequired] outcome (title-only). */
-val v2UpgradeRequiredError = V2PairingErrorContent(
+internal val v2UpgradeRequiredError = V2PairingErrorContent(
     title = R.string.sync_v2_error_upgrade_required,
     message = null,
 )
 
 /** Fixed copy for the same-account [com.duckduckgo.sync.impl.DispatchOutcome.AlreadyConnected] outcome. */
-val v2AlreadyPairedError = V2PairingErrorContent(
+internal val v2AlreadyPairedError = V2PairingErrorContent(
     title = R.string.sync_v2_already_paired_title,
     message = R.string.sync_v2_already_paired_message,
 )
@@ -71,7 +71,7 @@ val v2AlreadyPairedError = V2PairingErrorContent(
  * title-only dialog (the builder hides the message view when it is empty). [onDismissed] runs on
  * the positive-button tap, mirroring the v1 path's `viewModel.onErrorDialogDismissed()`.
  */
-fun Context.showV2PairingError(
+internal fun Context.showV2PairingError(
     content: V2PairingErrorContent,
     onDismissed: () -> Unit,
 ) {

--- a/sync/sync-impl/src/main/res/values/donottranslate.xml
+++ b/sync/sync-impl/src/main/res/values/donottranslate.xml
@@ -33,6 +33,7 @@
     <string name="sync_v2_error_pairing_rejected">Sync canceled from your other device.</string>
     <string name="sync_v2_error_pairing_canceled">Sync canceled</string>
     <string name="sync_v2_error_upgrade_required">Update the DuckDuckGo browser and try again.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Please Sync this device from an already-connected DuckDuckGo browser on another device</string>
     <string name="sync_v2_already_paired_title">Already Paired</string>
     <string name="sync_v2_already_paired_message">You\'re already paired with this account on both devices.</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values/donottranslate.xml
+++ b/sync/sync-impl/src/main/res/values/donottranslate.xml
@@ -28,12 +28,14 @@
     <string name="sync_v2_host_confirmation_positive">Allow</string>
     <string name="sync_v2_host_confirmation_negative">Cancel</string>
 
-    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-16. -->
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
     <string name="sync_v2_error_pairing_failed">Sync failed.</string>
     <string name="sync_v2_error_pairing_rejected">Sync canceled from your other device.</string>
-    <string name="sync_v2_error_pairing_canceled">Sync canceled</string>
+    <string name="sync_v2_error_pairing_canceled">Sync canceled.</string>
     <string name="sync_v2_error_upgrade_required">Update the DuckDuckGo browser and try again.</string>
     <string name="sync_v2_error_third_party_already_upgraded">Please Sync this device from an already-connected DuckDuckGo browser on another device</string>
-    <string name="sync_v2_already_paired_title">Already Paired</string>
-    <string name="sync_v2_already_paired_message">You\'re already paired with this account on both devices.</string>
+    <string name="sync_v2_error_try_again">Please try again.</string>
+    <string name="sync_v2_error_got_it">Got It</string>
+    <string name="sync_v2_already_paired_title">Already synced.</string>
+    <string name="sync_v2_already_paired_message">These devices are already connected to Sync &amp; Backup.</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values/donottranslate.xml
+++ b/sync/sync-impl/src/main/res/values/donottranslate.xml
@@ -27,4 +27,12 @@
     <string name="sync_v2_host_confirmation_message_unknown_peer">Allow the other device to join your Sync &amp; Backup?</string>
     <string name="sync_v2_host_confirmation_positive">Allow</string>
     <string name="sync_v2_host_confirmation_negative">Cancel</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-16. -->
+    <string name="sync_v2_error_pairing_failed">Sync failed.</string>
+    <string name="sync_v2_error_pairing_rejected">Sync canceled from your other device.</string>
+    <string name="sync_v2_error_pairing_canceled">Sync canceled</string>
+    <string name="sync_v2_error_upgrade_required">Update the DuckDuckGo browser and try again.</string>
+    <string name="sync_v2_already_paired_title">Already Paired</string>
+    <string name="sync_v2_already_paired_message">You\'re already paired with this account on both devices.</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values/donottranslate.xml
+++ b/sync/sync-impl/src/main/res/values/donottranslate.xml
@@ -17,16 +17,18 @@
 <resources>
     <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
     <string name="sync_v2_joiner_confirmation_title">Sync your data?</string>
-    <string name="sync_v2_joiner_confirmation_message" instruction="Placeholder is a peer device name, e.g. Samsung S23. May be null/empty so we fall back to a generic phrasing.">Sync your data with \"%1$s\"?</string>
-    <string name="sync_v2_joiner_confirmation_message_unknown_peer">Sync your data with the other device?</string>
-    <string name="sync_v2_joiner_confirmation_positive">Sync</string>
+    <string name="sync_v2_joiner_confirmation_positive">Sync Now</string>
     <string name="sync_v2_joiner_confirmation_negative">Cancel</string>
 
-    <string name="sync_v2_host_confirmation_title">Allow new device to sync?</string>
-    <string name="sync_v2_host_confirmation_message" instruction="Placeholder is a peer device name, e.g. Samsung S23.">Allow \"%1$s\" to join your Sync &amp; Backup?</string>
-    <string name="sync_v2_host_confirmation_message_unknown_peer">Allow the other device to join your Sync &amp; Backup?</string>
-    <string name="sync_v2_host_confirmation_positive">Allow</string>
+    <string name="sync_v2_host_confirmation_title">Sync your data?</string>
+    <string name="sync_v2_host_confirmation_positive">Sync Now</string>
     <string name="sync_v2_host_confirmation_negative">Cancel</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">\"%1$s\" will be able to access your synced DuckDuckGo passwords, autofill data, and Duck.ai chats.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">\"%1$s\" will be able to access your synced Duck.ai chats.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">The other device will be able to access your synced DuckDuckGo passwords, autofill data, and Duck.ai chats.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">The other device will be able to access your synced Duck.ai chats.</string>
 
     <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
     <string name="sync_v2_error_pairing_failed">Sync failed.</string>

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/AppSyncDeviceIdsTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/AppSyncDeviceIdsTest.kt
@@ -112,7 +112,6 @@ class AppSyncDeviceIdsTest {
             override var secretKey: String? = "secretKey"
             override var credentialId: String? = null
             override var scopedPassword: ScopedPassword? = null
-            override var protectedKeysJson: String? = null
             override fun isEncryptionSupported() = true
 
             override fun isSignedInFlow() = emptyFlow<Boolean>()
@@ -147,7 +146,6 @@ class AppSyncDeviceIdsTest {
             override var secretKey: String? = null
             override var credentialId: String? = null
             override var scopedPassword: ScopedPassword? = null
-            override var protectedKeysJson: String? = null
             override fun isEncryptionSupported() = true
 
             override fun isSignedInFlow() = emptyFlow<Boolean>()

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
@@ -1167,7 +1167,6 @@ class AppSyncAccountRepositoryTest {
 
         assertEquals(Success(true), result)
         verify(syncStore, times(0)).credentialId = any()
-        verify(syncStore, times(0)).protectedKeysJson = any()
     }
 
     @Test
@@ -1202,7 +1201,6 @@ class AppSyncAccountRepositoryTest {
         assertEquals(Success(true), result)
         verify(syncStore).credentialId = "ddg"
         verify(syncStore).scopedPassword = ScopedPassword("/+//")
-        verify(syncStore).protectedKeysJson = any()
     }
 
     @Test

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ProtectedKeyManagerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ProtectedKeyManagerTest.kt
@@ -91,23 +91,76 @@ class ProtectedKeyManagerTest {
         whenever(syncJweCrypto.generateRsaKeyPair()).thenReturn(RsaKeyPair("pubKey", "cHJpdktleQ"))
         whenever(syncJweCrypto.extractJwkComponents(anyString())).thenReturn("modulus" to "AQAB")
         whenever(nativeLib.encryptData(any<ByteArray>(), eq(secretKey))).thenReturn(EncryptBytesResult(0, "encrypted".toByteArray()))
-        whenever(syncApi.setProtectedKeyIfAbsent(eq(token), eq("ai_chats"), any())).thenReturn(Success(true))
+        // Happy path: server's response contains our entry (we wrote it).
+        val serverKey = ProtectedKeyEntry(
+            kid = "server-kid",
+            purpose = "ai_chats",
+            encryptedWith = "ddg",
+            encryptedPrivateKey = "encrypted",
+            publicKey = RsaJwk(n = "modulus", e = "AQAB"),
+        )
+        whenever(syncApi.setProtectedKeyIfAbsent(eq(token), eq("ai_chats"), any())).thenReturn(Success(listOf(serverKey)))
 
         val result = manager.create("ai_chats")
 
         assertTrue(result is Success)
-        // create() returns the created entry, not a bare boolean.
-        assertEquals("ai_chats", (result as Success).data.purpose)
-        assertEquals("ddg", result.data.encryptedWith)
+        // create() returns the server's authoritative entry, not the local one.
+        assertEquals(serverKey, (result as Success).data)
         verify(syncApi).setProtectedKeyIfAbsent(
             eq(token),
             eq("ai_chats"),
             check { sent ->
-                assertEquals("ai_chats", sent.purpose)
-                assertEquals("ddg", sent.encryptedWith)
-                assertEquals(RsaJwk(n = "modulus", e = "AQAB"), sent.publicKey)
+                assertEquals(1, sent.size)
+                val first = sent.first()
+                assertEquals("ai_chats", first.purpose)
+                assertEquals("ddg", first.encryptedWith)
+                assertEquals(RsaJwk(n = "modulus", e = "AQAB"), first.publicKey)
             },
         )
+    }
+
+    @Test
+    fun whenSetProtectedKeyIfAbsentReturnsExistingServerEntryThenCreateReturnsServerEntry() {
+        // Race-loser: server returns a different kid for the same (purpose, encrypted_with).
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+        whenever(syncStore.secretKey).thenReturn(secretKey)
+        whenever(nativeLib.prepareForLogin(primaryKey)).thenReturn(validLoginKeys)
+        whenever(syncJweCrypto.generateRsaKeyPair()).thenReturn(RsaKeyPair("pubKey", "cHJpdktleQ"))
+        whenever(syncJweCrypto.extractJwkComponents(anyString())).thenReturn("modulus" to "AQAB")
+        whenever(nativeLib.encryptData(any<ByteArray>(), eq(secretKey))).thenReturn(EncryptBytesResult(0, "encrypted".toByteArray()))
+        val serverKey = ProtectedKeyEntry(
+            kid = "kid-from-server",
+            purpose = "ai_chats",
+            encryptedWith = "ddg",
+            encryptedPrivateKey = "server-jwe",
+            publicKey = RsaJwk(n = "server-modulus", e = "AQAB"),
+        )
+        whenever(syncApi.setProtectedKeyIfAbsent(eq(token), eq("ai_chats"), any())).thenReturn(Success(listOf(serverKey)))
+
+        val result = manager.create("ai_chats")
+
+        assertTrue(result is Success)
+        assertEquals(serverKey, (result as Success).data)
+    }
+
+    @Test
+    fun whenServerResponseMissingPurposeEntryThenError() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+        whenever(syncStore.secretKey).thenReturn(secretKey)
+        whenever(nativeLib.prepareForLogin(primaryKey)).thenReturn(validLoginKeys)
+        whenever(syncJweCrypto.generateRsaKeyPair()).thenReturn(RsaKeyPair("pubKey", "cHJpdktleQ"))
+        whenever(syncJweCrypto.extractJwkComponents(anyString())).thenReturn("modulus" to "AQAB")
+        whenever(nativeLib.encryptData(any<ByteArray>(), eq(secretKey))).thenReturn(EncryptBytesResult(0, "encrypted".toByteArray()))
+        // Server returns a list that doesn't include an entry for our (purpose, ddg) slot.
+        whenever(syncApi.setProtectedKeyIfAbsent(eq(token), eq("ai_chats"), any())).thenReturn(Success(emptyList()))
+
+        val result = manager.create("ai_chats")
+
+        assertTrue(result is Error)
     }
 
     @Test

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
@@ -646,6 +646,46 @@ class RealSyncCodeDispatcherTest {
         assertEquals(DispatchOutcome.UpgradeRequired(codeMajor = 3), outcome)
     }
 
+    @Test fun `route LinkingV2 - Host_Aborted with UserDeniedHost maps to Failed PAIRING_CANCELLED`() = runTest {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        val outcome = withTimeoutOrNull(1000) {
+            val flow = (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { flow.first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Host.Confirming,
+                    to = ExchangeV2State.Host.Aborted,
+                    localTrigger = LocalTrigger.UserDeniedHost,
+                ),
+            )
+            job.await()
+        }
+        assertEquals(DispatchOutcome.Failed("user_denied", PAIRING_CANCELLED.code), outcome)
+    }
+
+    @Test fun `route LinkingV2 - Host_Aborted with HostUnavailable maps to Failed PAIRING_UNAVAILABLE`() = runTest {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        val outcome = withTimeoutOrNull(1000) {
+            val flow = (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { flow.first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Host.Sending,
+                    to = ExchangeV2State.Host.Aborted,
+                    localTrigger = LocalTrigger.HostUnavailable,
+                ),
+            )
+            job.await()
+        }
+        assertEquals(DispatchOutcome.Failed("host_unavailable", PAIRING_UNAVAILABLE.code), outcome)
+    }
+
     @Test fun `presentV2 emits Failed user_denied when Host_Aborted carries UserDeniedHost trigger`() = runTest {
         val outcome = withTimeoutOrNull(1000) {
             val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
@@ -609,9 +609,6 @@ class RealSyncCodeDispatcherTest {
     }
 
     @Test fun `presentV2 maps a version-too-new SessionError to UpgradeRequired`() = runTest {
-        // The runner emits this exact message when a peer envelope needs a higher protocol major
-        // (ExchangeV2Runner: "Peer requires protocol v<N>; please update this app"). The Presenter
-        // polls just like the Scanner, so it must surface UpgradeRequired, not a generic Failed.
         val outcome = withTimeoutOrNull(1000) {
             val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
             runnerEventsFlow.emit(
@@ -626,8 +623,6 @@ class RealSyncCodeDispatcherTest {
     }
 
     @Test fun `route LinkingV2 maps a version-too-new SessionError to UpgradeRequired`() = runTest {
-        // Locks the existing Scanner-side behaviour (previously untested) so it can't regress when
-        // the mapping is shared with the Presenter side.
         setV2(true)
         whenever(qrCode.parse(any())).thenReturn(
             ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
@@ -993,8 +988,6 @@ class RealSyncCodeDispatcherTest {
         val outcome = withTimeoutOrNull(100) { dispatcher.presentV2().first() }
         assertEquals(null, outcome)
     }
-
-    // ---- v2 abort error codes (linking / scanner side) ----
 
     private fun startLinking(): kotlinx.coroutines.flow.Flow<DispatchOutcome> {
         setV2(true)

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
@@ -608,6 +608,44 @@ class RealSyncCodeDispatcherTest {
         assertEquals(DispatchOutcome.LoggedIn, outcome)
     }
 
+    @Test fun `presentV2 maps a version-too-new SessionError to UpgradeRequired`() = runTest {
+        // The runner emits this exact message when a peer envelope needs a higher protocol major
+        // (ExchangeV2Runner: "Peer requires protocol v<N>; please update this app"). The Presenter
+        // polls just like the Scanner, so it must surface UpgradeRequired, not a generic Failed.
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(
+                ExchangeV2Event.SessionError(
+                    timestampMs = System.currentTimeMillis(),
+                    message = "Peer requires protocol v3; please update this app",
+                ),
+            )
+            job.await()
+        }
+        assertEquals(DispatchOutcome.UpgradeRequired(codeMajor = 3), outcome)
+    }
+
+    @Test fun `route LinkingV2 maps a version-too-new SessionError to UpgradeRequired`() = runTest {
+        // Locks the existing Scanner-side behaviour (previously untested) so it can't regress when
+        // the mapping is shared with the Presenter side.
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        val outcome = withTimeoutOrNull(1000) {
+            val flow = (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { flow.first() }
+            runnerEventsFlow.emit(
+                ExchangeV2Event.SessionError(
+                    timestampMs = System.currentTimeMillis(),
+                    message = "Peer requires protocol v3; please update this app",
+                ),
+            )
+            job.await()
+        }
+        assertEquals(DispatchOutcome.UpgradeRequired(codeMajor = 3), outcome)
+    }
+
     @Test fun `presentV2 emits Failed user_denied when Host_Aborted carries UserDeniedHost trigger`() = runTest {
         val outcome = withTimeoutOrNull(1000) {
             val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
@@ -32,6 +32,9 @@ import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
 import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
 import com.duckduckgo.sync.impl.exchange.v2.PairingRole
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.filter
@@ -168,7 +171,19 @@ class RealSyncCodeDispatcherTest {
         val decision = dispatcher.route("v2-link-url")
 
         assertTrue("expected V2InProgress, got $decision", decision is RouteDecision.V2InProgress)
+        assertEquals(SyncCodeType.LINKING, (decision as RouteDecision.V2InProgress).codeType)
         verify(syncAccountRepository, never()).parseSyncAuthCode(any())
+    }
+
+    @Test fun `isV2ExchangeUnderway is false at Bootstrapped or no session, true once exchanging`() {
+        whenever(runner.currentState).thenReturn(null)
+        assertFalse(dispatcher.isV2ExchangeUnderway())
+        whenever(runner.currentState).thenReturn(ExchangeV2State.Bootstrapped)
+        assertFalse(dispatcher.isV2ExchangeUnderway())
+        whenever(runner.currentState).thenReturn(ExchangeV2State.Negotiating)
+        assertTrue(dispatcher.isV2ExchangeUnderway())
+        whenever(runner.currentState).thenReturn(ExchangeV2State.Joiner.Waiting)
+        assertTrue(dispatcher.isV2ExchangeUnderway())
     }
 
     @Test fun `FF on, v2 RecoveryCode cid=ddg - flow emits LoggedIn after processCode succeeds`() = runTest {
@@ -182,10 +197,11 @@ class RealSyncCodeDispatcherTest {
         whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
 
         val decision = dispatcher.route("any") as RouteDecision.V2InProgress
+        assertEquals(SyncCodeType.RECOVERY, decision.codeType)
         val outcomes = decision.outcomes.toList()
 
         assertEquals(1, outcomes.size)
-        assertEquals(DispatchOutcome.LoggedIn, outcomes.single())
+        assertEquals(DispatchOutcome.LoggedIn(SetupPath.RECOVERY), outcomes.single())
     }
 
     @Test fun `FF on, v2 RecoveryCode cid=ddg - base64url secret is normalised to standard base64 for v1 login`() = runTest {
@@ -239,7 +255,7 @@ class RealSyncCodeDispatcherTest {
         val decision = dispatcher.route("any") as RouteDecision.V2InProgress
         val outcomes = decision.outcomes.toList()
 
-        assertEquals(DispatchOutcome.LoggedIn, outcomes.single())
+        assertEquals(DispatchOutcome.LoggedIn(SetupPath.RECOVERY), outcomes.single())
         verify(syncAccountRepository).joinAccountFromThirdPartyRecoveryCode(any())
         verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
     }
@@ -288,7 +304,7 @@ class RealSyncCodeDispatcherTest {
 
         val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
 
-        assertEquals(DispatchOutcome.LoggedIn, outcome)
+        assertEquals(DispatchOutcome.LoggedIn(SetupPath.RECOVERY), outcome)
 
         val captor = org.mockito.kotlin.argumentCaptor<String>()
         verify(syncAccountRepository).logoutAndJoinNewAccount(captor.capture())
@@ -350,7 +366,7 @@ class RealSyncCodeDispatcherTest {
         val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
 
         assertEquals(
-            DispatchOutcome.Failed("Login failed", com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED.code),
+            DispatchOutcome.Failed("Login failed", com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED.code, path = SetupPath.RECOVERY),
             outcome,
         )
     }
@@ -373,7 +389,11 @@ class RealSyncCodeDispatcherTest {
         val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
 
         assertEquals(
-            DispatchOutcome.Failed("Already signed in", com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN.code),
+            DispatchOutcome.Failed(
+                "Already signed in",
+                com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN.code,
+                path = SetupPath.RECOVERY,
+            ),
             outcome,
         )
         verify(syncAccountRepository, never()).logoutAndJoinNewAccount(any())
@@ -393,7 +413,7 @@ class RealSyncCodeDispatcherTest {
 
         val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
 
-        assertEquals(DispatchOutcome.Failed("Some other error"), outcome)
+        assertEquals(DispatchOutcome.Failed("Some other error", path = SetupPath.RECOVERY), outcome)
     }
 
     @Test fun `FF on, v2 RecoveryCode cid=3party - repository error becomes Failed with reason preserved`() = runTest {
@@ -410,7 +430,7 @@ class RealSyncCodeDispatcherTest {
 
         val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
 
-        assertEquals(DispatchOutcome.Failed("BE rejected"), outcome)
+        assertEquals(DispatchOutcome.Failed("BE rejected", path = SetupPath.RECOVERY), outcome)
     }
 
     @Test fun `FF on, v2 RecoveryCode with unknown cid - emits Failed with the cid in the reason`() = runTest {
@@ -584,7 +604,7 @@ class RealSyncCodeDispatcherTest {
         runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Done))
         job.join()
 
-        assertEquals(DispatchOutcome.LoggedIn, outcomes.single())
+        assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST), outcomes.single())
     }
 
     @Test fun `presentV2 emits HostConfirmationRequested with peerName when runner reaches Host_Confirming`() = runTest {
@@ -597,7 +617,36 @@ class RealSyncCodeDispatcherTest {
         assertEquals(DispatchOutcome.HostConfirmationRequested(peerName = "Peer Phone"), outcomes.single())
     }
 
-    @Test fun `presentV2 emits LoggedIn when runner reaches Host_Done`() = runTest {
+    @Test fun `presentV2 carries third-party peer kind on HostConfirmationRequested`() = runTest {
+        whenever(runner.peerName).thenReturn("Peer Phone")
+        whenever(runner.peerKind).thenReturn("3party")
+        val outcomes = mutableListOf<DispatchOutcome>()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().take(1).collect { outcomes += it } }
+        runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Confirming))
+        job.join()
+
+        assertEquals(
+            DispatchOutcome.HostConfirmationRequested(peerName = "Peer Phone", peerKind = PeerKind.THIRD_PARTY),
+            outcomes.single(),
+        )
+    }
+
+    @Test fun `presentV2 carries ddg peer kind on JoinerConfirmationRequested`() = runTest {
+        whenever(runner.peerName).thenReturn("Peer Phone")
+        whenever(runner.peerKind).thenReturn("ddg")
+        val outcomes = mutableListOf<DispatchOutcome>()
+        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().take(1).collect { outcomes += it } }
+        runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Joiner.Confirming))
+        job.join()
+
+        assertEquals(
+            DispatchOutcome.JoinerConfirmationRequested(peerName = "Peer Phone", peerKind = PeerKind.DDG),
+            outcomes.single(),
+        )
+    }
+
+    @Test fun `presentV2 emits LoggedIn with Host role and peer kind when runner reaches Host_Done`() = runTest {
+        whenever(runner.peerKind).thenReturn("3party")
         val outcome = withTimeoutOrNull(1000) {
             val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
                 dispatcher.presentV2().first { it is DispatchOutcome.LoggedIn || it is DispatchOutcome.Failed }
@@ -605,7 +654,7 @@ class RealSyncCodeDispatcherTest {
             runnerEventsFlow.emit(transition(from = ExchangeV2State.Host.Sending, to = ExchangeV2State.Host.Done))
             job.await()
         }
-        assertEquals(DispatchOutcome.LoggedIn, outcome)
+        assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST, PeerKind.THIRD_PARTY), outcome)
     }
 
     @Test fun `presentV2 maps a version-too-new SessionError to UpgradeRequired`() = runTest {
@@ -619,7 +668,7 @@ class RealSyncCodeDispatcherTest {
             )
             job.await()
         }
-        assertEquals(DispatchOutcome.UpgradeRequired(codeMajor = 3), outcome)
+        assertEquals(DispatchOutcome.UpgradeRequired(codeMajor = 3, path = SetupPath.PAIRING), outcome)
     }
 
     @Test fun `route LinkingV2 maps a version-too-new SessionError to UpgradeRequired`() = runTest {
@@ -638,7 +687,7 @@ class RealSyncCodeDispatcherTest {
             )
             job.await()
         }
-        assertEquals(DispatchOutcome.UpgradeRequired(codeMajor = 3), outcome)
+        assertEquals(DispatchOutcome.UpgradeRequired(codeMajor = 3, path = SetupPath.PAIRING), outcome)
     }
 
     @Test fun `route LinkingV2 - Host_Aborted with UserDeniedHost maps to Failed PAIRING_CANCELLED`() = runTest {
@@ -658,7 +707,10 @@ class RealSyncCodeDispatcherTest {
             )
             job.await()
         }
-        assertEquals(DispatchOutcome.Failed("user_denied", PAIRING_CANCELLED.code), outcome)
+        assertEquals(
+            DispatchOutcome.Failed("user_denied", PAIRING_CANCELLED.code, path = SetupPath.PAIRING, myRole = SetupRole.HOST),
+            outcome,
+        )
     }
 
     @Test fun `route LinkingV2 - Host_Aborted with HostUnavailable maps to Failed PAIRING_UNAVAILABLE`() = runTest {
@@ -678,7 +730,10 @@ class RealSyncCodeDispatcherTest {
             )
             job.await()
         }
-        assertEquals(DispatchOutcome.Failed("host_unavailable", PAIRING_UNAVAILABLE.code), outcome)
+        assertEquals(
+            DispatchOutcome.Failed("host_unavailable", PAIRING_UNAVAILABLE.code, path = SetupPath.PAIRING, myRole = SetupRole.HOST),
+            outcome,
+        )
     }
 
     @Test fun `presentV2 emits Failed user_denied when Host_Aborted carries UserDeniedHost trigger`() = runTest {
@@ -693,7 +748,10 @@ class RealSyncCodeDispatcherTest {
             )
             job.await()
         }
-        assertEquals(DispatchOutcome.Failed("user_denied", PAIRING_CANCELLED.code), outcome)
+        assertEquals(
+            DispatchOutcome.Failed("user_denied", PAIRING_CANCELLED.code, path = SetupPath.PAIRING, myRole = SetupRole.HOST),
+            outcome,
+        )
     }
 
     @Test fun `presentV2 emits Failed host_unavailable when Host_Aborted carries HostUnavailable trigger`() = runTest {
@@ -708,7 +766,10 @@ class RealSyncCodeDispatcherTest {
             )
             job.await()
         }
-        assertEquals(DispatchOutcome.Failed("host_unavailable", PAIRING_UNAVAILABLE.code), outcome)
+        assertEquals(
+            DispatchOutcome.Failed("host_unavailable", PAIRING_UNAVAILABLE.code, path = SetupPath.PAIRING, myRole = SetupRole.HOST),
+            outcome,
+        )
     }
 
     @Test fun `presentV2 emits AlreadyConnected when runner reaches SameAccountAbort`() = runTest {
@@ -728,7 +789,7 @@ class RealSyncCodeDispatcherTest {
             )
             job.await()
         }
-        assertEquals(DispatchOutcome.Failed("channel 5xx", PAIRING_FAILED.code), outcome)
+        assertEquals(DispatchOutcome.Failed("channel 5xx", PAIRING_FAILED.code, path = SetupPath.PAIRING), outcome)
     }
 
     @Test fun `presentV2 emits Failed when Joiner_Done arrives without a recovery code`() = runTest {
@@ -739,7 +800,15 @@ class RealSyncCodeDispatcherTest {
             runnerEventsFlow.emit(transition(from = ExchangeV2State.Joiner.Waiting, to = ExchangeV2State.Joiner.Done))
             job.await()
         }
-        assertEquals(DispatchOutcome.Failed("Pairing completed without a recovery code", NO_RECOVERY_CODE.code), outcome)
+        assertEquals(
+            DispatchOutcome.Failed(
+                "Pairing completed without a recovery code",
+                NO_RECOVERY_CODE.code,
+                path = SetupPath.PAIRING,
+                myRole = SetupRole.JOINER,
+            ),
+            outcome,
+        )
     }
 
     @Test fun `presentV2 emits LoggedIn when Joiner_Done carries a cid=ddg recovery code`() = runTest {
@@ -764,6 +833,7 @@ class RealSyncCodeDispatcherTest {
             recoveryCode = b64,
         )
         whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
+        whenever(runner.peerKind).thenReturn("ddg")
 
         val outcome = withTimeoutOrNull(1000) {
             val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
@@ -780,7 +850,7 @@ class RealSyncCodeDispatcherTest {
             )
             job.await()
         }
-        assertEquals(DispatchOutcome.LoggedIn, outcome)
+        assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.JOINER, PeerKind.DDG), outcome)
         verify(syncAccountRepository).processCode(any(), anyOrNull())
         verify(syncAccountRepository, never()).joinAccountFromThirdPartyRecoveryCode(any())
     }
@@ -823,7 +893,7 @@ class RealSyncCodeDispatcherTest {
             )
             job.await()
         }
-        assertEquals(DispatchOutcome.LoggedIn, outcome)
+        assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.JOINER), outcome)
         verify(syncAccountRepository).joinAccountFromThirdPartyRecoveryCode(any())
         verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
     }
@@ -840,7 +910,15 @@ class RealSyncCodeDispatcherTest {
             )
             job.await()
         }
-        assertEquals(DispatchOutcome.Failed("Pairing cancelled on this device", PAIRING_CANCELLED.code), outcome)
+        assertEquals(
+            DispatchOutcome.Failed(
+                "Pairing cancelled on this device",
+                PAIRING_CANCELLED.code,
+                path = SetupPath.PAIRING,
+                myRole = SetupRole.JOINER,
+            ),
+            outcome,
+        )
     }
 
     @Test fun `presentV2 calls runner_startPresent when Flow is collected`() = runTest {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
@@ -18,8 +18,15 @@ package com.duckduckgo.sync.impl
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.sync.impl.AccountErrorCodes.NEGOTIATION_ABORTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.NO_RECOVERY_CODE
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_UNAVAILABLE
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
@@ -535,13 +542,14 @@ class RealSyncCodeDispatcherTest {
     private fun transition(
         from: ExchangeV2State,
         to: ExchangeV2State,
+        trigger: ExchangeV2Message? = null,
         localTrigger: LocalTrigger? = null,
         timestampMs: Long = System.currentTimeMillis(),
     ): ExchangeV2Event.Transition = ExchangeV2Event.Transition(
         timestampMs = timestampMs,
         from = from,
         to = to,
-        trigger = null,
+        trigger = trigger,
         localTrigger = localTrigger,
     )
 
@@ -612,7 +620,7 @@ class RealSyncCodeDispatcherTest {
             )
             job.await()
         }
-        assertEquals(DispatchOutcome.Failed("user_denied"), outcome)
+        assertEquals(DispatchOutcome.Failed("user_denied", PAIRING_CANCELLED.code), outcome)
     }
 
     @Test fun `presentV2 emits Failed host_unavailable when Host_Aborted carries HostUnavailable trigger`() = runTest {
@@ -627,7 +635,7 @@ class RealSyncCodeDispatcherTest {
             )
             job.await()
         }
-        assertEquals(DispatchOutcome.Failed("host_unavailable"), outcome)
+        assertEquals(DispatchOutcome.Failed("host_unavailable", PAIRING_UNAVAILABLE.code), outcome)
     }
 
     @Test fun `presentV2 emits AlreadyConnected when runner reaches SameAccountAbort`() = runTest {
@@ -647,7 +655,7 @@ class RealSyncCodeDispatcherTest {
             )
             job.await()
         }
-        assertEquals(DispatchOutcome.Failed("channel 5xx"), outcome)
+        assertEquals(DispatchOutcome.Failed("channel 5xx", PAIRING_FAILED.code), outcome)
     }
 
     @Test fun `presentV2 emits Failed when Joiner_Done arrives without a recovery code`() = runTest {
@@ -658,7 +666,7 @@ class RealSyncCodeDispatcherTest {
             runnerEventsFlow.emit(transition(from = ExchangeV2State.Joiner.Waiting, to = ExchangeV2State.Joiner.Done))
             job.await()
         }
-        assertEquals(DispatchOutcome.Failed("Pairing completed without a recovery code"), outcome)
+        assertEquals(DispatchOutcome.Failed("Pairing completed without a recovery code", NO_RECOVERY_CODE.code), outcome)
     }
 
     @Test fun `presentV2 emits LoggedIn when Joiner_Done carries a cid=ddg recovery code`() = runTest {
@@ -759,7 +767,7 @@ class RealSyncCodeDispatcherTest {
             )
             job.await()
         }
-        assertEquals(DispatchOutcome.Failed("Pairing cancelled on this device"), outcome)
+        assertEquals(DispatchOutcome.Failed("Pairing cancelled on this device", PAIRING_CANCELLED.code), outcome)
     }
 
     @Test fun `presentV2 calls runner_startPresent when Flow is collected`() = runTest {
@@ -906,5 +914,115 @@ class RealSyncCodeDispatcherTest {
 
         val outcome = withTimeoutOrNull(100) { dispatcher.presentV2().first() }
         assertEquals(null, outcome)
+    }
+
+    // ---- v2 abort error codes (linking / scanner side) ----
+
+    private fun startLinking(): kotlinx.coroutines.flow.Flow<DispatchOutcome> {
+        setV2(true)
+        whenever(qrCode.parse(any())).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        return (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
+    }
+
+    @Test fun `linking - AbortedByHost with RecoveryCodeDenied maps to Failed PAIRING_REJECTED`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                ),
+            )
+            job.await()
+        }
+        assertTrue("expected Failed, got $outcome", outcome is DispatchOutcome.Failed)
+        assertEquals(PAIRING_REJECTED.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `linking - AbortedByHost with RecoveryCodeUnavailable maps to Failed PAIRING_UNAVAILABLE`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.RecoveryCodeUnavailable(rawJson = "{}"),
+                ),
+            )
+            job.await()
+        }
+        assertEquals(PAIRING_UNAVAILABLE.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `linking - Joiner AbortedLocal maps to Failed PAIRING_CANCELLED`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Joiner.Confirming, to = ExchangeV2State.Joiner.AbortedLocal))
+            job.await()
+        }
+        assertEquals(PAIRING_CANCELLED.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `linking - Aborted maps to Failed NEGOTIATION_ABORTED`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Aborted))
+            job.await()
+        }
+        assertEquals(NEGOTIATION_ABORTED.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `linking - Joiner Done without recovery code maps to Failed NO_RECOVERY_CODE`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Joiner.Waiting, to = ExchangeV2State.Joiner.Done))
+            job.await()
+        }
+        assertEquals(NO_RECOVERY_CODE.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `linking - SessionError maps to Failed PAIRING_FAILED`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(ExchangeV2Event.SessionError(timestampMs = System.currentTimeMillis(), message = "channel 500"))
+            job.await()
+        }
+        assertEquals(PAIRING_FAILED.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `linking - Host Aborted maps to Failed NEGOTIATION_ABORTED`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Host.Confirming, to = ExchangeV2State.Host.Aborted))
+            job.await()
+        }
+        assertEquals(NEGOTIATION_ABORTED.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `present - AbortedByHost with RecoveryCodeDenied maps to Failed PAIRING_REJECTED`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                ),
+            )
+            job.await()
+        }
+        assertEquals(PAIRING_REJECTED.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `present - Host Aborted with no localTrigger maps to Failed NEGOTIATION_ABORTED`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Host.Confirming, to = ExchangeV2State.Host.Aborted))
+            job.await()
+        }
+        assertEquals(NEGOTIATION_ABORTED.code, (outcome as DispatchOutcome.Failed).code)
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
@@ -20,9 +20,22 @@ import android.content.SharedPreferences
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.api.InMemorySharedPreferences
 import com.duckduckgo.common.utils.formatters.time.DatabaseDateFormatter
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.sync.api.engine.SyncableType
 import com.duckduckgo.sync.impl.API_CODE
+import com.duckduckgo.sync.impl.AccountErrorCodes
+import com.duckduckgo.sync.impl.DispatchOutcome
 import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.SyncCodeType
+import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupFailureReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
 import com.duckduckgo.sync.impl.stats.DailyStats
 import com.duckduckgo.sync.impl.stats.SyncStatsRepository
 import com.duckduckgo.sync.store.SharedPrefsProvider
@@ -40,6 +53,7 @@ class RealSyncPixelsTest {
     private var pixel: Pixel = mock()
     private var syncStatsRepository: SyncStatsRepository = mock()
     private var sharedPrefsProv: SharedPrefsProvider = mock()
+    private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
 
     private lateinit var sharedPreferences: SharedPreferences
     private lateinit var testee: RealSyncPixels
@@ -55,6 +69,7 @@ class RealSyncPixelsTest {
             pixel,
             syncStatsRepository,
             sharedPrefsProv,
+            syncFeature,
         )
     }
 
@@ -118,6 +133,385 @@ class RealSyncPixelsTest {
     fun whenSignupConnectPixelCalledWithSourceThenPixelFiredIncludesSource() {
         testee.fireSignupConnectPixel(source = "foo")
         verify(pixel).fire(SyncPixelName.SYNC_SIGNUP_CONNECT, mapOf("source" to "foo"))
+    }
+
+    @Test
+    fun whenBarcodeScreenShownAndV2FlowEnabledThenPixelFiredWithV2AndDdg() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncBarcodeScreenShown(ScreenType.SYNC_CONNECT)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_BARCODE_SCREEN_SHOWN,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenBarcodeScreenShownAndV2FlowDisabledThenPixelFiredWithV1AndDdg() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireSyncBarcodeScreenShown(ScreenType.SYNC_EXCHANGE)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_BARCODE_SCREEN_SHOWN,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenManualCodeEntryScreenShownAndV2FlowEnabledThenPixelFiredWithV2AndDdg() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupManualCodeScreenShown(ScreenType.SYNC_EXCHANGE)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTRY_SCREEN_SHOWN,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenManualCodeEntryScreenShownAndV2FlowDisabledThenPixelFiredWithV1AndDdg() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireSyncSetupManualCodeScreenShown(ScreenType.SYNC_CONNECT)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTRY_SCREEN_SHOWN,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenBarcodeScannerParseSuccessOnLegacyPathThenPixelFiredWithV1AndNoCodeType() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireBarcodeScannerParseSuccess(ScreenType.SYNC_CONNECT, CodeVersion.V1)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_CODE_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenBarcodeScannerParseSuccessForV2RecoveryCodeThenPixelFiredWithCodeMetadata() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireBarcodeScannerParseSuccess(ScreenType.SYNC_EXCHANGE, CodeVersion.V2, SyncCodeType.RECOVERY)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_CODE_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_CODE_TYPE to "recovery",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenManualCodeEnteredSuccessForV2LinkingCodeThenPixelFiredWithCodeMetadata() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupCodePastedParseSuccess(ScreenType.SYNC_CONNECT, CodeVersion.V2, SyncCodeType.LINKING)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_CODE_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_CODE_TYPE to "linking",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenManualCodeEnteredSuccessOnLegacyPathThenPixelFiredWithV1AndNoCodeType() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireSyncSetupCodePastedParseSuccess(ScreenType.SYNC_EXCHANGE, CodeVersion.V1)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_CODE_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenBarcodeScannerParseErrorThenPixelFiredWithFlowMetadata() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireBarcodeScannerParseError(ScreenType.SYNC_CONNECT)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenManualCodeEnteredFailureThenPixelFiredWithFlowMetadata() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupCodePastedParseFailure(ScreenType.SYNC_EXCHANGE)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenSetupFinishedV1ThenPixelFiredWithFlowMetadataOnly() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireSyncSetupFinishedSuccessfully(ScreenType.SYNC_CONNECT)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenSetupFinishedV2RecoveryThenPixelFiredWithPathNoRoleOrPeer() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupFinishedSuccessfully(ScreenType.SYNC_EXCHANGE, SetupPath.RECOVERY)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_PATH to "recovery",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenSetupFinishedV2PairingThenPixelFiredWithPathRoleAndPeer() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupFinishedSuccessfully(
+            ScreenType.SYNC_CONNECT,
+            SetupPath.PAIRING,
+            SetupRole.HOST,
+            PeerKind.THIRD_PARTY,
+        )
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_SUCCESS,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_PATH to "pairing",
+                SyncPixelParameters.SYNC_SETUP_MY_ROLE to "host",
+                SyncPixelParameters.SYNC_SETUP_PEER_KIND to "3party",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenSetupFailedWithAllDimsThenPixelFiredWithReasonPathRoleAndPeer() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupFailed(
+            SetupFailureReason.TRANSPORT_FAILURE,
+            SetupPath.PAIRING,
+            SetupRole.JOINER,
+            PeerKind.DDG,
+        )
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_REASON to "transport_failure",
+                SyncPixelParameters.SYNC_SETUP_PATH to "pairing",
+                SyncPixelParameters.SYNC_SETUP_MY_ROLE to "joiner",
+                SyncPixelParameters.SYNC_SETUP_PEER_KIND to "ddg",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenSetupFailedWithReasonOnlyThenOptionalDimsOmitted() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupFailed(SetupFailureReason.UNEXPECTED_FAILURE)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_REASON to "unexpected_failure",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSetupFailedForUpgradeRequiredThenNeedsUpgrade() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSetupFailed(DispatchOutcome.UpgradeRequired(codeMajor = 3, path = SetupPath.PAIRING, myRole = SetupRole.HOST))
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_REASON to "needs_upgrade",
+                SyncPixelParameters.SYNC_SETUP_PATH to "pairing",
+                SyncPixelParameters.SYNC_SETUP_MY_ROLE to "host",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSetupFailedForFailedOutcomeThenReasonMappedFromCode() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSetupFailed(
+            DispatchOutcome.Failed(
+                reason = "boom",
+                code = AccountErrorCodes.INVALID_CODE.code,
+                path = SetupPath.RECOVERY,
+            ),
+        )
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_REASON to "invalid_credentials",
+                SyncPixelParameters.SYNC_SETUP_PATH to "recovery",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSetupFailedForCancellationCodesThenPixelNotFired() {
+        testee.fireSetupFailed(DispatchOutcome.Failed(reason = "user", code = AccountErrorCodes.PAIRING_CANCELLED.code))
+        testee.fireSetupFailed(DispatchOutcome.Failed(reason = "peer", code = AccountErrorCodes.PAIRING_REJECTED.code))
+
+        verifyNoInteractions(pixel)
+    }
+
+    @Test
+    fun whenSetupAbandonedWithReasonThenPixelFiredWithReasonAndFlowMetadata() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupAbandoned(ScreenType.SYNC_CONNECT, CancellationReason.CANCELLED_BEFORE_FINISHED)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_ABANDONED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_REASON to "cancelled_before_finished",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenSetupAbandonedWithoutReasonThenReasonOmitted() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+
+        testee.fireSyncSetupAbandoned(ScreenType.SYNC_EXCHANGE)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_ABANDONED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v1",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSetupCancelledIfDeniedForPairingCancelledThenAbandonedFired() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSetupCancelledIfDenied(
+            DispatchOutcome.Failed(reason = "user_denied", code = AccountErrorCodes.PAIRING_CANCELLED.code),
+            ScreenType.SYNC_CONNECT,
+        )
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_ABANDONED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_REASON to "sync_confirmation_denied",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSetupCancelledIfDeniedForPeerRejectionOrOtherThenNotFired() {
+        testee.fireSetupCancelledIfDenied(
+            DispatchOutcome.Failed(reason = "peer", code = AccountErrorCodes.PAIRING_REJECTED.code),
+            ScreenType.SYNC_CONNECT,
+        )
+        testee.fireSetupCancelledIfDenied(
+            DispatchOutcome.Failed(reason = "boom", code = AccountErrorCodes.PAIRING_FAILED.code),
+            ScreenType.SYNC_CONNECT,
+        )
+
+        verifyNoInteractions(pixel)
     }
 
     @Test

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
@@ -150,7 +150,7 @@ internal class EnterCodeViewModelTest {
         testee.commands().test {
             val command = awaitItem()
             assertTrue("expected ShowError, got $command", command is ShowError)
-            assertEquals(R.string.sync_v2_error_pairing_failed, (command as ShowError).message)
+            assertEquals(R.string.sync_v2_error_third_party_already_upgraded, (command as ShowError).message)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
@@ -35,7 +35,10 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.CREATE_ACCOUNT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.GENERIC_ERROR
 import com.duckduckgo.sync.impl.AccountErrorCodes.INVALID_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
 import com.duckduckgo.sync.impl.AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
 import com.duckduckgo.sync.impl.Clipboard
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.RealSyncCodeDispatcher
@@ -387,6 +390,43 @@ internal class EnterCodeViewModelTest {
         testee.onPasteCodeClicked()
 
         testee.commands().test {
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2PairingRejectedByPeerThenShowErrorAndClearLoading() = runTest {
+        // Repro: peer rejects after this device confirmed → runner reaches Joiner.AbortedByHost with a
+        // RecoveryCodeDenied trigger → dispatcher emits Failed(PAIRING_REJECTED). Must surface a visible
+        // error and clear the Loading spinner, not hang silently.
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
+        val pastedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(clipboard.pasteFromClipboard()).thenReturn(pastedCode)
+        whenever(qrCode.parse(pastedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(
+                ExchangeV2Event.Transition(
+                    timestampMs = 0L,
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                    localTrigger = null,
+                ),
+            ),
+        )
+
+        testee.onPasteCodeClicked()
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowError, got $command", command is ShowError)
+            cancelAndIgnoreRemainingEvents()
+        }
+        testee.viewState().test {
+            assertTrue(awaitItem().authState is Idle)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
@@ -149,6 +149,7 @@ internal class EnterCodeViewModelTest {
         testee.commands().test {
             val command = awaitItem()
             assertTrue("expected ShowError, got $command", command is ShowError)
+            assertEquals(R.string.sync_v2_error_pairing_failed, (command as ShowError).message)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
@@ -57,6 +57,7 @@ import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState.Idle
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.AskToSwitchAccount
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.LoginSuccess
+import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.ShowAlreadyConnected
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.ShowError
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.SwitchAccountSuccess
 import kotlinx.coroutines.flow.flowOf
@@ -390,6 +391,47 @@ internal class EnterCodeViewModelTest {
         testee.onPasteCodeClicked()
 
         testee.commands().test {
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2SameAccountThenShowAlreadyConnected() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
+        val pastedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(clipboard.pasteFromClipboard()).thenReturn(pastedCode)
+        whenever(qrCode.parse(pastedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(
+                ExchangeV2Event.Transition(
+                    timestampMs = 0L,
+                    from = ExchangeV2State.Negotiating,
+                    to = ExchangeV2State.SameAccountAbort,
+                    trigger = null,
+                    localTrigger = null,
+                ),
+            ),
+        )
+
+        testee.onPasteCodeClicked()
+
+        testee.commands().test {
+            assertTrue(awaitItem() is ShowAlreadyConnected)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenAlreadyConnectedAcknowledgedThenLoginSuccess() = runTest {
+        whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
+
+        testee.onAlreadyConnectedAcknowledged()
+
+        testee.commands().test {
+            assertTrue(awaitItem() is LoginSuccess)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
@@ -35,10 +35,7 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.CREATE_ACCOUNT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.GENERIC_ERROR
 import com.duckduckgo.sync.impl.AccountErrorCodes.INVALID_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
-import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
 import com.duckduckgo.sync.impl.AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED
-import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
-import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
 import com.duckduckgo.sync.impl.Clipboard
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.RealSyncCodeDispatcher
@@ -51,8 +48,10 @@ import com.duckduckgo.sync.impl.SyncAuthCode.Unknown
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState.Idle

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
@@ -57,7 +57,6 @@ import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState.Idle
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.AskToSwitchAccount
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.LoginSuccess
-import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.ShowAlreadyConnected
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.ShowError
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.SwitchAccountSuccess
 import kotlinx.coroutines.flow.flowOf
@@ -396,7 +395,7 @@ internal class EnterCodeViewModelTest {
     }
 
     @Test
-    fun whenV2SameAccountThenShowAlreadyConnected() = runTest {
+    fun whenV2SameAccountThenShowAlreadyPaired() = runTest {
         syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
         whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
         val pastedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
@@ -419,28 +418,15 @@ internal class EnterCodeViewModelTest {
         testee.onPasteCodeClicked()
 
         testee.commands().test {
-            assertTrue(awaitItem() is ShowAlreadyConnected)
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
-    fun whenAlreadyConnectedAcknowledgedThenLoginSuccess() = runTest {
-        whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
-
-        testee.onAlreadyConnectedAcknowledged()
-
-        testee.commands().test {
-            assertTrue(awaitItem() is LoginSuccess)
+            val command = awaitItem()
+            assertTrue("expected ShowError, got $command", command is ShowError)
+            assertEquals(R.string.sync_v2_already_paired_message, (command as ShowError).message)
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
     fun whenV2PairingRejectedByPeerThenShowErrorAndClearLoading() = runTest {
-        // Repro: peer rejects after this device confirmed → runner reaches Joiner.AbortedByHost with a
-        // RecoveryCodeDenied trigger → dispatcher emits Failed(PAIRING_REJECTED). Must surface a visible
-        // error and clear the Loading spinner, not hang silently.
         syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
         whenever(syncAccountRepository.getAccountInfo()).thenReturn(noAccount)
         val pastedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
@@ -35,9 +35,9 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.CREATE_ACCOUNT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.GENERIC_ERROR
 import com.duckduckgo.sync.impl.AccountErrorCodes.INVALID_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
 import com.duckduckgo.sync.impl.AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED
 import com.duckduckgo.sync.impl.Clipboard
-import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.RealSyncCodeDispatcher
 import com.duckduckgo.sync.impl.RecoveryCode
 import com.duckduckgo.sync.impl.Result.Error
@@ -58,6 +58,7 @@ import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.AuthState.Idle
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.AskToSwitchAccount
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.LoginSuccess
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.ShowError
+import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.ShowV2Error
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.SwitchAccountSuccess
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -148,8 +149,8 @@ internal class EnterCodeViewModelTest {
 
         testee.commands().test {
             val command = awaitItem()
-            assertTrue("expected ShowError, got $command", command is ShowError)
-            assertEquals(R.string.sync_v2_error_third_party_already_upgraded, (command as ShowError).message)
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(THIRD_PARTY_ALREADY_UPGRADED.code.toV2PairingError(), (command as ShowV2Error).content)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -171,8 +172,8 @@ internal class EnterCodeViewModelTest {
 
         testee.commands().test {
             val command = awaitItem()
-            assertTrue("expected ShowError, got $command", command is ShowError)
-            assertEquals(R.string.sync_v2_error_upgrade_required, (command as ShowError).message)
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2UpgradeRequiredError, (command as ShowV2Error).content)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -419,8 +420,8 @@ internal class EnterCodeViewModelTest {
 
         testee.commands().test {
             val command = awaitItem()
-            assertTrue("expected ShowError, got $command", command is ShowError)
-            assertEquals(R.string.sync_v2_already_paired_message, (command as ShowError).message)
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2AlreadyPairedError, (command as ShowV2Error).content)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -450,7 +451,8 @@ internal class EnterCodeViewModelTest {
 
         testee.commands().test {
             val command = awaitItem()
-            assertTrue("expected ShowError, got $command", command is ShowError)
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_REJECTED.code.toV2PairingError(), (command as ShowV2Error).content)
             cancelAndIgnoreRemainingEvents()
         }
         testee.viewState().test {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
@@ -172,7 +172,7 @@ internal class EnterCodeViewModelTest {
         testee.commands().test {
             val command = awaitItem()
             assertTrue("expected ShowError, got $command", command is ShowError)
-            assertEquals(R.string.sync_flows_disabled_new_version, (command as ShowError).message)
+            assertEquals(R.string.sync_v2_error_upgrade_required, (command as ShowError).message)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
@@ -788,6 +788,18 @@ class SyncConnectViewModelTest {
     }
 
     @Test
+    fun whenAlreadyConnectedAcknowledgedThenLoginSuccess() = runTest {
+        whenever(syncRepository.getAccountInfo()).thenReturn(AccountInfo())
+
+        testee.onAlreadyConnectedAcknowledged()
+
+        testee.commands().test {
+            assertTrue(awaitItem() is LoginSuccess)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun whenV2UpgradeRequiredThenShowUpdateError() = runTest {
         syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
         whenever(syncRepository.getAccountInfo()).thenReturn(AccountInfo())

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
@@ -30,7 +30,6 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN
 import com.duckduckgo.sync.impl.AccountErrorCodes.CONNECT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
 import com.duckduckgo.sync.impl.AccountInfo
-import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
 import com.duckduckgo.sync.impl.Clipboard
 import com.duckduckgo.sync.impl.ConnectCode
 import com.duckduckgo.sync.impl.QREncoder
@@ -42,6 +41,7 @@ import com.duckduckgo.sync.impl.SyncAccountRepository.AuthCode
 import com.duckduckgo.sync.impl.SyncAuthCode.Connect
 import com.duckduckgo.sync.impl.SyncAuthCode.Recovery
 import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
@@ -53,6 +53,7 @@ import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.AskHostConfirmation
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.AskJoinerConfirmation
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.LoginSuccess
+import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.ShowAlreadyConnected
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.ShowError
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flowOf
@@ -783,6 +784,28 @@ class SyncConnectViewModelTest {
             testee.onQRCodeScanned(scannedCode)
             val command = awaitItem()
             assertTrue("expected ShowError, got $command", command is ShowError)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2PresentSameAccountThenShowAlreadyConnected() = runTest {
+        enableV2(displayOn = true)
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
+
+        testee.viewState(source = null).test {
+            awaitItem()
+            runnerEventsFlow.emit(presenterSessionStarted())
+            awaitItem()
+            runnerEventsFlow.emit(
+                transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.SameAccountAbort),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected ShowAlreadyConnected, got $command", command is ShowAlreadyConnected)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
@@ -42,6 +42,7 @@ import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAccountRepository.AuthCode
 import com.duckduckgo.sync.impl.SyncAuthCode.Connect
 import com.duckduckgo.sync.impl.SyncAuthCode.Recovery
+import com.duckduckgo.sync.impl.SyncCodeType
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
@@ -50,7 +51,12 @@ import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
 import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
 import com.duckduckgo.sync.impl.exchange.v2.PairingRole
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_CONNECT
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupFailureReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.AskHostConfirmation
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.AskJoinerConfirmation
@@ -70,6 +76,7 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -226,9 +233,9 @@ class SyncConnectViewModelTest {
             testee.onQRCodeScanned(jsonConnectKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.LoginSuccess)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_CONNECT))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_CONNECT), eq(CodeVersion.V1), isNull())
             verify(syncPixels).fireLoginPixel()
-            verify(syncPixels).fireSyncSetupFinishedSuccessfully(eq(SyncPixels.ScreenType.SYNC_CONNECT))
+            verify(syncPixels).fireSyncSetupFinishedSuccessfully(eq(SyncPixels.ScreenType.SYNC_CONNECT), isNull(), isNull(), isNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -241,9 +248,9 @@ class SyncConnectViewModelTest {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.ShowError)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_CONNECT))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_CONNECT), eq(CodeVersion.V1), isNull())
             verify(syncPixels, never()).fireLoginPixel()
-            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any())
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -257,9 +264,33 @@ class SyncConnectViewModelTest {
             testee.onQRCodeScanned(jsonConnectKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.ShowError)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_CONNECT))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_CONNECT), eq(CodeVersion.V1), isNull())
             verify(syncPixels, never()).fireLoginPixel()
-            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any())
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenUserScansV2RecoveryCodeThenBarcodeScannerParseSuccessFiredWithV2Recovery() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        val rawJson = org.json.JSONObject().apply {
+            put("user_id", "u-1")
+            put("secret", "s-1")
+            put("cid", "ddg")
+        }
+        whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
+        whenever(syncRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
+
+        testee.commands().test {
+            testee.onQRCodeScanned("v2-recovery-code")
+            val command = awaitItem()
+            assertTrue("expected LoginSuccess, got $command", command is LoginSuccess)
+            verify(syncPixels).fireBarcodeScannerParseSuccess(
+                eq(SyncPixels.ScreenType.SYNC_CONNECT),
+                eq(CodeVersion.V2),
+                eq(SyncCodeType.RECOVERY),
+            )
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -271,7 +302,8 @@ class SyncConnectViewModelTest {
             val command = awaitItem()
             assertTrue(command is Command.LoginSuccess)
             verify(syncPixels).fireLoginPixel()
-            verify(syncPixels).fireSyncSetupFinishedSuccessfully(eq(SyncPixels.ScreenType.SYNC_CONNECT))
+            // Manual entry fires "Setup success" from EnterCodeViewModel, not here.
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -279,7 +311,7 @@ class SyncConnectViewModelTest {
     @Test
     fun whenUserCancelsThenAbandonedPixelFired() = runTest {
         testee.onUserCancelledWithoutSyncSetup()
-        verify(syncPixels).fireSyncSetupAbandoned(eq(SYNC_CONNECT))
+        verify(syncPixels).fireSyncSetupAbandoned(eq(SYNC_CONNECT), eq(CancellationReason.SCANNING_CANCELLED))
     }
 
     @Test
@@ -437,6 +469,7 @@ class SyncConnectViewModelTest {
     fun whenJoinerConfirmingDuringV2PresentThenAskJoinerConfirmationCommandEmitted() = runTest {
         enableV2(displayOn = true)
         whenever(runner.peerName).thenReturn("Peer Phone")
+        whenever(runner.peerKind).thenReturn("ddg")
         whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
 
         testee.viewState(source = null).test {
@@ -453,6 +486,7 @@ class SyncConnectViewModelTest {
             val command = awaitItem()
             assertTrue("expected AskJoinerConfirmation, got $command", command is AskJoinerConfirmation)
             Assert.assertEquals("Peer Phone", (command as AskJoinerConfirmation).peerName)
+            Assert.assertEquals(PeerKind.DDG, (command as AskJoinerConfirmation).peerKind)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -461,6 +495,7 @@ class SyncConnectViewModelTest {
     fun whenHostConfirmingDuringV2PresentThenAskHostConfirmationCommandEmitted() = runTest {
         enableV2(displayOn = true)
         whenever(runner.peerName).thenReturn("Peer Phone")
+        whenever(runner.peerKind).thenReturn("3party")
         whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
 
         testee.viewState(source = null).test {
@@ -477,6 +512,7 @@ class SyncConnectViewModelTest {
             val command = awaitItem()
             assertTrue("expected AskHostConfirmation, got $command", command is AskHostConfirmation)
             Assert.assertEquals("Peer Phone", (command as AskHostConfirmation).peerName)
+            Assert.assertEquals(PeerKind.THIRD_PARTY, (command as AskHostConfirmation).peerKind)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -708,6 +744,18 @@ class SyncConnectViewModelTest {
             assertEquals(PAIRING_CANCELLED.code.toV2PairingError(), (command as ShowV2Error).content)
             cancelAndIgnoreRemainingEvents()
         }
+
+        // Denying the confirmation (PAIRING_CANCELLED) fires the cancellation pixel, not the failed one.
+        verify(syncPixels).fireSyncSetupAbandoned(eq(SYNC_CONNECT), eq(CancellationReason.CONFIRMATION_DENIED))
+    }
+
+    @Test
+    fun whenUserCancelsMidExchangeThenAbandonedWithCancelledBeforeFinished() = runTest {
+        whenever(runner.currentState).thenReturn(ExchangeV2State.Negotiating)
+
+        testee.onUserCancelledWithoutSyncSetup()
+
+        verify(syncPixels).fireSyncSetupAbandoned(eq(SYNC_CONNECT), eq(CancellationReason.CANCELLED_BEFORE_FINISHED))
     }
 
     @Test
@@ -731,6 +779,13 @@ class SyncConnectViewModelTest {
             assertEquals(PAIRING_FAILED.code.toV2PairingError(), (command as ShowV2Error).content)
             cancelAndIgnoreRemainingEvents()
         }
+
+        verify(syncPixels).fireSyncSetupFailed(
+            eq(SetupFailureReason.TRANSPORT_FAILURE),
+            eq(SetupPath.PAIRING),
+            isNull(),
+            isNull(),
+        )
     }
 
     @Test

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
@@ -53,7 +53,6 @@ import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.AskHostConfirmation
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.AskJoinerConfirmation
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.LoginSuccess
-import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.ShowAlreadyConnected
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.ShowError
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flowOf
@@ -789,7 +788,7 @@ class SyncConnectViewModelTest {
     }
 
     @Test
-    fun whenV2PresentSameAccountThenShowAlreadyConnected() = runTest {
+    fun whenV2PresentSameAccountThenShowAlreadyPaired() = runTest {
         enableV2(displayOn = true)
         whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
 
@@ -805,19 +804,8 @@ class SyncConnectViewModelTest {
 
         testee.commands().test {
             val command = awaitItem()
-            assertTrue("expected ShowAlreadyConnected, got $command", command is ShowAlreadyConnected)
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
-    fun whenAlreadyConnectedAcknowledgedThenLoginSuccess() = runTest {
-        whenever(syncRepository.getAccountInfo()).thenReturn(AccountInfo())
-
-        testee.onAlreadyConnectedAcknowledged()
-
-        testee.commands().test {
-            assertTrue(awaitItem() is LoginSuccess)
+            assertTrue("expected ShowError, got $command", command is ShowError)
+            assertEquals(R.string.sync_v2_already_paired_message, (command as ShowError).message)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
@@ -803,7 +803,7 @@ class SyncConnectViewModelTest {
             testee.onQRCodeScanned(scannedCode)
             val command = awaitItem()
             assertTrue("expected ShowError, got $command", command is ShowError)
-            assertEquals(R.string.sync_flows_disabled_new_version, (command as ShowError).message)
+            assertEquals(R.string.sync_v2_error_upgrade_required, (command as ShowError).message)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
@@ -30,9 +30,11 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN
 import com.duckduckgo.sync.impl.AccountErrorCodes.CONNECT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
 import com.duckduckgo.sync.impl.AccountInfo
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
 import com.duckduckgo.sync.impl.Clipboard
 import com.duckduckgo.sync.impl.ConnectCode
 import com.duckduckgo.sync.impl.QREncoder
+import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.RecoveryCode
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncAccountRepository
@@ -53,8 +55,10 @@ import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.AskJoinerConfirm
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.LoginSuccess
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.ShowError
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
@@ -753,5 +757,54 @@ class SyncConnectViewModelTest {
             cancelAndIgnoreRemainingEvents()
         }
         verify(runner, times(1)).startPresent()
+    }
+
+    @Test
+    fun whenV2PairingRejectedByPeerThenShowError() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncRepository.getAccountInfo()).thenReturn(AccountInfo())
+        val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(qrCode.parse(scannedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(
+                ExchangeV2Event.Transition(
+                    timestampMs = 0L,
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                    localTrigger = null,
+                ),
+            ),
+        )
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scannedCode)
+            val command = awaitItem()
+            assertTrue("expected ShowError, got $command", command is ShowError)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2UpgradeRequiredThenShowUpdateError() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncRepository.getAccountInfo()).thenReturn(AccountInfo())
+        val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(qrCode.parse(scannedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(ExchangeV2Event.SessionError(timestampMs = 0L, message = "Peer requires protocol v3; please update this app")),
+        )
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scannedCode)
+            val command = awaitItem()
+            assertTrue("expected ShowError, got $command", command is ShowError)
+            assertEquals(R.string.sync_flows_disabled_new_version, (command as ShowError).message)
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
@@ -29,11 +29,13 @@ import com.duckduckgo.sync.TestSyncFixtures.primaryKey
 import com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN
 import com.duckduckgo.sync.impl.AccountErrorCodes.CONNECT_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
 import com.duckduckgo.sync.impl.AccountInfo
 import com.duckduckgo.sync.impl.Clipboard
 import com.duckduckgo.sync.impl.ConnectCode
 import com.duckduckgo.sync.impl.QREncoder
-import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.RecoveryCode
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncAccountRepository
@@ -54,6 +56,7 @@ import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.AskHostConfirmat
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.AskJoinerConfirmation
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.LoginSuccess
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.ShowError
+import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.ShowV2Error
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -647,7 +650,8 @@ class SyncConnectViewModelTest {
 
         testee.commands().test {
             val command = awaitItem()
-            assertTrue("expected ShowError, got $command", command is ShowError)
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_REJECTED.code.toV2PairingError(), (command as ShowV2Error).content)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -673,7 +677,8 @@ class SyncConnectViewModelTest {
 
         testee.commands().test {
             val command = awaitItem()
-            assertTrue("expected ShowError, got $command", command is ShowError)
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_CANCELLED.code.toV2PairingError(), (command as ShowV2Error).content)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -699,7 +704,8 @@ class SyncConnectViewModelTest {
 
         testee.commands().test {
             val command = awaitItem()
-            assertTrue("expected ShowError, got $command", command is ShowError)
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_CANCELLED.code.toV2PairingError(), (command as ShowV2Error).content)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -721,7 +727,8 @@ class SyncConnectViewModelTest {
 
         testee.commands().test {
             val command = awaitItem()
-            assertTrue("expected ShowError, got $command", command is ShowError)
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_FAILED.code.toV2PairingError(), (command as ShowV2Error).content)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -782,7 +789,8 @@ class SyncConnectViewModelTest {
         testee.commands().test {
             testee.onQRCodeScanned(scannedCode)
             val command = awaitItem()
-            assertTrue("expected ShowError, got $command", command is ShowError)
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_REJECTED.code.toV2PairingError(), (command as ShowV2Error).content)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -804,8 +812,8 @@ class SyncConnectViewModelTest {
 
         testee.commands().test {
             val command = awaitItem()
-            assertTrue("expected ShowError, got $command", command is ShowError)
-            assertEquals(R.string.sync_v2_already_paired_message, (command as ShowError).message)
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2AlreadyPairedError, (command as ShowV2Error).content)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -825,8 +833,8 @@ class SyncConnectViewModelTest {
         testee.commands().test {
             testee.onQRCodeScanned(scannedCode)
             val command = awaitItem()
-            assertTrue("expected ShowError, got $command", command is ShowError)
-            assertEquals(R.string.sync_v2_error_upgrade_required, (command as ShowError).message)
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2UpgradeRequiredError, (command as ShowV2Error).content)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
@@ -33,8 +33,10 @@ import com.duckduckgo.sync.impl.SyncAuthCode.Recovery
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command
 import kotlinx.coroutines.flow.flowOf
@@ -115,6 +117,33 @@ class SyncLoginViewModelTest {
             val command = awaitItem()
             assertTrue("expected ShowError, got $command", command is Command.ShowError)
             assertEquals(R.string.sync_flows_disabled_new_version, (command as Command.ShowError).message)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2PairingRejectedByPeerThenShowError() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(qrCode.parse(scannedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(
+                ExchangeV2Event.Transition(
+                    timestampMs = 0L,
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                    localTrigger = null,
+                ),
+            ),
+        )
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scannedCode)
+            val command = awaitItem()
+            assertTrue("expected ShowError, got $command", command is Command.ShowError)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.sync.TestSyncFixtures.jsonRecoveryKey
 import com.duckduckgo.sync.TestSyncFixtures.jsonRecoveryKeyEncoded
 import com.duckduckgo.sync.TestSyncFixtures.primaryKey
 import com.duckduckgo.sync.impl.R
+import com.duckduckgo.sync.impl.AccountInfo
 import com.duckduckgo.sync.impl.RealSyncCodeDispatcher
 import com.duckduckgo.sync.impl.RecoveryCode
 import com.duckduckgo.sync.impl.Result.Success
@@ -39,6 +40,7 @@ import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command
+import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command.LoginSucess
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -155,6 +157,18 @@ class SyncLoginViewModelTest {
             val command = awaitItem()
             assertTrue(command is Command.LoginSucess)
             verify(syncPixels).fireLoginPixel()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenAlreadyConnectedAcknowledgedThenLoginSuccess() = runTest {
+        whenever(syncRepostitory.getAccountInfo()).thenReturn(AccountInfo())
+
+        testee.onAlreadyConnectedAcknowledged()
+
+        testee.commands().test {
+            assertTrue(awaitItem() is LoginSucess)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
@@ -24,7 +24,6 @@ import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.sync.TestSyncFixtures.jsonRecoveryKey
 import com.duckduckgo.sync.TestSyncFixtures.jsonRecoveryKeyEncoded
 import com.duckduckgo.sync.TestSyncFixtures.primaryKey
-import com.duckduckgo.sync.impl.AccountInfo
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.RealSyncCodeDispatcher
 import com.duckduckgo.sync.impl.RecoveryCode
@@ -162,7 +161,7 @@ class SyncLoginViewModelTest {
     }
 
     @Test
-    fun whenV2SameAccountThenShowAlreadyConnected() = runTest {
+    fun whenV2SameAccountThenShowAlreadyPaired() = runTest {
         syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
         val scanned = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
         whenever(qrCode.parse(scanned)).thenReturn(
@@ -182,19 +181,9 @@ class SyncLoginViewModelTest {
 
         testee.commands().test {
             testee.onQRCodeScanned(scanned)
-            assertTrue(awaitItem() is Command.ShowAlreadyConnected)
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
-    fun whenAlreadyConnectedAcknowledgedThenLoginSuccess() = runTest {
-        whenever(syncRepostitory.getAccountInfo()).thenReturn(AccountInfo())
-
-        testee.onAlreadyConnectedAcknowledged()
-
-        testee.commands().test {
-            assertTrue(awaitItem() is LoginSucess)
+            val command = awaitItem()
+            assertTrue("expected ShowError, got $command", command is Command.ShowError)
+            assertEquals(R.string.sync_v2_already_paired_message, (command as Command.ShowError).message)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
@@ -162,6 +162,32 @@ class SyncLoginViewModelTest {
     }
 
     @Test
+    fun whenV2SameAccountThenShowAlreadyConnected() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        val scanned = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(qrCode.parse(scanned)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(
+                ExchangeV2Event.Transition(
+                    timestampMs = 0L,
+                    from = ExchangeV2State.Negotiating,
+                    to = ExchangeV2State.SameAccountAbort,
+                    trigger = null,
+                    localTrigger = null,
+                ),
+            ),
+        )
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scanned)
+            assertTrue(awaitItem() is Command.ShowAlreadyConnected)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun whenAlreadyConnectedAcknowledgedThenLoginSuccess() = runTest {
         whenever(syncRepostitory.getAccountInfo()).thenReturn(AccountInfo())
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
@@ -24,8 +24,8 @@ import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.sync.TestSyncFixtures.jsonRecoveryKey
 import com.duckduckgo.sync.TestSyncFixtures.jsonRecoveryKeyEncoded
 import com.duckduckgo.sync.TestSyncFixtures.primaryKey
-import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.AccountInfo
+import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.RealSyncCodeDispatcher
 import com.duckduckgo.sync.impl.RecoveryCode
 import com.duckduckgo.sync.impl.Result.Success

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
@@ -116,7 +116,7 @@ class SyncLoginViewModelTest {
             testee.onQRCodeScanned(scanned)
             val command = awaitItem()
             assertTrue("expected ShowError, got $command", command is Command.ShowError)
-            assertEquals(R.string.sync_flows_disabled_new_version, (command as Command.ShowError).message)
+            assertEquals(R.string.sync_v2_error_upgrade_required, (command as Command.ShowError).message)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
@@ -24,7 +24,7 @@ import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.sync.TestSyncFixtures.jsonRecoveryKey
 import com.duckduckgo.sync.TestSyncFixtures.jsonRecoveryKeyEncoded
 import com.duckduckgo.sync.TestSyncFixtures.primaryKey
-import com.duckduckgo.sync.impl.R
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
 import com.duckduckgo.sync.impl.RealSyncCodeDispatcher
 import com.duckduckgo.sync.impl.RecoveryCode
 import com.duckduckgo.sync.impl.Result.Success
@@ -40,6 +40,7 @@ import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command.LoginSucess
+import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command.ShowV2Error
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -116,8 +117,8 @@ class SyncLoginViewModelTest {
         testee.commands().test {
             testee.onQRCodeScanned(scanned)
             val command = awaitItem()
-            assertTrue("expected ShowError, got $command", command is Command.ShowError)
-            assertEquals(R.string.sync_v2_error_upgrade_required, (command as Command.ShowError).message)
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2UpgradeRequiredError, (command as ShowV2Error).content)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -144,7 +145,8 @@ class SyncLoginViewModelTest {
         testee.commands().test {
             testee.onQRCodeScanned(scannedCode)
             val command = awaitItem()
-            assertTrue("expected ShowError, got $command", command is Command.ShowError)
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_REJECTED.code.toV2PairingError(), (command as ShowV2Error).content)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -182,8 +184,8 @@ class SyncLoginViewModelTest {
         testee.commands().test {
             testee.onQRCodeScanned(scanned)
             val command = awaitItem()
-            assertTrue("expected ShowError, got $command", command is Command.ShowError)
-            assertEquals(R.string.sync_v2_already_paired_message, (command as Command.ShowError).message)
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2AlreadyPairedError, (command as ShowV2Error).content)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncV2ConfirmationCopyTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncV2ConfirmationCopyTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui
+
+import com.duckduckgo.sync.impl.R
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SyncV2ConfirmationCopyTest {
+
+    @Test fun whenKnownDdgPeerThenFullDataList() {
+        assertEquals(
+            R.string.sync_v2_confirmation_message_ddg,
+            syncV2ConfirmationMessageRes(unknownPeer = false, peerKind = PeerKind.DDG),
+        )
+    }
+
+    @Test fun whenKnownThirdPartyPeerThenChatsOnly() {
+        assertEquals(
+            R.string.sync_v2_confirmation_message_3p,
+            syncV2ConfirmationMessageRes(unknownPeer = false, peerKind = PeerKind.THIRD_PARTY),
+        )
+    }
+
+    @Test fun whenUnknownDdgPeerThenFullDataListWithoutName() {
+        assertEquals(
+            R.string.sync_v2_confirmation_message_unknown_peer_ddg,
+            syncV2ConfirmationMessageRes(unknownPeer = true, peerKind = PeerKind.DDG),
+        )
+    }
+
+    @Test fun whenUnknownThirdPartyPeerThenChatsOnlyWithoutName() {
+        assertEquals(
+            R.string.sync_v2_confirmation_message_unknown_peer_3p,
+            syncV2ConfirmationMessageRes(unknownPeer = true, peerKind = PeerKind.THIRD_PARTY),
+        )
+    }
+
+    @Test fun whenKindNullThenFallsBackToFullDdgList() {
+        assertEquals(
+            R.string.sync_v2_confirmation_message_ddg,
+            syncV2ConfirmationMessageRes(unknownPeer = false, peerKind = null),
+        )
+        assertEquals(
+            R.string.sync_v2_confirmation_message_unknown_peer_ddg,
+            syncV2ConfirmationMessageRes(unknownPeer = true, peerKind = null),
+        )
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
@@ -63,6 +63,9 @@ import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
 import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
 import com.duckduckgo.sync.impl.exchange.v2.PairingRole
 import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
+import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_EXCHANGE
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.AskHostConfirmation
@@ -83,6 +86,7 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -263,9 +267,9 @@ class SyncWithAnotherDeviceViewModelTest {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.ShowError)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE), eq(CodeVersion.V1), isNull())
             verify(syncPixels, never()).fireLoginPixel()
-            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any())
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -281,9 +285,9 @@ class SyncWithAnotherDeviceViewModelTest {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.ShowError)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE), eq(CodeVersion.V1), isNull())
             verify(syncPixels, never()).fireLoginPixel()
-            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any())
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -297,9 +301,9 @@ class SyncWithAnotherDeviceViewModelTest {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.AskToSwitchAccount)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE), eq(CodeVersion.V1), isNull())
             verify(syncPixels, never()).fireLoginPixel()
-            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any())
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -314,9 +318,9 @@ class SyncWithAnotherDeviceViewModelTest {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.AskToSwitchAccount)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE), eq(CodeVersion.V1), isNull())
             verify(syncPixels, never()).fireLoginPixel()
-            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any())
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -431,9 +435,9 @@ class SyncWithAnotherDeviceViewModelTest {
             testee.onQRCodeScanned(jsonRecoveryKeyEncoded)
             val command = awaitItem()
             assertTrue(command is Command.ShowError)
-            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE))
+            verify(syncPixels).fireBarcodeScannerParseSuccess(eq(SyncPixels.ScreenType.SYNC_EXCHANGE), eq(CodeVersion.V1), isNull())
             verify(syncPixels, never()).fireLoginPixel()
-            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any())
+            verify(syncPixels, never()).fireSyncSetupFinishedSuccessfully(any(), anyOrNull(), anyOrNull(), anyOrNull())
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -441,7 +445,7 @@ class SyncWithAnotherDeviceViewModelTest {
     @Test
     fun whenUserCancelsThenAbandonedPixelFired() = runTest {
         testee.onUserCancelledWithoutSyncSetup()
-        verify(syncPixels).fireSyncSetupAbandoned(eq(SYNC_EXCHANGE))
+        verify(syncPixels).fireSyncSetupAbandoned(eq(SYNC_EXCHANGE), eq(CancellationReason.SCANNING_CANCELLED))
     }
 
     @Test
@@ -564,6 +568,7 @@ class SyncWithAnotherDeviceViewModelTest {
         enableV2(displayOn = true)
         whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
         whenever(runner.peerName).thenReturn("Peer Phone")
+        whenever(runner.peerKind).thenReturn("3party")
         whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
 
         testee.viewState().test {
@@ -580,6 +585,7 @@ class SyncWithAnotherDeviceViewModelTest {
             val command = awaitItem()
             assertTrue("expected AskHostConfirmation, got $command", command is AskHostConfirmation)
             Assert.assertEquals("Peer Phone", (command as AskHostConfirmation).peerName)
+            Assert.assertEquals(PeerKind.THIRD_PARTY, (command as AskHostConfirmation).peerKind)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
@@ -756,7 +756,7 @@ class SyncWithAnotherDeviceViewModelTest {
             testee.onQRCodeScanned(scannedCode)
             val command = awaitItem()
             assertTrue("expected ShowError, got $command", command is ShowError)
-            assertEquals(R.string.sync_flows_disabled_new_version, (command as ShowError).message)
+            assertEquals(R.string.sync_v2_error_upgrade_required, (command as ShowError).message)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
@@ -36,12 +36,14 @@ import com.duckduckgo.sync.TestSyncFixtures.primaryKey
 import com.duckduckgo.sync.TestSyncFixtures.validLoginKeys
 import com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
 import com.duckduckgo.sync.impl.Clipboard
 import com.duckduckgo.sync.impl.ExchangeResult.AccountSwitchingRequired
 import com.duckduckgo.sync.impl.ExchangeResult.LoggedIn
 import com.duckduckgo.sync.impl.InvitationCode
 import com.duckduckgo.sync.impl.QREncoder
-import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.RealSyncCodeDispatcher
 import com.duckduckgo.sync.impl.RecoveryCode
 import com.duckduckgo.sync.impl.Result
@@ -67,6 +69,7 @@ import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.AskH
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.AskToSwitchAccount
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.LoginSuccess
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.ShowError
+import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.ShowV2Error
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.SwitchAccountSuccess
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flowOf
@@ -623,8 +626,8 @@ class SyncWithAnotherDeviceViewModelTest {
 
         testee.commands().test {
             val command = awaitItem()
-            assertTrue("expected ShowError, got $command", command is ShowError)
-            assertEquals(R.string.sync_v2_already_paired_message, (command as ShowError).message)
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2AlreadyPairedError, (command as ShowV2Error).content)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -651,7 +654,8 @@ class SyncWithAnotherDeviceViewModelTest {
 
         testee.commands().test {
             val command = awaitItem()
-            assertTrue("expected ShowError, got $command", command is ShowError)
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_CANCELLED.code.toV2PairingError(), (command as ShowV2Error).content)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -674,7 +678,8 @@ class SyncWithAnotherDeviceViewModelTest {
 
         testee.commands().test {
             val command = awaitItem()
-            assertTrue("expected ShowError, got $command", command is ShowError)
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_FAILED.code.toV2PairingError(), (command as ShowV2Error).content)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -730,7 +735,8 @@ class SyncWithAnotherDeviceViewModelTest {
                 ),
             )
             val command = awaitItem()
-            assertTrue("expected ShowError, got $command", command is ShowError)
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(PAIRING_REJECTED.code.toV2PairingError(), (command as ShowV2Error).content)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -750,8 +756,8 @@ class SyncWithAnotherDeviceViewModelTest {
         testee.commands().test {
             testee.onQRCodeScanned(scannedCode)
             val command = awaitItem()
-            assertTrue("expected ShowError, got $command", command is ShowError)
-            assertEquals(R.string.sync_v2_error_upgrade_required, (command as ShowError).message)
+            assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
+            assertEquals(v2UpgradeRequiredError, (command as ShowV2Error).content)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
@@ -36,9 +36,6 @@ import com.duckduckgo.sync.TestSyncFixtures.primaryKey
 import com.duckduckgo.sync.TestSyncFixtures.validLoginKeys
 import com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
-import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
-import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
-import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
 import com.duckduckgo.sync.impl.Clipboard
 import com.duckduckgo.sync.impl.ExchangeResult.AccountSwitchingRequired
 import com.duckduckgo.sync.impl.ExchangeResult.LoggedIn
@@ -55,7 +52,9 @@ import com.duckduckgo.sync.impl.SyncAuthCode.Exchange
 import com.duckduckgo.sync.impl.SyncAuthCode.Recovery
 import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.encodeB64
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
@@ -36,6 +36,9 @@ import com.duckduckgo.sync.TestSyncFixtures.primaryKey
 import com.duckduckgo.sync.TestSyncFixtures.validLoginKeys
 import com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN
 import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
+import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
 import com.duckduckgo.sync.impl.Clipboard
 import com.duckduckgo.sync.impl.ExchangeResult.AccountSwitchingRequired
 import com.duckduckgo.sync.impl.ExchangeResult.LoggedIn
@@ -702,5 +705,36 @@ class SyncWithAnotherDeviceViewModelTest {
             cancelAndIgnoreRemainingEvents()
         }
         verify(runner, times(1)).startPresent()
+    }
+
+    // ---- v2 Joiner: abort-error codes surfaced through onQRCodeScanned ----
+
+    @Test
+    fun whenV2PairingRejectedByPeerThenShowError() = runTest {
+        // Signed-in device elected Joiner against a signed-in peer; peer rejects → Failed(PAIRING_REJECTED).
+        // Must show a visible error. (Previously force-mapped to CONNECT_FAILED, discarding the code;
+        // guards the visible-error contract once the real code is passed through.)
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(qrCode.parse(scannedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scannedCode)
+            runnerEventsFlow.emit(
+                ExchangeV2Event.Transition(
+                    timestampMs = System.currentTimeMillis(),
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
+                    localTrigger = null,
+                ),
+            )
+            val command = awaitItem()
+            assertTrue("expected ShowError, got $command", command is ShowError)
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
@@ -73,6 +73,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -606,7 +607,7 @@ class SyncWithAnotherDeviceViewModelTest {
     }
 
     @Test
-    fun whenSameAccountAbortDuringV2PresentThenLoginSuccessShowRecoveryFalse() = runTest {
+    fun whenSameAccountAbortDuringV2PresentThenShowAlreadyConnected() = runTest {
         enableV2(displayOn = true)
         whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
         whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
@@ -623,8 +624,21 @@ class SyncWithAnotherDeviceViewModelTest {
 
         testee.commands().test {
             val command = awaitItem()
-            assertTrue("expected LoginSuccess (friendly finish), got $command", command is LoginSuccess)
-            Assert.assertEquals(false, (command as LoginSuccess).showRecovery)
+            assertTrue("expected ShowAlreadyConnected, got $command", command is Command.ShowAlreadyConnected)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenAlreadyConnectedAcknowledgedThenLoginSuccessWithoutRecovery() = runTest {
+        whenever(syncRepository.getAccountInfo()).thenReturn(noAccount)
+
+        testee.onAlreadyConnectedAcknowledged()
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue(command is LoginSuccess)
+            assertFalse((command as LoginSuccess).showRecovery)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
@@ -73,7 +73,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Assert.assertEquals
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -607,7 +606,7 @@ class SyncWithAnotherDeviceViewModelTest {
     }
 
     @Test
-    fun whenSameAccountAbortDuringV2PresentThenShowAlreadyConnected() = runTest {
+    fun whenSameAccountAbortDuringV2PresentThenShowAlreadyPaired() = runTest {
         enableV2(displayOn = true)
         whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
         whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(TestSyncFixtures.qrBitmap())
@@ -624,21 +623,8 @@ class SyncWithAnotherDeviceViewModelTest {
 
         testee.commands().test {
             val command = awaitItem()
-            assertTrue("expected ShowAlreadyConnected, got $command", command is Command.ShowAlreadyConnected)
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
-    fun whenAlreadyConnectedAcknowledgedThenLoginSuccessWithoutRecovery() = runTest {
-        whenever(syncRepository.getAccountInfo()).thenReturn(noAccount)
-
-        testee.onAlreadyConnectedAcknowledged()
-
-        testee.commands().test {
-            val command = awaitItem()
-            assertTrue(command is LoginSuccess)
-            assertFalse((command as LoginSuccess).showRecovery)
+            assertTrue("expected ShowError, got $command", command is ShowError)
+            assertEquals(R.string.sync_v2_already_paired_message, (command as ShowError).message)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -723,13 +709,8 @@ class SyncWithAnotherDeviceViewModelTest {
         verify(runner, times(1)).startPresent()
     }
 
-    // ---- v2 Joiner: abort-error codes surfaced through onQRCodeScanned ----
-
     @Test
     fun whenV2PairingRejectedByPeerThenShowError() = runTest {
-        // Signed-in device elected Joiner against a signed-in peer; peer rejects → Failed(PAIRING_REJECTED).
-        // Must show a visible error. (Previously force-mapped to CONNECT_FAILED, discarding the code;
-        // guards the visible-error contract once the real code is passed through.)
         syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
         whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
         val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
@@ -44,6 +44,7 @@ import com.duckduckgo.sync.impl.ExchangeResult.AccountSwitchingRequired
 import com.duckduckgo.sync.impl.ExchangeResult.LoggedIn
 import com.duckduckgo.sync.impl.InvitationCode
 import com.duckduckgo.sync.impl.QREncoder
+import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.RealSyncCodeDispatcher
 import com.duckduckgo.sync.impl.RecoveryCode
 import com.duckduckgo.sync.impl.Result
@@ -69,8 +70,10 @@ import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.Logi
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.ShowError
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.SwitchAccountSuccess
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -734,6 +737,27 @@ class SyncWithAnotherDeviceViewModelTest {
             )
             val command = awaitItem()
             assertTrue("expected ShowError, got $command", command is ShowError)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenV2UpgradeRequiredThenShowUpdateError() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+        val scannedCode = "https://duckduckgo.com/sync/pairing/#&code2=v2code"
+        whenever(qrCode.parse(scannedCode)).thenReturn(
+            ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
+        )
+        whenever(runner.eventsSince(any())).thenReturn(
+            flowOf(ExchangeV2Event.SessionError(timestampMs = 0L, message = "Peer requires protocol v3; please update this app")),
+        )
+
+        testee.commands().test {
+            testee.onQRCodeScanned(scannedCode)
+            val command = awaitItem()
+            assertTrue("expected ShowError, got $command", command is ShowError)
+            assertEquals(R.string.sync_flows_disabled_new_version, (command as ShowError).message)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/V2PairingErrorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/V2PairingErrorTest.kt
@@ -32,8 +32,12 @@ class V2PairingErrorTest {
     @Test
     fun whenCodeIsAKnownPairingAbortThenReturnsSyncWithAnotherDeviceError() {
         listOf(
-            PAIRING_REJECTED, PAIRING_UNAVAILABLE, PAIRING_CANCELLED,
-            NEGOTIATION_ABORTED, NO_RECOVERY_CODE, PAIRING_FAILED,
+            PAIRING_REJECTED,
+            PAIRING_UNAVAILABLE,
+            PAIRING_CANCELLED,
+            NEGOTIATION_ABORTED,
+            NO_RECOVERY_CODE,
+            PAIRING_FAILED,
         ).forEach { code ->
             assertEquals(
                 "code $code should map to the pairing error string",

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/V2PairingErrorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/V2PairingErrorTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui
+
+import com.duckduckgo.sync.impl.AccountErrorCodes.GENERIC_ERROR
+import com.duckduckgo.sync.impl.AccountErrorCodes.NEGOTIATION_ABORTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.NO_RECOVERY_CODE
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_UNAVAILABLE
+import com.duckduckgo.sync.impl.R
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class V2PairingErrorTest {
+
+    @Test
+    fun whenCodeIsAKnownPairingAbortThenReturnsSyncWithAnotherDeviceError() {
+        listOf(
+            PAIRING_REJECTED, PAIRING_UNAVAILABLE, PAIRING_CANCELLED,
+            NEGOTIATION_ABORTED, NO_RECOVERY_CODE, PAIRING_FAILED,
+        ).forEach { code ->
+            assertEquals(
+                "code $code should map to the pairing error string",
+                R.string.sync_connect_login_error,
+                code.code.toV2PairingErrorMessage(),
+            )
+        }
+    }
+
+    @Test
+    fun whenCodeIsUnknownThenReturnsGenericError() {
+        assertEquals(R.string.sync_connect_generic_error, GENERIC_ERROR.code.toV2PairingErrorMessage())
+        assertEquals(R.string.sync_connect_generic_error, 9999.toV2PairingErrorMessage())
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/V2PairingErrorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/V2PairingErrorTest.kt
@@ -26,56 +26,58 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_UNAVAILABLE
 import com.duckduckgo.sync.impl.AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED
 import com.duckduckgo.sync.impl.R
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class V2PairingErrorTest {
 
     @Test
-    fun whenCodeIsPairingRejectedThenCanceledFromOtherDeviceCopy() {
+    fun whenCodeIsPairingRejectedThenCanceledFromOtherDeviceTitleWithTryAgain() {
         val content = PAIRING_REJECTED.code.toV2PairingError()
-        assertEquals(R.string.sync_dialog_error_title, content.title)
-        assertEquals(R.string.sync_v2_error_pairing_rejected, content.message)
+        assertEquals(R.string.sync_v2_error_pairing_rejected, content.title)
+        assertEquals(R.string.sync_v2_error_try_again, content.message)
     }
 
     @Test
-    fun whenCodeIsPairingCancelledThenCanceledCopy() {
+    fun whenCodeIsPairingCancelledThenCanceledTitleOnly() {
         val content = PAIRING_CANCELLED.code.toV2PairingError()
-        assertEquals(R.string.sync_dialog_error_title, content.title)
-        assertEquals(R.string.sync_v2_error_pairing_canceled, content.message)
+        assertEquals(R.string.sync_v2_error_pairing_canceled, content.title)
+        assertNull(content.message)
     }
 
     @Test
-    fun whenCodeIsThirdPartyAlreadyUpgradedThenSyncFromConnectedBrowserCopy() {
+    fun whenCodeIsThirdPartyAlreadyUpgradedThenSyncFailedTitleWithUpgradeMessage() {
         val content = THIRD_PARTY_ALREADY_UPGRADED.code.toV2PairingError()
         assertEquals(R.string.sync_v2_error_pairing_failed, content.title)
         assertEquals(R.string.sync_v2_error_third_party_already_upgraded, content.message)
     }
 
     @Test
-    fun whenCodeIsAnyOtherAbortThenSyncFailedCopy() {
+    fun whenCodeIsAnyOtherAbortThenSyncFailedTitleWithTryAgain() {
         listOf(PAIRING_UNAVAILABLE, NEGOTIATION_ABORTED, NO_RECOVERY_CODE, PAIRING_FAILED).forEach { code ->
-            assertEquals(
-                "code $code should map to Sync failed.",
-                R.string.sync_v2_error_pairing_failed,
-                code.code.toV2PairingError().message,
-            )
+            val content = code.code.toV2PairingError()
+            assertEquals("code $code title", R.string.sync_v2_error_pairing_failed, content.title)
+            assertEquals("code $code message", R.string.sync_v2_error_try_again, content.message)
         }
     }
 
     @Test
-    fun whenCodeIsGenericOrUnknownThenSyncFailedCopy() {
-        assertEquals(R.string.sync_v2_error_pairing_failed, GENERIC_ERROR.code.toV2PairingError().message)
-        assertEquals(R.string.sync_v2_error_pairing_failed, 9999.toV2PairingError().message)
+    fun whenCodeIsGenericOrUnknownThenSyncFailedTitleWithTryAgain() {
+        listOf(GENERIC_ERROR.code, 9999).forEach { code ->
+            val content = code.toV2PairingError()
+            assertEquals(R.string.sync_v2_error_pairing_failed, content.title)
+            assertEquals(R.string.sync_v2_error_try_again, content.message)
+        }
     }
 
     @Test
-    fun whenUpgradeRequiredThenUpdateBrowserCopy() {
-        assertEquals(R.string.sync_dialog_error_title, v2UpgradeRequiredError.title)
-        assertEquals(R.string.sync_v2_error_upgrade_required, v2UpgradeRequiredError.message)
+    fun whenUpgradeRequiredThenUpdateBrowserTitleOnly() {
+        assertEquals(R.string.sync_v2_error_upgrade_required, v2UpgradeRequiredError.title)
+        assertNull(v2UpgradeRequiredError.message)
     }
 
     @Test
-    fun whenAlreadyPairedThenAlreadyPairedCopy() {
+    fun whenAlreadyPairedThenAlreadySyncedTitleWithMessage() {
         assertEquals(R.string.sync_v2_already_paired_title, v2AlreadyPairedError.title)
         assertEquals(R.string.sync_v2_already_paired_message, v2AlreadyPairedError.message)
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/V2PairingErrorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/V2PairingErrorTest.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
 import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
 import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_UNAVAILABLE
+import com.duckduckgo.sync.impl.AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED
 import com.duckduckgo.sync.impl.R
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -41,6 +42,13 @@ class V2PairingErrorTest {
         val content = PAIRING_CANCELLED.code.toV2PairingError()
         assertEquals(R.string.sync_dialog_error_title, content.title)
         assertEquals(R.string.sync_v2_error_pairing_canceled, content.message)
+    }
+
+    @Test
+    fun whenCodeIsThirdPartyAlreadyUpgradedThenSyncFromConnectedBrowserCopy() {
+        val content = THIRD_PARTY_ALREADY_UPGRADED.code.toV2PairingError()
+        assertEquals(R.string.sync_dialog_error_title, content.title)
+        assertEquals(R.string.sync_v2_error_third_party_already_upgraded, content.message)
     }
 
     @Test

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/V2PairingErrorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/V2PairingErrorTest.kt
@@ -30,26 +30,39 @@ import org.junit.Test
 class V2PairingErrorTest {
 
     @Test
-    fun whenCodeIsAKnownPairingAbortThenReturnsSyncWithAnotherDeviceError() {
-        listOf(
-            PAIRING_REJECTED,
-            PAIRING_UNAVAILABLE,
-            PAIRING_CANCELLED,
-            NEGOTIATION_ABORTED,
-            NO_RECOVERY_CODE,
-            PAIRING_FAILED,
-        ).forEach { code ->
+    fun whenCodeIsPairingRejectedThenCanceledFromOtherDeviceCopy() {
+        val content = PAIRING_REJECTED.code.toV2PairingError()
+        assertEquals(R.string.sync_dialog_error_title, content.title)
+        assertEquals(R.string.sync_v2_error_pairing_rejected, content.message)
+    }
+
+    @Test
+    fun whenCodeIsPairingCancelledThenCanceledCopy() {
+        val content = PAIRING_CANCELLED.code.toV2PairingError()
+        assertEquals(R.string.sync_dialog_error_title, content.title)
+        assertEquals(R.string.sync_v2_error_pairing_canceled, content.message)
+    }
+
+    @Test
+    fun whenCodeIsAnyOtherAbortThenSyncFailedCopy() {
+        listOf(PAIRING_UNAVAILABLE, NEGOTIATION_ABORTED, NO_RECOVERY_CODE, PAIRING_FAILED).forEach { code ->
             assertEquals(
-                "code $code should map to the pairing error string",
-                R.string.sync_connect_login_error,
-                code.code.toV2PairingErrorMessage(),
+                "code $code should map to Sync failed.",
+                R.string.sync_v2_error_pairing_failed,
+                code.code.toV2PairingError().message,
             )
         }
     }
 
     @Test
-    fun whenCodeIsUnknownThenReturnsGenericError() {
-        assertEquals(R.string.sync_connect_generic_error, GENERIC_ERROR.code.toV2PairingErrorMessage())
-        assertEquals(R.string.sync_connect_generic_error, 9999.toV2PairingErrorMessage())
+    fun whenCodeIsGenericOrUnknownThenSyncFailedCopy() {
+        assertEquals(R.string.sync_v2_error_pairing_failed, GENERIC_ERROR.code.toV2PairingError().message)
+        assertEquals(R.string.sync_v2_error_pairing_failed, 9999.toV2PairingError().message)
+    }
+
+    @Test
+    fun whenUpgradeRequiredThenUpdateBrowserCopy() {
+        assertEquals(R.string.sync_dialog_error_title, v2UpgradeRequiredError.title)
+        assertEquals(R.string.sync_v2_error_upgrade_required, v2UpgradeRequiredError.message)
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/V2PairingErrorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/V2PairingErrorTest.kt
@@ -73,4 +73,10 @@ class V2PairingErrorTest {
         assertEquals(R.string.sync_dialog_error_title, v2UpgradeRequiredError.title)
         assertEquals(R.string.sync_v2_error_upgrade_required, v2UpgradeRequiredError.message)
     }
+
+    @Test
+    fun whenAlreadyPairedThenAlreadyPairedCopy() {
+        assertEquals(R.string.sync_v2_already_paired_title, v2AlreadyPairedError.title)
+        assertEquals(R.string.sync_v2_already_paired_message, v2AlreadyPairedError.message)
+    }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/V2PairingErrorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/V2PairingErrorTest.kt
@@ -47,7 +47,7 @@ class V2PairingErrorTest {
     @Test
     fun whenCodeIsThirdPartyAlreadyUpgradedThenSyncFromConnectedBrowserCopy() {
         val content = THIRD_PARTY_ALREADY_UPGRADED.code.toV2PairingError()
-        assertEquals(R.string.sync_dialog_error_title, content.title)
+        assertEquals(R.string.sync_v2_error_pairing_failed, content.title)
         assertEquals(R.string.sync_v2_error_third_party_already_upgraded, content.message)
     }
 

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
@@ -30,7 +30,6 @@ import com.duckduckgo.persistentstorage.api.PersistentStorage
 import com.duckduckgo.persistentstorage.api.PersistentStorageAvailability
 import com.duckduckgo.sync.api.favicons.FaviconsFetchingStore
 import com.duckduckgo.sync.impl.ConnectedDevice
-import com.duckduckgo.sync.impl.ProtectedKeyEntry
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
@@ -51,9 +50,6 @@ import com.duckduckgo.sync.internal.ui.SyncInternalSettingsViewModel.Command.Rea
 import com.duckduckgo.sync.internal.ui.SyncInternalSettingsViewModel.Command.ShowMessage
 import com.duckduckgo.sync.internal.ui.SyncInternalSettingsViewModel.Command.ShowQR
 import com.duckduckgo.sync.store.*
-import com.squareup.moshi.JsonAdapter
-import com.squareup.moshi.Moshi
-import com.squareup.moshi.Types
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
@@ -521,7 +517,6 @@ constructor(
     private fun buildV2StoreFieldsText(): String = buildString {
         appendLine("credentialId: ${syncStore.credentialId ?: "(not set)"}")
         appendLine("scopedPassword: ${syncStore.scopedPassword?.raw?.take(40)?.let { "$it..." } ?: "(not set)"}")
-        appendLine("protectedKeysJson: ${syncStore.protectedKeysJson?.take(60)?.let { "$it..." } ?: "(not set)"}")
     }.trim().also { logcat { "Sync-ScopedToken: v2 store fields:\n$it" } }
 
     fun onCreateThirdPartyCredentialClicked() {
@@ -598,9 +593,6 @@ constructor(
                     }
                 }
                 logcat { "Sync-ScopedToken: keys:\n$text" }
-                // Refresh the local cache to match the server — per Access Credentials TD,
-                // the cache is the device's last-known view of /sync/keys.
-                syncStore.protectedKeysJson = protectedKeysAdapter.toJson(result.data)
                 viewState.update { it.copy(keysText = text) }
             }
             is Error -> {
@@ -806,12 +798,5 @@ constructor(
     private fun isDeviceSecureLockEnabled(): Boolean {
         val keyguardManager = context.getSystemService(KeyguardManager::class.java)
         return keyguardManager?.isDeviceSecure == true
-    }
-
-    private companion object {
-        private val protectedKeysAdapter: JsonAdapter<List<ProtectedKeyEntry>> =
-            Moshi.Builder().build().adapter(
-                Types.newParameterizedType(List::class.java, ProtectedKeyEntry::class.java),
-            )
     }
 }

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugActivity.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugActivity.kt
@@ -319,13 +319,6 @@ class SyncV2PairingDebugActivity : DuckDuckGoActivity() {
                 else -> "Not created; needed before pairing with 3party peers"
             },
         )
-        binding.statusAiChatsKey.setSecondaryText(
-            when {
-                !status.signedIn -> "(not signed in)"
-                status.aiChatsProtectedKeyCreated -> "Yes"
-                else -> "Not created; needed for ai_chats sync"
-            },
-        )
     }
 
     private companion object {

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModel.kt
@@ -79,7 +79,6 @@ class SyncV2PairingDebugViewModel @Inject constructor(
         val signedIn: Boolean,
         val userId: String?,
         val thirdPartyCredentialCreated: Boolean,
-        val aiChatsProtectedKeyCreated: Boolean,
     )
 
     data class ViewState(
@@ -87,7 +86,7 @@ class SyncV2PairingDebugViewModel @Inject constructor(
         val linkingCode: String? = null,
         val rows: List<LogRow> = emptyList(),
         val autoApproveConfirmation: Boolean = true,
-        val accountStatus: AccountStatus = AccountStatus(false, null, false, false),
+        val accountStatus: AccountStatus = AccountStatus(false, null, false),
     )
 
     /**
@@ -535,23 +534,14 @@ class SyncV2PairingDebugViewModel @Inject constructor(
         }
     }
 
-    /**
-     * All three flags read from [SyncStore]. The cache is kept in sync with the server by the
-     * upstream Track A code paths (signup, login, Create Protected Key, Fetch Keys, 3party
-     * upgrade). Crude string match on `purpose` is fine here — the JSON shape is a list of
-     * `{kid, purpose, ...}` and "ai_chats" won't appear in other field values.
-     */
     private fun readAccountStatus(): AccountStatus {
         val userId = syncStore.userId
         val signedIn = userId != null
         val thirdParty = syncStore.scopedPassword != null
-        val keysJson = syncStore.protectedKeysJson.orEmpty()
-        val aiChats = signedIn && keysJson.contains("\"ai_chats\"")
         return AccountStatus(
             signedIn = signedIn,
             userId = userId,
             thirdPartyCredentialCreated = signedIn && thirdParty,
-            aiChatsProtectedKeyCreated = aiChats,
         )
     }
 

--- a/sync/sync-internal/src/main/res/layout/activity_sync_v2_pairing_debug.xml
+++ b/sync/sync-internal/src/main/res/layout/activity_sync_v2_pairing_debug.xml
@@ -71,13 +71,6 @@
                 app:primaryText="3party credential"
                 tools:secondaryText="Not created" />
 
-            <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
-                android:id="@+id/statusAiChatsKey"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:primaryText="ai_chats protected key"
-                tools:secondaryText="Not created" />
-
             <com.duckduckgo.common.ui.view.divider.HorizontalDivider
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />

--- a/sync/sync-internal/src/test/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModelTest.kt
+++ b/sync/sync-internal/src/test/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugViewModelTest.kt
@@ -25,12 +25,14 @@ import com.duckduckgo.sync.impl.RouteDecision
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode
 import com.duckduckgo.sync.impl.SyncCodeDispatcher
+import com.duckduckgo.sync.impl.SyncCodeType
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.Hello
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
 import com.duckduckgo.sync.impl.exchange.v2.RejectReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
 import com.duckduckgo.sync.store.SyncStore
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flowOf
@@ -207,7 +209,10 @@ class SyncV2PairingDebugViewModelTest {
 
     @Test fun `V2InProgress — collects the outcomes Flow without calling parseSyncAuthCode`() {
         whenever(dispatcher.route(any())).thenReturn(
-            RouteDecision.V2InProgress(outcomes = flowOf(DispatchOutcome.LoggedIn)),
+            RouteDecision.V2InProgress(
+                codeType = SyncCodeType.RECOVERY,
+                outcomes = flowOf(DispatchOutcome.LoggedIn(path = SetupPath.RECOVERY)),
+            ),
         )
         val viewModel = newViewModel()
 
@@ -219,7 +224,10 @@ class SyncV2PairingDebugViewModelTest {
 
     @Test fun `V2InProgress with Failed outcome — does NOT crash and does NOT fall back to legacy`() {
         whenever(dispatcher.route(any())).thenReturn(
-            RouteDecision.V2InProgress(outcomes = flowOf(DispatchOutcome.Failed("BE rejected"))),
+            RouteDecision.V2InProgress(
+                codeType = SyncCodeType.RECOVERY,
+                outcomes = flowOf(DispatchOutcome.Failed("BE rejected")),
+            ),
         )
         val viewModel = newViewModel()
 

--- a/sync/sync-store/src/main/java/com/duckduckgo/sync/store/SyncStore.kt
+++ b/sync/sync-store/src/main/java/com/duckduckgo/sync/store/SyncStore.kt
@@ -30,9 +30,6 @@ interface SyncStore {
     /** Scoped password (SP primary key) for the 3party credential. Only present when a 3party credential exists. */
     var scopedPassword: ScopedPassword?
 
-    /** JSON array of protected keys with kid, purpose, encrypted_with, encrypted_private_key. */
-    var protectedKeysJson: String?
-
     fun isEncryptionSupported(): Boolean
     fun isSignedInFlow(): Flow<Boolean>
     fun isSignedIn(): Boolean
@@ -166,14 +163,6 @@ constructor(
             }
         }
 
-    override var protectedKeysJson: String?
-        get() = encryptedPreferences?.getString(KEY_PROTECTED_KEYS_JSON, null)
-        set(value) {
-            encryptedPreferences?.edit(commit = true) {
-                if (value == null) remove(KEY_PROTECTED_KEYS_JSON) else putString(KEY_PROTECTED_KEYS_JSON, value)
-            }
-        }
-
     override fun isEncryptionSupported(): Boolean = encryptedPreferences != null
 
     override fun isSignedInFlow(): Flow<Boolean> = isSignedInStateFlow
@@ -218,6 +207,5 @@ constructor(
         private const val KEY_SK = "KEY_SK"
         private const val KEY_CREDENTIAL_ID = "KEY_CREDENTIAL_ID"
         private const val KEY_SCOPED_PASSWORD = "KEY_SCOPED_PASSWORD"
-        private const val KEY_PROTECTED_KEYS_JSON = "KEY_PROTECTED_KEYS_JSON"
     }
 }

--- a/sync/sync-store/src/test/java/com/duckduckgo/sync/store/SyncSharedPrefsStoreTest.kt
+++ b/sync/sync-store/src/test/java/com/duckduckgo/sync/store/SyncSharedPrefsStoreTest.kt
@@ -134,25 +134,13 @@ class SyncSharedPrefsStoreTest {
     }
 
     @Test
-    fun whenProtectedKeysJsonStoredThenValueUpdatedInPrefsStore() {
-        assertNull(store.protectedKeysJson)
-        val keysJson = """[{"kid":"k1","purpose":"ai_chats","encrypted_with":"ddg","encrypted_private_key":"jwe_data"}]"""
-        store.protectedKeysJson = keysJson
-        assertEquals(keysJson, store.protectedKeysJson)
-        store.protectedKeysJson = null
-        assertNull(store.protectedKeysJson)
-    }
-
-    @Test
     fun whenClearAllThenV2FieldsAlsoCleared() {
         store.credentialId = "ddg"
         store.scopedPassword = ScopedPassword("encrypted_sp")
-        store.protectedKeysJson = """[{"kid":"k1"}]"""
 
         store.clearAll()
 
         assertNull(store.credentialId)
         assertNull(store.scopedPassword)
-        assertNull(store.protectedKeysJson)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1149059203486286/task/1215770665368267?focus=true 
Tech Design URL (if applicable): 

### Description
Adds more granular error/abort events during sync v2
- Join/Host abort events
- recovery unavailable or denied
- generic abort

Use proposed copies for messages:
- Pairing rejected
- 3rd party upgrade reject
- Upgrade required
- Other terminal errors without specific copy

### Steps to test this PR

_Feature 1_
- [ ] Execute error scenarios from https://app.asana.com/1/137249556945/project/1142021229838617/task/1214801613721688?focus=true
- [ ] Validate the copies show as expected

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect live sync pairing, login, 3party upgrade, and protected-key API behavior; removing local protected-key caching shifts correctness to server responses and callers that fetch keys elsewhere.
> 
> **Overview**
> **Sync v2 pairing and setup UX** now surfaces terminal outcomes through dedicated v2 error dialogs (upgrade required, already paired, peer rejected/canceled, generic retry) instead of treating some cases like a successful login. Host/joiner confirmation copy varies by peer credential kind (DDG vs third-party), and abandonment/cancellation pixels distinguish scanning vs mid-exchange vs confirmation denied via `isV2ExchangeUnderway()`.
> 
> **Dispatch and telemetry:** `DispatchOutcome` carries setup path, role, and peer kind for success and failure; v2 flows map aborts and session errors to specific `AccountErrorCodes` (e.g. pairing rejected/unavailable/cancelled, negotiation aborted, no recovery code). A new `sync_setup.json5` pixel catalog and `SyncPixels` wiring fire screen, code-recognized, success, failed, and abandoned events with v1/v2 flow metadata.
> 
> **Account/crypto plumbing:** `setProtectedKeyIfAbsent` now POSTs a key list and returns the server’s authoritative keys; `ProtectedKeyManager` adopts the server entry on races and no longer writes a local protected-keys cache. Login/3party upgrade paths stop persisting `protectedKeysJson` on `SyncStore`; third-party credential extend only mints `ai_chats` when missing and keeps other ddg-wrapped purposes. `ExchangeV2Runner` exposes `peerKind` for the dispatcher and uses less verbose session error messages on the wire.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 487cbe8b5e3b262c0881ff0a1ff39c8a3fc1f7e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->