### PR TITLE
Set native input feature to @InternalAlwaysEnabled

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -133,6 +133,7 @@ interface DuckChatFeature {
     /**
      * @return `true` when the Native Input Field should be used instead of the web-based input.
      */
+    @InternalAlwaysEnabled
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun nativeInputField(): Toggle
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1215799448576674?focus=true
Tech Design URL (if applicable): 

### Description

- Always enables the native input internally

### Steps to test this PR

- [ ] Verify that the native input is enabled

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single annotation on a feature flag with no logic changes; scope is internal-build rollout of an existing UI path.
> 
> **Overview**
> Marks the **`nativeInputField`** Duck.ai feature toggle with **`@InternalAlwaysEnabled`**, so internal app builds always treat native input as on instead of relying only on the remote **`INTERNAL`** default.
> 
> This aligns **`nativeInputField()`** with toggles like **`showNewAddressBarPickerScreen()`** and should make native (vs web) Duck.ai input consistently available on internal builds, affecting omnibar behavior (e.g. fire vs + leading actions when the flag is on).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5e9985fc1fb3bfcd4456563554ba4a015639570. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->