### PR TITLE
Edgetoedge autofill - sync - VPN

### DIFF
--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/DuckDuckGoActivity.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/DuckDuckGoActivity.kt
@@ -61,6 +61,8 @@ abstract class DuckDuckGoActivity : DaggerActivity() {
 
     private var themeChangeReceiver: BroadcastReceiver? = null
 
+    private var displayCutoutModeManaged = false
+
     @SuppressLint("MissingSuperCall")
     override fun onCreate(savedInstanceState: Bundle?) {
         onCreate(savedInstanceState, true)
@@ -139,8 +141,13 @@ abstract class DuckDuckGoActivity : DaggerActivity() {
      * Sets the window's display-cutout mode from [orientation]: in landscape the window avoids the
      * cutout (the notch/camera area is reserved as a black letterbox), in portrait it keeps the
      * default behaviour and draws normally around the (typically top-centre) cutout.
+     *
+     * Calling this marks the cutout mode as managed, so it is re-applied on rotation via
+     * [onConfigurationChanged] for activities that declare `android:configChanges` and are not
+     * recreated. Non-edge-to-edge screens never call this, so their cutout stays at the platform default.
      */
     protected fun applyDisplayCutoutMode(orientation: Int) {
+        displayCutoutModeManaged = true
         if (Build.VERSION.SDK_INT >= 28) {
             window.attributes = window.attributes.apply {
                 layoutInDisplayCutoutMode = if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
@@ -149,6 +156,16 @@ abstract class DuckDuckGoActivity : DaggerActivity() {
                     WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT
                 }
             }
+        }
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        // Activities declaring android:configChanges (e.g. orientation) are not recreated on rotation,
+        // so re-apply the cutout mode here. Only screens that applied it once (edge-to-edge) are managed;
+        // others keep the platform default. Subclasses overriding this must call super.
+        if (displayCutoutModeManaged) {
+            applyDisplayCutoutMode(newConfig.orientation)
         }
     }
 

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/DuckDuckGoActivity.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/DuckDuckGoActivity.kt
@@ -21,10 +21,13 @@ import android.app.UiModeManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.pm.ActivityInfo
+import android.content.res.Configuration
 import android.graphics.Color
+import android.os.Build
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
+import android.view.WindowManager
 import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.widget.Toolbar
@@ -129,6 +132,24 @@ abstract class DuckDuckGoActivity : DaggerActivity() {
             SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT)
         }
         enableEdgeToEdge(statusBarStyle = barStyle, navigationBarStyle = barStyle)
+        applyDisplayCutoutMode(resources.configuration.orientation)
+    }
+
+    /**
+     * Sets the window's display-cutout mode from [orientation]: in landscape the window avoids the
+     * cutout (the notch/camera area is reserved as a black letterbox), in portrait it keeps the
+     * default behaviour and draws normally around the (typically top-centre) cutout.
+     */
+    protected fun applyDisplayCutoutMode(orientation: Int) {
+        if (Build.VERSION.SDK_INT >= 28) {
+            window.attributes = window.attributes.apply {
+                layoutInDisplayCutoutMode = if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
+                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_NEVER
+                } else {
+                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT
+                }
+            }
+        }
     }
 
     protected inline fun <reified V : ViewModel> bindViewModel() = lazy {

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ui/ManageRecentAppsProtectionActivity.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ui/ManageRecentAppsProtectionActivity.kt
@@ -33,6 +33,9 @@ import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.common.utils.extensions.launchAlwaysOnSystemSettings
 import com.duckduckgo.common.utils.extensions.launchIgnoreBatteryOptimizationSettings
 import com.duckduckgo.di.scopes.ActivityScope
@@ -76,6 +79,10 @@ class ManageRecentAppsProtectionActivity :
 
     @Inject lateinit var appBuildConfig: AppBuildConfig
 
+    @Inject lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val binding: ActivityManageRecentAppsProtectionBinding by viewBinding()
 
     private val viewModel: ManageAppsProtectionViewModel by bindViewModel()
@@ -88,6 +95,10 @@ class ManageRecentAppsProtectionActivity :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.VPN)
+        if (edgeToEdgeEnabled) {
+            enableTransparentEdgeToEdge()
+        }
 
         reportBreakage = registerForActivityResult(reportBreakageContract.get()) { result ->
             if (!result.isEmpty()) {
@@ -102,7 +113,17 @@ class ManageRecentAppsProtectionActivity :
         bindViews()
         observeViewModel()
 
+        if (edgeToEdgeEnabled) {
+            configureEdgeToEdgeInsets()
+        }
+
         lifecycle.addObserver(viewModel)
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.rootContainer)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.contentScrollView, drawBehindGestureNav = true)
     }
 
     override fun onDestroy() {

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ui/TrackingProtectionExclusionListActivity.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/apps/ui/TrackingProtectionExclusionListActivity.kt
@@ -38,6 +38,9 @@ import com.duckduckgo.common.ui.view.getColorFromAttr
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature
 import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature.APPTP_VPN
@@ -89,6 +92,10 @@ class TrackingProtectionExclusionListActivity :
 
     @Inject lateinit var dispatcherProvider: DispatcherProvider
 
+    @Inject lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val binding: ActivityTrackingProtectionExclusionListBinding by viewBinding()
 
     private val viewModel: ManageAppsProtectionViewModel by bindViewModel()
@@ -101,6 +108,10 @@ class TrackingProtectionExclusionListActivity :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.VPN)
+        if (edgeToEdgeEnabled) {
+            enableTransparentEdgeToEdge()
+        }
 
         reportBreakage = registerForActivityResult(reportBreakageContract.get()) { result ->
             if (!result.isEmpty()) {
@@ -115,11 +126,21 @@ class TrackingProtectionExclusionListActivity :
         bindViews()
         observeViewModel()
 
+        if (edgeToEdgeEnabled) {
+            configureEdgeToEdgeInsets()
+        }
+
         viewModel.applyAppsFilter(getAppsFilterOrDefault())
 
         deviceShieldPixels.didShowExclusionListActivity()
 
         lifecycle.addObserver(viewModel)
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.rootContainer)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.excludedAppsRecycler, drawBehindGestureNav = true)
     }
 
     override fun onDestroy() {

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/breakage/ReportBreakageAppListActivity.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/breakage/ReportBreakageAppListActivity.kt
@@ -39,6 +39,9 @@ import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.getColorFromAttr
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.mobile.android.vpn.R
 import com.duckduckgo.mobile.android.vpn.databinding.ActivityReportBreakageAppListBinding
@@ -70,6 +73,12 @@ class ReportBreakageAppListActivity : DuckDuckGoActivity(), ReportBreakageAppLis
     @AppTpBreakageCategories
     lateinit var breakageCategories: List<AppBreakageCategory>
 
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val viewModel: ReportBreakageAppListViewModel by bindViewModel()
 
     private lateinit var adapter: ReportBreakageAppListAdapter
@@ -87,6 +96,10 @@ class ReportBreakageAppListActivity : DuckDuckGoActivity(), ReportBreakageAppLis
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.VPN)
+        if (edgeToEdgeEnabled) {
+            enableTransparentEdgeToEdge()
+        }
 
         reportBreakage = registerForActivityResult(reportBreakageContract.get()) { result ->
             if (!result.isEmpty()) {
@@ -109,6 +122,16 @@ class ReportBreakageAppListActivity : DuckDuckGoActivity(), ReportBreakageAppLis
 
         setupViews()
         observeViewModel()
+
+        if (edgeToEdgeEnabled) {
+            configureEdgeToEdgeInsets()
+        }
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.rootContainer)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyNavigationBarInsetsAsMargin(binding.ctaSubmitAppBreakage)
     }
 
     override fun onStart() {

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/breakage/ReportBreakageCategorySingleChoiceActivity.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/breakage/ReportBreakageCategorySingleChoiceActivity.kt
@@ -28,6 +28,9 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.dialog.RadioListAlertDialogBuilder
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.mobile.android.vpn.R
 import com.duckduckgo.mobile.android.vpn.breakage.ReportBreakageCategorySingleChoiceViewModel.Command
@@ -51,6 +54,10 @@ class ReportBreakageCategorySingleChoiceActivity : DuckDuckGoActivity() {
 
     @Inject lateinit var metadataReporter: ReportBreakageMetadataReporter
 
+    @Inject lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val binding: ActivityReportBreakageCategorySingleChoiceBinding by viewBinding()
     private val viewModel: ReportBreakageCategorySingleChoiceViewModel by bindViewModel()
 
@@ -61,6 +68,10 @@ class ReportBreakageCategorySingleChoiceActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.VPN)
+        if (edgeToEdgeEnabled) {
+            enableTransparentEdgeToEdge()
+        }
 
         // The value should never be "unknown" we just do this because getParcelableExtra returns
         // nullable
@@ -76,6 +87,16 @@ class ReportBreakageCategorySingleChoiceActivity : DuckDuckGoActivity() {
         configureObservers()
         setupToolbar(toolbar)
         setupViews()
+
+        if (edgeToEdgeEnabled) {
+            configureEdgeToEdgeInsets()
+        }
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.rootContainer)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyNavigationBarInsetsAsMargin(binding.ctaNextFormSubmit)
     }
 
     override fun onStart() {

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/VpnOnboardingActivity.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/onboarding/VpnOnboardingActivity.kt
@@ -33,6 +33,9 @@ import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.getColorFromAttr
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.common.utils.extensions.launchAlwaysOnSystemSettings
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.mobile.android.app.tracking.ui.AppTrackingProtectionScreens.AppTrackerOnboardingActivityWithEmptyParamsParams
@@ -71,16 +74,34 @@ class VpnOnboardingActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var globalActivityStarter: GlobalActivityStarter
 
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val viewModel: VpnOnboardingViewModel by bindViewModel()
     private val binding: ActivityVpnOnboardingBinding by viewBinding()
 
     @Suppress("DEPRECATION")
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.VPN)
+        if (edgeToEdgeEnabled) {
+            enableTransparentEdgeToEdge()
+        }
 
         setContentView(binding.root)
         configureUI()
