### PR TITLE
Update content scope scripts to version 15.3.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -11860,7 +11860,10 @@
   function getFaviconList() {
     const selectors = [
       "link[href][rel='favicon']",
-      "link[href][rel*='icon']",
+      // `rel*='icon'` also matches Safari's `rel="mask-icon"` (safari-pinned-tab.svg) — a monochrome
+      // tint mask, not a real favicon, that renders as a solid black square. Exclude it via `:not`.
+      // Non-mask icons, including SVG favicons, are still matched.
+      "link[href][rel*='icon']:not([rel~='mask-icon' i])",
       "link[href][rel='apple-touch-icon']",
       "link[href][rel='apple-touch-icon-precomposed']"
     ];
@@ -11875,6 +11878,7 @@
 
   // src/features/page-context.js
   var MSG_PAGE_CONTEXT_RESPONSE = "collectionResult";
+  var MAX_JSON_LD_DEPTH = 32;
   function checkNodeIsVisible(node) {
     try {
       const style = window.getComputedStyle(node);
@@ -12028,6 +12032,68 @@ ${iframeContent}
       return "";
     }
     return href ? `[${trimmedContent}](${href})` : collapseWhitespace(children);
+  }
+  function extractPageTypeSignals(document2, { maxTypes = 10, maxBlockLength = 1e5 } = {}) {
+    return {
+      jsonLdType: extractJsonLdTypes(document2, maxTypes, maxBlockLength),
+      ogType: extractOgType(document2),
+      lang: extractLang(document2)
+    };
+  }
+  function extractJsonLdTypes(document2, maxTypes, maxBlockLength) {
+    const types = new Set2();
+    const recordType = (value) => {
+      if (types.size >= maxTypes) return;
+      if (typeof value !== "string") return;
+      const type = value.trim();
+      if (type) types.add(type);
+    };
+    const blocks = document2.querySelectorAll('script[type="application/ld+json" i]');
+    for (const block of blocks) {
+      if (types.size >= maxTypes) break;
+      const text2 = block.textContent || "";
+      if (!text2 || text2.length > maxBlockLength) continue;
+      let data;
+      try {
+        data = JSONparse(text2);
+      } catch (e) {
+        continue;
+      }
+      collectJsonLdTypes(data, recordType);
+    }
+    return Array.from(types);
+  }
+  function collectJsonLdTypes(node, recordType, depth = 0) {
+    if (depth > MAX_JSON_LD_DEPTH) return;
+    if (Array.isArray(node)) {
+      for (const item of node) collectJsonLdTypes(item, recordType, depth + 1);
+      return;
+    }
+    if (!node || typeof node !== "object") return;
+    const obj = (
+      /** @type {Record<string, unknown>} */
+      node
+    );
+    if (hasOwnProperty.call(obj, "@type")) {
+      const type = obj["@type"];
+      if (Array.isArray(type)) {
+        for (const value of type) recordType(value);
+      } else if (type != null) {
+        recordType(type);
+      }
+    }
+    if (hasOwnProperty.call(obj, "@graph")) {
+      collectJsonLdTypes(obj["@graph"], recordType, depth + 1);
+    }
+  }
+  function extractOgType(document2) {
+    const meta = document2.querySelector('meta[property="og:type"]');
+    const content = meta?.getAttribute("content");
+    const trimmed = typeof content === "string" ? content.trim() : "";
+    return trimmed || null;
+  }
+  function extractLang(document2) {
+    return (document2.documentElement?.getAttribute("lang") || "").trim();
   }
   var _cachedContent, _cachedTimestamp, _delayedRecheckTimer, _activeCapture;
   var PageContext = class extends ContentFeature {
@@ -12276,6 +12342,9 @@ ${iframeContent}
       if (this.getFeatureSettingEnabled("includeImages", "disabled")) {
         content.images = this.getImages();
       }
+      if (this.getFeatureSettingEnabled("includePageTypeSignals", "disabled")) {
+        content.pageTypeSignals = this.getPageTypeSignals();
+      }
       if (content.content.length > 0) {
         this.cachedContent = content;
       }
@@ -12374,6 +12443,25 @@ ${iframeContent}
         }
       });
       return links;
