### PR TITLE
Fix state issue/race condition with native input (Take 2)

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -134,6 +134,7 @@ class RealNativeInputManager @Inject constructor(
     private val queryUrlPredictor: QueryUrlPredictor,
     private val duckAiFeatureState: DuckAiFeatureState,
     private val pixel: Pixel,
+    private val nativeInputStateBugKillSwitch: NativeInputStateBugKillSwitch,
 ) : NativeInputManager {
     private lateinit var omnibarController: NativeInputOmnibarController
     private lateinit var rootView: ViewGroup
@@ -156,7 +157,7 @@ class RealNativeInputManager @Inject constructor(
         lifecycleOwner: LifecycleOwner,
         onDisabled: () -> Unit,
     ) {
-        this.omnibarController = RealNativeInputOmnibarController(omnibar, rootView)
+        this.omnibarController = RealNativeInputOmnibarController(omnibar, rootView, nativeInputStateBugKillSwitch)
         this.rootView = rootView
         this.layoutCoordinator = NativeInputLayoutCoordinator(rootView, this.omnibarController)
         duckChat.observeNativeInputFieldUserSettingEnabled()
@@ -282,7 +283,7 @@ class RealNativeInputManager @Inject constructor(
                 .setDuration(FADE_OUT_DURATION_MS)
                 .withEndAction {
                     widgetCard.alpha = 1f
-                    if (widgetRoot === animatingRoot) {
+                    if (!nativeInputStateBugKillSwitch.self().isEnabled() || widgetRoot === animatingRoot) {
                         removeWidget()
                     }
                 }

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -276,12 +276,15 @@ class RealNativeInputManager @Inject constructor(
         val widgetCard = rootView.findViewById<View?>(R.id.inputModeWidgetCard)
         if (widgetCard != null) {
             (widgetCard as? MaterialCardView)?.cardElevation = 0f
+            val animatingRoot = widgetRoot
             widgetCard.animate()
                 .alpha(0f)
                 .setDuration(FADE_OUT_DURATION_MS)
                 .withEndAction {
                     widgetCard.alpha = 1f
-                    removeWidget()
+                    if (widgetRoot === animatingRoot) {
+                        removeWidget()
+                    }
                 }
                 .start()
         } else {

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
@@ -69,6 +69,8 @@ class RealNativeInputOmnibarController(
 
     private var layoutListener: View.OnLayoutChangeListener? = null
 
+    private var overlayActive: Boolean = false
+
     override fun isDuckAiMode(): Boolean = omnibar.viewMode == DuckAI
 
     override fun isBrowserMode(): Boolean = omnibar.viewMode is Omnibar.ViewMode.Browser
@@ -87,6 +89,7 @@ class RealNativeInputOmnibarController(
 
     override fun hideBackground() {
         val omnibarView = omnibar.omnibarView as? View ?: return
+        overlayActive = true
         applyOnLayout(omnibarView) {
             makeOmnibarTransparent(omnibarView)
             hideOmnibarContent(omnibarView)
@@ -166,6 +169,11 @@ class RealNativeInputOmnibarController(
     private fun applyTierText(omnibarView: View) {
         val aiTitle = omnibarView.findViewById<TextView?>(R.id.aiTitle)
         val freePill = omnibarView.findViewById<View?>(R.id.duckAIFreePill)
+        if (!overlayActive) {
+            freePill?.gone()
+            freePill?.setOnClickListener(null)
+            return
+        }
         when (currentTier) {
             is DuckAiTier.Free -> {
                 aiTitle?.gone()
@@ -186,7 +194,7 @@ class RealNativeInputOmnibarController(
         removeLayoutListener(omnibarView)
         block()
         val listener = View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
-            if (rootView.findViewById<View?>(R.id.inputModeWidget) != null) block()
+            if (overlayActive && rootView.findViewById<View?>(R.id.inputModeWidget) != null) block()
         }
         layoutListener = listener
         omnibarView.addOnLayoutChangeListener(listener)
@@ -203,6 +211,7 @@ class RealNativeInputOmnibarController(
     }
 
     override fun restore() {
+        overlayActive = false
         currentTier = DuckAiTier.Unknown
         currentUpgradeClick = null
         (omnibar.omnibarView as? View)?.let { removeLayoutListener(it) }

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
@@ -65,6 +65,7 @@ interface NativeInputOmnibarController : OmnibarState {
 class RealNativeInputOmnibarController(
     private val omnibar: Omnibar,
     private val rootView: ViewGroup,
+    private val nativeInputStateBugKillSwitch: NativeInputStateBugKillSwitch,
 ) : NativeInputOmnibarController {
 
     private var layoutListener: View.OnLayoutChangeListener? = null
@@ -169,7 +170,7 @@ class RealNativeInputOmnibarController(
     private fun applyTierText(omnibarView: View) {
         val aiTitle = omnibarView.findViewById<TextView?>(R.id.aiTitle)
         val freePill = omnibarView.findViewById<View?>(R.id.duckAIFreePill)
-        if (!overlayActive) {
+        if (nativeInputStateBugKillSwitch.self().isEnabled() && !overlayActive) {
             freePill?.gone()
             freePill?.setOnClickListener(null)
             return
@@ -194,7 +195,11 @@ class RealNativeInputOmnibarController(
         removeLayoutListener(omnibarView)
         block()
         val listener = View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
-            if (overlayActive && rootView.findViewById<View?>(R.id.inputModeWidget) != null) block()
+            if ((!nativeInputStateBugKillSwitch.self().isEnabled() || overlayActive) &&
+                rootView.findViewById<View?>(R.id.inputModeWidget) != null
+            ) {
+                block()
+            }
         }
         layoutListener = listener
         omnibarView.addOnLayoutChangeListener(listener)

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputStateBugKillSwitch.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputStateBugKillSwitch.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.nativeinput
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "nativeInputStateBugKillSwitch",
+)
+interface NativeInputStateBugKillSwitch {
+
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun self(): Toggle
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.voice.api.VoiceSearchAvailability
 import org.junit.Assert.assertEquals
@@ -47,6 +48,7 @@ class RealNativeInputManagerTest {
     private val queryUrlPredictor: QueryUrlPredictor = mock()
     private val duckAiFeatureState: DuckAiFeatureState = mock()
     private val pixel: Pixel = mock()
+    private val nativeInputStateBugKillSwitch = FakeFeatureToggleFactory.create(NativeInputStateBugKillSwitch::class.java)
 
     private lateinit var testee: RealNativeInputManager
 
@@ -60,6 +62,7 @@ class RealNativeInputManagerTest {
             queryUrlPredictor,
             duckAiFeatureState,
             pixel,
+            nativeInputStateBugKillSwitch,
         )
     }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputOmnibarControllerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputOmnibarControllerTest.kt
@@ -26,6 +26,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.omnibar.Omnibar
 import com.duckduckgo.app.browser.omnibar.OmnibarView
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -38,8 +39,9 @@ class RealNativeInputOmnibarControllerTest {
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val omnibar: Omnibar = mock()
     private val rootView: ViewGroup = mock()
+    private val nativeInputStateBugKillSwitch = FakeFeatureToggleFactory.create(NativeInputStateBugKillSwitch::class.java)
 
-    private val testee = RealNativeInputOmnibarController(omnibar, rootView)
+    private val testee = RealNativeInputOmnibarController(omnibar, rootView, nativeInputStateBugKillSwitch)
 
     private val fireIconMenu = View(context).apply { id = R.id.fireIconMenu }
     private val plusIconMenu = View(context).apply { id = R.id.plusIconMenu }

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputOmnibarControllerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputOmnibarControllerTest.kt
@@ -20,14 +20,17 @@ import android.content.Context
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
+import android.widget.TextView
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.omnibar.Omnibar
+import com.duckduckgo.app.browser.omnibar.OmnibarView
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 
 @RunWith(AndroidJUnit4::class)
 class RealNativeInputOmnibarControllerTest {
@@ -43,11 +46,16 @@ class RealNativeInputOmnibarControllerTest {
     private val tabsMenu = View(context).apply { id = R.id.tabsMenu }
     private val browserMenu = View(context).apply { id = R.id.browserMenu }
 
-    private val omnibarView = FrameLayout(context).apply {
+    private val aiTitle = TextView(context).apply { id = R.id.aiTitle }
+    private val duckAIFreePill = View(context).apply { id = R.id.duckAIFreePill }
+
+    private val omnibarView = object : FrameLayout(context), OmnibarView by mock() {}.apply {
         addView(fireIconMenu)
         addView(plusIconMenu)
         addView(tabsMenu)
         addView(browserMenu)
+        addView(aiTitle)
+        addView(duckAIFreePill)
     }
 
     @Test
@@ -78,5 +86,38 @@ class RealNativeInputOmnibarControllerTest {
         assertEquals(View.GONE, fireIconMenu.visibility)
         assertEquals(View.GONE, tabsMenu.visibility)
         assertEquals(View.GONE, browserMenu.visibility)
+    }
+
+    @Test
+    fun whenTierUpdatedToFreeWithoutOverlayActiveThenFreePillStaysHidden() {
+        whenever(omnibar.omnibarView).thenReturn(omnibarView)
+        duckAIFreePill.visibility = View.VISIBLE
+
+        testee.updateTierTitle(DuckAiTier.Free) {}
+
+        assertEquals(View.GONE, duckAIFreePill.visibility)
+    }
+
+    @Test
+    fun whenOverlayActiveAndTierFreeThenFreePillShown() {
+        whenever(omnibar.omnibarView).thenReturn(omnibarView)
+        testee.updateTierTitle(DuckAiTier.Free) {}
+
+        testee.hideBackground()
+
+        assertEquals(View.VISIBLE, duckAIFreePill.visibility)
+    }
+
+    @Test
+    fun whenOverlayRestoredThenLaterFreeTierUpdateDoesNotResurrectFreePill() {
+        whenever(omnibar.omnibarView).thenReturn(omnibarView)
+        testee.updateTierTitle(DuckAiTier.Free) {}
+        testee.hideBackground()
+        assertEquals(View.VISIBLE, duckAIFreePill.visibility)
+
+        testee.restore()
+        testee.updateTierTitle(DuckAiTier.Free) {}
+
+        assertEquals(View.GONE, duckAIFreePill.visibility)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1215778085975940?focus=true
Tech Design URL (if applicable): 

### Description

- Another attempt at fixing https://github.com/duckduckgo/Android/pull/8886

### Steps to test this PR

_with native input enabled_
- [ ] Focus the and unfocus the input several times
- [ ] Verify that the state is consistent 
- [ ] Open Duck.ai
- [ ] Tap the “x"
- [ ] Verify that the omnibar state is restored successfully


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI/state fixes behind a remote toggle defaulting on; no auth, data, or network behavior changes.
> 
> **Overview**
> Adds remote feature toggle **`nativeInputStateBugKillSwitch`** (default on) and wires it through **`RealNativeInputManager`** and **`RealNativeInputOmnibarController`** to address native-input / Duck.ai omnibar state races (follow-up to PR #8886).
> 
> **Omnibar overlay:** Tracks **`overlayActive`** when `hideBackground()` runs and clears it on `restore()`. With the fix enabled, tier/header updates (e.g. free upgrade pill) and layout-change reapplication only run while the overlay is active, so late tier callbacks or layout passes don’t resurrect Duck.ai chrome after exit.
> 
> **Widget hide:** After the widget card fade-out, **`removeWidget()`** runs only if the kill switch is off or **`widgetRoot`** still matches the root captured at animation start, so a stale end-action doesn’t tear down a newly shown widget.
> 
> Unit tests cover free-pill visibility with/without overlay and post-restore tier updates; manager tests inject the fake toggle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19b8ef40a5d5a12c90e49b6101460753f772a847. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->