### PR TITLE
Update Metro to 1.3.1

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/di/AppConfigurationDownloaderModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/AppConfigurationDownloaderModule.kt
@@ -29,10 +29,10 @@ import dagger.Provides
 
 @Module
 @ContributesTo(AppScope::class)
-open class AppConfigurationDownloaderModule {
+object AppConfigurationDownloaderModule {
 
     @Provides
-    open fun appConfigurationDownloader(
+    fun appConfigurationDownloader(
         trackerDataDownloader: TrackerDataDownloader,
         httpsUpgradeDataDownloader: HttpsUpgradeDataDownloader,
         resourceSurrogateDownloader: ResourceSurrogateListDownloader,

--- a/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/DuckAiBridgeModule.kt
+++ b/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/DuckAiBridgeModule.kt
@@ -84,6 +84,7 @@ object DuckAiBridgeModule {
     fun provideFireFileMetaDao(db: FireModeDuckAiDatabase): DuckAiBridgeFileMetaDao = db.fileMetaDao()
 
     @Provides
+    @SingleInstanceIn(AppScope::class)
     @DuckAiBridgeFilesDir
     fun provideFilesDir(context: Context): File =
         File(context.filesDir, "duck_ai_bridge_files")

--- a/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/DuckAiBridgeModule.kt
+++ b/duckchat/duckchat-store/src/main/java/com/duckduckgo/duckchat/store/impl/DuckAiBridgeModule.kt
@@ -84,7 +84,6 @@ object DuckAiBridgeModule {
     fun provideFireFileMetaDao(db: FireModeDuckAiDatabase): DuckAiBridgeFileMetaDao = db.fileMetaDao()
 
     @Provides
-    @SingleInstanceIn(AppScope::class)
     @DuckAiBridgeFilesDir
     fun provideFilesDir(context: Context): File =
         File(context.filesDir, "duck_ai_bridge_files")

--- a/versions.properties
+++ b/versions.properties
@@ -111,9 +111,9 @@ version.com.nhaarman.mockitokotlin2..mockito-kotlin=2.2.0
 
 version.com.slack.lint.compose..compose-lint-checks=1.4.2
 
-version.dev.zacsweers.metro..gradle-plugin=1.3.0
+version.dev.zacsweers.metro..gradle-plugin=1.3.1
 
-version.dev.zacsweers.metro..runtime=1.3.0
+version.dev.zacsweers.metro..runtime=1.3.1
 
 version.google.android.flexbox=3.0.0
 

--- a/versions.properties
+++ b/versions.properties
@@ -111,9 +111,9 @@ version.com.nhaarman.mockitokotlin2..mockito-kotlin=2.2.0
 
 version.com.slack.lint.compose..compose-lint-checks=1.4.2
 
-version.dev.zacsweers.metro..gradle-plugin=1.2.1
+version.dev.zacsweers.metro..gradle-plugin=1.3.0
 
-version.dev.zacsweers.metro..runtime=1.2.1
+version.dev.zacsweers.metro..runtime=1.3.0
 
 version.google.android.flexbox=3.0.0
 

--- a/versions.properties
+++ b/versions.properties
@@ -111,9 +111,9 @@ version.com.nhaarman.mockitokotlin2..mockito-kotlin=2.2.0
 
 version.com.slack.lint.compose..compose-lint-checks=1.4.2
 
-version.dev.zacsweers.metro..gradle-plugin=1.0.1
+version.dev.zacsweers.metro..gradle-plugin=1.2.1
 
-version.dev.zacsweers.metro..runtime=1.0.1
+version.dev.zacsweers.metro..runtime=1.2.1
 
 version.google.android.flexbox=3.0.0
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214119362406643/task/1215907760038073?focus=true
Tech Design URL (if applicable): N/A

### Description
Updates Metro to 1.3.1

### Steps to test this PR
_Smoke check_
- [x] Verify unit and Android tests pass for both DI variants
- [x] Verify e2e tests pass for both DI variants
- [x]  1) Metro: https://github.com/duckduckgo/Android/actions/runs/28596698328
- [x]  2) Anvil: https://github.com/duckduckgo/Android/actions/runs/27950202725
- [x] Verify privacy tests pass for both DI variants
- [x]  1) Metro: https://github.com/duckduckgo/Android/actions/runs/28599293140
- [x]  2) Anvil: https://github.com/duckduckgo/Android/actions/runs/28596720625
- [x] Install build and smoke check the app


### UI changes
No UI changes



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches app-wide DI via a Metro upgrade; scope is limited to version pins and one module shape change, with both Anvil and Metro variants exercised in CI.
> 
> **Overview**
> Bumps **Metro** (`gradle-plugin` and `runtime`) from **1.0.1** to **1.3.1** in `versions.properties`.
> 
> Aligns `AppConfigurationDownloaderModule` with the new toolchain by converting it from an **`open class`** with **`open`** `@Provides` methods to a Kotlin **`object`** module with non-open providers—no change to what `ConfigurationDownloader` wires or which dependencies it takes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64e03613f77772433a6cfc9060e289960c67953e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->