### PR TITLE
Update ad-blocking strings

### DIFF
--- a/ad-blocking/ad-blocking-impl/src/main/res/values-bg/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-bg/strings-ad-blocking.xml
@@ -18,9 +18,9 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="ad_blocking_settings_title">Блокиране на реклами в YouTube</string>
-    <string name="ad_blocking_settings_toggle_title">Блокирай рекламите в YouTube</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo премахва рекламите на видеоклипове в YouTube, за да можеш да гледаш видеоклипове без прекъсване.\n\nКогато е включен, DuckDuckGo анонимно ще открива смущения от блокиране на реклами или грешки в YouTube, за да подобри изживяването за всички. DuckDuckGo никога не вижда кои видеоклипове гледаш или каквато и да е лична информация. <annotation type="learn_more_link">Научете повече</annotation></string>
-    <string name="ad_blocking_settings_description">DuckDuckGo премахва рекламите на видеоклипове в YouTube, за да можеш да гледаш видеоклипове без прекъсване. <annotation type="learn_more_link">Научете повече</annotation></string>
+    <string name="ad_blocking_settings_toggle_title">Блокирайте рекламите в YouTube</string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo блокира рекламите на видеоклипове в YouTube, за да можете да ги гледате без прекъсване. Когато функцията е включена, DuckDuckGo анонимно ще открива смущения от блокиране на реклами или грешки в YouTube, за да подобри изживяването за всички. DuckDuckGo никога не вижда кои видеоклипове гледате или каквато и да е лична информация. <annotation type="learn_more_link">Научете повече</annotation></string>
+    <string name="ad_blocking_settings_description">DuckDuckGo премахва рекламите на видеоклипове в YouTube, за да можете да гледате видеоклипове без прекъсване. <annotation type="learn_more_link">Научете повече</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Отваря видеоклипове в режим на киносалон, който предотвратява влиянието на гледаното от теб съдържание върху емисията ти в YouTube.</string>
+    <string name="ad_blocking_settings_duck_player_description">Отваря видеоклипове в режим на киносалон без разсейване, който предотвратява влиянието на гледаното съдържание върху емисията в YouTube.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-bg/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-bg/strings-ad-blocking.xml
@@ -18,9 +18,9 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="ad_blocking_settings_title">Блокиране на реклами в YouTube</string>
-    <string name="ad_blocking_settings_toggle_title">Блокирайте рекламите в YouTube</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo премахва рекламите на видеоклипове в YouTube, за да можете да ги гледате без прекъсване.Когато функцията е включена, DuckDuckGo анонимно ще открива смущения от блокиране на реклами или грешки в YouTube, за да подобри изживяването за всички. DuckDuckGo никога не вижда кои видеоклипове гледате или каквато и да е лична информация. <annotation type="learn_more_link">Научете повече</annotation></string>
-    <string name="ad_blocking_settings_description">DuckDuckGo премахва рекламите на видеоклипове в YouTube, за да можете да ги гледате без прекъсване. <annotation type="learn_more_link">Научете повече</annotation></string>
+    <string name="ad_blocking_settings_toggle_title">Блокирай рекламите в YouTube</string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo премахва рекламите на видеоклипове в YouTube, за да можеш да гледаш видеоклипове без прекъсване.\n\nКогато е включен, DuckDuckGo анонимно ще открива смущения от блокиране на реклами или грешки в YouTube, за да подобри изживяването за всички. DuckDuckGo никога не вижда кои видеоклипове гледаш или каквато и да е лична информация. <annotation type="learn_more_link">Научете повече</annotation></string>
+    <string name="ad_blocking_settings_description">DuckDuckGo премахва рекламите на видеоклипове в YouTube, за да можеш да гледаш видеоклипове без прекъсване. <annotation type="learn_more_link">Научете повече</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Отваря видеоклипове в режим на киносалон без разсейване, който предотвратява влиянието на гледаното съдържание върху емисията в YouTube.</string>
+    <string name="ad_blocking_settings_duck_player_description">Отваря видеоклипове в режим на киносалон, който предотвратява влиянието на гледаното от теб съдържание върху емисията ти в YouTube.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-cs/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-cs/strings-ad-blocking.xml
@@ -19,8 +19,8 @@
 <resources>
     <string name="ad_blocking_settings_title">Blokování reklam na YouTube</string>
     <string name="ad_blocking_settings_toggle_title">Blokovat reklamy na YouTube</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo odstraňuje při sledování videí na YouTube reklamy, takže se můžeš dívat bez přerušení.\n\nKdyž je tato funkce zapnutá, DuckDuckGo anonymně detekuje rušení blokováním reklam nebo chyby YouTube a vylepšuje zážitek pro všechny. DuckDuckGo nikdy nevidí, která videa si prohlížíš ani žádné osobní údaje. <annotation type="learn_more_link">Další informace</annotation></string>
-    <string name="ad_blocking_settings_description">DuckDuckGo odstraňuje při sledování videí na YouTube reklamy, takže se můžeš dívat bez přerušení. <annotation type="learn_more_link">Další informace</annotation></string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blokuje při sledování videí na YouTube reklamy, takže se můžeš dívat bez přerušení.\n\nKdyž je toto zapnuté, DuckDuckGo anonymně detekuje rušení blokováním reklam nebo chyby YouTube a vylepšuje zážitek pro všechny. DuckDuckGo nikdy nevidí, která videa si prohlížíš ani žádné osobní údaje. <annotation type="learn_more_link">Více informací</annotation></string>
+    <string name="ad_blocking_settings_description">DuckDuckGo blokuje při sledování videí na YouTube reklamy, takže se můžeš dívat bez přerušení. <annotation type="learn_more_link">Více informací</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Otevírá videa v režimu kina, který brání tomu, aby sledovaná videa ovlivňovala tvůj feed na YouTube.</string>
+    <string name="ad_blocking_settings_duck_player_description">Otevírat videa v režimu kina, který brání tomu, aby sledovaná videa ovlivňovala tvůj feed na YouTube.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-cs/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-cs/strings-ad-blocking.xml
@@ -19,8 +19,8 @@
 <resources>
     <string name="ad_blocking_settings_title">Blokování reklam na YouTube</string>
     <string name="ad_blocking_settings_toggle_title">Blokovat reklamy na YouTube</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blokuje při sledování videí na YouTube reklamy, takže se můžeš dívat bez přerušení.\n\nKdyž je toto zapnuté, DuckDuckGo anonymně detekuje rušení blokováním reklam nebo chyby YouTube a vylepšuje zážitek pro všechny. DuckDuckGo nikdy nevidí, která videa si prohlížíš ani žádné osobní údaje. <annotation type="learn_more_link">Více informací</annotation></string>
