### PR TITLE
Add sync with device activity starter params

### DIFF
--- a/sync/sync-api/src/main/java/com/duckduckgo/sync/api/SyncScreens.kt
+++ b/sync/sync-api/src/main/java/com/duckduckgo/sync/api/SyncScreens.kt
@@ -36,3 +36,13 @@ object SyncActivityWithEmptyParams : GlobalActivityStarter.ActivityParams
  * ```
  */
 data class SyncActivityFromSetupUrl(val url: String) : GlobalActivityStarter.ActivityParams
+
+/**
+ * Use this class to launch the sync screen and immediately start "sync with another device" flow.
+ * [source] is an optional telemetry tag identifying where the flow was started from.
+ *
+ * ```kotlin
+ * globalActivityStarter.start(context, SyncActivityWithAnotherDevice(source = "duckai_card"))
+ * ```
+ */
+data class SyncActivityWithAnotherDevice(val source: String?) : GlobalActivityStarter.ActivityParams

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivity.kt
@@ -80,6 +80,8 @@ import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.SyncWithAnother
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.OriginalFlow
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.SetupFlows
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.ViewState
+import com.duckduckgo.sync.impl.ui.SyncSetup.WithAnotherDevice
+import com.duckduckgo.sync.impl.ui.SyncSetup.WithUrl
 import com.duckduckgo.sync.impl.ui.qrcode.SyncBarcodeUrl
 import com.duckduckgo.sync.impl.ui.setup.ConnectFlowContract
 import com.duckduckgo.sync.impl.ui.setup.ConnectFlowContractInput
@@ -109,6 +111,7 @@ import javax.inject.Inject
 @ContributeToActivityStarter(SyncActivityWithEmptyParams::class)
 @ContributeToActivityStarter(SyncActivityWithSourceParams::class)
 @ContributeToActivityStarter(SyncActivityFromSetupUrl::class)
+@ContributeToActivityStarter(SyncActivityWithAnotherDevice::class)
 class SyncActivity : DuckDuckGoActivity() {
     private val binding: ActivitySyncBinding by viewBinding()
     private val viewModel: SyncActivityViewModel by bindViewModel()
@@ -235,8 +238,12 @@ class SyncActivity : DuckDuckGoActivity() {
         setupClickListeners()
         setupRecyclerView()
 
-        syncSetupUrl()?.let { setupUrl ->
-            viewModel.processSetupDeepLink(setupUrl)
+        if (savedInstanceState == null) {
+            when (val setup = syncSetup()) {
+                is WithAnotherDevice -> viewModel.onSyncWithAnotherDevice()
+                is WithUrl -> viewModel.processSetupDeepLink(setup.url)
+                null -> Unit
+            }
         }
     }
 
@@ -244,6 +251,17 @@ class SyncActivity : DuckDuckGoActivity() {
         super.onSaveInstanceState(outState)
         pendingOriginalFlow?.let { outState.putString(KEY_PENDING_ORIGINAL_FLOW, it.name) }
     }
+
+    private fun syncSetup(): SyncSetup? {
+        val syncUrl = syncSetupUrl()
+        if (syncUrl != null) return WithUrl(syncUrl)
+
+        if (isAnotherDeviceSync()) return WithAnotherDevice
+
+        return null
+    }
+
+    private fun isAnotherDeviceSync() = intent.getActivityParams(SyncActivityWithAnotherDevice::class.java) != null
 
     private fun syncSetupUrl() = intent.getActivityParams(SyncActivityFromSetupUrl::class.java)?.url
 
@@ -624,6 +642,7 @@ class SyncActivity : DuckDuckGoActivity() {
 
     private fun extractSource(): String? {
         return intent.getActivityParams(SyncActivityWithSourceParams::class.java)?.source
+            ?: intent.getActivityParams(SyncActivityWithAnotherDevice::class.java)?.source
     }
 
     private fun launchOriginalFlow(originalFlow: OriginalFlow?) {
@@ -648,3 +667,8 @@ private fun OriginalFlow.toPixelSource(): String = when (this) {
 }
 
 data class SyncActivityWithSourceParams(val source: String?) : GlobalActivityStarter.ActivityParams
+
+private sealed interface SyncSetup {
+    data class WithUrl(val url: String) : SyncSetup
+    data object WithAnotherDevice : SyncSetup
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215861182361180?focus=true
Tech Design URL (if applicable): 

### Description

Adds `SyncActivityWithAnotherDevice` type to the public API. It starts the `SyncActivity` and automatically launch the sync process.

The implementation wraps incoming intents in a new `SyncSetup` sealed type. Previously, we only had a public API to start the sync process via a URL when DuckDuckGo is used as the default browser and a QR code is scanned by, for example, an external camera app. This flow is now represented as `SyncSetup.WithUrl`, and the new one, which is mainly intended for in-app use, is represented as `SyncSetup.WithAnotherDevice`.

Intent handling is now gated behind `(savedInstanceState == null)`. Depending on how you look at it, it's either a bug fix or a behavior change. The underlying issue is that our dialogs do not survive config changes. So if someone sees a dialog and there's a config change, they won't be prompted again. However, at the same time, if someone synced using these activity params, stayed on the screen, and there was a config change, they'll be prompted to sync again even though they already synced. You can verify, if you want, that this is the current behavior of the production app. In my opinion this is a bug, but I don't mind removing the `savedInstanceState` gate if you disagree.

### Steps to test this PR

> [!NOTE]
> You'll need two devices for these tests. I'll call them Device A and Device B.

#### Sync with URL (regression)
- [ ] On Device A go to the Sync & Backup settings.
- [ ] Tap "Sync With Another Device" and proceed until you see the QR code.
- [ ] On Device B set DDG as the default browser.
- [ ] On Device B open the camera app.
- [ ] On Device B scan the QR code displayed on Device A with the camera app.
- [ ] On Device B tap the button that is shown under the QR code.
- [ ] Verify that you entered the sync flow.
- [ ] Finish the sync flow to validate it.

#### Sync with another device (new API)
- [ ] Apply the patch below.

```diff
diff --git a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingActivity.kt b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingActivity.kt
index d09ec8849a..6cb9cc287e 100644
--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingActivity.kt
@@ -36,6 +36,8 @@ import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import com.duckduckgo.sync.api.SyncActivityWithAnotherDevice
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -47,6 +49,9 @@ class OnboardingActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var duckChat: DuckChat
 
