### PR TITLE
Migrate to Kotlin 2.3.20

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -608,6 +608,9 @@ dependencies {
 
     // Dagger
     kapt Google.dagger.compiler
+    // Dagger 2.57+ reads Kotlin @Metadata via an external kotlin-metadata-jvm; pin it to the
+    // project Kotlin version so it understands 2.3 metadata (keep in sync with version.kotlin).
+    kapt "org.jetbrains.kotlin:kotlin-metadata-jvm:2.3.20"
     implementation Google.dagger
 
     // Glide

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -609,8 +609,7 @@ dependencies {
     // Dagger
     kapt Google.dagger.compiler
     // Dagger 2.57+ reads Kotlin @Metadata via an external kotlin-metadata-jvm; it must track the
-    // project Kotlin version so it understands the current metadata format. The refreshVersions `_`
-    // placeholder resolves to version.kotlin, keeping a single source of truth (no manual bump).
+    // project Kotlin version so it understands the current metadata format.
     kapt "org.jetbrains.kotlin:kotlin-metadata-jvm:_"
     implementation Google.dagger
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -608,9 +608,10 @@ dependencies {
 
     // Dagger
     kapt Google.dagger.compiler
-    // Dagger 2.57+ reads Kotlin @Metadata via an external kotlin-metadata-jvm; pin it to the
-    // project Kotlin version so it understands 2.3 metadata (keep in sync with version.kotlin).
-    kapt "org.jetbrains.kotlin:kotlin-metadata-jvm:2.3.20"
+    // Dagger 2.57+ reads Kotlin @Metadata via an external kotlin-metadata-jvm; it must track the
+    // project Kotlin version so it understands the current metadata format. The refreshVersions `_`
+    // placeholder resolves to version.kotlin, keeping a single source of truth (no manual bump).
+    kapt "org.jetbrains.kotlin:kotlin-metadata-jvm:_"
     implementation Google.dagger
 
     // Glide

--- a/build.gradle
+++ b/build.gradle
@@ -205,10 +205,10 @@ subprojects {
                     .because("Use guava's bundled ListenableFuture to avoid duplicate classes")
         }
         resolutionStrategy.eachDependency { details ->
-            // kotlinx-serialization runtime must match Kotlin 2.2.x compiler plugin output
+            // kotlinx-serialization runtime must match Kotlin 2.3.x compiler plugin output
             if (details.requested.group == 'org.jetbrains.kotlinx' && details.requested.name.startsWith('kotlinx-serialization')) {
                 details.useVersion '1.8.1'
-                details.because 'Kotlin 2.2.21 serialization compiler plugin requires runtime >= 1.8.x'
+                details.because 'Kotlin 2.3.20 serialization compiler plugin requires runtime >= 1.8.x'
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -280,8 +280,8 @@ if (diFramework == 'Metro') {
                 afterEvaluate {
                     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
                         compilerOptions {
-                            languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_2)
-                            apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_2)
+                            languageVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_3)
+                            apiVersion.set(org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_3)
                         }
                         // Remove Anvil from the compiler plugin classpath so it can't
                         // override language version or run its K1 compiler plugin

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -331,7 +331,7 @@ class InputScreenViewModel @AssistedInject constructor(
     val inputFieldCommand: Flow<InputFieldCommand> = _inputFieldCommand.receiveAsFlow()
 
     init {
-        combine(
+        combine<Any, Unit>(
             voiceServiceAvailable,
             voiceInputAllowed,
             isSearchModeFlow,

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/JsonRulesMapperTest.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/JsonRulesMapperTest.kt
@@ -50,7 +50,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         FakeMatchingAttribute(value = false),
                         Flavor(value = emptyList(), fallback = null),
                     ),
@@ -64,7 +64,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Locale(value = listOf("ES"), fallback = null),
                         Flavor(value = emptyList(), fallback = null),
                     ),
@@ -78,7 +78,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Locale(value = listOf("ES"), fallback = true),
                         Flavor(value = emptyList(), fallback = false),
                     ),
@@ -92,7 +92,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Locale(value = emptyList(), fallback = true),
                         Flavor(value = emptyList(), fallback = false),
                     ),
@@ -106,7 +106,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Locale(value = emptyList(), fallback = null),
                         Flavor(value = emptyList(), fallback = null),
                     ),
@@ -120,7 +120,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Unknown(fallback = null),
                         Unknown(fallback = null),
                     ),
@@ -134,7 +134,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Unknown(fallback = true),
                         Unknown(fallback = true),
                     ),
@@ -151,7 +151,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Api(value = 28, fallback = null),
                         SearchCount(value = 28, fallback = null),
                         Bookmarks(value = 28, fallback = null),
@@ -171,7 +171,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Api(value = 15, min = 20, max = 28, fallback = null),
                         SearchCount(value = 15, min = 20, max = 28, fallback = null),
                         Bookmarks(value = 15, min = 20, max = 28, fallback = null),
@@ -191,7 +191,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Api(min = 20, max = 28, fallback = null),
                         SearchCount(min = 20, max = 28, fallback = null),
                         Bookmarks(min = 20, max = 28, fallback = null),
@@ -211,7 +211,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Api(min = -1, max = 28, fallback = null),
                         SearchCount(min = -1, max = 28, fallback = null),
                         Bookmarks(min = -1, max = 28, fallback = null),
@@ -231,7 +231,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Api(min = 20, max = -1, fallback = null),
                         SearchCount(min = 20, max = -1, fallback = null),
                         Bookmarks(min = 20, max = -1, fallback = null),
@@ -251,7 +251,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Api(min = 20, max = 28, fallback = true),
                         SearchCount(min = 20, max = 28, fallback = true),
                         Bookmarks(min = 20, max = 28, fallback = true),
@@ -271,7 +271,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Unknown(fallback = true),
                         Unknown(fallback = true),
                         Unknown(fallback = true),
@@ -291,7 +291,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Unknown(fallback = true),
                         Unknown(fallback = true),
                         Unknown(fallback = true),
@@ -311,7 +311,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Unknown(fallback = null),
                         Unknown(fallback = null),
                         Unknown(fallback = null),
@@ -331,7 +331,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Api(),
                         SearchCount(),
                         Bookmarks(),
@@ -351,7 +351,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Api(fallback = true),
                         SearchCount(fallback = true),
                         Bookmarks(fallback = true),
@@ -368,7 +368,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         WebView(value = "28", fallback = null),
                         AppVersion(value = "28", fallback = null),
                     ),
