### PR TITLE
copy updates for custom ai onboarding

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxSubscriptionBrandDesignUpdateBubbleCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxSubscriptionBrandDesignUpdateBubbleCta.kt
@@ -74,7 +74,11 @@ data class DaxSubscriptionBrandDesignUpdateBubbleCta(
         view.findViewById<ImageView>(R.id.brandDesignHeaderImage)?.isVisible = true
 
         val buttonTextRes = if (isFreeTrialCopy) {
-            R.string.onboardingPrivacyProDaxDialogFreeTrialOkButton
+            if (isCustomAiOnboardingFlow) {
+                R.string.onboardingPrivacyProDaxDialogFreeTrialOkButtonBrandDesign
+            } else {
+                R.string.onboardingPrivacyProDaxDialogFreeTrialOkButton
+            }
         } else {
             R.string.onboardingPrivacyProDaxDialogOkButton
         }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -841,7 +841,9 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                     } else if (isCustomAiOnboardingFlow) {
                         binding.daxDialogCta.welcomeContent.bodyText1.text =
                             getString(R.string.preOnboardingWelcomeDialogBodyCustomAi).preventWidows().html(requireContext())
+                        binding.daxDialogCta.primaryCta.text = getString(R.string.preOnboardingDaxDialog1ButtonBrandDesign)
                     } else {
+                        binding.daxDialogCta.primaryCta.text = getString(R.string.preOnboardingDaxDialog1Button)
                         binding.daxDialogCta.welcomeContent.bodyText1.text =
                             getString(R.string.preOnboardingWelcomeDialogBody1).preventWidows()
                         binding.daxDialogCta.welcomeContent.bodyText2.text =
@@ -1562,7 +1564,9 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 } else if (isCustomAiOnboardingFlow) {
                     binding.daxDialogCta.welcomeContent.bodyText1.text =
                         getString(R.string.preOnboardingWelcomeDialogBodyCustomAi).preventWidows().html(requireContext())
+                    binding.daxDialogCta.primaryCta.text = getString(R.string.preOnboardingDaxDialog1ButtonBrandDesign)
                 } else {
+                    binding.daxDialogCta.primaryCta.text = getString(R.string.preOnboardingDaxDialog1Button)
                     binding.daxDialogCta.welcomeContent.bodyText1.text =
                         getString(R.string.preOnboardingWelcomeDialogBody1).preventWidows()
                     binding.daxDialogCta.welcomeContent.bodyText2.text =

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -87,7 +87,7 @@
     <!-- Input Mode Demo Onboarding step -->
     <string name="preOnboardingInputModeDemoTitle">Ready to get started?&lt;br/&gt;Try a search or AI chat!</string>
     <string name="preOnboardingInputModeDemoSearchHint">Search privately</string>
-    <string name="preOnboardingInputModeDemoChatHint">Ask privately</string>
+    <string name="preOnboardingInputModeDemoChatHint">Ask anything privately</string>
     <string name="preOnboardingInputModeDemoChatSuggestion1">Explain the stock market like I\'m 10</string>
     <string name="preOnboardingInputModeDemoChatSuggestion2">Plan a perfect day in London</string>
     <string name="preOnboardingInputModeDemoChatSuggestion3">Surprise me!</string>
@@ -125,6 +125,8 @@
     <string name="singleTabFireDialogTitleFireMode">Delete Fire Tabs and their data?</string>
 
     <!-- Custom AI onboarding flow -->
+    <string name="preOnboardingDaxDialog1ButtonBrandDesign">Let\'s get started!</string>
+    <string name="onboardingPrivacyProDaxDialogFreeTrialOkButtonBrandDesign">Try it free!</string>
     <!-- Pre-onboarding: AI comparison chart screen. -->
     <string name="preOnboardingDaxDialogAiTitle">AI protections activated!</string>
     <string name="preOnboardingAiComparisonChartPopularAis">Popular AIs</string>
@@ -135,7 +137,7 @@
     <string name="preOnboardingAiComparisonChartButton">Give Duck.ai a try!</string>
     <!-- In-context onboarding. -->
     <string name="onboardingEndCustomAiFlowDaxDialogDescription"><![CDATA[Start a private AI chat with Duck.ai or toggle to Search for protected browsing.<br/><br/>You can use Duck.ai from anywhere you see the chat icon]]></string>
-    <string name="onboardingPrivacyProCustomAiFlowDaxDialogDescription">We also offer a paid subscription featuring advanced AI models with higher chat limits from GPT, Claude, and Llama, a secure VPN, and more.</string>
+    <string name="onboardingPrivacyProCustomAiFlowDaxDialogDescription">We also offer a paid subscription featuring advanced AI models with higher chat limits from GPT and Claude, a secure VPN, and more.</string>
     <!-- Pre-onboarding: initial screens -->
     <string name="preOnboardingWelcomeDialogBodyCustomAi">Ready to chat privately with ChatGPT, Claude, and other AIs for free, in a browser that actively protects you?</string>
     <string name="preOnboardingDaxDialog2TitleCustomAi">Want to make DuckDuckGo your default browser?</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1215973561397270?focus=true
Tech Design URL (if applicable): 

### Description
1. Change `Try for free!`  → `Try it free!`  on subscription CTA.
2. Change `Let's do it!`  → `Let's get started!` on initial screen.
3. Change `Ask privately`  → `Ask anything privately` on input demo hint.
4. Change `We also offer a paid subscription featuring advanced AI models with higher chat limits from GPT, Claude, and Llama, a secure VPN, and more.` → `We also offer a paid subscription featuring advanced AI models with higher chat limits from GPT and Claude, a secure VPN, and more.`.

Changes applied only when the custom AI onboarding flow is enabled, since we will only target English audience.

### Steps to test this PR
- [ ] Apply this diff:
```diff
diff --git a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
index 8af0990326..3984ee875c 100644
--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -134,7 +134,7 @@ class CtaViewModel @Inject constructor(
     }
 
     private suspend fun isSubscriptionCtaAvailable(): Boolean =
-        subscriptions.isEligible() && hasNoSubscription() && extendedOnboardingFeatureToggles.privacyProCta().isEnabled()
+        true // subscriptions.isEligible() && hasNoSubscription() && extendedOnboardingFeatureToggles.privacyProCta().isEnabled()
 
     private suspend fun isBrandDesignUpdateEnabled(): Boolean = withContext(dispatchers.io()) {
         onboardingBrandDesignUpdateToggles.brandDesignUpdate().isEnabled()
diff --git a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxSubscriptionBrandDesignUpdateBubbleCta.kt b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxSubscriptionBrandDesignUpdateBubbleCta.kt
index a65c332945..885c8813c1 100644
--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxSubscriptionBrandDesignUpdateBubbleCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxSubscriptionBrandDesignUpdateBubbleCta.kt
@@ -73,7 +73,7 @@ data class DaxSubscriptionBrandDesignUpdateBubbleCta(
     override fun configureContentViews(view: View) {
         view.findViewById<ImageView>(R.id.brandDesignHeaderImage)?.isVisible = true
 
-        val buttonTextRes = if (isFreeTrialCopy) {
+        val buttonTextRes = if (true) {
             if (isCustomAiOnboardingFlow) {
                 R.string.onboardingPrivacyProDaxDialogFreeTrialOkButtonBrandDesign
             } else {
```
- [ ] Clean install the app
- [ ] Verify that on initial onboarding screen the CTA is 'Let's do it'.
- [ ] Verify that on subscription promo screen CTA is 'Try for free!'.
- [ ] Apply this diff:
```diff

diff --git a/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt b/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
index 9da0ed066d..11c72f0457 100644
--- a/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
@@ -102,6 +102,7 @@ class CustomAiOnboardingStoreImpl @Inject constructor(
 
     override suspend fun resolve() = resolveMutex.withLock {
         withContext(dispatcherProvider.io()) {
+            return@withContext true
             // Ensure the install referrer (and therefore the processing function) has resolved before reading.
             withTimeoutOrNull(MAX_REFERRER_WAIT_TIME_MS) { referrerStateListener.get().waitForReferrerCode() }
             val referrerExists = preferences.getBoolean(PREFS_KEY_REFERRER_PARAM_PRESENT, false)
@@ -119,6 +120,7 @@ class CustomAiOnboardingStoreImpl @Inject constructor(
 
     override suspend fun isEnabled(): Boolean = resolveMutex.withLock {
         withContext(dispatcherProvider.io()) {
+            return@withContext true
             preferences.getBoolean(PREFS_KEY_ENABLED, false)
         }
     }
```
- [ ] Clean install the app
- [ ] Verify that on initial onboarding screen the CTA is 'Let's get started'.
- [ ] Verify that on the input demo screen the input hint is 'Ask anything privately'
- [ ] Verify that on subscription promo screen CTA is 'Try it free!'.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String and UI label changes only, with no logic or security impact; subscription and welcome variants are gated on `isCustomAiOnboardingFlow`.
> 
> **Overview**
> Updates **custom AI onboarding** copy and wires UI to show flow-specific button labels without changing the default brand-design onboarding strings.
> 
> When `isCustomAiOnboardingFlow` is on, the welcome screen primary CTA uses **Let's get started!** (`preOnboardingDaxDialog1ButtonBrandDesign`); the default path still uses `preOnboardingDaxDialog1Button`. The same branching is applied in both animated and snap (`showDialogWithoutAnimation`) welcome setup.
> 
> For the Privacy Pro subscription bubble, free-trial primary button text switches to **Try it free!** in the custom AI flow; other flows keep the existing free-trial string.
> 
> Non-translated strings add those brand-design CTA entries, change the input demo chat hint to **Ask anything privately**, and shorten the custom-AI Privacy Pro body to mention **GPT and Claude** only (Llama removed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 400c7d0ab0fab68a70dcab9015b5b2a90b3b929a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->