### PR TITLE
Migrate AboutDuckDuckGoActivity from XML to Compose

### DIFF
--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/Component.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/Component.kt
@@ -20,6 +20,7 @@ enum class Component {
     BUTTON,
     FAB,
     CARD,
+    SCAFFOLD,
     TOP_APP_BAR,
     CHIP,
     DRAWER,

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentViewHolder.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentViewHolder.kt
@@ -23,13 +23,16 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -59,6 +62,7 @@ import com.duckduckgo.common.ui.compose.cards.DaxSurface
 import com.duckduckgo.common.ui.compose.checkbox.DaxCheckbox
 import com.duckduckgo.common.ui.compose.divider.DaxHorizontalDivider
 import com.duckduckgo.common.ui.compose.divider.DaxVerticalDivider
+import com.duckduckgo.common.ui.compose.layout.DaxScaffold
 import com.duckduckgo.common.ui.compose.message.DaxAction
 import com.duckduckgo.common.ui.compose.message.remote.DaxBigSingleActionMessage
 import com.duckduckgo.common.ui.compose.message.remote.DaxBigTwoActionsMessage
@@ -808,6 +812,49 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
         }
     }
 
+    class ScaffoldComponentViewHolder(
+        parent: ViewGroup,
+        private val isDarkTheme: Boolean,
+    ) : ComponentViewHolder(inflate(parent, R.layout.component_scaffold)) {
+        @OptIn(ExperimentalMaterial3Api::class)
+        override fun bind(component: Component) {
+            view.setupThemedComposeView(R.id.composeScaffold, isDarkTheme) {
+                val searchState = rememberTextFieldState()
+                var searchActive by remember { mutableStateOf(false) }
+                DaxScaffold(
+                    modifier = Modifier.height(400.dp),
+                    topBar = {
+                        DaxSearchTopAppBar(
+                            title = "Bookmarks",
+                            navigationIcon = {
+                                Back { }
+                            },
+                            shadow = true,
+                            searchActive = searchActive,
+                            searchState = searchState,
+                            searchPlaceholder = "Search…",
+                            onSearchBack = { searchActive = false },
+                            actions = {
+                                DaxIconButton(
+                                    onClick = { searchActive = true },
+                                    iconPainter = painterResource(CommonR.drawable.ic_find_search_24),
+                                    contentDescription = "Search",
+                                )
+                            },
+                        )
+                    },
+                ) { paddingValues ->
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        DaxText(text = "Content goes here")
+                    }
+                }
+            }
+        }
+    }
+
     class SettingsListItemComponentViewHolder(parent: ViewGroup) :
         ComponentViewHolder(inflate(parent, R.layout.component_settings)) {
         override fun bind(component: Component) {
@@ -841,6 +888,7 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
                 Component.TWO_LINE_LIST_ITEM -> TwoLineItemComponentViewHolder(parent)
                 Component.SECTION_DIVIDER -> DividerComponentViewHolder(parent, isDarkTheme)
                 Component.CARD -> CardComponentViewHolder(parent, isDarkTheme)
+                Component.SCAFFOLD -> ScaffoldComponentViewHolder(parent, isDarkTheme)
                 Component.SETTINGS_LIST_ITEM -> SettingsListItemComponentViewHolder(parent)
                 else -> {
                     TODO()

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentViewHolder.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentViewHolder.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -50,6 +51,8 @@ import com.airbnb.lottie.compose.LottieAnimation
 import com.airbnb.lottie.compose.LottieCompositionSpec
 import com.airbnb.lottie.compose.animateLottieCompositionAsState
 import com.airbnb.lottie.compose.rememberLottieComposition
+import com.duckduckgo.common.ui.compose.appbars.DaxSearchTopAppBar
+import com.duckduckgo.common.ui.compose.appbars.DaxTopAppBar
 import com.duckduckgo.common.ui.compose.button.DaxIconButton
 import com.duckduckgo.common.ui.compose.cards.DaxCard
 import com.duckduckgo.common.ui.compose.cards.DaxSurface
@@ -93,8 +96,60 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
     class ButtonComponentViewHolder(parent: ViewGroup) :
         ComponentViewHolder(inflate(parent, R.layout.component_buttons))
 
-    class TopAppBarComponentViewHolder(parent: ViewGroup) :
-        ComponentViewHolder(inflate(parent, R.layout.component_top_app_bar))
+    class TopAppBarComponentViewHolder(
+        parent: ViewGroup,
+        private val isDarkTheme: Boolean,
+    ) : ComponentViewHolder(inflate(parent, R.layout.component_top_app_bar)) {
+        override fun bind(component: Component) {
+            view.setupThemedComposeView(id = R.id.composeDaxTopAppBar, isDarkTheme = isDarkTheme) {
+                val searchState = rememberTextFieldState()
+                var searchActive by remember { mutableStateOf(false) }
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    DaxSearchTopAppBar(
+                        title = "Search bar",
+                        navigationIcon = {
+                            Back { }
+                        },
+                        searchActive = searchActive,
+                        searchState = searchState,
+                        searchPlaceholder = "Search…",
+                        onSearchBack = { searchActive = false },
+                        actions = {
+                            DaxIconButton(
+                                onClick = { },
+                                iconPainter = painterResource(CommonR.drawable.ic_ai_chat_24_solid_color),
+                                contentDescription = "Duck.ai",
+                            )
+                            DaxIconButton(
+                                onClick = { searchActive = true },
+                                iconPainter = painterResource(CommonR.drawable.ic_find_search_24),
+                                contentDescription = "Search",
+                            )
+                        },
+                    )
+                    DaxTopAppBar(
+                        title = "Top bar",
+                        shadow = true,
+                        navigationIcon = {
+                            Close { }
+                        },
+                        actions = {
+                            DaxIconButton(
+                                onClick = { },
+                                iconPainter = painterResource(CommonR.drawable.ic_add_24),
+                                contentDescription = "Add",
+                            )
+                            DaxIconButton(
+                                onClick = { },
+                                iconPainter = painterResource(CommonR.drawable.ic_ai_chat_24_solid_color),
+                                contentDescription = "Duck.ai",
+                            )
+                        },
+                    )
+                }
+            }
+        }
+    }
 
     class SwitchComponentViewHolder(
         parent: ViewGroup,
@@ -770,7 +825,7 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
         ): ComponentViewHolder {
             return when (Component.values()[viewType]) {
                 Component.BUTTON -> ButtonComponentViewHolder(parent)
-                Component.TOP_APP_BAR -> TopAppBarComponentViewHolder(parent)
+                Component.TOP_APP_BAR -> TopAppBarComponentViewHolder(parent, isDarkTheme)
                 Component.SWITCH -> SwitchComponentViewHolder(parent, isDarkTheme)
                 Component.RADIO_BUTTON -> RadioButtonComponentViewHolder(parent, isDarkTheme)
                 Component.CHECKBOX -> CheckboxComponentViewHolder(parent, isDarkTheme)

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/buttons/ComponentButtonsFragment.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/buttons/ComponentButtonsFragment.kt
@@ -23,6 +23,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
@@ -34,6 +35,7 @@ import com.duckduckgo.common.ui.compose.button.DaxDestructiveGhostSecondaryButto
 import com.duckduckgo.common.ui.compose.button.DaxDestructivePrimaryButton
 import com.duckduckgo.common.ui.compose.button.DaxGhostButton
 import com.duckduckgo.common.ui.compose.button.DaxIconButton
+import com.duckduckgo.common.ui.compose.button.DaxIconButtonDefaults
 import com.duckduckgo.common.ui.compose.button.DaxPrimaryButton
 import com.duckduckgo.common.ui.compose.button.DaxSecondaryButton
 import com.duckduckgo.common.ui.internal.databinding.ComponentButtonsBinding
@@ -288,11 +290,28 @@ class ComponentButtonsFragment : Fragment() {
             id = com.duckduckgo.common.ui.internal.R.id.compose_icon_button,
             isDarkTheme = isDarkTheme,
         ) {
-            DaxIconButton(
-                onClick = {},
-                iconPainter = painterResource(R.drawable.ic_union),
-                contentDescription = "Menu",
-            )
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                DaxIconButton(
+                    onClick = {},
+                    iconPainter = painterResource(R.drawable.ic_union),
+                    contentDescription = "Menu",
+                )
+                DaxIconButton(
+                    onClick = {},
+                    iconPainter = painterResource(R.drawable.ic_union),
+                    contentDescription = "Menu",
+                    colors = DaxIconButtonDefaults.filledColors,
+                )
+                DaxIconButton(
+                    onClick = {},
+                    iconPainter = painterResource(R.drawable.ic_union),
+                    contentDescription = "Menu",
+                    enabled = false,
+                )
+            }
         }
     }
 }

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/cards/ComponentLayoutsFragment.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/cards/ComponentLayoutsFragment.kt
@@ -21,6 +21,6 @@ import com.duckduckgo.common.ui.internal.ui.component.ComponentFragment
 
 class ComponentLayoutsFragment : ComponentFragment() {
     override fun getComponents(): List<Component> {
-        return listOf(Component.CARD, Component.TOP_APP_BAR)
+        return listOf(Component.CARD, Component.TOP_APP_BAR, Component.SCAFFOLD)
     }
 }

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/cards/ComponentLayoutsFragment.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/cards/ComponentLayoutsFragment.kt
@@ -21,6 +21,6 @@ import com.duckduckgo.common.ui.internal.ui.component.ComponentFragment
 
 class ComponentLayoutsFragment : ComponentFragment() {
     override fun getComponents(): List<Component> {
-        return listOf(Component.CARD)
+        return listOf(Component.CARD, Component.TOP_APP_BAR)
     }
 }

--- a/android-design-system/design-system-internal/src/main/res/layout/component_scaffold.xml
+++ b/android-design-system/design-system-internal/src/main/res/layout/component_scaffold.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+~ Copyright (C) 2019 The Android Open Source Project
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~      http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingTop="@dimen/keyline_5"
+    android:paddingBottom="@dimen/keyline_5"
+    android:clipChildren="false"
+    android:orientation="vertical">
+
+    <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+        android:id="@+id/daxBubbleLabel"
+        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        app:primaryText="Dax Scaffold"/>
+
+    <com.duckduckgo.common.ui.internal.ui.PlatformLabelView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/keyline_1"
+        android:layout_marginBottom="@dimen/keyline_1"
+        app:platformType="compose"/>
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/composeScaffold"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/keyline_1"
+        android:layout_marginBottom="@dimen/keyline_2" />
+
+</LinearLayout>

--- a/android-design-system/design-system-internal/src/main/res/layout/component_top_app_bar.xml
+++ b/android-design-system/design-system-internal/src/main/res/layout/component_top_app_bar.xml
@@ -14,36 +14,34 @@
 ~ limitations under the License.
 -->
 
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:clipChildren="false"
     android:clipToPadding="false"
-    android:paddingStart="@dimen/keyline_4"
+    android:orientation="vertical"
     android:paddingTop="@dimen/keyline_5"
-    android:paddingEnd="@dimen/keyline_4"
     android:paddingBottom="@dimen/keyline_5">
 
     <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
-        android:id="@+id/label"
-        android:layout_height="wrap_content"
-        android:layout_width="match_parent"
-        app:primaryText="Top app bar"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
-
-    <com.google.android.material.appbar.MaterialToolbar
-        android:id="@+id/toolbar"
-        style="?attr/toolbarStyle"
+        android:id="@+id/composeDaxTopAppBarLabel"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/keyline_4"
-        android:translationZ="@dimen/keyline_1"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/label"
-        app:menu="@menu/top_app_bar_menu"
-        app:navigationIcon="@drawable/ic_arrow_left_24"
-        app:title="@string/text_headline" />
+        app:primaryText="Top App Bar" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <com.duckduckgo.common.ui.internal.ui.PlatformLabelView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/keyline_1"
+        android:layout_marginBottom="@dimen/keyline_1"
+        app:platformType="compose" />
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/composeDaxTopAppBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/keyline_1"
+        android:layout_marginBottom="@dimen/keyline_2" />
+
+</LinearLayout>

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/appbars/DaxSearchTopAppBar.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/appbars/DaxSearchTopAppBar.kt
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui.compose.appbars
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.KeyboardActionHandler
+import androidx.compose.foundation.text.input.TextFieldLineLimits
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.input.clearText
+import androidx.compose.foundation.text.input.rememberTextFieldState
+import androidx.compose.material3.Surface
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.duckduckgo.common.ui.compose.button.DaxIconButton
+import com.duckduckgo.common.ui.compose.text.DaxText
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTextStyle
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+import com.duckduckgo.common.ui.compose.theme.asTextStyle
+import com.duckduckgo.common.ui.compose.tools.PreviewBox
+import com.duckduckgo.mobile.android.R
+
+/**
+ * DuckDuckGo themed top app bar with search functionality.
+ *
+ * @param title The title to display in the top app bar.
+ * @param searchState The state of the search text field.
+ * @param modifier Modifier for this top app bar.
+ * @param shadow Whether to display a shadow below the top app bar.
+ * @param searchActive Whether the search bar is active and visible.
+ * @param searchPlaceholder The placeholder text for the search field, if any.
+ * @param onSearchBack Callback when the back button is pressed in search mode.
+ * @param onSearch Callback when a search is submitted.
+ * @param navigationIcon Composable for the navigation icon, if any.
+ * @param actions Composable for the action icons, if any.
+ *
+ * Asana Task: https://app.asana.com/1/137249556945/project/1202857801505092/task/1215793353260352
+ * Figma reference: https://www.figma.com/design/BOHDESHODUXK7wSRNBOHdu/%F0%9F%A4%96-Android-Components?node-id=20800-183716&m=dev
+ */
+@Composable
+fun DaxSearchTopAppBar(
+    title: String,
+    searchState: TextFieldState,
+    modifier: Modifier = Modifier,
+    shadow: Boolean = false,
+    searchActive: Boolean = false,
+    searchPlaceholder: String? = null,
+    onSearchBack: () -> Unit = {},
+    onSearch: (String) -> Unit = {},
+    navigationIcon: (@Composable DaxTopAppBarNavigationIconScope.() -> Unit)? = null,
+    actions: @Composable RowScope.() -> Unit = {},
+) {
+    Box(modifier = modifier) {
+        DaxTopAppBar(
+            title = title,
+            shadow = shadow,
+            navigationIcon = navigationIcon,
+            actions = actions,
+        )
+        AnimatedVisibility(
+            visible = searchActive,
+            enter = slideInHorizontally(initialOffsetX = { it }),
+            exit = slideOutHorizontally(targetOffsetX = { it }),
+        ) {
+            SearchBarContent(
+                searchState = searchState,
+                searchPlaceholder = searchPlaceholder,
+                onSearchBack = onSearchBack,
+                onSearch = onSearch,
+                modifier = Modifier
+                    .windowInsetsPadding(TopAppBarDefaults.windowInsets)
+                    .fillMaxWidth()
+                    .background(DaxTopAppBarDefaults.colors.containerColor),
+            )
+        }
+    }
+}
+
+@Composable
+private fun SearchBarContent(
+    searchState: TextFieldState,
+    searchPlaceholder: String?,
+    onSearchBack: () -> Unit,
+    onSearch: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier.padding(DaxSearchTopAppBarDefaults.margin)) {
+        Surface(
+            shape = DaxSearchTopAppBarDefaults.shape,
+            color = DaxSearchTopAppBarDefaults.colors.surfaceColor,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Row(
+                modifier = Modifier.padding(DaxSearchTopAppBarDefaults.contentPadding),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                DaxIconButton(
+                    onClick = onSearchBack,
+                    iconPainter = painterResource(R.drawable.ic_arrow_left_24),
+                    contentDescription = stringResource(R.string.dax_top_app_bar_exit_search_content_description),
+                )
+                Spacer(Modifier.width(DaxSearchTopAppBarDefaults.spacing))
+                Box(modifier = Modifier.weight(1f)) {
+                    BasicTextField(
+                        state = searchState,
+                        modifier = Modifier.fillMaxWidth(),
+                        textStyle = DaxSearchTopAppBarDefaults.queryStyle.asTextStyle.copy(color = DaxSearchTopAppBarDefaults.colors.queryColor),
+                        lineLimits = TextFieldLineLimits.SingleLine,
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                        onKeyboardAction = KeyboardActionHandler { _ -> onSearch(searchState.text.toString()) },
+                        cursorBrush = SolidColor(DaxSearchTopAppBarDefaults.colors.cursorColor),
+                    )
+                    if (searchState.text.isEmpty() && searchPlaceholder != null) {
+                        DaxText(
+                            text = searchPlaceholder,
+                            style = DaxSearchTopAppBarDefaults.placeholderStyle,
+                            color = DaxSearchTopAppBarDefaults.colors.placeholderColor,
+                            maxLines = 1,
+                        )
+                    }
+                }
+                if (searchState.text.isNotEmpty()) {
+                    DaxIconButton(
+                        onClick = { searchState.clearText() },
+                        iconPainter = painterResource(R.drawable.ic_close_24),
+                        contentDescription = stringResource(R.string.dax_top_app_bar_clear_search_content_description),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Immutable
+internal data class DaxSearchTopAppBarColors(
+    val surfaceColor: Color,
+    val placeholderColor: Color,
+    val queryColor: Color,
+    val cursorColor: Color,
+)
+
+internal object DaxSearchTopAppBarDefaults {
+    val colors: DaxSearchTopAppBarColors
+        @Composable
+        get() = DaxSearchTopAppBarColors(
+            surfaceColor = DuckDuckGoTheme.colors.backgrounds.container,
+            placeholderColor = DuckDuckGoTheme.colors.text.secondary,
+            queryColor = DuckDuckGoTheme.colors.text.primary,
+            cursorColor = DuckDuckGoTheme.colors.text.primary,
+        )
+
+    val placeholderStyle: DuckDuckGoTextStyle
+        @Composable
+        get() = DuckDuckGoTheme.typography.body1
+
+    val queryStyle: DuckDuckGoTextStyle
+        @Composable
+        get() = DuckDuckGoTheme.typography.body1
+
+    val shape: Shape
+        @Composable
+        get() = DuckDuckGoTheme.shapes.large
+
+    val margin: PaddingValues = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
+
+    val contentPadding: PaddingValues = PaddingValues(start = 4.dp, end = 8.dp)
+
+    val spacing: Dp = 16.dp
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxTopAppBarSearchEmptyPreview() {
+    PreviewBox {
+        DaxSearchTopAppBar(
+            title = "Title",
+            searchActive = true,
+            searchState = rememberTextFieldState(),
+            searchPlaceholder = "Search…",
+            navigationIcon = {
+                Back { }
+            },
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxTopAppBarSearchTypedPreview() {
+    PreviewBox {
+        DaxSearchTopAppBar(
+            title = "Title",
+            searchActive = true,
+            searchState = rememberTextFieldState("query"),
+            searchPlaceholder = "Search…",
+            navigationIcon = {
+                Close { }
+            },
+        )
+    }
+}

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/appbars/DaxTopAppBar.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/appbars/DaxTopAppBar.kt
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui.compose.appbars
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.duckduckgo.common.ui.compose.button.DaxIconButton
+import com.duckduckgo.common.ui.compose.text.DaxText
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTextStyle
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+import com.duckduckgo.common.ui.compose.tools.PreviewBox
+import com.duckduckgo.mobile.android.R
+
+/**
+ * DuckDuckGo themed top app bar.
+ *
+ * @param title The title to display in the top app bar.
+ * @param modifier Modifier for this top app bar.
+ * @param shadow Whether to display a shadow below the top app bar.
+ * @param navigationIcon Composable for the navigation icon, if any.
+ * @param actions Composable for the action icons, if any.
+ *
+ * Asana Task: https://app.asana.com/1/137249556945/project/1202857801505092/task/1215793353260352
+ * Figma reference: https://www.figma.com/design/BOHDESHODUXK7wSRNBOHdu/%F0%9F%A4%96-Android-Components?node-id=20800-183716&m=dev
+ */
+@Composable
+fun DaxTopAppBar(
+    title: String,
+    modifier: Modifier = Modifier,
+    shadow: Boolean = false,
+    navigationIcon: (@Composable DaxTopAppBarNavigationIconScope.() -> Unit)? = null,
+    actions: @Composable RowScope.() -> Unit = {},
+) {
+    Row(
+        modifier = modifier
+            .then(if (shadow) Modifier.shadow(elevation = DaxTopAppBarDefaults.elevation) else Modifier)
+            .windowInsetsPadding(TopAppBarDefaults.windowInsets)
+            .clipToBounds()
+            .heightIn(min = DaxTopAppBarDefaults.height)
+            .fillMaxWidth()
+            .background(DaxTopAppBarDefaults.colors.containerColor)
+            .padding(paddingValues = DaxTopAppBarDefaults.contentPadding),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (navigationIcon != null) {
+            DaxTopAppBarNavigationIconScope.navigationIcon()
+            Spacer(Modifier.width(DaxTopAppBarDefaults.spacing))
+        }
+        DaxText(
+            text = title,
+            modifier = Modifier.weight(1f),
+            style = DaxTopAppBarDefaults.style,
+            color = DaxTopAppBarDefaults.colors.titleColor,
+            maxLines = 1,
+        )
+        actions(this)
+    }
+}
+
+@Immutable
+internal data class DaxTopAppBarColors(
+    val containerColor: Color,
+    val titleColor: Color,
+)
+
+internal object DaxTopAppBarDefaults {
+    val colors: DaxTopAppBarColors
+        @Composable
+        get() = DaxTopAppBarColors(
+            containerColor = DuckDuckGoTheme.colors.backgrounds.background,
+            titleColor = DuckDuckGoTheme.colors.text.primary,
+        )
+
+    val style: DuckDuckGoTextStyle
+        @Composable
+        get() = DuckDuckGoTheme.typography.h2
+
+    val contentPadding: PaddingValues = PaddingValues(start = 6.dp, end = 2.dp, top = 8.dp, bottom = 8.dp)
+
+    val spacing: Dp = 24.dp
+
+    val elevation: Dp = 2.dp
+
+    val height: Dp = 56.dp
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxTopAppBarDefaultPreview() {
+    PreviewBox {
+        DaxTopAppBar(
+            title = "Title",
+            navigationIcon = {
+                Back { }
+            },
+            actions = {
+                DaxIconButton(
+                    onClick = {},
+                    iconPainter = painterResource(R.drawable.ic_find_search_24),
+                    contentDescription = "Search",
+                )
+            },
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxTopAppBarLongTitlePreview() {
+    PreviewBox {
+        DaxTopAppBar(
+            title = "A very long title that should be truncated with an ellipsis at the end",
+            navigationIcon = {
+                Close { }
+            },
+            shadow = true,
+            actions = {
+                DaxIconButton(
+                    onClick = {},
+                    iconPainter = painterResource(R.drawable.ic_find_search_24),
+                    contentDescription = "Search",
+                )
+            },
+        )
+    }
+}

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/appbars/DaxTopAppBarNavigationIconScope.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/appbars/DaxTopAppBarNavigationIconScope.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui.compose.appbars
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import com.duckduckgo.common.ui.compose.button.DaxIconButton
+import com.duckduckgo.mobile.android.R
+
+object DaxTopAppBarNavigationIconScope {
+    @Composable
+    fun Back(onClick: () -> Unit) {
+        DaxIconButton(
+            onClick = onClick,
+            iconPainter = painterResource(R.drawable.ic_arrow_left_24),
+            contentDescription = stringResource(R.string.dax_top_app_bar_back_content_description),
+        )
+    }
+
+    @Composable
+    fun Close(onClick: () -> Unit) {
+        DaxIconButton(
+            onClick = onClick,
+            iconPainter = painterResource(R.drawable.ic_close_24),
+            contentDescription = stringResource(R.string.dax_top_app_bar_close_content_description),
+        )
+    }
+}

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxIconButton.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxIconButton.kt
@@ -17,9 +17,12 @@
 package com.duckduckgo.common.ui.compose.button
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonColors
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -30,6 +33,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
 import com.duckduckgo.common.ui.compose.tools.PreviewBox
 import com.duckduckgo.mobile.android.R
 
@@ -38,15 +42,19 @@ import com.duckduckgo.mobile.android.R
  *
  * Wraps Material3 [IconButton] for icon-only actions (e.g. close, back, overflow).
  *
- * No tint is applied — the icon renders with its native colors, matching the
- * View-system [IconButton][com.duckduckgo.common.ui.view.button.IconButton] which
- * relies on the drawable's own `?attr/` theme colors (e.g. `?attr/daxColorPrimaryIcon`).
+ * The icon is tinted with [colors]'s content color so it follows the Compose
+ * [DuckDuckGoTheme] (light/dark) rather than the drawable's baked-in colors. Pass
+ * [DaxIconButtonDefaults.filledColors] for a filled container.
  *
  * @param onClick Called when the button is clicked.
  * @param iconPainter The icon to display.
  * @param contentDescription Accessibility description, or null if decorative.
  * @param modifier Modifier for this button.
+ * @param enabled Whether the button is enabled.
+ * @param colors Container and content colors; defaults to [DaxIconButtonDefaults.colors].
  * @param interactionSource The interaction source for this button.
+ *
+ * Asana task: https://app.asana.com/1/137249556945/project/1202857801505092/task/1215540472063931?focus=true
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -55,6 +63,8 @@ fun DaxIconButton(
     iconPainter: Painter,
     contentDescription: String?,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    colors: IconButtonColors = DaxIconButtonDefaults.colors,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
     CompositionLocalProvider(
@@ -63,25 +73,59 @@ fun DaxIconButton(
         IconButton(
             onClick = onClick,
             modifier = modifier,
+            colors = colors,
+            enabled = enabled,
             interactionSource = interactionSource,
         ) {
             Icon(
                 painter = iconPainter,
                 contentDescription = contentDescription,
-                tint = Color.Unspecified,
+                tint = if (enabled) {
+                    colors.contentColor
+                } else {
+                    colors.disabledContentColor
+                },
             )
         }
     }
+}
+
+object DaxIconButtonDefaults {
+    val colors: IconButtonColors
+        @Composable
+        get() = IconButtonDefaults.iconButtonColors(
+            containerColor = Color.Transparent,
+            contentColor = DuckDuckGoTheme.colors.icons.primary,
+            disabledContainerColor = Color.Transparent,
+            disabledContentColor = DuckDuckGoTheme.colors.icons.disabled,
+        )
+
+    val filledColors: IconButtonColors
+        @Composable
+        get() = IconButtonDefaults.iconButtonColors(
+            containerColor = DuckDuckGoTheme.colors.backgrounds.container,
+            contentColor = DuckDuckGoTheme.colors.icons.primary,
+            disabledContainerColor = DuckDuckGoTheme.colors.backgrounds.container,
+            disabledContentColor = DuckDuckGoTheme.colors.icons.disabled,
+        )
 }
 
 @PreviewLightDark
 @Composable
 private fun DaxIconButtonPreview() {
     PreviewBox {
-        DaxIconButton(
-            onClick = {},
-            iconPainter = painterResource(R.drawable.ic_settings_24),
-            contentDescription = "Settings",
-        )
+        Column {
+            DaxIconButton(
+                onClick = {},
+                iconPainter = painterResource(R.drawable.ic_settings_24),
+                contentDescription = "Settings",
+            )
+            DaxIconButton(
+                onClick = {},
+                iconPainter = painterResource(R.drawable.ic_settings_24),
+                contentDescription = "Settings",
+                colors = DaxIconButtonDefaults.filledColors,
+            )
+        }
     }
 }

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxIconButton.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/button/DaxIconButton.kt
@@ -17,15 +17,16 @@
 package com.duckduckgo.common.ui.compose.button
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.IconButtonColors
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -33,6 +34,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
 import com.duckduckgo.common.ui.compose.tools.PreviewBox
 import com.duckduckgo.mobile.android.R
@@ -64,7 +66,7 @@ fun DaxIconButton(
     contentDescription: String?,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
-    colors: IconButtonColors = DaxIconButtonDefaults.colors,
+    colors: DaxIconButtonColors = DaxIconButtonDefaults.colors,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
     CompositionLocalProvider(
@@ -73,48 +75,56 @@ fun DaxIconButton(
         IconButton(
             onClick = onClick,
             modifier = modifier,
-            colors = colors,
+            colors = IconButtonDefaults.iconButtonColors(
+                containerColor = colors.containerColor,
+                contentColor = colors.contentColor,
+                disabledContainerColor = colors.disabledContainerColor,
+                disabledContentColor = colors.disabledContentColor,
+            ),
             enabled = enabled,
             interactionSource = interactionSource,
         ) {
             Icon(
                 painter = iconPainter,
                 contentDescription = contentDescription,
-                tint = if (enabled) {
-                    colors.contentColor
-                } else {
-                    colors.disabledContentColor
-                },
             )
         }
     }
 }
 
 object DaxIconButtonDefaults {
-    val colors: IconButtonColors
+    val colors: DaxIconButtonColors
         @Composable
-        get() = IconButtonDefaults.iconButtonColors(
-            containerColor = Color.Transparent,
+        get() = DaxIconButtonColors(
+            containerColor = Color.Unspecified,
             contentColor = DuckDuckGoTheme.colors.icons.primary,
-            disabledContainerColor = Color.Transparent,
+            disabledContainerColor = Color.Unspecified,
             disabledContentColor = DuckDuckGoTheme.colors.icons.disabled,
         )
 
-    val filledColors: IconButtonColors
+    val filledColors: DaxIconButtonColors
         @Composable
-        get() = IconButtonDefaults.iconButtonColors(
+        get() = DaxIconButtonColors(
             containerColor = DuckDuckGoTheme.colors.backgrounds.container,
             contentColor = DuckDuckGoTheme.colors.icons.primary,
-            disabledContainerColor = DuckDuckGoTheme.colors.backgrounds.container,
+            disabledContainerColor = DuckDuckGoTheme.colors.backgrounds.containerDisabled,
             disabledContentColor = DuckDuckGoTheme.colors.icons.disabled,
         )
 }
+
+@Immutable
+data class DaxIconButtonColors(
+    val containerColor: Color,
+    val contentColor: Color,
+    val disabledContainerColor: Color,
+    val disabledContentColor: Color,
+)
 
 @PreviewLightDark
 @Composable
 private fun DaxIconButtonPreview() {
     PreviewBox {
-        Column {
+        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
             DaxIconButton(
                 onClick = {},
                 iconPainter = painterResource(R.drawable.ic_settings_24),
@@ -124,6 +134,13 @@ private fun DaxIconButtonPreview() {
                 onClick = {},
                 iconPainter = painterResource(R.drawable.ic_settings_24),
                 contentDescription = "Settings",
+                colors = DaxIconButtonDefaults.filledColors,
+            )
+            DaxIconButton(
+                onClick = {},
+                iconPainter = painterResource(R.drawable.ic_settings_24),
+                contentDescription = "Settings",
+                enabled = false,
                 colors = DaxIconButtonDefaults.filledColors,
             )
         }

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/layout/DaxScaffold.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/layout/DaxScaffold.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui.compose.layout
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.ScaffoldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import com.duckduckgo.common.ui.compose.appbars.DaxTopAppBar
+import com.duckduckgo.common.ui.compose.button.DaxIconButton
+import com.duckduckgo.common.ui.compose.text.DaxText
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+import com.duckduckgo.mobile.android.R
+
+/**
+ * DuckDuckGo themed Scaffold layout.
+ * Wraps Material3 [Scaffold] with DuckDuckGo's default colors and styling.
+ *
+ * @param modifier Modifier for this Scaffold.
+ * @param topBar Composable for the top app bar.
+ * @param bottomBar Composable for the bottom bar.
+ * @param snackbarHost Composable for the snackbar host.
+ * @param contentWindowInsets Window insets for the content area.
+ * @param content Composable for the main content, with padding values provided by Scaffold.
+ *
+ * Asana Task: https://app.asana.com/1/137249556945/project/1202857801505092/task/1215519019861192?focus=true
+ */
+@Composable
+fun DaxScaffold(
+    modifier: Modifier = Modifier,
+    topBar: @Composable () -> Unit = {},
+    bottomBar: @Composable () -> Unit = {},
+    snackbarHost: @Composable () -> Unit = {},
+    contentWindowInsets: WindowInsets = ScaffoldDefaults.contentWindowInsets,
+    content: @Composable (PaddingValues) -> Unit,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = topBar,
+        bottomBar = bottomBar,
+        snackbarHost = snackbarHost,
+        containerColor = DaxScaffoldDefaults.containerColor,
+        contentColor = DaxScaffoldDefaults.contentColor,
+        contentWindowInsets = contentWindowInsets,
+        content = content,
+    )
+}
+
+object DaxScaffoldDefaults {
+    val containerColor: Color
+        @Composable
+        get() = DuckDuckGoTheme.colors.backgrounds.background
+
+    val contentColor: Color
+        @Composable
+        get() = DuckDuckGoTheme.colors.text.primary
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@PreviewLightDark
+@Composable
+private fun DaxScaffoldPreview() {
+    DuckDuckGoTheme {
+        DaxScaffold(
+            topBar = {
+                DaxTopAppBar(
+                    title = "Bookmarks",
+                    navigationIcon = {
+                        Back { }
+                    },
+                    actions = {
+                        DaxIconButton(
+                            iconPainter = painterResource(R.drawable.ic_ai_chat_24_solid_color),
+                            contentDescription = "Duck.ai",
+                            onClick = { },
+                        )
+                    },
+                )
+            },
+        ) { paddingValues ->
+            DaxText(
+                text = "Content goes here",
+                modifier = Modifier.padding(paddingValues),
+            )
+        }
+    }
+}

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/tools/PreviewBox.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/tools/PreviewBox.kt
@@ -16,15 +16,21 @@
 
 package com.duckduckgo.common.ui.compose.tools
 
+import android.view.ContextThemeWrapper
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+import com.duckduckgo.mobile.android.R
 
 @Composable
 fun PreviewBoxInverted(
@@ -43,12 +49,23 @@ fun PreviewBox(
     color: @Composable () -> Color = { DuckDuckGoTheme.colors.backgrounds.background },
     content: @Composable BoxScope.() -> Unit,
 ) {
-    DuckDuckGoTheme {
-        Box(
-            modifier = modifier
-                .background(color())
-                .padding(all = 16.dp),
-            content = content,
+    val isDarkTheme = isSystemInDarkTheme()
+    val baseContext = LocalContext.current
+    // Previews lack the View theme that painterResource uses to resolve drawable `?attr/daxColor*` fills, so without it icons render transparent.
+    val themedContext = remember(baseContext, isDarkTheme) {
+        ContextThemeWrapper(
+            baseContext,
+            if (isDarkTheme) R.style.Theme_DuckDuckGo_Dark else R.style.Theme_DuckDuckGo_Light,
         )
+    }
+    CompositionLocalProvider(LocalContext provides themedContext) {
+        DuckDuckGoTheme(isDarkTheme = isDarkTheme) {
+            Box(
+                modifier = modifier
+                    .background(color())
+                    .padding(all = 16.dp),
+                content = content,
+            )
+        }
     }
 }

--- a/android-design-system/design-system/src/main/res/values/donottranslate.xml
+++ b/android-design-system/design-system/src/main/res/values/donottranslate.xml
@@ -67,4 +67,10 @@
     <string name="duckAIUpdateTitle">Duck.ai PoC</string>
     <string name="duckAIUpdateMessage">This feature is in active development, intended for feedback purposes.</string>
 
+    <!-- TopApp Bars -->
+    <string name="dax_top_app_bar_back_content_description">Back</string>
+    <string name="dax_top_app_bar_close_content_description">Close</string>
+    <string name="dax_top_app_bar_clear_search_content_description">Clear search</string>
+    <string name="dax_top_app_bar_exit_search_content_description">Exit search</string>
+
 </resources>

--- a/app/src/main/java/com/duckduckgo/app/about/AboutDuckDuckGoActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/about/AboutDuckDuckGoActivity.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.app.about
 
+import android.annotation.SuppressLint
 import android.os.Bundle
 import android.text.Annotation
 import android.text.SpannableString
@@ -26,7 +27,10 @@ import android.text.style.ClickableSpan
 import android.text.style.ForegroundColorSpan
 import android.text.style.UnderlineSpan
 import android.view.View
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.ComposeView
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
@@ -40,12 +44,14 @@ import com.duckduckgo.app.about.AboutDuckDuckGoViewModel.Command.LaunchWebViewWi
 import com.duckduckgo.app.about.AboutDuckDuckGoViewModel.Command.LaunchWebViewWithPrivacyPolicyUrl
 import com.duckduckgo.app.about.AboutDuckDuckGoViewModel.Command.LaunchWebViewWithSubscriptionUrl
 import com.duckduckgo.app.about.AboutDuckDuckGoViewModel.Command.LaunchWebViewWithVPNUrl
+import com.duckduckgo.app.about.compose.AboutScreen
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.ActivityAboutDuckDuckGoBinding
 import com.duckduckgo.app.browser.mode.InAppNavigation
 import com.duckduckgo.browser.api.ui.BrowserScreens.WebViewActivityWithParams
 import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
 import com.duckduckgo.common.ui.view.getColorFromAttr
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.AppUrl.Url
@@ -78,16 +84,23 @@ class AboutDuckDuckGoActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var globalActivityStarter: GlobalActivityStarter
 
+    @Inject
+    lateinit var aboutScreenComposeFeature: AboutScreenComposeFeature
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (aboutScreenComposeFeature.self().isEnabled()) {
+            setContentInCompose()
+        } else {
+            setContentView(binding.root)
+            setupToolbar(binding.includeToolbar.toolbar)
+            supportActionBar?.setTitle(R.string.aboutActivityTitleNew)
+            configureUiEventHandlers()
+            observeXmlViewState()
+            configureClickableLinks()
+        }
 
-        setContentView(binding.root)
-        setupToolbar(binding.includeToolbar.toolbar)
-        supportActionBar?.setTitle(R.string.aboutActivityTitleNew)
-
-        configureUiEventHandlers()
-        observeViewModel()
-        configureClickableLinks()
+        observeCommands()
     }
 
     override fun onResume() {
@@ -184,15 +197,15 @@ class AboutDuckDuckGoActivity : DuckDuckGoActivity() {
         }
     }
 
-    private fun observeViewModel() {
+    private fun observeXmlViewState() {
         viewModel.viewState()
             .flowWithLifecycle(lifecycle, Lifecycle.State.RESUMED)
             .onEach { viewState ->
-                viewState.let {
-                    binding.includeContent.aboutVersion.setSecondaryText(it.version)
-                }
+                binding.includeContent.aboutVersion.setSecondaryText(viewState.version)
             }.launchIn(lifecycleScope)
+    }
 
+    private fun observeCommands() {
         viewModel.commands()
             .flowWithLifecycle(lifecycle, Lifecycle.State.CREATED)
             .onEach { processCommand(it) }
@@ -246,6 +259,38 @@ class AboutDuckDuckGoActivity : DuckDuckGoActivity() {
             this,
             GeneralSubscriptionFeedbackScreenNoParams,
         )
+    }
+
+    @SuppressLint("NoSetContentUsage")
+    private fun setContentInCompose() {
+        setContentView(
+            ComposeView(this).apply {
+                setContent {
+                    DuckDuckGoTheme {
+                        val state by viewModel.viewState().collectAsStateWithLifecycle(
+                            initialValue = AboutDuckDuckGoViewModel.ViewState(),
+                        )
+                        AboutScreen(
+                            version = state.version,
+                            onBack = { finish() },
+                            onLinkClick = ::onAboutLinkClicked,
+                            onPrivacyPolicyClick = viewModel::onPrivacyPolicyClicked,
+                            onVersionClick = viewModel::onVersionClicked,
+                        )
+                    }
+                }
+            },
+        )
+    }
+
+    private fun onAboutLinkClicked(tag: String) {
+        when (tag) {
+            COMPARISON_CHART_ANNOTATION -> viewModel.onComparisonChartLinkClicked()
+            SUBSCRIPTION_ANNOTATION -> viewModel.onSubscriptionHelpPageLinkClicked()
+            VPN_ANNOTATION -> viewModel.onVPNHelpPageLinkClicked()
+            PRIVACY_PROTECTION_ANNOTATION -> viewModel.onPrivacyProtectionsLinkClicked()
+            LEARN_MORE_ANNOTATION -> viewModel.onLearnMoreLinkClicked()
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/duckduckgo/app/about/AboutScreenComposeFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/about/AboutScreenComposeFeature.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.about
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "aboutScreenCompose",
+)
+interface AboutScreenComposeFeature {
+
+    /**
+     * Gates rendering the About screen with Jetpack Compose. When disabled, the
+     * original XML implementation is used. Allows instant rollback by flipping the flag.
+     */
+    @Toggle.DefaultValue(Toggle.DefaultFeatureValue.INTERNAL)
+    fun self(): Toggle
+}

--- a/app/src/main/java/com/duckduckgo/app/about/compose/AboutDescription.kt
+++ b/app/src/main/java/com/duckduckgo/app/about/compose/AboutDescription.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.about.compose
+
+import android.content.Context
+import android.text.Annotation
+import android.text.SpannedString
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextDecoration
+
+/** One inline clickable link extracted from the styled description resource. */
+data class AboutLinkSpan(
+    val value: String,
+    val start: Int,
+    val end: Int,
+)
+
+/**
+ * Pure, JVM-testable builder: applies a clickable, underlined, colored [LinkAnnotation]
+ * over each [AboutLinkSpan] range. [onLinkClick] receives the annotation value (tag).
+ */
+fun buildAboutDescription(
+    text: String,
+    links: List<AboutLinkSpan>,
+    linkColor: Color,
+    onLinkClick: (String) -> Unit,
+): AnnotatedString = buildAnnotatedString {
+    append(text)
+    val styles = TextLinkStyles(
+        style = SpanStyle(color = linkColor, textDecoration = TextDecoration.Underline),
+    )
+    links.forEach { link ->
+        addLink(
+            LinkAnnotation.Clickable(
+                tag = link.value,
+                styles = styles,
+                linkInteractionListener = { onLinkClick(link.value) },
+            ),
+            link.start,
+            link.end,
+        )
+    }
+}
+
+/**
+ * Reads the styled description resource and extracts its [Annotation] spans into
+ * [AboutLinkSpan]s, then delegates to [buildAboutDescription]. Verified via preview / manual run.
+ */
+fun Context.aboutDescription(
+    resId: Int,
+    linkColor: Color,
+    onLinkClick: (String) -> Unit,
+): AnnotatedString {
+    val styled = getText(resId) as SpannedString
+    val links = styled.getSpans(0, styled.length, Annotation::class.java).map { annotation ->
+        AboutLinkSpan(
+            value = annotation.value,
+            start = styled.getSpanStart(annotation),
+            end = styled.getSpanEnd(annotation),
+        )
+    }
+    return buildAboutDescription(styled.toString(), links, linkColor, onLinkClick)
+}

--- a/app/src/main/java/com/duckduckgo/app/about/compose/AboutScreen.kt
+++ b/app/src/main/java/com/duckduckgo/app/about/compose/AboutScreen.kt
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.about.compose
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import com.duckduckgo.app.browser.R
+import com.duckduckgo.common.ui.compose.appbars.DaxTopAppBar
+import com.duckduckgo.common.ui.compose.divider.DaxHorizontalDivider
+import com.duckduckgo.common.ui.compose.layout.DaxScaffold
+import com.duckduckgo.common.ui.compose.listitem.DaxOneLineListItem
+import com.duckduckgo.common.ui.compose.text.DaxText
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+import com.duckduckgo.mobile.android.R as CommonR
+
+@Composable
+fun AboutScreen(
+    version: String,
+    onBack: () -> Unit,
+    onLinkClick: (String) -> Unit,
+    onPrivacyPolicyClick: () -> Unit,
+    onVersionClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    DaxScaffold(
+        modifier = modifier,
+        topBar = {
+            DaxTopAppBar(
+                title = stringResource(R.string.aboutActivityTitleNew),
+                navigationIcon = { Back(onClick = onBack) },
+                shadow = true,
+            )
+        },
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxWidth(),
+            contentPadding = PaddingValues(
+                top = dimensionResource(CommonR.dimen.keyline_7),
+                bottom = dimensionResource(CommonR.dimen.keyline_5),
+            ),
+        ) {
+            item {
+                Box(
+                    modifier = Modifier.fillMaxWidth(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Image(
+                        painter = painterResource(CommonR.drawable.logo_full),
+                        contentDescription = stringResource(R.string.duckDuckGoLogoDescription),
+                        modifier = Modifier.size(150.dp),
+                    )
+                }
+            }
+            item {
+                DaxText(
+                    text = stringResource(R.string.aboutHeaderNewTagLine),
+                    style = DuckDuckGoTheme.typography.h3,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = dimensionResource(CommonR.dimen.keyline_4)),
+                )
+            }
+            item {
+                DaxText(
+                    text = "...",
+                    style = DuckDuckGoTheme.typography.title,
+                    color = DuckDuckGoTheme.colors.text.secondary,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(
+                            top = dimensionResource(CommonR.dimen.keyline_3),
+                            bottom = dimensionResource(CommonR.dimen.keyline_6),
+                        ),
+                )
+            }
+            item {
+                DaxText(
+                    text = context.aboutDescription(
+                        resId = R.string.aboutDescriptionBrandUpdate2025,
+                        linkColor = DuckDuckGoTheme.colors.brand.accentBlue,
+                        onLinkClick = onLinkClick,
+                    ),
+                    style = DuckDuckGoTheme.typography.body1,
+                    color = DuckDuckGoTheme.colors.text.secondary,
+                    modifier = Modifier.padding(horizontal = dimensionResource(CommonR.dimen.keyline_4)),
+                )
+            }
+            item {
+                DaxHorizontalDivider(modifier = Modifier.padding(vertical = dimensionResource(CommonR.dimen.keyline_2)))
+            }
+            item {
+                DaxOneLineListItem(
+                    text = stringResource(R.string.settingsPrivacyPolicyDuckduckgo),
+                    modifier = Modifier.clickable { onPrivacyPolicyClick() },
+                    containerColor = DuckDuckGoTheme.colors.backgrounds.background,
+                )
+            }
+            item {
+                AboutVersionListItem(
+                    primary = stringResource(R.string.settingsVersion),
+                    secondary = version,
+                    onClick = onVersionClick,
+                )
+            }
+        }
+    }
+}
+
+/**
+ * Local stopgap for the missing ADS Compose two-line list item (primary + secondary,
+ * clickable). Backlog: add DaxTwoLineListItem to the design system.
+ */
+@Composable
+private fun AboutVersionListItem(
+    primary: String,
+    secondary: String,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() }
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+    ) {
+        DaxText(text = primary, style = DuckDuckGoTheme.typography.body1)
+        DaxText(
+            text = secondary,
+            style = DuckDuckGoTheme.typography.body2,
+            color = DuckDuckGoTheme.colors.text.secondary,
+        )
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun AboutScreenPreview() {
+    DuckDuckGoTheme {
+        AboutScreen(
+            version = "5.123.0 (5123000)",
+            onBack = {},
+            onLinkClick = {},
+            onPrivacyPolicyClick = {},
+            onVersionClick = {},
+        )
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/about/compose/AboutDescriptionTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/about/compose/AboutDescriptionTest.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.about.compose
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.LinkAnnotation
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AboutDescriptionTest {
+
+    @Test
+    fun whenBuildingDescriptionThenPlainTextPreserved() {
+        val text = "Read the policy here and learn more."
+        val result = buildAboutDescription(
+            text = text,
+            links = listOf(AboutLinkSpan("policy_link", 9, 15)),
+            linkColor = Color.Blue,
+            onLinkClick = {},
+        )
+        assertEquals(text, result.text)
+    }
+
+    @Test
+    fun whenBuildingDescriptionThenOneLinkAnnotationPerSpanWithMatchingTagAndRange() {
+        val text = "Read the policy here and learn more."
+        val spans = listOf(
+            AboutLinkSpan("policy_link", 9, 15),
+            AboutLinkSpan("learn_more_link", 25, 35),
+        )
+        val result = buildAboutDescription(
+            text = text,
+            links = spans,
+            linkColor = Color.Blue,
+            onLinkClick = {},
+        )
+        val annotations = result.getLinkAnnotations(0, result.length)
+        assertEquals(2, annotations.size)
+        annotations.forEachIndexed { index, range ->
+            assertEquals(spans[index].start, range.start)
+            assertEquals(spans[index].end, range.end)
+            assertEquals(spans[index].value, (range.item as LinkAnnotation.Clickable).tag)
+        }
+    }
+}

--- a/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
@@ -58,6 +58,7 @@ import com.duckduckgo.lint.ui.NoMaterial3DividerUsageDetector.Companion.NO_MATER
 import com.duckduckgo.lint.ui.NoMaterial3DividerUsageDetector.Companion.NO_MATERIAL3_VERTICAL_DIVIDER_USAGE
 import com.duckduckgo.lint.ui.NoMaterial3RadioButtonUsageDetector.Companion.NO_MATERIAL3_RADIO_BUTTON_USAGE
 import com.duckduckgo.lint.ui.NoMaterial3SwitchUsageDetector.Companion.NO_MATERIAL3_SWITCH_USAGE
+import com.duckduckgo.lint.ui.NoMaterial3TopAppBarUsageDetector.Companion.NO_MATERIAL3_TOP_APP_BAR_USAGE
 import com.duckduckgo.lint.ui.DaxTextViewStylingDetector.Companion.INVALID_DAX_TEXT_VIEW_PROPERTY
 import com.duckduckgo.lint.ui.DeprecatedAndroidWidgetsUsedInXmlDetector.Companion.DEPRECATED_WIDGET_IN_XML
 import com.duckduckgo.lint.ui.MissingDividerDetector.Companion.MISSING_HORIZONTAL_DIVIDER
@@ -119,6 +120,7 @@ class DuckDuckGoIssueRegistry : IssueRegistry() {
             INVALID_DAX_TEXT_FIELD_TRAILING_ICON_USAGE,
             INVALID_DAX_SECURE_TEXT_FIELD_TRAILING_ICON_USAGE,
             NO_MATERIAL3_SWITCH_USAGE,
+            NO_MATERIAL3_TOP_APP_BAR_USAGE,
             NO_MATERIAL3_RADIO_BUTTON_USAGE,
             NO_MATERIAL3_CHECKBOX_USAGE,
             NO_MATERIAL3_HORIZONTAL_DIVIDER_USAGE,

--- a/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
@@ -57,6 +57,7 @@ import com.duckduckgo.lint.ui.NoMaterial3CheckboxUsageDetector.Companion.NO_MATE
 import com.duckduckgo.lint.ui.NoMaterial3DividerUsageDetector.Companion.NO_MATERIAL3_HORIZONTAL_DIVIDER_USAGE
 import com.duckduckgo.lint.ui.NoMaterial3DividerUsageDetector.Companion.NO_MATERIAL3_VERTICAL_DIVIDER_USAGE
 import com.duckduckgo.lint.ui.NoMaterial3RadioButtonUsageDetector.Companion.NO_MATERIAL3_RADIO_BUTTON_USAGE
+import com.duckduckgo.lint.ui.NoMaterial3ScaffoldUsageDetector.Companion.NO_MATERIAL3_SCAFFOLD_USAGE
 import com.duckduckgo.lint.ui.NoMaterial3SwitchUsageDetector.Companion.NO_MATERIAL3_SWITCH_USAGE
 import com.duckduckgo.lint.ui.NoMaterial3TopAppBarUsageDetector.Companion.NO_MATERIAL3_TOP_APP_BAR_USAGE
 import com.duckduckgo.lint.ui.DaxTextViewStylingDetector.Companion.INVALID_DAX_TEXT_VIEW_PROPERTY
@@ -125,6 +126,7 @@ class DuckDuckGoIssueRegistry : IssueRegistry() {
             NO_MATERIAL3_CHECKBOX_USAGE,
             NO_MATERIAL3_HORIZONTAL_DIVIDER_USAGE,
             NO_MATERIAL3_VERTICAL_DIVIDER_USAGE,
+            NO_MATERIAL3_SCAFFOLD_USAGE,
             NO_RAW_M3_BUTTON_USAGE,
             NO_RAW_M3_ALERT_DIALOG_USAGE,
             NO_RAW_M3_SURFACE_USAGE,

--- a/lint-rules/src/main/java/com/duckduckgo/lint/ui/NoMaterial3ScaffoldUsageDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/ui/NoMaterial3ScaffoldUsageDetector.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint.ui
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category.Companion.CUSTOM_LINT_CHECKS
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.TextFormat
+import org.jetbrains.uast.UCallExpression
+import java.util.EnumSet
+
+@Suppress("UnstableApiUsage")
+class NoMaterial3ScaffoldUsageDetector : Detector(), SourceCodeScanner {
+
+    override fun getApplicableUastTypes() = listOf(UCallExpression::class.java)
+
+    override fun createUastHandler(context: JavaContext): UElementHandler = ScaffoldUsageHandler(context)
+
+    internal class ScaffoldUsageHandler(private val context: JavaContext) : UElementHandler() {
+
+        override fun visitCallExpression(node: UCallExpression) {
+            if (isInDesignSystemModule()) return
+
+            val methodName = node.methodName ?: return
+            if (methodName == "Scaffold") {
+                val resolved = node.resolve() ?: return
+                val qualifiedName = context.evaluator.getPackage(resolved)?.qualifiedName ?: return
+                if (qualifiedName == MATERIAL3_PACKAGE) {
+                    context.report(
+                        issue = NO_MATERIAL3_SCAFFOLD_USAGE,
+                        location = context.getLocation(node),
+                        message = NO_MATERIAL3_SCAFFOLD_USAGE.getExplanation(TextFormat.RAW),
+                    )
+                }
+            }
+        }
+
+        private fun isInDesignSystemModule(): Boolean {
+            return context.project.name in DESIGN_SYSTEM_MODULES
+        }
+    }
+
+    companion object {
+        private const val MATERIAL3_PACKAGE = "androidx.compose.material3"
+        private val DESIGN_SYSTEM_MODULES = setOf("design-system", "design-system-internal")
+
+        val NO_MATERIAL3_SCAFFOLD_USAGE = Issue
+            .create(
+                id = "NoMaterial3ScaffoldUsage",
+                briefDescription = "Use DaxScaffold instead of Material3 Scaffold",
+                explanation = "Use `DaxScaffold` from the design system instead of the Material3 `Scaffold` composable " +
+                    "to ensure consistent styling across the app.",
+                moreInfo = "",
+                category = CUSTOM_LINT_CHECKS,
+                priority = 10,
+                severity = Severity.ERROR,
+                androidSpecific = true,
+                implementation = Implementation(
+                    NoMaterial3ScaffoldUsageDetector::class.java,
+                    EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES),
+                ),
+            )
+    }
+}

--- a/lint-rules/src/main/java/com/duckduckgo/lint/ui/NoMaterial3TopAppBarUsageDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/ui/NoMaterial3TopAppBarUsageDetector.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint.ui
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category.Companion.CUSTOM_LINT_CHECKS
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.TextFormat
+import org.jetbrains.uast.UCallExpression
+import java.util.EnumSet
+
+@Suppress("UnstableApiUsage")
+class NoMaterial3TopAppBarUsageDetector : Detector(), SourceCodeScanner {
+
+    override fun getApplicableUastTypes() = listOf(UCallExpression::class.java)
+
+    override fun createUastHandler(context: JavaContext): UElementHandler = TopAppBarUsageHandler(context)
+
+    internal class TopAppBarUsageHandler(private val context: JavaContext) : UElementHandler() {
+
+        override fun visitCallExpression(node: UCallExpression) {
+            if (isInDesignSystemModule()) return
+
+            val methodName = node.methodName ?: return
+            if (methodName in MATERIAL3_TOP_APP_BARS) {
+                val resolved = node.resolve() ?: return
+                val qualifiedName = context.evaluator.getPackage(resolved)?.qualifiedName ?: return
+                if (qualifiedName == MATERIAL3_PACKAGE) {
+                    context.report(
+                        issue = NO_MATERIAL3_TOP_APP_BAR_USAGE,
+                        location = context.getLocation(node),
+                        message = NO_MATERIAL3_TOP_APP_BAR_USAGE.getExplanation(TextFormat.RAW),
+                    )
+                }
+            }
+        }
+
+        private fun isInDesignSystemModule(): Boolean {
+            return context.project.name in DESIGN_SYSTEM_MODULES
+        }
+    }
+
+    companion object {
+        private const val MATERIAL3_PACKAGE = "androidx.compose.material3"
+        private val DESIGN_SYSTEM_MODULES = setOf("design-system", "design-system-internal")
+
+        // Every Material3 top app bar overload maps to the same design-system replacement.
+        private val MATERIAL3_TOP_APP_BARS = setOf(
+            "TopAppBar",
+            "CenterAlignedTopAppBar",
+            "MediumTopAppBar",
+            "LargeTopAppBar",
+        )
+
+        val NO_MATERIAL3_TOP_APP_BAR_USAGE = Issue
+            .create(
+                id = "NoMaterial3TopAppBarUsage",
+                briefDescription = "Use DaxTopAppBar instead of Material3 TopAppBar",
+                explanation = "Use `DaxTopAppBar` or `DaxSearchTopAppBar` from the design system instead of the Material3 " +
+                    "`TopAppBar` composable to ensure consistent styling across the app.",
+                moreInfo = "",
+                category = CUSTOM_LINT_CHECKS,
+                priority = 10,
+                severity = Severity.ERROR,
+                androidSpecific = true,
+                implementation = Implementation(
+                    NoMaterial3TopAppBarUsageDetector::class.java,
+                    EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES),
+                ),
+            )
+    }
+}

--- a/lint-rules/src/test/java/com/duckduckgo/lint/ui/NoMaterial3ScaffoldUsageDetectorTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/ui/NoMaterial3ScaffoldUsageDetectorTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint.ui
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.kotlin
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import com.duckduckgo.lint.ui.NoMaterial3ScaffoldUsageDetector.Companion.NO_MATERIAL3_SCAFFOLD_USAGE
+import org.junit.Test
+
+class NoMaterial3ScaffoldUsageDetectorTest {
+
+    private val scaffoldStub = kotlin(
+        """
+        package androidx.compose.material3
+
+        fun Scaffold(
+            content: () -> Unit,
+        ) {}
+        """.trimIndent(),
+    ).indented()
+
+    private val daxScaffoldStub = kotlin(
+        """
+        package com.duckduckgo.common.ui.compose.layout
+
+        fun DaxScaffold(
+            content: () -> Unit,
+        ) {}
+        """.trimIndent(),
+    ).indented()
+
+    @Test
+    fun whenMaterial3ScaffoldUsedThenError() {
+        lint()
+            .files(
+                scaffoldStub,
+                kotlin(
+                    """
+                    package com.example.test
+
+                    import androidx.compose.material3.Scaffold
+
+                    fun MyScreen() {
+                        Scaffold(content = {})
+                    }
+                    """.trimIndent(),
+                ).indented(),
+            )
+            .issues(NO_MATERIAL3_SCAFFOLD_USAGE)
+            .run()
+            .expect(
+                """
+                src/com/example/test/test.kt:6: Error: Use DaxScaffold from the design system instead of the Material3 Scaffold composable to ensure consistent styling across the app. [NoMaterial3ScaffoldUsage]
+                    Scaffold(content = {})
+                    ~~~~~~~~~~~~~~~~~~~~~~
+                1 errors, 0 warnings
+                """.trimIndent(),
+            )
+    }
+
+    @Test
+    fun whenDaxScaffoldUsedThenNoError() {
+        lint()
+            .files(
+                daxScaffoldStub,
+                kotlin(
+                    """
+                    package com.example.test
+
+                    import com.duckduckgo.common.ui.compose.layout.DaxScaffold
+
+                    fun MyScreen() {
+                        DaxScaffold(content = {})
+                    }
+                    """.trimIndent(),
+                ).indented(),
+            )
+            .issues(NO_MATERIAL3_SCAFFOLD_USAGE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenNoScaffoldUsedThenNoError() {
+        lint()
+            .files(
+                kotlin(
+                    """
+                    package com.example.test
+
+                    fun MyScreen() {
+                        val visible = true
+                    }
+                    """.trimIndent(),
+                ).indented(),
+            )
+            .issues(NO_MATERIAL3_SCAFFOLD_USAGE)
+            .run()
+            .expectClean()
+    }
+}

--- a/lint-rules/src/test/java/com/duckduckgo/lint/ui/NoMaterial3TopAppBarUsageDetectorTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/ui/NoMaterial3TopAppBarUsageDetectorTest.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint.ui
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.kotlin
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import com.duckduckgo.lint.ui.NoMaterial3TopAppBarUsageDetector.Companion.NO_MATERIAL3_TOP_APP_BAR_USAGE
+import org.junit.Test
+
+class NoMaterial3TopAppBarUsageDetectorTest {
+
+    private val topAppBarStub = kotlin(
+        """
+        package androidx.compose.material3
+
+        fun TopAppBar(title: () -> Unit) {}
+
+        fun CenterAlignedTopAppBar(title: () -> Unit) {}
+        """.trimIndent(),
+    ).indented()
+
+    private val daxTopAppBarStub = kotlin(
+        """
+        package com.duckduckgo.common.ui.compose.appbars
+
+        fun DaxTopAppBar(title: String) {}
+
+        fun DaxSearchTopAppBar(title: String) {}
+        """.trimIndent(),
+    ).indented()
+
+    @Test
+    fun whenMaterial3TopAppBarUsedThenError() {
+        lint()
+            .files(
+                topAppBarStub,
+                kotlin(
+                    """
+                    package com.example.test
+
+                    import androidx.compose.material3.TopAppBar
+
+                    fun MyScreen() {
+                        TopAppBar(title = {})
+                    }
+                    """.trimIndent(),
+                ).indented(),
+            )
+            .issues(NO_MATERIAL3_TOP_APP_BAR_USAGE)
+            .run()
+            .expect(
+                """
+                src/com/example/test/test.kt:6: Error: Use DaxTopAppBar or DaxSearchTopAppBar from the design system instead of the Material3 TopAppBar composable to ensure consistent styling across the app. [NoMaterial3TopAppBarUsage]
+                    TopAppBar(title = {})
+                    ~~~~~~~~~~~~~~~~~~~~~
+                1 errors, 0 warnings
+                """.trimIndent(),
+            )
+    }
+
+    @Test
+    fun whenMaterial3CenterAlignedTopAppBarUsedThenError() {
+        lint()
+            .files(
+                topAppBarStub,
+                kotlin(
+                    """
+                    package com.example.test
+
+                    import androidx.compose.material3.CenterAlignedTopAppBar
+
+                    fun MyScreen() {
+                        CenterAlignedTopAppBar(title = {})
+                    }
+                    """.trimIndent(),
+                ).indented(),
+            )
+            .issues(NO_MATERIAL3_TOP_APP_BAR_USAGE)
+            .run()
+            .expectErrorCount(1)
+    }
+
+    @Test
+    fun whenDaxTopAppBarUsedThenNoError() {
+        lint()
+            .files(
+                daxTopAppBarStub,
+                kotlin(
+                    """
+                    package com.example.test
+
+                    import com.duckduckgo.common.ui.compose.appbars.DaxTopAppBar
+
+                    fun MyScreen() {
+                        DaxTopAppBar(title = "Title")
+                    }
+                    """.trimIndent(),
+                ).indented(),
+            )
+            .issues(NO_MATERIAL3_TOP_APP_BAR_USAGE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenDaxSearchTopAppBarUsedThenNoError() {
+        lint()
+            .files(
+                daxTopAppBarStub,
+                kotlin(
+                    """
+                    package com.example.test
+
+                    import com.duckduckgo.common.ui.compose.appbars.DaxSearchTopAppBar
+
+                    fun MyScreen() {
+                        DaxSearchTopAppBar(title = "Title")
+                    }
+                    """.trimIndent(),
+                ).indented(),
+            )
+            .issues(NO_MATERIAL3_TOP_APP_BAR_USAGE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenNoTopAppBarUsedThenNoError() {
+        lint()
+            .files(
+                kotlin(
+                    """
+                    package com.example.test
+
+                    fun MyScreen() {
+                        val title = "Title"
+                    }
+                    """.trimIndent(),
+                ).indented(),
+            )
+            .issues(NO_MATERIAL3_TOP_APP_BAR_USAGE)
+            .run()
+            .expectClean()
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1215496415658080/task/1215811704141033 

### Description

Migrate the first screen in Compose to build knowledge and document how to apply the same kind of refactiring for the rest of the team when Compose will be production ready.

### Steps to test this PR

- [ ] Run the app and open About screen from settings
- [ ] Check the UI is exactly the same in XML and Compose

### UI changes
| Before  | After |
| ------ | ----- |
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/6cf6d818-1d93-4224-9f9d-0800241b5a69" /> | <img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/868d4cf6-53d3-490a-ac9e-5ebc8faba8f7" />
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/b8206a0c-4936-4425-b20e-45c96c0ad7c7" /> | <img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/647ea9d9-db78-4944-9233-289bd905feec" />
