### PR TITLE
Subscriptions: Improve Back button experience

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -17,15 +17,12 @@
 package com.duckduckgo.subscriptions.impl
 
 import android.content.Context
-import android.content.Intent
 import android.content.SharedPreferences
 import android.net.Uri
-import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.core.net.toUri
 import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.app.di.AppCoroutineScope
-import com.duckduckgo.browser.api.ui.BrowserScreens.SettingsScreenNoParams
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.extensions.toTldPlusOne
 import com.duckduckgo.data.store.api.SharedPreferencesProvider
@@ -128,7 +125,10 @@ class RealSubscriptions @Inject constructor(
 
     override fun launchSubscription(context: Context, uri: Uri?) {
         val origin = uri?.getQueryParameter("origin")
-        val settings = globalActivityStarter.startIntent(context, SettingsScreenNoParams) ?: return
+        // Launch the subscription web view on top of the caller's task, with no Settings screen
+        // pre-stacked beneath it. The user returns to wherever they came from on a plain back; the
+        // subscription screen navigates to Settings itself only on completion (see
+        // SubscriptionsWebViewActivity.backToSettings).
         val subscriptionIntent = globalActivityStarter.startIntent(
             context,
             SubscriptionsWebViewActivityWithParams(
@@ -136,12 +136,7 @@ class RealSubscriptions @Inject constructor(
                 origin = origin,
             ),
         ) ?: return
-        val intents: Array<Intent> = listOf(settings, subscriptionIntent).toTypedArray<Intent>()
-        intents[0] = Intent(intents[0])
-        if (!ContextCompat.startActivities(context, intents)) {
-            val topIntent = Intent(intents[intents.size - 1])
-            context.startActivity(topIntent)
-        }
+        context.startActivity(subscriptionIntent)
         pixel.reportSubscriptionRedirect()
     }
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
@@ -686,7 +686,10 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
         if (params.url == subscriptionsUrlProvider.activateUrl) {
             setResult(RESULT_OK)
         } else {
-            globalActivityStarter.start(this, SettingsScreenNoParams)
+            globalActivityStarter.startIntent(this, SettingsScreenNoParams)?.let { intent ->
+                intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                startActivity(intent)
+            }
         }
         finish()
     }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
@@ -47,6 +47,7 @@ import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.SpecialUrlDetector
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.browser.api.ui.BrowserScreens.SettingsScreenNoParams
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.hide
@@ -684,6 +685,10 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
     private fun backToSettings() {
         if (params.url == subscriptionsUrlProvider.activateUrl) {
             setResult(RESULT_OK)
+        } else {
+            // Completion path (purchase success / restore): Settings is a forward destination reached
+            // only on completion, so we open it explicitly here.
+            globalActivityStarter.start(this, SettingsScreenNoParams)
         }
         finish()
     }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
@@ -515,7 +515,7 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
 
     private fun processCommand(command: Command) {
         when (command) {
-            is BackToSettings, BackToSettingsActivateSuccess -> backToSettings()
+            is BackToSettings, BackToSettingsActivateSuccess -> finishToSettings()
             is SendJsEvent -> sendJsEvent(command.event)
             is SendResponseToJs -> sendResponseToJs(command.data)
             is SubscriptionSelected -> selectSubscription(command.id, command.offerId, command.experimentName, command.experimentCohort)
@@ -614,7 +614,7 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
             .addEventListener(
                 object : TextAlertDialogBuilder.EventListener() {
                     override fun onPositiveButtonClicked() {
-                        finish()
+                        finishToSettings()
                     }
                 },
             )
@@ -632,7 +632,7 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
                         if (subscriptionEventData != null) {
                             subscriptionJsMessaging.sendSubscriptionEvent(subscriptionEventData)
                         } else {
-                            finish()
+                            finishToSettings()
                         }
                     }
                 },
@@ -682,16 +682,20 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
         subscriptionJsMessaging.onResponse(data)
     }
 
