### PR TITLE
Revert "de-emphasize input in Duck.ai onboarding demo (#8962)"

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -49,8 +49,6 @@ import androidx.recyclerview.widget.RecyclerView
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion
 import com.duckduckgo.browser.ui.PulseAnimation
-import com.duckduckgo.common.ui.view.getColorFromAttr
-import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.ViewViewModelFactory
 import com.duckduckgo.common.utils.extensions.hideKeyboard
@@ -1462,33 +1460,15 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     private var interactionLocked = false
 
-    // The unlocked card elevation, captured before the first lock. The two omnibar positions wrap this
-    // widget in cards with different elevations (6dp top, 3dp bottom), so we can't hardcode the restore value.
-    private var unlockedCardElevation: Float? = null
-
     // Dims only this (transparent) widget, never the parent card surface, so the bar stays
     // colour-uniform with the page. Touch interception covers the plugin containers too.
     override fun setInteractionLocked(locked: Boolean) {
         if (interactionLocked == locked) return
         interactionLocked = locked
         alpha = if (locked) LOCKED_ALPHA else 1f
-        val rootCard = widgetRoot?.findViewById<MaterialCardView>(R.id.inputModeWidgetCard)
         if (locked) {
             clearInputFocus()
             hideKeyboard()
-            rootCard?.let {
-                // further de-emphasize the input field when the UI is locked
-                if (unlockedCardElevation == null) unlockedCardElevation = it.elevation
-                it.elevation = 0f
-                it.strokeWidth = 1.toPx(it.context)
-                it.strokeColor = it.context.getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorBackground)
-            }
-        } else {
-            rootCard?.let {
-                // restore original values
-                it.elevation = unlockedCardElevation ?: it.elevation
-                it.strokeWidth = 0
-            }
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1215957547369230?focus=true
Tech Design URL (if applicable): 

### Description
This reverts https://github.com/duckduckgo/Android/pull/8962.

### Steps to test this PR
QA optional.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI revert in native input lock handling with no auth, data, or API changes.
> 
> **Overview**
> Reverts the Duck.ai onboarding demo change that **de-emphasized the native input card** while interaction is locked (from #8962).
> 
> **`setInteractionLocked`** in `NativeInputModeWidget` no longer tweaks the inner `inputModeWidgetCard`: it stops zeroing elevation, adding a background-colored stroke, and restoring the saved elevation on unlock. Locking still dims the transparent widget (`LOCKED_ALPHA`), clears focus, hides the keyboard, and blocks touches.
> 
> Unused **`unlockedCardElevation`** state and the **`getColorFromAttr` / `toPx`** imports tied to that styling are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 141fb62e40129f4e8e1227199ca4525b30c766f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->