### PR TITLE
Cookies kmp integration

### DIFF
--- a/cookies/cookies-impl/build.gradle
+++ b/cookies/cookies-impl/build.gradle
@@ -39,6 +39,8 @@ dependencies {
     implementation project(':content-scope-scripts-api')
     implementation project(':duckchat-api')
 
+    implementation "io.github.fernandafbmarques:cookies-kmp-core:0.1.4"
+
     implementation "com.squareup.logcat:logcat:_"
     implementation Square.retrofit2.converter.moshi
 

--- a/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/features/CookiesFeatureTogglesPlugin.kt
+++ b/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/features/CookiesFeatureTogglesPlugin.kt
@@ -16,6 +16,9 @@
 
 package com.duckduckgo.cookies.impl.features
 
+import com.cookies.kmp.core.CookiesFeatureName
+import com.cookies.kmp.core.CookiesHostParityFacade
+import com.cookies.kmp.core.ToggleEvaluationInput
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.cookies.impl.cookiesFeatureValueOf
 import com.duckduckgo.cookies.store.CookiesFeatureToggleRepository
@@ -31,7 +34,15 @@ class CookiesFeatureTogglesPlugin @Inject constructor(
 ) : FeatureTogglesPlugin {
     override fun isEnabled(featureName: String, defaultValue: Boolean): Boolean? {
         val cookiesFeature = cookiesFeatureValueOf(featureName) ?: return null
-        return cookiesFeatureToggleRepository.get(cookiesFeature, defaultValue) &&
-            appBuildConfig.versionCode >= cookiesFeatureToggleRepository.getMinSupportedVersion(cookiesFeature)
+
+        val input = ToggleEvaluationInput(
+            featureName = CookiesFeatureName.Cookie,
+            defaultValue = defaultValue,
+            appVersionCode = appBuildConfig.versionCode,
+            enabled = cookiesFeatureToggleRepository.get(cookiesFeature, defaultValue),
+            minSupportedVersion = cookiesFeatureToggleRepository.getMinSupportedVersion(cookiesFeature),
+        )
+
+        return CookiesHostParityFacade.evaluateToggle(input).isEnabled
     }
 }

--- a/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/thirdpartycookienames/RealThirdPartyCookieNames.kt
+++ b/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/thirdpartycookienames/RealThirdPartyCookieNames.kt
@@ -16,6 +16,8 @@
 
 package com.duckduckgo.cookies.impl.thirdpartycookienames
 
+import com.cookies.kmp.core.CookieMatchInput
+import com.cookies.kmp.core.CookiesHostParityFacade
 import com.duckduckgo.cookies.api.ThirdPartyCookieNames
 import com.duckduckgo.cookies.store.CookiesRepository
 import com.duckduckgo.di.scopes.AppScope
@@ -28,6 +30,13 @@ class RealThirdPartyCookieNames @Inject constructor(
 ) : ThirdPartyCookieNames {
 
     override fun hasExcludedCookieName(cookieString: String): Boolean {
-        return cookiesRepository.cookieNames.any { cookieString.contains(it) }
+        return CookiesHostParityFacade.evaluateCookie(
+            CookieMatchInput(
+                cookieString = cookieString,
+                cookieDomain = "",
+                excludedCookieNames = cookiesRepository.cookieNames.toList(),
+                allowedDomains = emptyList(),
+            ),
+        ).hasExcludedCookieName
     }
 }

--- a/cookies/cookies-impl/src/test/java/com/duckduckgo/cookies/impl/CookiesHostParityFacadeIntegrationTest.kt
+++ b/cookies/cookies-impl/src/test/java/com/duckduckgo/cookies/impl/CookiesHostParityFacadeIntegrationTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.cookies.impl
+
+import com.cookies.kmp.core.CookiesHostParityFacade
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CookiesHostParityFacadeIntegrationTest {
+
+    @Test
+    fun configFormattingFixtures_matchExpectedOutputs() {
+        CookiesHostParityFacade.configFormattingFixtures().forEach { fixture ->
+            assertEquals(fixture.name, fixture.expectedOutput, CookiesHostParityFacade.formatConfig(fixture.input))
+        }
+    }
+
+    @Test
+    fun toggleEvaluationFixtures_matchExpectedOutputs() {
+        CookiesHostParityFacade.toggleEvaluationFixtures().forEach { fixture ->
+            assertEquals(fixture.name, fixture.expectedOutput, CookiesHostParityFacade.evaluateToggle(fixture.input))
+        }
+    }
+
+    @Test
+    fun cookieMatchFixtures_matchExpectedOutputs() {
+        CookiesHostParityFacade.cookieMatchFixtures().forEach { fixture ->
+            val result = CookiesHostParityFacade.evaluateCookie(fixture.input)
+            assertEquals(fixture.name, fixture.expectedOutput, result)
+        }
+    }
+
+    @Test
+    fun cookieMatchFixtures_coverPositiveAndNegativeParityCases() {
+        val fixtures = CookiesHostParityFacade.cookieMatchFixtures()
+
+        assertTrue(fixtures.any { it.expectedOutput.hasExcludedCookieName })
+        assertTrue(fixtures.any { it.expectedOutput.matchesAllowedDomain })
+        assertTrue(fixtures.any { !it.expectedOutput.hasExcludedCookieName })
+        assertTrue(fixtures.any { !it.expectedOutput.matchesAllowedDomain })
+        assertFalse(fixtures.isEmpty())
+    }
+}

--- a/cookies/cookies-impl/src/test/java/com/duckduckgo/cookies/impl/thirdpartycookienames/RealThirdPartyCookieNamesTest.kt
+++ b/cookies/cookies-impl/src/test/java/com/duckduckgo/cookies/impl/thirdpartycookienames/RealThirdPartyCookieNamesTest.kt
@@ -44,13 +44,13 @@ class RealThirdPartyCookieNamesTest {
     @Test
     fun whenHasExcludedCookieNameCalledAndContainsCookieNameThenReturnTrue() {
         whenever(cookiesRepository.cookieNames).thenReturn(CopyOnWriteArrayList(listOf("anotherCookieName", COOKIE_NAME)))
-        assertTrue(testee.hasExcludedCookieName(COOKIE_NAME))
+        assertTrue(testee.hasExcludedCookieName("foo=bar; $COOKIE_NAME=value"))
     }
 
     @Test
     fun whenHasExcludedCookieNameCalledAndDoesNotContainCookieNameThenReturnFalse() {
         whenever(cookiesRepository.cookieNames).thenReturn(CopyOnWriteArrayList(listOf("anotherCookieName")))
-        assertFalse(testee.hasExcludedCookieName(COOKIE_NAME))
+        assertFalse(testee.hasExcludedCookieName("foo=bar; $COOKIE_NAME=value"))
     }
 
     companion object {

--- a/cookies/cookies-store/build.gradle
+++ b/cookies/cookies-store/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     implementation project(path: ':feature-toggles-api')
     implementation project(path: ':common-utils')
 
+    implementation "io.github.fernandafbmarques:cookies-kmp-core:0.1.4"
+
     implementation AndroidX.core.ktx
 
     implementation "com.squareup.logcat:logcat:_"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes privacy-related cookie matching and feature-toggle enablement paths; behavior now depends on external KMP logic, so subtle parity differences could affect blocking or toggle rollout.
> 
> **Overview**
> Adds **`cookies-kmp-core` 0.1.4** to **`cookies-impl`** and **`cookies-store`**, and routes cookies feature-toggle and third-party cookie name checks through **`CookiesHostParityFacade`** instead of local Android-only logic.
> 
> **`CookiesFeatureTogglesPlugin`** now builds a **`ToggleEvaluationInput`** (repository enabled flag, min version, app version) and uses **`evaluateToggle(...).isEnabled`** rather than combining those values inline. **`RealThirdPartyCookieNames`** delegates **`hasExcludedCookieName`** to **`evaluateCookie`** with repository excluded names and empty allowed domains, so matching follows the shared KMP rules on full cookie header strings.
> 
> Adds **`CookiesHostParityFacadeIntegrationTest`** to assert config formatting, toggle evaluation, and cookie-match fixtures from the library. **`RealThirdPartyCookieNamesTest`** now uses realistic **`foo=bar; name=value`** cookie strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ac92673f81528092c66ba178d0db17b7bbb1777. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->