@@ -382,7 +382,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         WebView(value = "15", min = "20", max = "28", fallback = null),
                         AppVersion(value = "15", min = "20", max = "28", fallback = null),
                     ),
@@ -396,7 +396,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         WebView(min = "20", max = "28", fallback = null),
                         AppVersion(min = "20", max = "28", fallback = null),
                     ),
@@ -410,7 +410,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         WebView(min = "20", max = "", fallback = null),
                         AppVersion(min = "20", max = "", fallback = null),
                     ),
@@ -424,7 +424,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         WebView(min = "", max = "28", fallback = null),
                         AppVersion(min = "", max = "28", fallback = null),
                     ),
@@ -438,7 +438,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         WebView(min = "20", max = "28", fallback = true),
                         AppVersion(min = "20", max = "28", fallback = true),
                     ),
@@ -452,7 +452,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         WebView(min = "", max = "", fallback = null),
                         AppVersion(min = "", max = "", fallback = null),
                     ),
@@ -466,7 +466,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         WebView(min = "", max = "", fallback = true),
                         AppVersion(min = "", max = "", fallback = true),
                     ),
@@ -482,7 +482,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         InstalledGPlay(value = true),
                         DefaultBrowser(value = true),
                         EmailEnabled(value = true),
@@ -500,7 +500,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         InstalledGPlay(value = true, fallback = true),
                         DefaultBrowser(value = true, fallback = true),
                         EmailEnabled(value = true, fallback = true),
@@ -518,7 +518,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Unknown(fallback = null),
                         Unknown(fallback = null),
                         Unknown(fallback = null),
@@ -536,7 +536,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Unknown(fallback = true),
                         Unknown(fallback = true),
                         Unknown(fallback = true),
@@ -554,7 +554,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Unknown(fallback = null),
                         Unknown(fallback = null),
                         Unknown(fallback = null),
@@ -572,7 +572,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Unknown(fallback = true),
                         Unknown(fallback = true),
                         Unknown(fallback = true),
@@ -592,7 +592,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         AppId(value = "com.duckduckgo.mobile.android.debug"),
                         Atb(value = "v298-8"),
                         AppAtb(value = "v298-8"),
