### PR TITLE
Don't tag tasks from hotfix as included in LGC

### DIFF
--- a/.github/workflows/nightly-orchestrator.yml
+++ b/.github/workflows/nightly-orchestrator.yml
@@ -116,7 +116,7 @@ jobs:
           echo "task_ids=$TASK_IDS" >> $GITHUB_OUTPUT
 
   move_tasks_in_lgc:
-    name: Move tasks to release candidate section
+    name: Tag tasks as LGC
     runs-on: ubuntu-latest
     needs: [ collect_lgc_tasks ]
     if: ${{ success() && needs.collect_lgc_tasks.outputs.task_ids != '[]' }}
@@ -125,6 +125,14 @@ jobs:
         task_id: ${{ fromJson(needs.collect_lgc_tasks.outputs.task_ids) }}
       fail-fast: false
     steps:
+      - name: Tag task as LGC
+        uses: duckduckgo/native-github-asana-sync@v2.5.1
+        with:
+          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana-project: ${{ vars.GH_ANDROID_RELEASE_BOARD_PROJECT_ID }}
+          asana-section: ${{ vars.GH_ANDROID_RELEASE_BOARD_WAITING_FOR_RELEASE_SECTION_ID }}
+          asana-task-id: ${{ matrix.task_id }}
+          action: 'add-task-asana-project'
       - name: Tag task as LGC
         uses: duckduckgo/native-github-asana-sync@v2.5.1
         with:

--- a/.github/workflows/nightly-orchestrator.yml
+++ b/.github/workflows/nightly-orchestrator.yml
@@ -125,7 +125,7 @@ jobs:
         task_id: ${{ fromJson(needs.collect_lgc_tasks.outputs.task_ids) }}
       fail-fast: false
     steps:
-      - name: Tag task as LGC
+      - name: Add task to project (no-op if already there)
         uses: duckduckgo/native-github-asana-sync@v2.5.1
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/scripts/release/asana_release_utils.py
+++ b/scripts/release/asana_release_utils.py
@@ -98,6 +98,17 @@ def get_latest_public_release_tag(repo_path: str) -> str | None:
     return tags[-1] if tags else None
 
 
