### PR TITLE
Several Privacy Tests failed on 22 Jun 2026

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/espresso/RequestBlocklistTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/RequestBlocklistTest.kt
@@ -18,17 +18,10 @@ package com.duckduckgo.espresso
 
 import android.view.View
 import android.webkit.WebView
-import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.espresso.IdlingResource
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
-import androidx.test.espresso.action.ViewActions.clearText
-import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.action.ViewActions.pressImeActionButton
-import androidx.test.espresso.action.ViewActions.typeText
-import androidx.test.espresso.matcher.ViewMatchers.isRoot
-import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.web.model.Atoms
 import androidx.test.espresso.web.sugar.Web
 import androidx.test.ext.junit.rules.activityScenarioRule
@@ -54,7 +47,7 @@ class RequestBlocklistTest {
         BrowserActivity.intent(
             InstrumentationRegistry.getInstrumentation().targetContext,
             launchSource = InAppNavigation,
-            queryExtra = "https://privacy-test-pages.site/privacy-protections",
+            queryExtra = "https://privacy-test-pages.site/privacy-protections/request-blocklist/",
         ),
     )
 
@@ -65,37 +58,19 @@ class RequestBlocklistTest {
         registeredResources.forEach { IdlingRegistry.getInstance().unregister(it) }
     }
 
