### PR TITLE
Embed Asana task link in auto-generated PRs

### DIFF
--- a/.github/workflows/update-pir-broker-bundle.yml
+++ b/.github/workflows/update-pir-broker-bundle.yml
@@ -47,6 +47,30 @@ jobs:
         if: ${{ steps.broker-check.outputs.has_changes == 'true' }}
         run: echo "current_date=$(date +'%Y-%m-%d')" >> "$GITHUB_ENV"
 
+      - name: Create Asana task
+        if: ${{ steps.broker-check.outputs.has_changes == 'true' }}
+        id: create-task
+        uses: duckduckgo/native-github-asana-sync@v2.0
+        with:
+          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
+          asana-section: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
+          asana-task-name: "Update PIR broker bundle - ${{ env.current_date }}"
+          asana-task-description: |
+            PIR broker JSON files have been updated and a PR will be created.
+
+            ${{ env.changes_summary }}
+          action: 'create-asana-task'
+
+      - name: Get Asana task permalink
+        if: ${{ steps.broker-check.outputs.has_changes == 'true' }}
+        id: get-task-permalink
+        uses: duckduckgo/native-github-asana-sync@v2.0
+        with:
+          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana-task-id: ${{ steps.create-task.outputs.taskId }}
+          action: 'get-asana-task-permalink'
+
       - name: Create Pull Request
         if: ${{ steps.broker-check.outputs.has_changes == 'true' }}
         id: create-pr
@@ -60,6 +84,8 @@ jobs:
           branch: automated/update-pir-broker-bundle-${{ env.current_date }}
           add-paths: pir/pir-impl/src/main/assets/brokers
           body: |
+            Task/Issue URL: ${{ steps.get-task-permalink.outputs.asanaTaskPermalink }}
+
             ## PIR Broker Bundle Update
 
             Automated update of PIR broker JSON files from the remote bundle.
@@ -82,35 +108,6 @@ jobs:
             --method POST \
             -f "labels[]=pir" \
             -f "labels[]=automated pr"
-
-      - name: Create Asana task
-        if: ${{ steps.broker-check.outputs.has_changes == 'true' }}
-        id: create-task
-        uses: duckduckgo/native-github-asana-sync@v2.0
-        with:
-          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
-          asana-section: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
-          asana-task-name: "Update PIR broker bundle - ${{ env.current_date }}"
-          asana-task-description: |
-            PIR broker JSON files have been updated and a PR has been created.
-
-            ${{ env.changes_summary }}
-
-            See ${{ steps.create-pr.outputs.pull-request-url }}
-          action: 'create-asana-task'
-
-      - name: Update PR description with Asana task
-        if: ${{ steps.broker-check.outputs.has_changes == 'true' && steps.create-task.outputs.duplicate == 'false' }}
-        uses: duckduckgo/native-github-asana-sync@v2.0
-        with:
-          github-pat: ${{ secrets.GT_DAXMOBILE }}
-          github-pr: ${{ steps.create-pr.outputs.pull-request-number }}
-          github-repository: 'android'
-          github-org: 'duckduckgo'
-          asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
-          asana-task-id: ${{ steps.create-task.outputs.taskId }}
-          action: 'add-task-pr-description'
 
       - name: Create Asana task when workflow failed
         if: ${{ failure() }}

--- a/.github/workflows/update-ref-tests.yml
+++ b/.github/workflows/update-ref-tests.yml
@@ -69,6 +69,30 @@ jobs:
           string: ${{steps.find-latest-release.outputs.prop}}
           split-by: '#'
 
+      - name: Create Asana task in Android App project
+        if: ${{ steps.update-check.outcome == 'failure' }}
+        id: create-task
+        uses: duckduckgo/native-github-asana-sync@v2.0
+        with:
+          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
+          asana-section: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
+          asana-task-name: Update reference tests to version ${{ steps.extract-release-version.outputs._1}}
+          asana-task-description: |
+            Reference tests have been updated and a PR will be created.
+
+            If tests failed check out https://app.asana.com/0/0/1203766026095653/f for further information on what to do next.
+          action: 'create-asana-task'
+
+      - name: Get Asana task permalink
+        if: ${{ steps.update-check.outcome == 'failure' }}
+        id: get-task-permalink
+        uses: duckduckgo/native-github-asana-sync@v2.0
+        with:
+          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana-task-id: ${{ steps.create-task.outputs.taskId }}
+          action: 'get-asana-task-permalink'
+
       - name: Create Pull Request in Android repo
         if: ${{ steps.update-check.outcome == 'failure' }}
         env:
