### PR TITLE
Add installType and installAge to AI chat native config values

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
@@ -18,8 +18,11 @@ package com.duckduckgo.duckchat.impl.helper
 
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.browser.api.install.AppInstall
 import com.duckduckgo.common.ui.view.encodeBitmapToBase64
 import com.duckduckgo.common.utils.ConflatedJob
+import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
@@ -42,9 +45,12 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import logcat.logcat
 import org.json.JSONArray
 import org.json.JSONObject
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 import java.util.regex.Pattern
 import javax.inject.Inject
 
@@ -102,6 +108,9 @@ class RealDuckChatJSHelper @Inject constructor(
     private val voiceSessionStateManager: VoiceSessionStateManager,
     private val limitsHandler: LimitsHandler,
     private val nativeInputStatePublisher: NativeInputStatePublisher,
+    private val appInstall: AppInstall,
+    private val appBuildConfig: AppBuildConfig,
+    private val currentTimeProvider: CurrentTimeProvider,
 ) : DuckChatJSHelper {
 
     private val registerOpenedJob = ConflatedJob()
@@ -407,8 +416,30 @@ class RealDuckChatJSHelper @Inject constructor(
                     duckChat.isDuckChatContextualModeEnabled() &&
                         duckChat.areMultipleContentAttachmentsEnabled(),
                 )
+                put(INSTALL_TYPE, if (appBuildConfig.isAppReinstall()) INSTALL_TYPE_RETURNING else INSTALL_TYPE_NEW)
+                getInstallAgeBucket()?.let { put(INSTALL_AGE, it) }
             }.also { logcat { "DuckChat-Sync: getAIChatNativeConfigValues $it" } }
         return JsCallbackData(jsonPayload, featureName, method, id)
