### PR TITLE
Android: Fix chats menu not dismissing when NTP is shown

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -213,6 +213,7 @@ class DuckChatContextualFragment :
     private lateinit var backPressedCallback: OnBackPressedCallback
     internal val simpleWebview: WebView by lazy { binding.simpleWebview }
     private var isKeyboardVisible = false
+    private var chatsPopup: PopupMenu? = null
 
     private val keyboardVisibilityListener =
         ViewTreeObserver.OnGlobalLayoutListener {
@@ -781,6 +782,8 @@ class DuckChatContextualFragment :
             popup.onMenuItemClicked(viewAllRow) { viewModel.onViewAllChatsClicked() }
         }
 
+        popup.setOnDismissListener { chatsPopup = null }
+        chatsPopup = popup
         popup.showAnchoredView(requireActivity(), binding.root, binding.contextualNewChat)
     }
 
@@ -1074,6 +1077,11 @@ class DuckChatContextualFragment :
             cookieManager.flush()
         }
         super.onPause()
+    }
+
+    override fun onStop() {
+        chatsPopup?.dismiss()
+        super.onStop()
     }
 
     override fun onDestroyView() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1215828353176637?focus=true
Tech Design URL (if applicable): 

### Description
**What:** Dismiss the chats popup menu in onStop(), clearing the reference via its dismiss listener.

**Why:** The popup is a standalone window not tied to the sheet's lifecycle. When the NTP is shown, the popup is left open. The simplest solution is to hide the icon when the tab loses focus.

### Steps to test this PR

- [x] Ensure that you set the inactivity timer to Always (for easy testing)
- [x] Ensure you have some recent chats (to guarantee the menu from showing)
- [x] Open an article on one tab
- [x] Select contextual sheet
- [x] Click on the chats icon
- [x] Verify chats popup menu is shown 
- [x] Background the app / also try closing the screen
- [x] Come back to the app
- [x] Verify the NTP page is shown AND the chats menu is NOT shown.
- [x] Go back to the tab
- [x] Verify contextual sheet is open and chats menu still works


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI lifecycle change in one fragment; no auth, data, or business-logic impact.
> 
> **Overview**
> Fixes the **contextual Duck AI chats menu** staying on screen when the user navigates away (e.g. opening the NTP) while the popup is open.
> 
> `DuckChatContextualFragment` now **keeps a reference** to the active `PopupMenu`, **clears it on dismiss**, and **calls `dismiss()` in `onStop()`** so the overlay is torn down when the fragment is no longer visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 697e087ab6ad9385e08a12c93acb0ef79e5a0119. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->