-    <string name="ad_blocking_settings_description">DuckDuckGo blokuje při sledování videí na YouTube reklamy, takže se můžeš dívat bez přerušení. <annotation type="learn_more_link">Více informací</annotation></string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blokuje při sledování videí na YouTube reklamy, takže se můžeš dívat bez přerušení.\n\nKdyž je tato funkce zapnutá, DuckDuckGo anonymně detekuje rušení blokováním reklam nebo chyby YouTube a vylepšuje zážitek pro všechny. DuckDuckGo nikdy nevidí, která videa si prohlížíš ani žádné osobní údaje. <annotation type="learn_more_link">Další informace</annotation></string>
+    <string name="ad_blocking_settings_description">DuckDuckGo blokuje při sledování videí na YouTube reklamy, takže se můžeš dívat bez přerušení. <annotation type="learn_more_link">Další informace</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Otevírat videa v režimu kina, který brání tomu, aby sledovaná videa ovlivňovala tvůj feed na YouTube.</string>
+    <string name="ad_blocking_settings_duck_player_description">Otevírá videa v režimu kina, který brání tomu, aby sledovaná videa ovlivňovala tvůj feed na YouTube.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-da/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-da/strings-ad-blocking.xml
@@ -18,9 +18,9 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="ad_blocking_settings_title">Blokering af YouTube-annoncer</string>
-    <string name="ad_blocking_settings_toggle_title">Bloker annoncer på YouTube</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blokerer videoannoncer på YouTube, så du kan se videoer uden afbrydelser.\n\nNår funktionen er aktiveret, registrerer DuckDuckGo anonymt forstyrrelser fra annonceblokkere eller fejl på YouTube for at forbedre oplevelsen for alle. DuckDuckGo ser aldrig, hvilke videoer du ser, eller andre personligt identificerbare oplysninger. <annotation type="learn_more_link">Mere info</annotation></string>
-    <string name="ad_blocking_settings_description">DuckDuckGo blokerer videoannoncer på YouTube, så du kan se videoer uden afbrydelser. <annotation type="learn_more_link">Mere info</annotation></string>
+    <string name="ad_blocking_settings_toggle_title">Blokér annoncer på YouTube</string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blokerer videoannoncer på YouTube, så du kan se videoer uden afbrydelser. \n\nNår funktionen er aktiveret, registrerer DuckDuckGo anonymt forstyrrelser fra annonceblokkere eller fejl på YouTube for at forbedre oplevelsen for alle. DuckDuckGo ser aldrig, hvilke videoer du ser, eller andre personligt identificerbare oplysninger. <annotation type="learn_more_link">Læs mere</annotation></string>
+    <string name="ad_blocking_settings_description">DuckDuckGo blokerer videoannoncer på YouTube, så du kan se videoer uden afbrydelser. <annotation type="learn_more_link">Læs mere</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Åbner videoer i biograftilstand, så det, du ser, ikke påvirker dit YouTube-feed.</string>
+    <string name="ad_blocking_settings_duck_player_description">Åbner videoer i en distraktionsfri biograftilstand, der forhindrer, at det, du ser, påvirker dit YouTube-feed.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-de/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-de/strings-ad-blocking.xml
@@ -17,10 +17,10 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="ad_blocking_settings_title">YouTube-Werbeblocker</string>
+    <string name="ad_blocking_settings_title">YouTube-Werbung blockieren</string>
     <string name="ad_blocking_settings_toggle_title">Werbung auf YouTube blockieren</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blockiert Video-Werbung auf YouTube, sodass du Videos ohne Unterbrechungen ansehen kannst.\n\nWenn diese Funktion aktiviert ist, erkennt DuckDuckGo anonym, ob Werbeblocker stören oder YouTube-Fehler auftreten, um das Erlebnis für alle zu verbessern. DuckDuckGo sieht niemals, welche Videos du dir ansiehst, und erhält auch keine personenbezogenen Daten. <annotation type="learn_more_link">Mehr erfahren</annotation></string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blockiert Video-Werbung auf YouTube, sodass du Videos ohne Unterbrechungen ansehen kannst. \n\nWenn diese Funktion aktiviert ist, erkennt DuckDuckGo anonym, ob Werbeblocker stören oder YouTube-Fehler auftreten, um das Erlebnis für alle zu verbessern. DuckDuckGo sieht niemals, welche Videos du dir ansiehst, und erhält auch keine personenbezogenen Daten. <annotation type="learn_more_link">Mehr erfahren</annotation></string>
     <string name="ad_blocking_settings_description">DuckDuckGo blockiert Video-Werbung auf YouTube, sodass du Videos ohne Unterbrechungen ansehen kannst. <annotation type="learn_more_link">Mehr erfahren</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Öffnet Videos im Theatermodus, der verhindert, dass das, was du ansiehst, deinen YouTube-Feed beeinflusst.</string>
+    <string name="ad_blocking_settings_duck_player_description">Öffnet Videos in einem ablenkungsfreien Theatermodus, der verhindert, dass das, was du ansiehst, deinen YouTube-Feed beeinflusst.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-el/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-el/strings-ad-blocking.xml
@@ -18,9 +18,9 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="ad_blocking_settings_title">Αποκλεισμός διαφημίσεων YouTube</string>
-    <string name="ad_blocking_settings_toggle_title">Αποκλείστε διαφημίσεις στο YouTube</string>
-    <string name="ad_blocking_settings_description_with_consent">Το DuckDuckGo αποκλείει τις διαφημίσεις βίντεο στο YouTube, ώστε να μπορείς να βλέπεις βίντεο χωρίς διακοπές.\n\nΌταν είναι ενεργοποιημένο, το DuckDuckGo θα ανιχνεύει ανώνυμα παρεμβολές αποκλεισμού διαφημίσεων ή σφάλματα YouTube, για να βελτιώνει την εμπειρία για όλους. Το DuckDuckGo δεν βλέπει ποτέ ποια βίντεο παρακολουθείτε ούτε τυχόν προσωπικά στοιχεία ταυτοποίησης. <annotation type="learn_more_link">Μάθετε περισσότερα</annotation></string>
-    <string name="ad_blocking_settings_description">Το DuckDuckGo αποκλείει τις διαφημίσεις βίντεο στο YouTube, ώστε να μπορείς να βλέπεις βίντεο χωρίς διακοπές. <annotation type="learn_more_link">Μάθετε περισσότερα</annotation></string>
+    <string name="ad_blocking_settings_toggle_title">Απόκλεισε τις διαφημίσεις στο YouTube</string>
+    <string name="ad_blocking_settings_description_with_consent">Το DuckDuckGo αποκλείει τις διαφημίσεις βίντεο στο YouTube, ώστε να μπορείς να βλέπεις βίντεο χωρίς διακοπές. \n\nΌταν είναι ενεργοποιημένο, το DuckDuckGo θα ανιχνεύει ανώνυμα παρεμβολές αποκλεισμού διαφημίσεων ή σφάλματα YouTube, για να βελτιώνει την εμπειρία για όλους. Το DuckDuckGo δεν βλέπει ποτέ ποια βίντεο παρακολουθείς ούτε τυχόν προσωπικά στοιχεία ταυτοποίησης. <annotation type="learn_more_link">Μάθε περισσότερα</annotation></string>
+    <string name="ad_blocking_settings_description">Το DuckDuckGo αποκλείει τις διαφημίσεις βίντεο στο YouTube, ώστε να μπορείς να βλέπεις βίντεο χωρίς διακοπές. <annotation type="learn_more_link">Μάθε περισσότερα</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Ανοίγει βίντεο σε λειτουργία κινηματογράφου, η οποία εμποδίζει το περιεχόμενο που παρακολουθείτε να επηρεάσει τη ροή σας στο YouTube.</string>
+    <string name="ad_blocking_settings_duck_player_description">Ανοίγει βίντεο σε λειτουργία κινηματογράφου χωρίς περισπάσεις, η οποία εμποδίζει το περιεχόμενο που παρακολουθείς να επηρεάσει τη ροή σου στο YouTube.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-es/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-es/strings-ad-blocking.xml
@@ -22,5 +22,5 @@
     <string name="ad_blocking_settings_description_with_consent">DuckDuckGo bloquea los anuncios de vídeo en YouTube, para que puedas ver vídeos sin interrupciones.\n\nCuando esté activado, DuckDuckGo detectará de forma anónima las interferencias en el bloqueo de anuncios o los errores de YouTube para mejorar tu experiencia y la de todos. DuckDuckGo nunca ve los vídeos que ves ni ningún dato de identificación personal. <annotation type="learn_more_link">Más información</annotation></string>
     <string name="ad_blocking_settings_description">DuckDuckGo bloquea los anuncios de vídeo en YouTube, para que puedas ver vídeos sin interrupciones. <annotation type="learn_more_link">Más información</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Abre vídeos en modo teatro que impide que lo que ves influya en tu feed de YouTube.</string>
+    <string name="ad_blocking_settings_duck_player_description">Abre vídeos en modo teatro sin distracciones que impide que lo que ves influya en tu feed de YouTube.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-et/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-et/strings-ad-blocking.xml
@@ -19,8 +19,8 @@
 <resources>
     <string name="ad_blocking_settings_title">YouTube\'i reklaamide blokeerimine</string>
     <string name="ad_blocking_settings_toggle_title">Reklaamide blokeerimine YouTube\'is</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blokeerib YouTube\'is videoreklaamid, nii et saad videoid katkestusteta vaadata.\n\nKui DuckDuckGo on sisse lülitatud, tuvastab see anonüümselt reklaamiblokeerimise häireid või YouTube\'i vigu, et parandada kõigi kasutuskogemust. DuckDuckGo ei näe kunagi, milliseid videoid sa vaatad, ega mingeid isikuandmeid. <annotation type="learn_more_link">Loe edasi</annotation></string>
-    <string name="ad_blocking_settings_description">DuckDuckGo blokeerib YouTube\'is videoreklaamid, nii et saad videoid katkestusteta vaadata. <annotation type="learn_more_link">Loe edasi</annotation></string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blokeerib YouTube\'is videoreklaamid, nii et saad videoid katkestusteta vaadata. \n\nKui DuckDuckGo on sisse lülitatud, tuvastab see anonüümselt reklaamiblokeerimise häireid või YouTube\'i vigu, et parandada kõigi kasutuskogemust. DuckDuckGo ei näe kunagi, milliseid videoid sa vaatad, ega mingeid isikuandmeid. <annotation type="learn_more_link">Lisateave</annotation></string>
+    <string name="ad_blocking_settings_description">DuckDuckGo blokeerib YouTube\'is videoreklaamid, nii et saad videoid katkestusteta vaadata. <annotation type="learn_more_link">Lisateave</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Avab videod kinorežiimis, mis takistab vaadataval sisul sinu YouTube\'i voogu mõjutamast.</string>
+    <string name="ad_blocking_settings_duck_player_description">Avab videod segajatevabas kinorežiimis, mis hoiab ära selle, et vaadatav sisu mõjutaks sinu YouTube’i voogu.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-fi/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-fi/strings-ad-blocking.xml
@@ -19,8 +19,8 @@
 <resources>
     <string name="ad_blocking_settings_title">YouTube-mainosten esto</string>
     <string name="ad_blocking_settings_toggle_title">Estä mainokset YouTubessa</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo poistaa videomainokset YouTubesta, joten voit katsoa videoita keskeytyksettä.\n\nKun tämä toiminto on käytössä, DuckDuckGo tunnistaa nimettömästi mainosten eston aiheuttamat häiriöt tai YouTube-virheet parantaakseen kaikkien käyttökokemusta. DuckDuckGo ei koskaan näe, mitä videoita katsot tai mitään henkilökohtaisesti tunnistettavia tietoja. <annotation type="learn_more_link">Lue lisää</annotation></string>
