### PR TITLE
Sync v2: decrypt and show 3rd party browser entries in device list

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceFieldDecryptor.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/DeviceFieldDecryptor.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.crypto.SyncLib
+import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.duckduckgo.sync.store.SyncStore
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+/**
+ * Decrypts `name` + `type` for a single `entries_v2` entry. 3party uses the scoped MEK; ddg/null
+ * uses the local primary key. Stateless — caller handles refresh/retry on [Result.Error].
+ */
+interface DeviceFieldDecryptor {
+    fun decrypt(entry: DeviceV2): Result<DecryptedDevice>
+}
+
+data class DecryptedDevice(
+    val deviceId: String,
+    val name: String,
+    val type: String?,
+)
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealDeviceFieldDecryptor @Inject constructor(
+    private val syncStore: SyncStore,
+    private val syncJweCrypto: SyncJweCrypto,
+    private val nativeLib: SyncLib,
+) : DeviceFieldDecryptor {
+
+    override fun decrypt(entry: DeviceV2): Result<DecryptedDevice> {
+        val deviceId = entry.deviceId ?: return Result.Error(reason = "DeviceFieldDecryptor: entry missing id")
+
+        return when (entry.credentialId) {
+            CREDENTIAL_ID_3PARTY -> decryptThirdParty(entry, deviceId)
+            CREDENTIAL_ID_DDG, null -> decryptDdg(entry, deviceId)
+            else -> Result.Error(reason = "DeviceFieldDecryptor: unknown credential_id=${entry.credentialId}")
+        }
+    }
+
+    private fun decryptThirdParty(
+        entry: DeviceV2,
+        deviceId: String,
+    ): Result<DecryptedDevice> {
+        val scopedPassword = syncStore.scopedPassword?.raw ?: return Result.Error(reason = "DeviceFieldDecryptor: scopedPassword missing")
+        val userId = syncStore.userId ?: return Result.Error(reason = "DeviceFieldDecryptor: userId missing")
+
+        val thirdPartyMainKey = runCatching {
+            syncJweCrypto.hkdfDeriveBytes(scopedPassword, userId.toByteArray(Charsets.UTF_8), "Main Key", 32)
+        }.getOrElse {
+            return Result.Error(reason = "DeviceFieldDecryptor: 3p key derivation failed: ${it.message}")
+        }
+
+        val encryptedName = entry.deviceName ?: return Result.Error(reason = "DeviceFieldDecryptor: 3p entry $deviceId missing name")
+        val name = runCatching {
+            String(syncJweCrypto.jweDecryptSymmetric(encryptedName, thirdPartyMainKey), Charsets.UTF_8)
+        }.getOrElse {
+            return Result.Error(reason = "DeviceFieldDecryptor: 3p name decrypt failed: ${it.message}")
+        }
+
+        val type = entry.deviceType?.takeUnless { it.isEmpty() }?.let { encryptedType ->
+            runCatching {
+                String(syncJweCrypto.jweDecryptSymmetric(encryptedType, thirdPartyMainKey), Charsets.UTF_8)
+            }.getOrElse {
+                return Result.Error(reason = "DeviceFieldDecryptor: 3p type decrypt failed: ${it.message}")
+            }
+        }
+
+        return Result.Success(DecryptedDevice(deviceId, name, type))
+    }
+
+    private fun decryptDdg(
+        entry: DeviceV2,
+        deviceId: String,
+    ): Result<DecryptedDevice> {
+        val primaryKey = syncStore.primaryKey?.takeUnless { it.isEmpty() } ?: return Result.Error(reason = "DeviceFieldDecryptor: primaryKey missing")
+
+        val encryptedName = entry.deviceName ?: return Result.Error(reason = "DeviceFieldDecryptor: ddg entry $deviceId missing name")
+        val name = runCatching { nativeLib.decryptData(encryptedName, primaryKey).decryptedData }
+            .getOrElse {
+                return Result.Error(reason = "DeviceFieldDecryptor: ddg name decrypt failed: ${it.message}")
+            }
+
+        val type = entry.deviceType?.takeUnless { it.isEmpty() }?.let { encryptedType ->
+            runCatching { nativeLib.decryptData(encryptedType, primaryKey).decryptedData }
+                .getOrElse {
+                    return Result.Error(reason = "DeviceFieldDecryptor: ddg type decrypt failed: ${it.message}")
+                }
+        }
+
+        return Result.Success(DecryptedDevice(deviceId, name, type))
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
@@ -156,6 +156,7 @@ class AppSyncAccountRepository @Inject constructor(
     private val syncJweCrypto: SyncJweCrypto,
     private val thirdPartyCredentialManager: ThirdPartyCredentialManager,
     private val protectedKeyManager: ProtectedKeyManager,
+    private val thirdPartyDeviceListDecryptor: ThirdPartyDeviceListDecryptor,
 ) : SyncAccountRepository {
 
     /**
@@ -662,46 +663,93 @@ class AppSyncAccountRepository @Inject constructor(
         val primaryKey = syncStore.primaryKey.takeUnless { it.isNullOrEmpty() }
             ?: return Error(reason = "PrimaryKey not found")
 
-        return when (val result = syncApi.getDevices(token)) {
-            is Error -> {
-                connectedDevicesCached.clear()
-                result.alsoFireAccountErrorPixel().copy(code = GENERIC_ERROR.code)
-            }
-
-            is Success -> {
-                return Success(
-                    result.data.mapNotNull { device ->
-                        try {
-                            val decryptedDeviceName = nativeLib.decryptData(device.deviceName, primaryKey).decryptedData
-                            val decryptedDeviceType = device.deviceType.takeUnless { it.isNullOrEmpty() }?.let { encryptedDeviceType ->
-                                DeviceType(nativeLib.decryptData(encryptedDeviceType, primaryKey).decryptedData)
-                            } ?: DeviceType()
-
-                            ConnectedDevice(
-                                thisDevice = syncStore.deviceId == device.deviceId,
-                                deviceName = decryptedDeviceName,
-                                deviceId = device.deviceId,
-                                deviceType = decryptedDeviceType,
-                            )
-                        } catch (throwable: Throwable) {
-                            throwable.asErrorResult().alsoFireAccountErrorPixel()
-                            if (syncStore.deviceId != device.deviceId) {
-                                logout(device.deviceId)
-                            }
-                            null
-                        }
-                    }.sortedWith { a, b ->
-                        if (a.thisDevice) -1 else 1
-                    }.also { devices ->
-                        connectedDevicesCached.apply {
-                            clear()
-                            addAll(devices)
-                        }
-                        connectedDevicesObserver.onDevicesUpdated(devices)
-                    },
-                )
-            }
+        return if (syncFeature.canUseV2ConnectFlow().isEnabled()) {
+            getConnectedDevicesV2(token, primaryKey)
+        } else {
+            getConnectedDevicesLegacy(token, primaryKey)
         }
+    }
+
+    private fun getConnectedDevicesV2(
+        token: String,
+        primaryKey: String,
+    ): Result<List<ConnectedDevice>> = when (val result = syncApi.getDevices(token)) {
+        is Error -> {
+            connectedDevicesCached.clear()
+            result.alsoFireAccountErrorPixel().copy(code = GENERIC_ERROR.code)
+        }
+        is Success -> {
+            val entriesV2 = result.data.entriesV2
+            val devices = if (entriesV2 != null) {
+                val decryptResult = thirdPartyDeviceListDecryptor.decryptAll(entriesV2)
+                logoutFailedV2Devices(decryptResult.undecryptable)
+                decryptResult.decrypted.map { it.toConnectedDevice() }
+            } else {
+                // entries_v2 missing
+                decryptLegacyEntries(result.data.entries, primaryKey)
+            }
+            finishWith(devices)
+        }
+    }
+
+    private fun logoutFailedV2Devices(deviceIds: List<String>) {
+        val thisDeviceId = syncStore.deviceId
+        deviceIds.forEach { id ->
+            if (id != thisDeviceId) logout(id)
+        }
+    }
+
+    private fun getConnectedDevicesLegacy(
+        token: String,
+        primaryKey: String,
+    ): Result<List<ConnectedDevice>> = when (val result = syncApi.getDevices(token)) {
+        is Error -> {
+            connectedDevicesCached.clear()
+            result.alsoFireAccountErrorPixel().copy(code = GENERIC_ERROR.code)
+        }
+        is Success -> finishWith(decryptLegacyEntries(result.data.entries, primaryKey))
+    }
+
+    private fun decryptLegacyEntries(
+        devices: List<Device>,
+        primaryKey: String,
+    ): List<ConnectedDevice> = devices.mapNotNull { device ->
+        try {
+            val decryptedDeviceName = nativeLib.decryptData(device.deviceName, primaryKey).decryptedData
+            val decryptedDeviceType = device.deviceType.takeUnless { it.isNullOrEmpty() }?.let { encryptedDeviceType ->
+                DeviceType(nativeLib.decryptData(encryptedDeviceType, primaryKey).decryptedData)
+            } ?: DeviceType()
+
+            ConnectedDevice(
+                thisDevice = syncStore.deviceId == device.deviceId,
+                deviceName = decryptedDeviceName,
+                deviceId = device.deviceId,
+                deviceType = decryptedDeviceType,
+            )
+        } catch (throwable: Throwable) {
+            throwable.asErrorResult().alsoFireAccountErrorPixel()
+            if (syncStore.deviceId != device.deviceId) {
+                logout(device.deviceId)
+            }
+            null
+        }
+    }
+
+    private fun DecryptedDevice.toConnectedDevice(): ConnectedDevice = ConnectedDevice(
+        thisDevice = syncStore.deviceId == deviceId,
+        deviceName = name,
+        deviceId = deviceId,
+        deviceType = type?.takeUnless { it.isEmpty() }?.let { DeviceType(it) } ?: DeviceType(),
+    )
+
+    private fun finishWith(devices: List<ConnectedDevice>): Result<List<ConnectedDevice>> {
+        val sorted = devices.sortedWith { a, _ -> if (a.thisDevice) -1 else 1 }
+        connectedDevicesCached.apply {
+            clear()
+            addAll(sorted)
+        }
+        connectedDevicesObserver.onDevicesUpdated(sorted)
+        return Success(sorted)
     }
 
     override fun isSignedIn() = syncStore.isSignedIn()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncService.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncService.kt
@@ -201,6 +201,8 @@ data class AccountCreatedResponse(
     val token: String,
 )
 
+// Server sends a `devices_v2` field here too; intentionally not parsed because nothing consumes
+// `devices` from this response either — the device list is sourced from GET /devices instead.
 data class LoginResponse(
     val token: String,
     val protected_encryption_key: String,
@@ -215,6 +217,7 @@ data class DeviceResponse(
 
 data class DeviceEntries(
     val entries: List<Device>,
+    @field:Json(name = "entries_v2") val entriesV2: List<DeviceV2>? = null,
 )
 
 data class Device(
@@ -222,6 +225,15 @@ data class Device(
     @field:Json(name = "name") val deviceName: String,
     @field:Json(name = "type") val deviceType: String?,
     @field:Json(name = "jw_iat") val jwIat: String,
+)
+
+// `name` and `type` are encrypted with the credential in `credentialId`.
+data class DeviceV2(
+    @field:Json(name = "id") val deviceId: String? = null,
+    @field:Json(name = "name") val deviceName: String? = null,
+    @field:Json(name = "type") val deviceType: String? = null,
+    @field:Json(name = "jw_iat") val jwIat: String? = null,
+    @field:Json(name = "credential_id") val credentialId: String? = null,
 )
 
 data class ErrorResponse(

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
@@ -73,7 +73,7 @@ interface SyncApi {
 
     fun deleteAccount(token: String): Result<Boolean>
 
-    fun getDevices(token: String): Result<List<Device>>
+    fun getDevices(token: String): Result<DeviceEntries>
 
     fun getBookmarks(
         token: String,
@@ -193,7 +193,7 @@ class SyncServiceRemote @Inject constructor(
         }
     }
 
-    override fun getDevices(token: String): Result<List<Device>> {
+    override fun getDevices(token: String): Result<DeviceEntries> {
         val response = runCatching {
             val logoutCall = syncService.getDevices("Bearer $token")
             logoutCall.execute()
@@ -202,7 +202,7 @@ class SyncServiceRemote @Inject constructor(
         }
 
         return onSuccess(response) {
-            val devices = response.body()?.devices?.entries ?: return@onSuccess Result.Error(reason = "getDevices: empty body")
+            val devices = response.body()?.devices ?: return@onSuccess Result.Error(reason = "getDevices: empty body")
             Result.Success(devices)
         }
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ThirdPartyDeviceListDecryptor.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ThirdPartyDeviceListDecryptor.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import logcat.LogPriority.WARN
+import logcat.logcat
+import javax.inject.Inject
+
+/**
+ * Decrypts `entries_v2` with one-shot refresh-on-3p-failure. Splits the result so the caller
+ * can differentiate between those successfully decrypted and those with decryption failure.
+ *
+ * 3p failures only get classified as corrupted when `refresh()` returned `Success(true)` —
+ * otherwise we can't tell stale-SP from corruption, so we render a fallback row instead of
+ * logging the device out over a possibly-transient condition. ddg failures are always
+ * corrupted (primary key doesn't drift).
+ */
+interface ThirdPartyDeviceListDecryptor {
+    fun decryptAll(entries: List<DeviceV2>): DecryptAllResult
+
+    companion object {
+        const val FALLBACK_TYPE_3PARTY = "Browser"
+        const val FALLBACK_NAME = "Unknown"
+    }
+}
+
+data class DecryptAllResult(
+    val decrypted: List<DecryptedDevice>,
+    val undecryptable: List<String>,
+)
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealThirdPartyDeviceListDecryptor @Inject constructor(
+    private val deviceFieldDecryptor: DeviceFieldDecryptor,
+    private val thirdPartyCredentialManager: ThirdPartyCredentialManager,
+) : ThirdPartyDeviceListDecryptor {
+
+    override fun decryptAll(entries: List<DeviceV2>): DecryptAllResult {
+        if (entries.isEmpty()) return DecryptAllResult(emptyList(), emptyList())
+
+        val firstPass = entries.map { it to deviceFieldDecryptor.decrypt(it) }
+        var finalPass = firstPass
+
+        // if there are 3rd party failures, allow a refresh attempt on 3p credentials and retry at decrypting
+        var refreshGotFreshSp = false
+        if (firstPass.anyThirdPartyFailure()) {
+            val refreshResult = thirdPartyCredentialManager.refresh()
+            refreshGotFreshSp = refreshResult is Result.Success && refreshResult.data
+            finalPass = entries.map { it to deviceFieldDecryptor.decrypt(it) }
+        }
+
+        val decrypted = mutableListOf<DecryptedDevice>()
+        val undecryptable = mutableListOf<String>()
+        finalPass.forEach { (entry, result) ->
+            when (result) {
+                is Result.Success -> decrypted += result.data
+                is Result.Error -> classifyFailure(entry, result, refreshGotFreshSp, decrypted, undecryptable)
+            }
+        }
+        return DecryptAllResult(decrypted, undecryptable)
+    }
+
+    private fun List<Pair<DeviceV2, Result<DecryptedDevice>>>.anyThirdPartyFailure(): Boolean =
+        any { (entry, result) -> result is Result.Error && entry.credentialId == CREDENTIAL_ID_3PARTY }
+
+    private fun classifyFailure(
+        entry: DeviceV2,
+        result: Result.Error,
+        refreshGotFreshSp: Boolean,
+        decrypted: MutableList<DecryptedDevice>,
+        undecryptable: MutableList<String>,
+    ) {
+        val id = entry.deviceId ?: return
+        if (entry.credentialId == CREDENTIAL_ID_3PARTY && !refreshGotFreshSp) {
+            logcat(WARN) { "DeviceListDecryptor: $id → Unknown fallback (refresh inconclusive): ${result.reason}" }
+            decrypted += DecryptedDevice(
+                deviceId = id,
+                name = ThirdPartyDeviceListDecryptor.FALLBACK_NAME,
+                type = ThirdPartyDeviceListDecryptor.FALLBACK_TYPE_3PARTY,
+            )
+        } else {
+            logcat(WARN) { "DeviceListDecryptor: $id marked for logout (${entry.credentialId}): ${result.reason}" }
+            undecryptable += id
+        }
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/crypto/SyncJweCrypto.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/crypto/SyncJweCrypto.kt
@@ -119,7 +119,6 @@ class RealSyncJweCrypto @Inject constructor() : SyncJweCrypto {
     }
 
     override fun jweDecryptSymmetric(jweCompact: String, symmetricKey: ByteArray): ByteArray {
-        logcat { "Sync-ScopedToken: JWE decrypting with symmetric key" }
         val secretKey = SecretKeySpec(symmetricKey, "AES")
 
         return Jwts.parser()

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/TestSyncFixtures.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/TestSyncFixtures.kt
@@ -158,7 +158,7 @@ object TestSyncFixtures {
         "{\"error\":\"$invalidMessageErr\"}".toResponseBody(),
     )
 
-    val getDevicesSuccess = Result.Success(listOfDevices)
+    val getDevicesSuccess = Result.Success(DeviceEntries(entries = listOfDevices, entriesV2 = null))
     val getDevicesError = Result.Error(code = invalidCodeErr, reason = invalidMessageErr)
     val invalidCredentialsError = Result.Error(code = wrongCredentialsCodeErr, reason = invalidMessageErr)
     val connectedDevice = ConnectedDevice(thisDevice = true, deviceName = deviceName, deviceId = deviceId, deviceType = deviceType)

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
@@ -97,6 +97,7 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
@@ -129,6 +130,7 @@ class AppSyncAccountRepositoryTest {
     private val syncJweCrypto: SyncJweCrypto = mock()
     private val thirdPartyCredentialManager: ThirdPartyCredentialManager = mock()
     private val protectedKeyManager: ProtectedKeyManager = mock()
+    private val thirdPartyDeviceListDecryptor: ThirdPartyDeviceListDecryptor = mock()
 
     @Before
     fun before() {
@@ -149,6 +151,7 @@ class AppSyncAccountRepositoryTest {
             syncJweCrypto = syncJweCrypto,
             thirdPartyCredentialManager = thirdPartyCredentialManager,
             protectedKeyManager = protectedKeyManager,
+            thirdPartyDeviceListDecryptor = thirdPartyDeviceListDecryptor,
         )
 
         // passthrough by default (no modifications)
@@ -424,7 +427,7 @@ class AppSyncAccountRepositoryTest {
         for (i in 1..numberOfDevices) {
             devices.add(Device(deviceId = "$deviceId-$i", deviceName = "$deviceName-$i", jwIat = "", deviceType = deviceFactor))
         }
-        whenever(syncApi.getDevices(token)).thenReturn(Success(devices))
+        whenever(syncApi.getDevices(token)).thenReturn(Success(DeviceEntries(entries = devices, entriesV2 = null)))
         whenever(syncApi.logout(token, deviceId)).thenReturn(Success(Logout(deviceId)))
         syncRepo.getConnectedDevices()
     }
@@ -622,7 +625,9 @@ class AppSyncAccountRepositoryTest {
         val thisDevice = Device(deviceId = deviceId, deviceName = deviceName, jwIat = "", deviceType = deviceFactor)
         val anotherDevice = Device(deviceId = "anotherDeviceId", deviceName = deviceName, jwIat = "", deviceType = deviceFactor)
         val anotherRemoteDevice = Device(deviceId = "anotherRemoteDeviceId", deviceName = deviceName, jwIat = "", deviceType = deviceFactor)
-        whenever(syncApi.getDevices(anyString())).thenReturn(Success(listOf(anotherDevice, anotherRemoteDevice, thisDevice)))
+        whenever(syncApi.getDevices(anyString())).thenReturn(
+            Success(DeviceEntries(entries = listOf(anotherDevice, anotherRemoteDevice, thisDevice), entriesV2 = null)),
+        )
 
         val result = syncRepo.getConnectedDevices() as Success
 
@@ -651,12 +656,125 @@ class AppSyncAccountRepositoryTest {
         whenever(syncStore.deviceId).thenReturn(deviceId)
         whenever(syncStore.primaryKey).thenReturn(primaryKey)
         whenever(nativeLib.decryptData(anyString(), anyString())).thenThrow(NegativeArraySizeException())
-        whenever(syncApi.getDevices(anyString())).thenReturn(Success(listOf(thisDevice, otherDevice)))
+        whenever(syncApi.getDevices(anyString())).thenReturn(
+            Success(DeviceEntries(entries = listOf(thisDevice, otherDevice), entriesV2 = null)),
+        )
         whenever(syncApi.logout("token", "otherDeviceId")).thenReturn(Success(Logout("otherDeviceId")))
 
         val result = syncRepo.getConnectedDevices() as Success
         verify(syncApi).logout("token", "otherDeviceId")
         assertTrue(result.data.isEmpty())
+    }
+
+    // ----- entries_v2 device-list path (Track C) ----------------------------------------------
+
+    @Test
+    fun whenV2FlagOnAndEntriesV2PresentThenUsesV2Decryptor() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+        whenever(syncStore.deviceId).thenReturn(deviceId)
+        val v2Entry = DeviceV2(deviceId = "d1", deviceName = "ENC", deviceType = "ENC_T", credentialId = "3party")
+        whenever(syncApi.getDevices(anyString())).thenReturn(
+            Success(DeviceEntries(entries = emptyList(), entriesV2 = listOf(v2Entry))),
+        )
+        whenever(thirdPartyDeviceListDecryptor.decryptAll(listOf(v2Entry))).thenReturn(
+            DecryptAllResult(
+                decrypted = listOf(DecryptedDevice(deviceId = "d1", name = "Chrome/148", type = "Browser")),
+                undecryptable = emptyList(),
+            ),
+        )
+
+        val result = syncRepo.getConnectedDevices() as Success
+
+        assertEquals(1, result.data.size)
+        assertEquals("Chrome/148", result.data[0].deviceName)
+        verify(thirdPartyDeviceListDecryptor).decryptAll(listOf(v2Entry))
+        verify(syncApi, never()).logout(anyString(), anyString())
+    }
+
+    @Test
+    fun whenV2FlagOnAndEntriesV2NullThenFallsBackToLegacyDecryptOfEntries() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        givenAuthenticatedDevice()
+        prepareForEncryption()
+        val ddgDevice = Device(deviceId = deviceId, deviceName = deviceName, jwIat = "", deviceType = deviceFactor)
+        whenever(syncApi.getDevices(anyString())).thenReturn(
+            Success(DeviceEntries(entries = listOf(ddgDevice), entriesV2 = null)),
+        )
+
+        val result = syncRepo.getConnectedDevices() as Success
+
+        // Fell back to legacy decrypt — same library path as the legacy `entries`-only response.
+        assertEquals(1, result.data.size)
+        verify(thirdPartyDeviceListDecryptor, never()).decryptAll(any())
+    }
+
+    @Test
+    fun whenV2FlagOnAndDeviceListApiFailsThenReturnsGenericError() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+        whenever(syncApi.getDevices(anyString())).thenReturn(Error(reason = "boom"))
+
+        val result = syncRepo.getConnectedDevices() as Error
+
+        assertEquals(GENERIC_ERROR.code, result.code)
+    }
+
+    @Test
+    fun whenV2FlagOnAndDecryptorReportsLogoutThenLogoutIsCalledForOtherDevices() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+        whenever(syncStore.deviceId).thenReturn(deviceId)
+        val v2Entry = DeviceV2(deviceId = "d-other", deviceName = "BAD", credentialId = "3party")
+        whenever(syncApi.getDevices(anyString())).thenReturn(
+            Success(DeviceEntries(entries = emptyList(), entriesV2 = listOf(v2Entry))),
+        )
+        whenever(thirdPartyDeviceListDecryptor.decryptAll(any())).thenReturn(
+            DecryptAllResult(decrypted = emptyList(), undecryptable = listOf("d-other")),
+        )
+        whenever(syncApi.logout(eq(token), eq("d-other"))).thenReturn(Success(Logout("d-other")))
+
+        val result = syncRepo.getConnectedDevices() as Success
+
+        assertTrue(result.data.isEmpty())
+        verify(syncApi).logout(eq(token), eq("d-other"))
+    }
+
+    @Test
+    fun whenV2FlagOnAndDecryptFailsForThisDeviceThenDoesNotLogoutSelf() {
+        // Safety: never log out the local device, even if decrypt fails for it.
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+        whenever(syncStore.deviceId).thenReturn(deviceId)
+        val v2Entry = DeviceV2(deviceId = deviceId, deviceName = "BAD", credentialId = "3party")
+        whenever(syncApi.getDevices(anyString())).thenReturn(
+            Success(DeviceEntries(entries = emptyList(), entriesV2 = listOf(v2Entry))),
+        )
+        whenever(thirdPartyDeviceListDecryptor.decryptAll(any())).thenReturn(
+            DecryptAllResult(decrypted = emptyList(), undecryptable = listOf(deviceId)),
+        )
+
+        syncRepo.getConnectedDevices()
+
+        verify(syncApi, never()).logout(anyString(), eq(deviceId))
+    }
+
+    @Test
+    fun whenV2FlagOffThenLegacyPathUntouchedAndV2DecryptorNotCalled() {
+        // Sanity: with flag off, behaviour matches pre-Track-C.
+        whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+        whenever(syncStore.deviceId).thenReturn(deviceId)
+        prepareForEncryption()
+        whenever(syncApi.getDevices(anyString())).thenReturn(getDevicesSuccess)
+
+        syncRepo.getConnectedDevices()
+
+        verify(thirdPartyDeviceListDecryptor, never()).decryptAll(any())
     }
 
     @Test
@@ -1022,7 +1140,7 @@ class AppSyncAccountRepositoryTest {
         for (i in 0 until size) {
             listOfDevices.add(aDevice.copy(deviceId = "device$i"))
         }
-        whenever(syncApi.getDevices(anyString())).thenReturn(Success(listOfDevices))
+        whenever(syncApi.getDevices(anyString())).thenReturn(Success(DeviceEntries(entries = listOfDevices, entriesV2 = null)))
 
         syncRepo.getConnectedDevices() as Success
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/DeviceFieldDecryptorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/DeviceFieldDecryptorTest.kt
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.sync.crypto.DecryptResult
+import com.duckduckgo.sync.crypto.SyncLib
+import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.duckduckgo.sync.store.ScopedPassword
+import com.duckduckgo.sync.store.SyncStore
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class DeviceFieldDecryptorTest {
+
+    private val syncStore: SyncStore = mock()
+    private val syncJweCrypto: SyncJweCrypto = mock()
+    private val nativeLib: SyncLib = mock()
+
+    private lateinit var decryptor: DeviceFieldDecryptor
+
+    // Valid standard-base64 string so hkdfDeriveBytes' inner Base64.decode doesn't throw.
+    private val spBase64 = "AAECAwQFBgcICQoLDA0ODw=="
+    private val userId = "user-42"
+    private val primaryKey = "primaryKeyBase64"
+
+    @Before
+    fun before() {
+        decryptor = RealDeviceFieldDecryptor(syncStore, syncJweCrypto, nativeLib)
+    }
+
+    // ---------- 3party path ----------
+
+    @Test
+    fun whenThirdPartyEntryWithValidSpAndUserIdThenDecryptsNameAndType() {
+        whenever(syncStore.scopedPassword).thenReturn(ScopedPassword(spBase64))
+        whenever(syncStore.userId).thenReturn(userId)
+        whenever(syncJweCrypto.hkdfSha256SingleBlock(any(), any(), eq("Main Key"), eq(32))).thenReturn(ByteArray(32))
+        whenever(syncJweCrypto.jweDecryptSymmetric(eq("ENC_NAME"), any())).thenReturn("Chrome/148.0.0.0".toByteArray())
+        whenever(syncJweCrypto.jweDecryptSymmetric(eq("ENC_TYPE"), any())).thenReturn("Browser".toByteArray())
+
+        val result = decryptor.decrypt(
+            DeviceV2(deviceId = "d1", deviceName = "ENC_NAME", deviceType = "ENC_TYPE", credentialId = "3party"),
+        )
+
+        assertEquals(Success(DecryptedDevice("d1", "Chrome/148.0.0.0", "Browser")), result)
+    }
+
+    @Test
+    fun whenThirdPartyEntryHasNoTypeThenReturnsNullType() {
+        whenever(syncStore.scopedPassword).thenReturn(ScopedPassword(spBase64))
+        whenever(syncStore.userId).thenReturn(userId)
+        whenever(syncJweCrypto.hkdfSha256SingleBlock(any(), any(), eq("Main Key"), eq(32))).thenReturn(ByteArray(32))
+        whenever(syncJweCrypto.jweDecryptSymmetric(eq("ENC_NAME"), any())).thenReturn("Chrome/148.0.0.0".toByteArray())
+
+        val result = decryptor.decrypt(
+            DeviceV2(deviceId = "d1", deviceName = "ENC_NAME", deviceType = null, credentialId = "3party"),
+        )
+
+        assertEquals(Success(DecryptedDevice("d1", "Chrome/148.0.0.0", null)), result)
+    }
+
+    @Test
+    fun whenThirdPartyEntryHasEmptyTypeThenReturnsNullType() {
+        whenever(syncStore.scopedPassword).thenReturn(ScopedPassword(spBase64))
+        whenever(syncStore.userId).thenReturn(userId)
+        whenever(syncJweCrypto.hkdfSha256SingleBlock(any(), any(), eq("Main Key"), eq(32))).thenReturn(ByteArray(32))
+        whenever(syncJweCrypto.jweDecryptSymmetric(eq("ENC_NAME"), any())).thenReturn("Chrome/148.0.0.0".toByteArray())
+
+        val result = decryptor.decrypt(
+            DeviceV2(deviceId = "d1", deviceName = "ENC_NAME", deviceType = "", credentialId = "3party"),
+        )
+
+        assertEquals(Success(DecryptedDevice("d1", "Chrome/148.0.0.0", null)), result)
+    }
+
+    @Test
+    fun whenThirdPartyEntryAndScopedPasswordMissingThenError() {
+        whenever(syncStore.scopedPassword).thenReturn(null)
+        whenever(syncStore.userId).thenReturn(userId)
+
+        val result = decryptor.decrypt(DeviceV2(deviceId = "d1", deviceName = "ENC", credentialId = "3party"))
+
+        assertTrue(result is Error)
+    }
+
+    @Test
+    fun whenThirdPartyEntryAndUserIdMissingThenError() {
+        whenever(syncStore.scopedPassword).thenReturn(ScopedPassword(spBase64))
+        whenever(syncStore.userId).thenReturn(null)
+
+        val result = decryptor.decrypt(DeviceV2(deviceId = "d1", deviceName = "ENC", credentialId = "3party"))
+
+        assertTrue(result is Error)
+    }
+
+    @Test
+    fun whenThirdPartyMekDerivationThrowsThenError() {
+        whenever(syncStore.scopedPassword).thenReturn(ScopedPassword(spBase64))
+        whenever(syncStore.userId).thenReturn(userId)
+        whenever(syncJweCrypto.hkdfSha256SingleBlock(any(), any(), any(), any())).thenThrow(RuntimeException("hkdf boom"))
+
+        val result = decryptor.decrypt(DeviceV2(deviceId = "d1", deviceName = "ENC", credentialId = "3party"))
+
+        assertTrue(result is Error)
+    }
+
+    @Test
+    fun whenThirdPartyNameDecryptThrowsThenError() {
+        whenever(syncStore.scopedPassword).thenReturn(ScopedPassword(spBase64))
+        whenever(syncStore.userId).thenReturn(userId)
+        whenever(syncJweCrypto.hkdfSha256SingleBlock(any(), any(), any(), any())).thenReturn(ByteArray(32))
+        whenever(syncJweCrypto.jweDecryptSymmetric(eq("BAD"), any())).thenThrow(RuntimeException("bad envelope"))
+
+        val result = decryptor.decrypt(DeviceV2(deviceId = "d1", deviceName = "BAD", credentialId = "3party"))
+
+        assertTrue(result is Error)
+    }
+
+    @Test
+    fun whenThirdPartyTypeDecryptThrowsThenError() {
+        whenever(syncStore.scopedPassword).thenReturn(ScopedPassword(spBase64))
+        whenever(syncStore.userId).thenReturn(userId)
+        whenever(syncJweCrypto.hkdfSha256SingleBlock(any(), any(), any(), any())).thenReturn(ByteArray(32))
+        whenever(syncJweCrypto.jweDecryptSymmetric(eq("ENC_NAME"), any())).thenReturn("Chrome".toByteArray())
+        whenever(syncJweCrypto.jweDecryptSymmetric(eq("BAD_TYPE"), any())).thenThrow(RuntimeException("bad type"))
+
+        val result = decryptor.decrypt(
+            DeviceV2(deviceId = "d1", deviceName = "ENC_NAME", deviceType = "BAD_TYPE", credentialId = "3party"),
+        )
+
+        assertTrue(result is Error)
+    }
+
+    @Test
+    fun whenThirdPartyEntryHasNoNameThenError() {
+        whenever(syncStore.scopedPassword).thenReturn(ScopedPassword(spBase64))
+        whenever(syncStore.userId).thenReturn(userId)
+        whenever(syncJweCrypto.hkdfSha256SingleBlock(any(), any(), any(), any())).thenReturn(ByteArray(32))
+
+        val result = decryptor.decrypt(DeviceV2(deviceId = "d1", deviceName = null, credentialId = "3party"))
+
+        assertTrue(result is Error)
+    }
+
+    // ---------- ddg path ----------
+
+    @Test
+    fun whenDdgEntryWithValidPrimaryKeyThenDecryptsNameAndType() {
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+        whenever(nativeLib.decryptData(eq("ENC_NAME"), eq(primaryKey))).thenReturn(DecryptResult(0, "Pixel 7"))
+        whenever(nativeLib.decryptData(eq("ENC_TYPE"), eq(primaryKey))).thenReturn(DecryptResult(0, "phone"))
+
+        val result = decryptor.decrypt(
+            DeviceV2(deviceId = "d1", deviceName = "ENC_NAME", deviceType = "ENC_TYPE", credentialId = "ddg"),
+        )
+
+        assertEquals(Success(DecryptedDevice("d1", "Pixel 7", "phone")), result)
+    }
+
+    @Test
+    fun whenCredentialIdIsNullThenRoutesToDdgPath() {
+        // null credential_id is treated as ddg per spec (legacy entries don't carry the field).
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+        whenever(nativeLib.decryptData(eq("ENC_NAME"), eq(primaryKey))).thenReturn(DecryptResult(0, "Pixel 7"))
+
+        val result = decryptor.decrypt(DeviceV2(deviceId = "d1", deviceName = "ENC_NAME", credentialId = null))
+
+        assertEquals(Success(DecryptedDevice("d1", "Pixel 7", null)), result)
+    }
+
+    @Test
+    fun whenDdgEntryAndPrimaryKeyMissingThenError() {
+        whenever(syncStore.primaryKey).thenReturn(null)
+
+        val result = decryptor.decrypt(DeviceV2(deviceId = "d1", deviceName = "ENC", credentialId = "ddg"))
+
+        assertTrue(result is Error)
+    }
+
+    @Test
+    fun whenDdgEntryAndPrimaryKeyIsEmptyThenError() {
+        whenever(syncStore.primaryKey).thenReturn("")
+
+        val result = decryptor.decrypt(DeviceV2(deviceId = "d1", deviceName = "ENC", credentialId = "ddg"))
+
+        assertTrue(result is Error)
+    }
+
+    @Test
+    fun whenDdgNameDecryptThrowsThenError() {
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+        whenever(nativeLib.decryptData(eq("BAD"), eq(primaryKey))).thenThrow(RuntimeException("libsodium boom"))
+
+        val result = decryptor.decrypt(DeviceV2(deviceId = "d1", deviceName = "BAD", credentialId = "ddg"))
+
+        assertTrue(result is Error)
+    }
+
+    @Test
+    fun whenDdgEntryHasNoNameThenError() {
+        whenever(syncStore.primaryKey).thenReturn(primaryKey)
+
+        val result = decryptor.decrypt(DeviceV2(deviceId = "d1", deviceName = null, credentialId = "ddg"))
+
+        assertTrue(result is Error)
+    }
+
+    // ---------- generic ----------
+
+    @Test
+    fun whenEntryHasNoDeviceIdThenError() {
+        val result = decryptor.decrypt(DeviceV2(deviceId = null, deviceName = "ENC", credentialId = "ddg"))
+
+        assertTrue(result is Error)
+    }
+
+    @Test
+    fun whenCredentialIdIsUnknownThenError() {
+        val result = decryptor.decrypt(DeviceV2(deviceId = "d1", deviceName = "ENC", credentialId = "magic"))
+
+        assertTrue(result is Error)
+        // Sanity: didn't try to decrypt with either path.
+        verify(nativeLib, never()).decryptData(any<String>(), any())
+        verify(syncJweCrypto, never()).jweDecryptSymmetric(any(), any())
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ThirdPartyDeviceListDecryptorTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ThirdPartyDeviceListDecryptorTest.kt
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.impl.ThirdPartyDeviceListDecryptor.Companion.FALLBACK_NAME
+import com.duckduckgo.sync.impl.ThirdPartyDeviceListDecryptor.Companion.FALLBACK_TYPE_3PARTY
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class ThirdPartyDeviceListDecryptorTest {
+
+    private val fieldDecryptor: DeviceFieldDecryptor = mock()
+    private val thirdPartyCredentialManager: ThirdPartyCredentialManager = mock()
+
+    private lateinit var decryptor: ThirdPartyDeviceListDecryptor
+
+    @Before
+    fun before() {
+        decryptor = RealThirdPartyDeviceListDecryptor(fieldDecryptor, thirdPartyCredentialManager)
+    }
+
+    @Test
+    fun whenInputIsEmptyThenReturnsEmptyAndNoRefreshCall() {
+        val result = decryptor.decryptAll(emptyList())
+
+        assertTrue(result.decrypted.isEmpty())
+        assertTrue(result.undecryptable.isEmpty())
+        verify(thirdPartyCredentialManager, never()).refresh()
+    }
+
+    @Test
+    fun whenAllEntriesDecryptSuccessfullyThenNoRefreshAndNoLogout() {
+        val ddg = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "n")
+        val tp = DeviceV2(deviceId = "d2", credentialId = "3party", deviceName = "n")
+        whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Success(DecryptedDevice("d1", "Pixel 7", "phone")))
+        whenever(fieldDecryptor.decrypt(tp)).thenReturn(Success(DecryptedDevice("d2", "Chrome", "Browser")))
+
+        val result = decryptor.decryptAll(listOf(ddg, tp))
+
+        assertEquals(2, result.decrypted.size)
+        assertTrue(result.undecryptable.isEmpty())
+        verify(thirdPartyCredentialManager, never()).refresh()
+    }
+
+    @Test
+    fun when3PartyFailsButRefreshRecoversThenSuccessAndNoLogout() {
+        val tp = DeviceV2(deviceId = "d1", credentialId = "3party", deviceName = "ENC")
+        whenever(fieldDecryptor.decrypt(tp))
+            .thenReturn(Error(reason = "stale SP"))
+            .thenReturn(Success(DecryptedDevice("d1", "Chrome", "Browser")))
+        whenever(thirdPartyCredentialManager.refresh()).thenReturn(Success(true))
+
+        val result = decryptor.decryptAll(listOf(tp))
+
+        assertEquals(listOf(DecryptedDevice("d1", "Chrome", "Browser")), result.decrypted)
+        assertTrue(result.undecryptable.isEmpty())
+        verify(thirdPartyCredentialManager, times(1)).refresh()
+        verify(fieldDecryptor, times(2)).decrypt(tp)
+    }
+
+    @Test
+    fun when3PartyFailsAndRefreshConfirmsFreshSpAndRetryStillFailsThenAddedToLogoutList() {
+        val tp = DeviceV2(deviceId = "d1", credentialId = "3party", deviceName = "ENC")
+        whenever(fieldDecryptor.decrypt(tp)).thenReturn(Error(reason = "still bad"))
+        whenever(thirdPartyCredentialManager.refresh()).thenReturn(Success(true))
+
+        val result = decryptor.decryptAll(listOf(tp))
+
+        assertTrue(result.decrypted.isEmpty())
+        assertEquals(listOf("d1"), result.undecryptable)
+        verify(thirdPartyCredentialManager, times(1)).refresh()
+    }
+
+    @Test
+    fun when3PartyFailsAndRefreshReturnsErrorThenEntryFallsBackToUnknownNotLogout() {
+        val tp = DeviceV2(deviceId = "d1", credentialId = "3party", deviceName = "ENC")
+        whenever(fieldDecryptor.decrypt(tp)).thenReturn(Error(reason = "still bad"))
+        whenever(thirdPartyCredentialManager.refresh()).thenReturn(Error(reason = "server down"))
+
+        val result = decryptor.decryptAll(listOf(tp))
+
+        assertEquals(listOf(DecryptedDevice("d1", FALLBACK_NAME, FALLBACK_TYPE_3PARTY)), result.decrypted)
+        assertTrue(result.undecryptable.isEmpty())
+        verify(thirdPartyCredentialManager, times(1)).refresh()
+    }
+
+    @Test
+    fun when3PartyFailsAndRefreshReturnsSuccessFalseThenEntryFallsBackToUnknownNotLogout() {
+        val tp = DeviceV2(deviceId = "d1", credentialId = "3party", deviceName = "ENC")
+        whenever(fieldDecryptor.decrypt(tp)).thenReturn(Error(reason = "still bad"))
+        whenever(thirdPartyCredentialManager.refresh()).thenReturn(Success(false))
+
+        val result = decryptor.decryptAll(listOf(tp))
+
+        assertEquals(listOf(DecryptedDevice("d1", FALLBACK_NAME, FALLBACK_TYPE_3PARTY)), result.decrypted)
+        assertTrue(result.undecryptable.isEmpty())
+        verify(thirdPartyCredentialManager, times(1)).refresh()
+    }
+
+    @Test
+    fun whenMultiple3PartyEntriesFailAndRefreshConfirmsFreshSpThenAllAddedToLogout() {
+        val tp1 = DeviceV2(deviceId = "d1", credentialId = "3party", deviceName = "ENC1")
+        val tp2 = DeviceV2(deviceId = "d2", credentialId = "3party", deviceName = "ENC2")
+        whenever(fieldDecryptor.decrypt(tp1)).thenReturn(Error(reason = "bad"))
+        whenever(fieldDecryptor.decrypt(tp2)).thenReturn(Error(reason = "bad"))
+        whenever(thirdPartyCredentialManager.refresh()).thenReturn(Success(true))
+
+        val result = decryptor.decryptAll(listOf(tp1, tp2))
+
+        assertEquals(listOf("d1", "d2"), result.undecryptable)
+        verify(thirdPartyCredentialManager, times(1)).refresh()
+    }
+
+    @Test
+    fun whenDdgFailsThenNoRefreshAndAddedToLogoutList() {
+        val ddg = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC")
+        whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Error(reason = "primaryKey rotated?"))
+
+        val result = decryptor.decryptAll(listOf(ddg))
+
+        assertTrue(result.decrypted.isEmpty())
+        assertEquals(listOf("d1"), result.undecryptable)
+        verify(thirdPartyCredentialManager, never()).refresh()
+    }
+
+    @Test
+    fun whenMixedDdgFailureAnd3PartyFailureAndRefreshErrorsThenDdgLogoutAnd3PartyFallback() {
+        val ddg = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "ENC1")
+        val tp = DeviceV2(deviceId = "d2", credentialId = "3party", deviceName = "ENC2")
+        whenever(fieldDecryptor.decrypt(ddg)).thenReturn(Error(reason = "ddg bad"))
+        whenever(fieldDecryptor.decrypt(tp)).thenReturn(Error(reason = "3p bad"))
+        whenever(thirdPartyCredentialManager.refresh()).thenReturn(Error(reason = "network"))
+
+        val result = decryptor.decryptAll(listOf(ddg, tp))
+
+        assertEquals(listOf(DecryptedDevice("d2", FALLBACK_NAME, FALLBACK_TYPE_3PARTY)), result.decrypted)
+        assertEquals(listOf("d1"), result.undecryptable)
+    }
+
+    @Test
+    fun whenEntryHasNoDeviceIdAndFailsThenDroppedFromBothLists() {
+        // No deviceId → can't render and can't logout. Silently dropped.
+        val orphan = DeviceV2(deviceId = null, credentialId = "ddg", deviceName = "ENC")
+        whenever(fieldDecryptor.decrypt(orphan)).thenReturn(Error(reason = "no id"))
+
+        val result = decryptor.decryptAll(listOf(orphan))
+
+        assertTrue(result.decrypted.isEmpty())
+        assertTrue(result.undecryptable.isEmpty())
+    }
+
+    @Test
+    fun whenMixedListWithOne3PartyFailureThenRefreshAndRetryAllEntries() {
+        val ddgOk = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "n1")
+        val tpFail = DeviceV2(deviceId = "d2", credentialId = "3party", deviceName = "n2")
+        val tpOk = DeviceV2(deviceId = "d3", credentialId = "3party", deviceName = "n3")
+        whenever(fieldDecryptor.decrypt(ddgOk)).thenReturn(Success(DecryptedDevice("d1", "Pixel", "phone")))
+        whenever(fieldDecryptor.decrypt(tpFail))
+            .thenReturn(Error(reason = "stale"))
+            .thenReturn(Success(DecryptedDevice("d2", "Chrome", "Browser")))
+        whenever(fieldDecryptor.decrypt(tpOk)).thenReturn(Success(DecryptedDevice("d3", "Edge", "Browser")))
+        whenever(thirdPartyCredentialManager.refresh()).thenReturn(Success(true))
+
+        val result = decryptor.decryptAll(listOf(ddgOk, tpFail, tpOk))
+
+        assertEquals(3, result.decrypted.size)
+        assertTrue(result.undecryptable.isEmpty())
+        verify(thirdPartyCredentialManager, times(1)).refresh()
+        verify(fieldDecryptor, times(2)).decrypt(eq(ddgOk))
+        verify(fieldDecryptor, times(2)).decrypt(eq(tpFail))
+        verify(fieldDecryptor, times(2)).decrypt(eq(tpOk))
+    }
+
+    @Test
+    fun whenOnlyDdgEntriesAreInTheListThenNoRefreshEvenIfTheyFail() {
+        val ddg1 = DeviceV2(deviceId = "d1", credentialId = "ddg", deviceName = "n")
+        val ddg2 = DeviceV2(deviceId = "d2", credentialId = null, deviceName = "n")
+        whenever(fieldDecryptor.decrypt(any())).thenReturn(Error(reason = "bad"))
+
+        val result = decryptor.decryptAll(listOf(ddg1, ddg2))
+
+        assertEquals(listOf("d1", "d2"), result.undecryptable)
+        verify(thirdPartyCredentialManager, never()).refresh()
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1215138678558101?focus=true
Tech Design URL (if applicable):

### Description

Adds the V2 device-list path: parses `entries_v2` from `GET /devices`, decrypts each entry per `credential_id` (3party via the scoped MEK derived from the local scoped password, ddg via libsodium with the local primary key), and renders them in the Sync & Backup screen.

On 3party decrypt failure the orchestrator calls `ThirdPartyCredentialManager.refresh()` once and retries. Entries still failing post-refresh are logged out from the server when refresh confirmed a fresh SP (matching the legacy security policy), or shown with an "Unknown / Browser" placeholder when refresh itself was inconclusive (offline, no 3p credential on server, etc.).

Gated behind `canUseV2ConnectFlow`. Legacy path (flag off) untouched.

### Steps to test this PR

_3rd-party device list_
- [ ] Sign in to sync on an internal build with `canUseV2ConnectFlow` enabled.
- [ ] Pair a 3rd-party browser to the account (setup instruction [here](https://app.asana.com/1/137249556945/project/1201462886803403/task/1215282097325722?focus=true))
- [ ] Open Sync & Backup → verify the 3rd-party device appears in the list with a recognisable name/type (e.g. "Chrome/148.0.0.0", "Browser").
- [ ] Toggle \`canUseV2ConnectFlow\` off, re-open Sync & Backup → 3rd-party device disappears (legacy \`entries\`-only path; ddg-only by BE invariant).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches sync crypto, credential refresh, and automatic remote device logout on the connected-devices path; mistakes could hide devices, log out peers incorrectly, or mishandle scoped passwords.
> 
> **Overview**
> **Sync & Backup can show 3rd-party browsers** when `canUseV2ConnectFlow` is on: `GET /devices` now returns **`DeviceEntries`** with optional **`entries_v2`**, modeled as **`DeviceV2`** (per-entry **`credential_id`**).
> 
> **New decrypt pipeline:** **`DeviceFieldDecryptor`** decrypts each row’s name/type — **`3party`** via scoped MEK (HKDF + JWE), **`ddg`/null** via **`SyncLib`** + primary key. **`ThirdPartyDeviceListDecryptor`** runs the batch: on 3party failures it **refreshes credentials once and retries**; inconclusive refresh yields **"Unknown" / "Browser"** instead of logout; confirmed corruption adds device IDs to an **undecryptable** list.
> 
> **`getConnectedDevices`** branches on the feature flag: V2 uses the decryptor and **logs out other devices** that stay undecryptable (never the local device); missing **`entries_v2`** falls back to legacy **`entries`**. Legacy path is refactored into shared helpers without behavior change when the flag is off.
> 
> Tests cover decryptors and the V2 repository path; fixtures/API mocks updated for **`DeviceEntries`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b7e970b1ba01ee841248fc46f6164ef4f4931c7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->