+        if (edgeToEdgeEnabled) {
+            configureEdgeToEdgeInsets()
+        }
         observeViewModel()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyStatusBarAndHorizontalInsets(binding.onboardingRoot)
+        edgeToEdgeHandler.applyNavigationBarInsetsAsMargin(binding.onboardingNextCta)
     }
 
     private fun configureUI() {

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/privacyreport/DeviceShieldAppTrackersInfo.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/privacyreport/DeviceShieldAppTrackersInfo.kt
@@ -22,6 +22,9 @@ import android.os.Bundle
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.mobile.android.vpn.databinding.ActivityAppTrackersInfoBinding
 import com.duckduckgo.mobile.android.vpn.pixels.DeviceShieldPixels
@@ -32,15 +35,34 @@ class DeviceShieldAppTrackersInfo : DuckDuckGoActivity() {
     @Inject
     lateinit var deviceShieldPixels: DeviceShieldPixels
 
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val binding: ActivityAppTrackersInfoBinding by viewBinding()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.VPN)
+        if (edgeToEdgeEnabled) {
+            enableTransparentEdgeToEdge()
+        }
 
         setContentView(binding.root)
         setupToolbar(binding.includeToolbar.toolbar)
+        if (edgeToEdgeEnabled) {
+            configureEdgeToEdgeInsets()
+        }
 
         deviceShieldPixels.privacyReportArticleDisplayed()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.bookmarkRootView)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.contentScrollView, drawBehindGestureNav = true)
     }
 
     override fun onSupportNavigateUp(): Boolean {

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/AppTPCompanyTrackersActivity.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/AppTPCompanyTrackersActivity.kt
@@ -40,6 +40,9 @@ import com.duckduckgo.common.ui.view.setEnabledOpacity
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.common.utils.extensions.safeGetApplicationIcon
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.mobile.android.vpn.AppTpVpnFeature
@@ -93,6 +96,12 @@ class AppTPCompanyTrackersActivity : DuckDuckGoActivity() {
     @AppTpBreakageCategories
     lateinit var breakageCategories: List<AppBreakageCategory>
 
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val binding: ActivityApptpCompanyTrackersActivityBinding by viewBinding()
     private val viewModel: AppTPCompanyTrackersViewModel by bindViewModel()
 
@@ -110,6 +119,10 @@ class AppTPCompanyTrackersActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.VPN)
+        if (edgeToEdgeEnabled) {
+            enableTransparentEdgeToEdge()
+        }
 
         reportBreakage = registerForActivityResult(reportBreakageContract.get()) {
             if (!it.isEmpty()) {
@@ -126,6 +139,9 @@ class AppTPCompanyTrackersActivity : DuckDuckGoActivity() {
                 .error(TextDrawable.asIconDrawable(getAppName()))
                 .into(appIcon)
         }
+        if (edgeToEdgeEnabled) {
+            configureEdgeToEdgeInsets()
+        }
 
         binding.trackingLearnMore.addClickableLink("learn_more_link", getText(R.string.atp_CompanyDetailsTrackingLearnMore)) {
             globalActivityStarter.start(
@@ -141,6 +157,12 @@ class AppTPCompanyTrackersActivity : DuckDuckGoActivity() {
         binding.activityRecyclerView.adapter = itemsAdapter
 
         pixels.didOpenCompanyTrackersScreen()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.root)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.contentScrollView, drawBehindGestureNav = true)
     }
 
     private fun observeViewModel() {

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldMostRecentActivity.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldMostRecentActivity.kt
@@ -22,19 +22,42 @@ import android.os.Bundle
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.mobile.android.vpn.databinding.ActivityDeviceShieldAllTracerActivityBinding
+import javax.inject.Inject
 
 @InjectWith(ActivityScope::class)
 class DeviceShieldMostRecentActivity : DuckDuckGoActivity() {
+
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
 
     private val binding: ActivityDeviceShieldAllTracerActivityBinding by viewBinding()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.VPN)
+        if (edgeToEdgeEnabled) {
+            enableTransparentEdgeToEdge()
+        }
 
         setContentView(binding.root)
         setupToolbar(binding.includeToolbar.toolbar)
+        if (edgeToEdgeEnabled) {
+            configureEdgeToEdgeInsets()
+        }
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.activityList, drawBehindGestureNav = true)
     }
 
     override fun onBackPressed() {

--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivity.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/ui/tracker_activity/DeviceShieldTrackerActivity.kt
@@ -49,6 +49,9 @@ import com.duckduckgo.common.ui.view.quietlySetIsChecked
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.common.utils.extensions.launchAlwaysOnSystemSettings
 import com.duckduckgo.common.utils.plugins.ActivePlugin
 import com.duckduckgo.common.utils.plugins.ActivePluginPoint
@@ -117,6 +120,12 @@ class DeviceShieldTrackerActivity :
     @Inject
     lateinit var appTPStateMessagePluginPoint: ActivePluginPoint<AppTPStateMessagePlugin>
 
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val binding: ActivityDeviceShieldActivityBinding by viewBinding()
 
     private lateinit var deviceShieldSwitch: DaxSwitch
@@ -153,6 +162,10 @@ class DeviceShieldTrackerActivity :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.VPN)
+        if (edgeToEdgeEnabled) {
+            enableTransparentEdgeToEdge()
+        }
 
         reportBreakage =
             registerForActivityResult(reportBreakageContract.get()) {
@@ -163,12 +176,21 @@ class DeviceShieldTrackerActivity :
 
         setContentView(binding.root)
         setupToolbar(binding.includeToolbar.trackersToolbar)
+        if (edgeToEdgeEnabled) {
+            configureEdgeToEdgeInsets()
+        }
 
         bindViews()
         showDeviceShieldActivity()
         observeViewModel()
 
         deviceShieldPixels.didShowSummaryTrackerActivity()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.root)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.contentScrollView, drawBehindGestureNav = true)
     }
 
     private fun bindViews() {

--- a/app-tracking-protection/vpn-impl/src/main/res/layout/activity_app_trackers_info.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/layout/activity_app_trackers_info.xml
@@ -31,6 +31,7 @@
         layout="@layout/include_default_toolbar"/>
 
     <ScrollView
+        android:id="@+id/contentScrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:scrollbars="none">

--- a/app-tracking-protection/vpn-impl/src/main/res/layout/activity_apptp_company_trackers_activity.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/layout/activity_apptp_company_trackers_activity.xml
@@ -29,9 +29,10 @@
         layout="@layout/include_company_trackers_toolbar"/>
 
     <androidx.core.widget.NestedScrollView
+        android:id="@+id/contentScrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:clipToPadding="false"
+        android:clipToPadding="true"
         android:fillViewport="true">
 
         <LinearLayout

--- a/app-tracking-protection/vpn-impl/src/main/res/layout/activity_device_shield_activity.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/layout/activity_device_shield_activity.xml
@@ -29,6 +29,7 @@
         layout="@layout/include_trackers_toolbar" />
 
     <androidx.core.widget.NestedScrollView
+        android:id="@+id/contentScrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:fillViewport="true">

--- a/app-tracking-protection/vpn-impl/src/main/res/layout/activity_device_shield_all_tracer_activity.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/layout/activity_device_shield_all_tracer_activity.xml
@@ -19,6 +19,7 @@
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"

--- a/app-tracking-protection/vpn-impl/src/main/res/layout/activity_manage_recent_apps_protection.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/layout/activity_manage_recent_apps_protection.xml
@@ -18,6 +18,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/rootContainer"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -29,6 +30,7 @@
         app:layout_constraintTop_toTopOf="parent"/>
 
     <androidx.core.widget.NestedScrollView
+        android:id="@+id/contentScrollView"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/app-tracking-protection/vpn-impl/src/main/res/layout/activity_report_breakage_app_list.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/layout/activity_report_breakage_app_list.xml
@@ -18,6 +18,7 @@
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
         xmlns:tools="http://schemas.android.com/tools"
+        android:id="@+id/rootContainer"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="?attr/daxColorSurface"

--- a/app-tracking-protection/vpn-impl/src/main/res/layout/activity_report_breakage_category_single_choice.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/layout/activity_report_breakage_category_single_choice.xml
@@ -20,6 +20,7 @@
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools"
         xmlns:app="http://schemas.android.com/apk/res-auto"
+        android:id="@+id/rootContainer"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical"

--- a/app-tracking-protection/vpn-impl/src/main/res/layout/activity_tracking_protection_exclusion_list.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/layout/activity_tracking_protection_exclusion_list.xml
@@ -18,6 +18,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/rootContainer"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -70,8 +71,7 @@
             android:id="@+id/excludedAppsRecycler"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:clipToPadding="false"
-            android:paddingBottom="@dimen/keyline_2"
+            android:clipToPadding="true"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             tools:listItem="@layout/view_device_shield_excluded_app_entry"/>
 

--- a/app-tracking-protection/vpn-impl/src/main/res/layout/activity_vpn_onboarding.xml
+++ b/app-tracking-protection/vpn-impl/src/main/res/layout/activity_vpn_onboarding.xml
@@ -20,6 +20,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/onboardingRoot"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="com.duckduckgo.mobile.android.vpn.ui.onboarding.VpnOnboardingActivity"

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -1333,9 +1333,6 @@ open class BrowserActivity : DuckDuckGoActivity() {
         if (newConfig.orientation == Configuration.ORIENTATION_LANDSCAPE) {
             viewModel.sendPixelEventForLandscapeOrientation()
         }
-        if (edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BROWSER)) {
-            applyDisplayCutoutMode(newConfig.orientation)
-        }
     }
 
     private fun hideMockupOmnibar() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -33,7 +33,6 @@ import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
 import android.view.View.IMPORTANT_FOR_AUTOFILL_YES