+    }
+    getPageTypeSignals() {
+      return extractPageTypeSignals(document, {
+        maxTypes: this.clampedNumericSetting("maxPageTypeSignals", 10, 50),
+        maxBlockLength: this.clampedNumericSetting("maxJsonLdBlockLength", 1e5, 1e6)
+      });
+    }
+    /**
+     * Read a numeric feature setting, clamped to a safe ceiling. Malformed (non-finite) config
+     * falls back to the default rather than producing NaN — which would disable the cap — while an
+     * explicit 0 is still honored.
+     * @param {string} key
+     * @param {number} fallback
+     * @param {number} max
+     * @returns {number}
+     */
+    clampedNumericSetting(key, fallback, max) {
+      const value = this.getFeatureSetting(key);
+      return Math.min(typeof value === "number" && Number.isFinite(value) ? value : fallback, max);
     }
     getImages() {
       const images = [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.95.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.2.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.3.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "14.95.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.95.0.tgz",
-      "integrity": "sha512-iQWR1ui2Y2xaobp8WWitAQR7DzWa8XIIeMcWtMo5ZZCEpk9qdJfSvyWudII0Mw1SL2fJlF9Eer3nsqH4LC2zIg==",
+      "version": "14.97.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-14.97.0.tgz",
+      "integrity": "sha512-fNgWlM3RIhEMu+cVKgViei5eurenBoYORtRzinoY2aoH+wOKbCSTclCNJU0CXQvvLlt4T3ZjKDfN+XmpCCPwjQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "@ghostery/adblocker": "^2.0.4",
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#5d05cc82a8f5e3bacf35132e00f35315461f1d4e",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#5735b061ee14708ca17bc5b72b8eb9d21eb7f830",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -678,18 +678,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
-      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.3.tgz",
+      "integrity": "sha512-27ep5H9PzdBrNd5OFM/j3WCU8F3kPwM9D0BOaOf7uYfxMJfyr0K5Tjj69Gri+sZlh2WXd5buIm47NuPF29CDiw==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.4.2.tgz",
-      "integrity": "sha512-z2Lk9PdA6eiK4NrBqq3nTFpg0t22yhYvG4ggwB/sjdvEftRMerlAANoQnFBgOWqR1LVpjTmPF5egtKhCc1HDBg==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.4.3.tgz",
+      "integrity": "sha512-C7+TxJdmrhTA2fs1VvOcGrnFhK1qvOgYIAFJ0Q9L5GaoQ7QkR0TLm9ooXTgF4d4xgL6qm6qYtiYN3AX0DWwgBA==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.4.2"
+        "tldts-core": "^7.4.3"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.95.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.2.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.3.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1215854337921706?focus=true

- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [x] All tests must pass
- [x] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [x] All tests must pass
- [x] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes run in the page injection layer and can alter favicon detection and page-context payloads when features are enabled, though new signals are feature-gated and the app code in this repo is unchanged.
> 
> **Overview**
> Bumps **`@duckduckgo/content-scope-scripts`** from **15.2.0** to **15.3.0** and refreshes the vendored Android **`contentScope.js`** plus lockfile entries (including transitive bumps such as **autoconsent** and **tldts**).
> 
> The injected script changes in this release include a **favicon** selector fix that skips Safari **`mask-icon`** links so pinned-tab masks are not treated as favicons, and optional **page-type signals** on page context collection (**JSON-LD `@type`**, **`og:type`**, document **`lang`**) when **`includePageTypeSignals`** is enabled, with caps via **`clampedNumericSetting`** for malformed config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb27e30886df42e2e871777b1e47d113172f7c1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->