### PR TITLE
Sync: enable canUseV2ConnectFlow FF by default

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
@@ -85,7 +85,7 @@ interface SyncFeature {
      * Global switch for the v2 connect/exchange stack. When disabled, the device uses the
      * v1 stack only — no v2 keys, no v2 channel, no scoped credentials.
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun canUseV2ConnectFlow(): Toggle
 
     /**

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AppSyncAccountRepositoryTest.kt
@@ -1150,6 +1150,7 @@ class AppSyncAccountRepositoryTest {
 
     @Test
     fun whenLoginWithScopedCredentialsFlagOffThenV2DataNotStored() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
         prepareToProvideDeviceIds()
         prepareForEncryption()
         whenever(nativeLib.prepareForLogin(primaryKey)).thenReturn(validLoginKeys)
@@ -1233,6 +1234,7 @@ class AppSyncAccountRepositoryTest {
 
     @Test
     fun whenCreateAccountWithScopedCredentialsFlagOffThenCredentialIdNull() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
         prepareToProvideDeviceIds()
         prepareForCreateAccountSuccess()
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModelTest.kt
@@ -85,7 +85,9 @@ internal class EnterCodeViewModelTest {
         this.seamlessAccountSwitching().setRawStoredState(State(true))
     }
     private val syncPixels: SyncPixels = mock()
-    private val qrCode: ExchangeV2QrCode = mock()
+    private val qrCode: ExchangeV2QrCode = mock<ExchangeV2QrCode>().also {
+        whenever(it.parse(any())).thenReturn(ExchangeV2CodeParseResult.Unknown)
+    }
     private val runner: ExchangeV2Runner = mock()
 
     private val codeDispatcher = RealSyncCodeDispatcher(

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
@@ -96,7 +96,9 @@ class SyncConnectViewModelTest {
     private val syncFeature = com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory.create(SyncFeature::class.java)
 
     private val runnerEventsFlow = kotlinx.coroutines.flow.MutableSharedFlow<com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event>(replay = 0)
-    private val qrCode: com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode = mock()
+    private val qrCode: com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode = mock<com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode>().also {
+        whenever(it.parse(any())).thenReturn(ExchangeV2CodeParseResult.Unknown)
+    }
     private val runner: com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner = mock<com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner>().also {
         whenever(it.events).thenReturn(runnerEventsFlow)
         whenever(it.eventsSince(any())).thenAnswer { invocation ->

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModelTest.kt
@@ -63,7 +63,9 @@ class SyncLoginViewModelTest {
     private val syncRepostitory: SyncAccountRepository = mock()
     private val syncPixels: SyncPixels = mock()
     private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
-    private val qrCode: ExchangeV2QrCode = mock()
+    private val qrCode: ExchangeV2QrCode = mock<ExchangeV2QrCode>().also {
+        whenever(it.parse(any())).thenReturn(ExchangeV2CodeParseResult.Unknown)
+    }
     private val runner: ExchangeV2Runner = mock()
     private val codeDispatcher = RealSyncCodeDispatcher(
         syncFeature = syncFeature,

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
@@ -107,7 +107,9 @@ class SyncWithAnotherDeviceViewModelTest {
         this.seamlessAccountSwitching().setRawStoredState(State(true))
         this.exchangeKeysToSyncWithAnotherDevice().setRawStoredState(State(false))
     }
-    private val qrCode: ExchangeV2QrCode = mock()
+    private val qrCode: ExchangeV2QrCode = mock<ExchangeV2QrCode>().also {
+        whenever(it.parse(any())).thenReturn(ExchangeV2CodeParseResult.Unknown)
+    }
 
     private val runnerEventsFlow = kotlinx.coroutines.flow.MutableSharedFlow<com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event>(replay = 0)
     private val runner: ExchangeV2Runner = mock<ExchangeV2Runner>().also {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1215920159457749?focus=true
Tech Design URL (if applicable): 

### Description
- Enables `sync/canUseV2ConnectFlow` by default

### Steps to test this PR
- qa optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default-on changes sync pairing, login/signup credential handling, and device-list paths for all users unless remotely disabled; rollout risk is mitigated by the existing remote feature toggle but behavior shifts are broad across sync setup.
> 
> **Overview**
> Turns on the **v2 connect/exchange stack by default** by changing `canUseV2ConnectFlow()` in `SyncFeature` from `DefaultFeatureValue.FALSE` to **`TRUE`**. Fresh installs (and clients without a remote override) will use v2 keys, the v2 channel, and scoped credentials instead of v1-only behavior; **`canShowV2ConnectCode()` stays off by default**, so showing a v2 QR still depends on that separate toggle.
> 
> Tests are updated for the new default: repository tests that assert **v1 / no scoped credential** behavior now **force the flag off**, and sync UI ViewModel tests stub **`ExchangeV2QrCode.parse`** to `Unknown` so legacy v1 code paths stay stable when the fake toggle factory picks up the enabled default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14ea8766ccbe181eed9154a1ea71731789ea6692. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->