### PR TITLE
PIR: Add timing information to initial scan wide event

### DIFF
--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -2208,6 +2208,25 @@
                 ]
             },
             {
+                "key": "feature.data.ext.last_step_elapsed_ms_bucketed",
+                "description": "Time from run start to when last_step was reached, bucketed using the lower bucket boundary. Recorded on every step after 'started'. On UNKNOWN/killed runs this is the only signal for how long the run had been going before termination, since the total_*_duration intervals are never recorded when a run is killed.",
+                "enum": [
+                    "0",
+                    "10000",
+                    "30000",
+                    "60000",
+                    "120000",
+                    "300000",
+                    "600000",
+                    "900000",
+                    "1800000",
+                    "3600000",
+                    "7200000",
+                    "14400000",
+                    "28800000"
+                ]
+            },
+            {
                 "key": "feature.data.ext.failure_reason",
                 "description": "Reason a run failed. Only present on FAILURE events. Specific exception types are mapped to bounded values; anything not in the known set falls back to unknown_error. The phase the run was in when it failed is recoverable from last_step.",
                 "enum": [
@@ -2341,6 +2360,44 @@
                 "key": "feature.data.ext.opt_out_duration_ms_bucketed",
                 "description": "Time spent in the opt-out scheduling phase from opt_out_started to opt_out_completed, bucketed using the lower bucket boundary",
                 "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+            },
+            {
+                "key": "feature.data.ext.total_scan_duration_ms_bucketed",
+                "description": "Time from run start to scan_completed — the full scan phase, including the final 90-100% band that the per-decile intervals don't cover — bucketed using the lower bucket boundary. Absent on runs that never reach scan_completed (e.g. UNKNOWN/killed runs).",
+                "enum": [
+                    "0",
+                    "10000",
+                    "30000",
+                    "60000",
+                    "120000",
+                    "300000",
+                    "600000",
+                    "900000",
+                    "1800000",
+                    "3600000",
+                    "7200000",
+                    "14400000",
+                    "28800000"
+                ]
+            },
+            {
+                "key": "feature.data.ext.total_flow_duration_ms_bucketed",
+                "description": "Time from run start to flow finish — end-to-end, including the opt-out scheduling phase — bucketed using the lower bucket boundary. Absent on runs finalized by the cleanup timeout (e.g. UNKNOWN/killed runs).",
+                "enum": [
+                    "0",
+                    "10000",
+                    "30000",
+                    "60000",
+                    "120000",
+                    "300000",
+                    "600000",
+                    "900000",
+                    "1800000",
+                    "3600000",
+                    "7200000",
+                    "14400000",
+                    "28800000"
+                ]
             }
         ]
     },
@@ -2467,6 +2524,25 @@
                 ]
             },
             {
+                "key": "feature.data.ext.last_step_elapsed_ms_bucketed",
+                "description": "Time from run start to when last_step was reached, bucketed using the lower bucket boundary. Recorded on every step after 'started'. On UNKNOWN/killed runs this is the only signal for how long the run had been going before termination, since the total_*_duration intervals are never recorded when a run is killed.",
+                "enum": [
+                    "0",
+                    "10000",
+                    "30000",
+                    "60000",
+                    "120000",
+                    "300000",
+                    "600000",
+                    "900000",
+                    "1800000",
+                    "3600000",
+                    "7200000",
+                    "14400000",
+                    "28800000"
+                ]
+            },
+            {
                 "key": "feature.data.ext.failure_reason",
                 "description": "Reason a run failed. Only present on FAILURE events. Specific exception types are mapped to bounded values; anything not in the known set falls back to unknown_error. The phase the run was in when it failed is recoverable from last_step.",
                 "enum": [
@@ -2600,6 +2676,44 @@
                 "key": "feature.data.ext.opt_out_duration_ms_bucketed",
                 "description": "Time spent in the opt-out scheduling phase from opt_out_started to opt_out_completed, bucketed using the lower bucket boundary",
                 "enum": ["0", "1000", "5000", "10000", "30000", "60000", "300000", "600000"]
+            },
+            {
+                "key": "feature.data.ext.total_scan_duration_ms_bucketed",
+                "description": "Time from run start to scan_completed — the full scan phase, including the final 90-100% band that the per-decile intervals don't cover — bucketed using the lower bucket boundary. Absent on runs that never reach scan_completed (e.g. UNKNOWN/killed runs).",
+                "enum": [
+                    "0",
+                    "10000",
+                    "30000",
+                    "60000",
+                    "120000",
+                    "300000",
+                    "600000",
+                    "900000",
+                    "1800000",
+                    "3600000",
+                    "7200000",
+                    "14400000",
+                    "28800000"
+                ]
+            },
+            {
+                "key": "feature.data.ext.total_flow_duration_ms_bucketed",
+                "description": "Time from run start to flow finish — end-to-end, including the opt-out scheduling phase — bucketed using the lower bucket boundary. Absent on runs finalized by the cleanup timeout (e.g. UNKNOWN/killed runs).",
+                "enum": [
+                    "0",
+                    "10000",
+                    "30000",
+                    "60000",
+                    "120000",
+                    "300000",
+                    "600000",
+                    "900000",
+                    "1800000",
+                    "3600000",
+                    "7200000",
+                    "14400000",
+                    "28800000"
+                ]
             }
         ]
     },

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEvent.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEvent.kt
@@ -21,6 +21,7 @@ import androidx.annotation.VisibleForTesting
 import com.duckduckgo.app.statistics.wideevents.CleanupPolicy
 import com.duckduckgo.app.statistics.wideevents.FlowStatus
 import com.duckduckgo.app.statistics.wideevents.WideEventClient