-import android.view.WindowManager
 import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.SystemBarStyle
@@ -414,7 +413,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
             }
             enableEdgeToEdge(statusBarStyle = barStyle, navigationBarStyle = barStyle)
             edgeToEdgeHandler.applyStatusBarAndHorizontalInsets(binding.root)
-            updateLayoutForDisplayCutout(resources.configuration.orientation)
+            edgeToEdgeHandler.applyDisplayCutoutMode(window, resources.configuration.orientation)
         }
 
         setContentView(binding.root)
@@ -1335,19 +1334,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
             viewModel.sendPixelEventForLandscapeOrientation()
         }
         if (edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BROWSER)) {
-            updateLayoutForDisplayCutout(newConfig.orientation)
-        }
-    }
-
-    private fun updateLayoutForDisplayCutout(orientation: Int) {
-        if (Build.VERSION.SDK_INT >= 28) {
-            window.attributes = window.attributes.apply {
-                layoutInDisplayCutoutMode = if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
-                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_NEVER
-                } else {
-                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT
-                }
-            }
+            edgeToEdgeHandler.applyDisplayCutoutMode(window, newConfig.orientation)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -413,7 +413,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
             }
             enableEdgeToEdge(statusBarStyle = barStyle, navigationBarStyle = barStyle)
             edgeToEdgeHandler.applyStatusBarAndHorizontalInsets(binding.root)
-            edgeToEdgeHandler.applyDisplayCutoutMode(window, resources.configuration.orientation)
+            applyDisplayCutoutMode(resources.configuration.orientation)
         }
 
         setContentView(binding.root)
@@ -1334,7 +1334,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
             viewModel.sendPixelEventForLandscapeOrientation()
         }
         if (edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BROWSER)) {
-            edgeToEdgeHandler.applyDisplayCutoutMode(window, newConfig.orientation)
+            applyDisplayCutoutMode(newConfig.orientation)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabActivity.kt
@@ -73,7 +73,7 @@ class CustomTabActivity : DuckDuckGoActivity() {
             }
             enableEdgeToEdge(statusBarStyle = barStyle, navigationBarStyle = barStyle)
             edgeToEdgeHandler.applyStatusBarAndHorizontalInsets(binding.root)
-            edgeToEdgeHandler.applyDisplayCutoutMode(window, resources.configuration.orientation)
+            applyDisplayCutoutMode(resources.configuration.orientation)
         }
 
         setContentView(binding.root)
