### PR TITLE
Restrict sync barcode scanning to QR-code only

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
@@ -94,4 +94,12 @@ interface SyncFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun canShowV2ConnectCode(): Toggle
+
+    /**
+     * When enabled, the sync barcode scanner only attempts to decode QR codes. Sync codes are
+     * always encoded as QR, so other formats only add noise (and false-positive decodes) to
+     * the scanner.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun restrictScannedBarcodesToQrTypes(): Toggle
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/qrcode/SyncBarcodeView.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/qrcode/SyncBarcodeView.kt
@@ -31,6 +31,7 @@ import android.widget.FrameLayout
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.view.doOnNextLayout
+import androidx.lifecycle.LifecycleCoroutineScope
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
@@ -42,6 +43,7 @@ import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.sync.impl.R
+import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.databinding.ViewSquareDecoratedBarcodeBinding
 import com.duckduckgo.sync.impl.ui.qrcode.SquareDecoratedBarcodeViewModel.Command
 import com.duckduckgo.sync.impl.ui.qrcode.SquareDecoratedBarcodeViewModel.Command.CheckCameraAvailable
@@ -49,9 +51,13 @@ import com.duckduckgo.sync.impl.ui.qrcode.SquareDecoratedBarcodeViewModel.Comman
 import com.duckduckgo.sync.impl.ui.qrcode.SquareDecoratedBarcodeViewModel.Command.OpenSettings
 import com.duckduckgo.sync.impl.ui.qrcode.SquareDecoratedBarcodeViewModel.Command.RequestPermissions
 import com.duckduckgo.sync.impl.ui.qrcode.SquareDecoratedBarcodeViewModel.ViewState
+import com.google.zxing.BarcodeFormat.QR_CODE
+import com.journeyapps.barcodescanner.DefaultDecoderFactory
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 /**
@@ -87,6 +93,9 @@ constructor(
 
     @Inject
     lateinit var appBuildConfig: AppBuildConfig
+
+    @Inject
+    lateinit var syncFeature: SyncFeature
 
     private val cameraBlockedDrawable by lazy {
         ContextCompat.getDrawable(context, R.drawable.camera_blocked)
@@ -125,6 +134,19 @@ constructor(
 
         binding.goToSettingsButton.setOnClickListener {
             viewModel.goToSettings()
+        }
+
+        applyDecoderRestriction(scope)
+    }
+
+    private fun applyDecoderRestriction(scope: LifecycleCoroutineScope) {
+        scope.launch {
+            val restrictToQr = withContext(dispatchers.io()) {
+                syncFeature.restrictScannedBarcodesToQrTypes().isEnabled()
+            }
+            if (restrictToQr) {
+                binding.barcodeView.decoderFactory = DefaultDecoderFactory(listOf(QR_CODE))
+            }
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215807614340907?focus=true
Tech Design URL (if applicable): 

### Description
> [!NOTE] 
QA optional

### Steps to test this PR

- [ ] Open Sync & Backup and choose to `Sync with another device`
- [ ] Make sure another device's sync code scans
- [ ] Test a non QR-code (like an [EAN-13 barcode](https://en.wikipedia.org/wiki/International_Article_Number)) and confirm it doesn't scan

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7e96be80837c65e55e2687d67291691f61967870. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->