### PR TITLE
[Android Maintenance] Fix reasoning_effort enum for Duck.ai prompt submitted pixels

### DIFF
--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -986,8 +986,8 @@
             {
                 "key": "reasoning_effort",
                 "type": "string",
-                "description": "The reasoning effort level used for the prompt",
-                "enum": ["fast", "reasoning", "extended_reasoning"]
+                "description": "The resolved reasoning effort level used for the prompt",
+                "enum": ["none", "minimal", "low", "medium", "high"]
             },
             { "key": "has_image_attachment", "type": "boolean", "description": "Whether the prompt included an image attachment" },
             { "key": "has_file_attachment", "type": "boolean", "description": "Whether the prompt included a file attachment" },
@@ -1011,8 +1011,8 @@
             {
                 "key": "reasoning_effort",
                 "type": "string",
-                "description": "The reasoning effort level used for the prompt",
-                "enum": ["fast", "reasoning", "extended_reasoning"]
+                "description": "The resolved reasoning effort level used for the prompt",
+                "enum": ["none", "minimal", "low", "medium", "high"]
             },
             { "key": "has_image_attachment", "type": "boolean", "description": "Whether the prompt included an image attachment" },
             { "key": "has_file_attachment", "type": "boolean", "description": "Whether the prompt included a file attachment" },


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1213746476312668/task/1215891186389639

### Description

Live pixel validation reported that `m_aichat_unified_input_prompt_submitted_count` and `m_aichat_unified_input_prompt_submitted_daily` were failing with `/reasoning_effort must be equal to one of the allowed values`.

Root cause: the `reasoning_effort` parameter on these two pixels is populated by `NativeInputModeWidgetViewModel.fireSubmissionPixels()` → `getResolvedReasoningEffort()`, which returns `ReasoningEffort.rawValue` — one of `none`, `minimal`, `low`, `medium`, `high` (the same resolved effort value that is sent to the backend via `sendPrompt`). However, the pixel definition declared the enum as `["fast", "reasoning", "extended_reasoning"]`, which are the `ReasoningMode` raw values. Those mode values are correctly used by the separate `m_aichat_unified_input_reasoning_effort_selected` pixel's `effort_level` parameter (`ReasoningMode.toEffortParam()`), but not by the prompt-submitted pixels.

This change aligns the `reasoning_effort` enum on both prompt-submitted pixel definitions with the actual wire values (`ReasoningEffort` raw values). No code behaviour changes — only the definition in `PixelDefinitions/pixels/definitions/duck_chat.json5` is updated. The unrelated `reasoning_effort_selected` pixel's `effort_level` enum is intentionally left untouched.

🤖 Android Maintenance Worker

### Steps to test this PR

_Lint / formatting_
- [ ] `cd PixelDefinitions && npm run lint` (prettier — passes locally)
- [ ] `cd PixelDefinitions && npm run validate-defs-without-formatting` (pixel-schema validation)

Note: only a PixelDefinitions JSON5 file changed (no Kotlin/Android source), so `./gradlew spotlessCheck` / `lint_check` have nothing applicable to check for this change. `npm run lint` (prettier) passed locally; `npm run validate-defs-without-formatting` could not complete in the sandbox because it fetches the live target app version over the network (`ERROR in product.json target version: fetch failed`), which the CI sandbox firewall blocks — this is unrelated to the change and will run on CI.

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |




> [!NOTE]
> <details>
> <summary><b>🔒 Integrity filter blocked 3 items</b></summary>
>
> The following items were blocked because they don't meet the GitHub integrity level.
>
> - [#8942](https://github.com/duckduckgo/Android/pull/8942) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#8860](https://github.com/duckduckgo/Android/pull/8860) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#8844](https://github.com/duckduckgo/Android/pull/8844) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
>
> To allow these resources, lower `min-integrity` in your GitHub frontmatter:
>
> ```yaml
> tools:
>   github:
>     min-integrity: approved  # merged | approved | unapproved | none
> ```
>
> </details>


> Generated by [Android Maintenance Worker](https://github.com/duckduckgo/Android/actions/runs/28006631632/agentic_workflow) · [◷](https://github.com/search?q=repo%3Aduckduckgo%2FAndroid+%22gh-aw-workflow-id%3A+android-maintenance-worker%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Android Maintenance Worker, engine: claude, model: auto, id: 28006631632, workflow_id: android-maintenance-worker, run: https://github.com/duckduckgo/Android/actions/runs/28006631632 -->

<!-- gh-aw-workflow-id: android-maintenance-worker -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only change in PixelDefinitions with no Android runtime behavior changes; it restores validation for analytics events already emitted by the app.
> 
> **Overview**
> Fixes live pixel validation failures on **`m_aichat_unified_input_prompt_submitted_count`** and **`m_aichat_unified_input_prompt_submitted_daily`** by updating the **`reasoning_effort`** parameter schema in `duck_chat.json5`.
> 
> The allowed values change from **`fast` / `reasoning` / `extended_reasoning`** (UI **`ReasoningMode`**) to **`none` / `minimal` / `low` / `medium` / `high`**, matching what the app already sends via **`getResolvedReasoningEffort()`** (`ReasoningEffort` raw values). The parameter description now says **resolved** reasoning effort. **`m_aichat_unified_input_reasoning_effort_selected`** and its **`effort_level`** enum are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e704fae94ce67ab6aef0316dc2860edbbd0d2608. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->