### PR TITLE
adjust onboarding input demo spacing

### DIFF
--- a/app/src/main/res/layout/include_brand_design_input_screen_preview.xml
+++ b/app/src/main/res/layout/include_brand_design_input_screen_preview.xml
@@ -26,7 +26,7 @@
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="28dp"
+        android:layout_marginBottom="8dp"
         android:paddingHorizontal="12dp">
 
         <com.duckduckgo.common.ui.view.text.DaxTextView
@@ -54,7 +54,8 @@
         android:id="@+id/inputModeToggle"
         style="@style/Widget.DuckDuckGo.TabLayout.Rounded"
         android:layout_width="wrap_content"
-        android:layout_height="@dimen/inputModeSwitchHeight">
+        android:layout_height="@dimen/inputModeSwitchHeight"
+        android:layout_marginTop="8dp">
 
         <com.google.android.material.tabs.TabItem
             android:layout_width="wrap_content"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1215973431790114?focus=true
Tech Design URL (if applicable): 

### Description
Minor adjustments to onboarding input demo spacing.

### Steps to test this PR

QA optional, see screenshots below.

### UI changes
| Toggle  | No toggle |
| ------ | ----- |
|<img width="480" height="1071" alt="image(1)" src="https://github.com/user-attachments/assets/cb053ecf-3e39-4641-b76f-9d34de9c1f22" />|<img width="480" height="1071" alt="image(2)" src="https://github.com/user-attachments/assets/6ad826a2-7e4b-4457-b77f-973a4b575aa3" />|



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only margin changes in a single onboarding preview XML with no logic or data impact.
> 
> **Overview**
> Tightens vertical spacing on the **onboarding input mode demo** preview in `include_brand_design_input_screen_preview.xml`.
> 
> The title **FrameLayout** bottom margin is reduced from **28dp** to **8dp**, and **8dp** top margin is added on **`inputModeToggle`** so the gap between the animated title and the search/chat tabs matches the intended design (with and without the toggle visible).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c2235ab1f1509d4c390b477910c2dfe4b50bb46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->