### PR TITLE
Update test annotation to @InternalPrivacyTest for request blocklist …

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/espresso/RequestBlocklistTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/espresso/RequestBlocklistTest.kt
@@ -58,7 +58,7 @@ class RequestBlocklistTest {
         registeredResources.forEach { IdlingRegistry.getInstance().unregister(it) }
     }
 
-    @Test @PrivacyTest
+    @Test @InternalPrivacyTest
     fun whenRequestBlocklistIsEnabledRequestsAreHandledCorrectly() {
         preparationsForPrivacyTest()
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200905986587319/task/1215940160973445?focus=true
Tech Design URL (if applicable): 

### Description
As part of [✓ Several Privacy Tests failed on 22 Jun 2026](https://app.asana.com/1/137249556945/project/488551667048375/task/1215940160973432?focus=true) I moved this test out of Internal as I made some changes to how the privacy page was loaded.

It looks like there are some other parts related to this test that require an internal build.

Brought back the `@InternalPrivacyTest` annotation.

### Steps to test this PR
No QA, code review only.

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single test annotation change with no production or runtime behavior impact.
> 
> **Overview**
> Reverts the request blocklist Espresso test to **`@InternalPrivacyTest`** instead of **`@PrivacyTest`**, so it is scheduled only on the internal build variant again.
> 
> The test body is unchanged; only the annotation on `whenRequestBlocklistIsEnabledRequestsAreHandledCorrectly` is updated to match dependencies that still require internal-only behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a1e037b16def7351af139e07b5df70ba98983ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->