+    @Inject
+    lateinit var activityStarter: GlobalActivityStarter
+
     private lateinit var viewPageAdapter: PagerAdapter
 
     private val viewModel: OnboardingViewModel by bindViewModel()
@@ -84,7 +89,7 @@ class OnboardingActivity : DuckDuckGoActivity() {
 
     fun onSkipClicked() {
         viewModel.onOnboardingSkipped()
-        startActivity(BrowserActivity.intent(this@OnboardingActivity, launchSource = Onboarding))
+        activityStarter.start(this, SyncActivityWithAnotherDevice(source = "dummy_source"))
         finish()
     }
 

```

- [ ] On Device A enable both `canUseV2ConnectFlow` and `canShowV2ConnectCode` via the FF inventory
- [ ] On Device A go to the Sync & Backup settings.
- [ ] Tap "Sync With Another Device" and proceed until you see the QR code.
- [ ] Open the app on Device B and tap "Skip onboarding".
- [ ] Verify that you entered the sync flow.
- [ ] Continue with the flow until you see the camera page.
- [ ] On Device B scan the QR code from Device A.
- [ ] Finish the sync flow to validate it.

### UI changes
N/A


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sync entry and deep-link behavior on config changes; incorrect gating could skip or duplicate pairing flows, though scope is limited to SyncActivity launch.
> 
> **Overview**
> Adds **`SyncActivityWithAnotherDevice`** to the sync public API so in-app callers can open **`SyncActivity`** and immediately kick off the same “sync with another device” path as the settings CTA, with an optional **`source`** tag for telemetry.
> 
> **`SyncActivity`** now routes launch intents through a private **`SyncSetup`** model (**`WithUrl`** vs **`WithAnotherDevice`**) instead of only handling URL deep links. Auto-start (**`processSetupDeepLink`** / **`onSyncWithAnotherDevice`**) runs only when **`savedInstanceState == null`**, so rotation or other config changes do not re-launch pairing after the user already started or finished sync. **`extractSource()`** also reads **`source`** from the new activity params for downstream connect flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d4282400d24003be7cd672cb4d540cd1063c68c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->