### PR TITLE
Fix keyboard reappearing on search-only back

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -489,6 +489,12 @@ class RealNativeInputManager @Inject constructor(
         )
         widget.onChangeModelSubmitted = { modelId -> callbacks.onChangeModelSubmitted(modelId) }
         widget.onBack = {
+            // Clear focus before hiding the IME. In SEARCH_ONLY mode the input field still holds
+            // focus when Back is pressed, and a focused, attached EditText remains the IME target —
+            // the window re-requests the keyboard after the hide. Dropping focus first removes the
+            // target so the hide sticks. In SEARCH_AND_DUCK_AI the field has already lost focus, so
+            // this is a no-op there.
+            widget.clearInputFocus()
             widget.hideKeyboard()
             hideNativeInput()
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1215751565522437?focus=true
Tech Design URL (if applicable):

### Description

With native input enabled and the **Search Only** address-bar option selected, focusing the input field and pressing the top-left back arrow hid the keyboard but it immediately popped back up. **Search & Duck.ai** worked as expected.

Root cause: the native input `onBack` handler called `hideKeyboard()` but never cleared focus. In `SEARCH_ONLY` mode the input field still holds focus when Back is pressed, so a focused, still-attached `EditText` remains the IME target and the window re-requests the keyboard right after the hide. In `SEARCH_AND_DUCK_AI` the field had already lost focus, so the hide stuck — which is why only Search Only was affected.

Fix: clear the input field's focus before hiding the IME in the back handler, so there's no editor for the window to re-show the keyboard for. It's a no-op in `SEARCH_AND_DUCK_AI` where focus is already gone.

Confirmed on-device with temporary instrumentation (since removed). In Search Only, the dismiss trace went from `hideKeyboard: focus=true` / `onHide: focus=inputField` (keyboard returns) to `hideKeyboard: focus=false` / `onHide: focus=null` (keyboard stays down), matching the working Search & Duck.ai trace.

### Steps to test this PR

_Search Only (the fix)_
- [x] Settings → AI Features → select **Search Only**
- [x] On the NTP (or any page), tap the address bar to open the native input; the keyboard appears
- [x] Tap the top-left back arrow
- [x] Verify you return to the NTP / previous page **and the keyboard stays hidden** (does not pop back up)

_Search & Duck.ai (regression)_
- [x] Settings → AI Features → select **Search & Duck.ai**
- [x] Open the native input, then tap the back arrow
- [x] Verify the keyboard hides and you return to the NTP / previous page as before

### UI changes

No visual changes — keyboard dismissal behavior only. Verified on emulator (API 37) in both address-bar modes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line behavioral change in the back handler using an existing widget API; no auth, data, or broad refactors.
> 
> **Overview**
> Fixes the keyboard **popping back up** after tapping the native input’s top-left back control when **Search Only** is selected.
> 
> The `onBack` handler in `NativeInputManager` now calls **`clearInputFocus()`** before **`hideKeyboard()`** and closing the widget. In Search Only the field still had focus on Back, so the window kept treating the `EditText` as the IME target and re-requested the keyboard right after hide. Dropping focus first removes that target so dismissal sticks. Search & Duck.ai was unaffected (focus was already gone); **`clearInputFocus()`** is a no-op there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bcac4c131e2e3c1811cc05839f69bc06fcddd97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->