@@ -137,7 +137,7 @@ class CustomTabActivity : DuckDuckGoActivity() {
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
         if (edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BROWSER)) {
-            edgeToEdgeHandler.applyDisplayCutoutMode(window, newConfig.orientation)
+            applyDisplayCutoutMode(newConfig.orientation)
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabActivity.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.app.browser.customtabs
 
 import android.content.Context
 import android.content.Intent
-import android.content.res.Configuration
 import android.os.Bundle
 import android.os.Message
 import androidx.activity.OnBackPressedCallback
@@ -132,13 +131,6 @@ class CustomTabActivity : DuckDuckGoActivity() {
         val transaction = supportFragmentManager.beginTransaction()
         transaction.replace(R.id.fragmentTabContainer, fragment, viewState.tabId)
         transaction.commit()
-    }
-
-    override fun onConfigurationChanged(newConfig: Configuration) {
-        super.onConfigurationChanged(newConfig)
-        if (edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BROWSER)) {
-            applyDisplayCutoutMode(newConfig.orientation)
-        }
     }
 
     companion object {

--- a/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabActivity.kt
@@ -19,10 +19,8 @@ package com.duckduckgo.app.browser.customtabs
 import android.content.Context
 import android.content.Intent
 import android.content.res.Configuration
-import android.os.Build
 import android.os.Bundle
 import android.os.Message
-import android.view.WindowManager
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.SystemBarStyle
 import androidx.activity.enableEdgeToEdge
@@ -75,7 +73,7 @@ class CustomTabActivity : DuckDuckGoActivity() {
             }
             enableEdgeToEdge(statusBarStyle = barStyle, navigationBarStyle = barStyle)
             edgeToEdgeHandler.applyStatusBarAndHorizontalInsets(binding.root)
-            updateLayoutForDisplayCutout(resources.configuration.orientation)
+            edgeToEdgeHandler.applyDisplayCutoutMode(window, resources.configuration.orientation)
         }
 
         setContentView(binding.root)
@@ -139,19 +137,7 @@ class CustomTabActivity : DuckDuckGoActivity() {
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
         if (edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BROWSER)) {
-            updateLayoutForDisplayCutout(newConfig.orientation)
-        }
-    }
-
-    private fun updateLayoutForDisplayCutout(orientation: Int) {
-        if (Build.VERSION.SDK_INT >= 28) {
-            window.attributes = window.attributes.apply {
-                layoutInDisplayCutoutMode = if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
-                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_NEVER
-                } else {
-                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT
-                }
-            }
+            edgeToEdgeHandler.applyDisplayCutoutMode(window, newConfig.orientation)
         }
     }
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillManagementActivity.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillManagementActivity.kt
@@ -72,6 +72,9 @@ import com.duckduckgo.common.ui.view.hideKeyboard
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.view.showKeyboard
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.getActivityParams
 import com.google.android.material.snackbar.Snackbar
@@ -95,6 +98,12 @@ class AutofillManagementActivity : DuckDuckGoActivity(), PasswordsScreenPromotio
     @Inject
     lateinit var pixel: Pixel
 
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -102,10 +111,26 @@ class AutofillManagementActivity : DuckDuckGoActivity(), PasswordsScreenPromotio
             window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
         }
 
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.AUTOFILL)
+        if (edgeToEdgeEnabled) {
+            enableTransparentEdgeToEdge()
+        }
+
         setContentView(binding.root)
         setupToolbar(binding.toolbar)
+
+        if (edgeToEdgeEnabled) {
+            configureEdgeToEdgeInsets()
+        }
+
         observeViewModel()
         sendLaunchPixel(savedInstanceState)
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.appBarLayout)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.fragmentContainerView, drawBehindGestureNav = true)
     }
 
     private fun sendLaunchPixel(savedInstanceState: Bundle?) {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/ImportPasswordsActivity.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/ImportPasswordsActivity.kt
@@ -28,6 +28,9 @@ import com.duckduckgo.autofill.impl.ui.credential.management.importpassword.desk
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.common.utils.extensions.html
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
@@ -48,6 +51,12 @@ class ImportPasswordsActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var pixel: Pixel
 
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     val syncActivityLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
         viewModel.userReturnedFromSyncSettings()
     }
@@ -55,13 +64,29 @@ class ImportPasswordsActivity : DuckDuckGoActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.AUTOFILL)
+        if (edgeToEdgeEnabled) {
+            enableTransparentEdgeToEdge()
+        }
+
         setContentView(binding.root)
         setupToolbar(binding.includeToolbar.toolbar)
+
+        if (edgeToEdgeEnabled) {
+            configureEdgeToEdgeInsets()
+        }
+
         configureEventHandlers()
         configureNumberedInstructions()
         if (savedInstanceState == null) {
             viewModel.userLaunchedScreen()
         }
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.contentScrollView, drawBehindGestureNav = true)
     }
 
     private fun configureEventHandlers() {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/desktopapp/ImportPasswordsGetDesktopAppActivity.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/importpassword/desktopapp/ImportPasswordsGetDesktopAppActivity.kt
@@ -33,6 +33,9 @@ import com.duckduckgo.autofill.impl.ui.credential.management.importpassword.desk
 import com.duckduckgo.autofill.impl.ui.credential.management.importpassword.desktopapp.ImportPasswordsGetDesktopAppViewModel.Command.ShowCopiedNotification
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
@@ -58,8 +61,19 @@ class ImportPasswordsGetDesktopAppActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var globalActivityStarter: GlobalActivityStarter
 
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.AUTOFILL)
+        if (edgeToEdgeEnabled) {
+            enableTransparentEdgeToEdge()
+        }
 
         viewModel.commands.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
             .onEach { executeCommand(it) }