+def is_ancestor(repo_path: str, ancestor: str, descendant: str) -> bool:
+    """
+    Return True if `ancestor` is reachable from `descendant` (i.e. all commits
+    reachable from `ancestor` are already in `descendant`'s history).
+    """
+    result = subprocess.run(
+        ["git", "-C", repo_path, "merge-base", "--is-ancestor", ancestor, descendant],
+    )
+    return result.returncode == 0
+
+
 def get_public_release_tag_before(repo_path: str, current_tag: str) -> str | None:
     """
     Return the public release tag immediately before `current_tag` by semantic version.

--- a/scripts/release/collect-lgc-asana-tasks.py
+++ b/scripts/release/collect-lgc-asana-tasks.py
@@ -16,6 +16,8 @@ from asana_release_utils import (
     extract_asana_task_links,
     extract_task_id_from_url,
     get_latest_public_release_tag,
+    get_public_release_tag_before,
+    is_ancestor,
 )
 
 
@@ -38,11 +40,16 @@ def main():
         required=True,
         help="Prefix for Asana task URLs in commit messages",
     )
+    parser.add_argument(
+        "--start-tag",
+        default=None,
+        help="Override the start tag (defaults to the latest public release)",
+    )
 
     args = parser.parse_args()
 
     try:
-        start_tag = get_latest_public_release_tag(args.android_repo_path)
+        start_tag = args.start_tag or get_latest_public_release_tag(args.android_repo_path)
         if not start_tag:
             log("Error: No public release tag found")
             return 1
@@ -56,10 +63,29 @@ def main():
         task_links = extract_asana_task_links(commits, args.trigger_phrase)
         task_links_with_url = [link for link in task_links if link.url]
 
-        task_ids = [extract_task_id_from_url(link.url) for link in task_links_with_url]
+        # If `start_tag` is not an ancestor of `end_commit` (e.g. a hotfix branch
+        # that hasn't been merged back to develop), commits unique to that branch
+        # still show up in `start_tag..end_commit`, so tasks they reference would
+        # be wrongly reported as new. Exclude task IDs already shipped in
+        # `prior_release..start_tag`.
+        already_released_task_ids: set[str] = set()
+        if not is_ancestor(args.android_repo_path, start_tag, args.end_commit):
+            prior_tag = get_public_release_tag_before(args.android_repo_path, start_tag)
+            if prior_tag:
+                prior_commits = get_commits_between(args.android_repo_path, prior_tag, start_tag)
+                prior_links = extract_asana_task_links(prior_commits, args.trigger_phrase)
+                already_released_task_ids = {
+                    extract_task_id_from_url(link.url) for link in prior_links if link.url
+                }
+
+        filtered_links = [
+            link for link in task_links_with_url
+            if extract_task_id_from_url(link.url) not in already_released_task_ids
+        ]
+        task_ids = [extract_task_id_from_url(link.url) for link in filtered_links]
 
         log(f"Found {len(task_ids)} Asana tasks")
-        for link in task_links_with_url:
+        for link in filtered_links:
             log(f"  - {link.commit_hash[:9]}: {link.url}")
 
         print(json.dumps(task_ids))

--- a/scripts/release/test_asana_release_utils.py
+++ b/scripts/release/test_asana_release_utils.py
@@ -7,6 +7,7 @@ from asana_release_utils import (
     get_public_release_tags,
     get_latest_public_release_tag,
     get_public_release_tag_before,
+    is_ancestor,
     extract_asana_task_links,
     resolve_task_id,
     _build_flexible_prefix_pattern,
@@ -245,3 +246,166 @@ class TestBuildFlexiblePrefixPattern:
     def test_slash_gets_flexible_whitespace(self):
         pattern = _build_flexible_prefix_pattern("Task/Issue URL:")
         assert r"\s*/\s*" in pattern
+
+
+# --- collect-lgc-asana-tasks main(): filtering tasks already in prior release ---
+
+
+import importlib.util
+import json
+import os
+import sys
+from io import StringIO
+
+
+def _load_collect_lgc_module():
+    """Load collect-lgc-asana-tasks.py as a module (the hyphenated filename
+    blocks a plain `import`)."""
+    path = os.path.join(os.path.dirname(__file__), "collect-lgc-asana-tasks.py")
+    spec = importlib.util.spec_from_file_location("collect_lgc_asana_tasks", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run_main(module, argv, *, new_commits, prior_release_commits, prior_tag,
+              start_is_ancestor=False):
+    """Invoke main() with mocked git lookups and capture stdout."""
+
+    def fake_commits_between(_repo, start, _end):
+        # `start` disambiguates the two ranges: prior_tag..start_tag vs start_tag..end.
+        return prior_release_commits if start == prior_tag else new_commits
+
+    captured = StringIO()
+    with patch.object(module, "get_latest_public_release_tag", return_value="5.283.1"), \
+         patch.object(module, "get_public_release_tag_before", return_value=prior_tag), \
+         patch.object(module, "is_ancestor", return_value=start_is_ancestor), \
+         patch.object(module, "get_commits_between", side_effect=fake_commits_between), \
+         patch.object(sys, "argv", argv), \
+         patch.object(sys, "stdout", captured):
+        rc = module.main()
+    return rc, captured.getvalue()
+
+
+class TestCollectLgcMainPriorReleaseFilter:
+    BASE_ARGV = [
+        "collect-lgc-asana-tasks.py",
+        "--end-commit", "HEAD",
+        "--android-repo-path", ".",
+        "--trigger-phrase", "Task/Issue URL:",
+    ]
+
+    def test_filters_out_task_already_in_prior_release(self):
+        module = _load_collect_lgc_module()
+        new_commits = [
+            _fake_commit("n1", "Task/Issue URL: https://app.asana.com/0/p/111"),
+            _fake_commit("n2", "Task/Issue URL: https://app.asana.com/0/p/222"),
+            _fake_commit("n3", "Task/Issue URL: https://app.asana.com/0/p/333"),
+        ]
+        prior_release_commits = [
+            _fake_commit("p1", "Task/Issue URL: https://app.asana.com/0/p/222"),
+        ]
+
+        rc, stdout = _run_main(
+            module, self.BASE_ARGV,
+            new_commits=new_commits,
+            prior_release_commits=prior_release_commits,
+            prior_tag="5.283.0",
+        )
+
+        assert rc == 0
+        assert json.loads(stdout.strip()) == ["111", "333"]
+
+    def test_no_prior_tag_skips_filter(self):
+        module = _load_collect_lgc_module()
+        new_commits = [
+            _fake_commit("n1", "Task/Issue URL: https://app.asana.com/0/p/111"),
+            _fake_commit("n2", "Task/Issue URL: https://app.asana.com/0/p/222"),
+        ]
+
+        rc, stdout = _run_main(
+            module, self.BASE_ARGV,
+            new_commits=new_commits,
+            prior_release_commits=[],
+            prior_tag=None,
+        )
+
+        assert rc == 0
+        assert json.loads(stdout.strip()) == ["111", "222"]
+
+    def test_no_overlap_keeps_all_new_tasks(self):
+        module = _load_collect_lgc_module()
+        new_commits = [
+            _fake_commit("n1", "Task/Issue URL: https://app.asana.com/0/p/111"),
+            _fake_commit("n2", "Task/Issue URL: https://app.asana.com/0/p/222"),
+        ]
+        prior_release_commits = [
+            _fake_commit("p1", "Task/Issue URL: https://app.asana.com/0/p/999"),
+        ]
+
+        rc, stdout = _run_main(
+            module, self.BASE_ARGV,
+            new_commits=new_commits,
+            prior_release_commits=prior_release_commits,
+            prior_tag="5.283.0",
+        )
+
+        assert rc == 0
+        assert json.loads(stdout.strip()) == ["111", "222"]
+
+    def test_start_tag_override_used_as_start(self):
+        module = _load_collect_lgc_module()
+        new_commits = [
+            _fake_commit("n1", "Task/Issue URL: https://app.asana.com/0/p/111"),
+        ]
+
+        with patch.object(module, "get_latest_public_release_tag") as mock_latest, \
+             patch.object(module, "get_public_release_tag_before", return_value=None), \
+             patch.object(module, "is_ancestor", return_value=True), \
+             patch.object(module, "get_commits_between", return_value=new_commits), \
+             patch.object(sys, "argv", self.BASE_ARGV + ["--start-tag", "5.283.1"]), \
+             patch.object(sys, "stdout", StringIO()):
+            rc = module.main()
+
+        assert rc == 0
+        # When --start-tag is provided, the latest-tag lookup should be skipped.
+        mock_latest.assert_not_called()
+
+    def test_filter_skipped_when_start_tag_is_ancestor(self):
+        """For a normal release, start_tag is an ancestor of end_commit, so
+        `start_tag..end` already excludes prior-release commits — the explicit
+        filter is unnecessary and should be skipped."""
+        module = _load_collect_lgc_module()
+        new_commits = [
+            _fake_commit("n1", "Task/Issue URL: https://app.asana.com/0/p/111"),
+            _fake_commit("n2", "Task/Issue URL: https://app.asana.com/0/p/222"),
+        ]
+
+        captured = StringIO()
+        with patch.object(module, "get_latest_public_release_tag", return_value="5.283.0"), \
+             patch.object(module, "get_public_release_tag_before") as mock_prior, \
+             patch.object(module, "is_ancestor", return_value=True), \
+             patch.object(module, "get_commits_between", return_value=new_commits), \
+             patch.object(sys, "argv", self.BASE_ARGV), \
+             patch.object(sys, "stdout", captured):
+            rc = module.main()
+
+        assert rc == 0
+        assert json.loads(captured.getvalue().strip()) == ["111", "222"]
+        # When start_tag IS an ancestor, we don't need to look up the prior tag.
+        mock_prior.assert_not_called()
+
+
+# --- is_ancestor ---
+
+
+class TestIsAncestor:
+    @patch("asana_release_utils.subprocess.run")
+    def test_returns_true_when_exit_code_zero(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+        assert is_ancestor(".", "5.283.0", "HEAD") is True
+
+    @patch("asana_release_utils.subprocess.run")
+    def test_returns_false_when_exit_code_nonzero(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=1)
+        assert is_ancestor(".", "5.283.1", "HEAD") is False


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211760946270935/task/1215767779355614?focus=true
Tech Design URL (if applicable): 

### Description
* Filter out tasks from hotfix before manipulating them
* Before tagging tasks, add them to the release board (waiting for release)
   * If the task is already there, this is a no-op, so no notifications will be triggered
### Steps to test this PR

_Feature 1_
- [ ] Manually run `scripts/release/collect-lgc-asana-tasks.py --end-commit 4e0f10ba52c40837d90aa26f1d9f5739e7cf4284 --android-repo-path . --trigger-phrase "Task/Issue URL:" --start-tag 5.283.1` and check 12 tasks are returned, not 13
- [ ] Optionally, run the tests



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to release scripting and Asana automation; behavior is covered by new unit tests, with low blast radius if git ancestry detection is correct.
> 
> **Overview**
> Fixes **LGC Asana task collection** so tasks already shipped on a hotfix branch are not marked as newly contained in LGC when that hotfix tag is not merged into the nightly commit’s history.
> 
> When the latest public release tag is **not** an ancestor of the end commit, the collector now gathers task IDs from the prior release through that start tag and **drops** any of those IDs from the LGC candidate list. A new **`is_ancestor`** git helper and optional **`--start-tag`** override support that logic; normal releases skip the extra filter when the start tag is already on the end commit’s history.
> 
> The **nightly orchestrator** job that updates Asana now **adds each task to the release board** (“waiting for release”) before setting the LGC custom field—a no-op if the task is already on the board—and the job label reflects **tagging as LGC** rather than moving sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80bfafc4ee5f14a6fa339f57539670b2b86bd467. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->