### PR TITLE
Add workflows for hotfix start and finish

### DIFF
--- a/.github/workflows/hotfix_finish.yml
+++ b/.github/workflows/hotfix_finish.yml
@@ -1,0 +1,66 @@
+name: Hotfix - Finish (merge and tag)
+
+on:
+  workflow_call:
+    inputs:
+      app-version:
+        description: 'Hotfix version to release (e.g. 5.284.1)'
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      app-version:
+        description: 'Hotfix version to release (e.g. 5.284.1)'
+        required: true
+        type: string
+
+env:
+  ASANA_PAT: ${{ secrets.ASANA_ACCESS_TOKEN }}
+  GH_TOKEN: ${{ secrets.GT_DAXMOBILE }}
+
+jobs:
+  hotfix-finish:
+    name: Finish hotfix (merge to main and develop, tag)
+    runs-on: ubuntu-latest
+    env:
+      GIT_MERGE_AUTOEDIT: no
+
+    steps:
+      # Submodules are intentionally not checked out: this job only does git plumbing
+      # (merge to main/develop, tag, push) and never reads submodule contents.
+      # Populating them would leave the tree dirty when the lane switches branches
+      # (which can record different submodule commits), breaking the merge/tag.
+      - name: Checkout hotfix branch
+        uses: actions/checkout@v4
+        with:
+          ref: hotfix/${{ inputs.app-version }}
+          token: ${{ secrets.GT_DAXMOBILE }}
+          fetch-depth: 0
+
+      - name: Set up git config
+        run: |
+          git remote set-url origin https://${{ secrets.GT_DAXMOBILE }}@github.com/duckduckgo/Android.git/
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+      - name: Set up git-flow
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git-flow
+          git config gitflow.branch.master main
+          git config gitflow.branch.develop ${{ github.event.repository.default_branch }}
+          git config gitflow.prefix.feature feature/
+          git config gitflow.prefix.release release/
+          git config gitflow.prefix.hotfix hotfix/
+          git config gitflow.prefix.support support/
+          git config gitflow.prefix.versiontag ""
+
+      - name: Set up ruby env
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.2
+          bundler-cache: true
+
+      - name: Finish hotfix (merge to main and develop, tag, push)
+        run: |
+          bundle exec fastlane hotfix-finish

--- a/.github/workflows/hotfix_finish.yml
+++ b/.github/workflows/hotfix_finish.yml
@@ -43,6 +43,13 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 
+      - name: Fail if tag already exists
+        run: |
+          if git ls-remote --exit-code --tags origin "refs/tags/${{ inputs.app-version }}" >/dev/null 2>&1; then
+            echo "::error::Tag ${{ inputs.app-version }} already exists. Aborting hotfix."
+            exit 1
+          fi
+
       - name: Set up git-flow
         run: |
           sudo apt-get update

--- a/.github/workflows/hotfix_prepare.yml
+++ b/.github/workflows/hotfix_prepare.yml
@@ -49,6 +49,14 @@ jobs:
             exit 1
           fi
 
+      - name: Validate commit-hashes
+        run: |
+          commits=$(echo "${{ inputs.commit-hashes }}" | tr ',' ' ' | xargs)
+          if [[ -z "$commits" ]]; then
+            echo "::error::commit-hashes must contain at least one commit SHA, got '${{ inputs.commit-hashes }}'."
+            exit 1
+          fi
+
       # Submodules are intentionally not checked out: this job only does git plumbing
       # (branch, version bump, cherry-pick, push) and never reads submodule contents.
       # Populating them would leave the tree dirty when hotfix-start switches between
@@ -65,6 +73,16 @@ jobs:
           git remote set-url origin https://${{ secrets.GT_DAXMOBILE }}@github.com/duckduckgo/Android.git/
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
+
+      - name: Verify fix commits exist
+        run: |
+          commits=$(echo "${{ inputs.commit-hashes }}" | tr ',' ' ' | xargs)
+          for sha in $commits; do
+            if ! git rev-parse --verify --quiet "$sha^{commit}" >/dev/null; then
+              echo "::error::commit-hash '$sha' does not resolve to a commit in this repository."
+              exit 1
+            fi
+          done
 
       - name: Fail if tag already exists
         run: |
@@ -97,10 +115,14 @@ jobs:
 
       - name: Cherry-pick fix commits
         run: |
-          commits=$(echo "${{ inputs.commit-hashes }}" | tr ',' ' ')
+          commits=$(echo "${{ inputs.commit-hashes }}" | tr ',' ' ' | xargs)
           for sha in $commits; do
             echo "Cherry-picking $sha"
-            git cherry-pick "$sha"
+            if ! git cherry-pick "$sha"; then
+              echo "::error::Cherry-pick of '$sha' failed (likely a conflict). Aborting; no hotfix branch will be pushed."
+              git cherry-pick --abort || true
+              exit 1
+            fi
           done
 
       - name: Push hotfix branch