@@ -67,7 +81,18 @@ class ImportPasswordsGetDesktopAppActivity : DuckDuckGoActivity() {
 
         setContentView(binding.root)
         setupToolbar(binding.includeToolbar.toolbar)
+
+        if (edgeToEdgeEnabled) {
+            configureEdgeToEdgeInsets()
+        }
+
         configureUiEventHandlers()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.contentScrollView, drawBehindGestureNav = true)
     }
 
     private fun configureUiEventHandlers() {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/settings/AutofillSettingsActivity.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/settings/AutofillSettingsActivity.kt
@@ -50,6 +50,9 @@ import com.duckduckgo.common.ui.view.button.ButtonType.GHOST_ALT
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.prependIconToText
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.navigation.api.getActivityParams
@@ -63,6 +66,12 @@ class AutofillSettingsActivity : DuckDuckGoActivity() {
 
     @Inject
     lateinit var globalActivityStarter: GlobalActivityStarter
+
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
 
     val binding: ActivityAutofillSettingsBinding by viewBinding()
     private val viewModel: AutofillSettingsViewModel by bindViewModel()
@@ -89,13 +98,29 @@ class AutofillSettingsActivity : DuckDuckGoActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.AUTOFILL)
+        if (edgeToEdgeEnabled) {
+            enableTransparentEdgeToEdge()
+        }
+
         setContentView(binding.root)
         setupToolbar(binding.includeToolbar.toolbar)
         setTitle(R.string.autofillSettingsActivityTitle)
+
+        if (edgeToEdgeEnabled) {
+            configureEdgeToEdgeInsets()
+        }
+
         observeViewModel()
         configureViewListeners()
         configureInfoText()
         sendLaunchPixel(savedInstanceState)
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.viewSwitcher, drawBehindGestureNav = true)
     }
 
     private fun sendLaunchPixel(savedInstanceState: Bundle?) {

--- a/autofill/autofill-impl/src/main/res/layout/activity_get_desktop_app.xml
+++ b/autofill/autofill-impl/src/main/res/layout/activity_get_desktop_app.xml
@@ -26,6 +26,7 @@
         layout="@layout/include_default_toolbar" />
 
     <androidx.core.widget.NestedScrollView
+        android:id="@+id/contentScrollView"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:fillViewport="true"

--- a/autofill/autofill-impl/src/main/res/layout/activity_import_passwords.xml
+++ b/autofill/autofill-impl/src/main/res/layout/activity_import_passwords.xml
@@ -26,6 +26,7 @@
         layout="@layout/include_default_toolbar" />
 
     <androidx.core.widget.NestedScrollView
+        android:id="@+id/contentScrollView"
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintStart_toStartOf="parent"

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeBucket.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeBucket.kt
@@ -24,4 +24,5 @@ enum class EdgeToEdgeBucket {
     SETTINGS,
     AUTOFILL,
     SYNC,
+    VPN,
 }

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeBucket.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeBucket.kt
@@ -22,4 +22,5 @@ package com.duckduckgo.common.utils.edgetoedge
 enum class EdgeToEdgeBucket {
     BROWSER,
     SETTINGS,
+    AUTOFILL,
 }

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeBucket.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeBucket.kt
@@ -23,4 +23,5 @@ enum class EdgeToEdgeBucket {
     BROWSER,
     SETTINGS,
     AUTOFILL,
+    SYNC,
 }

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeFeature.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeFeature.kt
@@ -38,4 +38,7 @@ interface EdgeToEdgeFeature {
 
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun autofill(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun sync(): Toggle
 }

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeFeature.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeFeature.kt
@@ -35,4 +35,7 @@ interface EdgeToEdgeFeature {
 
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun settings(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun autofill(): Toggle
 }

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeFeature.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeFeature.kt
@@ -41,4 +41,7 @@ interface EdgeToEdgeFeature {
 
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun sync(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun vpn(): Toggle
 }

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeHandler.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeHandler.kt
@@ -16,12 +16,8 @@
 
 package com.duckduckgo.common.utils.edgetoedge
 
-import android.content.res.Configuration
-import android.os.Build
 import android.view.View
 import android.view.ViewGroup
-import android.view.Window
-import android.view.WindowManager
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.doOnAttach
@@ -153,29 +149,6 @@ class EdgeToEdgeHandler @Inject constructor() {
             insets
         }
         ViewCompat.requestApplyInsets(view)
-    }
-
-    /**
-     * Sets [window]'s display-cutout mode from [orientation]: in landscape the window avoids the
-     * cutout (the notch/camera area is reserved as a black letterbox), in portrait it keeps the
-     * default behaviour and draws normally around the (typically top-centre) cutout.
-     *
-     * @param window The activity window whose layout params are updated.
-     * @param orientation A [Configuration] orientation, e.g. [Configuration.ORIENTATION_LANDSCAPE].
-     */
-    fun applyDisplayCutoutMode(
-        window: Window,
-        orientation: Int,
-    ) {
-        if (Build.VERSION.SDK_INT >= 28) {
-            window.attributes = window.attributes.apply {
-                layoutInDisplayCutoutMode = if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
-                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_NEVER
-                } else {
-                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT
-                }
-            }
-        }
     }
 
     private fun View.applyInsets(apply: (WindowInsetsCompat) -> Unit) {

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeHandler.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeHandler.kt
@@ -16,8 +16,12 @@
 
 package com.duckduckgo.common.utils.edgetoedge
 
+import android.content.res.Configuration
+import android.os.Build
 import android.view.View
 import android.view.ViewGroup
+import android.view.Window
+import android.view.WindowManager
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.doOnAttach
@@ -149,6 +153,29 @@ class EdgeToEdgeHandler @Inject constructor() {
             insets
         }
         ViewCompat.requestApplyInsets(view)
+    }
+
+    /**
+     * Sets [window]'s display-cutout mode from [orientation]: in landscape the window avoids the
+     * cutout (the notch/camera area is reserved as a black letterbox), in portrait it keeps the
+     * default behaviour and draws normally around the (typically top-centre) cutout.
+     *
+     * @param window The activity window whose layout params are updated.
+     * @param orientation A [Configuration] orientation, e.g. [Configuration.ORIENTATION_LANDSCAPE].
+     */
+    fun applyDisplayCutoutMode(
+        window: Window,
+        orientation: Int,
+    ) {
+        if (Build.VERSION.SDK_INT >= 28) {
+            window.attributes = window.attributes.apply {
+                layoutInDisplayCutoutMode = if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
+                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_NEVER
+                } else {
+                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT
+                }
+            }
+        }
     }
 
     private fun View.applyInsets(apply: (WindowInsetsCompat) -> Unit) {

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/RealEdgeToEdgeProvider.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/RealEdgeToEdgeProvider.kt
@@ -46,6 +46,7 @@ class RealEdgeToEdgeProvider @Inject constructor(
                 edgeToEdgeFeature.self().isEnabled()
                 edgeToEdgeFeature.browser().isEnabled()
                 edgeToEdgeFeature.settings().isEnabled()
+                edgeToEdgeFeature.autofill().isEnabled()
             }
         }
     }
@@ -54,6 +55,7 @@ class RealEdgeToEdgeProvider @Inject constructor(
         val bucketToggle = when (bucket) {
             EdgeToEdgeBucket.BROWSER -> edgeToEdgeFeature.browser()
             EdgeToEdgeBucket.SETTINGS -> edgeToEdgeFeature.settings()
+            EdgeToEdgeBucket.AUTOFILL -> edgeToEdgeFeature.autofill()
         }
         bucketToggle.isEnabled()
     } else {

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/RealEdgeToEdgeProvider.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/RealEdgeToEdgeProvider.kt
@@ -48,6 +48,7 @@ class RealEdgeToEdgeProvider @Inject constructor(
                 edgeToEdgeFeature.settings().isEnabled()
                 edgeToEdgeFeature.autofill().isEnabled()
                 edgeToEdgeFeature.sync().isEnabled()
+                edgeToEdgeFeature.vpn().isEnabled()
             }
         }
     }
@@ -58,6 +59,7 @@ class RealEdgeToEdgeProvider @Inject constructor(
             EdgeToEdgeBucket.SETTINGS -> edgeToEdgeFeature.settings()
             EdgeToEdgeBucket.AUTOFILL -> edgeToEdgeFeature.autofill()
             EdgeToEdgeBucket.SYNC -> edgeToEdgeFeature.sync()
+            EdgeToEdgeBucket.VPN -> edgeToEdgeFeature.vpn()
         }
         bucketToggle.isEnabled()
     } else {

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/RealEdgeToEdgeProvider.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/RealEdgeToEdgeProvider.kt
@@ -47,6 +47,7 @@ class RealEdgeToEdgeProvider @Inject constructor(
                 edgeToEdgeFeature.browser().isEnabled()
                 edgeToEdgeFeature.settings().isEnabled()
                 edgeToEdgeFeature.autofill().isEnabled()
+                edgeToEdgeFeature.sync().isEnabled()
             }
         }
     }
