### PR TITLE
Privacy test job fails when there are no tests annotated with @InternalPrivacyTests 

### DIFF
--- a/.github/workflows/privacy.yml
+++ b/.github/workflows/privacy.yml
@@ -61,11 +61,13 @@ jobs:
             flank-task: runFlankPrivacyTests
             artifact-name: android-tests-report-privacy
             asana-task-name: GH Workflow Failure - Privacy tests
+            test-annotation: PrivacyTest
           - name: Internal Privacy Tests
             build-task: internalAndroidTestsBuild
             flank-task: runFlankInternalPrivacyTests
             artifact-name: android-tests-report-privacy-internal
             asana-task-name: GH Workflow Failure - Internal privacy tests
+            test-annotation: InternalPrivacyTest
     env:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
@@ -75,6 +77,22 @@ jobs:
         with:
           ref: ${{ inputs.commit || github.sha }}
           submodules: recursive
+
+      # The matrix may include an annotation for which no tests currently exist
+      # (e.g. Internal Privacy Tests).
+      # Flank fails hard with "no tests to run" in that case, so detect an empty
+      # set up front and skip the build/run/report steps below.
+      # The entry remains in the matrix and will automatically reactivate as soon
+      # as a test is tagged with that annotation again.
+      - name: Check whether any tests carry this annotation
+        id: tests-exist
+        run: |
+          if grep -rqlF "@${{ matrix.test-annotation }}" app/src/androidTest; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No @${{ matrix.test-annotation }} tests found — skipping ${{ matrix.name }}."
+          fi
 
       - name: Setup jq
         uses: dcarbone/install-jq-action@v1.0.1
@@ -103,26 +121,28 @@ jobs:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Build
+        if: ${{ steps.tests-exist.outputs.run == 'true' }}
         run: ./gradlew ${{ matrix.build-task }} -Pddg.di=${{ env.DDG_DI }}
 
       - name: Run Android Tests
+        if: ${{ steps.tests-exist.outputs.run == 'true' }}
         run: ./gradlew ${{ matrix.flank-task }} --no-configuration-cache -Pddg.di=${{ env.DDG_DI }}
 
       - name: Bundle the Android CI tests report
-        if: always()
+        if: ${{ always() && steps.tests-exist.outputs.run == 'true' }}
         run: find . -type d -name 'fladleResults' | zip -@ -r ${{ matrix.artifact-name }}${{ env.DI_HYPHEN_SUFFIX }}.zip
 
       - name: Generate json file with failures
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.tests-exist.outputs.run == 'true' }}
         run: cut -d\`  -f2 < build/fladle/fladleResults/HtmlErrorReport.html >> results.json
 
       - name: Print failure report
-        if: ${{ failure() }}
+        if: ${{ failure() && steps.tests-exist.outputs.run == 'true' }}
         run: |
           jq -r '.[] | .label as $id | .items[] | "Test:", $id, "Failure:", .label, "URL:", .url, "\n"' results.json
 
       - name: Upload the Android CI tests report
-        if: always()
+        if: ${{ always() && steps.tests-exist.outputs.run == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact-name }}${{ env.DI_HYPHEN_SUFFIX }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200905986587319/task/1215940160973440?focus=true
Tech Design URL (if applicable): 

### Description

  The Privacy Tests workflow runs two matrix entries: Privacy Tests (@PrivacyTest) and Internal Privacy Tests (@InternalPrivacyTest). All @InternalPrivacyTest tests have been re-tagged to
  @PrivacyTest, so no test currently carries @InternalPrivacyTest. Flank fails hard with "no tests to run" when its annotation matches nothing, so the Internal Privacy Tests job was failing on
  every run.

  This keeps the matrix entry (so internal privacy tests can be reinstated later) but makes it skip gracefully when empty:

  - Added a test-annotation field to each matrix entry (PrivacyTest / InternalPrivacyTest).
  - Added a guard step that greps app/src/androidTest for the entry's annotation and sets run=true/false, emitting a ::notice:: when skipping.
  - Gated the Build, Run, Bundle, failure-report, and Upload steps on steps.tests-exist.outputs.run == 'true'.

  Behaviour: Privacy Tests is unchanged (@PrivacyTest matches 7 files → runs as before); Internal Privacy Tests skips green while no @InternalPrivacyTest test exists, and reactivates
  automatically the moment one is added — no further workflow edits needed.

### Steps to test this PR

This should be green -> https://github.com/duckduckgo/Android/actions/runs/28044295567/job/83018298930

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes; no app or test code modified, and the Privacy Tests path with existing `@PrivacyTest` tests behaves as before.
> 
> **Overview**
> Fixes **Privacy Tests** workflow failures when a matrix entry’s Flank annotation matches no tests (notably **Internal Privacy Tests** after tests were re-tagged to `@PrivacyTest`).
> 
> Each matrix row gets a `test-annotation` (`PrivacyTest` / `InternalPrivacyTest`). A new step greps `app/src/androidTest` for `@<annotation>` and sets `run=true|false`, with a workflow notice when skipping. **Build**, **Run Android Tests**, report bundling, failure reporting, and artifact upload run only when `run` is true, so empty annotation sets exit green without removing the matrix slot—adding `@InternalPrivacyTest` again re-enables that job automatically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7518c3ff976685ebf887f82576de75e51c39b780. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->