### PR TITLE
Fix native input stop button bug

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StopStreamingViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StopStreamingViewModel.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.duckchat.impl.ui.nativeinput.views
 import androidx.lifecycle.ViewModel
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputContext
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -29,6 +30,7 @@ class StopStreamingViewModel @Inject constructor(
     nativeInputStateProvider: NativeInputStateProvider,
 ) : ViewModel() {
 
-    /** Show the stop button only while the chat is actively streaming a response. */
-    val isVisible: Flow<Boolean> = nativeInputStateProvider.state.map { it.isChatStreaming }
+    val isVisible: Flow<Boolean> = nativeInputStateProvider.state.map {
+        it.isChatStreaming && it.inputContext != InputContext.BROWSER
+    }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StopStreamingViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StopStreamingViewModelTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.nativeinput.views
+
+import app.cash.turbine.test
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputContext
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputMode
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StopStreamingViewModelTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val providerStateFlow = MutableSharedFlow<NativeInputState>(replay = 1)
+
+    private val nativeInputStateProvider: NativeInputStateProvider = mock<NativeInputStateProvider>().also {
+        whenever(it.state).thenReturn(providerStateFlow)
+    }
+
+    private val testee = StopStreamingViewModel(nativeInputStateProvider)
+
+    @Test
+    fun whenStreamingAndDuckAiContextThenVisible() = runTest {
+        providerStateFlow.emit(stateOf(InputContext.DUCK_AI, isChatStreaming = true))
+
+        testee.isVisible.test {
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenStreamingAndDuckAiContextualContextThenVisible() = runTest {
+        providerStateFlow.emit(stateOf(InputContext.DUCK_AI_CONTEXTUAL, isChatStreaming = true))
+
+        testee.isVisible.test {
+            assertTrue(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenStreamingButBrowserContextThenNotVisible() = runTest {
+        providerStateFlow.emit(stateOf(InputContext.BROWSER, isChatStreaming = true))
+
+        testee.isVisible.test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenNotStreamingThenNotVisible() = runTest {
+        providerStateFlow.emit(stateOf(InputContext.DUCK_AI, isChatStreaming = false))
+
+        testee.isVisible.test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenContextChangesToBrowserWhileStreamingThenBecomesNotVisible() = runTest {
+        providerStateFlow.emit(stateOf(InputContext.DUCK_AI, isChatStreaming = true))
+
+        testee.isVisible.test {
+            assertTrue(awaitItem())
+
+            providerStateFlow.emit(stateOf(InputContext.BROWSER, isChatStreaming = true))
+
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private fun stateOf(
+        context: InputContext,
+        isChatStreaming: Boolean,
+    ): NativeInputState = NativeInputState(
+        inputMode = InputMode.SEARCH_AND_DUCK_AI,
+        inputContext = context,
+        isChatStreaming = isChatStreaming,
+    )
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1215778085975943?focus=true
Tech Design URL (if applicable): 

### Description

- Hides the stop button in the native input in browser mode

### Steps to test this PR
- [ ] Type a prompt (e.g. “generate a long essay about ducks”)
- [ ] While it is still generating, go back
- [ ] Verify that the stop button is not visible in the browser native input

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI visibility change in one ViewModel with dedicated tests; no auth, data, or API changes.
> 
> **Overview**
> Fixes the native input **stop streaming** control appearing when it should not: visibility now requires active chat streaming **and** a non-browser `InputContext` (`DUCK_AI` or `DUCK_AI_CONTEXTUAL`), so browser/search native input no longer shows stop while a streaming flag may still be set.
> 
> Adds **`StopStreamingViewModelTest`** covering Duck AI visibility, suppression in `BROWSER` while streaming, non-streaming cases, and hiding when context switches to browser mid-stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d8d361dc6b5e7fa626f38ec3df87578ce420c15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->