+import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.pir.impl.PirRemoteFeatures
@@ -35,6 +36,8 @@ import java.io.IOException
 import javax.inject.Inject
 import kotlin.random.Random
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 interface PirScanWideEvent {
     suspend fun onRunStarted(
@@ -139,6 +142,7 @@ class PirScanWideEventImpl @Inject constructor(
     private val wideEventClient: WideEventClient,
     private val pirRemoteFeatures: PirRemoteFeatures,
     private val dispatchers: DispatcherProvider,
+    private val currentTimeProvider: CurrentTimeProvider,
 ) : PirScanWideEvent {
 
     private val manualState = RunState(WIDE_EVENT_NAME_MANUAL)
@@ -275,19 +279,41 @@ class PirScanWideEventImpl @Inject constructor(
     }
 
     /**
-     * Records a flow step and persists [stepName] as `last_step` metadata in the same write. Because
-     * flowStep metadata is merged into the event and persisted immediately, the furthest-reached step
-     * survives an abnormal termination — e.g. the `:pir` process being killed mid-scan and the flow
-     * finalized as [FlowStatus.Unknown] by the cleanup-on-timeout policy, which never calls
-     * flowFinish.
+     * Records a flow step and persists [stepName] as `last_step` metadata in the same write. When
+     * [elapsedMs] is provided, also persists the bucketed time-since-run-start as
+     * `last_step_elapsed_ms_bucketed`. Because flowStep metadata is merged into the event and
+     * persisted immediately, the furthest-reached step and its elapsed time survive an abnormal
+     * termination — e.g. the `:pir` process being killed mid-scan and the flow finalized as
+     * [FlowStatus.Unknown] by the cleanup-on-timeout policy, which never calls flowFinish. That is the
+     * only way to recover how long a killed run had been going, since the `total_*_duration` intervals
+     * are never closed (and thus never recorded) on such a run.
+     *
+     * [elapsedMs] is omitted for the initial `started` step (elapsed is ~0 there and carries no
+     * signal); the field therefore being absent on a flow means it was killed before the first
+     * progress decile.
      */
-    private suspend fun recordStep(flowId: Long, stepName: String) {
+    private suspend fun recordStep(flowId: Long, stepName: String, elapsedMs: Long? = null) {
+        val metadata = buildMap {
+            put(KEY_LAST_STEP, stepName)
+            elapsedMs?.let { put(KEY_LAST_STEP_ELAPSED, bucketedElapsedMs(it)) }
+        }
         wideEventClient.flowStep(
             wideEventId = flowId,
             stepName = stepName,
             success = true,
-            metadata = mapOf(KEY_LAST_STEP to stepName),
+            metadata = metadata,
         )
+    }
+
+    /**
+     * Floors [elapsedMs] to the nearest [PER_RUN_DURATION_BUCKETS] boundary (values below the smallest
+     * bucket become 0), mirroring how the wide-events framework buckets interval durations.
+     */
+    private fun bucketedElapsedMs(elapsedMs: Long): String {
+        val matched = PER_RUN_DURATION_BUCKETS
+            .filter { it.inWholeMilliseconds <= elapsedMs }
+            .maxByOrNull { it.inWholeMilliseconds }
+        return (matched?.inWholeMilliseconds ?: 0L).toString()
     }
 
     /**
@@ -302,6 +328,9 @@ class PirScanWideEventImpl @Inject constructor(
         private var lastReportedDecile: Int = 0
         private var currentDecileIntervalKey: String? = null
         private var optOutIntervalOpen: Boolean = false
+        private var totalScanIntervalOpen: Boolean = false
+        private var totalFlowIntervalOpen: Boolean = false
+        private var runStartElapsedMs: Long = 0
 
         suspend fun onRunStarted(
             executionType: PirExecutionType,
@@ -361,7 +390,22 @@ class PirScanWideEventImpl @Inject constructor(
                 ).getOrNull() ?: return@withLock
 
                 cachedFlowId = newFlowId
+                runStartElapsedMs = currentTimeProvider.elapsedRealtime()
                 recordStep(newFlowId, STEP_STARTED)
+
+                wideEventClient.intervalStart(
+                    wideEventId = newFlowId,
+                    key = INTERVAL_TOTAL_FLOW_DURATION,
+                    buckets = PER_RUN_DURATION_BUCKETS,
+                )
+                totalFlowIntervalOpen = true
+
+                wideEventClient.intervalStart(
+                    wideEventId = newFlowId,
+                    key = INTERVAL_TOTAL_SCAN_DURATION,
+                    buckets = PER_RUN_DURATION_BUCKETS,
+                )
+                totalScanIntervalOpen = true
 
                 if (totalScanJobs > 0) {
                     val key = decileIntervalKey(0, 10)
@@ -404,7 +448,7 @@ class PirScanWideEventImpl @Inject constructor(
                     }
 
                     val stepName = "$STEP_PROGRESS_PREFIX${currentDecile * 10}"
-                    recordStep(flowId, stepName)
+                    recordStep(flowId, stepName, elapsedSinceStart())
 
                     if (currentDecile < 9) {
                         val nextKey = decileIntervalKey(currentDecile * 10, (currentDecile + 1) * 10)
@@ -428,14 +472,19 @@ class PirScanWideEventImpl @Inject constructor(
                     currentDecileIntervalKey = null
                 }
 
-                recordStep(flowId, STEP_SCAN_COMPLETED)
+                if (totalScanIntervalOpen) {
+                    wideEventClient.intervalEnd(wideEventId = flowId, key = INTERVAL_TOTAL_SCAN_DURATION)
+                    totalScanIntervalOpen = false
+                }
+
+                recordStep(flowId, STEP_SCAN_COMPLETED, elapsedSinceStart())
             }
         }
 
         suspend fun onOptOutStarted() {
             mutex.withLock {
                 val flowId = cachedFlowId ?: return@withLock
-                recordStep(flowId, STEP_OPT_OUT_STARTED)
+                recordStep(flowId, STEP_OPT_OUT_STARTED, elapsedSinceStart())
                 wideEventClient.intervalStart(wideEventId = flowId, key = INTERVAL_OPT_OUT_DURATION)
                 optOutIntervalOpen = true
             }
@@ -446,7 +495,11 @@ class PirScanWideEventImpl @Inject constructor(
                 val flowId = cachedFlowId ?: return@withLock
                 wideEventClient.intervalEnd(wideEventId = flowId, key = INTERVAL_OPT_OUT_DURATION)
                 optOutIntervalOpen = false
-                recordStep(flowId, STEP_OPT_OUT_COMPLETED)
+                recordStep(flowId, STEP_OPT_OUT_COMPLETED, elapsedSinceStart())
+                if (totalFlowIntervalOpen) {
+                    wideEventClient.intervalEnd(wideEventId = flowId, key = INTERVAL_TOTAL_FLOW_DURATION)
+                    totalFlowIntervalOpen = false
+                }
                 wideEventClient.flowFinish(
                     wideEventId = flowId,
                     status = FlowStatus.Success,
@@ -459,7 +512,11 @@ class PirScanWideEventImpl @Inject constructor(
         suspend fun onOptOutSkipped() {
             mutex.withLock {
                 val flowId = cachedFlowId ?: return@withLock
-                recordStep(flowId, STEP_OPT_OUT_SKIPPED)
+                recordStep(flowId, STEP_OPT_OUT_SKIPPED, elapsedSinceStart())
+                if (totalFlowIntervalOpen) {
+                    wideEventClient.intervalEnd(wideEventId = flowId, key = INTERVAL_TOTAL_FLOW_DURATION)
+                    totalFlowIntervalOpen = false
+                }
                 wideEventClient.flowFinish(
                     wideEventId = flowId,
                     status = FlowStatus.Success,
@@ -530,7 +587,21 @@ class PirScanWideEventImpl @Inject constructor(
                 wideEventClient.intervalEnd(wideEventId = flowId, key = INTERVAL_OPT_OUT_DURATION)
                 optOutIntervalOpen = false
             }
+            if (totalScanIntervalOpen) {
+                wideEventClient.intervalEnd(wideEventId = flowId, key = INTERVAL_TOTAL_SCAN_DURATION)
+                totalScanIntervalOpen = false
+            }
+            if (totalFlowIntervalOpen) {
+                wideEventClient.intervalEnd(wideEventId = flowId, key = INTERVAL_TOTAL_FLOW_DURATION)
+                totalFlowIntervalOpen = false
+            }
         }
+
+        /**
+         * Wall-clock time since this run's flow started.
+         */
+        private fun elapsedSinceStart(): Long =
+            (currentTimeProvider.elapsedRealtime() - runStartElapsedMs).coerceAtLeast(0)
 
         private fun clearStateLocked() {
             cachedFlowId = null
@@ -539,6 +610,9 @@ class PirScanWideEventImpl @Inject constructor(
             lastReportedDecile = 0
             currentDecileIntervalKey = null
             optOutIntervalOpen = false
+            totalScanIntervalOpen = false
+            totalFlowIntervalOpen = false
+            runStartElapsedMs = 0
         }
     }
 
@@ -591,6 +665,7 @@ class PirScanWideEventImpl @Inject constructor(
         const val KEY_NOTIFICATIONS_PERMISSION_GRANTED = "notifications_permission_granted"
         const val KEY_TRACKER_BLOCKING_STATE = "tracker_blocking_state"
         const val KEY_LAST_STEP = "last_step"
+        const val KEY_LAST_STEP_ELAPSED = "last_step_elapsed_ms_bucketed"
         const val KEY_CANCELLATION_REASON = "cancellation_reason"
 
         const val STEP_STARTED = "started"
@@ -601,6 +676,23 @@ class PirScanWideEventImpl @Inject constructor(
         const val STEP_OPT_OUT_SKIPPED = "opt_out_skipped"
 
         const val INTERVAL_OPT_OUT_DURATION = "opt_out_duration_ms_bucketed"
+        const val INTERVAL_TOTAL_SCAN_DURATION = "total_scan_duration_ms_bucketed"
+        const val INTERVAL_TOTAL_FLOW_DURATION = "total_flow_duration_ms_bucketed"
+
+        val PER_RUN_DURATION_BUCKETS = setOf(
+            10.seconds,
+            30.seconds,
+            1.minutes,
+            2.minutes,
+            5.minutes,
+            10.minutes,
+            15.minutes,
+            30.minutes,
+            1.hours,
+            2.hours,
+            4.hours,
+            8.hours,
+        )
 
         /** Hardcoded sample rate for scheduled-scan wide events. Manual runs always send. */
         const val SCHEDULED_SCAN_SAMPLE_RATE: Double = 0.20

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEventTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEventTest.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.app.statistics.wideevents.CleanupPolicy
 import com.duckduckgo.app.statistics.wideevents.FlowStatus
 import com.duckduckgo.app.statistics.wideevents.WideEventClient
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.pir.impl.PirRemoteFeatures
@@ -36,11 +37,14 @@ import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.EXECUTI
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.EXECUTION_TYPE_MANUAL_INITIAL
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.EXECUTION_TYPE_SCHEDULED
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.INTERVAL_OPT_OUT_DURATION
+import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.INTERVAL_TOTAL_FLOW_DURATION
+import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.INTERVAL_TOTAL_SCAN_DURATION
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.KEY_BATTERY_OPTIMIZATIONS
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.KEY_BROKER_COUNT
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.KEY_CANCELLATION_REASON
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.KEY_EXECUTION_TYPE
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.KEY_LAST_STEP
+import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.KEY_LAST_STEP_ELAPSED
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.KEY_NOTIFICATIONS_PERMISSION_GRANTED
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.KEY_POWER_SAVING
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.KEY_PROFILE_QUERIES_COUNT
@@ -49,6 +53,7 @@ import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.KEY_TOT
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.KEY_TRACKER_BLOCKING_STATE
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.KEY_VPN_CONNECTION_STATE
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.KEY_WEB_VIEW_COUNT
+import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.PER_RUN_DURATION_BUCKETS
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.STEP_OPT_OUT_COMPLETED
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.STEP_OPT_OUT_SKIPPED
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.STEP_OPT_OUT_STARTED
@@ -70,6 +75,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import java.io.IOException
+import java.time.LocalDateTime
 import kotlin.time.Duration.Companion.hours
 
 class PirScanWideEventTest {
@@ -77,6 +83,9 @@ class PirScanWideEventTest {
     val coroutineRule = CoroutineTestRule()
 
     private val wideEventClient: WideEventClient = mock()
+
+    // Controllable monotonic clock. Defaults to 0 so steps record elapsed "0" unless a test advances it.
+    private val timeProvider = FakeTimeProvider()
 
     @SuppressLint("DenyListedApi")
     private val pirRemoteFeatures: PirRemoteFeatures =
@@ -94,6 +103,7 @@ class PirScanWideEventTest {
             wideEventClient = wideEventClient,
             pirRemoteFeatures = pirRemoteFeatures,
             dispatchers = coroutineRule.testDispatcherProvider,
+            currentTimeProvider = timeProvider,
         )
         // Force scheduled runs to be sampled in by default so scheduled tests fire deterministically.
         testee.sampleScheduledIn = { true }
@@ -244,6 +254,17 @@ class PirScanWideEventTest {
             success = true,
             metadata = mapOf(KEY_LAST_STEP to STEP_STARTED),
         )
+        // The two total-duration intervals open with the wider per-run buckets.
+        verify(wideEventClient).intervalStart(
+            wideEventId = 123L,
+            key = INTERVAL_TOTAL_FLOW_DURATION,
+            buckets = PER_RUN_DURATION_BUCKETS,
+        )
+        verify(wideEventClient).intervalStart(
+            wideEventId = 123L,
+            key = INTERVAL_TOTAL_SCAN_DURATION,
+            buckets = PER_RUN_DURATION_BUCKETS,
+        )
         verify(wideEventClient).intervalStart(
             wideEventId = 123L,
             key = "decile_0_10_duration_ms_bucketed",
@@ -300,19 +321,19 @@ class PirScanWideEventTest {
             wideEventId = 11L,
             stepName = "progress_50",
             success = true,
-            metadata = mapOf(KEY_LAST_STEP to "progress_50"),
+            metadata = mapOf(KEY_LAST_STEP to "progress_50", KEY_LAST_STEP_ELAPSED to "0"),
         )
         verify(wideEventClient).flowStep(
             wideEventId = 22L,
             stepName = "progress_30",
             success = true,
-            metadata = mapOf(KEY_LAST_STEP to "progress_30"),
+            metadata = mapOf(KEY_LAST_STEP to "progress_30", KEY_LAST_STEP_ELAPSED to "0"),
         )
         verify(wideEventClient).flowStep(
             wideEventId = 22L,
             stepName = STEP_SCAN_COMPLETED,
             success = true,
-            metadata = mapOf(KEY_LAST_STEP to STEP_SCAN_COMPLETED),
+            metadata = mapOf(KEY_LAST_STEP to STEP_SCAN_COMPLETED, KEY_LAST_STEP_ELAPSED to "0"),
         )
         verify(wideEventClient).flowFinish(
             wideEventId = 22L,
@@ -339,7 +360,7 @@ class PirScanWideEventTest {
             wideEventId = 42L,
             stepName = "progress_90",
             success = true,
-            metadata = mapOf(KEY_LAST_STEP to "progress_90"),
+            metadata = mapOf(KEY_LAST_STEP to "progress_90", KEY_LAST_STEP_ELAPSED to "0"),
         )
     }
 
@@ -375,27 +396,43 @@ class PirScanWideEventTest {
                 wideEventId = 44L,
                 stepName = "progress_${decile * 10}",
                 success = true,
-                metadata = mapOf(KEY_LAST_STEP to "progress_${decile * 10}"),
+                metadata = mapOf(KEY_LAST_STEP to "progress_${decile * 10}", KEY_LAST_STEP_ELAPSED to "0"),
             )
         }
     }
 
     @Test
-    fun whenRunStartedWithZeroTotalScanJobsThenNoIntervalStarted() = runTest {
+    fun whenRunStartedWithZeroTotalScanJobsThenTotalIntervalsStartButNoDecileInterval() = runTest {
         // Given
         whenever(wideEventClient.flowStart(any(), any(), any(), any())).thenReturn(Result.success(789L))
 
         // When
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 0, 0)
 
-        // Then
+        // Then - the total-duration intervals open regardless of job count, but the decile interval
+        // does not (there is no scan progress to measure).
         verify(wideEventClient).flowStep(
             wideEventId = 789L,
             stepName = STEP_STARTED,
             success = true,
             metadata = mapOf(KEY_LAST_STEP to STEP_STARTED),
         )
-        verify(wideEventClient, never()).intervalStart(any(), any(), any(), any())
+        verify(wideEventClient).intervalStart(
+            wideEventId = 789L,
+            key = INTERVAL_TOTAL_FLOW_DURATION,
+            buckets = PER_RUN_DURATION_BUCKETS,
+        )
+        verify(wideEventClient).intervalStart(
+            wideEventId = 789L,
+            key = INTERVAL_TOTAL_SCAN_DURATION,
+            buckets = PER_RUN_DURATION_BUCKETS,
+        )
+        verify(wideEventClient, never()).intervalStart(
+            any(),
+            eq("decile_0_10_duration_ms_bucketed"),
+            any(),
+            any(),
+        )
     }
 
     @Test
@@ -409,10 +446,13 @@ class PirScanWideEventTest {
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 1)
         runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 1)
 
-        // Then - the stale flow had decile_0_10 open from its onRunStarted; it must be ended
-        // before flowFinish so dangling intervals don't pollute timing analytics.
+        // Then - the stale flow had decile_0_10 and both total-duration intervals open from its
+        // onRunStarted; they must all be ended before flowFinish so dangling intervals don't pollute
+        // timing analytics.
         val order = inOrder(wideEventClient)
         order.verify(wideEventClient).intervalEnd(wideEventId = 100L, key = "decile_0_10_duration_ms_bucketed")
+        order.verify(wideEventClient).intervalEnd(wideEventId = 100L, key = INTERVAL_TOTAL_SCAN_DURATION)
+        order.verify(wideEventClient).intervalEnd(wideEventId = 100L, key = INTERVAL_TOTAL_FLOW_DURATION)
         order.verify(wideEventClient).flowFinish(
             wideEventId = 100L,
             status = FlowStatus.Cancelled,
@@ -434,6 +474,8 @@ class PirScanWideEventTest {
         // Then the stale flow is attributed specifically to the profile edit
         val order = inOrder(wideEventClient)
         order.verify(wideEventClient).intervalEnd(wideEventId = 101L, key = "decile_0_10_duration_ms_bucketed")
+        order.verify(wideEventClient).intervalEnd(wideEventId = 101L, key = INTERVAL_TOTAL_SCAN_DURATION)
+        order.verify(wideEventClient).intervalEnd(wideEventId = 101L, key = INTERVAL_TOTAL_FLOW_DURATION)
         order.verify(wideEventClient).flowFinish(
             wideEventId = 101L,
             status = FlowStatus.Cancelled,
@@ -464,7 +506,7 @@ class PirScanWideEventTest {
             wideEventId = 70L,
             stepName = "progress_50",
             success = true,
-            metadata = mapOf(KEY_LAST_STEP to "progress_50"),
+            metadata = mapOf(KEY_LAST_STEP to "progress_50", KEY_LAST_STEP_ELAPSED to "0"),
         )
     }
 
@@ -483,7 +525,7 @@ class PirScanWideEventTest {
                 wideEventId = 1L,
                 stepName = "progress_${decile * 10}",
                 success = true,
-                metadata = mapOf(KEY_LAST_STEP to "progress_${decile * 10}"),
+                metadata = mapOf(KEY_LAST_STEP to "progress_${decile * 10}", KEY_LAST_STEP_ELAPSED to "0"),
             )
         }
     }
@@ -502,31 +544,31 @@ class PirScanWideEventTest {
             wideEventId = 1L,
             stepName = "progress_20",
             success = true,
-            metadata = mapOf(KEY_LAST_STEP to "progress_20"),
+            metadata = mapOf(KEY_LAST_STEP to "progress_20", KEY_LAST_STEP_ELAPSED to "0"),
         )
         verify(wideEventClient).flowStep(
             wideEventId = 1L,
             stepName = "progress_40",
             success = true,
-            metadata = mapOf(KEY_LAST_STEP to "progress_40"),
+            metadata = mapOf(KEY_LAST_STEP to "progress_40", KEY_LAST_STEP_ELAPSED to "0"),
         )
         verify(wideEventClient).flowStep(
             wideEventId = 1L,
             stepName = "progress_60",
             success = true,
-            metadata = mapOf(KEY_LAST_STEP to "progress_60"),
+            metadata = mapOf(KEY_LAST_STEP to "progress_60", KEY_LAST_STEP_ELAPSED to "0"),
         )
         verify(wideEventClient).flowStep(
             wideEventId = 1L,
             stepName = "progress_80",
             success = true,
-            metadata = mapOf(KEY_LAST_STEP to "progress_80"),
+            metadata = mapOf(KEY_LAST_STEP to "progress_80", KEY_LAST_STEP_ELAPSED to "0"),
         )
         verify(wideEventClient).flowStep(
             wideEventId = 1L,
             stepName = "progress_90",
             success = true,
-            metadata = mapOf(KEY_LAST_STEP to "progress_90"),
+            metadata = mapOf(KEY_LAST_STEP to "progress_90", KEY_LAST_STEP_ELAPSED to "0"),
         )
         verify(wideEventClient, never()).flowStep(any(), eq("progress_10"), any(), any())
         verify(wideEventClient, never()).flowStep(any(), eq("progress_30"), any(), any())
@@ -550,15 +592,18 @@ class PirScanWideEventTest {
             wideEventId = 7L,
             stepName = "progress_90",
             success = true,
-            metadata = mapOf(KEY_LAST_STEP to "progress_90"),
+            metadata = mapOf(KEY_LAST_STEP to "progress_90", KEY_LAST_STEP_ELAPSED to "0"),
         )
         verify(wideEventClient).intervalEnd(wideEventId = 7L, key = "decile_0_10_duration_ms_bucketed")
         verify(wideEventClient).flowStep(
             wideEventId = 7L,
             stepName = STEP_SCAN_COMPLETED,
             success = true,
-            metadata = mapOf(KEY_LAST_STEP to STEP_SCAN_COMPLETED),
+            metadata = mapOf(KEY_LAST_STEP to STEP_SCAN_COMPLETED, KEY_LAST_STEP_ELAPSED to "0"),
         )
+        // The scan-phase total ends at scan_completed; the end-to-end total stays open until finish.
+        verify(wideEventClient).intervalEnd(wideEventId = 7L, key = INTERVAL_TOTAL_SCAN_DURATION)
+        verify(wideEventClient, never()).intervalEnd(wideEventId = 7L, key = INTERVAL_TOTAL_FLOW_DURATION)
     }
 
     @Test
@@ -609,7 +654,7 @@ class PirScanWideEventTest {
             wideEventId = 2L,
             stepName = STEP_SCAN_COMPLETED,
             success = true,
-            metadata = mapOf(KEY_LAST_STEP to STEP_SCAN_COMPLETED),
+            metadata = mapOf(KEY_LAST_STEP to STEP_SCAN_COMPLETED, KEY_LAST_STEP_ELAPSED to "0"),
         )
     }
 
@@ -628,7 +673,7 @@ class PirScanWideEventTest {
             wideEventId = 3L,
             stepName = STEP_OPT_OUT_STARTED,
             success = true,
-            metadata = mapOf(KEY_LAST_STEP to STEP_OPT_OUT_STARTED),
+            metadata = mapOf(KEY_LAST_STEP to STEP_OPT_OUT_STARTED, KEY_LAST_STEP_ELAPSED to "0"),
         )
         order.verify(wideEventClient).intervalStart(
             wideEventId = 3L,
@@ -652,7 +697,7 @@ class PirScanWideEventTest {
             wideEventId = 4L,
             stepName = STEP_OPT_OUT_COMPLETED,
             success = true,
-            metadata = mapOf(KEY_LAST_STEP to STEP_OPT_OUT_COMPLETED),
+            metadata = mapOf(KEY_LAST_STEP to STEP_OPT_OUT_COMPLETED, KEY_LAST_STEP_ELAPSED to "0"),
         )
         verify(wideEventClient).flowFinish(
             wideEventId = 4L,
@@ -675,7 +720,7 @@ class PirScanWideEventTest {
             wideEventId = 5L,
             stepName = STEP_OPT_OUT_SKIPPED,
             success = true,
-            metadata = mapOf(KEY_LAST_STEP to STEP_OPT_OUT_SKIPPED),
+            metadata = mapOf(KEY_LAST_STEP to STEP_OPT_OUT_SKIPPED, KEY_LAST_STEP_ELAPSED to "0"),
         )
         verify(wideEventClient).flowFinish(
             wideEventId = 5L,
@@ -685,6 +730,72 @@ class PirScanWideEventTest {
         verify(wideEventClient, never()).intervalEnd(
             wideEventId = 5L,
             key = INTERVAL_OPT_OUT_DURATION,
+        )
+    }
+
+    @Test
+    fun whenScanCompletedThenOptOutCompletedThenTotalScanEndsAtScanAndTotalFlowEndsAtFinish() = runTest {
+        // Given
+        whenever(wideEventClient.flowStart(any(), any(), any(), any())).thenReturn(Result.success(70L))
+        runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 0) // zero scan jobs, no decile interval
+
+        // When
+        testee.onScanCompleted(PirExecutionType.MANUAL_INITIAL)
+        testee.onOptOutStarted(PirExecutionType.MANUAL_INITIAL)
+        testee.onOptOutCompleted(PirExecutionType.MANUAL_INITIAL, totalOptOutJobs = 3)
+
+        // Then - the scan-phase total ends at scan_completed; the end-to-end total ends just before
+        // the success flowFinish so it spans the whole run (including opt-out).
+        val order = inOrder(wideEventClient)
+        order.verify(wideEventClient).intervalEnd(wideEventId = 70L, key = INTERVAL_TOTAL_SCAN_DURATION)
+        order.verify(wideEventClient).intervalEnd(wideEventId = 70L, key = INTERVAL_OPT_OUT_DURATION)
+        order.verify(wideEventClient).intervalEnd(wideEventId = 70L, key = INTERVAL_TOTAL_FLOW_DURATION)
+        order.verify(wideEventClient).flowFinish(
+            wideEventId = 70L,
+            status = FlowStatus.Success,
+            metadata = mapOf(KEY_TOTAL_OPT_OUT_JOBS to "3"),
+        )
+    }
+
+    @Test
+    fun whenOptOutSkippedThenTotalFlowIntervalEndedBeforeFlowFinish() = runTest {
+        // Given
+        whenever(wideEventClient.flowStart(any(), any(), any(), any())).thenReturn(Result.success(71L))
+        runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 0)
+        testee.onScanCompleted(PirExecutionType.MANUAL_INITIAL) // ends the scan-phase total
+
+        // When
+        testee.onOptOutSkipped(PirExecutionType.MANUAL_INITIAL)
+
+        // Then - the end-to-end total is closed before the success flowFinish.
+        val order = inOrder(wideEventClient)
+        order.verify(wideEventClient).intervalEnd(wideEventId = 71L, key = INTERVAL_TOTAL_SCAN_DURATION)
+        order.verify(wideEventClient).intervalEnd(wideEventId = 71L, key = INTERVAL_TOTAL_FLOW_DURATION)
+        order.verify(wideEventClient).flowFinish(
+            wideEventId = 71L,
+            status = FlowStatus.Success,
+            metadata = mapOf(KEY_TOTAL_OPT_OUT_JOBS to "0"),
+        )
+    }
+
+    @Test
+    fun whenRunFailedMidScanThenBothTotalIntervalsEndedBeforeFlowFinish() = runTest {
+        // Given - failure fires before scan_completed, so the scan-phase total is still open.
+        whenever(wideEventClient.flowStart(any(), any(), any(), any())).thenReturn(Result.success(72L))
+        runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 10) // decile_0_10 + both totals open
+
+        // When
+        testee.onRunFailed(PirExecutionType.MANUAL_INITIAL, FailureReason.UNKNOWN_ERROR)
+
+        // Then - closeOpenIntervalsLocked ends the decile and both total intervals before flowFinish,
+        // so the non-success run records partial (filterable) durations rather than dangling intervals.
+        val order = inOrder(wideEventClient)
+        order.verify(wideEventClient).intervalEnd(wideEventId = 72L, key = "decile_0_10_duration_ms_bucketed")
+        order.verify(wideEventClient).intervalEnd(wideEventId = 72L, key = INTERVAL_TOTAL_SCAN_DURATION)
+        order.verify(wideEventClient).intervalEnd(wideEventId = 72L, key = INTERVAL_TOTAL_FLOW_DURATION)
+        order.verify(wideEventClient).flowFinish(
+            wideEventId = 72L,
+            status = FlowStatus.Failure(reason = "unknown_error"),
         )
     }
 
@@ -1058,5 +1169,40 @@ class PirScanWideEventTest {
         testee.onUserReset()
 
         verify(wideEventClient).flowAbort(11L)
+    }
+
+    @Test
+    fun whenStepReachedAfterTimeElapsedThenLastStepElapsedIsBucketedSinceRunStart() = runTest {
+        // Given - the run starts at t=1s; a 10-job scan.
+        whenever(wideEventClient.flowStart(any(), any(), any(), any())).thenReturn(Result.success(73L))
+        timeProvider.elapsed = 1_000
+        runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 10)
+
+        // When - 65s of wall-clock pass, then the first job completes (crosses into progress_10).
+        timeProvider.elapsed = 66_000
+        testee.onScanJobCompleted(PirExecutionType.MANUAL_INITIAL)
+
+        // Then - the step carries elapsed-since-run-start, floored to the 60s bucket. This is the
+        // value that survives a process kill and lets us tell how long an UNKNOWN run had been going.
+        verify(wideEventClient).flowStep(
+            wideEventId = 73L,
+            stepName = "progress_10",
+            success = true,
+            metadata = mapOf(KEY_LAST_STEP to "progress_10", KEY_LAST_STEP_ELAPSED to "60000"),
+        )
+        // The initial 'started' step omits elapsed (it is ~0 and carries no signal).
+        verify(wideEventClient).flowStep(
+            wideEventId = 73L,
+            stepName = STEP_STARTED,
+            success = true,
+            metadata = mapOf(KEY_LAST_STEP to STEP_STARTED),
+        )
+    }
+
+    private class FakeTimeProvider : CurrentTimeProvider {
+        var elapsed: Long = 0L
+        override fun elapsedRealtime(): Long = elapsed
+        override fun currentTimeMillis(): Long = elapsed
+        override fun localDateTimeNow(): LocalDateTime = LocalDateTime.now()
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1215426452088655?focus=true
Tech Design URL (if applicable): N/A

### Description
- Adds two bucketed intervals: `total_scan_duration_ms_bucketed` (start → scan_completed, covers the previously-unmeasured 90–100% band) and `total_flow_duration_ms_bucketed` (start → finish, incl. opt-out).
- Adds `last_step_elapsed_ms_bucketed` which is elapsed-since-start recorded on every step, persisted immediately like `last_step`. This is the only way to tell how long an UNKNOWN/killed run had been going.

### Steps to test this PR

_Feature 1_
- [x] Clear PIR data and run a new scan to completion
- [x] Verify you see `pir-initial-scan` wide-event fired with the three new parameters and the values make sense
- [x] Apply the patch below to set wide-event timeout to 5 min
- [x] Clear PIR data and start a new scan
- [x] About 2 minutes into the scan, force stop the app (via App Info)
- [x] Wait for 5 minutes
- [x] Open the app and verify that pir-initial-scan` wide-event fired with `last_step_elapsed_ms_bucketed` of about 2 minutes


```
Index: pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEvent.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEvent.kt b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEvent.kt
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEvent.kt	(revision c12510f4fce76e768df962a6121a62f551838348)
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEvent.kt	(date 1781714870423)
@@ -640,7 +640,7 @@
     private fun Boolean.toTrackerBlockingState(): String = if (this) "enabled" else "disabled"
 
     companion object {
-        private val TIMEOUT_DURATION = 8.hours
+        private val TIMEOUT_DURATION = 5.minutes
 
         const val WIDE_EVENT_NAME_MANUAL = "pir-initial-scan"
         const val WIDE_EVENT_NAME_SCHEDULED = "pir-scheduled-scan"

```

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes to wide-event recording and pixel definitions; no user-facing behavior or security/data-handling logic.
> 
> **Overview**
> Adds **bucketed duration telemetry** to the manual (`pir-initial-scan`) and scheduled (`pir-scheduled-scan`) PIR scan wide events, with matching pixel schema updates.
> 
> **`last_step_elapsed_ms_bucketed`** is written on every step after `started` (persisted with `last_step`) so UNKNOWN/killed runs still expose how far the run got in time. **`total_scan_duration_ms_bucketed`** runs from run start through `scan_completed` (covers the 90–100% gap decile intervals miss). **`total_flow_duration_ms_bucketed`** spans start through successful opt-out finish or skip. Both total intervals start at run start and are closed on normal completion, failure, cancellation, or superseded runs via `closeOpenIntervalsLocked`.
> 
> Implementation uses `CurrentTimeProvider.elapsedRealtime()` and shared `PER_RUN_DURATION_BUCKETS` (10s–8h) for interval bucketing and step elapsed metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c12510f4fce76e768df962a6121a62f551838348. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->