### PR TITLE
Drop support for sync connect codes inside deep linking setup URLs

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
@@ -37,6 +37,7 @@ import com.duckduckgo.sync.impl.RecoveryCodePDF
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.SyncAccountRepository
+import com.duckduckgo.sync.impl.SyncAuthCode
 import com.duckduckgo.sync.impl.SyncFeatureToggle
 import com.duckduckgo.sync.impl.auth.DeviceAuthenticator
 import com.duckduckgo.sync.impl.autorestore.SyncAutoRestoreManager
@@ -603,13 +604,28 @@ class SyncActivityViewModel @Inject constructor(
     fun processSetupDeepLink(setupUrl: String) {
         logcat { "Sync-setup: got setup deep link $setupUrl" }
         viewModelScope.launch(dispatchers.io()) {
-            // parse here to test validity before asking user to use it
             val parsed = SyncBarcodeUrl.parseUrl(setupUrl)
-
             if (parsed == null) {
                 logcat { "Sync-setup: failed to parse setup URL $setupUrl" }
-            } else {
-                command.send(Command.AskSetupSyncDeepLink(parsed))
+                return@launch
+            }
+            when (parsed.protocolVersion) {
+                SyncBarcodeUrl.ProtocolVersion.V1 -> {
+                    // V1 URL-based sync setup only accepts exchange codes
+                    if (syncAccountRepository.parseSyncAuthCode(setupUrl) !is SyncAuthCode.Exchange) {
+                        logcat { "Sync-setup: v1 deep-link URL does not carry an exchange code; ignoring silently" }
+                        return@launch
+                    }
+                    command.send(Command.AskSetupSyncDeepLink(parsed))
+                }
+                SyncBarcodeUrl.ProtocolVersion.V2 -> {
+                    // V2 exchanges have their own user confirmation built into the protocol
+                    // (the Joiner/Host confirmation surfaced by the runner)
+                    logcat { "Sync-setup: v2 deep link; bypassing legacy confirmation dialog" }
+                    requiresSetupAuthentication {
+                        command.send(Command.DeepLinkIntoSetup(parsed))
+                    }
+                }
             }
         }
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
@@ -116,7 +116,9 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
         sessionStarted = true
         viewModelScope.launch(dispatchers.io()) {
             if (shouldUseV2()) {
-                startV2Present()
+                if (!isDeepLink) {
+                    startV2Present()
+                }
                 return@launch
             }
             showQRCode()

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModelTest.kt
@@ -40,6 +40,7 @@ import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAccountRepository.AuthCode
+import com.duckduckgo.sync.impl.SyncAuthCode
 import com.duckduckgo.sync.impl.SyncFeatureToggle
 import com.duckduckgo.sync.impl.auth.DeviceAuthenticator
 import com.duckduckgo.sync.impl.autorestore.SyncAutoRestoreManager
@@ -58,6 +59,7 @@ import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.OriginalFlow
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.SetupFlows.CreateAccountFlow
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.SetupFlows.SignInFlow
 import com.duckduckgo.sync.impl.ui.SyncDeviceListItem.SyncedDevice
+import com.duckduckgo.sync.impl.ui.qrcode.SyncBarcodeUrl
 import com.duckduckgo.sync.impl.wideevents.SyncSetupWideEvent
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -1102,6 +1104,71 @@ class SyncActivityViewModelTest {
         // SyncActivity returns to foreground — viewState() is re-subscribed.
         testee.viewState().test {
             assertTrue(expectMostRecentItem().autoRestoreEnabled)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenProcessSetupDeepLinkWithV1ExchangeUrlThenAskSetupSyncDeepLinkIsSent() = runTest {
+        val url = SyncBarcodeUrl(webSafeB64EncodedCode = "code").asUrl()
+        whenever(syncAccountRepository.parseSyncAuthCode(url)).thenReturn(SyncAuthCode.Exchange(mock()))
+
+        testee.commands().test {
+            testee.processSetupDeepLink(url)
+            awaitItem().assertCommandType(Command.AskSetupSyncDeepLink::class)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenProcessSetupDeepLinkWithV1ConnectUrlThenNoCommandIsSent() = runTest {
+        val url = SyncBarcodeUrl(webSafeB64EncodedCode = "code").asUrl()
+        whenever(syncAccountRepository.parseSyncAuthCode(url)).thenReturn(SyncAuthCode.Unknown("code"))
+
+        testee.commands().test {
+            testee.processSetupDeepLink(url)
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenProcessSetupDeepLinkWithV2UrlAndDeviceAuthEnrolledThenDeepLinkIntoSetupIsSent() = runTest {
+        whenever(deviceAuthenticator.hasValidDeviceAuthentication()).thenReturn(true)
+        val url = SyncBarcodeUrl(
+            webSafeB64EncodedCode = "code",
+            protocolVersion = SyncBarcodeUrl.ProtocolVersion.V2,
+        ).asUrl()
+
+        testee.commands().test {
+            testee.processSetupDeepLink(url)
+            awaitItem().assertCommandType(Command.DeepLinkIntoSetup::class)
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        verify(syncAccountRepository, never()).parseSyncAuthCode(any())
+    }
+
+    @Test
+    fun whenProcessSetupDeepLinkWithV2UrlAndDeviceAuthNotEnrolledThenRequestSetupAuthenticationIsSent() = runTest {
+        whenever(deviceAuthenticator.hasValidDeviceAuthentication()).thenReturn(false)
+        val url = SyncBarcodeUrl(
+            webSafeB64EncodedCode = "code",
+            protocolVersion = SyncBarcodeUrl.ProtocolVersion.V2,
+        ).asUrl()
+
+        testee.commands().test {
+            testee.processSetupDeepLink(url)
+            awaitItem().assertCommandType(RequestSetupAuthentication::class)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenProcessSetupDeepLinkWithMalformedUrlThenNoCommandIsSent() = runTest {
+        testee.commands().test {
+            testee.processSetupDeepLink("not-a-sync-url")
+            expectNoEvents()
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
@@ -723,6 +723,21 @@ class SyncWithAnotherDeviceViewModelTest {
     }
 
     @Test
+    fun whenIsDeepLinkAndV2EnabledThenStartPresentNotInvoked() = runTest {
+        enableV2(displayOn = true)
+        whenever(syncRepository.getAccountInfo()).thenReturn(accountA)
+
+        testee.viewState(isDeepLink = true).test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        verify(runner, never()).startPresent()
+        verify(syncRepository, never()).generateExchangeInvitationCode()
+        verify(syncRepository, never()).getRecoveryCode()
+    }
+
+    @Test
     fun whenV2PairingRejectedByPeerThenShowError() = runTest {
         syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
         whenever(syncRepository.getAccountInfo()).thenReturn(accountA)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1215920222849529?focus=true
Tech Design URL (if applicable):

### Description

Two related deep-link fixes:

1. **Drop V1 `connect` URL deep links silently.** V1 URL deep links now only honour exchange codes; anything else (connect, recovery, garbage) is dropped without any dialog or error. The user stays on the Sync & Backup screen. `connect` codes can still be processed via the in-app scanner / paste flow — only the deep-link surface is restricted.
2. **Fix V2 deep links.** V2 has its own user confirmation built into the exchange protocol. Also fixes a race where the deep-linked receiver was starting both a Presenter and a Scanner session over the shared V2 runner, leaving the runner with no listener once the Scanner pre-empted, so the user got stuck on "Setting Up Sync and Backup!" forever.

### Steps to test this PR

You'll need a physical Android (to scan with the system camera) and an emulator (to be scanned).

#### Pre-req setup
- [ ] Install the app from this branch on both your physical device and emulator
- [ ] On your physical Android, **set us as default browser** so deep links are intercepted

#### Scenario 1 — `canShowV2ConnectCode=false` on emulator (V1 exchange URL)
- [ ] No action needed — `canShowV2ConnectCode` is off by default
- [ ] On the emulator, open Sync & Backup settings and choose `Sync With Another Device` — it displays a URL-based **V1 exchange** code
- [ ] On your physical Android, choose `Sync With Another Device` and scan the emulator's barcode **using the system camera app**
- [ ] Verify the legacy "Sync with [emulator's device name]?" dialog appears with a real device name (not "null"). After agreeing, sync completes
- [ ] Remove the emulator from the sync account
- [ ] Repeat on the emulator, this time scan **using the in-app scanner**. Verify that works ok
- [ ] Remove the emulator from the sync account

#### Scenario 2 — `canShowV2ConnectCode=true` on emulator (V2 exchange URL)
- [ ] On the emulator, enable `canShowV2ConnectCode` via the FF inventory
- [ ] On the emulator, open Sync & Backup settings and choose `Sync With Another Device` — it displays a URL-based **V2 exchange** code
- [ ] On your physical Android, choose `Sync With Another Device` and scan the emulator's barcode **using the system camera app**
- [ ] Verify the physical Android goes straight into the V2 exchange flow — **no** \"Sync with null?\" dialog, and the V2 confirmation prompt (\"Sync your data with…?\") appears. After confirming, sync completes (not stuck on \"Setting Up Sync and Backup!\")
- [ ] Remove the emulator from the sync account
- [ ] Repeat on the emulator, this time scan **using the in-app scanner**. Verify that works ok
- [ ] Remove the emulator from the sync account

#### Scenario 3 — V1 connect URL deep link is silently dropped

This scenario uses the `Sync Connect` surface (from a fresh, signed-out device) which emits a V1 `connect` code. To get that as a URL:
- [ ] On the emulator (signed out of sync), **disable** `canUseV2ConnectFlow` in the FF inventory
- [ ] On the emulator, start the sync setup as a new device and choose `Sync With Another Device` — it displays a URL-based **V1 connect** code
- [ ] On your physical Android (signed in to sync), scan the emulator's barcode **using the system camera app**
- [ ] Expected: the physical Android stays on the Sync & Backup screen. No \"Sync with [device]?\" dialog, no error toast. logcat shows `Sync-setup: v1 deep-link URL does not carry an exchange code; ignoring silently`
- [ ] Sanity check: scan the same connect QR **using the in-app scanner**. Sync should complete normally (the restriction is on the deep-link surface only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sync pairing entry points and V2 runner lifecycle on deep links; wrong branching could block legitimate setup or regress pairing, but scope is limited and covered by new tests.
> 
> **Overview**
> Sync setup **deep links** are now handled differently by protocol version.
> 
> **V1 URL deep links** only proceed when the URL carries an **exchange** code; connect/recovery/invalid payloads are **ignored silently** (no legacy confirmation dialog). In-app scan/paste is unchanged.
> 
> **V2 URL deep links** skip the legacy “Sync with …?” dialog and go straight into setup after device auth, relying on V2’s built-in confirmation.
> 
> **V2 deep-link receiver fix:** when opening sync-from-URL with V2 enabled, the “Sync with another device” screen no longer starts a **Presenter** session (`startV2Present`), avoiding a race where Presenter and Scanner fought over the shared V2 runner and left users stuck on “Setting Up Sync and Backup!”.
> 
> Tests cover V1/V2/malformed deep-link commands and the deep-link + V2 no-present behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 152534994aaa1b6ecfb26bf643b791e634c7a3b2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->