### PR TITLE
Sync @-mentioned PR review comments to Asana

### DIFF
--- a/.github/workflows/pr-review-notifications.yaml
+++ b/.github/workflows/pr-review-notifications.yaml
@@ -1,24 +1,29 @@
-name: Pull Request Reviewed -> Sync With Asana
+name: Pull Request Review/Mentions -> Sync With Asana
 
 on:
   pull_request_review:
     types: [submitted]
+  pull_request_review_comment:
+    types: [created]
 
 jobs:
-  pr-reviewed:
-    name: Add PR reviewed comment
+  sync:
+    name: Sync PR review/mentions with Asana
     runs-on: ubuntu-latest
     steps:
       - name: Checkout native actions repo
         uses: actions/checkout@v4
         with:
-            ref: v1.9
-            # Do not change the below path (downstream actions expect it)
-            path: native-github-asana-sync
-            repository: duckduckgo/native-github-asana-sync
+          ref: v2.6.0
+          # Do not change the below path (the composite expects it)
+          path: native-github-asana-sync
+          repository: duckduckgo/native-github-asana-sync
 
-      - name: Trigger PR review workflow
+      # Posts canned review-event notes, and forwards review summaries and
+      # inline comments @-mentioning a user.
+      - name: Sync PR review/mentions with Asana
         uses: ./native-github-asana-sync/.github/actions/pr-review-notifications
         with:
           trigger-phrase: "Task/Issue URL:"
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          user-map: ${{ vars.GH_ANDROID_USER_MAP }}


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/project/1212608036467427/task/1215911521920631?focus=true
Tech Design URL (if applicable): 

### Description
Opt into the native pr-review-notifications action's @-mention forwarding by supplying GH_ANDROID_USER_MAP as user-map, and listen on pull_request_review_comment so inline review comments are covered in addition to review summaries. All logic lives in the native action; this workflow just enables it and passes the android user map.

### Steps to test this PR
tested locally with `act`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to a GitHub Actions workflow and reuse an existing org variable; no application or security-sensitive runtime code is affected.
> 
> **Overview**
> Extends the **Pull Request Review → Asana** workflow so inline review comments and @-mentions reach Asana, not only submitted review summaries.
> 
> The workflow now also runs on `pull_request_review_comment` (`created`), bumps `duckduckgo/native-github-asana-sync` from **v1.9** to **v2.6.0**, and passes `user-map: ${{ vars.GH_ANDROID_USER_MAP }}` into `pr-review-notifications` (same org variable as `action-pr-sync`). Job/step naming and comments were updated to reflect review events plus mention forwarding; behavior still lives in the native composite action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c8c678facc7205ed858dd5fb34f57a7f9ec1ae0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->