-    private fun backToSettings() {
+    private fun finishToSettings() {
         if (params.url == subscriptionsUrlProvider.activateUrl) {
             setResult(RESULT_OK)
         } else {
-            // Completion path (purchase success / restore): Settings is a forward destination reached
-            // only on completion, so we open it explicitly here.
             globalActivityStarter.start(this, SettingsScreenNoParams)
         }
         finish()
     }
+
+    private fun hasCompletedPurchaseFlow(): Boolean =
+        when (viewModel.currentPurchaseViewState.value.purchaseState) {
+            is PurchaseStateView.Success, PurchaseStateView.Waiting, PurchaseStateView.Recovered -> true
+            else -> false
+        }
 
     private val startForResultRestore = registerForActivityResult(StartActivityForResult()) { result: ActivityResult ->
         if (result.resultCode == RESULT_OK) {
@@ -729,6 +733,8 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
     override fun onBackPressed() {
         if (canGoBack()) {
             binding.webview.goBack()
+        } else if (hasCompletedPurchaseFlow()) {
+            finishToSettings()
         } else {
             super.onBackPressed()
         }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/RealSubscriptionsTest.kt
@@ -23,7 +23,6 @@ import androidx.core.net.toUri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import app.cash.turbine.test
-import com.duckduckgo.browser.api.ui.BrowserScreens.SettingsScreenNoParams
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
@@ -278,25 +277,23 @@ class RealSubscriptionsTest {
 
     @Test
     fun whenLaunchSubscriptionWithOriginThenPassTheOriginToActivity() = runTest {
-        whenever(globalActivityStarter.startIntent(any(), any<SettingsScreenNoParams>())).thenReturn(fakeIntent())
         whenever(globalActivityStarter.startIntent(any(), any<SubscriptionsWebViewActivityWithParams>())).thenReturn(fakeIntent())
 
         val captor = argumentCaptor<ActivityParams>()
         subscriptions.launchSubscription(context, "https://duckduckgo.com/pro?origin=test".toUri())
 
-        verify(globalActivityStarter, times(2)).startIntent(eq(context), captor.capture())
+        verify(globalActivityStarter, times(1)).startIntent(eq(context), captor.capture())
         assertEquals("test", (captor.lastValue as SubscriptionsWebViewActivityWithParams).origin)
     }
 
     @Test
     fun whenLaunchProUrlWithFeaturePageThenIncludeInSubscriptionURLToActivity() = runTest {
-        whenever(globalActivityStarter.startIntent(any(), any<SettingsScreenNoParams>())).thenReturn(fakeIntent())
         whenever(globalActivityStarter.startIntent(any(), any<SubscriptionsWebViewActivityWithParams>())).thenReturn(fakeIntent())
 
         val captor = argumentCaptor<ActivityParams>()
         subscriptions.launchSubscription(context, "https://duckduckgo.com/pro?featurePage=duckai".toUri())
 
-        verify(globalActivityStarter, times(2)).startIntent(eq(context), captor.capture())
+        verify(globalActivityStarter, times(1)).startIntent(eq(context), captor.capture())
         assertEquals(
             subscriptionsUrlProvider.buyUrl.appendQueryParams("featurePage=duckai"),
             (captor.lastValue as SubscriptionsWebViewActivityWithParams).url,
@@ -305,13 +302,12 @@ class RealSubscriptionsTest {
 
     @Test
     fun whenLaunchProWithMultipleQueryParametersThenTheyAreIncludedInSubscriptionURLToActivity() = runTest {
-        whenever(globalActivityStarter.startIntent(any(), any<SettingsScreenNoParams>())).thenReturn(fakeIntent())
         whenever(globalActivityStarter.startIntent(any(), any<SubscriptionsWebViewActivityWithParams>())).thenReturn(fakeIntent())
 
         val captor = argumentCaptor<ActivityParams>()
         subscriptions.launchSubscription(context, "https://duckduckgo.com/pro?usePaidDuckAi=true&featurePage=duckai".toUri())
 
-        verify(globalActivityStarter, times(2)).startIntent(eq(context), captor.capture())
+        verify(globalActivityStarter, times(1)).startIntent(eq(context), captor.capture())
         assertEquals(
             subscriptionsUrlProvider.buyUrl.appendQueryParams("usePaidDuckAi=true&featurePage=duckai"),
             (captor.lastValue as SubscriptionsWebViewActivityWithParams).url,
@@ -320,13 +316,12 @@ class RealSubscriptionsTest {
 
     @Test
     fun whenLaunchSubscriptionUrlWithFeaturePageThenIncludeInSubscriptionURLToActivity() = runTest {
-        whenever(globalActivityStarter.startIntent(any(), any<SettingsScreenNoParams>())).thenReturn(fakeIntent())
         whenever(globalActivityStarter.startIntent(any(), any<SubscriptionsWebViewActivityWithParams>())).thenReturn(fakeIntent())
 
         val captor = argumentCaptor<ActivityParams>()
         subscriptions.launchSubscription(context, "https://duckduckgo.com/subscriptions?featurePage=duckai".toUri())
 
-        verify(globalActivityStarter, times(2)).startIntent(eq(context), captor.capture())
+        verify(globalActivityStarter, times(1)).startIntent(eq(context), captor.capture())
         assertEquals(
             subscriptionsUrlProvider.buyUrl.appendQueryParams("featurePage=duckai"),
             (captor.lastValue as SubscriptionsWebViewActivityWithParams).url,
@@ -335,13 +330,12 @@ class RealSubscriptionsTest {
 
     @Test
     fun whenLaunchSubscriptionWithMultipleQueryParametersThenTheyAreIncludedInSubscriptionURLToActivity() = runTest {
-        whenever(globalActivityStarter.startIntent(any(), any<SettingsScreenNoParams>())).thenReturn(fakeIntent())
         whenever(globalActivityStarter.startIntent(any(), any<SubscriptionsWebViewActivityWithParams>())).thenReturn(fakeIntent())
 
         val captor = argumentCaptor<ActivityParams>()
         subscriptions.launchSubscription(context, "https://duckduckgo.com/subscriptions?usePaidDuckAi=true&featurePage=duckai".toUri())
 
-        verify(globalActivityStarter, times(2)).startIntent(eq(context), captor.capture())
+        verify(globalActivityStarter, times(1)).startIntent(eq(context), captor.capture())
         assertEquals(
             subscriptionsUrlProvider.buyUrl.appendQueryParams("usePaidDuckAi=true&featurePage=duckai"),
             (captor.lastValue as SubscriptionsWebViewActivityWithParams).url,
@@ -360,13 +354,12 @@ class RealSubscriptionsTest {
 
     @Test
     fun whenLaunchSubscriptionWithNoOriginThenDoNotPassTheOriginToActivity() = runTest {
-        whenever(globalActivityStarter.startIntent(any(), any<SettingsScreenNoParams>())).thenReturn(fakeIntent())
         whenever(globalActivityStarter.startIntent(any(), any<SubscriptionsWebViewActivityWithParams>())).thenReturn(fakeIntent())
 
         val captor = argumentCaptor<ActivityParams>()
         subscriptions.launchSubscription(context, "https://duckduckgo.com/pro".toUri())
 
-        verify(globalActivityStarter, times(2)).startIntent(eq(context), captor.capture())
+        verify(globalActivityStarter, times(1)).startIntent(eq(context), captor.capture())
         assertNull((captor.lastValue as SubscriptionsWebViewActivityWithParams).origin)
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1215248979171838?focus=true

### Description
Improve back behaviour in subscription screen

### Steps to test this PR

_Pre steps_
- [x] Apply patch on https://app.asana.com/1/137249556945/project/1209991789468715/task/1210448620621729?focus=true

_No purchase_
- [x] Instal from branch
- [x] Go to Settings > Onboarding Dev Settings
- [x] Toggle off DAX_INTRO_PRIVACY_PRO
- [x] Go back to browser where subscription dialog will appear
- [x] Tap on 'Learn More'
- [x] Exit subscription screen without finishing a purchase
- [x] Verify it gets back to the browser and no settings screen

_purchase success_
- [x] Go to Settings > Onboarding Dev Settings
- [x] Toggle off DAX_INTRO_PRIVACY_PRO
- [x] Go back to browser where subscription dialog will appear
- [x] Tap on 'Learn More'
- [x] Purchase a test subscription
- [x] Verify it now gets back to the settings screen

_restore success_
- [x] Remove account from device
- [x] Tap on 'I have a Subscription'
- [x] Tap on 'Add via Google Play Account'
- [x] Verify it now gets back to the settings screen


### No UI changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation-only changes in the subscriptions UI with no billing, auth, or data-handling logic modified; main risk is incorrect back-stack behavior in edge entry points.
> 
> **Overview**
> **Subscription launch** no longer pre-stacks Settings under the subscription web view. `launchSubscription` starts only `SubscriptionsWebViewActivity`, so dismissing without completing a purchase returns the user to the prior screen (e.g. browser) instead of Settings.
> 
> **Completion paths** route to Settings when appropriate. `backToSettings` is renamed to `finishToSettings`: for non-activate flows it starts Settings with `CLEAR_TOP` / `SINGLE_TOP` then finishes; activate URL still sets `RESULT_OK` only. Purchase success, recovered, and JS **BackToSettings** commands use this helper instead of a bare `finish()`.
> 
> **Hardware/toolbar back** after a completed purchase flow (success, waiting, or recovered) calls `finishToSettings()` when the WebView cannot go back, aligning back with post-purchase expectations. Unit tests for `launchSubscription` now expect a single `startIntent` (web view only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99f6629e06e8fd55a0cc0d17ea5bec9dc001df1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->