### PR TITLE
Remove eTLD+1 boundary from tracker-detection label walks

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/CachedTdsEntityLookup.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/CachedTdsEntityLookup.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.app.trackerdetection.db.TdsDomainEntityDao
 import com.duckduckgo.app.trackerdetection.db.TdsEntityDao
 import com.duckduckgo.app.trackerdetection.model.Entity
 import com.duckduckgo.common.utils.baseHost
-import com.duckduckgo.common.utils.extensions.toTldPlusOne
 import com.duckduckgo.di.scopes.AppScope
 import dagger.SingleInstanceIn
 import javax.inject.Inject
@@ -60,13 +59,11 @@ class CachedTdsEntityLookup @Inject constructor(
 
     private fun labelWalk(host: String): Entity? {
         val snap = activeSnapshot()
-        val eTldPlusOne = host.toTldPlusOne() ?: return null
         var candidate = host
         while (true) {
             snap.domainToEntityName[candidate]?.let { entityName ->
                 return snap.entityByName[entityName]
             }
-            if (candidate == eTldPlusOne) return null
             val dot = candidate.indexOf('.')
             if (dot < 0) return null
             candidate = candidate.substring(dot + 1)

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TdsClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TdsClient.kt
@@ -24,7 +24,6 @@ import com.duckduckgo.app.trackerdetection.model.Action.BLOCK
 import com.duckduckgo.app.trackerdetection.model.Action.IGNORE
 import com.duckduckgo.app.trackerdetection.model.Rule
 import com.duckduckgo.app.trackerdetection.model.TdsTracker
-import com.duckduckgo.common.utils.extensions.toTldPlusOne
 import logcat.logcat
 
 class TdsClient(
@@ -100,11 +99,9 @@ class TdsClient(
     }
 
     private fun findCompiledTrackerByLabelWalk(host: String): CompiledTracker? {
-        val eTldPlusOne = host.toTldPlusOne() ?: return null
         var candidate: String = host
         while (true) {
             compiledTrackerByDomain[candidate]?.let { return it }
-            if (candidate == eTldPlusOne) return null
             val dot = candidate.indexOf('.')
             if (dot < 0) return null
             candidate = candidate.substring(dot + 1)

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/TdsClientTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/TdsClientTest.kt
@@ -540,30 +540,6 @@ class TdsClientTest {
         assertEquals(true, testee.matches("http://tracker.co.uk/script.js", DOCUMENT_URL, mapOf()).matches)
     }
 
-    @Test
-    fun whenV3EnabledAndTrackerDomainIsAPublicSuffixThenWalkStopsAtETldPlusOne() {
-        // Walk for "static.tracker.co.uk" must stop after checking "tracker.co.uk" (the eTLD+1)
-        // and must not match a tracker whose domain is a public suffix like "co.uk".
-        val tracker = TdsTracker(Domain("co.uk"), BLOCK, OWNER, CATEGORY, emptyList())
-        val testee = TdsClient(TDS, listOf(tracker), mockUrlToTypeMapper, optimizeTrackerEvaluationV3 = true)
-
-        val result = testee.matches("http://static.tracker.co.uk/script.js", DOCUMENT_URL, mapOf())
-        assertEquals(false, result.matches)
-        assertEquals(false, result.isATracker)
-    }
-
-    @Test
-    fun whenV3EnabledAndHostHasNoETldPlusOneThenResultIsNoMatch() {
-        // Hosts without a resolvable eTLD+1 (single-label, IPs, public-suffix-only) must never
-        // match — even if a tracker entry exists at the exact host key.
-        val tracker = TdsTracker(Domain("localhost"), BLOCK, OWNER, CATEGORY, emptyList())
-        val testee = TdsClient(TDS, listOf(tracker), mockUrlToTypeMapper, optimizeTrackerEvaluationV3 = true)
-
-        val result = testee.matches("http://localhost/script.js", DOCUMENT_URL, mapOf())
-        assertEquals(false, result.matches)
-        assertEquals(false, result.isATracker)
-    }
-
     companion object {
         private const val OWNER = "A Network Owner"
         private val DOCUMENT_URL = "http://example.com/index.htm".toUri()

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackerallowlist/RealTrackerAllowlist.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackerallowlist/RealTrackerAllowlist.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.privacy.config.impl.features.trackerallowlist
 
 import androidx.core.net.toUri
 import com.duckduckgo.app.browser.UriString
-import com.duckduckgo.common.utils.extensions.toTldPlusOne
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.FeatureToggle
 import com.duckduckgo.privacy.config.api.PrivacyFeatureName
@@ -75,11 +74,9 @@ class RealTrackerAllowlist @Inject constructor(
         host: String,
         rulesByDomain: Map<String, List<CompiledRule>>,
     ): List<CompiledRule>? {
-        val eTldPlusOne = host.toTldPlusOne() ?: return null
         var candidate = host
         while (true) {
             rulesByDomain[candidate]?.let { return it }
-            if (candidate == eTldPlusOne) return null
             val dot = candidate.indexOf('.')
             if (dot < 0) return null
             candidate = candidate.substring(dot + 1)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1215758131949032?focus=true
Tech Design URL (if applicable):

### Description

The label-walk lookups in TdsClient, CachedTdsEntityLookup, and RealTrackerAllowlist stopped at the eTLD+1 (and bailed out early on hosts with no resolvable eTLD+1). This made the optimized path stricter than the legacy sameOrSubdomain path it's meant to mirror. It couldn't match entries keyed at a single-label host or a public suffix.

This drops the toTldPlusOne() guard from all three walks so each lookup is a pure label-suffix walk (most-specific → least-specific), restoring parity with sameOrSubdomain. The two TdsClientTest cases that asserted the old eTLD+1-bounded behavior are removed.

- CachedTdsEntityLookup.kt, TdsClient.kt, RealTrackerAllowlist.kt: remove the eTLD+1 guard and unused toTldPlusOne import.
- TdsClientTest.kt: delete the two now-obsolete eTLD+1 boundary tests.



### Steps to test this PR

Code review only.

Tests should pass.



### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core tracker blocking and allowlist domain resolution; wider suffix walks can alter which requests block or are excepted versus the previous optimized path.
> 
> **Overview**
> Removes the **eTLD+1 stop** from optimized **label-suffix domain walks** in tracker detection, entity lookup, and the tracker allowlist so they behave like the legacy **`sameOrSubdomain`** path instead of stopping early or refusing hosts with no resolvable eTLD+1.
> 
> In **`TdsClient`**, **`CachedTdsEntityLookup`**, and **`RealTrackerAllowlist`**, each walk now only strips labels (most specific → least) until there is no dot left—no **`toTldPlusOne()`** check. That restores matches for list keys on **public suffixes** (e.g. `co.uk`) and can allow hits on **single-label** hosts when data is keyed that way.
> 
> **`TdsClientTest`** drops two tests that encoded the old eTLD+1 boundary; other V3 label-walk coverage stays.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e541f82237d989a18f75ef83d800266f41e4bd13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->