### PR TITLE
Make Duck.ai picker E2E tests model agnostic

### DIFF
--- a/.maestro/unified_input_screen/shared/flow_duckai_model_reasoning.yaml
+++ b/.maestro/unified_input_screen/shared/flow_duckai_model_reasoning.yaml
@@ -10,42 +10,28 @@ appId: com.duckduckgo.mobile.android
 # as the tab title in the input mode switcher, so a text tap is unambiguous
 - tapOn: "Duck.ai"
 
-# wait for the Duck.ai bottom row to settle — model picker is the marker
+# wait for the Duck.ai bottom row to settle — model picker is the marker.
+# Generous timeout: the chip only renders once the model list loads from the
+# network, so a slow fetch on CI can otherwise leave it briefly hidden.
 - extendedWaitUntil:
     visible:
       id: "modelPickerChip"
-    timeout: 10000
+    timeout: 30000
 
-# default model is GPT-5 mini, chip text shows "GPT-5" (truncated)
-- assertVisible:
-    text: "GPT-5"
-    childOf:
-      id: "modelPickerChip"
-
-# open the model picker and assert at least one non-default model is listed
-- tapOn:
+# Capture the default model's chip label rather than hardcoding it. Model names
+# are backend-driven and have changed before (e.g. "GPT-5" -> "5.4-mini"), so we
+# read the label at runtime and assert on a *change* rather than a literal name.
+- copyTextFrom:
     id: "modelPickerChip"
-- assertVisible:
-    text: "Claude Haiku 2.5"
+- evalScript: ${output.defaultModel = maestro.copiedText}
 
-# pick Claude Haiku 2.5 and assert the chip updated away from the default
-# (the chip short name is backend-driven, so assert it's no longer "GPT-5"
-# rather than hardcoding Haiku's truncated label)
-- tapOn: "Claude Haiku 2.5"
-- assertNotVisible:
-    text: "GPT-5"
-    childOf:
-      id: "modelPickerChip"
-
-# switch back to GPT-5 mini so the reasoning picker is available
-- tapOn:
-    id: "modelPickerChip"
-- tapOn: "GPT-5 mini"
+# the default model supports reasoning, so the reasoning picker is available
 - extendedWaitUntil:
     visible:
       id: "reasoningModePickerButton"
     timeout: 5000
 
+# --- Reasoning picker: labels are local string resources, so they are stable ---
 # open the reasoning picker and assert both options are listed
 - tapOn:
     id: "reasoningModePickerButton"
@@ -69,3 +55,34 @@ appId: com.duckduckgo.mobile.android
     text: "Reasoning"
 - assertVisible:
     text: "Fast"
+# re-tap "Reasoning" (already selected, so a no-op) just to dismiss the picker
+- tapOn:
+    text: "Reasoning"
+- assertNotVisible:
+    text: "For complex tasks"
+
+# --- Model picker: verify we can switch to a different model ---
+- tapOn:
+    id: "modelPickerChip"
+# The picker renders each model as a row whose label uses id "label". Read the
+# labels straight from the list instead of hardcoding names: index 0 is the
+# selected default, index 1 is another model. Asserting they differ proves the
+# list actually offers an alternative to switch to (and fails clearly if only a
+# single model is available).
+- copyTextFrom:
+    id: "label"
+    index: 0
+- evalScript: ${output.firstModel = maestro.copiedText}
+- copyTextFrom:
+    id: "label"
+    index: 1
+- evalScript: ${output.secondModel = maestro.copiedText}
+- assertTrue: ${output.firstModel != output.secondModel}
+
+# switch to that other model and confirm the chip label moved off the default
+- tapOn:
+    id: "label"
+    index: 1
+- copyTextFrom:
+    id: "modelPickerChip"
+- assertTrue: ${maestro.copiedText != output.defaultModel}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215979853131334

### Description

The `UnifiedInput: change duck.ai model and reasoning effort` E2E flow kept
failing because it hardcoded backend-driven model names. Model labels are
served live from a remote endpoint (`DuckAiModelManager.fetchModels`) with no
bundled fallback, so the default model's short name drifts over time
(e.g. `GPT-5` → `5.4-mini`) and breaks the assertions. It had already been
patched once for the same reason in #8889. A secondary failure (`modelPickerChip`
reported not visible) came from the chip only rendering once the model list
finishes loading, with too tight a wait on CI.

This makes the shared `flow_duckai_model_reasoning.yaml` model agnostic:

- Reads the chip label at runtime (`copyTextFrom`) and asserts on a *change*
  rather than a literal model name.
- Exercises the reasoning picker first, on the default model — its labels
  (`Fast` / `Reasoning` / `For complex tasks`) are local string resources and
  stable. This also removes the old step that switched back to a named model.
- Drives the model switch from the picker rows themselves: reads two row labels
  (`id: "label"`, index 0/1), asserts they differ (fails clearly if only one
  model is available), taps the alternative, then confirms the chip moved off
  the captured default.
- Bumps the `modelPickerChip` wait `10s → 30s` for slow model loads.

No production code changed; the three-position wrapper flow is unchanged.

### Steps to test this PR

_Model + reasoning picker E2E_
- [ ] Run `maestro test .maestro/unified_input_screen/unified_input_duckai_model_reasoning.yaml` against an internal build (native input enabled)
- [ ] Confirm all three omnibar iterations (top / bottom / split) pass
- [ ] Confirm no model name is hardcoded anywhere in the flow

### UI changes

No UI changes (test-only).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Maestro YAML changes with no production or runtime behavior impact.
> 
> **Overview**
> Updates the shared Maestro flow **`flow_duckai_model_reasoning.yaml`** so Duck.ai model/reasoning E2E no longer depends on backend-driven model names.
> 
> **Waits:** `modelPickerChip` visibility timeout is **10s → 30s** to tolerate slow model-list loads on CI.
> 
> **Default model:** The flow **captures** the chip label at runtime (`copyTextFrom` + `evalScript`) instead of asserting literals like `"GPT-5"` or tapping named models such as `"Claude Haiku 2.5"` / `"GPT-5 mini"`.
> 
> **Order & reasoning:** **Reasoning picker** runs first on the default model (still asserts stable local strings `Fast`, `Reasoning`, `For complex tasks`), including a re-tap to dismiss; the old “switch back to a named default for reasoning” path is removed.
> 
> **Model switch:** Opens the picker, reads two row **`label`** texts (index 0 vs 1), asserts they differ, selects index 1, and asserts the chip text **≠** the captured default—so the test validates behavior without hardcoded model catalog strings.
> 
> No app/production code changes; wrapper flows that `runFlow` this file are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37d942f9f99552146b7614cf8eef6acff1660e0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->