### PR TITLE
Fix Dax legs cut off on the onboarding end CTA

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -236,15 +236,17 @@ class NativeInputLayoutCoordinator(
             return maxOf(0, anchorBottomInWindow - viewLocation[1])
         }
 
-        fun computeDeltaBottom(): Int {
+        fun computeDeltaBottom(view: View, anchorTopInWindow: Int): Int {
             if (!isBottom) return 0
-            return maxOf(0, widgetView.height)
+            val viewLocation = IntArray(2).also { view.getLocationInWindow(it) }
+            val viewBottomInWindow = viewLocation[1] + view.height
+            return maxOf(0, viewBottomInWindow - anchorTopInWindow)
         }
 
-        fun applyOffsetWithBottom(anchorBottomInWindow: Int) {
-            val deltaBottom = computeDeltaBottom()
+        fun applyOffsetWithBottom(anchorTopInWindow: Int, anchorBottomInWindow: Int) {
             targets.forEach { target ->
                 val deltaTop = computeDeltaTop(target.view, anchorBottomInWindow)
+                val deltaBottom = computeDeltaBottom(target.view, anchorTopInWindow)
                 applyPadding(target.view, target.basePadding, deltaTop, deltaBottom)
             }
         }
@@ -256,7 +258,7 @@ class NativeInputLayoutCoordinator(
             }
             val anchorLocation = IntArray(2).also { anchor.getLocationInWindow(it) }
             val anchorBottomInWindow = anchorLocation[1] + anchor.height
-            applyOffsetWithBottom(anchorBottomInWindow)
+            applyOffsetWithBottom(anchorTopInWindow = anchorLocation[1], anchorBottomInWindow = anchorBottomInWindow)
         }
 
         // Called from the enter/exit animators' onUpdate, BEFORE the layout pass that
@@ -278,7 +280,7 @@ class NativeInputLayoutCoordinator(
             val parentLocation = IntArray(2).also { parent.getLocationInWindow(it) }
             val cardVisualTopInWindow = parentLocation[1] + params.topMargin + card.translationY.toInt()
             val cardVisualBottomInWindow = cardVisualTopInWindow + params.height
-            applyOffsetWithBottom(cardVisualBottomInWindow)
+            applyOffsetWithBottom(anchorTopInWindow = cardVisualTopInWindow, anchorBottomInWindow = cardVisualBottomInWindow)
         }
 
         widgetView.post { applyOffset() }

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.adblocking.api.duckplayer.DuckPlayer
 import com.duckduckgo.adblocking.api.duckplayer.DuckPlayer.DuckPlayerState
 import com.duckduckgo.adblocking.api.duckplayer.PrivatePlayerMode.AlwaysAsk
 import com.duckduckgo.app.browser.DuckDuckGoUrlDetector
+import com.duckduckgo.app.browser.omnibar.OmnibarType
 import com.duckduckgo.app.cta.db.DismissedCtaDao
 import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.app.cta.model.DismissedCta
@@ -429,6 +430,7 @@ class CtaViewModel @Inject constructor(
                         appTheme.isLightModeEnabled(),
                         deviceInfo,
                         onboardingImprovementsEnabled = isOnboardingImprovementsEnabled(),
+                        isOmnibarBottom = settingsDataStore.omnibarType == OmnibarType.SINGLE_BOTTOM,
                     )
                 } else {
                     DaxBubbleCta.DaxEndCta(onboardingStore, appInstallStore)

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateBubbleCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateBubbleCta.kt
@@ -33,6 +33,7 @@ data class DaxEndBrandDesignUpdateBubbleCta(
     override val isLightTheme: Boolean,
     override val deviceInfo: DeviceInfo,
     override val onboardingImprovementsEnabled: Boolean,
+    val isOmnibarBottom: Boolean,
 ) : DaxBubbleCta.BrandDesignUpdateBubbleCta(
     ctaId = CtaId.DAX_END,
     title = R.string.onboardingEndDaxDialogTitle,
@@ -52,7 +53,9 @@ data class DaxEndBrandDesignUpdateBubbleCta(
     override val showArrow: Boolean = true
     override val wavingDaxSpec = WavingDaxSpec(
         rotationDegrees = 0f,
-        translationXDp = -40f,
+        // Bottom address bar (with native input enabled) doesn't stretch to the edge of the screen,
+        // so we need to nudge Dax to the right to ensure both his legs are behind the address bar.
+        translationXDp = if (isOmnibarBottom) -30f else -40f,
         translationYDp = -150f,
         heightDp = 178f,
         anchorToCardOnTablet = true,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215937292229504

### Description

The waving Dax on the onboarding end CTA has no legs in its asset, so it needs to sit flush against the bottom input field to read correctly. With a bottom address bar it floated above the input with its body cut off, because the new-tab content offset reserved the full input-widget height — including the part of the widget below the NTP container — leaving a dead gap.

Now the offset reserves only the height by which the input card overlaps the content, so NTP content (and the Dax) sits at the input card's top. The `DAX_END` Dax is also nudged right (bottom address bar only) so both legs tuck behind the card. The `DUCK_AI_DAX_END` Dax doesn't need similar nudge, because it is shown on top of input toggle, which is wider and covers his legs already.

### Steps to test this PR

_Onboarding end CTA — bottom address bar_
- [ ] Set the address bar to the bottom, then run onboarding to the end ("You've got this") CTA
- [ ] Confirm the Dax sits flush against the input field with both legs behind it — no gap, no cut-off body

_Top address bar (regression)_
- [ ] Repeat with the address bar at the top and confirm the Dax is unchanged

### UI changes
| Before  | After |
| ----- | ----- |
| <img width="1080" height="2400" alt="Screenshot_20260622_161555" src="https://github.com/user-attachments/assets/ca7cd1a6-aa8a-4886-902f-564c88935ddb" /> | <img width="1080" height="2400" alt="Screenshot_20260622_145921" src="https://github.com/user-attachments/assets/042c7858-f748-4105-a6cb-eb04e27d9d5b" /> |


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared native-input layout padding used by NTP and browser chrome during animations; wrong overlap math could affect bottom-bar browsing layout beyond onboarding.
> 
> **Overview**
> Fixes the onboarding **end** CTA with a **bottom address bar**: waving Dax no longer floats above the input with his body cut off.
> 
> **Native input content padding** — For bottom omnibar, bottom padding no longer uses the full `widgetView` height. It now reserves only the overlap between NTP/browser content and the input **card** top (same idea as autocomplete offset). Steady-state layout, layout listeners, and widget enter/exit animation frames all pass both the card’s top and bottom in window coordinates.
> 
> **Dax positioning** — `DaxEndBrandDesignUpdateBubbleCta` gets `isOmnibarBottom` from settings (`OmnibarType.SINGLE_BOTTOM`). When the bar is at the bottom, horizontal nudge changes from `-40dp` to `-30dp` so both legs sit behind the narrower bottom card.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8a0e1a3b52d0de3b6cbcc700005945b3235053b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->