### PR TITLE
Update content scope scripts to version 15.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -678,18 +678,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.3.tgz",
-      "integrity": "sha512-27ep5H9PzdBrNd5OFM/j3WCU8F3kPwM9D0BOaOf7uYfxMJfyr0K5Tjj69Gri+sZlh2WXd5buIm47NuPF29CDiw==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.4.tgz",
+      "integrity": "sha512-vwVLJVvvpslm7vqAH7+XNj/neA/Ynq7DT2EEcMuwc5YzN5XaMyRAqxwU+uX3azZ1FQtB2gvrvnLnAEkvYlVdfg==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.4.3.tgz",
-      "integrity": "sha512-C7+TxJdmrhTA2fs1VvOcGrnFhK1qvOgYIAFJ0Q9L5GaoQ7QkR0TLm9ooXTgF4d4xgL6qm6qYtiYN3AX0DWwgBA==",
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.4.4.tgz",
+      "integrity": "sha512-L1xvJQNZQFrhjyAFmFlOoijmd9lSOvK6bGs0+z8Nz91UCAIyVIShwOsPPStuQH4XCFwif5Hlmcr6DnEz7Ag7Xw==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.4.3"
+        "tldts-core": "^7.4.4"
       }
     },
     "node_modules/undici-types": {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1215987229321391

- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the version of injected content-scope privacy scripts shipped to users; scope is limited to a routine dependency bump rather than local app logic.
> 
> **Overview**
> **Bumps `@duckduckgo/content-scope-scripts` to `15.5.0`** (Git ref in `package.json` / lockfile), refreshing the resolved commit and any bundled assets copied from that package for the Android browser.
> 
> The lockfile also moves transitive **`tldts-core` / `tldts-experimental` from 7.4.3 to 7.4.4** (used by adblocker-related deps such as `@duckduckgo/autoconsent`).
> 
> This is an automated dependency refresh; CI only runs privacy/e2e paths when files under `node_modules/@duckduckgo/content-scope-scripts` change, not for a version-only lockfile tweak.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e91f8f30f2188d3017e48201ad504fad4cf1dd23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->