-    <string name="ad_blocking_settings_description">DuckDuckGo poistaa videomainokset YouTubesta, joten voit katsoa videoita keskeytyksettä. <annotation type="learn_more_link">Lue lisää</annotation></string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo estää videomainokset YouTubessa, joten voit katsoa videoita keskeytyksettä.\n\nKun tämä toiminto on käytössä, DuckDuckGo tunnistaa nimettömästi mainosten eston aiheuttamat häiriöt tai YouTube-virheet parantaakseen kaikkien käyttökokemusta. DuckDuckGo ei koskaan näe, mitä videoita katsot tai mitään henkilökohtaisesti tunnistettavia tietoja. <annotation type="learn_more_link">Lue lisää</annotation></string>
+    <string name="ad_blocking_settings_description">DuckDuckGo estää videomainokset YouTubessa, joten voit katsoa videoita keskeytyksettä. <annotation type="learn_more_link">Lue lisää</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Avaa videot häiriöttömässä teatteritilassa, jolloin katsomasi sisältö ei vaikuta YouTube-syötteeseesi.</string>
+    <string name="ad_blocking_settings_duck_player_description">Avaa videot teatteritilassa, jolloin katsomasi sisältö ei vaikuta YouTube-syötteeseesi.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-fi/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-fi/strings-ad-blocking.xml
@@ -19,8 +19,8 @@
 <resources>
     <string name="ad_blocking_settings_title">YouTube-mainosten esto</string>
     <string name="ad_blocking_settings_toggle_title">Estä mainokset YouTubessa</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo estää videomainokset YouTubessa, joten voit katsoa videoita keskeytyksettä.\n\nKun tämä toiminto on käytössä, DuckDuckGo tunnistaa nimettömästi mainosten eston aiheuttamat häiriöt tai YouTube-virheet parantaakseen kaikkien käyttökokemusta. DuckDuckGo ei koskaan näe, mitä videoita katsot tai mitään henkilökohtaisesti tunnistettavia tietoja. <annotation type="learn_more_link">Lue lisää</annotation></string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo estää videomainokset YouTubessa, joten voit katsoa videoita keskeytyksettä. \n\nKun tämä toiminto on käytössä, DuckDuckGo tunnistaa nimettömästi mainosten eston aiheuttamat häiriöt tai YouTube-virheet parantaakseen kaikkien käyttökokemusta. DuckDuckGo ei koskaan näe, mitä videoita katsot, eikä mitään henkilökohtaisesti tunnistettavia tietoja. <annotation type="learn_more_link">Lue lisää</annotation></string>
     <string name="ad_blocking_settings_description">DuckDuckGo estää videomainokset YouTubessa, joten voit katsoa videoita keskeytyksettä. <annotation type="learn_more_link">Lue lisää</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Avaa videot teatteritilassa, jolloin katsomasi sisältö ei vaikuta YouTube-syötteeseesi.</string>
+    <string name="ad_blocking_settings_duck_player_description">Avaa videot häiriöttömässä teatteritilassa, jolloin katsomasi sisältö ei vaikuta YouTube-syötteeseesi.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-fr/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-fr/strings-ad-blocking.xml
@@ -19,8 +19,8 @@
 <resources>
     <string name="ad_blocking_settings_title">Blocage des publicités sur YouTube</string>
     <string name="ad_blocking_settings_toggle_title">Bloquer les publicités sur YouTube</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo bloque les publicités vidéo sur YouTube, afin que vous puissiez regarder des vidéos sans interruption.\n\nLorsque cette fonction est activée, DuckDuckGo détecte anonymement les interférences liées au blocage des publicités ou les erreurs de YouTube, afin d\'améliorer l\'expérience pour tous. DuckDuckGo ne voit jamais les vidéos que vous regardez ni aucune information permettant de vous identifier personnellement. <annotation type="learn_more_link">En savoir plus</annotation></string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo bloque les publicités vidéo sur YouTube afin que vous puissiez regarder des vidéos sans interruption.\n\nLorsque cette fonction est activée, DuckDuckGo détecte anonymement les interférences liées au blocage des publicités ou les erreurs de YouTube, afin d\'améliorer l\'expérience pour tous. DuckDuckGo ne voit jamais les vidéos que vous regardez ni aucune information permettant de vous identifier personnellement. <annotation type="learn_more_link">En savoir plus</annotation></string>
     <string name="ad_blocking_settings_description">DuckDuckGo bloque les publicités vidéo sur YouTube, afin que vous puissiez regarder des vidéos sans interruption. <annotation type="learn_more_link">En savoir plus</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Ouvre les vidéos en mode « Salle de projection », ce qui empêche ce que vous regardez d\'influencer votre fil d\'actualité YouTube.</string>
+    <string name="ad_blocking_settings_duck_player_description">Ouvre les vidéos en mode « Salle de projection sans distractions », ce qui empêche ce que vous regardez d\'influencer votre fil d\'actualité YouTube.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-hr/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-hr/strings-ad-blocking.xml
@@ -19,8 +19,8 @@
 <resources>
     <string name="ad_blocking_settings_title">Blokiranje YouTube oglasa</string>
     <string name="ad_blocking_settings_toggle_title">Blokiraj oglase na YouTubeu</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blokira video oglase na YouTubeu, tako da možeš gledati videozapise bez prekida.\n\nKad je uključen, DuckDuckGo će anonimno otkriti smetnje u blokiranju oglasa ili pogreške na YouTubeu kako bi poboljšao iskustvo za sve. DuckDuckGo nikad ne vidi koje videozapise gledaš niti bilo kakve osobne podatke. <annotation type="learn_more_link">Saznaj više</annotation></string>
-    <string name="ad_blocking_settings_description">DuckDuckGo blokira video oglase na YouTubeu, tako da možeš gledati videozapise bez prekida. <annotation type="learn_more_link">Saznaj više</annotation></string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blokira video oglase na YouTubeu, tako da videozapise možeš gledati bez prekida. \n\nKada je uključen, DuckDuckGo će anonimno otkriti smetnje u blokiranju oglasa ili pogreške na YouTubeu kako bi poboljšao doživljaj za sve. DuckDuckGo nikada ne vidi koje videozapise gledaš niti bilo kakve osobne podatke. <annotation type="learn_more_link">Saznaj više</annotation></string>
+    <string name="ad_blocking_settings_description">DuckDuckGo blokira video oglase na YouTubeu, tako da videozapise možeš gledati bez prekida. <annotation type="learn_more_link">Saznaj više</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Otvara videozapise u načinu rada kina koji sprječava da ono što gledaš utječe na tvoj YouTube feed.</string>
+    <string name="ad_blocking_settings_duck_player_description">Otvara videozapise u kino načinu rada bez ometanja koji sprječava da ono što gledaš utječe na tvoj YouTube feed.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-hr/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-hr/strings-ad-blocking.xml
@@ -19,8 +19,8 @@
 <resources>
     <string name="ad_blocking_settings_title">Blokiranje YouTube oglasa</string>
     <string name="ad_blocking_settings_toggle_title">Blokiraj oglase na YouTubeu</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo uklanja video oglase na YouTubeu, tako da možeš gledati videozapise bez prekida.\n\nKada je uključen, DuckDuckGo će anonimno otkriti smetnje u blokiranju oglasa ili pogreške na YouTubeu kako bi poboljšao iskustvo za sve. DuckDuckGo nikada ne vidi koje videozapise gledaš niti bilo kakve osobne podatke. <annotation type="learn_more_link">Saznaj više</annotation></string>
