### PR TITLE
fix native input showing in expanded, unfocused state on NTP

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2812,6 +2812,14 @@ class BrowserTabFragment :
                 hideKeyboard()
             }
 
+            is Command.DropAddressBarFocus -> {
+                if (nativeInputManager.isNativeInputEnabled()) {
+                    nativeInputManager.hideNativeInput()
+                } else {
+                    hideKeyboard()
+                }
+            }
+
             is Command.ShowToast -> {
                 Toast.makeText(requireActivity(), it.textResId, Toast.LENGTH_LONG).show()
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3620,7 +3620,7 @@ class BrowserTabViewModel @Inject constructor(
         logcat { "shouldHideKeyboard: $shouldHideKeyboard" }
 
         command.value = if (shouldHideKeyboard) {
-            HideKeyboard
+            Command.DropAddressBarFocus
         } else {
             alreadyShownKeyboard = true
             ShowKeyboard

--- a/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
@@ -101,6 +101,8 @@ sealed class Command {
 
     data object HideKeyboardForChat : Command()
 
+    data object DropAddressBarFocus : Command()
+
     class ShowFullScreen(
         val view: View,
     ) : Command()

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -1112,7 +1112,7 @@ class BrowserTabViewModelTest {
 
             testee.onViewVisible()
 
-            assertCommandIssued<HideKeyboard>()
+            assertCommandIssued<Command.DropAddressBarFocus>()
         }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1215834913145830?focus=true
Tech Design URL (if applicable): 

### Description
Fixes a case where the native input stayed expanded but unfocused after onboarding finishes.

The fix introduces a distinct `DropAddressBarFocus` event, separate from generic `HideKeyboard` events. Fragment respects it by either dropping omnibar focus or hiding the native input widget, depending on which is enabled.

Keyboard handling is currently fairly messy: several paths conflate cases that should only hide the keyboard with cases that should also drop address bar focus, and every permutation is now multiplied by the native input. I'm deliberately not untangling all of those paths here - this is a narrow, focused fix. But it also introduces a clearer event type that defines address bar focus (whether the old omnibar or the native input widget) as something universally respected taht we can use to further clean up in the future.

### Steps to test this PR

- [ ] Clean install the app.
- [ ] Verify that by the end of onboarding, after seeing the widget bottom sheet promo, the address bar remains unfocused, collapsed, and keyboard is not visible.
- [ ] Regression testing:
  - [ ] Navigate the app, open/close the address bar, send queries and verify that keyboards behaves as expected.
  - [ ] Disable native input and repeat regression testing.
```diff
diff --git a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
index 45cf70f5b6..bcdddd1ff4 100644
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -133,8 +133,7 @@ interface DuckChatFeature {
     /**
      * @return `true` when the Native Input Field should be used instead of the web-based input.
      */
-    @InternalAlwaysEnabled
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun nativeInputField(): Toggle
 
     /**
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow UX fix in keyboard/focus command handling on the home screen; other `HideKeyboard` call sites are unchanged.
> 
> **Overview**
> Fixes the native input staying **expanded but unfocused** on the new tab page after onboarding (e.g. after the widget bottom sheet promo).
> 
> **`DropAddressBarFocus`** is added as a command distinct from **`HideKeyboard`**. When home/CTA logic decides the keyboard should stay hidden on repeat NTP visits (split omnibar path in **`showOrHideKeyboard`**), the ViewModel now emits **`DropAddressBarFocus`** instead of **`HideKeyboard`**.
> 
> **`BrowserTabFragment`** handles that command by calling **`hideNativeInput()`** when the native input is enabled, otherwise **`hideKeyboard()`**—so “dismiss address bar focus” covers both omnibar and native input without treating every hide-keyboard path the same.
> 
> Tests expect **`DropAddressBarFocus`** where **`HideKeyboard`** was previously asserted for the second **`onViewVisible()`** case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff67c00b81315a29a10f75c41f8637ba0ce4c167. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->