### PR TITLE
Embed Asana task link in auto-generated content-scope-update PRs

### DIFF
--- a/.github/workflows/update-content-scope.yml
+++ b/.github/workflows/update-content-scope.yml
@@ -72,7 +72,7 @@ jobs:
           asana-section: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
           asana-task-name: Update content scope scripts to version ${{ steps.extract-release-version.outputs._1}}
           asana-task-description: |
-            Content scope scripts have been updated and a PR created.
+            Content scope scripts have been updated and a PR will be created.
 
             Tests will **only** run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.
 

--- a/.github/workflows/update-content-scope.yml
+++ b/.github/workflows/update-content-scope.yml
@@ -62,6 +62,34 @@ jobs:
           string: ${{steps.find-latest-release.outputs.prop}}
           split-by: '#'
 
+      - name: Create Asana task in Android App project
+        if: ${{ steps.update-check.outcome == 'failure' }}
+        id: create-task
+        uses: duckduckgo/native-github-asana-sync@v2.0
+        with:
+          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
+          asana-section: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
+          asana-task-name: Update content scope scripts to version ${{ steps.extract-release-version.outputs._1}}
+          asana-task-description: |
+            Content scope scripts have been updated and a PR created.
+
+            Tests will **only** run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.
+
+            If only `content-scope-scripts` package version has changed, there is no need to run the tests.
+
+            If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.
+          action: 'create-asana-task'
+
+      - name: Get Asana task permalink
+        if: ${{ steps.update-check.outcome == 'failure' }}
+        id: get-task-permalink
+        uses: duckduckgo/native-github-asana-sync@v2.0
+        with:
+          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana-task-id: ${{ steps.create-task.outputs.taskId }}
+          action: 'get-asana-task-permalink'
+
       - name: Create Pull Request in Android repo
         if: ${{ steps.update-check.outcome == 'failure' }}
         env:
@@ -77,6 +105,8 @@ jobs:
           labels: content scope scripts, automated pr
           branch: automated/update-content-scope-scripts-dependencies-${{ steps.extract-release-version.outputs._1}}
           body: |
+            Task/Issue URL: ${{ steps.get-task-permalink.outputs.asanaTaskPermalink }}
+
             - Automated content scope scripts dependency update
 
             This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.
@@ -95,27 +125,6 @@ jobs:
             - [ ] All tests must pass
             - [ ] Privacy tests do not need to run
 
-      - name: Create Asana task in Android App project
-        if: ${{ steps.update-check.outcome == 'failure' }}
-        id: create-task
-        uses: duckduckgo/native-github-asana-sync@v2.0
-        with:
-          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
-          asana-section: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
-          asana-task-name: Update content scope scripts to version ${{ steps.extract-release-version.outputs._1}}
-          asana-task-description: |
-            Content scope scripts have been updated and a PR created.
-
-            Tests will **only** run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.
-
-            If only `content-scope-scripts` package version has changed, there is no need to run the tests.
-
-            If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.
-
-            See ${{ steps.create-pr.outputs.pull-request-url }}
-          action: 'create-asana-task'
-
       - name: Add Asana task to Release Board project
         if: ${{ steps.create-task.outputs.duplicate == 'false' }}
         uses: duckduckgo/native-github-asana-sync@v2.0
@@ -125,18 +134,6 @@ jobs:
           asana-section: ${{ vars.GH_ANDROID_RELEASE_BOARD_PR_SECTION_ID }}
           asana-task-id: ${{ steps.create-task.outputs.taskId }}
           action: 'add-task-asana-project'
-
-      - name: Update PR description with Asana task
-        if: ${{ steps.create-task.outputs.duplicate == 'false' }}
-        uses: duckduckgo/native-github-asana-sync@v2.0
-        with:
-          github-pat: ${{ secrets.GT_DAXMOBILE }}
-          github-pr: ${{ steps.create-pr.outputs.pull-request-number }}
-          github-repository: 'android'
-          github-org: 'duckduckgo'
-          asana-project: ${{ vars.GH_ANDROID_RELEASE_BOARD_PROJECT_ID }}
-          asana-task-id: ${{ steps.create-task.outputs.taskId }}
-          action: 'add-task-pr-description'
 
       - name: Create Asana task when workflow failed
         if: ${{ failure() }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201807753394693/task/1215839555466066?focus=true
Tech Design URL (if applicable): 

### Description
Automated dependency-update PRs now include the Asana task link in the description from the moment they're created.

  **Before:** the workflow created the PR first (no task link), then created the Asana task, then patched the link into the PR afterwards. Since action-pr-opened became a required check — it reads Task/Issue URL:
  from the PR body on the opened event — these PRs opened without the link and failed the check.

  **Now:** the workflow creates the Asana task first, fetches its permalink, and opens the PR with Task/Issue URL: <link> as the first line of the description. The redundant "update PR description afterwards" step
  is removed. The PR→task back-link is still added automatically by action-pr-opened (pinned comment), so nothing is lost.

  **Scope:** this PR changes only update-content-scope.yml. The same fix for `update-ref-tests.yml` and `update-pir-broker-bundle.yml` will follow in separate PRs, so a problem here can't break all three at once.


### Steps to test this PR
- [ ] CI passes

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes GitHub Actions ordering and Asana/PR wiring for one automated workflow; no application runtime behavior.
> 
> **Overview**
> **Automated content-scope dependency PRs** now satisfy `action-pr-opened` by putting **Task/Issue URL** in the body when the PR is opened, instead of patching it afterward.
> 
> In `update-content-scope.yml`, **Create Asana task** and a new **Get Asana task permalink** step run **before choosing** before **Create Pull Request**. The PR template’s first line is `Task/Issue URL: ${{ steps.get-task-permalink.outputs.asanaTaskPermalink }}`. The **Update PR description with Asana task** step (`add-task-pr-description`) is removed. The Asana task copy no longer links to the PR URL upfront (wording says a PR *will* be created).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fda911ebd1cbab98f9781722c1f85766adb9e8d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->