### PR TITLE
Limit Asana API tagging calls to single concurrency

### DIFF
--- a/.github/workflows/nightly-orchestrator.yml
+++ b/.github/workflows/nightly-orchestrator.yml
@@ -124,6 +124,7 @@ jobs:
       matrix:
         task_id: ${{ fromJson(needs.collect_lgc_tasks.outputs.task_ids) }}
       fail-fast: false
+      max-parallel: 1
     steps:
       - name: Tag task as LGC
         uses: duckduckgo/native-github-asana-sync@v2.5.1


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1215971637951737?focus=true
Tech Design URL (if applicable): 

### Description
Custom-field update runs sequentially instead of many at once, reducing concurrent Asana API traffic 

### Steps to test this PR
- QA optional 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow tuning with no app or production runtime impact; only slows parallel Asana updates during nightly success.
> 
> **Overview**
> The nightly orchestrator’s **`move_tasks_in_lgc`** job still runs one matrix entry per collected Asana task, but GitHub Actions will no longer run those matrix jobs in parallel.
> 
> **`max-parallel: 1`** is added under the job’s matrix strategy so each **`native-github-asana-sync`** custom-field update runs sequentially instead of many at once, reducing concurrent Asana API traffic (e.g. rate limits) when tagging tasks as contained in LGC.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3e3674a176c974c8ba182a75bd9c2555de237ea. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->