### PR TITLE
PIR: Add initial scan restart on PIR dashboard launch

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/PirRemoteFeatures.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/PirRemoteFeatures.kt
@@ -59,7 +59,7 @@ interface PirRemoteFeatures {
      * When enabled, opening the dashboard with an interrupted initial scan (pending scan jobs,
      * no scan currently running) restarts the foreground scan to finish it.
      */
-    @DefaultValue(DefaultFeatureValue.INTERNAL)
+    @DefaultValue(DefaultFeatureValue.TRUE)
     fun resumeInitialScanOnDashboardOpen(): Toggle
 }
 

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/PirRemoteFeatures.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/PirRemoteFeatures.kt
@@ -54,6 +54,13 @@ interface PirRemoteFeatures {
 
     @DefaultValue(DefaultFeatureValue.TRUE)
     fun sendScanWideEvent(): Toggle
+
+    /**
+     * When enabled, opening the dashboard with an interrupted initial scan (pending scan jobs,
+     * no scan currently running) restarts the foreground scan to finish it.
+     */
+    @DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun resumeInitialScanOnDashboardOpen(): Toggle
 }
 
 @SingleInstanceIn(AppScope::class)

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebInitialScanStatusMessageHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebInitialScanStatusMessageHandler.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.js.messaging.api.JsMessage
 import com.duckduckgo.js.messaging.api.JsMessageCallback
 import com.duckduckgo.js.messaging.api.JsMessaging
+import com.duckduckgo.pir.impl.PirRemoteFeatures
 import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebMessages
 import com.duckduckgo.pir.impl.dashboard.messaging.model.PirWebMessageResponse
 import com.duckduckgo.pir.impl.dashboard.messaging.model.PirWebMessageResponse.GetDataBrokersResponse.DataBroker
@@ -30,6 +31,7 @@ import com.duckduckgo.pir.impl.dashboard.messaging.model.PirWebMessageResponse.S
 import com.duckduckgo.pir.impl.dashboard.messaging.model.PirWebMessageResponse.ScannedBroker
 import com.duckduckgo.pir.impl.dashboard.state.PirDashboardInitialScanStateProvider
 import com.duckduckgo.pir.impl.pixels.PirPixelSender
+import com.duckduckgo.pir.impl.scan.PirForegroundScanServiceStarter
 import com.duckduckgo.pir.impl.store.PirRepository
 import com.squareup.anvil.annotations.ContributesMultibinding
 import kotlinx.coroutines.CoroutineScope