@@ -56,6 +57,7 @@ class RealEdgeToEdgeProvider @Inject constructor(
             EdgeToEdgeBucket.BROWSER -> edgeToEdgeFeature.browser()
             EdgeToEdgeBucket.SETTINGS -> edgeToEdgeFeature.settings()
             EdgeToEdgeBucket.AUTOFILL -> edgeToEdgeFeature.autofill()
+            EdgeToEdgeBucket.SYNC -> edgeToEdgeFeature.sync()
         }
         bucketToggle.isEnabled()
     } else {

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/exclusion/ui/NetpAppExclusionListActivity.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/exclusion/ui/NetpAppExclusionListActivity.kt
@@ -33,6 +33,9 @@ import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.mobile.android.vpn.VpnFeaturesRegistry
 import com.duckduckgo.navigation.api.GlobalActivityStarter
@@ -76,6 +79,12 @@ class NetpAppExclusionListActivity :
     @Inject
     lateinit var globalActivityStarter: GlobalActivityStarter
 
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private lateinit var adapter: AppExclusionListAdapter
 
     private val binding: ActivityNetpAppExclusionBinding by viewBinding()
@@ -85,14 +94,28 @@ class NetpAppExclusionListActivity :
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.VPN)
+        if (edgeToEdgeEnabled) {
+            enableTransparentEdgeToEdge()
+        }
+
         setContentView(binding.root)
         setupToolbar(binding.includeToolbar.toolbar)
+        if (edgeToEdgeEnabled) {
+            configureEdgeToEdgeInsets()
+        }
 
         bindViews()
         observeViewModel()
 
         viewModel.applyAppsFilter(AppsFilter.ALL)
         lifecycle.addObserver(viewModel)
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.netpAppExclusionListRecycler, drawBehindGestureNav = true)
     }
 
     override fun onDestroy() {

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/management/NetworkProtectionManagementActivity.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/management/NetworkProtectionManagementActivity.kt
@@ -41,6 +41,9 @@ import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.common.utils.extensions.isPrivateDnsStrict
 import com.duckduckgo.common.utils.extensions.launchAlwaysOnSystemSettings
 import com.duckduckgo.di.scopes.ActivityScope
@@ -95,6 +98,12 @@ class NetworkProtectionManagementActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var dispatcherProvider: DispatcherProvider
 
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val binding: ActivityNetpManagementBinding by viewBinding()
     private val viewModel: NetworkProtectionManagementViewModel by bindViewModel()
     private val vpnPermissionRequestActivityResult =
@@ -115,8 +124,16 @@ class NetworkProtectionManagementActivity : DuckDuckGoActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.VPN)
+        if (edgeToEdgeEnabled) {
+            enableTransparentEdgeToEdge()
+        }
+
         setContentView(binding.root)
         setupToolbar(binding.includeToolbar.toolbar)
+        if (edgeToEdgeEnabled) {
+            configureEdgeToEdgeInsets()
+        }
         bindViews()
         intent.getActivityParams(NetworkProtectionManagementScreenAndEnable::class.java)?.enable?.let { shouldEnable ->
             if (shouldEnable) {
@@ -130,6 +147,12 @@ class NetworkProtectionManagementActivity : DuckDuckGoActivity() {
 
         observeViewModel()
         lifecycle.addObserver(viewModel)
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.contentScrollView, drawBehindGestureNav = true)
     }
 
     override fun onDestroy() {

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/settings/geoswitching/NetpGeoswitchingActivity.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/settings/geoswitching/NetpGeoswitchingActivity.kt
@@ -28,6 +28,9 @@ import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.networkprotection.impl.R
@@ -38,20 +41,44 @@ import com.duckduckgo.networkprotection.impl.settings.geoswitching.NetpGeoSwitch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
 
 @InjectWith(ActivityScope::class)
 @ContributeToActivityStarter(NetpGeoswitchingScreenNoParams::class)
 class NetpGeoswitchingActivity : DuckDuckGoActivity() {
+
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val binding: ActivityNetpGeoswitchingBinding by viewBinding()
     private val viewModel: NetpGeoSwitchingViewModel by bindViewModel()
     private var lastSelectedButton: CompoundButton? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.VPN)
+        if (edgeToEdgeEnabled) {
+            enableTransparentEdgeToEdge()
+        }
+
         setContentView(binding.root)
         setupToolbar(binding.includeToolbar.toolbar)
+        if (edgeToEdgeEnabled) {
+            configureEdgeToEdgeInsets()
+        }
+
         observeViewModel()
         lifecycle.addObserver(viewModel)
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.contentScrollView, drawBehindGestureNav = true)
     }
 
     override fun onDestroy() {

--- a/network-protection/network-protection-impl/src/main/res/layout/activity_netp_app_exclusion.xml
+++ b/network-protection/network-protection-impl/src/main/res/layout/activity_netp_app_exclusion.xml
@@ -66,8 +66,7 @@
         android:id="@+id/netp_app_exclusion_list_recycler"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:clipToPadding="false"
-        android:paddingBottom="@dimen/keyline_2"
+        android:clipToPadding="true"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         tools:listItem="@layout/view_device_shield_excluded_app_entry" />
 </LinearLayout>

--- a/network-protection/network-protection-impl/src/main/res/layout/activity_netp_geoswitching.xml
+++ b/network-protection/network-protection-impl/src/main/res/layout/activity_netp_geoswitching.xml
@@ -25,6 +25,7 @@
         layout="@layout/include_default_toolbar" />
 
     <androidx.core.widget.NestedScrollView
+        android:id="@+id/contentScrollView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 

--- a/network-protection/network-protection-impl/src/main/res/layout/activity_netp_management.xml
+++ b/network-protection/network-protection-impl/src/main/res/layout/activity_netp_management.xml
@@ -25,6 +25,7 @@
         layout="@layout/include_default_toolbar" />
 
     <androidx.core.widget.NestedScrollView
+        android:id="@+id/contentScrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/SyncGetOnOtherPlatformsActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/SyncGetOnOtherPlatformsActivity.kt
@@ -27,6 +27,9 @@ import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.navigation.api.getActivityParams
@@ -54,8 +57,19 @@ class SyncGetOnOtherPlatformsActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var globalActivityStarter: GlobalActivityStarter
 
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.SYNC)
+        if (edgeToEdgeEnabled) {
+            enableTransparentEdgeToEdge()
+        }
 
         viewModel.commands.flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
             .onEach { executeCommand(it) }
@@ -67,10 +81,21 @@ class SyncGetOnOtherPlatformsActivity : DuckDuckGoActivity() {
 
         setContentView(binding.root)
         setupToolbar(binding.includeToolbar.toolbar)
+
+        if (edgeToEdgeEnabled) {
+            configureEdgeToEdgeInsets()
+        }
+
         configureUiEventHandlers()
         if (savedInstanceState == null) {
             viewModel.onScreenShownToUser(extractLaunchSource())
         }
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.contentScrollView, drawBehindGestureNav = true)
     }
 
     private fun configureUiEventHandlers() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/DeviceUnsupportedActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/DeviceUnsupportedActivity.kt
@@ -22,13 +22,23 @@ import android.os.Bundle
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.sync.impl.databinding.ActivityDeviceUnsupportedBinding
+import javax.inject.Inject
 
 @InjectWith(ActivityScope::class)
 class DeviceUnsupportedActivity : DuckDuckGoActivity() {
 
     private val binding: ActivityDeviceUnsupportedBinding by viewBinding()
+
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
 
     private val toolbar
         get() = binding.includeToolbar.toolbar
@@ -36,8 +46,23 @@ class DeviceUnsupportedActivity : DuckDuckGoActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.SYNC)
+        if (edgeToEdgeEnabled) {
+            enableTransparentEdgeToEdge()
+        }
+
         setContentView(binding.root)
         setupToolbar(toolbar)