+    }
+
+    // Bucketed install age for the Duck.ai prompt pixel; null when the install timestamp isn't recorded
+    // yet or is in the future (clock skew), so the caller omits the param instead of sending a
+    // misleading bucket.
+    private suspend fun getInstallAgeBucket(): Int? {
+        val installTimestamp = withContext(dispatcherProvider.io()) { appInstall.getInstallationTimestamp() }
+        val nowTimestamp = currentTimeProvider.currentTimeMillis()
+        if (installTimestamp <= 0L || installTimestamp > nowTimestamp) return null
+        val installedAt = Instant.ofEpochMilli(installTimestamp)
+        val now = Instant.ofEpochMilli(nowTimestamp)
+        val days = ChronoUnit.DAYS.between(installedAt, now)
+        return when {
+            days == 0L -> 0
+            days <= 7L -> 1
+            days <= 14L -> 2
+            days <= 21L -> 3
+            days <= 28L -> 4
+            else -> 5
+        }
     }
 
     private fun getAIChatNativePrompt(
@@ -577,6 +608,10 @@ class RealDuckChatJSHelper @Inject constructor(
         private const val SUPPORTS_PAGE_CONTEXT = "supportsPageContext"
         private const val SUPPORTS_MULTIPLE_PAGE_CONTEXT = "supportsMultipleContexts"
         private const val SUPPORTS_NATIVE_STORAGE = "supportsNativeStorage"
+        private const val INSTALL_TYPE = "installType"
+        private const val INSTALL_TYPE_NEW = "new"
+        private const val INSTALL_TYPE_RETURNING = "returning"
+        private const val INSTALL_AGE = "installAge"
         private const val REPORT_METRIC = "reportMetric"
         private const val PLATFORM = "platform"
         private const val ANDROID = "android"

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
@@ -19,7 +19,10 @@ package com.duckduckgo.duckchat.impl.helper
 import android.annotation.SuppressLint
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.browser.favicon.FaviconManager
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.browser.api.install.AppInstall
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
 import com.duckduckgo.duckchat.impl.ChatState
@@ -55,6 +58,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -81,6 +85,15 @@ class RealDuckChatJSHelperTest {
     private val mockVoiceSessionStateManager: VoiceSessionStateManager = mock()
     private val mockLimitsHandler: LimitsHandler = mock()
     private val mockNativeInputStatePublisher: NativeInputStatePublisher = mock()
+    private val mockAppInstall: AppInstall = mock {
+        on { getInstallationTimestamp() } doReturn DEFAULT_INSTALL_TIMESTAMP
+    }
+    private val mockAppBuildConfig: AppBuildConfig = mock {
+        onBlocking { isAppReinstall() } doReturn false
+    }
+    private val mockCurrentTimeProvider: CurrentTimeProvider = mock {
+        on { currentTimeMillis() } doReturn DEFAULT_INSTALL_TIMESTAMP
+    }
     private val testee = RealDuckChatJSHelper(
         duckChat = mockDuckChat,
         duckChatPixels = mockDuckChatPixels,
@@ -94,6 +107,9 @@ class RealDuckChatJSHelperTest {
         voiceSessionStateManager = mockVoiceSessionStateManager,
         limitsHandler = mockLimitsHandler,
         nativeInputStatePublisher = mockNativeInputStatePublisher,
+        appInstall = mockAppInstall,
+        appBuildConfig = mockAppBuildConfig,
+        currentTimeProvider = mockCurrentTimeProvider,
     )
     private val viewModel =
         object {
@@ -288,6 +304,8 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", false)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", false)
+            put("installType", "new")
+            put("installAge", 0)
         }
 
         val expected = JsCallbackData(jsonPayload, featureName, method, id)
@@ -296,6 +314,105 @@ class RealDuckChatJSHelperTest {
         assertEquals(expected.method, result.method)
         assertEquals(expected.featureName, result.featureName)
         assertEquals(expected.params.toString(), result.params.toString())
+    }
+
+    @Test
+    fun whenGetAIChatNativeConfigValuesAndAppReinstallThenInstallTypeIsReturning() = runTest {
+        whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(true)
+
+        val result = testee.processJsCallbackMessage(
+            featureName = "aiChat",
+            method = "getAIChatNativeConfigValues",
+            id = "123",
+            data = null,
+            pageContext = viewModel.updatedPageContext,
+        )
+
+        assertEquals("returning", result!!.params.getString("installType"))
+    }
+
+    @Test
+    fun whenGetAIChatNativeConfigValuesAndNotReinstallThenInstallTypeIsNew() = runTest {
+        whenever(mockAppBuildConfig.isAppReinstall()).thenReturn(false)
+
+        val result = testee.processJsCallbackMessage(
+            featureName = "aiChat",
+            method = "getAIChatNativeConfigValues",
+            id = "123",
+            data = null,
+            pageContext = viewModel.updatedPageContext,
+        )
+
+        assertEquals("new", result!!.params.getString("installType"))
+    }
+
+    @Test
+    fun whenGetAIChatNativeConfigValuesThenInstallAgeIsBucketedByDaysSinceInstall() = runTest {
+        val now = 1_700_000_000_000L
+        whenever(mockCurrentTimeProvider.currentTimeMillis()).thenReturn(now)
+
+        val daysToExpectedBucket = mapOf(
+            0L to 0,
+            1L to 1,
+            7L to 1,
+            8L to 2,
+            14L to 2,
+            15L to 3,
+            21L to 3,
+            22L to 4,
+            28L to 4,
+            29L to 5,
+        )
+
+        daysToExpectedBucket.forEach { (days, expectedBucket) ->
+            whenever(mockAppInstall.getInstallationTimestamp()).thenReturn(now - days * DAY_MILLIS)
+
+            val result = testee.processJsCallbackMessage(
+                featureName = "aiChat",
+                method = "getAIChatNativeConfigValues",
+                id = "123",
+                data = null,
+                pageContext = viewModel.updatedPageContext,
+            )
+
+            assertEquals(
+                "days=$days should map to bucket $expectedBucket",
+                expectedBucket,
+                result!!.params.getInt("installAge"),
+            )
+        }
+    }
+
+    @Test
+    fun whenInstallTimestampIsInFutureThenInstallAgeIsOmitted() = runTest {
+        val now = 1_700_000_000_000L
+        whenever(mockCurrentTimeProvider.currentTimeMillis()).thenReturn(now)
+        whenever(mockAppInstall.getInstallationTimestamp()).thenReturn(now + 5 * DAY_MILLIS)
+
+        val result = testee.processJsCallbackMessage(
+            featureName = "aiChat",
+            method = "getAIChatNativeConfigValues",
+            id = "123",
+            data = null,
+            pageContext = viewModel.updatedPageContext,
+        )
+
+        assertFalse(result!!.params.has("installAge"))
+    }
+
+    @Test
+    fun whenInstallTimestampNotRecordedThenInstallAgeIsOmitted() = runTest {
+        whenever(mockAppInstall.getInstallationTimestamp()).thenReturn(0L)
+
+        val result = testee.processJsCallbackMessage(
+            featureName = "aiChat",
+            method = "getAIChatNativeConfigValues",
+            id = "123",
+            data = null,
+            pageContext = viewModel.updatedPageContext,
+        )
+
+        assertFalse(result!!.params.has("installAge"))
     }
 
     @Test
@@ -547,6 +664,8 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", false)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", false)
+            put("installType", "new")
+            put("installAge", 0)
         }
 
         val expected = JsCallbackData(jsonPayload, featureName, method, id)
@@ -590,6 +709,8 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", false)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", false)
+            put("installType", "new")
+            put("installAge", 0)
         }
 
         val expected = JsCallbackData(jsonPayload, featureName, method, id)
