### PR TITLE
Add Model recovery mode pixels

### DIFF
--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -1061,5 +1061,29 @@
                 "enum": ["purchase", "upgrade"]
             }
         ]
+    },
+    "aichat_unified_input_show_model_picker": {
+        "description": "FE recovery flow: the native model picker was opened in response to a showModelPicker message",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "aichat_unified_input_submit_change_model": {
+        "description": "FE recovery flow: the user's chosen model was reported to the FE via submitChangeModelAction",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": [
+            "appVersion",
+            { "key": "model_id", "type": "string", "description": "Identifier of the model the user recovered to" }
+        ]
+    },
+    "aichat_unified_input_submit_change_model_prompt_sent": {
+        "description": "FE recovery flow: a prompt was submitted after recovering the chat's model",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": ["appVersion"]
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
@@ -201,7 +201,10 @@ class RealDuckChatJSHelper @Inject constructor(
             }
 
             METHOD_SHOW_MODEL_PICKER -> {
-                if (tabId.isNotEmpty()) duckChat.requestShowModelPicker(tabId)
+                if (tabId.isNotEmpty()) {
+                    duckChat.requestShowModelPicker(tabId)
+                    duckChatPixels.fireShowModelPicker()
+                }
                 null
             }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -161,6 +161,16 @@ interface DuckChatPixels {
     )
     fun fireModelSelected(modelId: String)
     fun fireReasoningEffortSelected(effortLevel: String)
+
+    /** FE recovery flow: native model picker opened in response to a `showModelPicker` message. */
+    fun fireShowModelPicker()
+
+    /** FE recovery flow: the chosen model reported back to the FE via `submitChangeModelAction`. */
+    fun fireSubmitChangeModel(modelId: String)
+
+    /** FE recovery flow: a prompt submitted after recovering the chat's model. */
+    fun fireSubmitChangeModelPromptSent()
+
     fun fireSubscriptionUpsellTriggered(source: String, currentTier: String, requiredTier: String, flowType: String)
     fun fireImageAttached(source: String)
     fun fireImageValidationFailed(reason: String)
@@ -517,6 +527,28 @@ class RealDuckChatPixels @Inject constructor(
         }
     }
 