+
+        if (edgeToEdgeEnabled) {
+            configureEdgeToEdgeInsets()
+        }
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.contentContainer, drawBehindGestureNav = true)
     }
 
     companion object {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
@@ -87,7 +87,7 @@ class EnterCodeActivity : DuckDuckGoActivity() {
     private fun configureEdgeToEdgeInsets() {
         edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
         edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
-        edgeToEdgeHandler.applyNavigationBarInsets(binding.pasteCodeButton, drawBehindGestureNav = true)
+        edgeToEdgeHandler.applyNavigationBarInsetsAsMargin(binding.pasteCodeButton)
     }
 
     private fun configureListeners() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
@@ -29,6 +29,9 @@ import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.hide
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.databinding.ActivityEnterCodeBinding
@@ -43,24 +46,48 @@ import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.SwitchAccountSucce
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.ViewState
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
 
 @InjectWith(ActivityScope::class)
 class EnterCodeActivity : DuckDuckGoActivity() {
     private val binding: ActivityEnterCodeBinding by viewBinding()
     private val viewModel: EnterCodeViewModel by bindViewModel()
 
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private lateinit var codeType: Code
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         codeType = intent.getSerializableExtra(EXTRA_CODE_TYPE) as? Code ?: Code.RECOVERY_CODE
+
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.SYNC)
+        if (edgeToEdgeEnabled) {
+            enableTransparentEdgeToEdge()
+        }
+
         setContentView(binding.root)
         setupToolbar(binding.includeToolbar.toolbar)
+
+        if (edgeToEdgeEnabled) {
+            configureEdgeToEdgeInsets()
+        }
+
         observeUiEvents()
         configureListeners()
         if (savedInstanceState == null) {
             viewModel.onEnterManualCodeScreenShown(codeType)
         }
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.pasteCodeButton, drawBehindGestureNav = true)
     }
 
     private fun configureListeners() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivity.kt
@@ -34,6 +34,9 @@ import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.makeSnackbarWithNoBottomInset
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.*
 import com.duckduckgo.di.scopes.*
 import com.duckduckgo.navigation.api.GlobalActivityStarter