@@ -614,7 +614,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         AppId(value = "com.duckduckgo.mobile.android.debug", fallback = true),
                         Atb(value = "v298-8", fallback = true),
                         AppAtb(value = "v298-8", fallback = true),
@@ -636,7 +636,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Unknown(fallback = null),
                         Unknown(fallback = null),
                         Unknown(fallback = null),
@@ -658,7 +658,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Unknown(fallback = true),
                         Unknown(fallback = true),
                         Unknown(fallback = true),
@@ -680,7 +680,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         AppId(value = "", fallback = null),
                         Atb(value = "", fallback = null),
                         AppAtb(value = "", fallback = null),
@@ -702,7 +702,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         AppId(value = "", fallback = true),
                         Atb(value = "", fallback = true),
                         AppAtb(value = "", fallback = true),
@@ -719,7 +719,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         DaysUsedSince(since = SimpleDateFormat("yyyy-mm-dd").parse("2020-08-09")!!, value = 2),
                     ),
                 ),
@@ -731,7 +731,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         DaysUsedSince(since = SimpleDateFormat("yyyy-mm-dd").parse("2020-08-09")!!, value = 2, fallback = true),
                     ),
                 ),
@@ -743,7 +743,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Unknown(fallback = true),
                     ),
                 ),
@@ -755,7 +755,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Unknown(fallback = null),
                     ),
                 ),
@@ -767,7 +767,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Unknown(fallback = true),
                     ),
                 ),
@@ -779,7 +779,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Unknown(fallback = null),
                     ),
                 ),
@@ -791,7 +791,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Unknown(fallback = true),
                     ),
                 ),
@@ -804,7 +804,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                     ),
                 ),
                 matchingRule(
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Unknown(fallback = null),
                         Unknown(fallback = true),
                     ),