-    <string name="ad_blocking_settings_description">DuckDuckGo uklanja video oglase na YouTubeu, tako da možeš gledati videozapise bez prekida. <annotation type="learn_more_link">Saznaj više</annotation></string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blokira video oglase na YouTubeu, tako da možeš gledati videozapise bez prekida.\n\nKad je uključen, DuckDuckGo će anonimno otkriti smetnje u blokiranju oglasa ili pogreške na YouTubeu kako bi poboljšao iskustvo za sve. DuckDuckGo nikad ne vidi koje videozapise gledaš niti bilo kakve osobne podatke. <annotation type="learn_more_link">Saznaj više</annotation></string>
+    <string name="ad_blocking_settings_description">DuckDuckGo blokira video oglase na YouTubeu, tako da možeš gledati videozapise bez prekida. <annotation type="learn_more_link">Saznaj više</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Otvara videozapise u kino načinu rada bez ometanja koji sprječava da ono što gledaš utječe na tvoj YouTube feed.</string>
+    <string name="ad_blocking_settings_duck_player_description">Otvara videozapise u načinu rada kina koji sprječava da ono što gledaš utječe na tvoj YouTube feed.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-hu/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-hu/strings-ad-blocking.xml
@@ -19,8 +19,8 @@
 <resources>
     <string name="ad_blocking_settings_title">YouTube-hirdetésblokkolás</string>
     <string name="ad_blocking_settings_toggle_title">Hirdetések blokkolása a YouTube-on</string>
-    <string name="ad_blocking_settings_description_with_consent">A DuckDuckGo letiltja a videóhirdetéseket a YouTube-ról, így megszakítás nélkül nézhetsz videókat.\n\nAmikor be van kapcsolva, a DuckDuckGo névtelenül észleli a hirdetésblokkolási interferenciát vagy a YouTube-hibákat, hogy mindenki számára jobb élményt nyújtson. A DuckDuckGo soha nem látja, hogy mely videókat nézed meg, és nem fér hozzá személyazonosításra alkalmas információkhoz sem. <annotation type="learn_more_link">További részletek</annotation></string>
-    <string name="ad_blocking_settings_description">A DuckDuckGo letiltja a videóhirdetéseket a YouTube-ról, így megszakítás nélkül nézhetsz videókat. <annotation type="learn_more_link">További részletek</annotation></string>
+    <string name="ad_blocking_settings_description_with_consent">A DuckDuckGo blokkolja a videohirdetéseket a YouTube-on, így megszakítás nélkül nézhetsz videókat.\n\nAmikor be van kapcsolva, a DuckDuckGo névtelenül észleli, ha valami zavarja a hirdetésblokkolást, vagy ha YouTube-hiba lép fel, hogy mindenki számára javíthassa az élményt. A DuckDuckGo soha nem látja, hogy mely videókat nézed meg, és nem fér hozzá személyazonosításra alkalmas információkhoz sem. <annotation type="learn_more_link">További információk</annotation></string>
+    <string name="ad_blocking_settings_description">A DuckDuckGo blokkolja a videohirdetéseket a YouTube-on, így megszakítás nélkül nézhetsz videókat. <annotation type="learn_more_link">További információk</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Mozis módban nyitja meg a videókat, így a nézett tartalom nem befolyásolja a YouTube-hírfolyamodat.</string>
+    <string name="ad_blocking_settings_duck_player_description">Zavaró elemektől mentes, mozis nézetben nyitja meg a videókat, így a nézett tartalom nem befolyásolja a YouTube-hírfolyamodat.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-it/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-it/strings-ad-blocking.xml
@@ -19,8 +19,8 @@
 <resources>
     <string name="ad_blocking_settings_title">Blocco degli annunci su YouTube</string>
     <string name="ad_blocking_settings_toggle_title">Blocca gli annunci su YouTube</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blocca gli annunci video su YouTube, così puoi guardare video senza interruzioni.\n\nQuando questa opzione è attivata, DuckDuckGo rileverà in modo anonimo interferenze nel blocco degli annunci o errori di YouTube per migliorare l\'esperienza di tutti. DuckDuckGo non vede mai quali video visualizzi né alcuna informazione di identificazione personale. <annotation type="learn_more_link">Ulteriori informazioni</annotation></string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blocca gli annunci video su YouTube, così puoi guardare video senza interruzioni. \n\nQuando questa opzione è attivata, DuckDuckGo rileverà in modo anonimo interferenze nel blocco degli annunci o errori di YouTube per migliorare l\'esperienza di tutti. DuckDuckGo non vede mai quali video visualizzi né alcuna informazione di identificazione personale. <annotation type="learn_more_link">Ulteriori informazioni</annotation></string>
     <string name="ad_blocking_settings_description">DuckDuckGo blocca gli annunci video su YouTube, così puoi guardare video senza interruzioni. <annotation type="learn_more_link">Ulteriori informazioni</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Apre i video in una modalità cinema che impedisce a ciò che guardi di influenzare il tuo feed di YouTube.</string>
+    <string name="ad_blocking_settings_duck_player_description">Apre i video in una modalità cinema senza distrazioni che impedisce a ciò che guardi di influenzare il tuo feed di YouTube.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-lt/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-lt/strings-ad-blocking.xml
@@ -18,9 +18,9 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="ad_blocking_settings_title">„YouTube“ reklamų blokavimas</string>
-    <string name="ad_blocking_settings_toggle_title">Blokuoti reklamas „YouTube“</string>
-    <string name="ad_blocking_settings_description_with_consent">„DuckDuckGo“ blokuoja vaizdo įrašų reklamas „YouTube“ platformoje, todėl galite žiūrėti vaizdo įrašus be trukdžių.\n\nKai įjungta, „DuckDuckGo“ anonimiškai aptiks skelbimų blokavimo trukdžius arba „YouTube“ klaidas, kad pagerintų patirtį visiems. „DuckDuckGo“ niekada nemato, kokius vaizdo įrašus žiūrite, ar bet kokios asmenį identifikuojančios informacijos. <annotation type="learn_more_link">Sužinoti daugiau</annotation></string>
-    <string name="ad_blocking_settings_description">„DuckDuckGo“ blokuoja vaizdo įrašų reklamas „YouTube“ platformoje, todėl galite žiūrėti vaizdo įrašus be trukdžių. <annotation type="learn_more_link">Sužinoti daugiau</annotation></string>
+    <string name="ad_blocking_settings_toggle_title">Blokuoti „YouTube“ reklamas</string>
+    <string name="ad_blocking_settings_description_with_consent">„DuckDuckGo“ blokuoja vaizdo įrašų reklamas platformoje „YouTube“, todėl galite žiūrėti vaizdo įrašus be trukdžių.Kai įjungta, „DuckDuckGo“ anonimiškai aptiks skelbimų blokavimo trukdžius arba „YouTube“ klaidas, kad pagerintų patirtį visiems. „DuckDuckGo“ niekada nemato, kokius vaizdo įrašus žiūrite, ar bet kokios asmenį identifikuojančios informacijos. <annotation type="learn_more_link">Sužinokite daugiau</annotation></string>
+    <string name="ad_blocking_settings_description">„DuckDuckGo“ blokuoja vaizdo įrašų reklamas platformoje „YouTube“, todėl galite žiūrėti vaizdo įrašus be trukdžių. <annotation type="learn_more_link">Sužinokite daugiau</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Atidaro vaizdo įrašus kino teatro režimu, kad tai, ką žiūri, nedarytų įtakos tavo „YouTube“ srautui.</string>
+    <string name="ad_blocking_settings_duck_player_description">Atidaro vaizdo įrašus neblaškančiu kino teatro režimu, kad tai, ką žiūri, nedarytų įtakos tavo „YouTube“ srautui.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-lt/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-lt/strings-ad-blocking.xml
@@ -19,7 +19,7 @@
 <resources>
     <string name="ad_blocking_settings_title">„YouTube“ reklamų blokavimas</string>
     <string name="ad_blocking_settings_toggle_title">Blokuoti „YouTube“ reklamas</string>
-    <string name="ad_blocking_settings_description_with_consent">„DuckDuckGo“ blokuoja vaizdo įrašų reklamas platformoje „YouTube“, todėl galite žiūrėti vaizdo įrašus be trukdžių.Kai įjungta, „DuckDuckGo“ anonimiškai aptiks skelbimų blokavimo trukdžius arba „YouTube“ klaidas, kad pagerintų patirtį visiems. „DuckDuckGo“ niekada nemato, kokius vaizdo įrašus žiūrite, ar bet kokios asmenį identifikuojančios informacijos. <annotation type="learn_more_link">Sužinokite daugiau</annotation></string>
+    <string name="ad_blocking_settings_description_with_consent">„DuckDuckGo“ blokuoja vaizdo įrašų reklamas platformoje „YouTube“, todėl galite žiūrėti vaizdo įrašus be trukdžių.\n\nKai įjungta, „DuckDuckGo“ anonimiškai aptiks skelbimų blokavimo trukdžius arba „YouTube“ klaidas, kad pagerintų patirtį visiems. „DuckDuckGo“ niekada nemato, kokius vaizdo įrašus žiūrite, ar bet kokios asmenį identifikuojančios informacijos. <annotation type="learn_more_link">Sužinokite daugiau</annotation></string>
     <string name="ad_blocking_settings_description">„DuckDuckGo“ blokuoja vaizdo įrašų reklamas platformoje „YouTube“, todėl galite žiūrėti vaizdo įrašus be trukdžių. <annotation type="learn_more_link">Sužinokite daugiau</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Atidaro vaizdo įrašus neblaškančiu kino teatro režimu, kad tai, ką žiūri, nedarytų įtakos tavo „YouTube“ srautui.</string>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-lv/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-lv/strings-ad-blocking.xml