@@ -115,6 +118,12 @@ class SyncActivity : DuckDuckGoActivity() {
 
     @Inject
     lateinit var globalActivityStarter: GlobalActivityStarter
+
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
 
     private val syncedDevicesAdapter = SyncedDevicesAdapter(
         object : ConnectedDeviceClickListener {
@@ -199,8 +208,18 @@ class SyncActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.SYNC)
+        if (edgeToEdgeEnabled) {
+            enableTransparentEdgeToEdge()
+        }
+
         setContentView(binding.root)
         setupToolbar(binding.includeToolbar.toolbar)
+
+        if (edgeToEdgeEnabled) {
+            configureEdgeToEdgeInsets()
+        }
 
         savedInstanceState?.getString(KEY_PENDING_ORIGINAL_FLOW)?.let { name ->
             pendingOriginalFlow = OriginalFlow.valueOf(name)
@@ -227,6 +246,12 @@ class SyncActivity : DuckDuckGoActivity() {
     }
 
     private fun syncSetupUrl() = intent.getActivityParams(SyncActivityFromSetupUrl::class.java)?.url
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.contentScrollView, drawBehindGestureNav = true)
+    }
 
     private fun registerForPermission() {
         storagePermission.registerResultsCallback(this) {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectActivity.kt
@@ -31,6 +31,9 @@ import com.duckduckgo.common.ui.view.button.DaxButtonGhost
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.mobile.android.databinding.IncludeDefaultToolbarBinding
 import com.duckduckgo.sync.impl.R
@@ -64,6 +67,12 @@ class SyncConnectActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var dispatcherProvider: DispatcherProvider
 
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private lateinit var binding: ConnectSyncBinding
     private val viewModel: SyncConnectViewModel by bindViewModel()
 
@@ -78,6 +87,8 @@ class SyncConnectActivity : DuckDuckGoActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.SYNC)
+
         lifecycleScope.launch {
             withContext(dispatcherProvider.io()) {
                 syncFeature.useExpandableBarcodeConnectSyncLayout().isEnabled()
@@ -91,8 +102,16 @@ class SyncConnectActivity : DuckDuckGoActivity() {
                         ConnectSyncBinding.OldBinding(viewBinding)
                     }
 
+                    if (edgeToEdgeEnabled) {
+                        enableTransparentEdgeToEdge()
+                    }
+
                     setContentView(binding.root)
                     setupToolbar(binding.includeToolbar.toolbar)
+
+                    if (edgeToEdgeEnabled) {
+                        configureEdgeToEdgeInsets()
+                    }
 
                     onBackPressedDispatcher.addCallback(this@SyncConnectActivity) {
                         onUserCancelled()
@@ -105,6 +124,12 @@ class SyncConnectActivity : DuckDuckGoActivity() {
                     }
                 }
         }
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.contentView, drawBehindGestureNav = true)
     }
 
     override fun onResume() {
@@ -207,6 +232,7 @@ class SyncConnectActivity : DuckDuckGoActivity() {
 private sealed interface ConnectSyncBinding {
     val root: View
     val includeToolbar: IncludeDefaultToolbarBinding
+    val contentView: View
     val qrCodeReader: SyncBarcodeView
     val qrCodeImageView: ImageView
     val copyCodeButton: DaxButtonGhost
@@ -214,6 +240,7 @@ private sealed interface ConnectSyncBinding {
     data class OldBinding(private val binding: ActivityConnectSyncBinding) : ConnectSyncBinding {
         override val root: View get() = binding.root
         override val includeToolbar: IncludeDefaultToolbarBinding get() = binding.includeToolbar
+        override val contentView: View get() = binding.contentScrollView
         override val qrCodeReader: SyncBarcodeView get() = binding.qrCodeReader
         override val qrCodeImageView: ImageView get() = binding.qrCodeImageView
         override val copyCodeButton: DaxButtonGhost get() = binding.copyCodeButton
@@ -222,6 +249,7 @@ private sealed interface ConnectSyncBinding {
     data class NewBinding(private val binding: ActivityConnectSyncNewBinding) : ConnectSyncBinding {
         override val root: View get() = binding.root
         override val includeToolbar: IncludeDefaultToolbarBinding get() = binding.includeToolbar
+        override val contentView: View get() = binding.contentScrollView
         override val qrCodeReader: SyncBarcodeView get() = binding.qrCodeReader
         override val qrCodeImageView: ImageView get() = binding.qrCodeImageView
         override val copyCodeButton: DaxButtonGhost get() = binding.copyCodeButton

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginActivity.kt
@@ -26,6 +26,9 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.databinding.ActivityLoginSyncBinding
@@ -39,11 +42,18 @@ import com.duckduckgo.sync.impl.ui.setup.EnterCodeContract
 import com.duckduckgo.sync.impl.ui.setup.EnterCodeContract.EnterCodeContractOutput
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
 
 @InjectWith(ActivityScope::class)
 class SyncLoginActivity : DuckDuckGoActivity() {
     private val binding: ActivityLoginSyncBinding by viewBinding()
     private val viewModel: SyncLoginViewModel by bindViewModel()
+
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
 
     private val enterCodeLauncher = registerForActivityResult(
         EnterCodeContract(),
@@ -55,11 +65,27 @@ class SyncLoginActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.SYNC)
+        if (edgeToEdgeEnabled) {
+            enableTransparentEdgeToEdge()
+        }
+
         setContentView(binding.root)
         setupToolbar(binding.includeToolbar.toolbar)
 
+        if (edgeToEdgeEnabled) {
+            configureEdgeToEdgeInsets()
+        }
+
         observeUiEvents()
         configureListeners()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.qrCodeReader, drawBehindGestureNav = true)
     }
 
     override fun onResume() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceActivity.kt
@@ -30,6 +30,9 @@ import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.databinding.ActivityConnectSyncBinding
@@ -48,12 +51,19 @@ import com.duckduckgo.sync.impl.ui.setup.SyncSetupDeepLinkFragment
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
 
 @InjectWith(ActivityScope::class)
 class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
 
     private val binding: ActivityConnectSyncBinding by viewBinding()
     private val viewModel: SyncWithAnotherActivityViewModel by bindViewModel()
+
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
 
     private var deepLinkSetupFragment: Fragment? = null
 
@@ -65,8 +75,18 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.SYNC)
+        if (edgeToEdgeEnabled) {
+            enableTransparentEdgeToEdge()
+        }
+
         setContentView(binding.root)
         setupToolbar(binding.includeToolbar.toolbar)
+
+        if (edgeToEdgeEnabled) {
+            configureEdgeToEdgeInsets()
+        }
 
         extractDeepLinkCode()?.let {
             configureDeepLinkMode(it)
@@ -81,6 +101,12 @@ class SyncWithAnotherDeviceActivity : DuckDuckGoActivity() {
         if (savedInstanceState == null && !isDeepLinkSetup()) {
             viewModel.onBarcodeScreenShown()
         }
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.contentScrollView, drawBehindGestureNav = true)
     }
 
     private fun configureDeepLinkMode(deepLink: String) {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/SetupAccountActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/SetupAccountActivity.kt
@@ -28,6 +28,9 @@ import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.sync.impl.R.id
@@ -66,6 +69,12 @@ class SetupAccountActivity : DuckDuckGoActivity(), SyncSetupNavigationFlowListen
     @Inject
     lateinit var globalActivityStarter: GlobalActivityStarter
 
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private lateinit var screen: Screen
 
     private val loginFlow = registerForActivityResult(LoginContract()) { resultOk ->
@@ -76,14 +85,30 @@ class SetupAccountActivity : DuckDuckGoActivity(), SyncSetupNavigationFlowListen
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.SYNC)
+        if (edgeToEdgeEnabled) {
+            enableTransparentEdgeToEdge()
+        }
+
         screen = if (savedInstanceState != null) {
             savedInstanceState.getSerializable(SETUP_ACCOUNT_SCREEN_EXTRA) as Screen
         } else {
             intent.getSerializableExtra(SETUP_ACCOUNT_SCREEN_EXTRA) as? Screen ?: SETUP_COMPLETE
         }
         setContentView(binding.root)
+
+        if (edgeToEdgeEnabled) {
+            configureEdgeToEdgeInsets()
+        }
+
         observeUiEvents()
         configureListeners()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyStatusBarAndHorizontalInsets(binding.root)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.fragmentContainerView, drawBehindGestureNav = true)
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/sync/sync-impl/src/main/res/layout/activity_connect_sync.xml
+++ b/sync/sync-impl/src/main/res/layout/activity_connect_sync.xml
@@ -25,6 +25,7 @@
         layout="@layout/include_default_toolbar" />
 
     <ScrollView
+        android:id="@+id/contentScrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:fillViewport="true"

--- a/sync/sync-impl/src/main/res/layout/activity_connect_sync_new.xml
+++ b/sync/sync-impl/src/main/res/layout/activity_connect_sync_new.xml
@@ -25,6 +25,7 @@
         layout="@layout/include_default_toolbar" />
 
         <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/contentScrollView"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 

--- a/sync/sync-impl/src/main/res/layout/activity_device_unsupported.xml
+++ b/sync/sync-impl/src/main/res/layout/activity_device_unsupported.xml
@@ -27,6 +27,7 @@
         layout="@layout/include_default_toolbar" />
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/contentContainer"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 

--- a/sync/sync-impl/src/main/res/layout/activity_sync.xml
+++ b/sync/sync-impl/src/main/res/layout/activity_sync.xml
@@ -14,23 +14,24 @@
   ~ limitations under the License.
   -->
 
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fadeScrollbars="false"
-    android:scrollbarAlwaysDrawVerticalTrack="true"
-    android:scrollbars="vertical">
+    android:orientation="vertical">
 
-    <LinearLayout
+    <include
+        android:id="@+id/includeToolbar"
+        layout="@layout/include_default_toolbar" />
+
+    <ScrollView
+        android:id="@+id/contentScrollView"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical">
-
-        <include
-            android:id="@+id/includeToolbar"
-            layout="@layout/include_default_toolbar" />
+        android:layout_height="match_parent"
+        android:fadeScrollbars="false"
+        android:scrollbarAlwaysDrawVerticalTrack="true"
+        android:scrollbars="vertical">
 
         <ViewSwitcher
             android:id="@+id/viewSwitcher"
@@ -47,5 +48,5 @@
                 layout="@layout/view_sync_enabled" />
 
         </ViewSwitcher>
-    </LinearLayout>
-</ScrollView>
+    </ScrollView>
+</LinearLayout>

--- a/sync/sync-impl/src/main/res/layout/activity_sync_get_on_other_devices.xml
+++ b/sync/sync-impl/src/main/res/layout/activity_sync_get_on_other_devices.xml
@@ -26,6 +26,7 @@
         layout="@layout/include_default_toolbar" />
 
     <androidx.core.widget.NestedScrollView
+        android:id="@+id/contentScrollView"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:fillViewport="true"


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/project/1212608036467427/task/1214047527401579?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1212608036467427/task/1213993229311556?focus=true

### Description
Enable edge-to-edge in autofill / sync / vpn settings activities
This is a follow up on: github.com/duckduckgo/Android/pull/8848 work.

### Steps to test this PR
https://app.asana.com/1/137249556945/project/1212608036467427/task/1215835538351260?focus=true

Testing the VPN is a bit tricky, as it requires a production build and a valid subscription, I did it by manually changing the toggle values and building a test production build.
 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide UI-only rollout gated by feature flags, but many screens and rotation/cutout behavior changes could cause layout regressions on notched devices if a bucket is enabled.
> 
> **Overview**
> Extends the edge-to-edge rollout to **autofill**, **sync**, and **VPN / network protection** flows behind new remote toggles (`EdgeToEdgeBucket.AUTOFILL`, `SYNC`, and `VPN`), using the same gated pattern as existing browser/settings buckets.
> 
> When a bucket is on, affected activities call **`enableTransparentEdgeToEdge()`** and **`EdgeToEdgeHandler`** to pad toolbars, roots, scroll views, and bottom CTAs; layouts gain stable ids (e.g. `contentScrollView`, `rootContainer`) and some lists drop manual bottom padding in favor of navigation-bar insets.
> 
> **`DuckDuckGoActivity`** now centralizes **display cutout** behavior: landscape uses `LAYOUT_IN_DISPLAY_CUTOUT_MODE_NEVER`, portrait uses default, with re-application on rotation for edge-to-edge screens. **`BrowserActivity`** and **`CustomTabActivity`** drop duplicated cutout helpers and call the base **`applyDisplayCutoutMode`** instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ae50732f918cc623b01bdb52084f18005fb2fe4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->