+    override fun fireShowModelPicker() {
+        fireCountAndDaily(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SHOW_MODEL_PICKER_COUNT,
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SHOW_MODEL_PICKER_DAILY,
+        )
+    }
+
+    override fun fireSubmitChangeModel(modelId: String) {
+        fireCountAndDaily(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SUBMIT_CHANGE_MODEL_COUNT,
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SUBMIT_CHANGE_MODEL_DAILY,
+            parameters = mapOf(DuckChatPixelParameters.MODEL_ID to modelId),
+        )
+    }
+
+    override fun fireSubmitChangeModelPromptSent() {
+        fireCountAndDaily(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SUBMIT_CHANGE_MODEL_PROMPT_SENT_COUNT,
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SUBMIT_CHANGE_MODEL_PROMPT_SENT_DAILY,
+        )
+    }
+
     override fun fireSubscriptionUpsellTriggered(source: String, currentTier: String, requiredTier: String, flowType: String) {
         appCoroutineScope.launch(dispatcherProvider.io()) {
             pixel.fire(
@@ -787,6 +819,12 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_CHAT_UNIFIED_INPUT_MODEL_SELECTED("m_aichat_unified_input_model_selected"),
     DUCK_CHAT_UNIFIED_INPUT_REASONING_EFFORT_SELECTED("m_aichat_unified_input_reasoning_effort_selected"),
     DUCK_CHAT_UNIFIED_INPUT_SUBSCRIPTION_UPSELL_TRIGGERED("m_aichat_unified_input_subscription_upsell_triggered"),
+    DUCK_CHAT_UNIFIED_INPUT_SHOW_MODEL_PICKER_COUNT("aichat_unified_input_show_model_picker_count"),
+    DUCK_CHAT_UNIFIED_INPUT_SHOW_MODEL_PICKER_DAILY("aichat_unified_input_show_model_picker_daily"),
+    DUCK_CHAT_UNIFIED_INPUT_SUBMIT_CHANGE_MODEL_COUNT("aichat_unified_input_submit_change_model_count"),
+    DUCK_CHAT_UNIFIED_INPUT_SUBMIT_CHANGE_MODEL_DAILY("aichat_unified_input_submit_change_model_daily"),
+    DUCK_CHAT_UNIFIED_INPUT_SUBMIT_CHANGE_MODEL_PROMPT_SENT_COUNT("aichat_unified_input_submit_change_model_prompt_sent_count"),
+    DUCK_CHAT_UNIFIED_INPUT_SUBMIT_CHANGE_MODEL_PROMPT_SENT_DAILY("aichat_unified_input_submit_change_model_prompt_sent_daily"),
     DUCK_CHAT_UNIFIED_INPUT_IMAGE_ATTACHED_COUNT("m_aichat_unified_input_image_attached_count"),
     DUCK_CHAT_UNIFIED_INPUT_IMAGE_ATTACHED_DAILY("m_aichat_unified_input_image_attached_daily"),
     DUCK_CHAT_UNIFIED_INPUT_IMAGE_REMOVED_COUNT("m_aichat_unified_input_image_removed_count"),
@@ -1003,6 +1041,8 @@ class DuckChatParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin
             // upsell, attachments, voice, stop) AND the app-side chat_header_upgrade_tapped, which
             // shares the prefix — the interceptor matches outgoing pixel names with startsWith.
             "m_aichat_unified_input_" to PixelParameter.removeAtb(),
+            // Same coverage for unified_input pixels added without the legacy m_ prefix.
+            "aichat_unified_input_" to PixelParameter.removeAtb(),
         )
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -374,6 +374,12 @@ class NativeInputModeWidgetViewModel @Inject constructor(
      * Called when a prompt is submitted
      * */
     fun onPromptSubmitted() {
+        // A prompt submitted while still in the recovery window means the user sent a prompt after
+        // recovering the chat's model — report it before the window is cleared below.
+        val tabId = activeTabId.value
+        if (tabId != null && nativeInputStateProvider.stateForTab(tabId).value.modelChangeMode) {
+            duckChatPixels.fireSubmitChangeModelPromptSent()
+        }
         // Ends the FE recovery model-change window for the active tab.
         endModelChangeMode()
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
@@ -174,6 +174,7 @@ class ModelPickerViewModel @Inject constructor(
                 if (model.id != recoverySelectedModelId.value) {
                     duckChatPixels.fireModelSelected(model.id)
                 }
+                duckChatPixels.fireSubmitChangeModel(model.id)
                 recoverySelectedModelId.value = model.id
                 modelChangeChannel.trySend(PickerModelChange.ChangeModel(model.id))
             } else {

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsPickerTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsPickerTest.kt
@@ -80,4 +80,41 @@ class RealDuckChatPixelsPickerTest {
             ),
         )
     }
+
+    @Test
+    fun whenShowModelPickerThenFiresCountAndDaily() = runTest {
+        testee.fireShowModelPicker()
+
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SHOW_MODEL_PICKER_COUNT, parameters = emptyMap())
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SHOW_MODEL_PICKER_DAILY,
+            parameters = emptyMap(),
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+
+    @Test
+    fun whenSubmitChangeModelThenFiresCountAndDailyWithModelId() = runTest {
+        testee.fireSubmitChangeModel(modelId = "gpt-5")
+
+        val params = mapOf(DuckChatPixelParameters.MODEL_ID to "gpt-5")
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SUBMIT_CHANGE_MODEL_COUNT, parameters = params)
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SUBMIT_CHANGE_MODEL_DAILY,
+            parameters = params,
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+
+    @Test
+    fun whenSubmitChangeModelPromptSentThenFiresCountAndDaily() = runTest {
+        testee.fireSubmitChangeModelPromptSent()
+
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SUBMIT_CHANGE_MODEL_PROMPT_SENT_COUNT, parameters = emptyMap())
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SUBMIT_CHANGE_MODEL_PROMPT_SENT_DAILY,
+            parameters = emptyMap(),
+            type = Pixel.PixelType.Daily(),
+        )
+    }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
@@ -1137,6 +1137,20 @@ class RealDuckChatJSHelperTest {
     }
 
     @Test
+    fun whenShowModelPickerThenShowModelPickerPixelFired() = runTest {
+        testee.processJsCallbackMessage("aiChat", "showModelPicker", "123", null, tabId = "tab-1")
+
+        verify(mockDuckChatPixels).fireShowModelPicker()
+    }
+
+    @Test
+    fun whenShowModelPickerWithEmptyTabIdThenShowModelPickerPixelNotFired() = runTest {
+        testee.processJsCallbackMessage("aiChat", "showModelPicker", "123", null, tabId = "")
+
+        verify(mockDuckChatPixels, never()).fireShowModelPicker()
+    }
+
+    @Test
     fun whenGetAIChatNativeConfigValuesAndSupportsImageUploadThenReturnJsCallbackDataWithSupportsImageUploadEnabled() = runTest {
         val featureName = "aiChat"
         val method = "getAIChatNativeConfigValues"

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
@@ -300,6 +300,17 @@ class ModelPickerViewModelTest {
     }
 
     @Test
+    fun whenAccessibleModelTappedInModelChangeModeThenSubmitChangeModelPixelFired() = runTest {
+        nativeInputState.value = nativeInputState.value.copy(chatId = "c1", modelChangeMode = true)
+        advanceUntilIdle()
+        val model = freeModel(id = "new-model", shortName = "New")
+
+        testee.onModelTapped(model, PickerSurface.MODEL_PICKER_ADDRESS_BAR)
+
+        verify(duckChatPixels).fireSubmitChangeModel("new-model")
+    }
+
+    @Test
     fun whenAccessibleModelTappedNotInModelChangeModeThenSelectModelCalled() = runTest {
         nativeInputState.value = nativeInputState.value.copy(chatId = null, modelChangeMode = false)
         advanceUntilIdle()

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -792,6 +792,30 @@ class NativeInputModeWidgetViewModelTest {
     }
 
     @Test
+    fun whenPromptSubmittedDuringRecoveryThenSubmitChangeModelPromptSentPixelFired() = runTest {
+        val viewModel = createViewModel()
+        viewModel.configure(tabId = "tab-A", isDuckAiMode = true, isBottom = false)
+        advanceUntilIdle()
+        showModelPickerEvents.tryEmit("tab-A")
+        advanceUntilIdle()
+
+        viewModel.onPromptSubmitted()
+
+        verify(duckChatPixels).fireSubmitChangeModelPromptSent()
+    }
+
+    @Test
+    fun whenPromptSubmittedOutsideRecoveryThenSubmitChangeModelPromptSentPixelNotFired() = runTest {
+        val viewModel = createViewModel()
+        viewModel.configure(tabId = "tab-A", isDuckAiMode = true, isBottom = false)
+        advanceUntilIdle()
+
+        viewModel.onPromptSubmitted()
+
+        verify(duckChatPixels, never()).fireSubmitChangeModelPromptSent()
+    }
+
+    @Test
     fun whenChatIdChangesThenSubmitEnabledResetsToTrue() = runTest {
         val viewModel = createViewModel()
         viewModel.configure(tabId = "tab-A", isDuckAiMode = true, isBottom = false)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1215723000513641?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/481882893211075/task/1215708562820722?focus=true

### Description

Privacy Review: https://app.asana.com/1/137249556945/project/69071770703008/task/1215799225333577?focus=true

Adds pixels for the Duck.ai model-recovery flow in the native Unified Input (picker opened → model recovered → prompt sent). Three pixels, each fired as a **count** and a **daily**:

- **`aichat_unified_input_show_model_picker`**: the native model picker was opened in response to the FE `showModelPicker` message (the "Switch Model" recovery CTA).
- **`aichat_unified_input_submit_change_model`**: the chosen model was reported back to the FE via `submitChangeModelAction`. Carries a `model_id` param (the recovered model).
- **`aichat_unified_input_submit_change_model_prompt_sent`**: a prompt was submitted while still in the recovery window.

### Steps to test this PR

**Prerequisites**
- Internal build with `native-input` enabled, and an FE build that shows the recovery banner.
- Reproduce an unavailable model: open an ongoing chat whose stored model the current account can't access (e.g. a Plus/Pro model on a Free account, or after signing out) → the FE shows the recovery banner.

- Observe pixels via logcat:
  ```
  adb logcat | grep -i "Pixel sent" | grep "aichat_unified_input"
  ```
Or use android studio.

_Emission - recovery flow_
- [ ] Tap **Switch Model** on the recovery banner → picker opens → `aichat_unified_input_show_model_picker_count` (and `_daily` on first time today) is emitted.
- [ ] Pick a supported model → `aichat_unified_input_submit_change_model_count` (and `_daily`) is emitted, with `model_id` set to the chosen model.
- [ ] Submit a prompt while still in the recovery window → `aichat_unified_input_submit_change_model_prompt_sent_count` (and `_daily`) is emitted.
- [ ] Confirm none of the three carry an `atb` parameter.
- [ ] (Daily check) The `_daily` variants fire once per calendar day.

_Not emitted: normal (non-recovery) flow_
- [ ] Open a **new chat** and open the model picker normally (not via the recovery banner) → **no** `aichat_unified_input_show_model_picker` is emitted.
- [ ] Select a model in that normal picker → **no** `aichat_unified_input_submit_change_model` is emitted (the existing `aichat_unified_input_model_selected` fires instead).
- [ ] Submit a prompt in a normal chat (never entered recovery) → **no** `aichat_unified_input_submit_change_model_prompt_sent` is emitted.

### UI changes

No UI changes



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only hooks gated to recovery `modelChangeMode` and the `showModelPicker` JS path; no auth or submission logic changes beyond firing pixels.
> 
> **Overview**
> Adds **count + daily** telemetry for the Duck.ai **FE model-recovery** path in native Unified Input, without changing recovery UX.
> 
> Three events are wired only in recovery contexts: **`show_model_picker`** when the FE `showModelPicker` bridge opens the native picker (with a valid tab id); **`submit_change_model`** when the user picks an accessible model in `modelChangeMode` (includes `model_id`); **`submit_change_model_prompt_sent`** when a prompt is submitted while the tab is still in that recovery window.
> 
> Pixel definitions are registered in `duck_chat.json5`, mapped in `DuckChatPixelName`, and **`atb` is stripped** via a new `aichat_unified_input_` prefix rule alongside the existing `m_aichat_unified_input_` matcher. Unit tests cover pixel firing and the JS helper / view-model hooks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit deff977c9de4234eaefc36427ddebd9daafcb64d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->