### PR TITLE
PIR: Add interaction DAU/WAU/MAU pixels

### DIFF
--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -288,6 +288,82 @@
         "suffixes": ["daily_count_short", "form_factor"],
         "parameters": ["appVersion"]
     },
+    "m_dbp_interaction_dau": {
+        "description": "Pixel for PIR user-interacted daily active users. Fired when the PIR dashboard is presented to the user.",
+        "owners": ["landomen"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count_short", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "is_authenticated",
+                "description": "Whether the user is authenticated (has an active subscription). Always true on Android, which has no freemium PIR.",
+                "type": "boolean"
+            },
+            {
+                "key": "free_scan",
+                "description": "Whether this is a freemium (unauthenticated) scan. Always false on Android, which has no freemium PIR.",
+                "type": "boolean"
+            }
+        ]
+    },
+    "m_dbp_interaction_wau": {
+        "description": "Pixel for PIR user-interacted weekly active users. Fired when the PIR dashboard is presented to the user.",
+        "owners": ["landomen"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count_short", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "is_authenticated",
+                "description": "Whether the user is authenticated (has an active subscription). Always true on Android, which has no freemium PIR.",
+                "type": "boolean"
+            },
+            {
+                "key": "free_scan",
+                "description": "Whether this is a freemium (unauthenticated) scan. Always false on Android, which has no freemium PIR.",
+                "type": "boolean"
+            }
+        ]
+    },
+    "m_dbp_interaction_mau": {
+        "description": "Pixel for PIR user-interacted monthly active users. Fired when the PIR dashboard is presented to the user.",
+        "owners": ["landomen"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count_short", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "is_authenticated",
+                "description": "Whether the user is authenticated (has an active subscription). Always true on Android, which has no freemium PIR.",
+                "type": "boolean"
+            },
+            {
+                "key": "free_scan",
+                "description": "Whether this is a freemium (unauthenticated) scan. Always false on Android, which has no freemium PIR.",
+                "type": "boolean"
+            }
+        ]
+    },
+    "m_dbp_first_scan_u": {
+        "description": "Fired once per install when the user starts their first PIR scan.",
+        "owners": ["landomen"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "is_authenticated",
+                "description": "Whether the user is authenticated (has an active subscription). Always true on Android, which has no freemium PIR.",
+                "type": "boolean"
+            },
+            {
+                "key": "free_scan",
+                "description": "Whether this is a freemium (unauthenticated) scan. Always false on Android, which has no freemium PIR.",
+                "type": "boolean"
+            }
+        ]
+    },
     "m_dbp_weekly_child-broker_orphaned-optouts": {
         "description": "Pixel to know orphaned opt-out records on child data brokers that don't have matching profiles on their parent broker.",
         "owners": ["karlenDimla", "landomen"],

--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -290,7 +290,7 @@
     },
     "m_dbp_interaction_dau": {
         "description": "Pixel for PIR user-interacted daily active users. Fired when the PIR dashboard is presented to the user.",
-        "owners": ["landomen"],
+        "owners": ["karlenDimla", "landomen"],
         "triggers": ["other"],
         "suffixes": ["daily_count_short", "form_factor"],
         "parameters": [
@@ -309,7 +309,7 @@
     },
     "m_dbp_interaction_wau": {
         "description": "Pixel for PIR user-interacted weekly active users. Fired when the PIR dashboard is presented to the user.",
-        "owners": ["landomen"],
+        "owners": ["karlenDimla", "landomen"],
         "triggers": ["other"],
         "suffixes": ["daily_count_short", "form_factor"],
         "parameters": [
@@ -328,7 +328,7 @@
     },
     "m_dbp_interaction_mau": {
         "description": "Pixel for PIR user-interacted monthly active users. Fired when the PIR dashboard is presented to the user.",
-        "owners": ["landomen"],
+        "owners": ["karlenDimla", "landomen"],
         "triggers": ["other"],
         "suffixes": ["daily_count_short", "form_factor"],
         "parameters": [
@@ -347,7 +347,7 @@
     },
     "m_dbp_first_scan_u": {
         "description": "Fired once per install when the user starts their first PIR scan.",
-        "owners": ["landomen"],
+        "owners": ["karlenDimla", "landomen"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
         "parameters": [

--- a/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/fakes/FakePirDataStore.kt
+++ b/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/fakes/FakePirDataStore.kt
@@ -27,6 +27,9 @@ class FakePirDataStore : PirDataStore {
     override var dauLastSentMs: Long = 0L
     override var wauLastSentMs: Long = 0L
     override var mauLastSentMs: Long = 0L
+    override var interactionDauLastSentMs: Long = 0L
+    override var interactionWauLastSentMs: Long = 0L
+    override var interactionMauLastSentMs: Long = 0L
     override var weeklyStatLastSentMs: Long = 0L
     override var hasBrokerConfigBeenManuallyUpdated: Boolean = false
     override var latestBackgroundScanRunInMs: Long = 0L
@@ -48,6 +51,9 @@ class FakePirDataStore : PirDataStore {
         dauLastSentMs = 0L
         wauLastSentMs = 0L
         mauLastSentMs = 0L
+        interactionDauLastSentMs = 0L
+        interactionWauLastSentMs = 0L
+        interactionMauLastSentMs = 0L
         weeklyStatLastSentMs = 0L
         latestBackgroundScanRunInMs = 0L
         hasInitialScanEverStarted = false

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/PirDashboardWebViewViewModel.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/PirDashboardWebViewViewModel.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.appbuildconfig.api.isInternalBuild
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.js.messaging.api.JsCallbackData
 import com.duckduckgo.js.messaging.api.SubscriptionEventData
+import com.duckduckgo.pir.impl.pixels.PirInteractionReporter
 import com.duckduckgo.pir.impl.pixels.PirPixelSender
 import com.duckduckgo.pir.impl.store.PirRepository
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
@@ -41,6 +42,7 @@ import javax.inject.Inject
 @ContributesViewModel(ActivityScope::class)
 class PirDashboardWebViewViewModel @Inject constructor(
     private val pirPixelSender: PirPixelSender,
+    private val pirInteractionReporter: PirInteractionReporter,
     private val appBuildConfig: AppBuildConfig,
     private val pirRepository: PirRepository,
 ) : ViewModel(), DefaultLifecycleObserver {
@@ -60,6 +62,9 @@ class PirDashboardWebViewViewModel @Inject constructor(
     override fun onStart(owner: LifecycleOwner) {
         super.onStart(owner)
         pirPixelSender.reportDashboardOpened()
+        viewModelScope.launch {
+            pirInteractionReporter.attemptFirePixel()
+        }
 
         if (appBuildConfig.isInternalBuild()) {
             viewModelScope.launch {

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/PirDashboardWebViewViewModel.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/PirDashboardWebViewViewModel.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.appbuildconfig.api.isInternalBuild
 import com.duckduckgo.di.scopes.ActivityScope
@@ -30,6 +31,7 @@ import com.duckduckgo.js.messaging.api.SubscriptionEventData
 import com.duckduckgo.pir.impl.pixels.PirInteractionReporter
 import com.duckduckgo.pir.impl.pixels.PirPixelSender
 import com.duckduckgo.pir.impl.store.PirRepository
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -45,6 +47,7 @@ class PirDashboardWebViewViewModel @Inject constructor(
     private val pirInteractionReporter: PirInteractionReporter,
     private val appBuildConfig: AppBuildConfig,
     private val pirRepository: PirRepository,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) : ViewModel(), DefaultLifecycleObserver {
 
     private val command = Channel<Command>(1, DROP_OLDEST)
@@ -62,7 +65,7 @@ class PirDashboardWebViewViewModel @Inject constructor(
     override fun onStart(owner: LifecycleOwner) {
         super.onStart(owner)
         pirPixelSender.reportDashboardOpened()
-        viewModelScope.launch {
+        appCoroutineScope.launch {
             pirInteractionReporter.attemptFirePixel()
         }
 

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirInteractionReporter.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirInteractionReporter.kt
@@ -21,7 +21,10 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.pir.impl.store.PirRepository
 import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.time.Instant
 import java.time.ZoneId
@@ -39,6 +42,7 @@ interface PirInteractionReporter {
     suspend fun attemptFirePixel()
 }
 
+@SingleInstanceIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 class RealPirInteractionReporter @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
@@ -46,6 +50,9 @@ class RealPirInteractionReporter @Inject constructor(
     private val currentTimeProvider: CurrentTimeProvider,
     private val pirPixelSender: PirPixelSender,
 ) : PirInteractionReporter {
+
+    private val mutex = Mutex()
+
     override suspend fun attemptFirePixel() {
         withContext(dispatcherProvider.io()) {
             val nowMs = currentTimeProvider.currentTimeMillis()
@@ -56,33 +63,39 @@ class RealPirInteractionReporter @Inject constructor(
     }
 
     private suspend fun attemptToFireDauPixel(nowMs: Long) {
-        val lastPixelMs = pirRepository.getLastPirInteractionDauPixelTimeMs()
-
-        if (!hasDateElapsed(DIFF_DATE_DAU, lastPixelMs, nowMs)) return
+        if (!hasDateElapsed(DIFF_DATE_DAU, pirRepository.getLastPirInteractionDauPixelTimeMs(), nowMs)) return
 
         delayToReduceSessioning()
-        pirPixelSender.reportInteractionDAU()
-        pirRepository.setLastPirInteractionDauPixelTimeMs(nowMs)
+
+        mutex.withLock {
+            if (!hasDateElapsed(DIFF_DATE_DAU, pirRepository.getLastPirInteractionDauPixelTimeMs(), nowMs)) return@withLock
+            pirPixelSender.reportInteractionDAU()
+            pirRepository.setLastPirInteractionDauPixelTimeMs(nowMs)
+        }
     }
 
     private suspend fun attemptToFireWauPixel(nowMs: Long) {
-        val lastPixelMs = pirRepository.getLastPirInteractionWauPixelTimeMs()
-
-        if (!hasDateElapsed(DIFF_DATE_WAU, lastPixelMs, nowMs)) return
+        if (!hasDateElapsed(DIFF_DATE_WAU, pirRepository.getLastPirInteractionWauPixelTimeMs(), nowMs)) return
 
         delayToReduceSessioning()
-        pirPixelSender.reportInteractionWAU()
-        pirRepository.setLastPirInteractionWauPixelTimeMs(nowMs)
+
+        mutex.withLock {
+            if (!hasDateElapsed(DIFF_DATE_WAU, pirRepository.getLastPirInteractionWauPixelTimeMs(), nowMs)) return@withLock
+            pirPixelSender.reportInteractionWAU()
+            pirRepository.setLastPirInteractionWauPixelTimeMs(nowMs)
+        }
     }
 
     private suspend fun attemptToFireMauPixel(nowMs: Long) {
-        val lastPixelMs = pirRepository.getLastPirInteractionMauPixelTimeMs()
-
-        if (!hasDateElapsed(DIFF_DATE_MAU, lastPixelMs, nowMs)) return
+        if (!hasDateElapsed(DIFF_DATE_MAU, pirRepository.getLastPirInteractionMauPixelTimeMs(), nowMs)) return
 
         delayToReduceSessioning()
-        pirPixelSender.reportInteractionMAU()
-        pirRepository.setLastPirInteractionMauPixelTimeMs(nowMs)
+
+        mutex.withLock {
+            if (!hasDateElapsed(DIFF_DATE_MAU, pirRepository.getLastPirInteractionMauPixelTimeMs(), nowMs)) return@withLock
+            pirPixelSender.reportInteractionMAU()
+            pirRepository.setLastPirInteractionMauPixelTimeMs(nowMs)
+        }
     }
 
     /**

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirInteractionReporter.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirInteractionReporter.kt
@@ -21,11 +21,13 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.pir.impl.store.PirRepository
 import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import java.time.Instant
 import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 import javax.inject.Inject
+import kotlin.random.Random
 
 /**
  * Reports user-interacted DAU/WAU/MAU pixels for PIR. Unlike [PirEngagementReporter] (which reports
@@ -58,6 +60,7 @@ class RealPirInteractionReporter @Inject constructor(
 
         if (!hasDateElapsed(DIFF_DATE_DAU, lastPixelMs, nowMs)) return
 
+        delayToReduceSessioning()
         pirPixelSender.reportInteractionDAU()
         pirRepository.setLastPirInteractionDauPixelTimeMs(nowMs)
     }
@@ -67,6 +70,7 @@ class RealPirInteractionReporter @Inject constructor(
 
         if (!hasDateElapsed(DIFF_DATE_WAU, lastPixelMs, nowMs)) return
 
+        delayToReduceSessioning()
         pirPixelSender.reportInteractionWAU()
         pirRepository.setLastPirInteractionWauPixelTimeMs(nowMs)
     }
@@ -76,8 +80,16 @@ class RealPirInteractionReporter @Inject constructor(
 
         if (!hasDateElapsed(DIFF_DATE_MAU, lastPixelMs, nowMs)) return
 
+        delayToReduceSessioning()
         pirPixelSender.reportInteractionMAU()
         pirRepository.setLastPirInteractionMauPixelTimeMs(nowMs)
+    }
+
+    /**
+     * Waits a random 0.5–5s before firing each interaction pixel.
+     */
+    private suspend fun delayToReduceSessioning() {
+        delay(Random.nextLong(MIN_INTER_PIXEL_DELAY_MS, MAX_INTER_PIXEL_DELAY_MS))
     }
 
     private fun hasDateElapsed(
@@ -96,5 +108,8 @@ class RealPirInteractionReporter @Inject constructor(
         private const val DIFF_DATE_DAU = 1L
         private const val DIFF_DATE_WAU = 7L
         private const val DIFF_DATE_MAU = 28L
+
+        private const val MIN_INTER_PIXEL_DELAY_MS = 500L
+        private const val MAX_INTER_PIXEL_DELAY_MS = 5_000L
     }
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirInteractionReporter.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirInteractionReporter.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.pixels
+
+import com.duckduckgo.common.utils.CurrentTimeProvider
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.pir.impl.store.PirRepository
+import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.withContext
+import java.time.Instant
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+import javax.inject.Inject
+
+/**
+ * Reports user-interacted DAU/WAU/MAU pixels for PIR. Unlike [PirEngagementReporter] (which reports
+ * product-active users on a scheduled tick and is gated on profile existence), this is driven by the
+ * user opening the PIR dashboard. Opening the dashboard is itself the interaction, so there is no
+ * active-user gate. Day/week/month deduplication is done with the same elapsed-time pattern.
+ */
+interface PirInteractionReporter {
+    suspend fun attemptFirePixel()
+}
+
+@ContributesBinding(AppScope::class)
+class RealPirInteractionReporter @Inject constructor(
+    private val dispatcherProvider: DispatcherProvider,
+    private val pirRepository: PirRepository,
+    private val currentTimeProvider: CurrentTimeProvider,
+    private val pirPixelSender: PirPixelSender,
+) : PirInteractionReporter {
+    override suspend fun attemptFirePixel() {
+        withContext(dispatcherProvider.io()) {
+            val nowMs = currentTimeProvider.currentTimeMillis()
+            attemptToFireDauPixel(nowMs)
+            attemptToFireWauPixel(nowMs)
+            attemptToFireMauPixel(nowMs)
+        }
+    }
+
+    private suspend fun attemptToFireDauPixel(nowMs: Long) {
+        val lastPixelMs = pirRepository.getLastPirInteractionDauPixelTimeMs()
+
+        if (!hasDateElapsed(DIFF_DATE_DAU, lastPixelMs, nowMs)) return
+
+        pirPixelSender.reportInteractionDAU()
+        pirRepository.setLastPirInteractionDauPixelTimeMs(nowMs)
+    }
+
+    private suspend fun attemptToFireWauPixel(nowMs: Long) {
+        val lastPixelMs = pirRepository.getLastPirInteractionWauPixelTimeMs()
+
+        if (!hasDateElapsed(DIFF_DATE_WAU, lastPixelMs, nowMs)) return
+
+        pirPixelSender.reportInteractionWAU()
+        pirRepository.setLastPirInteractionWauPixelTimeMs(nowMs)
+    }
+
+    private suspend fun attemptToFireMauPixel(nowMs: Long) {
+        val lastPixelMs = pirRepository.getLastPirInteractionMauPixelTimeMs()
+
+        if (!hasDateElapsed(DIFF_DATE_MAU, lastPixelMs, nowMs)) return
+
+        pirPixelSender.reportInteractionMAU()
+        pirRepository.setLastPirInteractionMauPixelTimeMs(nowMs)
+    }
+
+    private fun hasDateElapsed(
+        requiredDiff: Long,
+        lastPixelMs: Long,
+        nowMs: Long,
+    ): Boolean {
+        if (lastPixelMs == 0L) return true
+
+        val lastPixelDate = Instant.ofEpochMilli(lastPixelMs).atZone(ZoneId.systemDefault()).toLocalDate()
+        val nowDate = Instant.ofEpochMilli(nowMs).atZone(ZoneId.systemDefault()).toLocalDate()
+        return ChronoUnit.DAYS.between(lastPixelDate, nowDate) >= requiredDiff
+    }
+
+    companion object {
+        private const val DIFF_DATE_DAU = 1L
+        private const val DIFF_DATE_WAU = 7L
+        private const val DIFF_DATE_MAU = 28L
+    }
+}

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixel.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixel.kt
@@ -181,6 +181,26 @@ enum class PirPixel(
         type = Count,
     ),
 
+    PIR_INTERACTION_DAU(
+        baseName = "m_dbp_interaction_dau",
+        type = Count,
+    ),
+
+    PIR_INTERACTION_WAU(
+        baseName = "m_dbp_interaction_wau",
+        type = Count,
+    ),
+
+    PIR_INTERACTION_MAU(
+        baseName = "m_dbp_interaction_mau",
+        type = Count,
+    ),
+
+    PIR_FIRST_SCAN_STARTED(
+        baseName = "m_dbp_first_scan",
+        type = Unique(),
+    ),
+
     PIR_WEEKLY_CHILD_ORPHANED_OPTOUTS(
         baseName = "m_dbp_weekly_child-broker_orphaned-optouts",
         type = Count,

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
@@ -51,12 +51,16 @@ import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_EMAIL_CONFIRMATION_RUN_STARTE
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_ENGAGEMENT_DAU
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_ENGAGEMENT_MAU
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_ENGAGEMENT_WAU
+import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_FIRST_SCAN_STARTED
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_FOREGROUND_RUN_COMPLETED
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_FOREGROUND_RUN_LOW_MEMORY
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_FOREGROUND_RUN_STARTED
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_FOREGROUND_RUN_START_FAILED
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_INITIAL_SCAN_DURATION
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_INITIAL_SCAN_INCOMPLETE
+import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_INTERACTION_DAU
+import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_INTERACTION_MAU
+import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_INTERACTION_WAU
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_INTERNAL_SECURE_STORAGE_UNAVAILABLE
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_MANUAL_RESET
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_OPTOUT_INVALID_EVENT
@@ -433,6 +437,26 @@ interface PirPixelSender {
      * Emits a pixel to report Monthly Active Users for PIR.
      */
     fun reportMAU()
+
+    /**
+     * Emits a pixel to report user-interacted Daily Active Users for PIR (the PIR dashboard was presented).
+     */
+    fun reportInteractionDAU()
+
+    /**
+     * Emits a pixel to report user-interacted Weekly Active Users for PIR (the PIR dashboard was presented).
+     */
+    fun reportInteractionWAU()
+
+    /**
+     * Emits a pixel to report user-interacted Monthly Active Users for PIR (the PIR dashboard was presented).
+     */
+    fun reportInteractionMAU()
+
+    /**
+     * Emits a unique pixel (once per install) when the user starts their first PIR scan.
+     */
+    fun reportFirstScanStarted()
 
     /**
      * Emits a pixel to report weekly data on orphaned opt-out records on child data brokers that don't have matching profiles on their parent broker.
@@ -1047,6 +1071,22 @@ class RealPirPixelSender @Inject constructor(
         enqueueFire(PIR_ENGAGEMENT_MAU)
     }
 
+    override fun reportInteractionDAU() {
+        enqueueFire(PIR_INTERACTION_DAU, usageParams())
+    }
+
+    override fun reportInteractionWAU() {
+        enqueueFire(PIR_INTERACTION_WAU, usageParams())
+    }
+
+    override fun reportInteractionMAU() {
+        enqueueFire(PIR_INTERACTION_MAU, usageParams())
+    }
+
+    override fun reportFirstScanStarted() {
+        enqueueFire(PIR_FIRST_SCAN_STARTED, usageParams())
+    }
+
     override fun reportWeeklyChildOrphanedOptOuts(
         brokerUrl: String,
         childParentRecordDifference: Int,
@@ -1585,6 +1625,12 @@ class RealPirPixelSender @Inject constructor(
         fire(PIR_MANUAL_RESET)
     }
 
+    private fun usageParams(): Map<String, String> = mapOf(
+        // hardcoded values for now until we support freemium
+        PARAM_KEY_IS_AUTHENTICATED to "true",
+        PARAM_KEY_FREE_SCAN to "false",
+    )
+
     private fun fire(
         pixel: PirPixel,
         params: Map<String, String> = emptyMap(),
@@ -1646,6 +1692,8 @@ class RealPirPixelSender @Inject constructor(
         private const val PARAM_ATTEMPT_NUMBER = "attempt_number"
         private const val PARAM_TOTAL_FETCH = "totalFetchAttempts"
         private const val PARAM_TOTAL_EMAIL_CONFIRMATION = "totalEmailConfirmationJobs"
+        private const val PARAM_KEY_IS_AUTHENTICATED = "is_authenticated"
+        private const val PARAM_KEY_FREE_SCAN = "free_scan"
 
         private const val PARAM_KEY_BROKER = "data_broker"
         private const val PARAM_KEY_PARENT = "parent"

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
@@ -146,6 +146,11 @@ class RealPirJobsRunner @Inject constructor(
             emptyList()
         }
 
+        // Activation pixel: once per install when the user starts their first scan.
+        if (executionType == PirExecutionType.MANUAL_INITIAL && eligibleJobs.isNotEmpty()) {
+            pixelSender.reportFirstScanStarted()
+        }
+
         val isPowerSavingEnabled = context.isPowerSavingModeEnabled()
         val isVpnConnected = networkProtectionState.safeIsVpnRunning()
         val batteryOptimizationsEnabled = !context.isIgnoringBatteryOptimizations()

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/PirDataStore.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/PirDataStore.kt
@@ -26,6 +26,9 @@ interface PirDataStore {
     var dauLastSentMs: Long
     var wauLastSentMs: Long
     var mauLastSentMs: Long
+    var interactionDauLastSentMs: Long
+    var interactionWauLastSentMs: Long
+    var interactionMauLastSentMs: Long
     var weeklyStatLastSentMs: Long
     var hasBrokerConfigBeenManuallyUpdated: Boolean
     var latestBackgroundScanRunInMs: Long
@@ -100,6 +103,30 @@ internal class RealPirDataStore(
         set(value) {
             preferences.edit {
                 putLong(KEY_ENGAGEMENT_MAU_LAST_MS, value)
+            }
+        }
+
+    override var interactionDauLastSentMs: Long
+        get() = preferences.getLong(KEY_INTERACTION_DAU_LAST_MS, 0L)
+        set(value) {
+            preferences.edit {
+                putLong(KEY_INTERACTION_DAU_LAST_MS, value)
+            }
+        }
+
+    override var interactionWauLastSentMs: Long
+        get() = preferences.getLong(KEY_INTERACTION_WAU_LAST_MS, 0L)
+        set(value) {
+            preferences.edit {
+                putLong(KEY_INTERACTION_WAU_LAST_MS, value)
+            }
+        }
+
+    override var interactionMauLastSentMs: Long
+        get() = preferences.getLong(KEY_INTERACTION_MAU_LAST_MS, 0L)
+        set(value) {
+            preferences.edit {
+                putLong(KEY_INTERACTION_MAU_LAST_MS, value)
             }
         }
 
@@ -179,6 +206,9 @@ internal class RealPirDataStore(
         dauLastSentMs = 0L
         wauLastSentMs = 0L
         mauLastSentMs = 0L
+        interactionDauLastSentMs = 0L
+        interactionWauLastSentMs = 0L
+        interactionMauLastSentMs = 0L
         weeklyStatLastSentMs = 0L
         latestBackgroundScanRunInMs = 0L
         hasInitialScanEverStarted = false
@@ -194,6 +224,9 @@ internal class RealPirDataStore(
         private const val KEY_ENGAGEMENT_DAU_LAST_MS = "KEY_ENGAGEMENT_DAU_LAST_MS"
         private const val KEY_ENGAGEMENT_WAU_LAST_MS = "KEY_ENGAGEMENT_WAU_LAST_MS"
         private const val KEY_ENGAGEMENT_MAU_LAST_MS = "KEY_ENGAGEMENT_MAU_LAST_MS"
+        private const val KEY_INTERACTION_DAU_LAST_MS = "KEY_INTERACTION_DAU_LAST_MS"
+        private const val KEY_INTERACTION_WAU_LAST_MS = "KEY_INTERACTION_WAU_LAST_MS"
+        private const val KEY_INTERACTION_MAU_LAST_MS = "KEY_INTERACTION_MAU_LAST_MS"
         private const val KEY_WEEKLY_STATS_LAST_SENT_MS = "KEY_WEEKLY_STATS_LAST_SENT_MS"
         private const val KEY_BROKER_CONFIG_MANUALLY_UPDATED = "KEY_BROKER_CONFIG_MANUALLY_UPDATED"
         private const val KEY_LAST_BG_SCAN_RUN = "KEY_LAST_BG_SCAN_RUN_MS"

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/PirRepository.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/PirRepository.kt
@@ -206,6 +206,18 @@ interface PirRepository {
 
     suspend fun setLastPirMauPixelTimeMs(timeMs: Long)
 
+    suspend fun getLastPirInteractionDauPixelTimeMs(): Long
+
+    suspend fun setLastPirInteractionDauPixelTimeMs(timeMs: Long)
+
+    suspend fun getLastPirInteractionWauPixelTimeMs(): Long
+
+    suspend fun setLastPirInteractionWauPixelTimeMs(timeMs: Long)
+
+    suspend fun getLastPirInteractionMauPixelTimeMs(): Long
+
+    suspend fun setLastPirInteractionMauPixelTimeMs(timeMs: Long)
+
     suspend fun getWeeklyStatLastSentMs(): Long
 
     suspend fun setWeeklyStatLastSentMs(timeMs: Long)
@@ -760,6 +772,36 @@ class RealPirRepository(
     override suspend fun setLastPirMauPixelTimeMs(timeMs: Long) {
         withContext(dispatcherProvider.io()) {
             pirDataStore.mauLastSentMs = timeMs
+        }
+    }
+
+    override suspend fun getLastPirInteractionDauPixelTimeMs(): Long = withContext(dispatcherProvider.io()) {
+        return@withContext pirDataStore.interactionDauLastSentMs
+    }
+
+    override suspend fun setLastPirInteractionDauPixelTimeMs(timeMs: Long) {
+        withContext(dispatcherProvider.io()) {
+            pirDataStore.interactionDauLastSentMs = timeMs
+        }
+    }
+
+    override suspend fun getLastPirInteractionWauPixelTimeMs(): Long = withContext(dispatcherProvider.io()) {
+        return@withContext pirDataStore.interactionWauLastSentMs
+    }
+
+    override suspend fun setLastPirInteractionWauPixelTimeMs(timeMs: Long) {
+        withContext(dispatcherProvider.io()) {
+            pirDataStore.interactionWauLastSentMs = timeMs
+        }
+    }
+
+    override suspend fun getLastPirInteractionMauPixelTimeMs(): Long = withContext(dispatcherProvider.io()) {
+        return@withContext pirDataStore.interactionMauLastSentMs
+    }
+
+    override suspend fun setLastPirInteractionMauPixelTimeMs(timeMs: Long) {
+        withContext(dispatcherProvider.io()) {
+            pirDataStore.interactionMauLastSentMs = timeMs
         }
     }
 

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirInitialScanCompletionWideEventTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirInitialScanCompletionWideEventTest.kt
@@ -477,6 +477,9 @@ private class FakePirDataStore : PirDataStore {
     override var dauLastSentMs: Long = 0L
     override var wauLastSentMs: Long = 0L
     override var mauLastSentMs: Long = 0L
+    override var interactionDauLastSentMs: Long = 0L
+    override var interactionWauLastSentMs: Long = 0L
+    override var interactionMauLastSentMs: Long = 0L
     override var weeklyStatLastSentMs: Long = 0L
     override var hasBrokerConfigBeenManuallyUpdated: Boolean = false
     override var latestBackgroundScanRunInMs: Long = 0L
@@ -498,6 +501,9 @@ private class FakePirDataStore : PirDataStore {
         dauLastSentMs = 0L
         wauLastSentMs = 0L
         mauLastSentMs = 0L
+        interactionDauLastSentMs = 0L
+        interactionWauLastSentMs = 0L
+        interactionMauLastSentMs = 0L
         weeklyStatLastSentMs = 0L
         latestBackgroundScanRunInMs = 0L
         hasInitialScanEverStarted = false

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirInteractionReporterTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirInteractionReporterTest.kt
@@ -58,7 +58,7 @@ class RealPirInteractionReporterTest {
     private val twentyEightDaysLaterMs = baseDate.plusDays(28).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
 
     @Test
-    fun whenNoLastPixelForAnyThenFiresAllPixels() = runTest {
+    fun whenNoLastPixelForAnyThenFiresAllPixels() = coroutineRule.testScope.runTest {
         whenever(mockPirRepository.getLastPirInteractionDauPixelTimeMs()).thenReturn(0L)
         whenever(mockPirRepository.getLastPirInteractionWauPixelTimeMs()).thenReturn(0L)
         whenever(mockPirRepository.getLastPirInteractionMauPixelTimeMs()).thenReturn(0L)
@@ -75,7 +75,7 @@ class RealPirInteractionReporterTest {
     }
 
     @Test
-    fun whenOneDayPassedThenFiresDauPixelOnly() = runTest {
+    fun whenOneDayPassedThenFiresDauPixelOnly() = coroutineRule.testScope.runTest {
         whenever(mockPirRepository.getLastPirInteractionDauPixelTimeMs()).thenReturn(baseDateMs)
         whenever(mockPirRepository.getLastPirInteractionWauPixelTimeMs()).thenReturn(baseDateMs)
         whenever(mockPirRepository.getLastPirInteractionMauPixelTimeMs()).thenReturn(baseDateMs)
@@ -91,7 +91,7 @@ class RealPirInteractionReporterTest {
     }
 
     @Test
-    fun whenSameDayThenDoesNotFireAnyPixel() = runTest {
+    fun whenSameDayThenDoesNotFireAnyPixel() = coroutineRule.testScope.runTest {
         whenever(mockPirRepository.getLastPirInteractionDauPixelTimeMs()).thenReturn(baseDateMs)
         whenever(mockPirRepository.getLastPirInteractionWauPixelTimeMs()).thenReturn(baseDateMs)
         whenever(mockPirRepository.getLastPirInteractionMauPixelTimeMs()).thenReturn(baseDateMs)
@@ -106,7 +106,7 @@ class RealPirInteractionReporterTest {
     }
 
     @Test
-    fun whenSevenDaysPassedThenFiresWauPixel() = runTest {
+    fun whenSevenDaysPassedThenFiresWauPixel() = coroutineRule.testScope.runTest {
         whenever(mockPirRepository.getLastPirInteractionDauPixelTimeMs()).thenReturn(sevenDaysLaterMs) // Emitted already
         whenever(mockPirRepository.getLastPirInteractionWauPixelTimeMs()).thenReturn(baseDateMs)
         whenever(mockPirRepository.getLastPirInteractionMauPixelTimeMs()).thenReturn(baseDateMs)
@@ -122,7 +122,7 @@ class RealPirInteractionReporterTest {
     }
 
     @Test
-    fun whenTwentyEightDaysPassedThenFiresMauPixel() = runTest {
+    fun whenTwentyEightDaysPassedThenFiresMauPixel() = coroutineRule.testScope.runTest {
         whenever(mockPirRepository.getLastPirInteractionDauPixelTimeMs()).thenReturn(twentyEightDaysLaterMs) // Emitted already
         whenever(mockPirRepository.getLastPirInteractionWauPixelTimeMs()).thenReturn(twentyEightDaysLaterMs) // Emitted already
         whenever(mockPirRepository.getLastPirInteractionMauPixelTimeMs()).thenReturn(baseDateMs)
@@ -138,7 +138,7 @@ class RealPirInteractionReporterTest {
     }
 
     @Test
-    fun whenAllPixelsEligibleThenFiresAllPixels() = runTest {
+    fun whenAllPixelsEligibleThenFiresAllPixels() = coroutineRule.testScope.runTest {
         whenever(mockPirRepository.getLastPirInteractionDauPixelTimeMs()).thenReturn(baseDateMs)
         whenever(mockPirRepository.getLastPirInteractionWauPixelTimeMs()).thenReturn(baseDateMs)
         whenever(mockPirRepository.getLastPirInteractionMauPixelTimeMs()).thenReturn(baseDateMs)
@@ -152,7 +152,7 @@ class RealPirInteractionReporterTest {
     }
 
     @Test
-    fun whenLastPixelInFutureThenDoesNotFirePixels() = runTest {
+    fun whenLastPixelInFutureThenDoesNotFirePixels() = coroutineRule.testScope.runTest {
         val futureDateMs = baseDate.plusDays(1).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
         whenever(mockPirRepository.getLastPirInteractionDauPixelTimeMs()).thenReturn(futureDateMs)
         whenever(mockPirRepository.getLastPirInteractionWauPixelTimeMs()).thenReturn(futureDateMs)
@@ -162,5 +162,23 @@ class RealPirInteractionReporterTest {
         testee.attemptFirePixel()
 
         verifyNoInteractions(mockPirPixelSender)
+    }
+
+    @Test
+    fun whenPixelsFireThenEachIsPrecededByAntiSessioningDelay() = coroutineRule.testScope.runTest {
+        whenever(mockPirRepository.getLastPirInteractionDauPixelTimeMs()).thenReturn(0L)
+        whenever(mockPirRepository.getLastPirInteractionWauPixelTimeMs()).thenReturn(0L)
+        whenever(mockPirRepository.getLastPirInteractionMauPixelTimeMs()).thenReturn(0L)
+        whenever(mockCurrentTimeProvider.currentTimeMillis()).thenReturn(baseDateMs)
+
+        val startVirtualTime = testScheduler.currentTime
+        testee.attemptFirePixel()
+        val elapsed = testScheduler.currentTime - startVirtualTime
+
+        // All three pixels fire, each preceded by a jitter delay of at least the 500ms minimum.
+        verify(mockPirPixelSender).reportInteractionDAU()
+        verify(mockPirPixelSender).reportInteractionWAU()
+        verify(mockPirPixelSender).reportInteractionMAU()
+        assert(elapsed >= 3 * 500L)
     }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirInteractionReporterTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirInteractionReporterTest.kt
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.pixels
+
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.CurrentTimeProvider
+import com.duckduckgo.pir.impl.store.PirRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+class RealPirInteractionReporterTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val mockDispatcherProvider = coroutineRule.testDispatcherProvider
+    private val mockPirRepository: PirRepository = mock()
+    private val mockCurrentTimeProvider: CurrentTimeProvider = mock()
+    private val mockPirPixelSender: PirPixelSender = mock()
+
+    private val testee = RealPirInteractionReporter(
+        dispatcherProvider = mockDispatcherProvider,
+        pirRepository = mockPirRepository,
+        currentTimeProvider = mockCurrentTimeProvider,
+        pirPixelSender = mockPirPixelSender,
+    )
+
+    // January 1, 2024 12:00:00
+    private val baseDate = LocalDateTime.of(2024, 1, 1, 12, 0, 0)
+    private val baseDateMs = baseDate.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+
+    private val oneDayLaterMs = baseDate.plusDays(1).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+    private val sevenDaysLaterMs = baseDate.plusDays(7).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+    private val twentyEightDaysLaterMs = baseDate.plusDays(28).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+
+    @Test
+    fun whenNoLastPixelForAnyThenFiresAllPixels() = runTest {
+        whenever(mockPirRepository.getLastPirInteractionDauPixelTimeMs()).thenReturn(0L)
+        whenever(mockPirRepository.getLastPirInteractionWauPixelTimeMs()).thenReturn(0L)
+        whenever(mockPirRepository.getLastPirInteractionMauPixelTimeMs()).thenReturn(0L)
+        whenever(mockCurrentTimeProvider.currentTimeMillis()).thenReturn(baseDateMs)
+
+        testee.attemptFirePixel()
+
+        verify(mockPirPixelSender).reportInteractionDAU()
+        verify(mockPirRepository).setLastPirInteractionDauPixelTimeMs(baseDateMs)
+        verify(mockPirPixelSender).reportInteractionWAU()
+        verify(mockPirRepository).setLastPirInteractionWauPixelTimeMs(baseDateMs)
+        verify(mockPirPixelSender).reportInteractionMAU()
+        verify(mockPirRepository).setLastPirInteractionMauPixelTimeMs(baseDateMs)
+    }
+
+    @Test
+    fun whenOneDayPassedThenFiresDauPixelOnly() = runTest {
+        whenever(mockPirRepository.getLastPirInteractionDauPixelTimeMs()).thenReturn(baseDateMs)
+        whenever(mockPirRepository.getLastPirInteractionWauPixelTimeMs()).thenReturn(baseDateMs)
+        whenever(mockPirRepository.getLastPirInteractionMauPixelTimeMs()).thenReturn(baseDateMs)
+        whenever(mockCurrentTimeProvider.currentTimeMillis()).thenReturn(oneDayLaterMs)
+
+        testee.attemptFirePixel()
+
+        verify(mockPirPixelSender).reportInteractionDAU()
+        verify(mockPirRepository).setLastPirInteractionDauPixelTimeMs(oneDayLaterMs)
+        verifyNoMoreInteractions(mockPirPixelSender)
+        verify(mockPirRepository, never()).setLastPirInteractionWauPixelTimeMs(any())
+        verify(mockPirRepository, never()).setLastPirInteractionMauPixelTimeMs(any())
+    }
+
+    @Test
+    fun whenSameDayThenDoesNotFireAnyPixel() = runTest {
+        whenever(mockPirRepository.getLastPirInteractionDauPixelTimeMs()).thenReturn(baseDateMs)
+        whenever(mockPirRepository.getLastPirInteractionWauPixelTimeMs()).thenReturn(baseDateMs)
+        whenever(mockPirRepository.getLastPirInteractionMauPixelTimeMs()).thenReturn(baseDateMs)
+        whenever(mockCurrentTimeProvider.currentTimeMillis()).thenReturn(baseDateMs)
+
+        testee.attemptFirePixel()
+
+        verifyNoInteractions(mockPirPixelSender)
+        verify(mockPirRepository, never()).setLastPirInteractionDauPixelTimeMs(any())
+        verify(mockPirRepository, never()).setLastPirInteractionWauPixelTimeMs(any())
+        verify(mockPirRepository, never()).setLastPirInteractionMauPixelTimeMs(any())
+    }
+
+    @Test
+    fun whenSevenDaysPassedThenFiresWauPixel() = runTest {
+        whenever(mockPirRepository.getLastPirInteractionDauPixelTimeMs()).thenReturn(sevenDaysLaterMs) // Emitted already
+        whenever(mockPirRepository.getLastPirInteractionWauPixelTimeMs()).thenReturn(baseDateMs)
+        whenever(mockPirRepository.getLastPirInteractionMauPixelTimeMs()).thenReturn(baseDateMs)
+        whenever(mockCurrentTimeProvider.currentTimeMillis()).thenReturn(sevenDaysLaterMs)
+
+        testee.attemptFirePixel()
+
+        verify(mockPirPixelSender).reportInteractionWAU()
+        verify(mockPirRepository).setLastPirInteractionWauPixelTimeMs(sevenDaysLaterMs)
+        verifyNoMoreInteractions(mockPirPixelSender)
+        verify(mockPirRepository, never()).setLastPirInteractionDauPixelTimeMs(any())
+        verify(mockPirRepository, never()).setLastPirInteractionMauPixelTimeMs(any())
+    }
+
+    @Test
+    fun whenTwentyEightDaysPassedThenFiresMauPixel() = runTest {
+        whenever(mockPirRepository.getLastPirInteractionDauPixelTimeMs()).thenReturn(twentyEightDaysLaterMs) // Emitted already
+        whenever(mockPirRepository.getLastPirInteractionWauPixelTimeMs()).thenReturn(twentyEightDaysLaterMs) // Emitted already
+        whenever(mockPirRepository.getLastPirInteractionMauPixelTimeMs()).thenReturn(baseDateMs)
+        whenever(mockCurrentTimeProvider.currentTimeMillis()).thenReturn(twentyEightDaysLaterMs)
+
+        testee.attemptFirePixel()
+
+        verify(mockPirPixelSender).reportInteractionMAU()
+        verify(mockPirRepository).setLastPirInteractionMauPixelTimeMs(twentyEightDaysLaterMs)
+        verifyNoMoreInteractions(mockPirPixelSender)
+        verify(mockPirRepository, never()).setLastPirInteractionDauPixelTimeMs(any())
+        verify(mockPirRepository, never()).setLastPirInteractionWauPixelTimeMs(any())
+    }
+
+    @Test
+    fun whenAllPixelsEligibleThenFiresAllPixels() = runTest {
+        whenever(mockPirRepository.getLastPirInteractionDauPixelTimeMs()).thenReturn(baseDateMs)
+        whenever(mockPirRepository.getLastPirInteractionWauPixelTimeMs()).thenReturn(baseDateMs)
+        whenever(mockPirRepository.getLastPirInteractionMauPixelTimeMs()).thenReturn(baseDateMs)
+        whenever(mockCurrentTimeProvider.currentTimeMillis()).thenReturn(twentyEightDaysLaterMs)
+
+        testee.attemptFirePixel()
+
+        verify(mockPirPixelSender).reportInteractionDAU()
+        verify(mockPirPixelSender).reportInteractionWAU()
+        verify(mockPirPixelSender).reportInteractionMAU()
+    }
+
+    @Test
+    fun whenLastPixelInFutureThenDoesNotFirePixels() = runTest {
+        val futureDateMs = baseDate.plusDays(1).atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        whenever(mockPirRepository.getLastPirInteractionDauPixelTimeMs()).thenReturn(futureDateMs)
+        whenever(mockPirRepository.getLastPirInteractionWauPixelTimeMs()).thenReturn(futureDateMs)
+        whenever(mockPirRepository.getLastPirInteractionMauPixelTimeMs()).thenReturn(futureDateMs)
+        whenever(mockCurrentTimeProvider.currentTimeMillis()).thenReturn(baseDateMs)
+
+        testee.attemptFirePixel()
+
+        verifyNoInteractions(mockPirPixelSender)
+    }
+}

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirInteractionReporterTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirInteractionReporterTest.kt
@@ -19,12 +19,14 @@ package com.duckduckgo.pir.impl.pixels
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.pir.impl.store.PirRepository
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
@@ -180,5 +182,27 @@ class RealPirInteractionReporterTest {
         verify(mockPirPixelSender).reportInteractionWAU()
         verify(mockPirPixelSender).reportInteractionMAU()
         assert(elapsed >= 3 * 500L)
+    }
+
+    @Test
+    fun whenTwoOverlappingAttemptsThenDauPixelFiresOnce() = coroutineRule.testScope.runTest {
+        // Stateful DAU timestamp so the re-check after the jitter delay reflects the first fire.
+        var dauStored = 0L
+        whenever(mockPirRepository.getLastPirInteractionDauPixelTimeMs()).thenAnswer { dauStored }
+        whenever(mockPirRepository.setLastPirInteractionDauPixelTimeMs(any())).thenAnswer { invocation ->
+            dauStored = invocation.getArgument(0)
+            Unit
+        }
+        // Keep WAU/MAU ineligible so the test focuses on the DAU dedup race.
+        whenever(mockPirRepository.getLastPirInteractionWauPixelTimeMs()).thenReturn(baseDateMs)
+        whenever(mockPirRepository.getLastPirInteractionMauPixelTimeMs()).thenReturn(baseDateMs)
+        whenever(mockCurrentTimeProvider.currentTimeMillis()).thenReturn(baseDateMs)
+
+        val first = launch { testee.attemptFirePixel() }
+        val second = launch { testee.attemptFirePixel() }
+        first.join()
+        second.join()
+
+        verify(mockPirPixelSender, times(1)).reportInteractionDAU()
     }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
@@ -1159,4 +1159,72 @@ class RealPirPixelSenderTest {
         assert(paramsCaptor.firstValue["vpn_connection_state"] == "connected")
         assert(paramsCaptor.firstValue["notifications_permission_granted"] == "false")
     }
+
+    @Test
+    fun whenReportInteractionDAUThenEnqueuesPixelWithAuthParams() = runTest {
+        testee.reportInteractionDAU()
+
+        val paramsCaptor = argumentCaptor<Map<String, String>>()
+        verify(mockPixelSender).enqueueFire(
+            pixelName = any(),
+            parameters = paramsCaptor.capture(),
+            encodedParameters = any(),
+            type = any(),
+        )
+
+        assert(paramsCaptor.firstValue["is_authenticated"] == "true")
+        assert(paramsCaptor.firstValue["free_scan"] == "false")
+    }
+
+    @Test
+    fun whenReportInteractionWAUThenEnqueuesPixelWithAuthParams() = runTest {
+        testee.reportInteractionWAU()
+
+        val paramsCaptor = argumentCaptor<Map<String, String>>()
+        verify(mockPixelSender).enqueueFire(
+            pixelName = any(),
+            parameters = paramsCaptor.capture(),
+            encodedParameters = any(),
+            type = any(),
+        )
+
+        assert(paramsCaptor.firstValue["is_authenticated"] == "true")
+        assert(paramsCaptor.firstValue["free_scan"] == "false")
+    }
+
+    @Test
+    fun whenReportInteractionMAUThenEnqueuesPixelWithAuthParams() = runTest {
+        testee.reportInteractionMAU()
+
+        val paramsCaptor = argumentCaptor<Map<String, String>>()
+        verify(mockPixelSender).enqueueFire(
+            pixelName = any(),
+            parameters = paramsCaptor.capture(),
+            encodedParameters = any(),
+            type = any(),
+        )
+
+        assert(paramsCaptor.firstValue["is_authenticated"] == "true")
+        assert(paramsCaptor.firstValue["free_scan"] == "false")
+    }
+
+    @Test
+    fun whenReportFirstScanStartedThenEnqueuesUniquePixelWithAuthParams() = runTest {
+        testee.reportFirstScanStarted()
+
+        val pixelNameCaptor = argumentCaptor<String>()
+        val paramsCaptor = argumentCaptor<Map<String, String>>()
+        val typeCaptor = argumentCaptor<Pixel.PixelType>()
+        verify(mockPixelSender).enqueueFire(
+            pixelName = pixelNameCaptor.capture(),
+            parameters = paramsCaptor.capture(),
+            encodedParameters = any(),
+            type = typeCaptor.capture(),
+        )
+
+        assert(pixelNameCaptor.firstValue == "m_dbp_first_scan_u")
+        assert(typeCaptor.firstValue is Pixel.PixelType.Unique)
+        assert(paramsCaptor.firstValue["is_authenticated"] == "true")
+        assert(paramsCaptor.firstValue["free_scan"] == "false")
+    }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealPirJobsRunnerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealPirJobsRunnerTest.kt
@@ -235,6 +235,8 @@ class RealPirJobsRunnerTest {
         // Then
         verify(mockPirRepository, never()).setLatestBackgroundScanRunInMs(any())
         verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL), any())
+        // No eligible scan jobs (no active brokers) -> first-scan activation pixel does not fire
+        verify(mockPixelSender, never()).reportFirstScanStarted()
         verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL), any())
         verify(mockPirScan).stop()
         verifyNoMoreInteractions(mockPixelSender)
@@ -287,6 +289,7 @@ class RealPirJobsRunnerTest {
 
         // Then
         verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL), any())
+        verify(mockPixelSender).reportFirstScanStarted()
         // we just dont attempt what the mock for time provider is giving us
         verify(mockPixelSender).reportInitialScanDuration(eq(0L), eq(2), eq(false), eq(false), eq(1), eq(MANUAL_INITIAL), any())
         verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL), any())
@@ -342,6 +345,7 @@ class RealPirJobsRunnerTest {
 
         // Then
         verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL), any())
+        verify(mockPixelSender).reportFirstScanStarted()
         verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL), any())
         // we just dont attempt what the mock for time provider is giving us
         verify(mockPixelSender).reportInitialScanDuration(eq(0L), eq(2), eq(false), eq(false), eq(2), eq(MANUAL_INITIAL), any())
@@ -384,6 +388,7 @@ class RealPirJobsRunnerTest {
         verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_EDIT_PROFILE), any())
         verify(mockPixelSender).reportInitialScanDuration(any(), any(), any(), any(), any(), eq(MANUAL_EDIT_PROFILE), any())
         verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_EDIT_PROFILE), any())
+        verify(mockPixelSender, never()).reportFirstScanStarted()
     }
 
     @Test
@@ -429,6 +434,7 @@ class RealPirJobsRunnerTest {
         // Then
         verify(mockPixelSender).reportScheduledScanStarted(any(), any())
         verify(mockPixelSender).reportScheduledScanCompleted(any(), any(), any(), any(), any())
+        verify(mockPixelSender, never()).reportFirstScanStarted()
         verify(mockPirScan).executeScanForJobs(
             eq(listOf(testScanJobRecord)),
             eq(mockContext),
@@ -1211,6 +1217,8 @@ class RealPirJobsRunnerTest {
         // Then
         verify(mockBrokerJsonUpdater).update()
         verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL), any())
+        // No eligible scan jobs (broker data still empty) -> first-scan activation pixel does not fire
+        verify(mockPixelSender, never()).reportFirstScanStarted()
         verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL), any())
         verifyNoMoreInteractions(mockPixelSender)
         verifyNoInteractions(mockEligibleScanJobProvider)
@@ -1264,6 +1272,8 @@ class RealPirJobsRunnerTest {
         // Then
         verifyNoInteractions(mockBrokerJsonUpdater)
         verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL), any())
+        // No eligible scan jobs (no active brokers) -> first-scan activation pixel does not fire
+        verify(mockPixelSender, never()).reportFirstScanStarted()
         verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL), any())
         verifyNoMoreInteractions(mockPixelSender)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215149268720144?focus=true
Tech Design URL (if applicable): N/A

### Description
Adds new PIR pixels to help us get a better sense of how many users use PIR and interact with it.

### Steps to test this PR
QA-optional

- [ ] Clear all PIR data
- [ ] Finish onboarding and start a new scan
- [ ] Check that `m_dbp_first_scan_u` is fired
- [ ] Open dashboard and check that `m_dbp_interaction_dau` is fired
- [ ] Change WAU/MAU values in RealPirInteractionReporter to something like 1min and 3 min and open dashboard again to check they are fired

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes with no product logic beyond when pixels fire; first-scan uses platform unique-pixel dedup rather than new persisted state.
> 
> **Overview**
> Adds **PIR analytics** to measure dashboard engagement separately from existing scheduled **engagement** DAU/WAU/MAU, plus a **once-per-install** first-scan activation pixel.
> 
> **Interaction DAU/WAU/MAU** (`m_dbp_interaction_*`) fire when the PIR dashboard is shown: `PirDashboardWebViewViewModel` invokes new `PirInteractionReporter` on lifecycle start. Dedup uses 1/7/28 calendar-day windows with persisted last-sent timestamps, random 0.5–5s delays, and a mutex so concurrent opens do not double-fire. Pixels include `is_authenticated` and `free_scan` (hardcoded `true`/`false` on Android until freemium exists).
> 
> **First scan** (`m_dbp_first_scan_u`, unique) fires from `PirJobsRunner` when a **manual initial** run has eligible scan jobs. Pixel definitions and `PirPixel`/`PirPixelSender` wiring were extended; fakes and unit tests cover reporter behavior and job-runner gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e865a314616305627de096b1c86ff706b5d2ba82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->