### PR TITLE
PIR: Update pixels and wide events to handle scan resume

### DIFF
--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -1384,7 +1384,7 @@
                 "key": "scan_trigger",
                 "description": "What triggered the scan run",
                 "type": "string",
-                "enum": ["onboarding", "profile_edit", "scheduled"]
+                "enum": ["onboarding", "onboarding_resume", "profile_edit", "scheduled"]
             },
             {
                 "key": "vpn_connection_state",
@@ -1480,7 +1480,7 @@
                 "key": "scan_trigger",
                 "description": "What triggered the scan run",
                 "type": "string",
-                "enum": ["onboarding", "profile_edit", "scheduled"]
+                "enum": ["onboarding", "onboarding_resume", "profile_edit", "scheduled"]
             },
             {
                 "key": "vpn_connection_state",
@@ -1564,7 +1564,7 @@
                 "key": "scan_trigger",
                 "description": "What triggered the scan run",
                 "type": "string",
-                "enum": ["onboarding", "profile_edit", "scheduled"]
+                "enum": ["onboarding", "onboarding_resume", "profile_edit", "scheduled"]
             },
             {
                 "key": "vpn_connection_state",
@@ -2183,12 +2183,12 @@
             {
                 "key": "context.name",
                 "description": "Entry point that triggered the manual PIR run",
-                "enum": ["funnel_pir_initial_android", "funnel_pir_edit_profile_android"]
+                "enum": ["funnel_pir_initial_android", "funnel_pir_edit_profile_android", "funnel_pir_initial_resume_android"]
             },
             {
                 "key": "feature.data.ext.execution_type",
-                "description": "Distinguishes between the user's first manual scan after onboarding and a re-scan triggered by editing a saved profile",
-                "enum": ["manual_initial", "manual_edit_profile"]
+                "description": "Distinguishes the user's first manual scan after onboarding (manual_initial), a dashboard-triggered resume of an interrupted initial scan (manual_initial_resume), and a re-scan triggered by editing a saved profile (manual_edit_profile)",
+                "enum": ["manual_initial", "manual_edit_profile", "manual_initial_resume"]
             },
             {
                 "key": "feature.data.ext.profile_queries_count",

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
@@ -1673,6 +1673,7 @@ class RealPirPixelSender @Inject constructor(
 
     private fun PirExecutionType.toScanTriggerParam(): String = when (this) {
         PirExecutionType.MANUAL_INITIAL -> "onboarding"
+        PirExecutionType.MANUAL_INITIAL_RESUME -> "onboarding_resume"
         PirExecutionType.MANUAL_EDIT_PROFILE -> "profile_edit"
         PirExecutionType.SCHEDULED -> "scheduled"
     }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scan/PirForegroundScanServiceStarter.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scan/PirForegroundScanServiceStarter.kt
@@ -32,10 +32,8 @@ class RealPirForegroundScanServiceStarter @Inject constructor(
     private val context: Context,
 ) : PirForegroundScanServiceStarter {
     override fun startResumeScan() {
-        // Resume the interrupted initial scan as MANUAL_INITIAL — the same execution type a manual
-        // re-trigger uses. Only the still-pending brokers are scanned (already-scanned jobs are skipped).
         context.startForegroundService(
-            PirForegroundScanService.intentFor(context, PirExecutionType.MANUAL_INITIAL),
+            PirForegroundScanService.intentFor(context, PirExecutionType.MANUAL_INITIAL_RESUME),
         )
     }
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirExecutionType.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirExecutionType.kt
@@ -19,16 +19,18 @@ package com.duckduckgo.pir.impl.scheduling
 /**
  * This class tells us if PIR was triggered by a scheduled work or manually run by the user.
  *
- * The two manual variants distinguish between the user's initial manual scan
- * ([MANUAL_INITIAL]) and the user having edited an already-saved profile later
- * ([MANUAL_EDIT_PROFILE]). This is used to attribute foreground-scan pixels to the right source.
+ * The three manual variants distinguish between the user's initial manual scan
+ * ([MANUAL_INITIAL]), dashboard-triggered resume of an interrupted initial scan ([MANUAL_INITIAL_RESUME]),
+ * and the user having edited an already-saved profile later ([MANUAL_EDIT_PROFILE]).
+ * This is used to attribute foreground-scan pixels to the right source.
  */
 enum class PirExecutionType {
     MANUAL_INITIAL,
     MANUAL_EDIT_PROFILE,
+    MANUAL_INITIAL_RESUME,
     SCHEDULED,
     ;
 
     val isManual: Boolean
-        get() = this == MANUAL_INITIAL || this == MANUAL_EDIT_PROFILE
+        get() = this == MANUAL_INITIAL || this == MANUAL_EDIT_PROFILE || this == MANUAL_INITIAL_RESUME
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirInitialScanCompletionWideEvent.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirInitialScanCompletionWideEvent.kt
@@ -152,6 +152,7 @@ class PirInitialScanCompletionWideEventImpl @Inject constructor(
                 when (executionType) {
                     PirExecutionType.MANUAL_INITIAL,
                     PirExecutionType.MANUAL_EDIT_PROFILE,
+                    PirExecutionType.MANUAL_INITIAL_RESUME,
                     -> {
                         pirDataStore.initialScanCompletionForegroundRunCount += 1
                     }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEvent.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEvent.kt
@@ -270,7 +270,7 @@ class PirScanWideEventImpl @Inject constructor(
     }
 
     private fun stateFor(executionType: PirExecutionType): RunState = when (executionType) {
-        PirExecutionType.MANUAL_INITIAL, PirExecutionType.MANUAL_EDIT_PROFILE -> manualState
+        PirExecutionType.MANUAL_INITIAL, PirExecutionType.MANUAL_EDIT_PROFILE, PirExecutionType.MANUAL_INITIAL_RESUME -> manualState
         PirExecutionType.SCHEDULED -> scheduledState
     }
 
@@ -619,17 +619,19 @@ class PirScanWideEventImpl @Inject constructor(
     private fun entryPointFor(executionType: PirExecutionType): String = when (executionType) {
         PirExecutionType.MANUAL_INITIAL -> ENTRY_POINT_MANUAL_INITIAL
         PirExecutionType.MANUAL_EDIT_PROFILE -> ENTRY_POINT_MANUAL_EDIT_PROFILE
+        PirExecutionType.MANUAL_INITIAL_RESUME -> ENTRY_POINT_MANUAL_INITIAL_RESUME
         PirExecutionType.SCHEDULED -> ENTRY_POINT_SCHEDULED
     }
 
     private fun wideEventNameFor(executionType: PirExecutionType): String = when (executionType) {
-        PirExecutionType.MANUAL_INITIAL, PirExecutionType.MANUAL_EDIT_PROFILE -> WIDE_EVENT_NAME_MANUAL
+        PirExecutionType.MANUAL_INITIAL, PirExecutionType.MANUAL_EDIT_PROFILE, PirExecutionType.MANUAL_INITIAL_RESUME -> WIDE_EVENT_NAME_MANUAL
         PirExecutionType.SCHEDULED -> WIDE_EVENT_NAME_SCHEDULED
     }
 
     private fun PirExecutionType.metadataValue(): String = when (this) {
         PirExecutionType.MANUAL_INITIAL -> EXECUTION_TYPE_MANUAL_INITIAL
         PirExecutionType.MANUAL_EDIT_PROFILE -> EXECUTION_TYPE_MANUAL_EDIT_PROFILE
+        PirExecutionType.MANUAL_INITIAL_RESUME -> EXECUTION_TYPE_MANUAL_INITIAL_RESUME
         PirExecutionType.SCHEDULED -> EXECUTION_TYPE_SCHEDULED
     }
 
@@ -647,10 +649,12 @@ class PirScanWideEventImpl @Inject constructor(
 
         const val ENTRY_POINT_MANUAL_INITIAL = "funnel_pir_initial_android"
         const val ENTRY_POINT_MANUAL_EDIT_PROFILE = "funnel_pir_edit_profile_android"
+        const val ENTRY_POINT_MANUAL_INITIAL_RESUME = "funnel_pir_initial_resume_android"
         const val ENTRY_POINT_SCHEDULED = "funnel_pir_scheduled_android"
 
         const val EXECUTION_TYPE_MANUAL_INITIAL = "manual_initial"
         const val EXECUTION_TYPE_MANUAL_EDIT_PROFILE = "manual_edit_profile"
+        const val EXECUTION_TYPE_MANUAL_INITIAL_RESUME = "manual_initial_resume"
         const val EXECUTION_TYPE_SCHEDULED = "scheduled"
 
         const val KEY_EXECUTION_TYPE = "execution_type"

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirInitialScanCompletionWideEventTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirInitialScanCompletionWideEventTest.kt
@@ -270,6 +270,27 @@ class PirInitialScanCompletionWideEventTest {
     }
 
     @Test
+    fun whenManualInitialResumeRunStartedAndNoFlowOpenThenNothingIsStarted() = runTest {
+        runStarted(executionType = PirExecutionType.MANUAL_INITIAL_RESUME)
+
+        verifyNoInteractions(wideEventClient)
+        assertFalse(dataStore.hasInitialScanEverStarted)
+    }
+
+    @Test
+    fun whenManualInitialResumeRunStartedWhileFlowOpenThenForegroundCountIncremented() = runTest {
+        whenever(wideEventClient.flowStart(any(), any(), any(), any())).thenReturn(Result.success(1L))
+        runStarted(executionType = PirExecutionType.MANUAL_INITIAL)
+
+        runStarted(executionType = PirExecutionType.MANUAL_INITIAL_RESUME)
+
+        // The resume continues the open journey flow (no second flowStart) and counts as a foreground run.
+        verify(wideEventClient).flowStart(any(), any(), any(), any())
+        assertEquals(2, dataStore.initialScanCompletionForegroundRunCount)
+        assertEquals(0, dataStore.initialScanCompletionScheduledRunCount)
+    }
+
+    @Test
     fun whenScanCompletedAndAllJobsDoneThenFlowFinishedWithSuccess() = runTest {
         whenever(wideEventClient.flowStart(any(), any(), any(), any())).thenReturn(Result.success(99L))
         runStarted(executionType = PirExecutionType.MANUAL_INITIAL)

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEventTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEventTest.kt
@@ -32,9 +32,11 @@ import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent.CancellationReason
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent.FailureReason
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.ENTRY_POINT_MANUAL_EDIT_PROFILE
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.ENTRY_POINT_MANUAL_INITIAL
+import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.ENTRY_POINT_MANUAL_INITIAL_RESUME
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.ENTRY_POINT_SCHEDULED
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.EXECUTION_TYPE_MANUAL_EDIT_PROFILE
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.EXECUTION_TYPE_MANUAL_INITIAL
+import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.EXECUTION_TYPE_MANUAL_INITIAL_RESUME
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.EXECUTION_TYPE_SCHEDULED
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.INTERVAL_OPT_OUT_DURATION
 import com.duckduckgo.pir.impl.wideevents.PirScanWideEventImpl.Companion.INTERVAL_TOTAL_FLOW_DURATION
@@ -300,6 +302,34 @@ class PirScanWideEventTest {
     }
 
     @Test
+    fun whenManualInitialResumeRunStartedThenEntryPointAndExecutionTypeReflectThat() = runTest {
+        // Given
+        whenever(wideEventClient.flowStart(any(), any(), any(), any())).thenReturn(Result.success(789L))
+
+        // When
+        runStarted(PirExecutionType.MANUAL_INITIAL_RESUME, 1, 3, 6)
+
+        // Then - a resume reuses the pir-initial-scan flow but is tagged with its own entry point / type
+        verify(wideEventClient).flowStart(
+            name = WIDE_EVENT_NAME_MANUAL,
+            flowEntryPoint = ENTRY_POINT_MANUAL_INITIAL_RESUME,
+            metadata = mapOf(
+                KEY_EXECUTION_TYPE to EXECUTION_TYPE_MANUAL_INITIAL_RESUME,
+                KEY_PROFILE_QUERIES_COUNT to "1",
+                KEY_BROKER_COUNT to "3",
+                KEY_TOTAL_SCAN_JOBS to "6",
+                KEY_WEB_VIEW_COUNT to "6",
+                KEY_POWER_SAVING to "false",
+                KEY_BATTERY_OPTIMIZATIONS to "false",
+                KEY_VPN_CONNECTION_STATE to "disconnected",
+                KEY_NOTIFICATIONS_PERMISSION_GRANTED to "true",
+                KEY_TRACKER_BLOCKING_STATE to "disabled",
+            ),
+            cleanupPolicy = CleanupPolicy.OnTimeout(duration = 8.hours, flowStatus = FlowStatus.Unknown),
+        )
+    }
+
+    @Test
     fun whenManualAndScheduledFlowsBothActiveThenTheyDoNotInterfere() = runTest {
         // Given
         whenever(wideEventClient.flowStart(any(), any(), any(), any()))
@@ -480,6 +510,29 @@ class PirScanWideEventTest {
             wideEventId = 101L,
             status = FlowStatus.Cancelled,
             metadata = mapOf(KEY_CANCELLATION_REASON to "superseded_by_profile_edit"),
+        )
+    }
+
+    @Test
+    fun whenManualFlowOpenAndInitialResumeRunStartsThenStaleFlowFinishedWithSupersededByNewRun() = runTest {
+        // Given an open manual flow (the interrupted initial scan)
+        whenever(wideEventClient.flowStart(any(), any(), any(), any()))
+            .thenReturn(Result.success(102L))
+            .thenReturn(Result.success(202L))
+        runStarted(PirExecutionType.MANUAL_INITIAL, 1, 1, 1)
+
+        // When the dashboard resumes it with a MANUAL_INITIAL_RESUME run that supersedes the stale flow
+        runStarted(PirExecutionType.MANUAL_INITIAL_RESUME, 1, 1, 1)
+
+        // Then the stale flow is cancelled as a generic superseded-by-new-run (a resume is not a profile edit)
+        val order = inOrder(wideEventClient)
+        order.verify(wideEventClient).intervalEnd(wideEventId = 102L, key = "decile_0_10_duration_ms_bucketed")
+        order.verify(wideEventClient).intervalEnd(wideEventId = 102L, key = INTERVAL_TOTAL_SCAN_DURATION)
+        order.verify(wideEventClient).intervalEnd(wideEventId = 102L, key = INTERVAL_TOTAL_FLOW_DURATION)
+        order.verify(wideEventClient).flowFinish(
+            wideEventId = 102L,
+            status = FlowStatus.Cancelled,
+            metadata = mapOf(KEY_CANCELLATION_REASON to "superseded_by_new_run"),
         )
     }
 

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
@@ -1161,6 +1161,31 @@ class RealPirPixelSenderTest {
     }
 
     @Test
+    fun whenReportInitialScanDurationWithInitialResumeThenScanTriggerIsOnboardingResume() = runTest {
+        whenever(mockNetworkProtectionState.isRunning()).thenReturn(false)
+
+        testee.reportInitialScanDuration(
+            durationMs = 1L,
+            profileQueryCount = 1,
+            isPowerSavingEnabled = false,
+            batteryOptimizationsEnabled = false,
+            brokerCount = 1,
+            executionType = PirExecutionType.MANUAL_INITIAL_RESUME,
+            notificationsPermissionGranted = true,
+        )
+
+        val paramsCaptor = argumentCaptor<Map<String, String>>()
+        verify(mockPixelSender).fire(
+            pixelName = any(),
+            parameters = paramsCaptor.capture(),
+            encodedParameters = any(),
+            type = any(),
+        )
+
+        assert(paramsCaptor.firstValue["scan_trigger"] == "onboarding_resume")
+    }
+
+    @Test
     fun whenReportInteractionDAUThenEnqueuesPixelWithAuthParams() = runTest {
         testee.reportInteractionDAU()
 

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealPirJobsRunnerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealPirJobsRunnerTest.kt
@@ -36,6 +36,7 @@ import com.duckduckgo.pir.impl.pixels.PirPixelSender
 import com.duckduckgo.pir.impl.scan.PirScan
 import com.duckduckgo.pir.impl.scheduling.PirExecutionType.MANUAL_EDIT_PROFILE
 import com.duckduckgo.pir.impl.scheduling.PirExecutionType.MANUAL_INITIAL
+import com.duckduckgo.pir.impl.scheduling.PirExecutionType.MANUAL_INITIAL_RESUME
 import com.duckduckgo.pir.impl.scheduling.PirExecutionType.SCHEDULED
 import com.duckduckgo.pir.impl.store.PirRepository
 import com.duckduckgo.pir.impl.store.PirSchedulingRepository
@@ -389,6 +390,63 @@ class RealPirJobsRunnerTest {
         verify(mockPixelSender).reportInitialScanDuration(any(), any(), any(), any(), any(), eq(MANUAL_EDIT_PROFILE), any())
         verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_EDIT_PROFILE), any())
         verify(mockPixelSender, never()).reportFirstScanStarted()
+    }
+
+    @Test
+    fun whenInitialResumeExecutionTypeThenForwardsResumeTriggerAndDoesNotReportFirstScan() = runTest {
+        // Given
+        whenever(mockPirRepository.getAllActiveBrokers()).thenReturn(listOf(testBrokerName))
+        whenever(mockPirRepository.getAllUserProfileQueries()).thenReturn(listOf(testProfileQuery))
+        whenever(mockPirRepository.getBrokersForOptOut(true)).thenReturn(emptyList())
+        whenever(
+            mockPirSchedulingRepository.getValidScanJobRecord(
+                testBrokerName,
+                testProfileQuery.id,
+            ),
+        ).thenReturn(testScanJobRecord)
+        whenever(mockEligibleScanJobProvider.getAllEligibleScanJobs(testCurrentTime)).thenReturn(
+            emptyList(),
+        )
+        whenever(mockPirRepository.getAllExtractedProfiles()).thenReturn(emptyList())
+        whenever(mockEligibleOptOutJobProvider.getAllEligibleOptOutJobs(testCurrentTime)).thenReturn(
+            emptyList(),
+        )
+        whenever(mockCurrentTimeProvider.currentTimeMillis()).thenReturn(testCurrentTime)
+        whenever(mockPirRepository.latestBackgroundScanRunInMs()).thenReturn(testCurrentTime)
+
+        // When
+        testee.runEligibleJobs(mockContext, MANUAL_INITIAL_RESUME)
+
+        // Then - a resume is a manual run (forwards the resume trigger to pixels and both wide events)
+        // but must NOT re-fire the once-per-install first-scan pixel.
+        verify(mockPixelSender).reportManualScanStarted(any(), any(), any(), eq(MANUAL_INITIAL_RESUME), any())
+        verify(mockPixelSender).reportInitialScanDuration(any(), any(), any(), any(), any(), eq(MANUAL_INITIAL_RESUME), any())
+        verify(mockPixelSender).reportManualScanCompleted(any(), any(), any(), any(), any(), any(), any(), eq(MANUAL_INITIAL_RESUME), any())
+        verify(mockPixelSender, never()).reportFirstScanStarted()
+        verify(mockPirScanWideEvent).onRunStarted(
+            executionType = eq(MANUAL_INITIAL_RESUME),
+            profileQueriesCount = any(),
+            brokerCount = any(),
+            totalScanJobs = any(),
+            webViewCount = any(),
+            isPowerSavingEnabled = any(),
+            isVpnConnected = any(),
+            batteryOptimizationsEnabled = any(),
+            notificationsPermissionGranted = any(),
+            isTrackerBlockingEnabled = any(),
+        )
+        verify(mockPirInitialScanCompletionWideEvent).onRunStarted(
+            executionType = eq(MANUAL_INITIAL_RESUME),
+            profileQueriesCount = any(),
+            brokerCount = any(),
+            totalScanJobs = any(),
+            webViewCount = any(),
+            isPowerSavingEnabled = any(),
+            isVpnConnected = any(),
+            batteryOptimizationsEnabled = any(),
+            notificationsPermissionGranted = any(),
+            isTrackerBlockingEnabled = any(),
+        )
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215725818623012?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1203581873609357/task/1213368145276564?focus=true

### Description
Updated the pixels and wide events to account for the new scan resume.

### Steps to test this PR
See https://app.asana.com/1/137249556945/task/1215956488456650?focus=true

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to analytics attribution and enum wiring; scan behavior is unchanged aside from passing the new execution type through existing manual-run paths.
> 
> **Overview**
> Introduces **`MANUAL_INITIAL_RESUME`** so dashboard “resume interrupted initial scan” is no longer reported as a fresh **`MANUAL_INITIAL`** onboarding run.
> 
> **`PirForegroundScanServiceStarter`** now starts the foreground service with **`MANUAL_INITIAL_RESUME`**. Pixels gain **`scan_trigger: onboarding_resume`** (via **`PirExecutionType.toScanTriggerParam()`**), and **`personal_information_removal.json5`** extends the allowed **`scan_trigger`** values and **`wide_pir-initial-scan`** context/execution enums (**`funnel_pir_initial_resume_android`**, **`manual_initial_resume`**).
> 
> **`PirScanWideEvent`** and **`PirInitialScanCompletionWideEvent`** treat resume like other manual runs for routing and foreground-run counting, while resume keeps its own entry point and execution metadata; stale manual flows superseded by a resume are cancelled with **`superseded_by_new_run`** (not profile-edit). Resume runs still skip the once-per-install first-scan pixel. Tests cover pixel mapping, wide-event tagging, completion counters, and jobs-runner forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37027fd279cabbed368a617b6a06a0a040334dcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->