@@ -820,7 +820,7 @@ class JsonRulesMapperTest(private val testCase: TestCase) {
                 ),
                 matchingRule(
                     percentile = 0.4f,
-                    matchingAttribute = arrayOf(
+                    matchingAttribute = arrayOf<MatchingAttribute>(
                         Unknown(fallback = null),
                         Unknown(fallback = true),
                     ),

--- a/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/db/migration/WideEventsMigration1To2Test.kt
+++ b/statistics/statistics-impl/src/test/java/com/duckduckgo/app/statistics/wideevents/db/migration/WideEventsMigration1To2Test.kt
@@ -93,7 +93,7 @@ private fun androidx.sqlite.db.SupportSQLiteDatabase.insertWideEvent(
             ?
         )
         """.trimIndent(),
-        arrayOf(id, activeIntervals),
+        arrayOf<Any>(id, activeIntervals),
     )
 }
 

--- a/versions.properties
+++ b/versions.properties
@@ -15,7 +15,7 @@ plugin.org.jetbrains.dokka=1.8.20
 
 plugin.com.osacky.fulladle=0.17.4
 
-plugin.com.google.devtools.ksp=2.2.21-2.0.5
+plugin.com.google.devtools.ksp=2.3.7
 
 plugin.com.diffplug.spotless=8.0.0
 
@@ -104,7 +104,7 @@ version.com.github.bumptech.glide..glide=4.16.0
 
 version.com.github.bumptech.glide..okhttp3-integration=4.16.0
 
-version.com.google.devtools.ksp..symbol-processing-api=2.2.21-2.0.5
+version.com.google.devtools.ksp..symbol-processing-api=2.3.7
 
 version.com.google.guava..guava=33.4.0-android
 
@@ -139,7 +139,7 @@ version.io.jsonwebtoken..jjwt-orgjson=0.12.6
 
 version.jakewharton.rxrelay2=2.0.0
 
-version.kotlin=2.2.21
+version.kotlin=2.3.20
 
 # Cannot update to 0.4.0 because it requires Kotlin 2.1.20
 version.kotlinx.collections.immutable=0.3.8

--- a/versions.properties
+++ b/versions.properties
@@ -15,7 +15,7 @@ plugin.org.jetbrains.dokka=1.8.20
 
 plugin.com.osacky.fulladle=0.17.4
 
-plugin.com.google.devtools.ksp=2.3.7
+plugin.com.google.devtools.ksp=2.3.9
 
 plugin.com.diffplug.spotless=8.0.0
 
@@ -31,7 +31,6 @@ version.androidx.arch.core=2.2.0
 
 version.androidx.browser=1.8.0
 
-# Cannot update past 1.0.0-alpha08 because alpha09+ requires Kotlin 2.x
 version.androidx.pdf=1.0.0-alpha08
 
 version.androidx.compose=2026.05.01
@@ -104,7 +103,7 @@ version.com.github.bumptech.glide..glide=4.16.0
 
 version.com.github.bumptech.glide..okhttp3-integration=4.16.0
 
-version.com.google.devtools.ksp..symbol-processing-api=2.3.7
+version.com.google.devtools.ksp..symbol-processing-api=2.3.9
 
 version.com.google.guava..guava=33.4.0-android
 
@@ -124,7 +123,6 @@ version.google.android.play-services-auth-blockstore=16.4.0
 
 version.google.dagger=2.57.2
 
-#Cannot update to 3.4+ because we need at least Kotlin 2.3.x
 version.io.coil-kt.coil3..coil-bom=3.3.0
 
 version.io.github.pcmind..leveldb=1.2
@@ -141,7 +139,6 @@ version.jakewharton.rxrelay2=2.0.0
 
 version.kotlin=2.3.20
 
-# Cannot update to 0.4.0 because it requires Kotlin 2.1.20
 version.kotlinx.collections.immutable=0.3.8
 
 version.kotlinx.coroutines=1.8.1


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214119362406643/task/1214799610249614?focus=true
Tech Design URL (if applicable): N/A

### Description
- Bump versions (versions.properties): version.kotlin 2.2.21 → 2.3.20; KSP 2.2.21-2.0.5 → 2.3.7 (both KSP lines; KSP moved to a decoupled version scheme — 2.3.7 is the build aligned to Kotlin 2.3.20).
 - Bump Metro language level (build.gradle:283-284): Metro-mode languageVersion/apiVersion KOTLIN_2_2 → KOTLIN_2_3.
- Fix Dagger metadata reader (app/build.gradle): add kapt "org.jetbrains.kotlin:kotlin-metadata-jvm:2.3.20" — Dagger 2.57.2's reader caps at metadata 2.2.0 but 2.3.20 emits 2.3.0 (:app KAPT only). Dagger itself not bumped (even 2.59.2 ships a 2.2.x reader).
- Fix 28 LV-2.3 compile errors (explicit type args): reified-type-param-inferred-to-intersection became an error at LV 2.3 — combine<Any, Unit>(...) in InputScreenViewModel.kt, arrayOf<MatchingAttribute>(...) ×26 in JsonRulesMapperTest.kt, arrayOf<Any>(...) in WideEventsMigration1To2Test.kt.
 - Keep Metro at 1.0.1 for now, bump in separate PR

### Steps to test this PR

_Smoke check_
- [x] Verify unit and Android tests pass for both DI variants
- [x] Verify e2e tests pass for both DI variants
- [x]  1) Metro: https://github.com/duckduckgo/Android/actions/runs/27945052008
- [x]  2) Anvil: https://github.com/duckduckgo/Android/actions/runs/27950202725
- [x] Verify privacy tests pass for both DI variants
- [x]  1) Metro: https://github.com/duckduckgo/Android/actions/runs/27944967007
- [x]  2) Anvil: https://github.com/duckduckgo/Android/actions/runs/27947878923
- [x] Install build and smoke check the app

### UI changes
No UI changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide toolchain bump affects all modules and both Anvil/Dagger and Metro DI builds; risk is mostly build/annotation processing rather than product logic, with only mechanical Kotlin typing fixes in app code.
> 
> **Overview**
> **Upgrades the Android monorepo to Kotlin 2.3.20** and aligns KSP (2.3.9), Metro `languageVersion`/`apiVersion` (2.3), and kotlinx-serialization resolution comments with the new compiler.
> 
> **Build/DI:** Adds `kotlin-metadata-jvm` on the `:app` KAPT classpath so Dagger 2.57.2 can read Kotlin 2.3 metadata; Dagger itself is unchanged.
> 
> **Compile fixes for Kotlin 2.3 stricter typing:** Explicit type arguments where reified inference to intersections is now an error—`combine<Any, Unit>` in `InputScreenViewModel`, `arrayOf<MatchingAttribute>` across remote-messaging mapper tests, and `arrayOf<Any>` in wide-events migration tests. No runtime behavior changes intended.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9aa133f78b61cf3e3ed5f75a2738be4c4c29b1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->