### PR TITLE
Pixels: allow `unknown` as valid value for `v` param in `m_anr_exception`

### DIFF
--- a/PixelDefinitions/pixels/definitions/atb_pixels.json5
+++ b/PixelDefinitions/pixels/definitions/atb_pixels.json5
@@ -26,8 +26,8 @@
                 "key": "v",
                 "description": "App version recorded at the time of the ANR (may differ from appVersion if the app has been updated since).",
                 "type": "string",
-                "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)?$",
-                "examples": ["0.89.3"]
+                "pattern": "^([0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)?|unknown)$",
+                "examples": ["0.89.3", "unknown"]
             }
         ]
     },


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1211195376835782
Tech Design URL (if applicable): 

### Description

The `v` parameter on `m_anr_exception` represents the app version at the time the ANR was captured. In practice, `v=unknown` is sometimes sent — the validator was rejecting this as it only accepted the semver pattern.

Updated the regex for that one parameter to accept either a semver string or the literal `unknown`.

### Steps to test this PR

- [ ] QA Optional
