### PR TITLE
Update PIR broker bundle - 2026-06-22

### DIFF
--- a/pir/pir-impl/src/main/assets/brokers/clustrmaps.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/clustrmaps.com.json
@@ -1,7 +1,7 @@
 {
   "name": "ClustrMaps",
   "url": "clustrmaps.com",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "parent": "neighbor.report",
   "addedDatetime": 1692594000000,
   "optOutUrl": "https://clustrmaps.com/bl/opt-out",
@@ -72,5 +72,5 @@
     "maintenanceScan": 120,
     "maxAttempts": -1
   },
-  "removedAt": null
+  "removedAt": 1781696481849
 }

--- a/pir/pir-impl/src/main/assets/brokers/neighbor.report.json
+++ b/pir/pir-impl/src/main/assets/brokers/neighbor.report.json
@@ -1,7 +1,7 @@
 {
   "name": "Neighbor Report",
   "url": "neighbor.report",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "addedDatetime": 1703570400000,
   "optOutUrl": "https://neighbor.report/remove",
   "steps": [
@@ -213,5 +213,5 @@
     "maintenanceScan": 120,
     "maxAttempts": -1
   },
-  "removedAt": null
+  "removedAt": 1781696481849
 }

--- a/pir/pir-impl/src/main/assets/brokers/officialusa.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/officialusa.com.json
@@ -1,7 +1,7 @@
 {
   "name": "OfficialUSA",
   "url": "officialusa.com",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "parent": "neighbor.report",
   "addedDatetime": 1692594000000,
   "optOutUrl": "https://www.officialusa.com/opt-out/",
@@ -65,5 +65,5 @@
     "maintenanceScan": 120,
     "maxAttempts": -1
   },
-  "removedAt": null
+  "removedAt": 1781696481849
 }


### PR DESCRIPTION
## PIR Broker Bundle Update

Automated update of PIR broker JSON files from the remote bundle.

### Changes

**Updated (3):**
- clustrmaps.com.json (0.7.0 → 0.8.0)
- neighbor.report.json (0.10.0 → 0.11.0)
- officialusa.com.json (0.7.0 → 0.8.0)

### Checklist

- [x] Verify broker changes look correct
- [x] All tests must pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Retiring brokers stops new scans/opt-outs for those sites; users with in-flight work on these brokers may need correct handling when `removedAt` is applied at runtime.
> 
> **Overview**
> Automated PIR broker bundle sync bumps versions and **schedules removal** for three related data brokers.
> 
> **Neighbor Report** (`neighbor.report.json`) goes **0.10.0 → 0.11.0**; child sites **ClustrMaps** and **OfficialUSA** go **0.7.0 → 0.8.0** and **0.7.0 → 0.8.0** respectively. In all three files, `removedAt` changes from `null` to **`1781696481849`** (same timestamp). Scan/opt-out step definitions are unchanged in this diff—only metadata/version/removal fields.
> 
> This effectively marks the Neighbor Report family (including parent opt-out for the two child brokers) for deprecation in the shipped bundle rather than changing automation behavior in the JSON itself.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed25111d9154774a040bed88244dc8c43622bd3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->