### PR TITLE
Use custom fields for LGC instead of column

### DIFF
--- a/.github/workflows/nightly-orchestrator.yml
+++ b/.github/workflows/nightly-orchestrator.yml
@@ -1,4 +1,4 @@
-name: Nightly orchestrator
+name: Generate LGC if release blocking checks are successful
 
 on:
   schedule:
@@ -125,11 +125,10 @@ jobs:
         task_id: ${{ fromJson(needs.collect_lgc_tasks.outputs.task_ids) }}
       fail-fast: false
     steps:
-      - name: Add task to release board in the release candidate section
-        uses: duckduckgo/native-github-asana-sync@v2.0
+      - name: Tag task as LGC
+        uses: duckduckgo/native-github-asana-sync@v2.5.1
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          asana-project: ${{ vars.GH_ANDROID_RELEASE_BOARD_PROJECT_ID }}
-          asana-section: ${{ vars.GH_ANDROID_RELEASE_BOARD_LGC_SECTION_ID }}
           asana-task-id: ${{ matrix.task_id }}
-          action: 'add-task-asana-project'
+          asana-task-custom-fields: '{"${{ vars.GH_ANDROID_RELEASE_BOARD_RELEASE_STATUS_FIELD_KEY_ID }}":"${{ vars.GH_ANDROID_RELEASE_BOARD_RELEASE_STATUS_FIELD_CONTAINED_IN_LGC_VALUE_ID }}"}'
+          action: 'update-task-custom-fields'


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211760946270935/task/1214396533395984?focus=true
Tech Design URL (if applicable): 

### Description 
* When tagging LGC, tag tasks using a custom field instead of moving to a column to prevent inbox noise. Uses changes in https://github.com/duckduckgo/native-github-asana-sync/pull/37
* Give workflow a more descriptive name

### Steps to test this PR

_Feature 1_
- [ ] Check [action](https://github.com/duckduckgo/Android/actions/runs/27676587321) tagged tasks successfully (Ignore manually canceled nightly checks)
- [ ] Check [task1](https://app.asana.com/1/137249556945/project/1200415422192046/task/1209870678583429) has LGC custom field and preserves prior "Test" custom field 
- [ ] Check [task2](https://app.asana.com/1/137249556945/project/1200415422192046/task/1209271241636977) has no custom fields
- [ ] Check [task3](https://app.asana.com/1/137249556945/project/1200415422192046/task/1212699261164265) has LGC custom field

### UI changes
n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions and Asana automation; misconfigured custom-field vars could fail to tag tasks but do not affect the app or production runtime.
> 
> **Overview**
> After nightly release-blocking checks pass, the orchestrator workflow now **labels collected Asana tasks as contained in LGC** by updating a release-status custom field, instead of **adding each task to the release board’s LGC column**.
> 
> The workflow display name is updated to **Generate LGC if release blocking checks are successful**, and the Asana sync action is bumped to **`native-github-asana-sync@v2.5.1`** with action **`update-task-custom-fields`** (using `GH_ANDROID_RELEASE_BOARD_RELEASE_STATUS_FIELD_*` vars) in place of **`add-task-asana-project`** with project/section IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01623ba029d3c2111a76a7081fcaf7f258df4a24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->