@@ -19,8 +19,8 @@
 <resources>
     <string name="ad_blocking_settings_title">YouTube reklāmu bloķēšana</string>
     <string name="ad_blocking_settings_toggle_title">Bloķēt reklāmas pakalpojumā YouTube</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo noņem videoreklāmas pakalpojumā YouTube, lai tu varētu skatīties videoklipus bez pārtraukumiem.\n\nKad šī funkcija ir ieslēgta, DuckDuckGo anonīmi nosaka reklāmu bloķēšanas traucējumus vai YouTube kļūdas, lai uzlabotu tavu pieredzi. DuckDuckGo nekad neredz, kādus videoklipus skaties, vai jebkādu personu identificējamu informāciju. <annotation type="learn_more_link">Uzzināt vairāk</annotation></string>
-    <string name="ad_blocking_settings_description">DuckDuckGo noņem videoreklāmas pakalpojumā YouTube, lai tu varētu skatīties videoklipus bez pārtraukumiem. <annotation type="learn_more_link">Uzzināt vairāk</annotation></string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo bloķē videoreklāmas pakalpojumā YouTube, lai tu varētu skatīties videoklipus bez pārtraukumiem.\n\nKad DuckDuckGo ir ieslēgts, tas anonīmi noteiks reklāmu bloķēšanas traucējumus vai YouTube kļūdas, lai uzlabotu pieredzi visiem. DuckDuckGo nekad neredz, kādus videoklipus skaties, vai jebkādu personiski identificējamu informāciju. <annotation type="learn_more_link">Uzzināt vairāk</annotation></string>
+    <string name="ad_blocking_settings_description">DuckDuckGo bloķē videoreklāmas pakalpojumā YouTube, lai tu varētu skatīties videoklipus bez pārtraukumiem. <annotation type="learn_more_link">Uzzināt vairāk</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Atver videoklipus teātra režīmā bez uzmanības novēršanas, kas neļauj skatītajam ietekmēt tavu YouTube plūsmu.</string>
+    <string name="ad_blocking_settings_duck_player_description">Atver videoklipus kino režīmā, kas neļauj tam, ko tu skaties, ietekmēt tavu YouTube plūsmu.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-lv/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-lv/strings-ad-blocking.xml
@@ -19,8 +19,8 @@
 <resources>
     <string name="ad_blocking_settings_title">YouTube reklāmu bloķēšana</string>
     <string name="ad_blocking_settings_toggle_title">Bloķēt reklāmas pakalpojumā YouTube</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo bloķē videoreklāmas pakalpojumā YouTube, lai tu varētu skatīties videoklipus bez pārtraukumiem.\n\nKad DuckDuckGo ir ieslēgts, tas anonīmi noteiks reklāmu bloķēšanas traucējumus vai YouTube kļūdas, lai uzlabotu pieredzi visiem. DuckDuckGo nekad neredz, kādus videoklipus skaties, vai jebkādu personiski identificējamu informāciju. <annotation type="learn_more_link">Uzzināt vairāk</annotation></string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo bloķē videoreklāmas pakalpojumā YouTube, lai tu varētu skatīties videoklipus bez pārtraukumiem. \n\nKad DuckDuckGo ir ieslēgts, tas anonīmi noteiks reklāmu bloķēšanas traucējumus vai YouTube kļūdas, lai uzlabotu pieredzi visiem. DuckDuckGo nekad neredz, kādus videoklipus skaties, vai jebkādu personu identificējamu informāciju. <annotation type="learn_more_link">Uzzināt vairāk</annotation></string>
     <string name="ad_blocking_settings_description">DuckDuckGo bloķē videoreklāmas pakalpojumā YouTube, lai tu varētu skatīties videoklipus bez pārtraukumiem. <annotation type="learn_more_link">Uzzināt vairāk</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Atver videoklipus kino režīmā, kas neļauj tam, ko tu skaties, ietekmēt tavu YouTube plūsmu.</string>
+    <string name="ad_blocking_settings_duck_player_description">Atver videoklipus teātra režīmā bez uzmanības novēršanas, kas neļauj skatītajam ietekmēt tavu YouTube plūsmu.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-nb/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-nb/strings-ad-blocking.xml
@@ -19,8 +19,8 @@
 <resources>
     <string name="ad_blocking_settings_title">Annonseblokkering på YouTube</string>
     <string name="ad_blocking_settings_toggle_title">Blokker annonser på YouTube</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo fjerner videoannonser på YouTube, slik at du kan se videoer uten avbrudd.\n\nNår dette er på, vil DuckDuckGo anonymt oppdage forstyrrelser fra annonseblokkering eller YouTube-feil for å forbedre opplevelsen for alle. DuckDuckGo ser aldri hvilke videoer du ser på, eller noen personlig identifiserbar informasjon. <annotation type="learn_more_link">Finn ut mer</annotation></string>
-    <string name="ad_blocking_settings_description">DuckDuckGo fjerner videoannonser på YouTube, slik at du kan se videoer uten avbrudd. <annotation type="learn_more_link">Finn ut mer</annotation></string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blokkerer videoannonser på YouTube, slik at du kan se videoer uten avbrudd.\n\nNår dette er aktivert, registrerer DuckDuckGo anonymt forstyrrelser i annonseblokkering eller feil i YouTube, for å forbedre opplevelsen for alle. DuckDuckGo ser aldri hvilke videoer du ser på, eller noen personlig identifiserbar informasjon. <annotation type="learn_more_link">Finn ut mer</annotation></string>
+    <string name="ad_blocking_settings_description">DuckDuckGo blokkerer videoannonser på YouTube, slik at du kan se videoer uten avbrudd. <annotation type="learn_more_link">Finn ut mer</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Åpner videoer i en distraksjonsfri kinomodus som hindrer at det du ser på påvirker YouTube-feeden din.</string>
+    <string name="ad_blocking_settings_duck_player_description">Åpner videoer i en kinomodus som hindrer at det du ser på, påvirker YouTube-feeden din.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-nb/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-nb/strings-ad-blocking.xml
@@ -19,8 +19,8 @@
 <resources>
     <string name="ad_blocking_settings_title">Annonseblokkering på YouTube</string>
     <string name="ad_blocking_settings_toggle_title">Blokker annonser på YouTube</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blokkerer videoannonser på YouTube, slik at du kan se videoer uten avbrudd.\n\nNår dette er aktivert, registrerer DuckDuckGo anonymt forstyrrelser i annonseblokkering eller feil i YouTube, for å forbedre opplevelsen for alle. DuckDuckGo ser aldri hvilke videoer du ser på, eller noen personlig identifiserbar informasjon. <annotation type="learn_more_link">Finn ut mer</annotation></string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blokkerer videoannonser på YouTube, slik at du kan se videoer uten avbrudd. \n\nNår dette er aktivert, registrerer DuckDuckGo anonymt forstyrrelser i annonseblokkering eller feil i YouTube, for å forbedre opplevelsen for alle. DuckDuckGo ser aldri hvilke videoer du ser på, eller noen personlig identifiserbar informasjon. <annotation type="learn_more_link">Finn ut mer</annotation></string>
     <string name="ad_blocking_settings_description">DuckDuckGo blokkerer videoannonser på YouTube, slik at du kan se videoer uten avbrudd. <annotation type="learn_more_link">Finn ut mer</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Åpner videoer i en kinomodus som hindrer at det du ser på, påvirker YouTube-feeden din.</string>