-    @Test @InternalPrivacyTest
+    @Test @PrivacyTest
     fun whenRequestBlocklistIsEnabledRequestsAreHandledCorrectly() {
         preparationsForPrivacyTest()
 
-        val grabber = WebViewGrabber()
-        onView(withId(R.id.browserWebView)).perform(grabber)
-        val webView = grabber.webView ?: error("browserWebView not present after waitForView")
+        var webView: WebView? = null
+        activityScenarioRule.scenario.onActivity {
+            webView = it.findViewById(R.id.browserWebView)
+        }
 
-        WebViewIdlingResource(webView).track()
-
-        // On internal builds native input is enabled, which disables the legacy omnibar field
-        // and routes a tap to the unified input screen. Drive that flow — open the input screen
-        // and type the URL into the native input field — instead of typing into the disabled
-        // omnibar. Loading the warm-up page first also gives the privacy config time to load
-        // before the test page fires its requests.
-        // inputField lives in :duckchat-impl; resolve its id by name so we don't import an impl
-        // R class (forbidden by the NoImplImportsInAppModule lint rule).
-        val inputFieldId = inputFieldId()
-        onView(withId(R.id.omnibarTextInputClickCatcher)).perform(click())
-        onView(isRoot()).perform(waitFor(1000))
-        onView(isRoot()).perform(waitForView(withId(inputFieldId)))
-        onView(withId(inputFieldId)).perform(
-            clearText(),
-            typeText("https://privacy-test-pages.site/privacy-protections/request-blocklist/"),
-            pressImeActionButton(),
-        )
-
-        WebViewIdlingResource(webView).track()
+        WebViewIdlingResource(webView!!).track()
 
         // window.results won't exist until the request-blocklist page's finished() fires
-        JsObjectIdlingResource(webView, "window.results").track()
+        JsObjectIdlingResource(webView!!, "window.results").track()
 
         val results = Web.onWebView()
             .perform(Atoms.script(SCRIPT))

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/FingerprintProtectionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/FingerprintProtectionTest.kt
@@ -20,8 +20,11 @@ import android.webkit.WebView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.espresso.IdlingResource
+import androidx.test.espresso.action.ViewActions.clearText
+import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.pressImeActionButton
 import androidx.test.espresso.action.ViewActions.typeText
+import androidx.test.espresso.matcher.ViewMatchers.isRoot
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.web.assertion.WebViewAssertions.webMatches
 import androidx.test.espresso.web.model.Atoms.script
@@ -35,9 +38,11 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.mode.InAppNavigation
+import com.duckduckgo.espresso.InternalPrivacyTest
 import com.duckduckgo.espresso.JsObjectIdlingResource
-import com.duckduckgo.espresso.PrivacyTest
 import com.duckduckgo.espresso.WebViewIdlingResource
+import com.duckduckgo.espresso.waitFor
+import com.duckduckgo.espresso.waitForView
 import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
@@ -61,7 +66,7 @@ class FingerprintProtectionTest {
 
     private val registeredResources = mutableListOf<IdlingResource>()
 
-    @Test @PrivacyTest
+    @Test @InternalPrivacyTest
     fun whenProtectionsAreFingerprintProtected() {
         preparationsForPrivacyTest()
 
@@ -71,7 +76,18 @@ class FingerprintProtectionTest {
         }
 
         WebViewIdlingResource(webView!!).track()
-        onView(withId(R.id.omnibarTextInput)).perform(
+
+        // On internal builds native input is enabled, which disables the legacy omnibar field
+        // and routes a tap to the unified input screen. Drive that flow — open the input screen
+        // and type the URL into the native input field — instead of typing into the disabled omnibar.
+        // inputField lives in :duckchat-impl; resolve its id by name so we don't import an impl
+        // R class (forbidden by the NoImplImportsInAppModule lint rule).
+        val inputFieldId = inputFieldId()
+        onView(withId(R.id.omnibarTextInputClickCatcher)).perform(click())
+        onView(isRoot()).perform(waitFor(1000))
+        onView(isRoot()).perform(waitForView(withId(inputFieldId)))
+        onView(withId(inputFieldId)).perform(
+            clearText(),
             typeText("https://privacy-test-pages.site/privacy-protections/fingerprinting/?disable_tests=navigator.requestMediaKeySystemAccess"),
             pressImeActionButton(),
         )
@@ -113,6 +129,12 @@ class FingerprintProtectionTest {
     private fun IdlingResource.track() = apply {
         registeredResources += this
         IdlingRegistry.getInstance().register(this)
+    }
+
+    private fun inputFieldId(): Int {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        return context.resources.getIdentifier("inputField", "id", context.packageName)
+            .also { require(it != 0) { "inputField id not found in ${context.packageName}" } }
     }
 
     private fun getTestJson(jsonString: String): TestJson? {

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/FingerprintProtectionTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/FingerprintProtectionTest.kt
@@ -17,15 +17,8 @@
 package com.duckduckgo.espresso.privacy
 
 import android.webkit.WebView
-import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.espresso.IdlingResource
-import androidx.test.espresso.action.ViewActions.clearText
-import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.action.ViewActions.pressImeActionButton
-import androidx.test.espresso.action.ViewActions.typeText
-import androidx.test.espresso.matcher.ViewMatchers.isRoot
-import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.web.assertion.WebViewAssertions.webMatches
 import androidx.test.espresso.web.model.Atoms.script
 import androidx.test.espresso.web.sugar.Web.onWebView
@@ -38,11 +31,9 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.mode.InAppNavigation
-import com.duckduckgo.espresso.InternalPrivacyTest
 import com.duckduckgo.espresso.JsObjectIdlingResource
+import com.duckduckgo.espresso.PrivacyTest
 import com.duckduckgo.espresso.WebViewIdlingResource
-import com.duckduckgo.espresso.waitFor
-import com.duckduckgo.espresso.waitForView
 import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
@@ -60,13 +51,13 @@ class FingerprintProtectionTest {
         BrowserActivity.intent(
             InstrumentationRegistry.getInstrumentation().targetContext,
             launchSource = InAppNavigation,
-            "https://privacy-test-pages.site/privacy-protections",
+            "https://privacy-test-pages.site/privacy-protections/fingerprinting/?disable_tests=navigator.requestMediaKeySystemAccess",
         ),
     )
 
     private val registeredResources = mutableListOf<IdlingResource>()
 
-    @Test @InternalPrivacyTest
+    @Test @PrivacyTest
     fun whenProtectionsAreFingerprintProtected() {
         preparationsForPrivacyTest()
 
@@ -75,22 +66,6 @@ class FingerprintProtectionTest {
             webView = it.findViewById(R.id.browserWebView)
         }
 
-        WebViewIdlingResource(webView!!).track()
-
-        // On internal builds native input is enabled, which disables the legacy omnibar field
-        // and routes a tap to the unified input screen. Drive that flow — open the input screen
-        // and type the URL into the native input field — instead of typing into the disabled omnibar.
-        // inputField lives in :duckchat-impl; resolve its id by name so we don't import an impl
-        // R class (forbidden by the NoImplImportsInAppModule lint rule).
-        val inputFieldId = inputFieldId()
-        onView(withId(R.id.omnibarTextInputClickCatcher)).perform(click())
-        onView(isRoot()).perform(waitFor(1000))
-        onView(isRoot()).perform(waitForView(withId(inputFieldId)))
-        onView(withId(inputFieldId)).perform(
-            clearText(),
-            typeText("https://privacy-test-pages.site/privacy-protections/fingerprinting/?disable_tests=navigator.requestMediaKeySystemAccess"),
-            pressImeActionButton(),
-        )
         WebViewIdlingResource(webView!!).track()
 
         // asserts we have injected css by querying the duckduckgo object
@@ -129,12 +104,6 @@ class FingerprintProtectionTest {
     private fun IdlingResource.track() = apply {
         registeredResources += this
         IdlingRegistry.getInstance().register(this)
-    }
-
-    private fun inputFieldId(): Int {
-        val context = InstrumentationRegistry.getInstrumentation().targetContext
-        return context.resources.getIdentifier("inputField", "id", context.packageName)
-            .also { require(it != 0) { "inputField id not found in ${context.packageName}" } }
     }
 
     private fun getTestJson(jsonString: String): TestJson? {

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/GpcTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/GpcTest.kt
@@ -20,6 +20,8 @@ import android.webkit.WebView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.espresso.IdlingResource
+import androidx.test.espresso.action.ViewActions.clearText
+import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.pressImeActionButton
 import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.matcher.ViewMatchers.*
@@ -35,9 +37,11 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.mode.InAppNavigation
+import com.duckduckgo.espresso.InternalPrivacyTest
 import com.duckduckgo.espresso.JsObjectIdlingResource
-import com.duckduckgo.espresso.PrivacyTest
 import com.duckduckgo.espresso.WebViewIdlingResource
+import com.duckduckgo.espresso.waitFor
+import com.duckduckgo.espresso.waitForView
 import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
@@ -60,7 +64,7 @@ class GpcTest {
 
     private val registeredResources = mutableListOf<IdlingResource>()
 
-    @Test @PrivacyTest
+    @Test @InternalPrivacyTest
     fun whenProtectionsAreEnableGpcSetCorrectly() {
         preparationsForPrivacyTest()
 
@@ -71,7 +75,18 @@ class GpcTest {
         }
 
         WebViewIdlingResource(webView!!).track()
-        onView(withId(R.id.omnibarTextInput)).perform(
+
+        // On internal builds native input is enabled, which disables the legacy omnibar field
+        // and routes a tap to the unified input screen. Drive that flow — open the input screen
+        // and type the URL into the native input field — instead of typing into the disabled omnibar.
+        // inputField lives in :duckchat-impl; resolve its id by name so we don't import an impl
+        // R class (forbidden by the NoImplImportsInAppModule lint rule).
+        val inputFieldId = inputFieldId()
+        onView(withId(R.id.omnibarTextInputClickCatcher)).perform(click())
+        onView(isRoot()).perform(waitFor(1000))
+        onView(isRoot()).perform(waitForView(withId(inputFieldId)))
+        onView(withId(inputFieldId)).perform(
+            clearText(),
             typeText("https://privacy-test-pages.site/privacy-protections/gpc/"),
             pressImeActionButton(),
         )
@@ -113,6 +128,12 @@ class GpcTest {
     private fun IdlingResource.track() = apply {
         registeredResources += this
         IdlingRegistry.getInstance().register(this)
+    }
+
+    private fun inputFieldId(): Int {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        return context.resources.getIdentifier("inputField", "id", context.packageName)
+            .also { require(it != 0) { "inputField id not found in ${context.packageName}" } }
     }
 
     companion object {

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/GpcTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/GpcTest.kt
@@ -17,14 +17,8 @@
 package com.duckduckgo.espresso.privacy
 
 import android.webkit.WebView
-import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.espresso.IdlingResource
-import androidx.test.espresso.action.ViewActions.clearText
-import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.action.ViewActions.pressImeActionButton
-import androidx.test.espresso.action.ViewActions.typeText
-import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.espresso.web.assertion.WebViewAssertions.webMatches
 import androidx.test.espresso.web.model.Atoms.script
 import androidx.test.espresso.web.sugar.Web.onWebView
@@ -37,11 +31,9 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.mode.InAppNavigation
-import com.duckduckgo.espresso.InternalPrivacyTest
 import com.duckduckgo.espresso.JsObjectIdlingResource
+import com.duckduckgo.espresso.PrivacyTest
 import com.duckduckgo.espresso.WebViewIdlingResource
-import com.duckduckgo.espresso.waitFor
-import com.duckduckgo.espresso.waitForView
 import com.duckduckgo.privacy.config.impl.network.JSONObjectAdapter
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
@@ -58,13 +50,13 @@ class GpcTest {
         BrowserActivity.intent(
             InstrumentationRegistry.getInstrumentation().targetContext,
             launchSource = InAppNavigation,
-            queryExtra = "https://privacy-test-pages.site/privacy-protections",
+            queryExtra = "https://privacy-test-pages.site/privacy-protections/gpc/",
         ),
     )
 
     private val registeredResources = mutableListOf<IdlingResource>()
 
-    @Test @InternalPrivacyTest
+    @Test @PrivacyTest
     fun whenProtectionsAreEnableGpcSetCorrectly() {
         preparationsForPrivacyTest()
 
@@ -74,22 +66,6 @@ class GpcTest {
             webView = it.findViewById(R.id.browserWebView)
         }
 
-        WebViewIdlingResource(webView!!).track()
-
-        // On internal builds native input is enabled, which disables the legacy omnibar field
-        // and routes a tap to the unified input screen. Drive that flow — open the input screen
-        // and type the URL into the native input field — instead of typing into the disabled omnibar.
-        // inputField lives in :duckchat-impl; resolve its id by name so we don't import an impl
-        // R class (forbidden by the NoImplImportsInAppModule lint rule).
-        val inputFieldId = inputFieldId()
-        onView(withId(R.id.omnibarTextInputClickCatcher)).perform(click())
-        onView(isRoot()).perform(waitFor(1000))
-        onView(isRoot()).perform(waitForView(withId(inputFieldId)))
-        onView(withId(inputFieldId)).perform(
-            clearText(),
-            typeText("https://privacy-test-pages.site/privacy-protections/gpc/"),
-            pressImeActionButton(),
-        )
         WebViewIdlingResource(webView!!).track()
 
         // asserts we have injected css by querying the duckduckgo object
@@ -128,12 +104,6 @@ class GpcTest {
     private fun IdlingResource.track() = apply {
         registeredResources += this
         IdlingRegistry.getInstance().register(this)
-    }
-
-    private fun inputFieldId(): Int {
-        val context = InstrumentationRegistry.getInstrumentation().targetContext
-        return context.resources.getIdentifier("inputField", "id", context.packageName)
-            .also { require(it != 0) { "inputField id not found in ${context.packageName}" } }
     }
 
     companion object {

--- a/app/src/androidTest/java/com/duckduckgo/espresso/privacy/SurrogatesTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/privacy/SurrogatesTest.kt
@@ -96,9 +96,15 @@ class SurrogatesTest {
         IdlingRegistry.getInstance().register(idlingResourceForDisableProtections)
 
         onView(allOf(withId(R.id.browserMenu), isClickable())).perform(ViewActions.click())
-        clickMenuItem(withText("Disable Privacy Protection"))
+        // Protections may already be disabled for privacy-test-pages.site if a previous test in
+        // the same run left that state behind — the user allowlist persists across tests and is
+        // only cleared between orchestrated (CI) runs, not local connectedAndroidTest runs. When
+        // already disabled, the menu shows "Enable Privacy Protection" instead, and we're already
+        // in the state under test, so skip the disable click rather than failing to find it.
+        runCatching { clickMenuItem(withText("Disable Privacy Protection")) }
 
-        // handle the privacy protection toggle check screen showing
+        // Dismiss the privacy protection toggle check screen (if we disabled) or the menu (if it
+        // was already disabled).
         onView(isRoot()).perform(ViewActions.pressBack())
 
         val idlingResourceForScript: IdlingResource = WebViewIdlingResource(webView!!)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1215940160973432?focus=true
Tech Design URL (if applicable):

### Description

  Fixes several flaky/failing privacy Espresso tests by removing the fragile post-launch URL typing and navigating directly to the target test page.

  Previously these tests launched the browser on a generic landing page (/privacy-protections) and then typed the specific test URL into the omnibar. On internal builds native input is enabled,
  which disables the legacy omnibar field and routes taps to the unified input screen — making the typing step unreliable.

  Changes:
  - RequestBlocklistTest, FingerprintProtectionTest, GpcTest — pass the full test-page URL directly in the launch intent (queryExtra) instead of typing it into the omnibar after launch. All
  omnibar/native-input-handling code and the associated Espresso imports are removed; the WebView is now grabbed via scenario.onActivity.
  - RequestBlocklistTest — re-tagged from `@InternalPrivacyTest` to `@PrivacyTest` now that it no longer depends on internal-only input behavior.
  - SurrogatesTest — tolerate protections already being disabled for privacy-test-pages.site from a prior test in the same run (the user allowlist persists across local connectedAndroidTest
  runs). The "Disable Privacy Protection" click is now wrapped in runCatching, and the back-press dismisses either the toggle-check screen or the menu.


No production code changed — all changes are confined to the androidTest sources.

### Steps to test this PR

  - [ ] Run the privacy Espresso suite (FingerprintProtectionTest, GpcTest, RequestBlocklistTest, SurrogatesTest) on an internal build and confirm they pass.
  - [ ] Run the suite twice back-to-back locally to confirm SurrogatesTest passes when the allowlist state persists from the first run.

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to androidTest sources with no production behavior impact.
> 
> **Overview**
> Fixes failing privacy Espresso tests by **opening each privacy test page in the activity intent** instead of loading a hub URL and typing the destination into the omnibar (which breaks when the unified input / disabled omnibar path is used on internal builds).
> 
> **RequestBlocklistTest**, **FingerprintProtectionTest**, and **GpcTest** now pass the final `privacy-test-pages.site` URL (including fingerprint query flags where needed) via `queryExtra`, grab the `WebView` with `onActivity`, and drop the removed Espresso omnibar / click-catcher / input-field steps. Request blocklist is tagged **`@PrivacyTest`** again instead of **`@InternalPrivacyTest`**.
> 
> **SurrogatesTest** wraps the “Disable Privacy Protection” menu action in **`runCatching`** so a prior run that left protections disabled no longer fails when the menu label is “Enable…”; back still dismisses the sheet or menu.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81e8c9c210efd16e84d021dcbb7b507c61ffb026. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->