### PR TITLE
Fix sending empty prompt to duck.ai in fresh install

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
@@ -74,6 +74,19 @@ interface DuckChatJSHelper {
     fun clearTabContextPromptEvent()
 
     fun consumeTabContextPromptOnHandoff(method: String): SubscriptionEventData?
+
+    /**
+     * On a fresh install the Duck.ai web frontend shows the terms/conditions landing page before any
+     * chat is available, so a pending native prompt cannot be auto-submitted on first load. Once the
+     * user accepts the conditions (reported via the [ReportMetric.USER_DID_ACCEPT_TERMS_AND_CONDITIONS]
+     * metric) the chat becomes ready, so we push the pending prompt to the frontend via the
+     * [SUBSCRIPTION_SUBMIT_NATIVE_PROMPT] subscription. Returns null when this isn't the terms-accepted
+     * message or there is no pending prompt to deliver.
+     */
+    fun consumeNativePromptOnTermsAccepted(
+        method: String,
+        data: JSONObject?,
+    ): SubscriptionEventData?
 }
 
 enum class Mode {
@@ -411,58 +424,83 @@ class RealDuckChatJSHelper @Inject constructor(
         return JsCallbackData(jsonPayload, featureName, method, id)
     }
 
-    private fun getAIChatNativePrompt(
+    private suspend fun getAIChatNativePrompt(
         featureName: String,
         method: String,
         id: String,
     ): JsCallbackData {
-        val pending = pendingNativePromptStore.consume()
+        // Until the user has accepted the Duck.ai terms, the frontend is on the landing page and can't
+        // auto-submit. Keep the pending prompt in the store so it isn't lost — it is delivered instead
+        // via the SUBSCRIPTION_SUBMIT_NATIVE_PROMPT push once terms are accepted (see
+        // consumeNativePromptOnTermsAccepted).
+        val pending = if (dataStore.hasUserAcceptedTerms()) pendingNativePromptStore.consume() else null
         val jsonPayload = JSONObject().apply {
             put(PLATFORM, ANDROID)
             if (pending != null) {
                 put("tool", "query")
+                put("query", buildNativePromptQuery(pending))
+            }
+        }
+        return JsCallbackData(jsonPayload, featureName, method, id)
+    }
+
+    override fun consumeNativePromptOnTermsAccepted(
+        method: String,
+        data: JSONObject?,
+    ): SubscriptionEventData? {
+        if (method != REPORT_METRIC) return null
+        if (data?.optString("metricName") != ReportMetric.USER_DID_ACCEPT_TERMS_AND_CONDITIONS.metric) return null
+        val pending = pendingNativePromptStore.consume() ?: return null
+        val params = JSONObject().apply {
+            put(PLATFORM, ANDROID)
+            put("tool", "query")
+            put("query", buildNativePromptQuery(pending))
+        }
+        return SubscriptionEventData(
+            featureName = DUCK_CHAT_FEATURE_NAME,
+            subscriptionName = SUBSCRIPTION_SUBMIT_NATIVE_PROMPT,
+            params = params,
+        )
+    }
+
+    private fun buildNativePromptQuery(pending: PendingNativePrompt): JSONObject =
+        JSONObject().apply {
+            put("prompt", pending.prompt)
+            put("autoSubmit", true)
+            if (pending.modelId != null) {
+                put("modelId", pending.modelId)
+            }
+            if (pending.reasoningEffort != null) {
+                put("reasoningEffort", pending.reasoningEffort)
+            }
+            if (pending.selectedTool != null) {
+                put("toolChoice", JSONArray().apply { put(pending.selectedTool) })
+            }
+            if (pending.images.isNotEmpty()) {
                 put(
-                    "query",
-                    JSONObject().apply {
-                        put("prompt", pending.prompt)
-                        put("autoSubmit", true)
-                        if (pending.modelId != null) {
-                            put("modelId", pending.modelId)
-                        }
-                        if (pending.reasoningEffort != null) {
-                            put("reasoningEffort", pending.reasoningEffort)
-                        }
-                        if (pending.selectedTool != null) {
-                            put("toolChoice", JSONArray().apply { put(pending.selectedTool) })
-                        }
-                        if (pending.images.isNotEmpty()) {
+                    "images",
+                    JSONArray().apply {
+                        pending.images.forEach { image ->
                             put(
-                                "images",
-                                JSONArray().apply {
-                                    pending.images.forEach { image ->
-                                        put(
-                                            JSONObject().apply {
-                                                put("data", image.base64Data)
-                                                put("format", image.format)
-                                            },
-                                        )
-                                    }
+                                JSONObject().apply {
+                                    put("data", image.base64Data)
+                                    put("format", image.format)
                                 },
                             )
                         }
-                        if (pending.files.isNotEmpty()) {
+                    },
+                )
+            }
+            if (pending.files.isNotEmpty()) {
+                put(
+                    "files",
+                    JSONArray().apply {
+                        pending.files.forEach { file ->
                             put(
-                                "files",
-                                JSONArray().apply {
-                                    pending.files.forEach { file ->
-                                        put(
-                                            JSONObject().apply {
-                                                put("data", file.base64Data)
-                                                put("fileName", file.fileName)
-                                                put("mimeType", file.mimeType)
-                                            },
-                                        )
-                                    }
+                                JSONObject().apply {
+                                    put("data", file.base64Data)
+                                    put("fileName", file.fileName)
+                                    put("mimeType", file.mimeType)
                                 },
                             )
                         }
@@ -470,8 +508,6 @@ class RealDuckChatJSHelper @Inject constructor(
                 )
             }
         }
-        return JsCallbackData(jsonPayload, featureName, method, id)
-    }
 
     private fun getEmptyPageContextResponse(
         featureName: String,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -50,6 +50,7 @@ import com.duckduckgo.duckchat.impl.feature.DuckAiChatHistoryFeature
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.feature.maxUrlSuggestions
 import com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper
+import com.duckduckgo.duckchat.impl.helper.PendingNativePromptStore
 import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenConfigResolver
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command
 import com.duckduckgo.duckchat.impl.inputscreen.ui.command.Command.EditWithSelectedQuery
@@ -158,6 +159,7 @@ class InputScreenViewModel @AssistedInject constructor(
     private val tabPageContextRepository: TabPageContextRepository,
     private val duckChatJSHelper: DuckChatJSHelper,
     private val autocompleteHistoryDeleteFeature: AutocompleteHistoryDeleteFeature,
+    private val pendingNativePromptStore: PendingNativePromptStore,
 ) : ViewModel() {
 
     private val autoComplete: AutoComplete = autoCompleteFactory.create(
@@ -995,6 +997,10 @@ class InputScreenViewModel @AssistedInject constructor(
     }
 
     private fun navigateToDuckChat(query: String) {
+        if (query.isNotEmpty()) {
+            // Store the prompt so it survives the Duck.ai terms/onboarding gate on fresh install
+            pendingNativePromptStore.store(prompt = query, modelId = null, reasoningEffort = null)
+        }
         when {
             visibilityState.value.fullScreenMode -> {
                 val url = duckChat.getDuckChatUrl(query, true)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatWebViewFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatWebViewFragment.kt
@@ -310,6 +310,13 @@ open class DuckChatWebViewFragment : DuckDuckGoFragment(R.layout.activity_duck_c
                                             contentScopeScripts.sendSubscriptionEvent(event)
                                         }
                                     }
+                                    duckChatJSHelper.consumeNativePromptOnTermsAccepted(method, data)?.let { event ->
+                                        // Fresh install: the prompt couldn't be auto-submitted while the
+                                        // terms landing page was showing; deliver it now that terms are accepted.
+                                        withContext(dispatcherProvider.main()) {
+                                            contentScopeScripts.sendSubscriptionEvent(event)
+                                        }
+                                    }
                                 }
                             }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
@@ -42,6 +42,7 @@ import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.js.messaging.api.JsCallbackData
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
@@ -50,6 +51,7 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -112,6 +114,13 @@ class RealDuckChatJSHelperTest {
                 }
                 """.trimIndent()
         }
+
+    @Before
+    fun setup() {
+        // Default to terms accepted so the native-prompt pull path behaves as before; the
+        // fresh-install (terms-not-accepted) behaviour is covered by dedicated tests.
+        runBlocking { whenever(mockDataStore.hasUserAcceptedTerms()).thenReturn(true) }
+    }
 
     @Test
     fun whenMethodIsUnknownThenReturnNull() = runTest {
@@ -1757,6 +1766,66 @@ class RealDuckChatJSHelperTest {
         )
 
         assertNull(result)
+    }
+
+    @Test
+    fun whenGetAIChatNativePromptAndTermsNotAcceptedThenPromptPreservedAndNotReturned() = runTest {
+        whenever(mockDataStore.hasUserAcceptedTerms()).thenReturn(false)
+
+        val result = testee.processJsCallbackMessage(
+            "aiChat",
+            "getAIChatNativePrompt",
+            "123",
+            null,
+            pageContext = viewModel.updatedPageContext,
+        )
+
+        assertNotNull(result)
+        assertEquals("android", result!!.params.getString("platform"))
+        assertFalse(result.params.has("tool"))
+        assertFalse(result.params.has("query"))
+        // The pending prompt must NOT be consumed before terms are accepted, so it can be
+        // delivered via the terms-accepted push instead.
+        verify(mockPendingNativePromptStore, never()).consume()
+    }
+
+    @Test
+    fun whenTermsAcceptedMetricWithPendingPromptThenReturnsSubmitNativePromptSubscription() {
+        val pending = PendingNativePrompt("test prompt", "model", "medium")
+        whenever(mockPendingNativePromptStore.consume()).thenReturn(pending)
+        val data = JSONObject().apply { put("metricName", "userDidAcceptTermsAndConditions") }
+
+        val event = testee.consumeNativePromptOnTermsAccepted("reportMetric", data)
+
+        assertNotNull(event)
+        assertEquals("aiChat", event!!.featureName)
+        assertEquals("submitAIChatNativePrompt", event.subscriptionName)
+        assertEquals("query", event.params.getString("tool"))
+        val query = event.params.getJSONObject("query")
+        assertEquals("test prompt", query.getString("prompt"))
+        assertTrue(query.getBoolean("autoSubmit"))
+        assertEquals("model", query.getString("modelId"))
+        assertEquals("medium", query.getString("reasoningEffort"))
+    }
+
+    @Test
+    fun whenTermsAcceptedMetricWithNoPendingPromptThenReturnsNull() {
+        whenever(mockPendingNativePromptStore.consume()).thenReturn(null)
+        val data = JSONObject().apply { put("metricName", "userDidAcceptTermsAndConditions") }
+
+        val event = testee.consumeNativePromptOnTermsAccepted("reportMetric", data)
+
+        assertNull(event)
+    }
+
+    @Test
+    fun whenDifferentMetricThenConsumeNativePromptOnTermsAcceptedReturnsNullAndDoesNotConsume() {
+        val data = JSONObject().apply { put("metricName", "userDidSubmitPrompt") }
+
+        val event = testee.consumeNativePromptOnTermsAccepted("reportMetric", data)
+
+        assertNull(event)
+        verify(mockPendingNativePromptStore, never()).consume()
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
@@ -105,6 +105,7 @@ class InputScreenViewModelTest {
     private val tabsFlow = MutableStateFlow<List<TabEntity>>(emptyList())
     private val tabPageContextRepository: com.duckduckgo.app.tabs.model.TabPageContextRepository = mock()
     private val duckChatJSHelper: com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper = mock()
+    private val pendingNativePromptStore: com.duckduckgo.duckchat.impl.helper.PendingNativePromptStore = mock()
 
     private val duckAiFeatureState: DuckAiFeatureState = mock()
     private val chatSuggestionsReader: com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.reader.ChatSuggestionsReader = mock()
@@ -165,6 +166,7 @@ class InputScreenViewModelTest {
             tabPageContextRepository = tabPageContextRepository,
             duckChatJSHelper = duckChatJSHelper,
             autocompleteHistoryDeleteFeature = autocompleteHistoryDeleteFeature,
+            pendingNativePromptStore = pendingNativePromptStore,
         )
 
     private fun aTab(id: String) = TabEntity(tabId = id, url = null, title = null)
@@ -584,6 +586,30 @@ class InputScreenViewModelTest {
             viewModel.onChatSubmitted(query)
 
             assertEquals(SubmitChat(query), viewModel.command.value)
+        }
+
+    @Test
+    fun `when onChatSubmitted with query then prompt is stored so it survives the onboarding gate`() =
+        runTest {
+            val viewModel = createViewModel()
+            val query = "example"
+
+            viewModel.onChatSubmitted(query)
+
+            verify(pendingNativePromptStore).store(prompt = query, modelId = null, reasoningEffort = null)
+        }
+
+    @Test
+    fun `when onChatSubmitted with web url then prompt is not stored`() =
+        runTest {
+            val viewModel = createViewModel()
+            val url = "https://example.com"
+
+            whenever(queryUrlPredictor.isUrl(url)).thenReturn(true)
+
+            viewModel.onChatSubmitted(url)
+
+            verify(pendingNativePromptStore, never()).store(any(), any(), any(), any(), any(), any())
         }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1215862725570121?focus=true
Tech Design URL (if applicable): 

### Description
Fix sending an empty prompt to duck.ai in fresh install

### Steps to test this PR

_Feature 1_
- [ ] Fresh install
- [ ] Go through onboarding until it's finished
- [ ] Write a prompt in native unified input field with Duck.ai selected and send
- [ ] Verify the prompt appears in Duck.ai chat

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to Duck.ai submit navigation using an existing in-memory store; no auth or data-model changes.
> 
> **Overview**
> Fixes **empty prompts reaching Duck.ai on first use** by persisting the user’s chat text before opening Duck Chat from the experimental omnibar.
> 
> **InputScreenViewModel** now depends on **`PendingNativePromptStore`**. In **`navigateToDuckChat`**, when the query is non-empty, it calls **`store(prompt, modelId = null, reasoningEffort = null)`** so the prompt can be replayed after the Duck.ai terms/onboarding gate on a fresh install (same mechanism used elsewhere in duckchat).
> 
> URL submissions in chat mode are unchanged and do **not** write to the pending store. Unit tests cover store-on-query and no-store-on-URL behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84cf8ae52f28f618051cee799ac17771a297f7d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->