+    <string name="ad_blocking_settings_duck_player_description">Åpner videoer i en distraksjonsfri kinomodus som hindrer at det du ser på påvirker YouTube-feeden din.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-nl/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-nl/strings-ad-blocking.xml
@@ -17,10 +17,10 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="ad_blocking_settings_title">Blokkering van YouTube-advertenties</string>
-    <string name="ad_blocking_settings_toggle_title">Blokkeer advertenties op YouTube</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo verwijdert videoadvertenties op YouTube, zodat je ongestoord video\'s kunt bekijken.\n\nAls deze optie is ingeschakeld, detecteert DuckDuckGo anoniem verstoring van advertentieblokkeringen of YouTube-fouten, om de ervaring voor iedereen te verbeteren. DuckDuckGo ziet niet welke video\'s je bekijkt of en heeft geen toegang tot je persoonlijk identificeerbare informatie. <annotation type="learn_more_link">Meer informatie</annotation></string>
-    <string name="ad_blocking_settings_description">DuckDuckGo verwijdert videoadvertenties op YouTube, zodat je ongestoord video\'s kunt bekijken. <annotation type="learn_more_link">Meer informatie</annotation></string>
+    <string name="ad_blocking_settings_title">YouTube-advertentieblokkering</string>
+    <string name="ad_blocking_settings_toggle_title">Advertenties op YouTube blokkeren</string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blokkeert videoadvertenties op YouTube, zodat je video\'s zonder onderbreking kunt bekijken.\n\nAls deze optie is ingeschakeld, detecteert DuckDuckGo anoniem verstoring van advertentieblokkeringen of YouTube-fouten, om de ervaring voor iedereen te verbeteren. DuckDuckGo ziet niet welke video\'s je bekijkt en heeft geen toegang tot je persoonlijk identificeerbare informatie. <annotation type="learn_more_link">Meer informatie</annotation></string>
+    <string name="ad_blocking_settings_description">DuckDuckGo blokkeert videoadvertenties op YouTube, zodat je video\'s zonder onderbreking kunt bekijken. <annotation type="learn_more_link">Meer informatie</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Opent video\'s in een afleidingsvrije theatermodus die voorkomt dat wat je bekijkt je YouTube-feed beïnvloedt.</string>
+    <string name="ad_blocking_settings_duck_player_description">Opent video\'s in een bioscoopmodus die voorkomt dat wat je bekijkt je YouTube-feed beïnvloedt.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-nl/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-nl/strings-ad-blocking.xml
@@ -17,10 +17,10 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="ad_blocking_settings_title">YouTube-advertentieblokkering</string>
-    <string name="ad_blocking_settings_toggle_title">Advertenties op YouTube blokkeren</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blokkeert videoadvertenties op YouTube, zodat je video\'s zonder onderbreking kunt bekijken.\n\nAls deze optie is ingeschakeld, detecteert DuckDuckGo anoniem verstoring van advertentieblokkeringen of YouTube-fouten, om de ervaring voor iedereen te verbeteren. DuckDuckGo ziet niet welke video\'s je bekijkt en heeft geen toegang tot je persoonlijk identificeerbare informatie. <annotation type="learn_more_link">Meer informatie</annotation></string>
+    <string name="ad_blocking_settings_title">Blokkering van YouTube-advertenties</string>
+    <string name="ad_blocking_settings_toggle_title">Blokkeer advertenties op YouTube</string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blokkeert videoadvertenties op YouTube, zodat je ongestoord video\'s kunt bekijken. \n\nAls deze optie is ingeschakeld, detecteert DuckDuckGo anoniem verstoring van advertentieblokkeringen of YouTube-fouten, om de ervaring voor iedereen te verbeteren. DuckDuckGo ziet niet welke video\'s je bekijkt en heeft geen toegang tot je persoonlijk identificeerbare informatie. <annotation type="learn_more_link">Meer informatie</annotation></string>
     <string name="ad_blocking_settings_description">DuckDuckGo blokkeert videoadvertenties op YouTube, zodat je video\'s zonder onderbreking kunt bekijken. <annotation type="learn_more_link">Meer informatie</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Opent video\'s in een bioscoopmodus die voorkomt dat wat je bekijkt je YouTube-feed beïnvloedt.</string>
+    <string name="ad_blocking_settings_duck_player_description">Opent video\'s in een afleidingsvrije theatermodus die voorkomt dat wat je bekijkt je YouTube-feed beïnvloedt.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-pl/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-pl/strings-ad-blocking.xml
@@ -17,10 +17,10 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="ad_blocking_settings_title">Blokowanie reklam na YouTube</string>
+    <string name="ad_blocking_settings_title">Blokowanie reklam w serwisie YouTube</string>
     <string name="ad_blocking_settings_toggle_title">Blokuj reklamy na YouTube</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blokuje reklamy wideo na YouTube, dzięki czemu możesz oglądać filmy bez przerw.\n\nPo włączeniu DuckDuckGo anonimowo wykrywa zakłócenia blokowania reklam lub błędy YouTube, aby poprawić wrażenia dla wszystkich. DuckDuckGo nigdy nie widzi filmów, jakie oglądasz, ani żadnych danych osobowych. <annotation type="learn_more_link">Dowiedz się więcej</annotation></string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blokuje reklamy wideo na YouTube, dzięki czemu możesz oglądać filmy bez przerw. \n\nPo włączeniu DuckDuckGo anonimowo wykrywa zakłócenia blokowania reklam lub błędy YouTube, aby poprawić wrażenia u wszystkich użytkowników. DuckDuckGo nigdy nie widzi filmów, jakie oglądasz, ani żadnych danych osobowych. <annotation type="learn_more_link">Dowiedz się więcej</annotation></string>
     <string name="ad_blocking_settings_description">DuckDuckGo blokuje reklamy wideo na YouTube, dzięki czemu możesz oglądać filmy bez przerw. <annotation type="learn_more_link">Dowiedz się więcej</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Otwiera filmy w trybie kinowym, dzięki czemu oglądane treści nie wpływają na Twój kanał na YouTube.</string>
+    <string name="ad_blocking_settings_duck_player_description">Otwiera filmy w trybie kinowym bez rozpraszania uwagi, który zapobiega wpływowi oglądania na Twój kanał YouTube.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-pt/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-pt/strings-ad-blocking.xml
@@ -19,8 +19,8 @@
 <resources>
     <string name="ad_blocking_settings_title">Bloqueio de anúncios do YouTube</string>
     <string name="ad_blocking_settings_toggle_title">Bloquear anúncios no YouTube</string>
-    <string name="ad_blocking_settings_description_with_consent">O DuckDuckGo bloqueia anúncios em vídeo no YouTube, para que possas ver vídeos sem interrupções.\n\nQuando ativado, o DuckDuckGo irá detetar anonimamente interferências no bloqueio de anúncios ou erros no YouTube, para melhorar a experiência de todos. O DuckDuckGo nunca vê os vídeos que vês nem nenhuma informação pessoal identificável. <annotation type="learn_more_link">Sabe mais</annotation></string>
-    <string name="ad_blocking_settings_description">O DuckDuckGo bloqueia anúncios em vídeo no YouTube, para que possas ver vídeos sem interrupções. <annotation type="learn_more_link">Sabe mais</annotation></string>
+    <string name="ad_blocking_settings_description_with_consent">O DuckDuckGo bloqueia anúncios de vídeo no YouTube para que possas ver vídeos sem interrupções.\n\nSe esta funcionalidade estiver ativada, o DuckDuckGo irá detetar anonimamente interferências no bloqueio de anúncios ou erros no YouTube, para melhorar a experiência de todos. O DuckDuckGo nunca vê quais os vídeos que tu vês nem qualquer informação pessoalmente identificável. <annotation type="learn_more_link">Sabe mais</annotation></string>
+    <string name="ad_blocking_settings_description">O DuckDuckGo bloqueia anúncios de vídeo no YouTube para que possas ver vídeos sem interrupções. <annotation type="learn_more_link">Sabe mais</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Abre vídeos num modo de cinema que impede que o que vês influencie o teu feed do YouTube.</string>
+    <string name="ad_blocking_settings_duck_player_description">Abre vídeos num modo de cinema sem distrações que impede que os vídeos que vês influenciem o teu feed do YouTube.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-ro/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-ro/strings-ad-blocking.xml
@@ -19,8 +19,8 @@
 <resources>
     <string name="ad_blocking_settings_title">Blocarea reclamelor pe YouTube</string>
     <string name="ad_blocking_settings_toggle_title">Blochează reclamele pe YouTube</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blochează reclamele video pe YouTube, astfel încât să poți viziona videoclipuri fără întrerupere.\n\nÎn cazul activării, DuckDuckGo va detecta anonim interferențele de blocare a reclamelor sau erorile YouTube, pentru a îmbunătăți experiența pentru toți utilizatorii. DuckDuckGo nu vede niciodată videoclipurile pe care le vizionezi sau orice informație de identificare personală. <annotation type="learn_more_link">Află mai multe</annotation></string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blochează reclamele video de pe YouTube, astfel încât să poți viziona videoclipuri fără întrerupere. \n\nCând este activat, DuckDuckGo va detecta anonim interferențele de blocare a reclamelor sau erorile YouTube pentru a îmbunătăți experiența tuturor utilizatorilor. DuckDuckGo nu vede niciodată videoclipurile pe care le vizionezi sau orice informații de identificare personală. <annotation type="learn_more_link">Află mai multe</annotation></string>
     <string name="ad_blocking_settings_description">DuckDuckGo blochează reclamele video pe YouTube, astfel încât să poți viziona videoclipuri fără întrerupere. <annotation type="learn_more_link">Află mai multe</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Deschide videoclipuri într-un mod cinematografic privat, care împiedică ceea ce vizionezi să îți influențeze feedul de pe YouTube.</string>