--- a/.github/workflows/hotfix_prepare.yml
+++ b/.github/workflows/hotfix_prepare.yml
@@ -1,0 +1,101 @@
+name: Hotfix - Prepare branch
+
+on:
+  workflow_call:
+    inputs:
+      app-version:
+        description: 'Hotfix version to release (e.g. 5.284.1)'
+        required: true
+        type: string
+      commit-hashes:
+        description: 'Commit SHA(s) to cherry-pick into the hotfix (space- or comma-separated)'
+        required: true
+        type: string
+      release-notes:
+        description: 'Release notes for the Play Store listing'
+        required: false
+        default: 'Bug fixes and other improvements'
+        type: string
+  workflow_dispatch:
+    inputs:
+      app-version:
+        description: 'Hotfix version to release (e.g. 5.284.1)'
+        required: true
+        type: string
+      commit-hashes:
+        description: 'Commit SHA(s) to cherry-pick into the hotfix (space- or comma-separated)'
+        required: true
+        type: string
+      release-notes:
+        description: 'Release notes for the Play Store listing'
+        required: false
+        default: 'Bug fixes and other improvements'
+        type: string
+
+env:
+  ASANA_PAT: ${{ secrets.ASANA_ACCESS_TOKEN }}
+  GH_TOKEN: ${{ secrets.GT_DAXMOBILE }}
+
+jobs:
+  hotfix-prepare:
+    name: Create hotfix branch and cherry-pick fixes
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate app-version
+        run: |
+          if [[ ! "${{ inputs.app-version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::app-version must be in X.Y.Z format, got '${{ inputs.app-version }}'."
+            exit 1
+          fi
+
+      # Submodules are intentionally not checked out: this job only does git plumbing
+      # (branch, version bump, cherry-pick, push) and never reads submodule contents.
+      # Populating them would leave the tree dirty when hotfix-start switches between
+      # develop/main (which can record different submodule commits), breaking the lane.
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          token: ${{ secrets.GT_DAXMOBILE }}
+          fetch-depth: 0
+
+      - name: Set up git config
+        run: |
+          git remote set-url origin https://${{ secrets.GT_DAXMOBILE }}@github.com/duckduckgo/Android.git/
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+      - name: Set up git-flow
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y git-flow
+          git config gitflow.branch.master main
+          git config gitflow.branch.develop ${{ github.event.repository.default_branch }}
+          git config gitflow.prefix.feature feature/
+          git config gitflow.prefix.release release/
+          git config gitflow.prefix.hotfix hotfix/
+          git config gitflow.prefix.support support/
+          git config gitflow.prefix.versiontag ""
+
+      - name: Set up ruby env
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7.2
+          bundler-cache: true
+
+      - name: Start hotfix (create branch, bump version and release notes)
+        run: |
+          bundle exec fastlane hotfix-start version:${{ inputs.app-version }} release_notes:"${{ inputs.release-notes }}"
+
+      - name: Cherry-pick fix commits
+        run: |
+          commits=$(echo "${{ inputs.commit-hashes }}" | tr ',' ' ')
+          for sha in $commits; do
+            echo "Cherry-picking $sha"
+            git cherry-pick "$sha"
+          done
+
+      - name: Push hotfix branch
+        run: |
+          git push origin hotfix/${{ inputs.app-version }}

--- a/.github/workflows/hotfix_prepare.yml
+++ b/.github/workflows/hotfix_prepare.yml
@@ -66,6 +66,13 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 
+      - name: Fail if tag already exists
+        run: |
+          if git ls-remote --exit-code --tags origin "refs/tags/${{ inputs.app-version }}" >/dev/null 2>&1; then
+            echo "::error::Tag ${{ inputs.app-version }} already exists. Aborting hotfix."
+            exit 1
+          fi
+
       - name: Set up git-flow
         run: |
           sudo apt-get update

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -481,15 +481,17 @@ platform :android do
         end
 
        desc "Start new hotfix"
-       lane :"hotfix-start" do
+       lane :"hotfix-start" do |options|
             UI.important("Starting a new hotfix")
 
             ensure_git_status_clean
             sh('git checkout develop && git pull')
             sh('git checkout main && git pull')
 
-            newVersion = determine_version_number()
-            releaseNotes = determine_release_notes_interactive()
+            # When :version / :release_notes are provided (e.g. from CI) the helpers skip their
+            # interactive prompts; omitting them keeps the original interactive behaviour for local use.
+            newVersion = determine_version_number(release_number: options[:version])
+            releaseNotes = determine_release_notes_interactive(release_notes: options[:release_notes])
 
             sh("git flow hotfix start #{newVersion}")
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211760946270935/task/1215937462489050?focus=true
Tech Design URL (if applicable): 

### Description 
* Add workflows to prepare and finish a hotfix. Minimal set of changes to better enforce branch protections

### Steps to test this PR

_Feature 1_
- [ ] 

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Workflows push merges and tags to protected branches using automation credentials; mistakes in inputs or lane behavior could publish incorrect releases, though validation and duplicate-tag checks reduce that risk.
> 
> **Overview**
> Adds **automated hotfix release plumbing** so hotfixes can run through GitHub Actions instead of only local Fastlane, aligning with branch protection.
> 
> **Hotfix - Prepare** (`hotfix_prepare.yml`) accepts `app-version`, `commit-hashes`, and optional `release-notes` via `workflow_call` or `workflow_dispatch`. It validates semver and SHAs, blocks duplicate tags, runs `hotfix-start` with non-interactive version/notes, cherry-picks the listed commits (failing cleanly on conflict), and pushes `hotfix/{version}`. Checkouts omit submodules so branch switches during git-flow do not dirty the tree.
> 
> **Hotfix - Finish** (`hotfix_finish.yml`) takes `app-version`, checks out `hotfix/{version}`, guards against an existing tag, and runs `hotfix-finish` to merge to `main` and develop and push the release tag.
> 
> **Fastlane** `hotfix-start` now accepts optional `version` and `release_notes` options so CI can pass inputs while local runs keep the existing interactive prompts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e15d14454a2607f96571467a2e23b1ada4b9f810. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->