@@ -84,29 +108,14 @@ jobs:
           labels: reference tests, automated pr
           branch: automated/update-ref-tests-dependencies-${{ steps.extract-release-version.outputs._1}}
           body: |
+            Task/Issue URL: ${{ steps.get-task-permalink.outputs.asanaTaskPermalink }}
+
             - Automated reference tests dependency update
-            
+
             This PR updates the reference tests dependency to the latest available version and copies the necessary files.
             If tests have failed, see https://app.asana.com/0/0/1203766026095653/f for further information on what to do next.
-            
-            - [ ] All tests must pass
 
-      - name: Create Asana task in Android App project
-        if: ${{ steps.update-check.outcome == 'failure' }}
-        id: create-task
-        uses: duckduckgo/native-github-asana-sync@v2.0
-        with:
-          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
-          asana-section: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
-          asana-task-name: Update reference tests to version ${{ steps.extract-release-version.outputs._1}}
-          asana-task-description: |
-            Reference tests have been updated and a PR created.
-            
-            If tests failed check out https://app.asana.com/0/0/1203766026095653/f for further information on what to do next.
-            
-            See ${{ steps.create-pr.outputs.pull-request-url }}
-          action: 'create-asana-task'
+            - [ ] All tests must pass
 
       - name: Add Asana task to Release Board project
         if: ${{ steps.create-task.outputs.duplicate == 'false' }}
@@ -117,18 +126,6 @@ jobs:
           asana-section: ${{ vars.GH_ANDROID_RELEASE_BOARD_PR_SECTION_ID }}
           asana-task-id: ${{ steps.create-task.outputs.taskId }}
           action: 'add-task-asana-project'
-
-      - name: Update PR description with Asana task
-        if: ${{ steps.create-task.outputs.duplicate == 'false' }}
-        uses: duckduckgo/native-github-asana-sync@v2.0
-        with:
-          github-pat: ${{ secrets.GT_DAXMOBILE }}
-          github-pr: ${{ steps.create-pr.outputs.pull-request-number }}
-          github-repository: 'android'
-          github-org: 'duckduckgo'
-          asana-project: ${{ vars.GH_ANDROID_RELEASE_BOARD_PROJECT_ID }}
-          asana-task-id: ${{ steps.create-task.outputs.taskId }}
-          action: 'add-task-pr-description'
 
       - name: Create Asana task when workflow failed
         if: ${{ failure() }}

--- a/.github/workflows/update-ref-tests.yml
+++ b/.github/workflows/update-ref-tests.yml
@@ -104,7 +104,7 @@ jobs:
           title: Update reference tests to version ${{ steps.extract-release-version.outputs._1}}
           author: daxmobile <daxmobile@users.noreply.github.com>
           token: ${{ secrets.GT_DAXMOBILE }}
-          commit-message: Update content scope scripts to version ${{ steps.extract-release-version.outputs._1}}
+          commit-message: Update reference tests to version ${{ steps.extract-release-version.outputs._1}}
           labels: reference tests, automated pr
           branch: automated/update-ref-tests-dependencies-${{ steps.extract-release-version.outputs._1}}
           body: |


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1215839555466064?focus=true

### Description
Automated dependency-update PRs now include the Asana task link in the description from the moment they're created.

  **Before:** the workflow created the PR first (no task link), then created the Asana task, then patched the link into the PR afterwards. Since action-pr-opened became a required check — it reads Task/Issue URL:
  from the PR body on the opened event — these PRs opened without the link and failed the check.

  **Now:** the workflow creates the Asana task first, fetches its permalink, and opens the PR with Task/Issue URL: <link> as the first line of the description. The redundant "update PR description afterwards" step
  is removed. The PR→task back-link is still added automatically by action-pr-opened (pinned comment), so nothing is lost.

  **Scope:** this PR changes `update-ref-tests.yml` and `update-pir-broker-bundle.yml`. `pdate-content-scope.yml` was already fixed.


### Steps to test this PR
- [ ] CI passes

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow ordering and PR body content only; no app runtime or security-sensitive code paths.
> 
> **Overview**
> Automated **PIR broker bundle** and **reference tests** workflows now create the Asana task and fetch its permalink **before** opening the PR, with `Task/Issue URL:` as the first line of the PR body at creation time.
> 
> The follow-up steps that patched the PR description after open (`add-task-pr-description`) are **removed**, since `action-pr-opened` expects that link on the opened event. Asana task copy is updated to say a PR “will be created” instead of linking the PR URL in the task description.
> 
> In **update-ref-tests**, the automated PR **commit message** is corrected from content-scope scripts wording to reference tests version text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac27a0524a06b0314d8469c917546dae682a48e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->