### PR TITLE
de-emphasize input in Duck.ai onboarding demo

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -49,6 +49,8 @@ import androidx.recyclerview.widget.RecyclerView
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion
 import com.duckduckgo.browser.ui.PulseAnimation
+import com.duckduckgo.common.ui.view.getColorFromAttr
+import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.ViewViewModelFactory
 import com.duckduckgo.common.utils.extensions.hideKeyboard
@@ -1466,9 +1468,22 @@ class NativeInputModeWidget @JvmOverloads constructor(
         if (interactionLocked == locked) return
         interactionLocked = locked
         alpha = if (locked) LOCKED_ALPHA else 1f
+        val rootCard = widgetRoot?.findViewById<MaterialCardView>(R.id.inputModeWidgetCard)
         if (locked) {
             clearInputFocus()
             hideKeyboard()
+            rootCard?.let {
+                // further de-emphasize the input field when the UI is locked
+                it.elevation = 0f
+                it.strokeWidth = 1.toPx(it.context)
+                it.strokeColor = it.context.getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorBackground)
+            }
+        } else {
+            rootCard?.let {
+                // restore original values
+                it.elevation = 3f.toPx(it.context)
+                it.strokeWidth = 0
+            }
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -1462,6 +1462,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     private var interactionLocked = false
 
+    // The unlocked card elevation, captured before the first lock. The two omnibar positions wrap this
+    // widget in cards with different elevations (6dp top, 3dp bottom), so we can't hardcode the restore value.
+    private var unlockedCardElevation: Float? = null
+
     // Dims only this (transparent) widget, never the parent card surface, so the bar stays
     // colour-uniform with the page. Touch interception covers the plugin containers too.
     override fun setInteractionLocked(locked: Boolean) {
@@ -1474,6 +1478,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
             hideKeyboard()
             rootCard?.let {
                 // further de-emphasize the input field when the UI is locked
+                if (unlockedCardElevation == null) unlockedCardElevation = it.elevation
                 it.elevation = 0f
                 it.strokeWidth = 1.toPx(it.context)
                 it.strokeColor = it.context.getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorBackground)
@@ -1481,7 +1486,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         } else {
             rootCard?.let {
                 // restore original values
-                it.elevation = 3f.toPx(it.context)
+                it.elevation = unlockedCardElevation ?: it.elevation
                 it.strokeWidth = 0
             }
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1215914551889857?focus=true
Tech Design URL (if applicable): 

### Description
De-emphasize input in Duck.ai onboarding demo.

### Steps to test this PR
- [x] Apply this diff
```diff
diff --git a/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt b/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
index 9da0ed066d..d75613086b 100644
--- a/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
@@ -101,6 +101,7 @@ class CustomAiOnboardingStoreImpl @Inject constructor(
     }
 
     override suspend fun resolve() = resolveMutex.withLock {
+        return@withLock true
         withContext(dispatcherProvider.io()) {
             // Ensure the install referrer (and therefore the processing function) has resolved before reading.
             withTimeoutOrNull(MAX_REFERRER_WAIT_TIME_MS) { referrerStateListener.get().waitForReferrerCode() }
@@ -118,6 +119,7 @@ class CustomAiOnboardingStoreImpl @Inject constructor(
     }
 
     override suspend fun isEnabled(): Boolean = resolveMutex.withLock {
+        return@withLock true
         withContext(dispatcherProvider.io()) {
             preferences.getBoolean(PREFS_KEY_ENABLED, false)
         }
```
- [x] Clean install the app
- [x] Go through the onboarding until reaching the Duck.ai demo
- [x] Verify the elevation is removed and a small stroke is applied
- [x] Finish onboarding
- [x] Open Duck.ai
- [x] Verify the full-size shadow is applied

### UI changes
| Before  | After |
| ------ | ----- |
<img width="480" height="1071" alt="Screenshot_20260622_163731" src="https://github.com/user-attachments/assets/18dc40a0-aa95-43b8-9282-4dc256340bdf" />|<img width="480" height="1071" alt="Screenshot_20260622_180707" src="https://github.com/user-attachments/assets/79fa27fc-ff21-4acf-aa64-866c35b1a9af" />|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI styling in an existing lock/unlock path; no auth, data, or submission logic changes.
> 
> **Overview**
> Extends **`setInteractionLocked`** on the native Duck.ai input widget so onboarding (and any other **interaction lock**) de-emphasizes the omnibar input, not only dimming controls and blocking touches.
> 
> When locked, the widget now finds the wrapping **`inputModeWidgetCard`** on **`widgetRoot`**, stores its current **elevation** (top vs bottom omnibar use different values), sets elevation to **0**, and applies a **1dp stroke** tinted with the background attribute so the field reads flatter and less prominent. Unlock restores the saved elevation and clears the stroke.
> 
> Adds **`getColorFromAttr`** / **`toPx`** helpers for that stroke styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bacecddb3b8c181cb85d2733710976539b96b4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->