### PR TITLE
Add immediate and data parameter templates to EventHub

### DIFF
--- a/event-hub/event-hub-impl/src/main/java/com/duckduckgo/eventhub/impl/pixels/EventHubConfig.kt
+++ b/event-hub/event-hub-impl/src/main/java/com/duckduckgo/eventhub/impl/pixels/EventHubConfig.kt
@@ -26,8 +26,13 @@ data class TelemetryPixelConfig(
 }
 
 data class TelemetryTriggerConfig(
-    val period: TelemetryPeriodConfig,
-)
+    val type: String = "period",
+    val period: TelemetryPeriodConfig = TelemetryPeriodConfig(),
+    val source: String? = null,
+) {
+    val isImmediate: Boolean get() = type == "immediate"
+    val isPeriod: Boolean get() = type == "period"
+}
 
 data class TelemetryPeriodConfig(
     val seconds: Int = 0,
@@ -41,10 +46,12 @@ data class TelemetryPeriodConfig(
 
 data class TelemetryParameterConfig(
     val template: String,
-    val source: String,
-    val buckets: Map<String, BucketConfig>,
+    val source: String? = null,
+    val dataKey: String? = null,
+    val buckets: Map<String, BucketConfig> = emptyMap(),
 ) {
     val isCounter: Boolean get() = template == "counter"
+    val isData: Boolean get() = template == "data"
 }
 
 data class BucketConfig(
@@ -52,7 +59,11 @@ data class BucketConfig(
     val lt: Int?,
 )
 
-data class ParamState(val value: Int, val stopCounting: Boolean = false)
+data class ParamState(
+    val value: Int,
+    val stopCounting: Boolean = false,
+    val lastDataValue: String? = null,
+)
 
 data class PixelState(
     val pixelName: String,

--- a/event-hub/event-hub-impl/src/main/java/com/duckduckgo/eventhub/impl/pixels/EventHubConfigParser.kt
+++ b/event-hub/event-hub-impl/src/main/java/com/duckduckgo/eventhub/impl/pixels/EventHubConfigParser.kt
@@ -32,7 +32,9 @@ private data class TelemetryPixelJson(
 )
 
 private data class TelemetryTriggerJson(
-    val period: TelemetryPeriodJson,
+    val type: String? = null,
+    val period: TelemetryPeriodJson? = null,
+    val source: String? = null,
 )
 
 private data class TelemetryPeriodJson(
@@ -45,6 +47,7 @@ private data class TelemetryPeriodJson(
 private data class TelemetryParameterJson(
     val template: String,
     val source: String? = null,
+    val dataKey: String? = null,
     val buckets: Map<String, BucketJson>? = null,
 )
 
@@ -85,18 +88,21 @@ object EventHubConfigParser {
         val pixelJson = TelemetryPixelJson(
             state = config.state,
             trigger = TelemetryTriggerJson(
+                type = config.trigger.type,
                 period = TelemetryPeriodJson(
                     seconds = config.trigger.period.seconds,
                     minutes = config.trigger.period.minutes,
                     hours = config.trigger.period.hours,
                     days = config.trigger.period.days,
                 ),
+                source = config.trigger.source,
             ),
             parameters = config.parameters.mapValues { (_, paramConfig) ->
                 TelemetryParameterJson(
                     template = paramConfig.template,
                     source = paramConfig.source,
-                    buckets = paramConfig.buckets.mapValues { (_, bucket) ->
+                    dataKey = paramConfig.dataKey,
+                    buckets = paramConfig.buckets.takeIf { it.isNotEmpty() }?.mapValues { (_, bucket) ->
                         BucketJson(gte = bucket.gte, lt = bucket.lt)
                     },
                 )
@@ -108,41 +114,66 @@ object EventHubConfigParser {
     }
 
     private fun toTelemetryPixelConfig(name: String, json: TelemetryPixelJson): TelemetryPixelConfig? {
-        val periodJson = json.trigger.period
-        if (periodJson.seconds == 0 && periodJson.minutes == 0 && periodJson.hours == 0 && periodJson.days == 0) return null
-
-        val period = TelemetryPeriodConfig(
-            seconds = periodJson.seconds,
-            minutes = periodJson.minutes,
-            hours = periodJson.hours,
-            days = periodJson.days,
-        )
-        if (period.periodSeconds <= 0) return null
+        val trigger = toTriggerConfig(json.trigger) ?: return null
 
         val parameters = mutableMapOf<String, TelemetryParameterConfig>()
         for ((paramName, paramJson) in json.parameters) {
             toParameterConfig(paramJson)?.let { parameters[paramName] = it }
         }
-        if (parameters.isEmpty()) return null
+        // Period pixels need at least one parameter to produce a payload; immediate pixels may fire with none.
+        if (trigger.isPeriod && parameters.isEmpty()) return null
 
         return TelemetryPixelConfig(
             name = name,
             state = json.state,
-            trigger = TelemetryTriggerConfig(period = period),
+            trigger = trigger,
             parameters = parameters,
         )
     }
 
-    private fun toParameterConfig(json: TelemetryParameterJson): TelemetryParameterConfig? {
-        if (json.template != "counter") return null
-        val source = json.source ?: return null
-        val bucketsJson = json.buckets ?: return null
-
-        val buckets = bucketsJson.mapValuesTo(linkedMapOf()) { (_, bucketJson) ->
-            BucketConfig(gte = bucketJson.gte, lt = bucketJson.lt)
+    private fun toTriggerConfig(json: TelemetryTriggerJson): TelemetryTriggerConfig? {
+        return when (json.type ?: PERIOD) {
+            PERIOD -> {
+                val periodJson = json.period ?: return null
+                val period = TelemetryPeriodConfig(
+                    seconds = periodJson.seconds,
+                    minutes = periodJson.minutes,
+                    hours = periodJson.hours,
+                    days = periodJson.days,
+                )
+                if (period.periodSeconds <= 0) return null
+                TelemetryTriggerConfig(type = PERIOD, period = period)
+            }
+            IMMEDIATE -> {
+                val source = json.source?.takeIf { it.isNotEmpty() } ?: return null
+                TelemetryTriggerConfig(type = IMMEDIATE, source = source)
+            }
+            else -> null
         }
-        if (buckets.isEmpty()) return null
-
-        return TelemetryParameterConfig(template = json.template, source = source, buckets = buckets)
     }
+
+    private fun toParameterConfig(json: TelemetryParameterJson): TelemetryParameterConfig? {
+        return when (json.template) {
+            COUNTER -> {
+                val source = json.source ?: return null
+                val bucketsJson = json.buckets ?: return null
+                val buckets = bucketsJson.mapValuesTo(linkedMapOf()) { (_, bucketJson) ->
+                    BucketConfig(gte = bucketJson.gte, lt = bucketJson.lt)
+                }
+                if (buckets.isEmpty()) return null
+                TelemetryParameterConfig(template = COUNTER, source = source, buckets = buckets)
+            }
+            DATA -> {
+                val dataKey = json.dataKey ?: return null
+                // source is optional: aggregate pixels use it to select the source event; immediate pixels omit it.
+                TelemetryParameterConfig(template = DATA, source = json.source, dataKey = dataKey)
+            }
+            else -> null
+        }
+    }
+
+    private const val PERIOD = "period"
+    private const val IMMEDIATE = "immediate"
+    private const val COUNTER = "counter"
+    private const val DATA = "data"
 }

--- a/event-hub/event-hub-impl/src/main/java/com/duckduckgo/eventhub/impl/pixels/EventHubConfigParser.kt
+++ b/event-hub/event-hub-impl/src/main/java/com/duckduckgo/eventhub/impl/pixels/EventHubConfigParser.kt
@@ -164,7 +164,7 @@ object EventHubConfigParser {
                 TelemetryParameterConfig(template = COUNTER, source = source, buckets = buckets)
             }
             DATA -> {
-                val dataKey = json.dataKey ?: return null
+                val dataKey = json.dataKey?.takeIf { it.isNotEmpty() } ?: return null
                 // source is optional: aggregate pixels use it to select the source event; immediate pixels omit it.
                 TelemetryParameterConfig(template = DATA, source = json.source, dataKey = dataKey)
             }

--- a/event-hub/event-hub-impl/src/main/java/com/duckduckgo/eventhub/impl/pixels/EventHubPixelManager.kt
+++ b/event-hub/event-hub-impl/src/main/java/com/duckduckgo/eventhub/impl/pixels/EventHubPixelManager.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.launch
 import logcat.LogPriority.DEBUG
 import logcat.LogPriority.VERBOSE
 import logcat.logcat
+import org.json.JSONArray
 import org.json.JSONObject
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
@@ -125,7 +126,12 @@ class RealEventHubPixelManager @Inject constructor(
 
         if (!isEnabled()) return
 
+        val eventData = data.optJSONObject("data")
+
         appCoroutineScope.launch(pixelDispatcher) {
+            // Immediate pixels fire right away on a matching event: no period, persistence, dedup, or foreground gating.
+            fireImmediatePixels(eventType, eventData)
+
             val nowMillis = timeProvider.currentTimeMillis()
 
             for (pixelState in repository.getAllPixelStates()) {
@@ -150,6 +156,11 @@ class RealEventHubPixelManager @Inject constructor(
                         val newValue = paramState.value + 1
                         updatedParams[paramName] = paramState.copy(value = newValue)
                         logcat(VERBOSE) { "EventHub: ${pixelState.pixelName}.$paramName incremented to $newValue" }
+                    } else if (paramConfig.isData && paramConfig.source == eventType) {
+                        // Aggregate data params keep the most recent value seen on the matching source event.
+                        val paramState = updatedParams[paramName] ?: ParamState(0)
+                        updatedParams[paramName] = paramState.copy(lastDataValue = extractDataParam(eventData, paramConfig.dataKey))
+                        changed = true
                     }
                 }
 
@@ -157,6 +168,18 @@ class RealEventHubPixelManager @Inject constructor(
                     repository.savePixelState(pixelState.copy(params = updatedParams))
                 }
             }
+        }
+    }
+
+    private fun fireImmediatePixels(eventType: String, eventData: JSONObject?) {
+        for (config in getTelemetryConfigs()) {
+            if (!config.isEnabled || !config.trigger.isImmediate || config.trigger.source != eventType) continue
+            logcat(DEBUG) { "EventHub: firing immediate pixel ${config.name}" }
+            pixel.enqueueFire(
+                pixelName = config.name,
+                parameters = emptyMap(),
+                encodedParameters = buildDataParams(config, eventData),
+            )
         }
     }
 
@@ -192,6 +215,7 @@ class RealEventHubPixelManager @Inject constructor(
     private fun initMissingPixels(): Long {
         var nextDeadline = Long.MAX_VALUE
         for (pixelConfig in getTelemetryConfigs()) {
+            if (!pixelConfig.trigger.isPeriod) continue
             if (repository.getPixelState(pixelConfig.name) == null) {
                 val deadline = startNewPeriod(pixelConfig)
                 if (deadline != null) {
@@ -222,6 +246,7 @@ class RealEventHubPixelManager @Inject constructor(
                 nextDeadline = minOf(nextDeadline, pixelState.periodEndMillis)
             }
             for (pixelConfig in telemetry) {
+                if (!pixelConfig.trigger.isPeriod) continue
                 if (repository.getPixelState(pixelConfig.name) == null) {
                     val deadline = startNewPeriod(pixelConfig)
                     if (deadline != null) {
@@ -254,20 +279,21 @@ class RealEventHubPixelManager @Inject constructor(
     }
 
     private fun fireTelemetry(pixelState: PixelState): Long? {
-        val pixelData = buildPixel(pixelState)
+        val (parameters, encodedParameters) = buildPixel(pixelState)
 
-        if (pixelData.isNotEmpty()) {
-            val additionalParams = mapOf(
+        if (parameters.isNotEmpty() || encodedParameters.isNotEmpty()) {
+            val attributionParams = mapOf(
                 PARAM_ATTRIBUTION_PERIOD to calculateAttributionPeriod(
                     pixelState.periodStartMillis,
                     pixelState.config.trigger.period,
                 ).toString(),
             )
-            val allParams = pixelData + additionalParams
-            logcat(DEBUG) { "EventHub: firing pixel ${pixelState.pixelName} params=$allParams" }
+            val allParams = parameters + attributionParams
+            logcat(DEBUG) { "EventHub: firing pixel ${pixelState.pixelName} params=$allParams encoded=$encodedParameters" }
             pixel.enqueueFire(
                 pixelName = pixelState.pixelName,
                 parameters = allParams,
+                encodedParameters = encodedParameters,
             )
         } else {
             logcat(VERBOSE) { "EventHub: skipping pixel ${pixelState.pixelName}, no params" }
@@ -302,24 +328,57 @@ class RealEventHubPixelManager @Inject constructor(
         return periodEndMillis
     }
 
-    private fun buildPixel(pixelState: PixelState): Map<String, String> {
-        val pixelData = mutableMapOf<String, String>()
+    private fun buildPixel(pixelState: PixelState): Pair<Map<String, String>, Map<String, String>> {
+        val parameters = mutableMapOf<String, String>()
+        val encodedParameters = mutableMapOf<String, String>()
 
         for ((paramName, paramConfig) in pixelState.config.parameters) {
             if (paramConfig.isCounter) {
                 val value = (pixelState.params[paramName] ?: ParamState(0)).value
                 val bucketName = BucketCounter.bucketCount(value, paramConfig.buckets)
                 if (bucketName != null) {
-                    pixelData[paramName] = bucketName
+                    parameters[paramName] = bucketName
                 }
+            } else if (paramConfig.isData) {
+                pixelState.params[paramName]?.lastDataValue?.let { encodedParameters[paramName] = it }
             }
         }
 
-        return pixelData
+        return parameters to encodedParameters
+    }
+
+    private fun buildDataParams(config: TelemetryPixelConfig, eventData: JSONObject?): Map<String, String> {
+        val encodedParameters = mutableMapOf<String, String>()
+        for ((paramName, paramConfig) in config.parameters) {
+            if (!paramConfig.isData) continue
+            extractDataParam(eventData, paramConfig.dataKey)?.let { encodedParameters[paramName] = it }
+        }
+        return encodedParameters
+    }
+
+    /**
+     * Reads [dataKey] from a webEvent's `data` payload and returns the compact-JSON value %-encoded, or null
+     * when the key is absent (so the parameter is omitted). Mirrors the encoding used elsewhere for detection data.
+     */
+    private fun extractDataParam(eventData: JSONObject?, dataKey: String?): String? {
+        if (eventData == null || dataKey == null || !eventData.has(dataKey)) return null
+        val compactJson = if (eventData.isNull(dataKey)) {
+            "null"
+        } else {
+            when (val value = eventData.get(dataKey)) {
+                is JSONObject, is JSONArray -> value.toString()
+                is String -> JSONObject.quote(value)
+                else -> value.toString()
+            }
+        }
+        return percentEncode(compactJson)
     }
 
     companion object {
         const val PARAM_ATTRIBUTION_PERIOD = "attributionPeriod"
+
+        // RFC 3986 unreserved characters pass through; everything else is %-encoded.
+        private const val UNRESERVED = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~"
 
         fun calculateAttributionPeriod(periodStartMillis: Long, period: TelemetryPeriodConfig): Long {
             return toStartOfInterval(periodStartMillis, period.periodSeconds)
@@ -328,6 +387,23 @@ class RealEventHubPixelManager @Inject constructor(
         fun toStartOfInterval(timestampMillis: Long, periodSeconds: Long): Long {
             val epochSeconds = timestampMillis / 1000
             return (epochSeconds / periodSeconds) * periodSeconds
+        }
+
+        /**
+         * Percent-encodes [value] per RFC 3986. The data-template payload is already a compact-JSON string; this
+         * encodes it once so it can be sent verbatim as an encoded pixel parameter without double-encoding.
+         */
+        fun percentEncode(value: String): String {
+            val builder = StringBuilder()
+            for (byte in value.toByteArray(Charsets.UTF_8)) {
+                val code = byte.toInt() and 0xFF
+                if (code.toChar() in UNRESERVED) {
+                    builder.append(code.toChar())
+                } else {
+                    builder.append('%').append("%02X".format(code))
+                }
+            }
+            return builder.toString()
         }
     }
 }

--- a/event-hub/event-hub-impl/src/test/java/com/duckduckgo/eventhub/impl/pixels/EventHubDataParameterTest.kt
+++ b/event-hub/event-hub-impl/src/test/java/com/duckduckgo/eventhub/impl/pixels/EventHubDataParameterTest.kt
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.eventhub.impl.pixels
+
+import android.annotation.SuppressLint
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.CurrentTimeProvider
+import com.duckduckgo.eventhub.impl.EventHubFeature
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+/**
+ * A `data`-template parameter forwards `webEvent.data[dataKey]` into the pixel as the compact-JSON value
+ * %-encoded (without double-encoding), carried as an already-encoded pixel parameter. Absent keys are
+ * omitted. Immediate pixels use the triggering message's data (no `source`); aggregate pixels use the
+ * last value seen on a matching `source`. Ported from the Windows EventHub spec (EventHubDataParameterTests).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class EventHubDataParameterTest {
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule(StandardTestDispatcher())
+
+    private val repository = FakeEventHubRepository()
+    private val pixel: Pixel = mock()
+    private val timeProvider = FakeCurrentTimeProvider()
+    private val eventHubFeature: EventHubFeature = FakeFeatureToggleFactory.create(EventHubFeature::class.java)
+    private lateinit var manager: RealEventHubPixelManager
+
+    private val immediateDataConfig = """
+        {
+            "telemetry": {
+                "webEvent_login": {
+                    "state": "enabled",
+                    "trigger": { "type": "immediate", "source": "login" },
+                    "parameters": {
+                        "loginState": { "template": "data", "dataKey": "loginState" }
+                    }
+                }
+            }
+        }
+    """.trimIndent()
+
+    private fun eventWithData(type: String, dataJson: String) =
+        JSONObject().put("type", type).put("data", JSONObject(dataJson))
+
+    @SuppressLint("DenyListedApi")
+    private fun activeManager(settings: String) {
+        eventHubFeature.self().setRawStoredState(Toggle.State(enable = false))
+        manager = RealEventHubPixelManager(
+            repository, pixel, timeProvider, coroutineTestRule.testScope,
+            UnconfinedTestDispatcher(coroutineTestRule.testScope.testScheduler), eventHubFeature,
+        )
+        manager.onAppForegrounded()
+        eventHubFeature.self().setRawStoredState(Toggle.State(enable = true, settings = settings))
+    }
+
+    private fun firedEncodedParams(pixelName: String): Map<String, String> {
+        val encoded = argumentCaptor<Map<String, String>>()
+        verify(pixel).enqueueFire(eq(pixelName), any(), encoded.capture(), any())
+        return encoded.firstValue
+    }
+
+    @Test
+    fun `immediate data param encodes string value`() {
+        activeManager(immediateDataConfig)
+
+        manager.handleWebEvent(eventWithData("login", """{ "loginState": "logged-in" }"""), "tab1")
+
+        assertEquals("%22logged-in%22", firedEncodedParams("webEvent_login")["loginState"])
+    }
+
+    @Test
+    fun `immediate data param encodes object value`() {
+        val config = """
+            {
+                "telemetry": {
+                    "webEvent_login": {
+                        "state": "enabled",
+                        "trigger": { "type": "immediate", "source": "login" },
+                        "parameters": { "payload": { "template": "data", "dataKey": "payload" } }
+                    }
+                }
+            }
+        """.trimIndent()
+        activeManager(config)
+
+        manager.handleWebEvent(eventWithData("login", """{ "payload": { "a": true } }"""), "tab1")
+
+        assertEquals("%7B%22a%22%3Atrue%7D", firedEncodedParams("webEvent_login")["payload"])
+    }
+
+    @Test
+    fun `immediate data param encodes null value`() {
+        activeManager(immediateDataConfig)
+
+        manager.handleWebEvent(eventWithData("login", """{ "loginState": null }"""), "tab1")
+
+        assertEquals("null", firedEncodedParams("webEvent_login")["loginState"])
+    }
+
+    @Test
+    fun `immediate data param omitted when key absent`() {
+        activeManager(immediateDataConfig)
+
+        manager.handleWebEvent(eventWithData("login", """{ "other": "x" }"""), "tab1")
+
+        assertFalse(firedEncodedParams("webEvent_login").containsKey("loginState"))
+    }
+
+    @Test
+    fun `aggregate data param uses last value from matching source`() {
+        val config = """
+            {
+                "telemetry": {
+                    "yt": {
+                        "state": "enabled",
+                        "trigger": { "period": { "seconds": 60 } },
+                        "parameters": {
+                            "count": { "template": "counter", "source": "yt", "buckets": {"0-9": {"gte": 0, "lt": 10}, "10+": {"gte": 10}} },
+                            "loginState": { "template": "data", "source": "yt", "dataKey": "loginState" }
+                        }
+                    }
+                }
+            }
+        """.trimIndent()
+        activeManager(config)
+        manager.onConfigChanged()
+
+        manager.handleWebEvent(eventWithData("yt", """{ "loginState": "a" }"""), "tab1")
+        manager.handleWebEvent(eventWithData("yt", """{ "loginState": "b" }"""), "tab2")
+        timeProvider.time = 60_000L
+        manager.onAppForegrounded()
+
+        assertEquals("%22b%22", firedEncodedParams("yt")["loginState"])
+    }
+
+    private class FakeCurrentTimeProvider : CurrentTimeProvider {
+        var time: Long = 0L
+        override fun currentTimeMillis(): Long = time
+        override fun elapsedRealtime(): Long = time
+        override fun localDateTimeNow(): java.time.LocalDateTime = java.time.LocalDateTime.now()
+    }
+
+    private class FakeEventHubRepository : EventHubRepository {
+        private val states = linkedMapOf<String, PixelState>()
+        override fun getPixelState(name: String): PixelState? = states[name]
+        override fun getAllPixelStates(): List<PixelState> = states.values.toList()
+        override fun savePixelState(state: PixelState) {
+            states[state.pixelName] = state
+        }
+        override fun deletePixelState(name: String) {
+            states.remove(name)
+        }
+        override fun deleteAllPixelStates() = states.clear()
+    }
+}

--- a/event-hub/event-hub-impl/src/test/java/com/duckduckgo/eventhub/impl/pixels/EventHubImmediatePixelTest.kt
+++ b/event-hub/event-hub-impl/src/test/java/com/duckduckgo/eventhub/impl/pixels/EventHubImmediatePixelTest.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.eventhub.impl.pixels
+
+import android.annotation.SuppressLint
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.CurrentTimeProvider
+import com.duckduckgo.eventhub.impl.EventHubFeature
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.json.JSONObject
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+/**
+ * Immediate pixels use `trigger.type == "immediate"` with a trigger `source` and no period: each
+ * matching event fires exactly one pixel right away, with no counter, period, persistence, dedup, or
+ * foreground-gating. Ported from the Windows EventHub spec (EventHubImmediatePixelTests).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class EventHubImmediatePixelTest {
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule(StandardTestDispatcher())
+
+    private val repository: EventHubRepository = mock()
+    private val pixel: Pixel = mock()
+    private val timeProvider = FakeCurrentTimeProvider()
+    private val eventHubFeature: EventHubFeature = FakeFeatureToggleFactory.create(EventHubFeature::class.java)
+    private lateinit var manager: RealEventHubPixelManager
+
+    private val immediateConfig = """
+        {
+            "telemetry": {
+                "webEvent_impression": {
+                    "state": "enabled",
+                    "trigger": { "type": "immediate", "source": "impression" },
+                    "parameters": {}
+                }
+            }
+        }
+    """.trimIndent()
+
+    private fun webEvent(type: String) = JSONObject().put("type", type)
+
+    @SuppressLint("DenyListedApi")
+    private fun activeManager(enabled: Boolean = true, settings: String = immediateConfig, foreground: Boolean = true) {
+        whenever(repository.getAllPixelStates()).thenReturn(emptyList())
+        eventHubFeature.self().setRawStoredState(Toggle.State(enable = false))
+        manager = RealEventHubPixelManager(
+            repository, pixel, timeProvider, coroutineTestRule.testScope,
+            UnconfinedTestDispatcher(coroutineTestRule.testScope.testScheduler), eventHubFeature,
+        )
+        if (foreground) manager.onAppForegrounded()
+        eventHubFeature.self().setRawStoredState(Toggle.State(enable = enabled, settings = settings))
+    }
+
+    @Test
+    fun `immediate trigger fires one pixel per event`() {
+        activeManager()
+
+        manager.handleWebEvent(webEvent("impression"), "tab1")
+
+        verify(pixel).enqueueFire(eq("webEvent_impression"), any(), any(), any())
+    }
+
+    @Test
+    fun `immediate pixels are not deduplicated`() {
+        activeManager()
+
+        manager.handleWebEvent(webEvent("impression"), "tab1")
+        manager.handleWebEvent(webEvent("impression"), "tab1")
+        manager.handleWebEvent(webEvent("impression"), "tab1")
+
+        verify(pixel, times(3)).enqueueFire(eq("webEvent_impression"), any(), any(), any())
+    }
+
+    @Test
+    fun `immediate pixels fire without foreground`() {
+        activeManager(foreground = false)
+
+        manager.handleWebEvent(webEvent("impression"), "tab1")
+
+        verify(pixel).enqueueFire(eq("webEvent_impression"), any(), any(), any())
+    }
+
+    @Test
+    fun `immediate pixels do not persist state`() {
+        activeManager()
+
+        manager.handleWebEvent(webEvent("impression"), "tab1")
+
+        verify(repository, never()).savePixelState(any())
+    }
+
+    @Test
+    fun `immediate ignores unknown event type`() {
+        activeManager()
+
+        manager.handleWebEvent(webEvent("something-else"), "tab1")
+
+        verify(pixel, never()).enqueueFire(any<String>(), any(), any(), any())
+    }
+
+    @Test
+    fun `immediate does not fire when disabled`() {
+        activeManager(enabled = false)
+
+        manager.handleWebEvent(webEvent("impression"), "tab1")
+
+        verify(pixel, never()).enqueueFire(any<String>(), any(), any(), any())
+    }
+
+    private class FakeCurrentTimeProvider : CurrentTimeProvider {
+        var time: Long = 0L
+        override fun currentTimeMillis(): Long = time
+        override fun elapsedRealtime(): Long = time
+        override fun localDateTimeNow(): java.time.LocalDateTime = java.time.LocalDateTime.now()
+    }
+}


### PR DESCRIPTION
Task/Issue URL: [Postmortem: Implement remote configured telemetry for C-S-S events on Windows](https://app.asana.com/1/137249556945/project/45878998844068/task/1213690772916070)
Tech Design URL (if applicable): [Tech Design: Add immediate firing pixels to the EventHub specification](https://app.asana.com/1/137249556945/project/481882893211075/task/1215327441118832)

### Description

Brings the Android EventHub framework up to the cross-platform spec additions made while implementing EventHub on Windows. Closes the postmortem action item: *"Implement data property and immediate templates on Android."*

- **`immediate` trigger type** — `trigger: { "type": "immediate", "source": "<event>" }`. Fires one pixel per matching `webEvent`, immediately, with no period, persistence, dedup, or foreground gating. `trigger.type` defaults to `"period"` when omitted, so existing configs are unaffected.
- **`data` parameter template** — `{ "template": "data", "dataKey": "<key>", "source": "<event>" }`. Forwards a value from `webEvent.data` as its compact JSON, percent-encoded once (RFC 3986) and sent as an already-encoded pixel parameter to avoid double-encoding. Absent keys are omitted. Immediate pixels use the triggering message's data; aggregate (period) pixels keep the last value seen on a matching `source`.

The third spec change (config-generation collapsing durations to integer `seconds`) needs no Android change — it already lands for all platforms in privacy-configuration, and Android already reads `trigger.period.seconds`.

### Steps to test this PR

_EventHub immediate + data templates_
- [ ] Run `./gradlew :event-hub-impl:testDebugUnitTest --tests "com.duckduckgo.eventhub.impl.pixels.*"` and confirm it passes, including the new `EventHubImmediatePixelTest` and `EventHubDataParameterTest` (ported from the Windows EventHub suites).
- [ ] Confirm existing counter/period EventHub behaviour is unchanged (`RealEventHubPixelManagerTest`, `EventHubConfigParserTest`).

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes telemetry firing paths and pixel parameter encoding for web-derived event data; behavior is well-tested but affects privacy/statistics payloads when remote configs enable the new templates.
> 
> **Overview**
> Aligns Android EventHub with the cross-platform spec by adding **`immediate`** triggers and **`data`** parameters, while keeping period/counter configs backward-compatible (`trigger.type` defaults to `period`).
> 
> **Immediate pixels** fire on each matching `webEvent` via `fireImmediatePixels`, with no period state, dedup, persistence, or foreground gating. Period-only setup paths (`initMissingPixels`, `onConfigChanged`, `startNewPeriod`) now skip non-period configs.
> 
> **Data parameters** read `webEvent.data[dataKey]`, serialize to compact JSON, RFC 3986 percent-encode once, and pass values through `Pixel.enqueueFire` as **`encodedParameters`** (period aggregates keep the last value per matching `source`; immediate pixels use the triggering event’s payload). `ParamState` gains `lastDataValue`; period fires can proceed when only encoded data params are present.
> 
> Config parsing/serialization now supports trigger `type`/`source`, optional parameter `source`, `dataKey`, and the `data` template. New unit tests cover immediate behavior and data encoding (ported from Windows).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69846a813e86f635d062eb3335b22a8e5e58cf42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->