### PR TITLE
fix duck ai end cta copy for custom ai onboarding

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxDuckAiEndBrandDesignUpdateBubbleCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxDuckAiEndBrandDesignUpdateBubbleCta.kt
@@ -37,7 +37,11 @@ data class DaxDuckAiEndBrandDesignUpdateBubbleCta(
 ) : DaxBubbleCta.BrandDesignUpdateBubbleCta(
     ctaId = CtaId.DAX_DUCK_AI_END,
     title = R.string.onboardingDuckAiEndCtaTitle,
-    description = R.string.onboardingDuckAiEndCtaDescription,
+    description = if (onboardingStore.isCustomAiOnboardingFlow()) {
+        R.string.onboardingEndCustomAiFlowDaxDialogDescription
+    } else {
+        R.string.onboardingDuckAiEndCtaDescription
+    },
     backgroundRes = CommonR.drawable.bg_onboarding_end,
     shownPixel = AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
     okPixel = AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateBubbleCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateBubbleCta.kt
@@ -16,7 +16,6 @@
 
 package com.duckduckgo.app.cta.ui
 
-import android.content.Context
 import android.view.View
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.cta.model.CtaId
@@ -24,7 +23,6 @@ import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.common.ui.view.appendIconToText
 import com.duckduckgo.common.utils.device.DeviceInfo
 import com.google.android.material.button.MaterialButton
 import com.duckduckgo.mobile.android.R as CommonR
@@ -38,11 +36,7 @@ data class DaxEndBrandDesignUpdateBubbleCta(
 ) : DaxBubbleCta.BrandDesignUpdateBubbleCta(
     ctaId = CtaId.DAX_END,
     title = R.string.onboardingEndDaxDialogTitle,
-    description = if (onboardingStore.isCustomAiOnboardingFlow()) {
-        R.string.onboardingEndCustomAiFlowDaxDialogDescription
-    } else {
-        R.string.onboardingEndDaxDialogDescription
-    },
+    description = R.string.onboardingEndDaxDialogDescription,
     backgroundRes = CommonR.drawable.bg_onboarding_end,
     shownPixel = AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
     okPixel = AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
@@ -67,11 +61,4 @@ data class DaxEndBrandDesignUpdateBubbleCta(
     override fun configureContentViews(view: View) {
         view.findViewById<MaterialButton>(R.id.primaryCta)?.setText(R.string.onboardingEndDaxDialogButton)
     }
-
-    override fun decorateDescription(context: Context, text: CharSequence): CharSequence =
-        if (onboardingStore.isCustomAiOnboardingFlow()) {
-            context.appendIconToText(text, CommonR.drawable.ic_ai_chat_16)
-        } else {
-            text
-        }
 }


### PR DESCRIPTION
Fixes a regression in https://github.com/duckduckgo/Android/pull/8888. The PR introduced a new end CTA for DUck.ai flow, so the custom AI copy needs to move to it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding copy routing only; no auth, data, or core browser behavior changes.
> 
> **Overview**
> Fixes a regression where **custom AI onboarding** end messaging lived on the generic **Dax end** bubble after a separate **Duck AI end** CTA was added.
> 
> **`DaxDuckAiEndBrandDesignUpdateBubbleCta`** now picks the description from `onboardingStore.isCustomAiOnboardingFlow()`: custom flow uses `onboardingEndCustomAiFlowDaxDialogDescription`, otherwise the standard Duck AI end string.
> 
> **`DaxEndBrandDesignUpdateBubbleCta`** is simplified back to always using `onboardingEndDaxDialogDescription`, with the custom-flow branch and `decorateDescription` AI icon logic removed from that class.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8b07112b23f4a83c636a8d63a69b3fa0b7b788c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->