+    <string name="ad_blocking_settings_duck_player_description">Deschide videoclipurile într-un mod cinematografic fără distrageri, care te împiedică să influențezi fluxul de YouTube prin ceea ce vizionezi.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-ru/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-ru/strings-ad-blocking.xml
@@ -19,8 +19,8 @@
 <resources>
     <string name="ad_blocking_settings_title">Блокировка рекламы на YouTube</string>
     <string name="ad_blocking_settings_toggle_title">Блокировать рекламу на YouTube</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo блокирует видеорекламу на YouTube, чтобы вы могли смотреть видео без перерывов.\n\nЕсли функция включена, DuckDuckGo будет анонимно выявлять проблемы при блокировке рекламы и ошибки YouTube, чтобы улучшить работу сервиса для всех. DuckDuckGo не получает данные о просмотренных вами видео или ваши персональные данные. <annotation type="learn_more_link">Подробнее</annotation></string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo блокирует видеорекламу на YouTube, чтобы вы могли смотреть видео без перерывов. \n\nКогда эта функция включена, DuckDuckGo анонимно обнаруживает помехи при блокировке рекламы или ошибки YouTube, чтобы сделать работу удобнее для всех. DuckDuckGo никогда не видит, какие видео вы просматриваете, и не отслеживает никакую личную информацию, по которой вас можно идентифицировать. <annotation type="learn_more_link">Подробнее</annotation></string>
     <string name="ad_blocking_settings_description">DuckDuckGo блокирует видеорекламу на YouTube, чтобы вы могли смотреть видео без перерывов. <annotation type="learn_more_link">Подробнее</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Проигрыватель Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Открывает видео в режиме кинотеатра: ваши просмотры не влияют на ленту рекомендаций YouTube.</string>
+    <string name="ad_blocking_settings_duck_player_description">Открывает видео в режиме кинотеатра без отвлекающих элементов, чтобы просмотренные видео не влияли на вашу ленту YouTube.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-sk/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-sk/strings-ad-blocking.xml
@@ -19,8 +19,8 @@
 <resources>
     <string name="ad_blocking_settings_title">Blokovanie reklám na YouTube</string>
     <string name="ad_blocking_settings_toggle_title">Blokuje reklamy na YouTube</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blokuje videoreklamy na YouTube, takže môžeš sledovať videá bez prerušenia.\n\nKeď je zapnutá, DuckDuckGo anonymne zistí rušenie blokovania reklám alebo chyby na YouTube, aby zlepšil používateľský zážitok pre všetkých. DuckDuckGo nikdy nevidí, ktoré videá si pozeráš, ani žiadne osobné údaje. <annotation type="learn_more_link">Zisti viac</annotation></string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blokuje videoreklamy na YouTube, takže môžeš sledovať videá bez prerušenia.\n\nKeď je táto funkcia zapnutá, DuckDuckGo bude anonymne zisťovať rušenie blokovania reklám alebo chyby na YouTube, aby zlepšil používateľský zážitok pre všetkých. DuckDuckGo nikdy nevidí, ktoré videá si pozeráš, ani žiadne osobné údaje. <annotation type="learn_more_link">Zisti viac</annotation></string>
     <string name="ad_blocking_settings_description">DuckDuckGo blokuje videoreklamy na YouTube, takže môžeš sledovať videá bez prerušenia. <annotation type="learn_more_link">Zisti viac</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Otvára videá v režime prehrávania so súkromím, ktorý zabraňuje tomu, aby sledované položky ovplyvňovali tvoj YouTube kanál.</string>
+    <string name="ad_blocking_settings_duck_player_description">Otvára videá v režime kina bez rušivých vplyvov, ktorý zabraňuje tomu, aby sledované položky ovplyvňovali tvoj kanál YouTube.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-sk/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-sk/strings-ad-blocking.xml
@@ -19,8 +19,8 @@
 <resources>
     <string name="ad_blocking_settings_title">Blokovanie reklám na YouTube</string>
     <string name="ad_blocking_settings_toggle_title">Blokuje reklamy na YouTube</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo odstraňuje reklamy na videá v službe YouTube, takže môžeš sledovať videá bez prerušenia.\n\nKeď je táto funkcia zapnutá, DuckDuckGo anonymne zistí rušenie blokovania reklám alebo chyby na YouTube, aby zlepšil používateľský zážitok pre všetkých. DuckDuckGo nikdy nevidí, ktoré videá si pozeráš, ani žiadne osobné údaje. <annotation type="learn_more_link">Zisti viac</annotation></string>
-    <string name="ad_blocking_settings_description">DuckDuckGo odstraňuje reklamy na videá v službe YouTube, takže môžeš sledovať videá bez prerušenia. <annotation type="learn_more_link">Zisti viac</annotation></string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blokuje videoreklamy na YouTube, takže môžeš sledovať videá bez prerušenia.\n\nKeď je zapnutá, DuckDuckGo anonymne zistí rušenie blokovania reklám alebo chyby na YouTube, aby zlepšil používateľský zážitok pre všetkých. DuckDuckGo nikdy nevidí, ktoré videá si pozeráš, ani žiadne osobné údaje. <annotation type="learn_more_link">Zisti viac</annotation></string>
+    <string name="ad_blocking_settings_description">DuckDuckGo blokuje videoreklamy na YouTube, takže môžeš sledovať videá bez prerušenia. <annotation type="learn_more_link">Zisti viac</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Otvára videá v režime kina bez rušivých vplyvov, ktorý zabraňuje tomu, aby sledované položky ovplyvňovali tvoj kanál YouTube.</string>
+    <string name="ad_blocking_settings_duck_player_description">Otvára videá v režime prehrávania so súkromím, ktorý zabraňuje tomu, aby sledované položky ovplyvňovali tvoj YouTube kanál.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-sl/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-sl/strings-ad-blocking.xml
@@ -17,10 +17,10 @@
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
-    <string name="ad_blocking_settings_title">Blokiranje oglasov na YouTube</string>
-    <string name="ad_blocking_settings_toggle_title">Blokiraj oglase na YouTube</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blokira video oglase na YouTubu, tako da si lahko videoposnetke ogledate brez prekinitev.\n\nKo je to vklopljeno, DuckDuckGo anonimno zaznava motnje pri blokiranju oglasov ali napake v YouTubu, da izboljša izkušnjo za vse uporabnike. DuckDuckGo nikoli ne vidi, katere videoposnetke si ogledujete, niti nobenih osebnih podatkov. <annotation type="learn_more_link">Več o tem</annotation></string>
+    <string name="ad_blocking_settings_title">Blokiranje oglasov na YouTubu</string>
+    <string name="ad_blocking_settings_toggle_title">Blokiraj oglase na YouTubu</string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blokira video oglase na YouTubu, tako da si lahko videoposnetke ogledate brez prekinitev. \n\nKo je to vklopljeno, DuckDuckGo anonimno zaznava motnje pri blokiranju oglasov ali napake v YouTubu, da izboljša izkušnjo za vse uporabnike. DuckDuckGo nikoli ne vidi, katere videoposnetke si ogledujete, niti nobenih osebnih podatkov. <annotation type="learn_more_link">Več o tem</annotation></string>
     <string name="ad_blocking_settings_description">DuckDuckGo blokira video oglase na YouTubu, tako da si lahko videoposnetke ogledate brez prekinitev. <annotation type="learn_more_link">Več o tem</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Odpre videoposnetke v kinematografskem načinu, ki preprečuje, da bi vsebina, ki jo gledate, vplivala na vaš vir na YouTubu.</string>