@@ -52,6 +54,8 @@ class PirWebInitialScanStatusMessageHandler @Inject constructor(
     private val stateProvider: PirDashboardInitialScanStateProvider,
     private val pirRepository: PirRepository,
     private val pirPixelSender: PirPixelSender,
+    private val pirRemoteFeatures: PirRemoteFeatures,
+    private val foregroundScanServiceStarter: PirForegroundScanServiceStarter,
 ) : PirWebJsMessageHandler() {
 
     override val message = PirDashboardWebMessages.INITIAL_SCAN_STATUS
@@ -98,7 +102,7 @@ class PirWebInitialScanStatusMessageHandler @Inject constructor(
 
     /**
      * Checks if the initial foreground scan should be resumed (was interrupted with remaining brokers).
-     * Currently emits a pixel to measure how often this scenario occurs.
+     * Emits a pixel to measure how often this scenario occurs, and resumes the scan if the toggle is enabled.
      */
     private suspend fun checkForIncompleteInitialScan() {
         if (!stateProvider.shouldRestartInitialScan()) {
@@ -109,6 +113,13 @@ class PirWebInitialScanStatusMessageHandler @Inject constructor(
         // Emit pixel to measure how often interrupted scans could be resumed
         logcat { "PIR-WEB: Detected opportunity to resume interrupted scan, emitting pixel" }
         pirPixelSender.reportInitialScanIncomplete()
+
+        if (pirRemoteFeatures.resumeInitialScanOnDashboardOpen().isEnabled()) {
+            logcat { "PIR-WEB: Resuming interrupted initial scan via foreground service" }
+            foregroundScanServiceStarter.startResumeScan()
+        } else {
+            logcat { "PIR-WEB: Resume-on-dashboard-open is disabled; not starting scan" }
+        }
     }
 
     private suspend fun getResultsFound(): List<ScanResult> {

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/state/PirDashboardInitialScanStateProvider.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/dashboard/state/PirDashboardInitialScanStateProvider.kt
@@ -16,7 +16,6 @@
 
 package com.duckduckgo.pir.impl.dashboard.state
 
-import android.content.Context
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
@@ -26,7 +25,8 @@ import com.duckduckgo.pir.impl.dashboard.state.PirDashboardInitialScanStateProvi
 import com.duckduckgo.pir.impl.dashboard.state.PirDashboardInitialScanStateProvider.DashboardBrokerWithStatus.Status.IN_PROGRESS
 import com.duckduckgo.pir.impl.dashboard.state.PirDashboardInitialScanStateProvider.DashboardBrokerWithStatus.Status.NOT_STARTED
 import com.duckduckgo.pir.impl.models.scheduling.JobRecord.ScanJobRecord.ScanJobStatus
-import com.duckduckgo.pir.impl.scan.PirForegroundScanService
+import com.duckduckgo.pir.impl.scan.PirForegroundScanServiceMonitor
+import com.duckduckgo.pir.impl.scan.PirScanScheduler
 import com.duckduckgo.pir.impl.store.PirRepository
 import com.duckduckgo.pir.impl.store.PirSchedulingRepository
 import com.squareup.anvil.annotations.ContributesBinding
@@ -99,7 +99,8 @@ class RealPirDashboardInitialScanStateProvider @Inject constructor(
     private val pirRepository: PirRepository,
     private val pirSchedulingRepository: PirSchedulingRepository,
     private val brokerStepsParser: BrokerStepsParser,
-    private val context: Context,
+    private val pirForegroundScanServiceMonitor: PirForegroundScanServiceMonitor,
+    private val pirScanScheduler: PirScanScheduler,
 ) : PirDashboardStateProvider(currentTimeProvider, pirRepository, pirSchedulingRepository),
     PirDashboardInitialScanStateProvider {
     override suspend fun getActiveBrokersAndMirrorSitesTotal(): Int = withContext(dispatcherProvider.io()) {
@@ -138,13 +139,18 @@ class RealPirDashboardInitialScanStateProvider @Inject constructor(
     }
 
     override suspend fun shouldRestartInitialScan(): Boolean {
-        // Check if a scan is already running
-        if (PirForegroundScanService.isServiceRunning(context)) {
+        // Don't resume if a foreground scan is already running
+        if (pirForegroundScanServiceMonitor.isRunning()) {
             logcat { "PIR-WEB: Scan is already running, no need to resume initial scan" }
             return false
         }
 
-        // Get all scan jobs that haven't been executed yet
+        // Don't resume if a scheduled background scan worker is currently running
+        if (pirScanScheduler.isScheduledScanRunning()) {
+            logcat { "PIR-WEB: Scheduled scan worker is running, no need to resume initial scan" }
+            return false
+        }
+
         val notExecutedJobs = pirSchedulingRepository.getAllValidScanJobRecords().filter { record ->
             record.status == ScanJobStatus.NOT_EXECUTED && record.lastScanDateInMillis == 0L
         }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scan/PirForegroundScanServiceMonitor.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scan/PirForegroundScanServiceMonitor.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.scan
+
+import android.content.Context
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+/**
+ * Injectable wrapper around [PirForegroundScanService.isServiceRunning] so the running-state check
+ * can be mocked and unit-tested by callers (the dashboard resume guard and the scheduled worker guard).
+ */
+interface PirForegroundScanServiceMonitor {
+    fun isRunning(): Boolean
+}
+
+@ContributesBinding(AppScope::class)
+class RealPirForegroundScanServiceMonitor @Inject constructor(
+    private val context: Context,
+) : PirForegroundScanServiceMonitor {
+    override fun isRunning(): Boolean = PirForegroundScanService.isServiceRunning(context)
+}

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scan/PirForegroundScanServiceStarter.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scan/PirForegroundScanServiceStarter.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.scan
+
+import android.content.Context
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.pir.impl.scheduling.PirExecutionType
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+/** Starts [PirForegroundScanService] to resume an interrupted initial scan from the dashboard. */
+interface PirForegroundScanServiceStarter {
+    fun startResumeScan()
+}
+
+@ContributesBinding(ActivityScope::class)
+class RealPirForegroundScanServiceStarter @Inject constructor(
+    private val context: Context,
+) : PirForegroundScanServiceStarter {
+    override fun startResumeScan() {
+        // Resume the interrupted initial scan as MANUAL_INITIAL — the same execution type a manual
+        // re-trigger uses. Only the still-pending brokers are scanned (already-scanned jobs are skipped).
+        context.startForegroundService(
+            PirForegroundScanService.intentFor(context, PirExecutionType.MANUAL_INITIAL),
+        )
+    }
+}

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scan/PirScanScheduler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scan/PirScanScheduler.kt
@@ -25,6 +25,7 @@ import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequest
 import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import androidx.work.multiprocess.RemoteListenableWorker
 import com.duckduckgo.app.di.AppCoroutineScope
@@ -48,6 +49,7 @@ import com.duckduckgo.pir.impl.store.db.EventType
 import com.duckduckgo.pir.impl.store.db.PirEventLog
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import logcat.logcat
 import java.util.concurrent.TimeUnit
@@ -63,6 +65,12 @@ interface PirScanScheduler {
     fun reschedulePirScans()
 
     fun cancelScheduledScans(context: Context)
+
+    /**
+     * @return true if the periodic scheduled-scan worker ([PirScheduledScanRemoteWorker]) is currently
+     * in [WorkInfo.State.RUNNING].
+     */
+    suspend fun isScheduledScanRunning(): Boolean
 }
 
 @ContributesBinding(AppScope::class)
@@ -176,6 +184,17 @@ class RealPirScanScheduler @Inject constructor(
             ExistingPeriodicWorkPolicy.UPDATE,
             periodicWorkRequest,
         )
+    }
+
+    override suspend fun isScheduledScanRunning(): Boolean {
+        return runCatching {
+            workManager.getWorkInfosForUniqueWorkFlow(TAG_SCHEDULED_SCAN)
+                .firstOrNull()
+                ?.any { it.state == WorkInfo.State.RUNNING } ?: false
+        }.getOrElse {
+            logcat { "PIR-SCHEDULED: Failed to read scheduled scan work info: $it" }
+            false
+        }
     }
 
     override fun cancelScheduledScans(context: Context) {

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scan/PirScheduledScanWorker.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scan/PirScheduledScanWorker.kt
@@ -50,6 +50,9 @@ class PirScheduledScanRemoteWorker(
     @Inject
     lateinit var pirFeatureDataCleaner: PirFeatureDataCleaner
 
+    @Inject
+    lateinit var pirForegroundScanServiceMonitor: PirForegroundScanServiceMonitor
+
     override suspend fun doRemoteWork(): Result {
         logcat { "PIR-WORKER ($this}: doRemoteWork ${Process.myPid()}" }
         return try {
@@ -59,6 +62,11 @@ class PirScheduledScanRemoteWorker(
                 pirWorkHandler.cancelWork(CancellationReason.fromDisabledReason(eligibility.reason))
                 pirFeatureDataCleaner.removeAllData()
                 return Result.failure()
+            }
+
+            if (pirForegroundScanServiceMonitor.isRunning()) {
+                logcat { "PIR-WORKER ($this}: Foreground scan running, skipping this scheduled run" }
+                return Result.success()
             }
 
             val result = pirJobsRunner.runEligibleJobs(context.applicationContext, PirExecutionType.SCHEDULED)

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebInitialScanStatusMessageHandlerTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/messaging/handlers/PirWebInitialScanStatusMessageHandlerTest.kt
@@ -19,7 +19,9 @@ package com.duckduckgo.pir.impl.dashboard.messaging.handlers
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.json.JSONObjectAdapter
+import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.js.messaging.api.JsMessageCallback
+import com.duckduckgo.pir.impl.PirRemoteFeatures
 import com.duckduckgo.pir.impl.dashboard.messaging.PirDashboardWebMessages
 import com.duckduckgo.pir.impl.dashboard.messaging.handlers.PirMessageHandlerUtils.createJsMessage
 import com.duckduckgo.pir.impl.dashboard.messaging.model.PirWebMessageResponse.InitialScanResponse
@@ -30,6 +32,7 @@ import com.duckduckgo.pir.impl.dashboard.state.PirDashboardInitialScanStateProvi
 import com.duckduckgo.pir.impl.models.AddressCityState
 import com.duckduckgo.pir.impl.models.ExtractedProfile
 import com.duckduckgo.pir.impl.pixels.PirPixelSender
+import com.duckduckgo.pir.impl.scan.PirForegroundScanServiceStarter
 import com.duckduckgo.pir.impl.store.PirRepository
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
@@ -65,10 +68,15 @@ class PirWebInitialScanStatusMessageHandlerTest {
     private val testScope = TestScope()
     private val mockRepository: PirRepository = mock()
     private val mockPirPixelSender: PirPixelSender = mock()
+    private val mockPirRemoteFeatures: PirRemoteFeatures = mock()
+    private val resumeToggle: Toggle = mock()
+    private val mockForegroundScanServiceStarter: PirForegroundScanServiceStarter = mock()
 
     @Before
     fun setUp() = runTest {
         whenever(mockStateProvider.shouldRestartInitialScan()).thenReturn(false)
+        whenever(mockPirRemoteFeatures.resumeInitialScanOnDashboardOpen()).thenReturn(resumeToggle)
+        whenever(resumeToggle.isEnabled()).thenReturn(true)
 
         testee = PirWebInitialScanStatusMessageHandler(
             dispatcherProvider = coroutineRule.testDispatcherProvider,
@@ -76,6 +84,8 @@ class PirWebInitialScanStatusMessageHandlerTest {
             stateProvider = mockStateProvider,
             pirRepository = mockRepository,
             pirPixelSender = mockPirPixelSender,
+            pirRemoteFeatures = mockPirRemoteFeatures,
+            foregroundScanServiceStarter = mockForegroundScanServiceStarter,
         )
         fakeJsMessaging.reset()
     }
@@ -402,6 +412,55 @@ class PirWebInitialScanStatusMessageHandlerTest {
         // and pixel should also only have been emitted once
         verify(mockStateProvider).shouldRestartInitialScan()
         verify(mockPirPixelSender).reportInitialScanIncomplete()
+    }
+
+    @Test
+    fun whenShouldRestartAndToggleEnabledThenStartsForegroundScan() = runTest {
+        val jsMessage = createJsMessage("", PirDashboardWebMessages.INITIAL_SCAN_STATUS)
+        whenever(mockRepository.getValidUserProfileQueries()).thenReturn(listOf(mock()))
+        whenever(mockStateProvider.getScanResults()).thenReturn(emptyList())
+        whenever(mockStateProvider.getFullyCompletedBrokersTotal()).thenReturn(1)
+        whenever(mockStateProvider.getActiveBrokersAndMirrorSitesTotal()).thenReturn(3)
+        whenever(mockStateProvider.getAllScannedBrokersStatus()).thenReturn(emptyList())
+        whenever(mockStateProvider.shouldRestartInitialScan()).thenReturn(true)
+        whenever(resumeToggle.isEnabled()).thenReturn(true)
+
+        testee.process(jsMessage, fakeJsMessaging, mockJsMessageCallback)
+
+        verify(mockPirPixelSender).reportInitialScanIncomplete()
+        verify(mockForegroundScanServiceStarter).startResumeScan()
+    }
+
+    @Test
+    fun whenShouldRestartButToggleDisabledThenEmitsPixelButDoesNotStartScan() = runTest {
+        val jsMessage = createJsMessage("", PirDashboardWebMessages.INITIAL_SCAN_STATUS)
+        whenever(mockRepository.getValidUserProfileQueries()).thenReturn(listOf(mock()))
+        whenever(mockStateProvider.getScanResults()).thenReturn(emptyList())
+        whenever(mockStateProvider.getFullyCompletedBrokersTotal()).thenReturn(1)
+        whenever(mockStateProvider.getActiveBrokersAndMirrorSitesTotal()).thenReturn(3)
+        whenever(mockStateProvider.getAllScannedBrokersStatus()).thenReturn(emptyList())
+        whenever(mockStateProvider.shouldRestartInitialScan()).thenReturn(true)
+        whenever(resumeToggle.isEnabled()).thenReturn(false)
+
+        testee.process(jsMessage, fakeJsMessaging, mockJsMessageCallback)
+
+        verify(mockPirPixelSender).reportInitialScanIncomplete()
+        verify(mockForegroundScanServiceStarter, never()).startResumeScan()
+    }
+
+    @Test
+    fun whenShouldNotRestartThenDoesNotStartScan() = runTest {
+        val jsMessage = createJsMessage("", PirDashboardWebMessages.INITIAL_SCAN_STATUS)
+        whenever(mockRepository.getValidUserProfileQueries()).thenReturn(listOf(mock()))
+        whenever(mockStateProvider.getScanResults()).thenReturn(emptyList())
+        whenever(mockStateProvider.getFullyCompletedBrokersTotal()).thenReturn(3)
+        whenever(mockStateProvider.getActiveBrokersAndMirrorSitesTotal()).thenReturn(3)
+        whenever(mockStateProvider.getAllScannedBrokersStatus()).thenReturn(emptyList())
+        whenever(mockStateProvider.shouldRestartInitialScan()).thenReturn(false)
+
+        testee.process(jsMessage, fakeJsMessaging, mockJsMessageCallback)
+
+        verify(mockForegroundScanServiceStarter, never()).startResumeScan()
     }
 
     private fun verifyInitialScanResponse(

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/state/RealPirDashboardInitialScanStateProviderTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/dashboard/state/RealPirDashboardInitialScanStateProviderTest.kt
@@ -16,7 +16,6 @@
 
 package com.duckduckgo.pir.impl.dashboard.state
 
-import android.content.Context
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.pir.impl.common.BrokerStepsParser
@@ -32,8 +31,11 @@ import com.duckduckgo.pir.impl.models.scheduling.JobRecord.OptOutJobRecord
 import com.duckduckgo.pir.impl.models.scheduling.JobRecord.OptOutJobRecord.OptOutJobStatus
 import com.duckduckgo.pir.impl.models.scheduling.JobRecord.ScanJobRecord
 import com.duckduckgo.pir.impl.models.scheduling.JobRecord.ScanJobRecord.ScanJobStatus
+import com.duckduckgo.pir.impl.scan.PirForegroundScanServiceMonitor
+import com.duckduckgo.pir.impl.scan.PirScanScheduler
 import com.duckduckgo.pir.impl.store.PirRepository
 import com.duckduckgo.pir.impl.store.PirSchedulingRepository
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -59,7 +61,8 @@ class RealPirDashboardInitialScanStateProviderTest {
     private val mockPirRepository: PirRepository = mock()
     private val mockPirSchedulingRepository: PirSchedulingRepository = mock()
     private val mockBrokerStepsParser: BrokerStepsParser = mock()
-    private val mockContext: Context = mock()
+    private val mockForegroundScanServiceMonitor: PirForegroundScanServiceMonitor = mock()
+    private val mockPirScanScheduler: PirScanScheduler = mock()
 
     private val currentTime = 1640995200000L
 
@@ -71,10 +74,12 @@ class RealPirDashboardInitialScanStateProviderTest {
             pirRepository = mockPirRepository,
             pirSchedulingRepository = mockPirSchedulingRepository,
             brokerStepsParser = mockBrokerStepsParser,
-            context = mockContext,
+            pirForegroundScanServiceMonitor = mockForegroundScanServiceMonitor,
+            pirScanScheduler = mockPirScanScheduler,
         )
-
         whenever(mockCurrentTimeProvider.currentTimeMillis()).thenReturn(currentTime)
+        whenever(mockForegroundScanServiceMonitor.isRunning()).thenReturn(false)
+        runBlocking { whenever(mockPirScanScheduler.isScheduledScanRunning()).thenReturn(false) }
     }
 
     private suspend fun setupBrokersWithScannableSteps(brokers: List<Broker>) {
@@ -913,6 +918,28 @@ class RealPirDashboardInitialScanStateProviderTest {
 
         // Then
         assertFalse("Should not restart scan when all jobs are in ERROR state", result)
+    }
+
+    @Test
+    fun whenForegroundServiceRunningThenShouldNotRestartScan() = runTest {
+        // Given - unscanned jobs exist (would otherwise restart) but the foreground scan is running
+        whenever(mockPirSchedulingRepository.getAllValidScanJobRecords())
+            .thenReturn(listOf(createScanJobRecord("Broker1", 1L, ScanJobStatus.NOT_EXECUTED, 0L)))
+        whenever(mockForegroundScanServiceMonitor.isRunning()).thenReturn(true)
+
+        // When / Then
+        assertFalse(testee.shouldRestartInitialScan())
+    }
+
+    @Test
+    fun whenScheduledScanWorkerIsRunningThenShouldNotRestartScan() = runTest {
+        // Given - unscanned jobs exist but a scheduled background scan is running
+        whenever(mockPirSchedulingRepository.getAllValidScanJobRecords())
+            .thenReturn(listOf(createScanJobRecord("Broker1", 1L, ScanJobStatus.NOT_EXECUTED, 0L)))
+        whenever(mockPirScanScheduler.isScheduledScanRunning()).thenReturn(true)
+
+        // When / Then
+        assertFalse(testee.shouldRestartInitialScan())
     }
 
     private suspend fun setupForEmptyBrokersAndJobs() {

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scan/PirScheduledScanRemoteWorkerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scan/PirScheduledScanRemoteWorkerTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.scan
+
+import android.content.Context
+import androidx.work.ListenableWorker
+import androidx.work.testing.TestListenableWorkerBuilder
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.pir.impl.PirFeatureDataCleaner
+import com.duckduckgo.pir.impl.checker.PirEligibility
+import com.duckduckgo.pir.impl.checker.PirWorkHandler
+import com.duckduckgo.pir.impl.scheduling.PirJobsRunner
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class PirScheduledScanRemoteWorkerTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val mockPirJobsRunner: PirJobsRunner = mock()
+    private val mockPirWorkHandler: PirWorkHandler = mock()
+    private val mockPirFeatureDataCleaner: PirFeatureDataCleaner = mock()
+    private val mockMonitor: PirForegroundScanServiceMonitor = mock()
+    private lateinit var context: Context
+
+    @Before
+    fun setup() {
+        context = mock()
+        whenever(context.applicationContext).thenReturn(context)
+    }
+
+    private fun buildWorker(): PirScheduledScanRemoteWorker =
+        TestListenableWorkerBuilder<PirScheduledScanRemoteWorker>(context = context).build().also {
+            it.pirJobsRunner = mockPirJobsRunner
+            it.pirWorkHandler = mockPirWorkHandler
+            it.pirFeatureDataCleaner = mockPirFeatureDataCleaner
+            it.dispatcherProvider = coroutineRule.testDispatcherProvider
+            it.pirForegroundScanServiceMonitor = mockMonitor
+        }
+
+    @Test
+    fun whenForegroundScanServiceRunningThenSkipsRunWithSuccessWithoutRunningJobs() = runTest {
+        whenever(mockPirWorkHandler.canRunPir()).thenReturn(flowOf(PirEligibility.Enabled))
+        whenever(mockMonitor.isRunning()).thenReturn(true)
+
+        val result = buildWorker().doRemoteWork()
+
+        assertEquals(ListenableWorker.Result.success(), result)
+        verify(mockPirJobsRunner, never()).runEligibleJobs(any(), any())
+    }
+
+    @Test
+    fun whenForegroundScanServiceNotRunningThenRunsEligibleJobs() = runTest {
+        whenever(mockPirWorkHandler.canRunPir()).thenReturn(flowOf(PirEligibility.Enabled))
+        whenever(mockMonitor.isRunning()).thenReturn(false)
+        whenever(mockPirJobsRunner.runEligibleJobs(any(), any())).thenReturn(kotlin.Result.success(Unit))
+
+        val result = buildWorker().doRemoteWork()
+
+        assertEquals(ListenableWorker.Result.success(), result)
+        verify(mockPirJobsRunner).runEligibleJobs(any(), any())
+    }
+}

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scan/RealPirScanSchedulerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scan/RealPirScanSchedulerTest.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.PeriodicWorkRequest
+import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.CurrentTimeProvider
@@ -30,10 +31,12 @@ import com.duckduckgo.pir.impl.pixels.PirPixelSender
 import com.duckduckgo.pir.impl.store.PirEventsRepository
 import com.duckduckgo.pir.impl.store.db.EventType
 import com.duckduckgo.pir.impl.store.db.PirEventLog
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -347,5 +350,33 @@ class RealPirScanSchedulerTest {
         verify(mockWorkManager).cancelUniqueWork(eq(PirEmailConfirmationRemoteWorker.TAG_EMAIL_CONFIRMATION))
         verify(mockWorkManager).cancelUniqueWork(eq(PirCustomStatsWorker.TAG_PIR_RECURRING_CUSTOM_STATS))
         verify(mockWorkManager).cancelUniqueWork(eq(PirBackgroundScanStatsWorker.TAG_PIR_BACKGROUND_STATS_DAILY))
+    }
+
+    @Test
+    fun whenScheduledScanWorkerIsRunningThenIsScheduledScanRunningReturnsTrue() = runTest {
+        val running: WorkInfo = mock()
+        whenever(running.state).thenReturn(WorkInfo.State.RUNNING)
+        whenever(mockWorkManager.getWorkInfosForUniqueWorkFlow(PirScheduledScanRemoteWorker.TAG_SCHEDULED_SCAN))
+            .thenReturn(flowOf(listOf(running)))
+
+        assertTrue(testee.isScheduledScanRunning())
+    }
+
+    @Test
+    fun whenScheduledScanWorkerIsEnqueuedThenIsScheduledScanRunningReturnsFalse() = runTest {
+        val enqueued: WorkInfo = mock()
+        whenever(enqueued.state).thenReturn(WorkInfo.State.ENQUEUED)
+        whenever(mockWorkManager.getWorkInfosForUniqueWorkFlow(PirScheduledScanRemoteWorker.TAG_SCHEDULED_SCAN))
+            .thenReturn(flowOf(listOf(enqueued)))
+
+        assertFalse(testee.isScheduledScanRunning())
+    }
+
+    @Test
+    fun whenNoScheduledScanWorkThenIsScheduledScanRunningReturnsFalse() = runTest {
+        whenever(mockWorkManager.getWorkInfosForUniqueWorkFlow(PirScheduledScanRemoteWorker.TAG_SCHEDULED_SCAN))
+            .thenReturn(flowOf(emptyList()))
+
+        assertFalse(testee.isScheduledScanRunning())
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203581873609357/task/1215725818623013?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1203581873609357/task/1213368145276564?focus=true

### Description

- Triggers the foreground scan when PIR dashboard is opened and there are incomplete jobs. 
- Handles coordination between foreground service and scheduled worker to now cancel each other
- TODO: pixel updates - next PR

### Steps to test this PR
See https://app.asana.com/1/137249556945/project/1203581873609357/task/1215930117038075?focus=true

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes scan scheduling and foreground/background coordination; mis-guarding could duplicate scans or leave interrupted initial scans unfinished, though toggles and explicit skip paths limit blast radius.
> 
> **Overview**
> When the PIR dashboard loads and detects an interrupted initial scan (pending `NOT_EXECUTED` jobs, nothing running), it can now **restart the foreground scan** instead of only logging a pixel. Behavior is gated by a new remote toggle **`resumeInitialScanOnDashboardOpen`** (default on).
> 
> **Resume path:** On the first `INITIAL_SCAN_STATUS` message per dashboard activity, if resume is warranted, the handler still emits `reportInitialScanIncomplete`, then calls **`PirForegroundScanServiceStarter.startResumeScan()`** with `MANUAL_INITIAL` so only remaining brokers run.
> 
> **Coordination:** Resume is suppressed when a foreground scan or the periodic scheduled scan worker is already running. The scheduled worker **skips its run** (success, no jobs) if the foreground service is active—avoiding overlapping scan execution. Running-state checks move behind injectable **`PirForegroundScanServiceMonitor`** and **`PirScanScheduler.isScheduledScanRunning()`** for testability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a569742b88dafb8eb910b4366a44b00f7f61e9e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->