### PR TITLE
Use @ContributesServiceApi when fetching models

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelsService.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelsService.kt
@@ -16,12 +16,12 @@
 
 package com.duckduckgo.duckchat.impl.models
 
-import com.duckduckgo.anvil.annotations.ContributesNonCachingServiceApi
+import com.duckduckgo.anvil.annotations.ContributesServiceApi
 import com.duckduckgo.di.scopes.AppScope
 import retrofit2.http.GET
 import retrofit2.http.Url
 
-@ContributesNonCachingServiceApi(AppScope::class)
+@ContributesServiceApi(AppScope::class)
 interface DuckAiModelsService {
     @GET
     suspend fun getModels(@Url url: String): AIChatModelsResponse


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1215937451370054?focus=true
Tech Design URL (if applicable): 

### Description

- Use `@ContributesServiceApi` instead of `@ContributesNonCachingServiceApi` when fetching Duck.ai models

### Steps to test this PR

- [ ] Verify that the model picker works as expected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single annotation change alters HTTP caching for the models endpoint only; no auth or broader API surface changes.
> 
> **Overview**
> **`DuckAiModelsService`** is switched from **`@ContributesNonCachingServiceApi`** to **`@ContributesServiceApi`**, so Anvil-generated DI binds it to **`@Named("api")` Retrofit** instead of the non-caching stack.
> 
> That changes how **`RealDuckAiModelManager`** loads **`/duckchat/v1/models`**: requests can use the standard API OkHttp client (including its HTTP cache) rather than always bypassing cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 542d45e553c0273c2a5081a3a99fd8b4ea6cbba6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->