### PR TITLE
add pixels for custom AI onboarding

### DIFF
--- a/PixelDefinitions/pixels/definitions/onboarding.json5
+++ b/PixelDefinitions/pixels/definitions/onboarding.json5
@@ -96,5 +96,33 @@
                 "description": "Only set when e=clicked. Composite encoding of the user's Quick Setup selections, formatted as 'set_as_default:on|off,widget:on|off,address_bar:top|bottom|split,input_type:search|search_and_duckai'."
             }
         ]
+    },
+    "onboarding_ai_started": {
+        "description": "Fires once when the custom AI onboarding plan starts, i.e. when the AI-referred onboarding path is selected at plan build time.",
+        "owners": ["LukasPaczos"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "onboarding_ai_finished": {
+        "description": "Fires once when a user who went through the custom AI onboarding reaches the ESTABLISHED app stage (onboarding finished).",
+        "owners": ["LukasPaczos"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "onboarding_ai_ai-comparison-screen-shown": {
+        "description": "Fires once when the AI comparison chart screen is shown during the custom AI onboarding.",
+        "owners": ["LukasPaczos"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "onboarding_ai_returning-sync-user-ignored": {
+        "description": "Fires once when a returning sync-restore-capable user enters the custom AI onboarding. That flow has no sync-restore step, so the restore offer is suppressed and the reinstall dialog is shown instead; this pixel records that the returning sync user was ignored.",
+        "owners": ["LukasPaczos"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingPixels.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingPixels.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding
+
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.app.onboarding.store.AppStage
+import com.duckduckgo.app.onboarding.store.AppUserStageStore
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin
+import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+
+enum class CustomAiOnboardingPixelName(override val pixelName: String) : Pixel.PixelName {
+    PLAN_STARTED("onboarding_ai_started"),
+    PLAN_FINISHED("onboarding_ai_finished"),
+    AI_COMPARISON_SCREEN_SHOW("onboarding_ai_ai-comparison-screen-shown"),
+    RETURNING_SYNC_USER_IGNORED("onboarding_ai_returning-sync-user-ignored"),
+}
+
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = MainProcessLifecycleObserver::class,
+)
+class CustomAiOnboardingPixels @Inject constructor(
+    @AppCoroutineScope private val coroutineScope: CoroutineScope,
+    appUserStageStore: AppUserStageStore,
+    private val customAiOnboardingStore: CustomAiOnboardingStore,
+    private val pixel: Pixel,
+) : MainProcessLifecycleObserver {
+    init {
+        appUserStageStore.userAppStageFlow().onEach {
+            if (it == AppStage.ESTABLISHED && customAiOnboardingStore.isEnabled()) {
+                pixel.fire(CustomAiOnboardingPixelName.PLAN_FINISHED, type = Pixel.PixelType.Unique())
+            }
+        }.launchIn(coroutineScope)
+    }
+}
+
+@ContributesMultibinding(AppScope::class)
+class CustomAiOnboardingPixelRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin {
+    override fun names(): List<Pair<String, Set<PixelParameter>>> {
+        return listOf(
+            CustomAiOnboardingPixelName.PLAN_STARTED.pixelName to PixelParameter.removeAtb(),
+            CustomAiOnboardingPixelName.PLAN_FINISHED.pixelName to PixelParameter.removeAtb(),
+            CustomAiOnboardingPixelName.AI_COMPARISON_SCREEN_SHOW.pixelName to PixelParameter.removeAtb(),
+            CustomAiOnboardingPixelName.RETURNING_SYNC_USER_IGNORED.pixelName to PixelParameter.removeAtb(),
+        )
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProvider.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.app.cta.db.DismissedCtaDao
 import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.app.cta.model.DismissedCta
 import com.duckduckgo.app.global.DefaultRoleBrowserDialog
+import com.duckduckgo.app.onboarding.CustomAiOnboardingPixelName
 import com.duckduckgo.app.onboarding.CustomAiOnboardingResolver
 import com.duckduckgo.app.onboarding.CustomAiOnboardingStore
 import com.duckduckgo.app.onboarding.DuckAiOnboardingAvailability
@@ -110,6 +111,8 @@ class NewUserOnboardingPlanProvider @Inject constructor(
             // prepare in-context CTAs
             duckAiOnboardingDemo.arm()
 
+            pixel.fire(CustomAiOnboardingPixelName.PLAN_STARTED, type = Unique())
+
             buildCustomAiPlan(onCompleted, onSkipped)
         } else {
             buildDefaultPlan(onCompleted, onSkipped)
@@ -152,7 +155,7 @@ class NewUserOnboardingPlanProvider @Inject constructor(
         rootOnSkipped: suspend () -> Unit,
     ): LinearOnboardingPlan {
         val ctx = NewUserOnboardingPlanContext()
-        val firstDialog = SuspendMemo { resolveFirstDialog(ctx, isCustomAiPlan = true) }
+        val firstDialog = SuspendMemo { resolveFirstDialog(ctx) }
 
         val skipPlan = skipPlan()
         val quickSetupPlan = quickSetupPlan(ctx)
@@ -186,7 +189,7 @@ class NewUserOnboardingPlanProvider @Inject constructor(
             steps = listOf(
                 introAnimationStep(withDuckAi = true),
                 notificationPermissionStep(),
-                initialReinstallUserStep(firstDialog, skipPlan, quickSetupPlan),
+                initialReinstallUserStep(firstDialog, skipPlan, quickSetupPlan, isCustomAiPlan = true),
                 initialStep(firstDialog),
                 aiComparisonChartStep(),
                 customAiInputScreenPreviewStep(ctx),
@@ -237,9 +240,9 @@ class NewUserOnboardingPlanProvider @Inject constructor(
             }
         }
 
-    private suspend fun resolveFirstDialog(ctx: NewUserOnboardingPlanContext, isCustomAiPlan: Boolean = false): FirstDialog =
+    private suspend fun resolveFirstDialog(ctx: NewUserOnboardingPlanContext): FirstDialog =
         withContext(dispatchers.io()) {
-            val canRestore = !isCustomAiPlan && withTimeoutOrNull(BLOCK_STORE_TIMEOUT_MS) {
+            val canRestore = withTimeoutOrNull(BLOCK_STORE_TIMEOUT_MS) {
                 try {
                     logcat { "Sync-AutoRestore: checking canRestore..." }
                     val result = syncAutoRestore.canRestore()
@@ -315,9 +318,23 @@ class NewUserOnboardingPlanProvider @Inject constructor(
         firstDialog: SuspendMemo<FirstDialog>,
         skipPlan: LinearOnboardingPlan,
         quickSetupPlan: LinearOnboardingPlan,
+        isCustomAiPlan: Boolean = false,
     ) = NewUserOnboardingActivityStep(
         id = NewUserOnboardingStepIds.INITIAL_REINSTALL_USER,
-        precondition = { firstDialog() == FirstDialog.REINSTALL },
+        precondition = {
+            when (firstDialog()) {
+                FirstDialog.SYNC_RESTORE -> {
+                    if (isCustomAiPlan) {
+                        pixel.fire(CustomAiOnboardingPixelName.RETURNING_SYNC_USER_IGNORED, type = Unique())
+                        true
+                    } else {
+                        false
+                    }
+                }
+                FirstDialog.REINSTALL -> true
+                FirstDialog.INITIAL -> false
+            }
+        },
         resolveDialog = { NewUserOnboardingActivityDialog.InitialReinstallUser },
         transition = { event ->
             when (event) {
@@ -588,9 +605,9 @@ class NewUserOnboardingPlanProvider @Inject constructor(
 
     companion object {
 
-        const val ROOT_PLAN_ID = "new_user_onboarding"
-        const val SKIP_PLAN_ID = "skip"
-        const val QUICK_SETUP_PLAN_ID = "quick_setup"
+        const val ROOT_PLAN_ID = "new-user_onboarding"
+        const val SKIP_PLAN_ID = "new-user_skip"
+        const val QUICK_SETUP_PLAN_ID = "new-user_quick-setup"
 
         private const val BLOCK_STORE_TIMEOUT_MS = 3_000L
     }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModel.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.app.browser.omnibar.OmnibarType
 import com.duckduckgo.app.cta.ui.DaxBubbleCta.DaxDialogIntroOption
 import com.duckduckgo.app.global.DefaultRoleBrowserDialog
 import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.onboarding.CustomAiOnboardingPixelName
 import com.duckduckgo.app.onboarding.CustomAiOnboardingStore
 import com.duckduckgo.app.onboarding.DuckAiOnboardingAvailability
 import com.duckduckgo.app.onboarding.orchestrator.NewUserOnboardingActivityDialog
@@ -266,9 +267,7 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
             INITIAL_REINSTALL_USER -> pixel.fire(PREONBOARDING_INTRO_REINSTALL_USER_SHOWN_UNIQUE, type = Unique())
             INITIAL -> pixel.fire(PREONBOARDING_INTRO_SHOWN_UNIQUE, type = Unique())
             COMPARISON_CHART -> pixel.fire(PREONBOARDING_COMPARISON_CHART_SHOWN_UNIQUE, type = Unique())
-            AI_COMPARISON_CHART -> {
-                // TODO add pixel when trigger is wired
-            }
+            AI_COMPARISON_CHART -> pixel.fire(CustomAiOnboardingPixelName.AI_COMPARISON_SCREEN_SHOW, type = Unique())
             SKIP_ONBOARDING_OPTION -> pixel.fire(PREONBOARDING_SKIP_ONBOARDING_SHOWN_UNIQUE, type = Unique())
             ADDRESS_BAR_POSITION -> pixel.fire(PREONBOARDING_ADDRESS_BAR_POSITION_SHOWN_UNIQUE, type = Unique())
             INPUT_SCREEN -> pixel.fire(PREONBOARDING_CHOOSE_SEARCH_EXPERIENCE_IMPRESSIONS_UNIQUE, type = Unique())

--- a/app/src/test/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProviderTest.kt
@@ -20,6 +20,7 @@ import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserDetector
 import com.duckduckgo.app.browser.omnibar.OmnibarType
 import com.duckduckgo.app.cta.db.DismissedCtaDao
 import com.duckduckgo.app.global.DefaultRoleBrowserDialog
+import com.duckduckgo.app.onboarding.CustomAiOnboardingPixelName
 import com.duckduckgo.app.onboarding.CustomAiOnboardingResolver
 import com.duckduckgo.app.onboarding.CustomAiOnboardingStore
 import com.duckduckgo.app.onboarding.DuckAiOnboardingAvailability
@@ -197,6 +198,8 @@ class NewUserOnboardingPlanProviderTest {
         verify(syncAutoRestore).restoreSyncAccount()
         // Advances past the mutually-exclusive reinstall/initial steps to comparison chart.
         assertStep(NewUserOnboardingStepIds.COMPARISON_CHART)
+        // The custom-AI "returning sync user ignored" pixel must not leak into the default plan
+        verify(pixel, never()).fire(CustomAiOnboardingPixelName.RETURNING_SYNC_USER_IGNORED, type = Unique())
     }
 
     @Test
@@ -524,5 +527,44 @@ class NewUserOnboardingPlanProviderTest {
         // Continue from the comparison chart skips both gated steps (precondition false) and lands on the next satisfied step.
         orchestrator.onEvent(NewUserOnboardingEvent.ContinueClicked)
         assertStep(NewUserOnboardingStepIds.COMPARISON_CHART)
+    }
+
+    @Test
+    fun `when custom ai path then fires plan started pixel`() = runTest {
+        whenever(customAiOnboardingResolver.resolve()).thenReturn(true)
+        start()
+        verify(pixel).fire(CustomAiOnboardingPixelName.PLAN_STARTED, type = Unique())
+    }
+
+    @Test
+    fun `when default path then does not fire plan started pixel`() = runTest {
+        start()
+        verify(pixel, never()).fire(CustomAiOnboardingPixelName.PLAN_STARTED, type = Unique())
+    }
+
+    @Test
+    fun `when custom ai path and can restore then shows reinstall dialog and fires returning sync user ignored pixel`() = runTest {
+        whenever(customAiOnboardingResolver.resolve()).thenReturn(true)
+        whenever(syncAutoRestore.canRestore()).thenReturn(true)
+        start()
+        orchestrator.onEvent(NewUserOnboardingEvent.IntroAnimationFinished)
+        orchestrator.onEvent(NewUserOnboardingEvent.NotificationPermissionFinished)
+        // The custom-AI plan has no sync-restore step, so a restore-capable user gets the reinstall dialog instead.
+        assertStep(NewUserOnboardingStepIds.INITIAL_REINSTALL_USER)
+        verify(pixel).fire(CustomAiOnboardingPixelName.RETURNING_SYNC_USER_IGNORED, type = Unique())
+        // No restore is offered: the sync-restore step does not exist on this plan.
+        verify(syncAutoRestore, never()).restoreSyncAccount()
+        orchestrator.onEvent(NewUserOnboardingEvent.ContinueClicked)
+        assertStep(NewUserOnboardingStepIds.AI_COMPARISON_CHART)
+    }
+
+    @Test
+    fun `when custom ai path and initial user then does not fire returning sync user ignored pixel`() = runTest {
+        whenever(customAiOnboardingResolver.resolve()).thenReturn(true)
+        start()
+        orchestrator.onEvent(NewUserOnboardingEvent.IntroAnimationFinished)
+        orchestrator.onEvent(NewUserOnboardingEvent.NotificationPermissionFinished)
+        assertStep(NewUserOnboardingStepIds.INITIAL)
+        verify(pixel, never()).fire(CustomAiOnboardingPixelName.RETURNING_SYNC_USER_IGNORED, type = Unique())
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModelTest.kt
@@ -25,8 +25,12 @@ import com.duckduckgo.app.browser.omnibar.OmnibarType
 import com.duckduckgo.app.cta.ui.DaxBubbleCta.DaxDialogIntroOption
 import com.duckduckgo.app.global.DefaultRoleBrowserDialog
 import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.onboarding.CustomAiOnboardingPixelName
 import com.duckduckgo.app.onboarding.CustomAiOnboardingStore
 import com.duckduckgo.app.onboarding.DuckAiOnboardingAvailability
+import com.duckduckgo.app.onboarding.orchestrator.NewUserOnboardingActivityDialog
+import com.duckduckgo.app.onboarding.orchestrator.NewUserOnboardingActivityStep
+import com.duckduckgo.app.onboarding.orchestrator.NewUserOnboardingPlanProvider
 import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.onboarding.ui.page.BrandDesignUpdatePageViewModel.Command
 import com.duckduckgo.app.onboardingquicksetup.OnboardingQuickSetupExperimentManager
@@ -63,7 +67,9 @@ import com.duckduckgo.duckchat.impl.inputscreen.wideevents.InputScreenOnboarding
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.onboarding.api.LinearOnboardingOrchestrator
+import com.duckduckgo.onboarding.api.LinearOnboardingPlan
 import com.duckduckgo.onboarding.api.LinearOnboardingState
+import com.duckduckgo.onboarding.api.LinearOnboardingTransition
 import com.duckduckgo.sync.api.SyncAutoRestore
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
@@ -109,9 +115,9 @@ class BrandDesignUpdatePageViewModelTest {
     private val mockQuickSetupPixelSender: QuickSetupPixelSender = mock()
     private val mockCustomAiOnboardingStore: CustomAiOnboardingStore = mock()
 
-    // Legacy mode: the VM derives its mode from orchestrator.state, which this mock holds at NotStarted.
+    private val orchestratorState = MutableStateFlow<LinearOnboardingState>(LinearOnboardingState.NotStarted)
     private val mockOrchestrator: LinearOnboardingOrchestrator = mock {
-        on { state } doReturn MutableStateFlow(LinearOnboardingState.NotStarted)
+        on { state } doReturn orchestratorState
     }
 
     @Before
@@ -1646,6 +1652,37 @@ class BrandDesignUpdatePageViewModelTest {
         whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(true)
         whenever(mockOnboardingQuickSetupExperimentManager.enroll()).thenReturn(QuickSetupExperimentVariant.TREATMENT)
     }
+
+    // endregion
+
+    // region AI comparison chart shown pixel (orchestrator-driven flow)
+
+    @Test
+    fun whenAiComparisonChartShownThenFiresAiComparisonScreenShowPixel() = runTest {
+        whenever(mockCustomAiOnboardingStore.isEnabled()).thenReturn(true)
+        val plan = LinearOnboardingPlan(
+            id = NewUserOnboardingPlanProvider.ROOT_PLAN_ID,
+            steps = listOf(aiComparisonChartStep()),
+        )
+        orchestratorState.value = LinearOnboardingState.InProgress(
+            rootPlanId = NewUserOnboardingPlanProvider.ROOT_PLAN_ID,
+            currentPlan = plan,
+            currentStepIndex = 0,
+        )
+
+        createViewModel()
+        advanceUntilIdle()
+
+        verify(mockPixel).fire(CustomAiOnboardingPixelName.AI_COMPARISON_SCREEN_SHOW, type = Unique())
+    }
+
+    private fun aiComparisonChartStep() =
+        NewUserOnboardingActivityStep(
+            id = "ai_comparison_chart",
+            showsStepIndicator = true,
+            transition = { LinearOnboardingTransition.Stay },
+            resolveDialog = { NewUserOnboardingActivityDialog.AiComparisonChart },
+        )
 
     // endregion
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1215863467331162?focus=true
Tech Design URL (if applicable): 

### Description
Adds pixels for the Custom AI onboarding flow.

### Steps to test this PR

Apply below diff:
```diff
diff --git a/app/src/main/java/com/duckduckgo/app/onboarding/CustomDuckAiOnboardingFeature.kt b/app/src/main/java/com/duckduckgo/app/onboarding/CustomDuckAiOnboardingFeature.kt
index 8ccb40d67a..d862242281 100644
--- a/app/src/main/java/com/duckduckgo/app/onboarding/CustomDuckAiOnboardingFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/CustomDuckAiOnboardingFeature.kt
@@ -27,6 +27,6 @@ import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 )
 interface CustomDuckAiOnboardingFeature {
 
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 }
diff --git a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
index 45cf70f5b6..bcdddd1ff4 100644
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -133,8 +133,7 @@ interface DuckChatFeature {
     /**
      * @return `true` when the Native Input Field should be used instead of the web-based input.
      */
-    @InternalAlwaysEnabled
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun nativeInputField(): Toggle
 
     /**
```
- [x] Filter logcat by `onboarding_ai`

_regression_
- [x] Clean install the app
- [x] Go through onboarding
- [x] Verify these pixels were **not** sent:
  - [x] `onboarding_ai_started`
  - [x] `onboarding_ai_returning-sync-user-ignored`
  - [x] `onboarding_ai_ai-comparison-screen-shown`
  - [x] `onboarding_ai_finished`

- [x] Additionally apply below diff:
```diff
diff --git a/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt b/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
index 4daa9aad30..470bfcd092 100644
--- a/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
@@ -101,6 +101,7 @@ class CustomAiOnboardingStoreImpl @Inject constructor(
     }
 
     override suspend fun resolve() = resolveMutex.withLock {
+        return@withLock true
         withContext(dispatcherProvider.io()) {
             // Ensure the install referrer (and therefore the processing function) has resolved before reading.
             withTimeoutOrNull(MAX_REFERRER_WAIT_TIME_MS) { referrerStateListener.get().waitForReferrerCode() }
@@ -118,6 +119,7 @@ class CustomAiOnboardingStoreImpl @Inject constructor(
     }
 
     override suspend fun isEnabled(): Boolean = resolveMutex.withLock {
+        return@withLock true
         withContext(dispatcherProvider.io()) {
             preferences.getBoolean(PREFS_KEY_ENABLED, false)
         }
```

_onboarding_
- [x] Clean install the app
- [x] Go through onboarding
- [x] Verify these pixels were sent, without ATB:
  - [x] `onboarding_ai_started`
  - [x] `onboarding_ai_ai-comparison-screen-shown`
  - [x] `onboarding_ai_finished`

_skip_
- [x] Clean install the app
- [x] Click 'I've been here before' -> 'Start AI Chat'
- [x] Verify these pixels were sent, without ATB:
  - [x] `onboarding_ai_started`
  - [x] `onboarding_ai_finished`

_sync returning user_
- [x] Enable Sync on the device ('Settings -> Sync & Backup -> Sync and Backup This Device')
- [x] Uninstall the app, do **not remove caches**
- [x] Install the app
- [x] Verify you see the base returning user screen, no 'Restore my stuff' string
- [x] Verify these pixels were sent, without ATB:
  - [x] `onboarding_ai_started`
  - [x] `onboarding_ai_returning-sync-user-ignored`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Custom AI onboarding now suppresses sync restore for eligible users (behavior change) and renames persisted plan IDs, which could affect in-flight orchestrator state; otherwise changes are telemetry-only with tests.
> 
> **Overview**
> Adds **four unique `onboarding_ai_*` pixels** (definitions plus app wiring) to measure the custom AI onboarding funnel: plan start, finish at `ESTABLISHED`, AI comparison screen shown, and returning sync-restore users routed to reinstall instead of restore.
> 
> **Instrumentation:** `CustomAiOnboardingPixels` fires `onboarding_ai_finished` when app stage becomes `ESTABLISHED` and custom AI onboarding is enabled; ATB is stripped for all four events via `CustomAiOnboardingPixelRemovalPlugin`. `PLAN_STARTED` fires when the custom AI root plan is built; the AI comparison chart fires from `BrandDesignUpdatePageViewModel` (replacing a TODO). **Returning sync users on the custom AI path:** `initialReinstallUserStep` now treats `SYNC_RESTORE` as reinstall when `isCustomAiPlan`, fires `RETURNING_SYNC_USER_IGNORED`, and no longer skips sync restore via `resolveFirstDialog(isCustomAiPlan)`. Root/skip/quick-setup **plan IDs** were renamed to `new-user_*` strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d316de0a4be4a11fefd73c39c077fda35cb305fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->