+    <string name="ad_blocking_settings_duck_player_description">Videoposnetke odpre v načinu zasebnega kina, ki preprečuje, da bi vsebina, ki jo gledate, vplivala na vaša priporočila v YouTubu.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-sv/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-sv/strings-ad-blocking.xml
@@ -18,9 +18,9 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="ad_blocking_settings_title">Annonsblockering på YouTube</string>
-    <string name="ad_blocking_settings_toggle_title">Blockera annonser på YouTube</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo tar bort videoannonser på YouTube, så du kan titta på videor utan avbrott.\n\nNär det här alternativet är på identifierar DuckDuckGo anonymt störningar i annonsblockeringen eller YouTube-fel för att förbättra upplevelsen för dig och alla andra. DuckDuckGo ser aldrig vilka videor du tittar på eller någon personligt identifierbar information. <annotation type="learn_more_link">Läs mer</annotation></string>
-    <string name="ad_blocking_settings_description">DuckDuckGo tar bort videoannonser på YouTube, så du kan titta på videor utan avbrott. <annotation type="learn_more_link">Läs mer</annotation></string>
+    <string name="ad_blocking_settings_toggle_title">Annonsblockering på YouTube</string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blockerar videoannonser på YouTube, så du kan titta på videor utan avbrott.\n\nNär det här alternativet är på identifierar DuckDuckGo anonymt störningar i annonsblockeringen eller YouTube-fel för att förbättra upplevelsen för dig och alla andra. DuckDuckGo ser aldrig vilka videor du tittar på eller någon personligt identifierbar information. <annotation type="learn_more_link">Läs mer</annotation></string>
+    <string name="ad_blocking_settings_description">DuckDuckGo blockerar videoannonser på YouTube, så du kan titta på videor utan avbrott. <annotation type="learn_more_link">Läs mer</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Öppnar videor i ett störningsfritt visningsläge som förhindrar att det du tittar på påverkar ditt YouTube-flöde.</string>
+    <string name="ad_blocking_settings_duck_player_description">Öppnar videor i ett visningsläge som förhindrar att det du tittar på påverkar ditt YouTube-flöde.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-sv/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-sv/strings-ad-blocking.xml
@@ -18,9 +18,9 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="ad_blocking_settings_title">Annonsblockering på YouTube</string>
-    <string name="ad_blocking_settings_toggle_title">Annonsblockering på YouTube</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blockerar videoannonser på YouTube, så du kan titta på videor utan avbrott.\n\nNär det här alternativet är på identifierar DuckDuckGo anonymt störningar i annonsblockeringen eller YouTube-fel för att förbättra upplevelsen för dig och alla andra. DuckDuckGo ser aldrig vilka videor du tittar på eller någon personligt identifierbar information. <annotation type="learn_more_link">Läs mer</annotation></string>
+    <string name="ad_blocking_settings_toggle_title">Blockera annonser på YouTube</string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blockerar videoannonser på YouTube, så du kan titta på videor utan avbrott. \n\nNär det här alternativet är på identifierar DuckDuckGo anonymt störningar i annonsblockeringen eller YouTube-fel för att förbättra upplevelsen för dig och alla andra. DuckDuckGo ser aldrig vilka videor du tittar på eller någon personligt identifierbar information. <annotation type="learn_more_link">Läs mer</annotation></string>
     <string name="ad_blocking_settings_description">DuckDuckGo blockerar videoannonser på YouTube, så du kan titta på videor utan avbrott. <annotation type="learn_more_link">Läs mer</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Öppnar videor i ett visningsläge som förhindrar att det du tittar på påverkar ditt YouTube-flöde.</string>
+    <string name="ad_blocking_settings_duck_player_description">Öppnar videor i ett störningsfritt visningsläge som förhindrar att det du tittar på påverkar ditt YouTube-flöde.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-tr/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-tr/strings-ad-blocking.xml
@@ -18,9 +18,9 @@
 <!-- smartling.instruction_attributes = instruction -->
 <resources>
     <string name="ad_blocking_settings_title">YouTube\'da Reklam Engelleme</string>
-    <string name="ad_blocking_settings_toggle_title">YouTube\'da reklamları engelleyin</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo, YouTube\'daki video reklamlarını engelleyerek videoları kesintisiz izlemenizi sağlar.\n\nEtkinleştirildiğinde, DuckDuckGo herkesin deneyimini iyileştirmek için reklam engelleme müdahalesini veya YouTube hatalarını anonim olarak algılar. DuckDuckGo, hangi videoları izlediğinizi veya kişisel olarak tanımlanabilir bilgileri asla görmez. <annotation type="learn_more_link">Daha Fazla Bilgi</annotation></string>
-    <string name="ad_blocking_settings_description">DuckDuckGo, YouTube\'daki video reklamlarını engelleyerek videoları kesintisiz izlemenizi sağlar. <annotation type="learn_more_link">Daha Fazla Bilgi</annotation></string>
+    <string name="ad_blocking_settings_toggle_title">YouTube\'da Reklamları engelleyin</string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo, YouTube\'daki video reklamları engelleyerek videoları kesintisiz izlemenizi sağlar. \n\nEtkinleştirildiğinde, DuckDuckGo herkesin deneyimini iyileştirmek için reklam engelleme müdahalesini veya YouTube hatalarını anonim olarak algılar. DuckDuckGo, hangi videoları izlediğinizi veya kişisel olarak tanımlanabilir bilgileri asla görmez. <annotation type="learn_more_link">Daha fazla bilgi</annotation></string>
+    <string name="ad_blocking_settings_description">DuckDuckGo, YouTube\'daki video reklamlarını engelleyerek videoları kesintisiz izlemenizi sağlar. <annotation type="learn_more_link">Daha fazla bilgi</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
-    <string name="ad_blocking_settings_duck_player_description">Videoları sinema modunda açarak izlediğiniz içeriklerin YouTube akışınızı etkilemesini engeller.</string>
+    <string name="ad_blocking_settings_duck_player_description">Videoları, izlediğiniz içeriğin YouTube akışınızı etkilemesini engelleyen, dikkat dağıtıcı unsurlardan arındırılmış bir sinema moduyla açar.</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values/strings-ad-blocking.xml
@@ -18,7 +18,7 @@
 <resources>
     <string name="ad_blocking_settings_title">YouTube Ad Blocking</string>
     <string name="ad_blocking_settings_toggle_title">Block Ads on YouTube</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blocks video ads on YouTube, so you can watch videos without interruption. \n\nDuckDuckGo blocks video ads on YouTube, so you can watch videos without interruption. <annotation type="learn_more_link">Learn more</annotation></string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blocks video ads on YouTube, so you can watch videos without interruption. \n\nWhen on, DuckDuckGo will anonymously detect ad blocking interference or YouTube errors, to improve the experience for everyone. DuckDuckGo never sees which videos you view or any personally identifiable information. <annotation type="learn_more_link">Learn more</annotation></string>
     <string name="ad_blocking_settings_description">DuckDuckGo blocks video ads on YouTube, so you can watch videos without interruption. <annotation type="learn_more_link">Learn more</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Opens videos in a distraction-free theater mode that prevents what you watch from influencing your YouTube feed.</string>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values/strings-ad-blocking.xml
@@ -18,8 +18,8 @@
 <resources>
     <string name="ad_blocking_settings_title">YouTube Ad Blocking</string>
     <string name="ad_blocking_settings_toggle_title">Block Ads on YouTube</string>
-    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo removes video ads on YouTube, so you can watch videos without interruption.\n\nWhen this is on, DuckDuckGo will anonymously detect ad blocking interference or YouTube errors, to improve the experience for everyone. DuckDuckGo never sees which videos you view or any personally identifiable information. <annotation type="learn_more_link">Learn more</annotation></string>
-    <string name="ad_blocking_settings_description">DuckDuckGo removes video ads on YouTube, so you can watch videos without interruption. <annotation type="learn_more_link">Learn more</annotation></string>
+    <string name="ad_blocking_settings_description_with_consent">DuckDuckGo blocks video ads on YouTube, so you can watch videos without interruption. \n\nDuckDuckGo blocks video ads on YouTube, so you can watch videos without interruption. <annotation type="learn_more_link">Learn more</annotation></string>
+    <string name="ad_blocking_settings_description">DuckDuckGo blocks video ads on YouTube, so you can watch videos without interruption. <annotation type="learn_more_link">Learn more</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Opens videos in a distraction-free theater mode that prevents what you watch from influencing your YouTube feed.</string>
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212227266948491/task/1215826519845505?focus=true
Tech Design URL (if applicable): 

### Description

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-resource updates only; no application logic, APIs, or security-sensitive code changed.
> 
> **Overview**
> Updates **copy only** for YouTube ad-blocking settings across the default `strings-ad-blocking.xml` and many locale variants—no Kotlin or behavior changes.
> 
> The main messaging shift is **“removes” → “blocks”** (and equivalent translations) for video ads on YouTube in `ad_blocking_settings_description` and `ad_blocking_settings_description_with_consent`. English consent text also shortens **“When this is on”** to **“When on”**, with minor paragraph spacing tweaks in several locales.
> 
> **Duck Player** helper text is aligned to stress a **distraction-free theater mode** in locales that previously described plain theater mode. Additional locale-only edits cover titles, toggle labels, “learn more” links, and consent/privacy phrasing (e.g. German screen title, Danish/Norwegian/Swedish blocking vs removing wording).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff3d8df6a95c5875a6ef7478f91b0e13baca0171. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->