### PR TITLE
enable 'customAiOnboarding' feature

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingFeature.kt
@@ -23,10 +23,10 @@ import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
-    featureName = "customDuckAiOnboarding",
+    featureName = "customAiOnboarding",
 )
-interface CustomDuckAiOnboardingFeature {
+interface CustomAiOnboardingFeature {
 
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.onboarding
 
 import androidx.core.content.edit
 import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
@@ -35,6 +36,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import logcat.LogPriority.INFO
 import logcat.LogPriority.WARN
 import logcat.logcat
+import java.util.Locale
 import javax.inject.Inject
 
 interface CustomAiOnboardingStore {
@@ -85,6 +87,7 @@ class CustomAiOnboardingStoreImpl @Inject constructor(
     private val customAiOnboardingFeature: CustomAiOnboardingFeature,
     private val orchestratorFeature: LinearOnboardingOrchestratorFeature,
     private val brandDesignUpdateToggles: OnboardingBrandDesignUpdateToggles,
+    private val appBuildConfig: AppBuildConfig,
 ) : CustomAiOnboardingStore, CustomAiOnboardingResolver, ReferrerParserPlugin {
 
     private val preferences by lazy { sharedPreferencesProvider.getSharedPreferences(PREFS_FILENAME) }
@@ -109,8 +112,10 @@ class CustomAiOnboardingStoreImpl @Inject constructor(
             val customAiOnboardingEnabled = customAiOnboardingFeature.self().isEnabled()
             val orchestratorEnabled = orchestratorFeature.self().isEnabled()
             val brandDesignEnabled = brandDesignUpdateToggles.brandDesignUpdate().isEnabled()
+            // Only English strings exist for the custom AI onboarding, so restrict it to English locales for now.
+            val englishLocale = appBuildConfig.deviceLocale.language == Locale.ENGLISH.language
 
-            val resolution = referrerExists && customAiOnboardingEnabled && orchestratorEnabled && brandDesignEnabled
+            val resolution = referrerExists && customAiOnboardingEnabled && orchestratorEnabled && brandDesignEnabled && englishLocale
             preferences.edit { putBoolean(PREFS_KEY_ENABLED, resolution) }
 
             return@withContext resolution

--- a/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
@@ -82,7 +82,7 @@ class CustomAiOnboardingStoreImpl @Inject constructor(
     private val sharedPreferencesProvider: SharedPreferencesProvider,
     private val referrerStateListener: Lazy<AppInstallationReferrerStateListener>,
     private val dispatcherProvider: DispatcherProvider,
-    private val customDuckAiOnboardingFeature: CustomDuckAiOnboardingFeature,
+    private val customAiOnboardingFeature: CustomAiOnboardingFeature,
     private val orchestratorFeature: LinearOnboardingOrchestratorFeature,
     private val brandDesignUpdateToggles: OnboardingBrandDesignUpdateToggles,
 ) : CustomAiOnboardingStore, CustomAiOnboardingResolver, ReferrerParserPlugin {
@@ -106,7 +106,7 @@ class CustomAiOnboardingStoreImpl @Inject constructor(
             withTimeoutOrNull(MAX_REFERRER_WAIT_TIME_MS) { referrerStateListener.get().waitForReferrerCode() }
             val referrerExists = preferences.getBoolean(PREFS_KEY_REFERRER_PARAM_PRESENT, false)
 
-            val customAiOnboardingEnabled = customDuckAiOnboardingFeature.self().isEnabled()
+            val customAiOnboardingEnabled = customAiOnboardingFeature.self().isEnabled()
             val orchestratorEnabled = orchestratorFeature.self().isEnabled()
             val brandDesignEnabled = brandDesignUpdateToggles.brandDesignUpdate().isEnabled()
 

--- a/app/src/test/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStoreImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStoreImplTest.kt
@@ -48,7 +48,7 @@ class CustomAiOnboardingStoreImplTest {
 
     private val enabledToggle: Toggle = mock { on { isEnabled() } doReturn true }
     private val disabledToggle: Toggle = mock { on { isEnabled() } doReturn false }
-    private val customDuckAiOnboardingFeature: CustomDuckAiOnboardingFeature = mock()
+    private val customAiOnboardingFeature: CustomAiOnboardingFeature = mock()
     private val orchestratorFeature: LinearOnboardingOrchestratorFeature = mock()
     private val brandDesignUpdateToggles: OnboardingBrandDesignUpdateToggles = mock()
 
@@ -66,14 +66,14 @@ class CustomAiOnboardingStoreImplTest {
             sharedPreferencesProvider = sharedPreferencesProvider,
             referrerStateListener = Lazy { listener },
             dispatcherProvider = coroutineRule.testDispatcherProvider,
-            customDuckAiOnboardingFeature = customDuckAiOnboardingFeature,
+            customAiOnboardingFeature = customAiOnboardingFeature,
             orchestratorFeature = orchestratorFeature,
             brandDesignUpdateToggles = brandDesignUpdateToggles,
         )
 
     @Before
     fun setup() {
-        whenever(customDuckAiOnboardingFeature.self()).thenReturn(enabledToggle)
+        whenever(customAiOnboardingFeature.self()).thenReturn(enabledToggle)
         whenever(orchestratorFeature.self()).thenReturn(enabledToggle)
         whenever(brandDesignUpdateToggles.brandDesignUpdate()).thenReturn(enabledToggle)
     }
@@ -87,7 +87,7 @@ class CustomAiOnboardingStoreImplTest {
 
     @Test
     fun `when referrer ai but custom ai feature disabled then resolves false`() = runTest {
-        whenever(customDuckAiOnboardingFeature.self()).thenReturn(disabledToggle)
+        whenever(customAiOnboardingFeature.self()).thenReturn(disabledToggle)
         val store = store()
         store.process(mapOf("origin" to "funnel_playstore", "onboarding" to "ai"))
         assertFalse(store.resolve())
@@ -178,7 +178,7 @@ class CustomAiOnboardingStoreImplTest {
         store.resolve()
         assertTrue(store.isEnabled())
 
-        whenever(customDuckAiOnboardingFeature.self()).thenReturn(disabledToggle) // flips after the decision
+        whenever(customAiOnboardingFeature.self()).thenReturn(disabledToggle) // flips after the decision
         assertTrue(store.isEnabled()) // read does not re-evaluate preconditions
     }
 

--- a/app/src/test/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStoreImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStoreImplTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.onboarding
 
 import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.api.InMemorySharedPreferences
 import com.duckduckgo.data.store.api.SharedPreferencesProvider
@@ -35,6 +36,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import java.util.Locale
 
 class CustomAiOnboardingStoreImplTest {
 
@@ -51,6 +53,7 @@ class CustomAiOnboardingStoreImplTest {
     private val customAiOnboardingFeature: CustomAiOnboardingFeature = mock()
     private val orchestratorFeature: LinearOnboardingOrchestratorFeature = mock()
     private val brandDesignUpdateToggles: OnboardingBrandDesignUpdateToggles = mock()
+    private val appBuildConfig: AppBuildConfig = mock()
 
     private val resolvedListener = object : AppInstallationReferrerStateListener {
         override fun initialiseReferralRetrieval() {}
@@ -69,6 +72,7 @@ class CustomAiOnboardingStoreImplTest {
             customAiOnboardingFeature = customAiOnboardingFeature,
             orchestratorFeature = orchestratorFeature,
             brandDesignUpdateToggles = brandDesignUpdateToggles,
+            appBuildConfig = appBuildConfig,
         )
 
     @Before
@@ -76,6 +80,7 @@ class CustomAiOnboardingStoreImplTest {
         whenever(customAiOnboardingFeature.self()).thenReturn(enabledToggle)
         whenever(orchestratorFeature.self()).thenReturn(enabledToggle)
         whenever(brandDesignUpdateToggles.brandDesignUpdate()).thenReturn(enabledToggle)
+        whenever(appBuildConfig.deviceLocale).thenReturn(Locale.US)
     }
 
     @Test
@@ -107,6 +112,22 @@ class CustomAiOnboardingStoreImplTest {
         val store = store()
         store.process(mapOf("origin" to "funnel_playstore", "onboarding" to "ai"))
         assertFalse(store.resolve())
+    }
+
+    @Test
+    fun `when referrer ai but non-english locale then resolves false`() = runTest {
+        whenever(appBuildConfig.deviceLocale).thenReturn(Locale.FRANCE)
+        val store = store()
+        store.process(mapOf("origin" to "funnel_playstore", "onboarding" to "ai"))
+        assertFalse(store.resolve())
+    }
+
+    @Test
+    fun `when referrer ai and non-us english locale then resolves true`() = runTest {
+        whenever(appBuildConfig.deviceLocale).thenReturn(Locale.UK)
+        val store = store()
+        store.process(mapOf("origin" to "funnel_playstore", "onboarding" to "ai"))
+        assertTrue(store.resolve())
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1215913073420417
Tech Design URL (if applicable): 

### Description
Enables the custom AI onboarding flow, executed when the `onboarding=ai` referral param is present and locale language is English.

### Steps to test this PR
- [ ] Apply this patch:
```diff
diff --git a/app/build.gradle b/app/build.gradle
index 541dfe1a58..5f5570725f 100644
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -142,7 +142,7 @@ android {
     }
     buildTypes {
         debug {
-            applicationIdSuffix ".debug"
+//            applicationIdSuffix ".debug"
             pseudoLocalesEnabled false
             manifestPlaceholders = [
                     appIcon     : "@mipmap/ic_launcher_blue",
 }
```
- [ ] Change build type to `PlayDebug`
- [ ] Change device language to **English**
- [ ] Open this link on the test device: https://play.google.com/store/apps/details?id=com.duckduckgo.mobile.android&referrer=utm_campaign%3Dappnosupport-atb-appnosupport%26origin%3Dfunnel_appnosupport_website%26onboarding%3Dai
- [ ] Install the app (remember to use `PlayDebug`)
- [ ] Verify you **see** the `+ Duck.ai` on the intro animation and a **custom AI onboarding flow** launches
- [ ] Uninstall the app
- [ ] Change device language to **non-English**
- [ ] Open this link on the test device: https://play.google.com/store/apps/details?id=com.duckduckgo.mobile.android&referrer=utm_campaign%3Dappnosupport-atb-appnosupport%26origin%3Dfunnel_appnosupport_website%26onboarding%3Dai
- [ ] Install the app (remember to use `PlayDebug`)
- [ ] Verify you **don't see** the `+ Duck.ai` on the intro animation and a **regular onboarding flow** launches

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default onboarding behavior for AI-referrer installs and adds a locale gate; impact is scoped to first-run onboarding plan selection with existing frozen resolve semantics.
> 
> **Overview**
> Turns on the **custom AI onboarding** remote feature by default and aligns naming from `customDuckAiOnboarding` / `CustomDuckAiOnboardingFeature` to **`customAiOnboarding`** / **`CustomAiOnboardingFeature`**.
> 
> **`CustomAiOnboardingStoreImpl.resolve()`** now requires an **English device locale** (via `AppBuildConfig.deviceLocale`) in addition to the existing referrer (`onboarding=ai`) and feature toggles, because copy exists only in English. Tests cover non-English locales resolving false and other English locales (e.g. UK) still resolving true when other preconditions pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b4442ab5aeb6afe930d4f29714211b1b298ea14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->