@@ -746,6 +867,8 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", true)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", false)
+            put("installType", "new")
+            put("installAge", 0)
         }
 
         val expected = JsCallbackData(jsonPayload, featureName, method, id)
@@ -791,6 +914,8 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", true)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", true)
+            put("installType", "new")
+            put("installAge", 0)
         }
 
         val expected = JsCallbackData(jsonPayload, featureName, method, id)
@@ -833,6 +958,8 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", false)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", false)
+            put("installType", "new")
+            put("installAge", 0)
         }
 
         val expected = JsCallbackData(jsonPayload, featureName, method, id)
@@ -875,6 +1002,8 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", false)
             put("supportsNativeStorage", true)
             put("supportsMultipleContexts", false)
+            put("installType", "new")
+            put("installAge", 0)
         }
 
         val expected = JsCallbackData(jsonPayload, featureName, method, id)
@@ -1184,6 +1313,8 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", false)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", false)
+            put("installType", "new")
+            put("installAge", 0)
         }
 
         assertEquals(expectedPayload.toString(), result!!.params.toString())
@@ -1223,6 +1354,8 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", false)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", false)
+            put("installType", "new")
+            put("installAge", 0)
         }
 
         assertEquals(expectedPayload.toString(), result!!.params.toString())
@@ -1262,6 +1395,8 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", false)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", false)
+            put("installType", "new")
+            put("installAge", 0)
         }
 
         assertEquals(expectedPayload.toString(), result!!.params.toString())
@@ -1970,5 +2105,10 @@ class RealDuckChatJSHelperTest {
         )
 
         verify(mockVoiceSessionStateManager, never()).onVoiceSessionEnded(any())
+    }
+
+    companion object {
+        private const val DAY_MILLIS = 24L * 60 * 60 * 1000
+        private const val DEFAULT_INSTALL_TIMESTAMP = 1_700_000_000_000L
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205648422731273/task/1215106436913174?focus=true
Tech Design URL (if applicable):

### Description

Adds two properties to the `getAIChatNativeConfigValues` JS-messaging response so the
Duck.ai web frontend can attach them to its `web.conversion.duckai.prompt` pixel ahead of
the upcoming Duck.ai ad campaign:

- `installType`: `"new"` | `"returning"` — derived from `AppBuildConfig.isAppReinstall()`
  (the same signal already behind the `isReinstall` pixel param).
- `installAge`: `0`–`5` — bucketed days since install (0 = same day, 1 = days 1–7,
  2 = 8–14, 3 = 15–21, 4 = 22–28, 5 = after day 28).

### Steps to test this PR

- [x] Install internalDebug variant of the app
- [x] Go to internal settings - duck.ai -> Custom Duck.ai URL and set https://use-serp-dev-testing9.duck.ai
- [x] Restart the app
- [x] Open Duck.ai
- [x] Open chrome://inspect in a desktop browser and start recording network activity from the device's WebView
- [x] Send a prompt in Duck.ai
- [x] Check logcat for DuckChat-Sync: getAIChatNativeConfigValues entry and confirm it contains installAge and installType params.
- [x] Check chrome dev tools and confirm https://improving.duckduckgo.com/t/web_conversion_duckai_prompt request is executed with installAge and installType params.

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive JS config fields for analytics only; no changes to chat behavior, auth, or data persistence beyond reading existing install metadata.
> 
> **Overview**
> Extends the **`getAIChatNativeConfigValues`** JS bridge payload so the Duck.ai web layer can attach install cohort fields to the **`web.conversion.duckai.prompt`** pixel.
> 
> **`installType`** is always sent as **`"new"`** or **`"returning"`**, using the same reinstall signal as existing pixels (`AppBuildConfig.isAppReinstall()`). **`installAge`** is an integer bucket **0–5** (same day through >28 days) computed from `AppInstall.getInstallationTimestamp()`; the key is **left out** when the timestamp is missing, zero, or in the future so bad data is not sent.
> 
> `RealDuckChatJSHelperTest` expectations and dedicated tests cover reinstall vs new, bucket boundaries, and omitted `installAge`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c636d76c1b40f2ab40e0ea64d127e7343ea08a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->