### PR TITLE
Sync exchange v2: ensure implicit aborts go to terminal state

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
 import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
 import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_UNAVAILABLE
+import com.duckduckgo.sync.impl.AccountErrorCodes.UNEXPECTED_EVENT
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
@@ -120,40 +121,9 @@ class RealSyncCodeDispatcher @Inject constructor(
         }
     }
 
-    /**
-     * Translate one runner event into a [DispatchOutcome] for the v2 Presenter flow,
-     * or null for intermediate events the caller should ignore. Both Host and Joiner roles are
-     * reachable here; mirrors [mapV2LinkingEventToOutcome] (login on Joiner.Done, preserve abort reason).
-     */
     private fun mapV2PresentEventToOutcome(event: ExchangeV2Event, peerKind: PeerKind?): DispatchOutcome? = when (event) {
         is ExchangeV2Event.SessionStarted -> event.linkingCode?.let { DispatchOutcome.LinkingCodeReady(it) }
-        is ExchangeV2Event.Transition -> when (event.to) {
-            ExchangeV2State.Joiner.Confirming ->
-                DispatchOutcome.JoinerConfirmationRequested(peerName = runner.peerName, peerKind = peerKind)
-            ExchangeV2State.Host.Confirming ->
-                DispatchOutcome.HostConfirmationRequested(peerName = runner.peerName, peerKind = peerKind)
-            ExchangeV2State.Host.Done -> DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST, peerKind)
-            ExchangeV2State.Host.Aborted -> hostAbortedToOutcome(event.localTrigger)
-            ExchangeV2State.SameAccountAbort -> DispatchOutcome.AlreadyConnected
-            ExchangeV2State.Joiner.Done -> {
-                val received = (event.trigger as? ExchangeV2Message.RecoveryCodeResponse)?.recoveryCode
-                if (received.isNullOrBlank()) {
-                    DispatchOutcome.Failed("Pairing completed without a recovery code", NO_RECOVERY_CODE.code)
-                } else {
-                    loginWithV2RecoveryCode(received, peerKind)
-                }
-            }
-            ExchangeV2State.Joiner.AbortedByHost -> when (event.trigger) {
-                is ExchangeV2Message.RecoveryCodeDenied ->
-                    DispatchOutcome.Failed("Pairing declined by peer", PAIRING_REJECTED.code)
-                is ExchangeV2Message.RecoveryCodeUnavailable ->
-                    DispatchOutcome.Failed("Peer has no recovery code", PAIRING_UNAVAILABLE.code)
-                else -> DispatchOutcome.Failed("Pairing aborted by peer", PAIRING_REJECTED.code)
-            }
-            ExchangeV2State.Joiner.AbortedLocal -> DispatchOutcome.Failed("Pairing cancelled on this device", PAIRING_CANCELLED.code)
-            ExchangeV2State.Aborted -> DispatchOutcome.Failed("negotiation_aborted", NEGOTIATION_ABORTED.code)
-            else -> null
-        }
+        is ExchangeV2Event.Transition -> mapV2Transition(event, peerKind)
         is ExchangeV2Event.SessionError -> sessionErrorToOutcome(event.message)
         else -> null
     }
@@ -317,41 +287,41 @@ class RealSyncCodeDispatcher @Inject constructor(
         -> true
     }
 
-    /**
-     * Translate one runner event into a terminal [DispatchOutcome] for the v2 scanner flow,
-     * or null for intermediate events the caller should ignore.
-     */
     private fun mapV2LinkingEventToOutcome(event: ExchangeV2Event, peerKind: PeerKind?): DispatchOutcome? = when (event) {
-        is ExchangeV2Event.Transition -> when (event.to) {
-            ExchangeV2State.Joiner.Confirming ->
-                DispatchOutcome.JoinerConfirmationRequested(peerName = runner.peerName, peerKind = peerKind)
-            ExchangeV2State.Host.Confirming ->
-                DispatchOutcome.HostConfirmationRequested(peerName = runner.peerName, peerKind = peerKind)
-            ExchangeV2State.Joiner.Done -> {
-                val received = (event.trigger as? ExchangeV2Message.RecoveryCodeResponse)?.recoveryCode
-                if (received.isNullOrBlank()) {
-                    DispatchOutcome.Failed("Pairing completed without a recovery code", NO_RECOVERY_CODE.code)
-                } else {
-                    loginWithV2RecoveryCode(received, peerKind)
-                }
-            }
-            ExchangeV2State.Joiner.AbortedByHost -> when (event.trigger) {
-                is ExchangeV2Message.RecoveryCodeDenied ->
-                    DispatchOutcome.Failed("Pairing declined by peer", PAIRING_REJECTED.code)
-                is ExchangeV2Message.RecoveryCodeUnavailable ->
-                    DispatchOutcome.Failed("Peer has no recovery code", PAIRING_UNAVAILABLE.code)
-                else -> DispatchOutcome.Failed("Pairing aborted by peer", PAIRING_REJECTED.code)
-            }
-            ExchangeV2State.Joiner.AbortedLocal -> DispatchOutcome.Failed("Pairing cancelled on this device", PAIRING_CANCELLED.code)
-            ExchangeV2State.Host.Aborted -> hostAbortedToOutcome(event.localTrigger)
-            // Per spec §"Same-account case": not an abort; both devices share an account already.
-            ExchangeV2State.SameAccountAbort -> DispatchOutcome.AlreadyConnected
-            // Elected Host and shared a recovery code — success from this device's perspective.
-            ExchangeV2State.Host.Done -> DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST, peerKind)
-            ExchangeV2State.Aborted -> DispatchOutcome.Failed("negotiation_aborted", NEGOTIATION_ABORTED.code)
-            else -> null
-        }
+        is ExchangeV2Event.Transition -> mapV2Transition(event, peerKind)
         is ExchangeV2Event.SessionError -> sessionErrorToOutcome(event.message)
+        else -> null
+    }
+
+    private fun mapV2Transition(
+        transition: ExchangeV2Event.Transition,
+        peerKind: PeerKind?,
+    ): DispatchOutcome? = when (transition.to) {
+        ExchangeV2State.Joiner.Confirming ->
+            DispatchOutcome.JoinerConfirmationRequested(peerName = runner.peerName, peerKind = peerKind)
+        ExchangeV2State.Host.Confirming ->
+            DispatchOutcome.HostConfirmationRequested(peerName = runner.peerName, peerKind = peerKind)
+        ExchangeV2State.Host.Done -> DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST, peerKind)
+        ExchangeV2State.Host.Aborted -> hostAbortedToOutcome(transition.localTrigger, transition.trigger)
+        // Per spec §"Same-account case": not an abort; both devices share an account already.
+        ExchangeV2State.SameAccountAbort -> DispatchOutcome.AlreadyConnected
+        ExchangeV2State.Joiner.Done -> {
+            val received = (transition.trigger as? ExchangeV2Message.RecoveryCodeResponse)?.recoveryCode
+            if (received.isNullOrBlank()) {
+                DispatchOutcome.Failed("joiner_done_missing_recovery_code", NO_RECOVERY_CODE.code)
+            } else {
+                loginWithV2RecoveryCode(received, peerKind)
+            }
+        }
+        ExchangeV2State.Joiner.AbortedByHost -> when (transition.trigger) {
+            is ExchangeV2Message.RecoveryCodeDenied ->
+                DispatchOutcome.Failed("peer_denied_recovery_code", PAIRING_REJECTED.code)
+            is ExchangeV2Message.RecoveryCodeUnavailable ->
+                DispatchOutcome.Failed("peer_recovery_code_unavailable", PAIRING_UNAVAILABLE.code)
+            else -> DispatchOutcome.Failed("peer_aborted", PAIRING_REJECTED.code)
+        }
+        ExchangeV2State.Joiner.AbortedLocal -> joinerAbortedLocalToOutcome(transition.localTrigger, transition.trigger)
+        ExchangeV2State.Aborted -> DispatchOutcome.Failed("negotiation_aborted", NEGOTIATION_ABORTED.code)
         else -> null
     }
 
@@ -364,10 +334,23 @@ class RealSyncCodeDispatcher @Inject constructor(
         }
     }
 
-    private fun hostAbortedToOutcome(localTrigger: LocalTrigger?): DispatchOutcome = when (localTrigger) {
-        LocalTrigger.UserDeniedHost -> DispatchOutcome.Failed("user_denied", PAIRING_CANCELLED.code)
-        LocalTrigger.HostUnavailable -> DispatchOutcome.Failed("host_unavailable", PAIRING_UNAVAILABLE.code)
+    private fun hostAbortedToOutcome(
+        localTrigger: LocalTrigger?,
+        wireTrigger: ExchangeV2Message?,
+    ): DispatchOutcome = when {
+        localTrigger == LocalTrigger.UserDeniedHost -> DispatchOutcome.Failed("user_denied", PAIRING_CANCELLED.code)
+        localTrigger == LocalTrigger.HostUnavailable -> DispatchOutcome.Failed("host_unavailable", PAIRING_UNAVAILABLE.code)
+        wireTrigger != null -> DispatchOutcome.Failed("host_protocol_error", UNEXPECTED_EVENT.code)
         else -> DispatchOutcome.Failed("host_aborted", NEGOTIATION_ABORTED.code)
+    }
+
+    private fun joinerAbortedLocalToOutcome(
+        localTrigger: LocalTrigger?,
+        wireTrigger: ExchangeV2Message?,
+    ): DispatchOutcome = when {
+        localTrigger == LocalTrigger.UserDeniedJoiner -> DispatchOutcome.Failed("user_denied_joiner", PAIRING_CANCELLED.code)
+        wireTrigger != null -> DispatchOutcome.Failed("joiner_protocol_error", UNEXPECTED_EVENT.code)
+        else -> DispatchOutcome.Failed("joiner_local_aborted", PAIRING_FAILED.code)
     }
 
     /**
@@ -433,17 +416,6 @@ class RealSyncCodeDispatcher @Inject constructor(
         Base64.encodeToString(bytes, Base64.NO_WRAP)
     }.getOrNull()
 
-    /**
-     * Map a repo [Result] to a [DispatchOutcome].
-     *
-     * If [codeForAccountSwitch] is supplied and the repo failed with [ALREADY_SIGNED_IN], switch
-     * accounts transparently via [SyncAccountRepository.logoutAndJoinNewAccount] with no prompt:
-     * the Confirmations phase is already the consent step, so the v1 `AskToSwitchAccount` dialog
-     * does not apply.
-     *
-     * [codeForAccountSwitch] must be a v1 b64 shape [SyncAccountRepository.parseSyncAuthCode] can
-     * re-parse, so v2 callers convert first (see [encodeV1RecoveryCodeAsB64]).
-     */
     /** Map the runner's raw peer credential id ("ddg"/"3party") to the telemetry [PeerKind], or null. */
     private fun String?.toPeerKind(): PeerKind? = when (this) {
         CID_DDG -> PeerKind.DDG

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
@@ -1493,6 +1493,7 @@ enum class AccountErrorCodes(val code: Int) {
     NEGOTIATION_ABORTED(61),
     NO_RECOVERY_CODE(62),
     PAIRING_FAILED(63),
+    UNEXPECTED_EVENT(64),
 }
 
 sealed interface SyncAuthCode {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachine.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachine.kt
@@ -82,7 +82,6 @@ internal class RealExchangeV2StateMachine(
             ExchangeV2State.Negotiating -> receiveInNegotiating(state, msg)
             ExchangeV2State.Joiner.Confirming -> receiveInJoinerConfirming(state, msg)
             ExchangeV2State.Joiner.Waiting -> receiveInJoinerWaiting(state, msg)
-            // All other states: any known incoming message is an implicit abort.
             else -> abort(state, msg, RejectReason.ImplicitAbort)
         }
     }
@@ -98,7 +97,11 @@ internal class RealExchangeV2StateMachine(
     }
 
     private fun receiveInBootstrapped(state: ExchangeV2State, msg: ExchangeV2Message): TransitionResult {
-        return if (msg is Hello) accept(state, ExchangeV2State.Negotiating, msg) else abort(state, msg, RejectReason.ImplicitAbort)
+        return if (msg is Hello) {
+            accept(state, ExchangeV2State.Negotiating, msg)
+        } else {
+            abort(state, msg, RejectReason.ImplicitAbort)
+        }
     }
 
     private fun receiveInNegotiating(state: ExchangeV2State, msg: ExchangeV2Message): TransitionResult {
@@ -107,7 +110,7 @@ internal class RealExchangeV2StateMachine(
             // (Scanner: by scanning the QR; Presenter: consumed in receiveInBootstrapped).
             // Any further hello is a duplicate or the double-scan race → abort and close the
             // channel. Deliberate "record a pixel; abort (scope-cut)" (pixel deferred: Asana 1215473364991760).
-            is Hello -> abort(state, msg, RejectReason.ImplicitAbort, newState = ExchangeV2State.Aborted)
+            is Hello -> abort(state, msg, RejectReason.ImplicitAbort)
             is RecoveryCodeAvailable -> {
                 if (localUserId != null && msg.userId == localUserId) {
                     abort(state, msg, RejectReason.SameAccount, newState = ExchangeV2State.SameAccountAbort)
@@ -131,16 +134,8 @@ internal class RealExchangeV2StateMachine(
         }
     }
 
-    /**
-     * The SM-spec diagram (1215056232572322) lists no valid *incoming wire message* in
-     * Joiner.Confirming — the only expected transitions out are the local UserConfirmedJoiner /
-     * UserDeniedJoiner — so per the implicit-abort rule every received message here would abort.
-     * We extend that: if the peer explicitly tells us they're aborting (recovery_code_denied /
-     * recovery_code_unavailable), we accept it and end the session instead of making the user
-     * confirm a doomed pairing first. The remaining host-side messages (awaiting_confirmation,
-     * confirmed, response) are still rejected here; the runner buffers them and replays after
-     * the user confirms.
-     */
+    // If the peer aborts while we're still showing the confirm prompt, act on it now instead of
+    // making the user confirm a doomed pairing.
     private fun receiveInJoinerConfirming(state: ExchangeV2State, msg: ExchangeV2Message): TransitionResult {
         return when (msg) {
             is RecoveryCodeDenied -> accept(state, ExchangeV2State.Joiner.AbortedByHost, msg)
@@ -260,7 +255,7 @@ internal class RealExchangeV2StateMachine(
         from: ExchangeV2State,
         msg: ExchangeV2Message,
         reason: RejectReason,
-        newState: ExchangeV2State = from,
+        newState: ExchangeV2State = from.abortTerminal(),
     ): TransitionResult {
         currentState = newState
         val event = if (newState == from) {
@@ -285,11 +280,11 @@ internal class RealExchangeV2StateMachine(
         from: ExchangeV2State,
         trigger: LocalTrigger,
     ): TransitionResult {
-        // Local triggers that are out-of-sequence are protocol misuse from the runner. We
-        // surface them as a synthetic rejection rather than crashing
+        val newState = from.abortTerminal()
+        currentState = newState
         return TransitionResult(
-            newState = from,
-            event = ExchangeV2Event.Transition(clock.nowMs(), from, from, trigger = null, localTrigger = trigger),
+            newState = newState,
+            event = ExchangeV2Event.Transition(clock.nowMs(), from, newState, trigger = null, localTrigger = trigger),
             outcome = TransitionOutcome.Aborted(RejectReason.ImplicitAbort),
         )
     }
@@ -301,4 +296,19 @@ internal class RealExchangeV2StateMachine(
             outcome = TransitionOutcome.Dropped,
         )
     }
+}
+
+/** Terminal state to drive into on an implicit abort from [this]. Terminals return themselves. */
+private fun ExchangeV2State.abortTerminal(): ExchangeV2State = when (this) {
+    ExchangeV2State.Host.Confirming, ExchangeV2State.Host.Sending -> ExchangeV2State.Host.Aborted
+    ExchangeV2State.Joiner.Confirming, ExchangeV2State.Joiner.Waiting -> ExchangeV2State.Joiner.AbortedLocal
+    ExchangeV2State.Bootstrapped, ExchangeV2State.Negotiating -> ExchangeV2State.Aborted
+    ExchangeV2State.Aborted,
+    ExchangeV2State.SameAccountAbort,
+    ExchangeV2State.Host.Aborted,
+    ExchangeV2State.Host.Done,
+    ExchangeV2State.Joiner.AbortedByHost,
+    ExchangeV2State.Joiner.AbortedLocal,
+    ExchangeV2State.Joiner.Done,
+    -> this
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachine.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachine.kt
@@ -245,11 +245,11 @@ internal class RealExchangeV2StateMachine(
     }
 
     /**
-     * The SM rejected [msg] in state [from]. When [newState] == [from] the SM stays put (e.g.
-     * a duplicate `hello` in Negotiating) and the event is a [MessageRejected]; when [newState]
-     * differs the SM is actually transitioning into [newState] driven by [msg] (e.g. same-account
-     * detected, per Asana state-machine spec `1215056232572322`), and we emit a [Transition] so
-     * downstream consumers can react to the new terminal state.
+     * Reject [msg] and abort. By default we drive to [from]'s terminal state (see [abortTerminal]):
+     *  - If [from] is still active, that's a real transition into the terminal → emit [Transition].
+     *  - If [from] is already terminal, [abortTerminal] returns itself, so we stay put → emit [MessageRejected].
+     *
+     * Callers can override [newState] to abort somewhere other than the default terminal.
      */
     private fun abort(
         from: ExchangeV2State,

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeActivity.kt
@@ -153,7 +153,8 @@ class EnterCodeActivity : DuckDuckGoActivity() {
             is Command.AskJoinerConfirmation -> askJoinerConfirmation(command.peerName, command.peerKind)
             is Command.AskHostConfirmation -> askHostConfirmation(command.peerName, command.peerKind)
             Command.FinishWithError -> {
-                setResult(RESULT_CANCELED)
+                val resultIntent = Intent().putExtra(EXTRA_FINISHED_WITH_ERROR, true)
+                setResult(RESULT_CANCELED, resultIntent)
                 finish()
             }
         }
@@ -228,6 +229,7 @@ class EnterCodeActivity : DuckDuckGoActivity() {
         private const val EXTRA_CODE_TYPE = "codeType"
 
         const val EXTRA_USER_SWITCHED_ACCOUNT = "userSwitchedAccount"
+        const val EXTRA_FINISHED_WITH_ERROR = "finishedWithError"
 
         internal fun intent(context: Context, codeType: Code): Intent {
             return Intent(context, EnterCodeActivity::class.java).apply {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectActivity.kt
@@ -82,8 +82,15 @@ class SyncConnectActivity : DuckDuckGoActivity() {
     private val enterCodeLauncher = registerForActivityResult(
         EnterCodeContract(),
     ) { result ->
-        if (result != EnterCodeContractOutput.Error) {
-            viewModel.onLoginSuccess()
+        when (result) {
+            EnterCodeContractOutput.LoginSuccess,
+            EnterCodeContractOutput.SwitchAccountSuccess,
+            -> viewModel.onLoginSuccess()
+            EnterCodeContractOutput.Error -> {
+                setResult(RESULT_CANCELED)
+                finish()
+            }
+            EnterCodeContractOutput.Cancelled -> {}
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginActivity.kt
@@ -59,8 +59,15 @@ class SyncLoginActivity : DuckDuckGoActivity() {
     private val enterCodeLauncher = registerForActivityResult(
         EnterCodeContract(),
     ) { result ->
-        if (result != EnterCodeContractOutput.Error) {
-            viewModel.onLoginSuccess()
+        when (result) {
+            EnterCodeContractOutput.LoginSuccess,
+            EnterCodeContractOutput.SwitchAccountSuccess,
+            -> viewModel.onLoginSuccess()
+            EnterCodeContractOutput.Error -> {
+                setResult(RESULT_CANCELED)
+                finish()
+            }
+            EnterCodeContractOutput.Cancelled -> {}
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
@@ -443,7 +443,8 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
     fun onEnterCodeResult(result: EnterCodeContractOutput) {
         viewModelScope.launch {
             when (result) {
-                EnterCodeContractOutput.Error -> {}
+                EnterCodeContractOutput.Error -> command.send(FinishWithError)
+                EnterCodeContractOutput.Cancelled -> {}
                 EnterCodeContractOutput.LoginSuccess -> {
                     // Manual entry: EnterCodeViewModel fires "Setup success"; only fire login pixel here.
                     syncPixels.fireLoginPixel()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/EnterCodeContract.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/EnterCodeContract.kt
@@ -22,6 +22,7 @@ import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
 import com.duckduckgo.sync.impl.ui.EnterCodeActivity
 import com.duckduckgo.sync.impl.ui.EnterCodeActivity.Companion.Code
+import com.duckduckgo.sync.impl.ui.EnterCodeActivity.Companion.EXTRA_FINISHED_WITH_ERROR
 import com.duckduckgo.sync.impl.ui.EnterCodeActivity.Companion.EXTRA_USER_SWITCHED_ACCOUNT
 import com.duckduckgo.sync.impl.ui.setup.EnterCodeContract.EnterCodeContractOutput
 
@@ -37,23 +38,18 @@ class EnterCodeContract : ActivityResultContract<Code, EnterCodeContractOutput>(
         resultCode: Int,
         intent: Intent?,
     ): EnterCodeContractOutput {
-        when {
-            resultCode == Activity.RESULT_OK -> {
-                val userSwitchedAccount = intent?.getBooleanExtra(EXTRA_USER_SWITCHED_ACCOUNT, false) ?: false
-                return if (userSwitchedAccount) {
-                    EnterCodeContractOutput.SwitchAccountSuccess
-                } else {
-                    EnterCodeContractOutput.LoginSuccess
-                }
-            }
-
-            else -> return EnterCodeContractOutput.Error
+        if (resultCode == Activity.RESULT_OK) {
+            val userSwitchedAccount = intent?.getBooleanExtra(EXTRA_USER_SWITCHED_ACCOUNT, false) ?: false
+            return if (userSwitchedAccount) EnterCodeContractOutput.SwitchAccountSuccess else EnterCodeContractOutput.LoginSuccess
         }
+        val finishedWithError = intent?.getBooleanExtra(EXTRA_FINISHED_WITH_ERROR, false) ?: false
+        return if (finishedWithError) EnterCodeContractOutput.Error else EnterCodeContractOutput.Cancelled
     }
 
     sealed class EnterCodeContractOutput {
         data object LoginSuccess : EnterCodeContractOutput()
         data object SwitchAccountSuccess : EnterCodeContractOutput()
         data object Error : EnterCodeContractOutput()
+        data object Cancelled : EnterCodeContractOutput()
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
@@ -16,8 +16,13 @@
 
 package com.duckduckgo.sync.impl
 
+import android.annotation.SuppressLint
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN
+import com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.NEGOTIATION_ABORTED
 import com.duckduckgo.sync.impl.AccountErrorCodes.NO_RECOVERY_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
@@ -36,15 +41,12 @@ import com.duckduckgo.sync.impl.exchange.v2.PairingRole
 import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
-import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONObject
 import org.junit.Assert.assertArrayEquals
 import org.junit.Assert.assertEquals
@@ -61,15 +63,15 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
+@SuppressLint("DenyListedApi")
 @RunWith(AndroidJUnit4::class)
 class RealSyncCodeDispatcherTest {
 
-    private val syncFeature: SyncFeature = mock()
-    private val canUseV2: Toggle = mock()
+    private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
     private val syncAccountRepository: SyncAccountRepository = mock()
     private val qrCode: ExchangeV2QrCode = mock()
 
-    private val runnerEventsFlow = MutableSharedFlow<com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event>(replay = 0)
+    private val runnerEventsFlow = MutableSharedFlow<ExchangeV2Event>(replay = 0)
     private val runner: ExchangeV2Runner = mock<ExchangeV2Runner>().also {
         whenever(it.events).thenReturn(runnerEventsFlow)
         whenever(it.eventsSince(any())).thenAnswer { invocation ->
@@ -85,13 +87,12 @@ class RealSyncCodeDispatcherTest {
         runner = runner,
     )
 
-    private fun setV2(enabled: Boolean) {
-        whenever(syncFeature.canUseV2ConnectFlow()).thenReturn(canUseV2)
-        whenever(canUseV2.isEnabled()).thenReturn(enabled)
+    private fun configureFeatureFlag(canUseV2Code: Boolean) {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(Toggle.State(enable = canUseV2Code))
     }
 
-    @Test fun `FF off - returns Legacy with whatever parseSyncAuthCode returned, and never touches qrCode parse`() {
-        setV2(false)
+    @Test fun `v2 flag off - returns Legacy with whatever parseSyncAuthCode returned, and never touches qrCode parse`() {
+        configureFeatureFlag(canUseV2Code = false)
         val expectedAuthCode = SyncAuthCode.Recovery(RecoveryCode(primaryKey = "pk", userId = "u"))
         whenever(syncAccountRepository.parseSyncAuthCode("the-code")).thenReturn(expectedAuthCode)
 
@@ -101,8 +102,8 @@ class RealSyncCodeDispatcherTest {
         verify(qrCode, never()).parse(any())
     }
 
-    @Test fun `FF off - v1 Connect codes return Legacy(Connect) unchanged`() {
-        setV2(false)
+    @Test fun `v2 flag off - v1 Connect codes return Legacy(Connect) unchanged`() {
+        configureFeatureFlag(canUseV2Code = false)
         val connect = SyncAuthCode.Connect(mock())
         whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(connect)
 
@@ -111,8 +112,8 @@ class RealSyncCodeDispatcherTest {
         assertSame(connect, decision.authCode)
     }
 
-    @Test fun `FF off - v1 Exchange codes return Legacy(Exchange) unchanged`() {
-        setV2(false)
+    @Test fun `v2 flag off - v1 Exchange codes return Legacy(Exchange) unchanged`() {
+        configureFeatureFlag(canUseV2Code = false)
         val exchange = SyncAuthCode.Exchange(mock())
         whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(exchange)
 
@@ -121,8 +122,8 @@ class RealSyncCodeDispatcherTest {
         assertSame(exchange, decision.authCode)
     }
 
-    @Test fun `FF off - Unknown codes still bubble back as Legacy(Unknown)`() {
-        setV2(false)
+    @Test fun `v2 flag off - Unknown codes still bubble back as Legacy(Unknown)`() {
+        configureFeatureFlag(canUseV2Code = false)
         val unknown = SyncAuthCode.Unknown("garbage")
         whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(unknown)
 
@@ -131,8 +132,8 @@ class RealSyncCodeDispatcherTest {
         assertSame(unknown, decision.authCode)
     }
 
-    @Test fun `FF off - even a v2-shaped code is routed via legacy parseSyncAuthCode (no v2 parser touched)`() {
-        setV2(false)
+    @Test fun `v2 flag off - even a v2-shaped code is routed via legacy parseSyncAuthCode (no v2 parser touched)`() {
+        configureFeatureFlag(canUseV2Code = false)
         whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(SyncAuthCode.Unknown("v2-shaped-input"))
 
         dispatcher.route("https://duckduckgo.com/sync/pairing/#&code2=anything")
@@ -141,8 +142,8 @@ class RealSyncCodeDispatcherTest {
         verify(syncAccountRepository).parseSyncAuthCode("https://duckduckgo.com/sync/pairing/#&code2=anything")
     }
 
-    @Test fun `FF on but v2 parser returns LinkingV1 - falls back to legacy stack`() {
-        setV2(true)
+    @Test fun `v2 flag on but v2 parser returns LinkingV1 - falls back to legacy stack`() {
+        configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.LinkingV1)
         val connect = SyncAuthCode.Connect(mock())
         whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(connect)
@@ -152,8 +153,8 @@ class RealSyncCodeDispatcherTest {
         assertSame(connect, decision.authCode)
     }
 
-    @Test fun `FF on but v2 parser returns Unknown - falls back to legacy stack`() {
-        setV2(true)
+    @Test fun `v2 flag on but v2 parser returns Unknown - falls back to legacy stack`() {
+        configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.Unknown)
         val recovery = SyncAuthCode.Recovery(RecoveryCode(primaryKey = "pk", userId = "u"))
         whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(recovery)
@@ -163,8 +164,8 @@ class RealSyncCodeDispatcherTest {
         assertSame(recovery, decision.authCode)
     }
 
-    @Test fun `FF on, v2 LinkingV2 - returns V2InProgress and does NOT call parseSyncAuthCode`() {
-        setV2(true)
+    @Test fun `v2 flag on, v2 LinkingV2 - returns V2InProgress and does NOT call parseSyncAuthCode`() {
+        configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
             ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
         )
@@ -187,8 +188,8 @@ class RealSyncCodeDispatcherTest {
         assertTrue(dispatcher.isV2ExchangeUnderway())
     }
 
-    @Test fun `FF on, v2 RecoveryCode cid=ddg - flow emits LoggedIn after processCode succeeds`() = runTest {
-        setV2(true)
+    @Test fun `v2 flag on, v2 RecoveryCode cid=ddg - flow emits LoggedIn after processCode succeeds`() = runTest {
+        configureFeatureFlag(canUseV2Code = true)
         val rawJson = JSONObject().apply {
             put("user_id", "u-1")
             put("secret", "s-1")
@@ -205,9 +206,9 @@ class RealSyncCodeDispatcherTest {
         assertEquals(DispatchOutcome.LoggedIn(SetupPath.RECOVERY), outcomes.single())
     }
 
-    @Test fun `FF on, v2 RecoveryCode cid=ddg - base64url secret is normalised to standard base64 for v1 login`() = runTest {
+    @Test fun `v2 flag on, v2 RecoveryCode cid=ddg - base64url secret is normalised to standard base64 for v1 login`() = runTest {
         // Spec 1214802412121967: the v2 wire `secret` is base64url; v1 login decodes as standard base64.
-        setV2(true)
+        configureFeatureFlag(canUseV2Code = true)
         val base64urlSecret = "rUzlGqLLlbonAC_zIeh1nrCmuDsDAn6UooUUDz-6x3o"
         val expectedBytes = java.util.Base64.getUrlDecoder().decode(base64urlSecret)
         val rawJson = JSONObject().apply {
@@ -228,8 +229,8 @@ class RealSyncCodeDispatcherTest {
         assertArrayEquals(expectedBytes, java.util.Base64.getDecoder().decode(primaryKey))
     }
 
-    @Test fun `FF on, v2 RecoveryCode cid=ddg with missing user_id - emits Failed without calling processCode`() = runTest {
-        setV2(true)
+    @Test fun `v2 flag on, v2 RecoveryCode cid=ddg with missing user_id - emits Failed without calling processCode`() = runTest {
+        configureFeatureFlag(canUseV2Code = true)
         val rawJson = JSONObject().apply {
             put("secret", "s-1")
             put("cid", "ddg")
@@ -243,8 +244,8 @@ class RealSyncCodeDispatcherTest {
         verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
     }
 
-    @Test fun `FF on, v2 RecoveryCode cid=3party - flow calls joinAccountFromThirdPartyRecoveryCode`() = runTest {
-        setV2(true)
+    @Test fun `v2 flag on, v2 RecoveryCode cid=3party - flow calls joinAccountFromThirdPartyRecoveryCode`() = runTest {
+        configureFeatureFlag(canUseV2Code = true)
         val rawJson = JSONObject().apply {
             put("user_id", "u-3p")
             put("secret", "s-3p")
@@ -261,8 +262,8 @@ class RealSyncCodeDispatcherTest {
         verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
     }
 
-    @Test fun `FF on, v2 RecoveryCode cid=3party - re-encoded code is canonical JSON without escaped slashes`() = runTest {
-        setV2(true)
+    @Test fun `v2 flag on, v2 RecoveryCode cid=3party - re-encoded code is canonical JSON without escaped slashes`() = runTest {
+        configureFeatureFlag(canUseV2Code = true)
         val secretWithSlashes = "apZ+7PAe89rDhuG4DRyi/M3zU2/D5DZNdRsR3RM6Ujw="
         val rawJson = JSONObject().apply {
             put("user_id", "u-3p")
@@ -286,8 +287,8 @@ class RealSyncCodeDispatcherTest {
         assertEquals("2.0", recovery.getString("v"))
     }
 
-    @Test fun `FF on, v2 RecoveryCode cid=ddg - ALREADY_SIGNED_IN triggers logoutAndJoinNewAccount and emits LoggedIn`() = runTest {
-        setV2(true)
+    @Test fun `v2 flag on, v2 RecoveryCode cid=ddg - ALREADY_SIGNED_IN triggers logoutAndJoinNewAccount and emits LoggedIn`() = runTest {
+        configureFeatureFlag(canUseV2Code = true)
         val base64urlSecret = "rUzlGqLLlbonAC_zIeh1nrCmuDsDAn6UooUUDz-6x3o"
         val rawJson = JSONObject().apply {
             put("user_id", "u-other")
@@ -297,7 +298,7 @@ class RealSyncCodeDispatcherTest {
         whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
         whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(
             Result.Error(
-                code = com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN.code,
+                code = ALREADY_SIGNED_IN.code,
                 reason = "Already signed in",
             ),
         )
@@ -318,8 +319,8 @@ class RealSyncCodeDispatcherTest {
         assertEquals("u-other", recovery.getString("user_id"))
     }
 
-    @Test fun `FF on, v2 RecoveryCode cid=ddg - account-switch code is canonical v1 JSON without escaped slashes`() = runTest {
-        setV2(true)
+    @Test fun `v2 flag on, v2 RecoveryCode cid=ddg - account-switch code is canonical v1 JSON without escaped slashes`() = runTest {
+        configureFeatureFlag(canUseV2Code = true)
         val secretWithSlashes = "apZ+7PAe89rDhuG4DRyi/M3zU2/D5DZNdRsR3RM6Ujw="
         val rawJson = JSONObject().apply {
             put("user_id", "u-other")
@@ -329,7 +330,7 @@ class RealSyncCodeDispatcherTest {
         whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
         whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(
             Result.Error(
-                code = com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN.code,
+                code = ALREADY_SIGNED_IN.code,
                 reason = "Already signed in",
             ),
         )
@@ -346,8 +347,8 @@ class RealSyncCodeDispatcherTest {
         assertEquals("u-other", recovery.getString("user_id"))
     }
 
-    @Test fun `FF on, v2 RecoveryCode cid=ddg - ALREADY_SIGNED_IN then logoutAndJoinNewAccount failure surfaces as Failed`() = runTest {
-        setV2(true)
+    @Test fun `v2 flag on, v2 RecoveryCode cid=ddg - ALREADY_SIGNED_IN then logoutAndJoinNewAccount failure surfaces as Failed`() = runTest {
+        configureFeatureFlag(canUseV2Code = true)
         val rawJson = JSONObject().apply {
             put("user_id", "u-other")
             put("secret", "s-other")
@@ -356,24 +357,24 @@ class RealSyncCodeDispatcherTest {
         whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
         whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(
             Result.Error(
-                code = com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN.code,
+                code = ALREADY_SIGNED_IN.code,
                 reason = "Already signed in",
             ),
         )
         whenever(syncAccountRepository.logoutAndJoinNewAccount(any())).thenReturn(
-            Result.Error(code = com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED.code, reason = "Login failed"),
+            Result.Error(code = LOGIN_FAILED.code, reason = "Login failed"),
         )
 
         val outcome = (dispatcher.route("any") as RouteDecision.V2InProgress).outcomes.first()
 
         assertEquals(
-            DispatchOutcome.Failed("Login failed", com.duckduckgo.sync.impl.AccountErrorCodes.LOGIN_FAILED.code, path = SetupPath.RECOVERY),
+            DispatchOutcome.Failed("Login failed", LOGIN_FAILED.code, path = SetupPath.RECOVERY),
             outcome,
         )
     }
 
-    @Test fun `FF on, v2 RecoveryCode cid=3party - ALREADY_SIGNED_IN does NOT trigger transparent switch (fails as Failed)`() = runTest {
-        setV2(true)
+    @Test fun `v2 flag on, v2 RecoveryCode cid=3party - ALREADY_SIGNED_IN does NOT trigger transparent switch (fails as Failed)`() = runTest {
+        configureFeatureFlag(canUseV2Code = true)
         val rawJson = JSONObject().apply {
             put("user_id", "u-3p")
             put("secret", "s-3p")
@@ -382,7 +383,7 @@ class RealSyncCodeDispatcherTest {
         whenever(qrCode.parse(any())).thenReturn(ExchangeV2CodeParseResult.RecoveryCode(rawJson))
         whenever(syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(any())).thenReturn(
             Result.Error(
-                code = com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN.code,
+                code = ALREADY_SIGNED_IN.code,
                 reason = "Already signed in",
             ),
         )
@@ -392,7 +393,7 @@ class RealSyncCodeDispatcherTest {
         assertEquals(
             DispatchOutcome.Failed(
                 "Already signed in",
-                com.duckduckgo.sync.impl.AccountErrorCodes.ALREADY_SIGNED_IN.code,
+                ALREADY_SIGNED_IN.code,
                 path = SetupPath.RECOVERY,
             ),
             outcome,
@@ -400,8 +401,8 @@ class RealSyncCodeDispatcherTest {
         verify(syncAccountRepository, never()).logoutAndJoinNewAccount(any())
     }
 
-    @Test fun `FF on, v2 RecoveryCode cid=ddg - non-ALREADY_SIGNED_IN error still becomes Failed`() = runTest {
-        setV2(true)
+    @Test fun `v2 flag on, v2 RecoveryCode cid=ddg - non-ALREADY_SIGNED_IN error still becomes Failed`() = runTest {
+        configureFeatureFlag(canUseV2Code = true)
         val rawJson = JSONObject().apply {
             put("user_id", "u")
             put("secret", "AQID") // valid base64 so decoding succeeds and processCode is reached
@@ -417,8 +418,8 @@ class RealSyncCodeDispatcherTest {
         assertEquals(DispatchOutcome.Failed("Some other error", path = SetupPath.RECOVERY), outcome)
     }
 
-    @Test fun `FF on, v2 RecoveryCode cid=3party - repository error becomes Failed with reason preserved`() = runTest {
-        setV2(true)
+    @Test fun `v2 flag on, v2 RecoveryCode cid=3party - repository error becomes Failed with reason preserved`() = runTest {
+        configureFeatureFlag(canUseV2Code = true)
         val rawJson = JSONObject().apply {
             put("user_id", "u-3p")
             put("secret", "s-3p")
@@ -434,8 +435,8 @@ class RealSyncCodeDispatcherTest {
         assertEquals(DispatchOutcome.Failed("BE rejected", path = SetupPath.RECOVERY), outcome)
     }
 
-    @Test fun `FF on, v2 RecoveryCode with unknown cid - emits Failed with the cid in the reason`() = runTest {
-        setV2(true)
+    @Test fun `v2 flag on, v2 RecoveryCode with unknown cid - emits Failed with the cid in the reason`() = runTest {
+        configureFeatureFlag(canUseV2Code = true)
         val rawJson = JSONObject().apply {
             put("user_id", "u")
             put("secret", "s")
@@ -450,7 +451,7 @@ class RealSyncCodeDispatcherTest {
     }
 
     @Test fun `Legacy path - dispatcher never invokes processCode (caller owns that)`() {
-        setV2(false)
+        configureFeatureFlag(canUseV2Code = false)
         whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(SyncAuthCode.Recovery(mock()))
 
         dispatcher.route("any")
@@ -460,7 +461,7 @@ class RealSyncCodeDispatcherTest {
     }
 
     @Test fun `Legacy path - dispatcher does not start the v2 runner`() {
-        setV2(false)
+        configureFeatureFlag(canUseV2Code = false)
         whenever(syncAccountRepository.parseSyncAuthCode(any())).thenReturn(SyncAuthCode.Unknown("x"))
 
         dispatcher.route("any")
@@ -468,22 +469,22 @@ class RealSyncCodeDispatcherTest {
         verify(runner, never()).startScan(any())
     }
 
-    @Test fun `FF on, LinkingV2 - ignores stale terminal events from prior sessions in the replay cache`() = runTest {
-        setV2(true)
+    @Test fun `v2 flag on, LinkingV2 - ignores stale terminal events from prior sessions in the replay cache`() = runTest {
+        configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
             ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
         )
-        val staleJoinerDone = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event.Transition(
+        val staleJoinerDone = ExchangeV2Event.Transition(
             timestampMs = 1L,
-            from = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.Joiner.Waiting,
-            to = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.Joiner.Done,
-            trigger = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse(
+            from = ExchangeV2State.Joiner.Waiting,
+            to = ExchangeV2State.Joiner.Done,
+            trigger = ExchangeV2Message.RecoveryCodeResponse(
                 rawJson = "{}",
                 recoveryCode = "stale-code-from-prior-session",
             ),
             localTrigger = null,
         )
-        val staleFlow = MutableSharedFlow<com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event>(replay = 10)
+        val staleFlow = MutableSharedFlow<ExchangeV2Event>(replay = 10)
         staleFlow.tryEmit(staleJoinerDone)
         whenever(runner.events).thenReturn(staleFlow)
         whenever(runner.eventsSince(any())).thenAnswer { invocation ->
@@ -493,13 +494,15 @@ class RealSyncCodeDispatcherTest {
 
         val decision = dispatcher.route("v2-url") as RouteDecision.V2InProgress
 
-        val outcome = kotlinx.coroutines.withTimeoutOrNull(100) { decision.outcomes.first() }
-        assertEquals(null, outcome)
+        decision.outcomes.test {
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
         verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
     }
 
-    @Test fun `FF on, LinkingV2 - runner_startScan deferred until Flow is collected (cold)`() = runTest {
-        setV2(true)
+    @Test fun `v2 flag on, LinkingV2 - runner_startScan deferred until Flow is collected (cold)`() = runTest {
+        configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
             ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
         )
@@ -508,13 +511,13 @@ class RealSyncCodeDispatcherTest {
 
         verify(runner, never()).startScan(any())
 
-        kotlinx.coroutines.withTimeoutOrNull(50) { decision.outcomes.first() }
+        decision.outcomes.test { cancelAndIgnoreRemainingEvents() }
         verify(runner).startScan(eq("v2-url"))
     }
 
-    @Test fun `FF on, LinkingV2 exchange - base64url recovery secret is normalised to standard base64 for v1 login`() = runTest {
+    @Test fun `v2 flag on, LinkingV2 exchange - base64url recovery secret is normalised to standard base64 for v1 login`() = runTest {
         // Spec 1214802412121967: the v2 wire `secret` is base64url; v1 login decodes as standard base64.
-        setV2(true)
+        configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
             ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
         )
@@ -534,20 +537,22 @@ class RealSyncCodeDispatcherTest {
         val recoveryCodeB64 = java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(payloadJson.toByteArray())
 
         val flow = (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
-        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { flow.take(1).toList() }
-        runnerEventsFlow.emit(
-            ExchangeV2Event.Transition(
-                timestampMs = System.currentTimeMillis(),
-                from = ExchangeV2State.Joiner.Waiting,
-                to = ExchangeV2State.Joiner.Done,
-                trigger = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse(
-                    rawJson = payloadJson,
-                    recoveryCode = recoveryCodeB64,
+        flow.test {
+            runnerEventsFlow.emit(
+                ExchangeV2Event.Transition(
+                    timestampMs = System.currentTimeMillis(),
+                    from = ExchangeV2State.Joiner.Waiting,
+                    to = ExchangeV2State.Joiner.Done,
+                    trigger = ExchangeV2Message.RecoveryCodeResponse(
+                        rawJson = payloadJson,
+                        recoveryCode = recoveryCodeB64,
+                    ),
+                    localTrigger = null,
                 ),
-                localTrigger = null,
-            ),
-        )
-        job.join()
+            )
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
 
         val captor = org.mockito.kotlin.argumentCaptor<SyncAuthCode>()
         verify(syncAccountRepository).processCode(captor.capture(), anyOrNull())
@@ -582,123 +587,108 @@ class RealSyncCodeDispatcherTest {
             linkingCode = linkingCode,
         )
 
-    @Test fun `presentV2 emits LinkingCodeReady when runner emits SessionStarted with a linkingCode`() = runTest {
-        val flow = dispatcher.presentV2()
-        val outcomes = mutableListOf<DispatchOutcome>()
-        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
-            flow.take(1).collect { outcomes += it }
+    @Test fun `Presenter emits LinkingCodeReady when runner emits SessionStarted with a linkingCode`() = runTest {
+        dispatcher.presentV2().test {
+            runnerEventsFlow.emit(sessionStarted(linkingCode = "https://duckduckgo.com/sync/pairing?code2=abc"))
+            assertEquals(
+                DispatchOutcome.LinkingCodeReady("https://duckduckgo.com/sync/pairing?code2=abc"),
+                awaitItem(),
+            )
+            cancelAndIgnoreRemainingEvents()
         }
-        runnerEventsFlow.emit(sessionStarted(linkingCode = "https://duckduckgo.com/sync/pairing?code2=abc"))
-        job.join()
-
-        assertEquals(1, outcomes.size)
-        assertEquals(
-            DispatchOutcome.LinkingCodeReady("https://duckduckgo.com/sync/pairing?code2=abc"),
-            outcomes.single(),
-        )
     }
 
-    @Test fun `presentV2 ignores SessionStarted with null linkingCode (Scanner side leakage protection)`() = runTest {
-        val outcomes = mutableListOf<DispatchOutcome>()
-        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().take(1).collect { outcomes += it } }
-        runnerEventsFlow.emit(sessionStarted(linkingCode = null))
-        runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Done))
-        job.join()
-
-        assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST), outcomes.single())
+    @Test fun `Presenter ignores SessionStarted with null linkingCode (Scanner side leakage protection)`() = runTest {
+        dispatcher.presentV2().test {
+            runnerEventsFlow.emit(sessionStarted(linkingCode = null))
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Done))
+            assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
-    @Test fun `presentV2 emits HostConfirmationRequested with peerName when runner reaches Host_Confirming`() = runTest {
+    @Test fun `Presenter emits HostConfirmationRequested with peerName when runner reaches Host_Confirming`() = runTest {
         whenever(runner.peerName).thenReturn("Peer Phone")
-        val outcomes = mutableListOf<DispatchOutcome>()
-        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().take(1).collect { outcomes += it } }
-        runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Confirming))
-        job.join()
-
-        assertEquals(DispatchOutcome.HostConfirmationRequested(peerName = "Peer Phone"), outcomes.single())
+        dispatcher.presentV2().test {
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Confirming))
+            assertEquals(DispatchOutcome.HostConfirmationRequested(peerName = "Peer Phone"), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
-    @Test fun `presentV2 carries third-party peer kind on HostConfirmationRequested`() = runTest {
+    @Test fun `Presenter carries third-party peer kind on HostConfirmationRequested`() = runTest {
         whenever(runner.peerName).thenReturn("Peer Phone")
         whenever(runner.peerKind).thenReturn("3party")
-        val outcomes = mutableListOf<DispatchOutcome>()
-        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().take(1).collect { outcomes += it } }
-        runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Confirming))
-        job.join()
-
-        assertEquals(
-            DispatchOutcome.HostConfirmationRequested(peerName = "Peer Phone", peerKind = PeerKind.THIRD_PARTY),
-            outcomes.single(),
-        )
+        dispatcher.presentV2().test {
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Host.Confirming))
+            assertEquals(
+                DispatchOutcome.HostConfirmationRequested(peerName = "Peer Phone", peerKind = PeerKind.THIRD_PARTY),
+                awaitItem(),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
-    @Test fun `presentV2 carries ddg peer kind on JoinerConfirmationRequested`() = runTest {
+    @Test fun `Presenter carries ddg peer kind on JoinerConfirmationRequested`() = runTest {
         whenever(runner.peerName).thenReturn("Peer Phone")
         whenever(runner.peerKind).thenReturn("ddg")
-        val outcomes = mutableListOf<DispatchOutcome>()
-        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().take(1).collect { outcomes += it } }
-        runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Joiner.Confirming))
-        job.join()
-
-        assertEquals(
-            DispatchOutcome.JoinerConfirmationRequested(peerName = "Peer Phone", peerKind = PeerKind.DDG),
-            outcomes.single(),
-        )
+        dispatcher.presentV2().test {
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Joiner.Confirming))
+            assertEquals(
+                DispatchOutcome.JoinerConfirmationRequested(peerName = "Peer Phone", peerKind = PeerKind.DDG),
+                awaitItem(),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
-    @Test fun `presentV2 emits LoggedIn with Host role and peer kind when runner reaches Host_Done`() = runTest {
+    @Test fun `Presenter emits LoggedIn with Host role and peer kind when runner reaches Host_Done`() = runTest {
         whenever(runner.peerKind).thenReturn("3party")
-        val outcome = withTimeoutOrNull(1000) {
-            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
-                dispatcher.presentV2().first { it is DispatchOutcome.LoggedIn || it is DispatchOutcome.Failed }
-            }
+        dispatcher.presentV2().test {
             runnerEventsFlow.emit(transition(from = ExchangeV2State.Host.Sending, to = ExchangeV2State.Host.Done))
-            job.await()
+            assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST, PeerKind.THIRD_PARTY), awaitItem())
+            cancelAndIgnoreRemainingEvents()
         }
-        assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.HOST, PeerKind.THIRD_PARTY), outcome)
     }
 
-    @Test fun `presentV2 maps a version-too-new SessionError to UpgradeRequired`() = runTest {
-        val outcome = withTimeoutOrNull(1000) {
-            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+    @Test fun `Presenter maps a version-too-new SessionError to UpgradeRequired`() = runTest {
+        dispatcher.presentV2().test {
             runnerEventsFlow.emit(
                 ExchangeV2Event.SessionError(
                     timestampMs = System.currentTimeMillis(),
                     message = "Peer requires protocol v3; please update this app",
                 ),
             )
-            job.await()
+            assertEquals(DispatchOutcome.UpgradeRequired(codeMajor = 3, path = SetupPath.PAIRING), awaitItem())
+            cancelAndIgnoreRemainingEvents()
         }
-        assertEquals(DispatchOutcome.UpgradeRequired(codeMajor = 3, path = SetupPath.PAIRING), outcome)
     }
 
-    @Test fun `route LinkingV2 maps a version-too-new SessionError to UpgradeRequired`() = runTest {
-        setV2(true)
+    @Test fun `Scanner maps a version-too-new SessionError to UpgradeRequired`() = runTest {
+        configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
             ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
         )
-        val outcome = withTimeoutOrNull(1000) {
-            val flow = (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
-            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { flow.first() }
+        val flow = (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
+        flow.test {
             runnerEventsFlow.emit(
                 ExchangeV2Event.SessionError(
                     timestampMs = System.currentTimeMillis(),
                     message = "Peer requires protocol v3; please update this app",
                 ),
             )
-            job.await()
+            assertEquals(DispatchOutcome.UpgradeRequired(codeMajor = 3, path = SetupPath.PAIRING), awaitItem())
+            cancelAndIgnoreRemainingEvents()
         }
-        assertEquals(DispatchOutcome.UpgradeRequired(codeMajor = 3, path = SetupPath.PAIRING), outcome)
     }
 
-    @Test fun `route LinkingV2 - Host_Aborted with UserDeniedHost maps to Failed PAIRING_CANCELLED`() = runTest {
-        setV2(true)
+    @Test fun `Scanner - Host_Aborted with UserDeniedHost maps to Failed PAIRING_CANCELLED`() = runTest {
+        configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
             ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
         )
-        val outcome = withTimeoutOrNull(1000) {
-            val flow = (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
-            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { flow.first() }
+        val flow = (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
+        flow.test {
             runnerEventsFlow.emit(
                 transition(
                     from = ExchangeV2State.Host.Confirming,
@@ -706,22 +696,21 @@ class RealSyncCodeDispatcherTest {
                     localTrigger = LocalTrigger.UserDeniedHost,
                 ),
             )
-            job.await()
+            assertEquals(
+                DispatchOutcome.Failed("user_denied", PAIRING_CANCELLED.code, path = SetupPath.PAIRING, myRole = SetupRole.HOST),
+                awaitItem(),
+            )
+            cancelAndIgnoreRemainingEvents()
         }
-        assertEquals(
-            DispatchOutcome.Failed("user_denied", PAIRING_CANCELLED.code, path = SetupPath.PAIRING, myRole = SetupRole.HOST),
-            outcome,
-        )
     }
 
-    @Test fun `route LinkingV2 - Host_Aborted with HostUnavailable maps to Failed PAIRING_UNAVAILABLE`() = runTest {
-        setV2(true)
+    @Test fun `Scanner - Host_Aborted with HostUnavailable maps to Failed PAIRING_UNAVAILABLE`() = runTest {
+        configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
             ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
         )
-        val outcome = withTimeoutOrNull(1000) {
-            val flow = (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
-            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { flow.first() }
+        val flow = (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
+        flow.test {
             runnerEventsFlow.emit(
                 transition(
                     from = ExchangeV2State.Host.Sending,
@@ -729,17 +718,16 @@ class RealSyncCodeDispatcherTest {
                     localTrigger = LocalTrigger.HostUnavailable,
                 ),
             )
-            job.await()
+            assertEquals(
+                DispatchOutcome.Failed("host_unavailable", PAIRING_UNAVAILABLE.code, path = SetupPath.PAIRING, myRole = SetupRole.HOST),
+                awaitItem(),
+            )
+            cancelAndIgnoreRemainingEvents()
         }
-        assertEquals(
-            DispatchOutcome.Failed("host_unavailable", PAIRING_UNAVAILABLE.code, path = SetupPath.PAIRING, myRole = SetupRole.HOST),
-            outcome,
-        )
     }
 
-    @Test fun `presentV2 emits Failed user_denied when Host_Aborted carries UserDeniedHost trigger`() = runTest {
-        val outcome = withTimeoutOrNull(1000) {
-            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+    @Test fun `Presenter emits Failed user_denied when Host_Aborted carries UserDeniedHost trigger`() = runTest {
+        dispatcher.presentV2().test {
             runnerEventsFlow.emit(
                 transition(
                     from = ExchangeV2State.Host.Confirming,
@@ -747,17 +735,16 @@ class RealSyncCodeDispatcherTest {
                     localTrigger = LocalTrigger.UserDeniedHost,
                 ),
             )
-            job.await()
+            assertEquals(
+                DispatchOutcome.Failed("user_denied", PAIRING_CANCELLED.code, path = SetupPath.PAIRING, myRole = SetupRole.HOST),
+                awaitItem(),
+            )
+            cancelAndIgnoreRemainingEvents()
         }
-        assertEquals(
-            DispatchOutcome.Failed("user_denied", PAIRING_CANCELLED.code, path = SetupPath.PAIRING, myRole = SetupRole.HOST),
-            outcome,
-        )
     }
 
-    @Test fun `presentV2 emits Failed host_unavailable when Host_Aborted carries HostUnavailable trigger`() = runTest {
-        val outcome = withTimeoutOrNull(1000) {
-            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+    @Test fun `Presenter emits Failed host_unavailable when Host_Aborted carries HostUnavailable trigger`() = runTest {
+        dispatcher.presentV2().test {
             runnerEventsFlow.emit(
                 transition(
                     from = ExchangeV2State.Host.Sending,
@@ -765,55 +752,49 @@ class RealSyncCodeDispatcherTest {
                     localTrigger = LocalTrigger.HostUnavailable,
                 ),
             )
-            job.await()
+            assertEquals(
+                DispatchOutcome.Failed("host_unavailable", PAIRING_UNAVAILABLE.code, path = SetupPath.PAIRING, myRole = SetupRole.HOST),
+                awaitItem(),
+            )
+            cancelAndIgnoreRemainingEvents()
         }
-        assertEquals(
-            DispatchOutcome.Failed("host_unavailable", PAIRING_UNAVAILABLE.code, path = SetupPath.PAIRING, myRole = SetupRole.HOST),
-            outcome,
-        )
     }
 
-    @Test fun `presentV2 emits AlreadyConnected when runner reaches SameAccountAbort`() = runTest {
-        val outcome = withTimeoutOrNull(1000) {
-            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+    @Test fun `Presenter emits AlreadyConnected when runner reaches SameAccountAbort`() = runTest {
+        dispatcher.presentV2().test {
             runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.SameAccountAbort))
-            job.await()
+            assertEquals(DispatchOutcome.AlreadyConnected, awaitItem())
+            cancelAndIgnoreRemainingEvents()
         }
-        assertEquals(DispatchOutcome.AlreadyConnected, outcome)
     }
 
-    @Test fun `presentV2 emits Failed when runner emits SessionError`() = runTest {
-        val outcome = withTimeoutOrNull(1000) {
-            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+    @Test fun `Presenter emits Failed when runner emits SessionError`() = runTest {
+        dispatcher.presentV2().test {
             runnerEventsFlow.emit(
                 ExchangeV2Event.SessionError(timestampMs = System.currentTimeMillis(), message = "channel 5xx"),
             )
-            job.await()
+            assertEquals(DispatchOutcome.Failed("channel 5xx", PAIRING_FAILED.code, path = SetupPath.PAIRING), awaitItem())
+            cancelAndIgnoreRemainingEvents()
         }
-        assertEquals(DispatchOutcome.Failed("channel 5xx", PAIRING_FAILED.code, path = SetupPath.PAIRING), outcome)
     }
 
-    @Test fun `presentV2 emits Failed when Joiner_Done arrives without a recovery code`() = runTest {
-        val outcome = withTimeoutOrNull(1000) {
-            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
-                dispatcher.presentV2().first { it !is DispatchOutcome.LinkingCodeReady }
-            }
+    @Test fun `Presenter emits Failed when Joiner_Done arrives without a recovery code`() = runTest {
+        dispatcher.presentV2().test {
             runnerEventsFlow.emit(transition(from = ExchangeV2State.Joiner.Waiting, to = ExchangeV2State.Joiner.Done))
-            job.await()
+            assertEquals(
+                DispatchOutcome.Failed(
+                    "joiner_done_missing_recovery_code",
+                    NO_RECOVERY_CODE.code,
+                    path = SetupPath.PAIRING,
+                    myRole = SetupRole.JOINER,
+                ),
+                awaitItem(),
+            )
+            cancelAndIgnoreRemainingEvents()
         }
-        assertEquals(
-            DispatchOutcome.Failed(
-                "joiner_done_missing_recovery_code",
-                NO_RECOVERY_CODE.code,
-                path = SetupPath.PAIRING,
-                myRole = SetupRole.JOINER,
-            ),
-            outcome,
-        )
     }
 
-    @Test fun `presentV2 emits LoggedIn when Joiner_Done carries a cid=ddg recovery code`() = runTest {
-        setV2(true)
+    @Test fun `Presenter emits LoggedIn when Joiner_Done carries a cid=ddg recovery code`() = runTest {
         val recoveryJson = JSONObject().apply {
             put(
                 "recovery",
@@ -829,17 +810,14 @@ class RealSyncCodeDispatcherTest {
             recoveryJson.toByteArray(Charsets.UTF_8),
             android.util.Base64.URL_SAFE or android.util.Base64.NO_PADDING or android.util.Base64.NO_WRAP,
         )
-        val responseMessage = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse(
+        val responseMessage = ExchangeV2Message.RecoveryCodeResponse(
             rawJson = "{}",
             recoveryCode = b64,
         )
         whenever(syncAccountRepository.processCode(any(), anyOrNull())).thenReturn(Result.Success(true))
         whenever(runner.peerKind).thenReturn("ddg")
 
-        val outcome = withTimeoutOrNull(1000) {
-            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
-                dispatcher.presentV2().first { it !is DispatchOutcome.LinkingCodeReady }
-            }
+        dispatcher.presentV2().test {
             runnerEventsFlow.emit(
                 ExchangeV2Event.Transition(
                     timestampMs = System.currentTimeMillis(),
@@ -849,15 +827,14 @@ class RealSyncCodeDispatcherTest {
                     localTrigger = null,
                 ),
             )
-            job.await()
+            assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.JOINER, PeerKind.DDG), awaitItem())
+            cancelAndIgnoreRemainingEvents()
         }
-        assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.JOINER, PeerKind.DDG), outcome)
         verify(syncAccountRepository).processCode(any(), anyOrNull())
         verify(syncAccountRepository, never()).joinAccountFromThirdPartyRecoveryCode(any())
     }
 
-    @Test fun `presentV2 emits LoggedIn via 3party upgrade when Joiner_Done carries a cid=3party recovery code`() = runTest {
-        setV2(true)
+    @Test fun `Presenter emits LoggedIn via 3party upgrade when Joiner_Done carries a cid=3party recovery code`() = runTest {
         val recoveryJson = JSONObject().apply {
             put(
                 "recovery",
@@ -873,16 +850,13 @@ class RealSyncCodeDispatcherTest {
             recoveryJson.toByteArray(Charsets.UTF_8),
             android.util.Base64.URL_SAFE or android.util.Base64.NO_PADDING or android.util.Base64.NO_WRAP,
         )
-        val responseMessage = com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message.RecoveryCodeResponse(
+        val responseMessage = ExchangeV2Message.RecoveryCodeResponse(
             rawJson = "{}",
             recoveryCode = b64,
         )
         whenever(syncAccountRepository.joinAccountFromThirdPartyRecoveryCode(any())).thenReturn(Result.Success(true))
 
-        val outcome = withTimeoutOrNull(1000) {
-            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
-                dispatcher.presentV2().first { it !is DispatchOutcome.LinkingCodeReady }
-            }
+        dispatcher.presentV2().test {
             runnerEventsFlow.emit(
                 ExchangeV2Event.Transition(
                     timestampMs = System.currentTimeMillis(),
@@ -892,16 +866,15 @@ class RealSyncCodeDispatcherTest {
                     localTrigger = null,
                 ),
             )
-            job.await()
+            assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.JOINER), awaitItem())
+            cancelAndIgnoreRemainingEvents()
         }
-        assertEquals(DispatchOutcome.LoggedIn(SetupPath.PAIRING, SetupRole.JOINER), outcome)
         verify(syncAccountRepository).joinAccountFromThirdPartyRecoveryCode(any())
         verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
     }
 
-    @Test fun `presentV2 emits Failed PAIRING_CANCELLED when Joiner AbortedLocal driven by UserDeniedJoiner`() = runTest {
-        val outcome = withTimeoutOrNull(1000) {
-            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+    @Test fun `Presenter emits Failed PAIRING_CANCELLED when Joiner_AbortedLocal driven by UserDeniedJoiner`() = runTest {
+        dispatcher.presentV2().test {
             runnerEventsFlow.emit(
                 transition(
                     from = ExchangeV2State.Joiner.Confirming,
@@ -909,22 +882,21 @@ class RealSyncCodeDispatcherTest {
                     localTrigger = LocalTrigger.UserDeniedJoiner,
                 ),
             )
-            job.await()
+            assertEquals(
+                DispatchOutcome.Failed(
+                    "user_denied_joiner",
+                    PAIRING_CANCELLED.code,
+                    path = SetupPath.PAIRING,
+                    myRole = SetupRole.JOINER,
+                ),
+                awaitItem(),
+            )
+            cancelAndIgnoreRemainingEvents()
         }
-        assertEquals(
-            DispatchOutcome.Failed(
-                "user_denied_joiner",
-                PAIRING_CANCELLED.code,
-                path = SetupPath.PAIRING,
-                myRole = SetupRole.JOINER,
-            ),
-            outcome,
-        )
     }
 
-    @Test fun `presentV2 emits Failed UNEXPECTED_EVENT when Joiner AbortedLocal driven by wire message`() = runTest {
-        val outcome = withTimeoutOrNull(1000) {
-            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+    @Test fun `Presenter emits Failed UNEXPECTED_EVENT when Joiner_AbortedLocal driven by wire message`() = runTest {
+        dispatcher.presentV2().test {
             runnerEventsFlow.emit(
                 transition(
                     from = ExchangeV2State.Joiner.Waiting,
@@ -932,14 +904,13 @@ class RealSyncCodeDispatcherTest {
                     trigger = ExchangeV2Message.Hello(rawJson = "{}"),
                 ),
             )
-            job.await()
+            assertEquals(UNEXPECTED_EVENT.code, (awaitItem() as DispatchOutcome.Failed).code)
+            cancelAndIgnoreRemainingEvents()
         }
-        assertEquals(UNEXPECTED_EVENT.code, (outcome as DispatchOutcome.Failed).code)
     }
 
-    @Test fun `presentV2 emits Failed UNEXPECTED_EVENT when Host Aborted driven by wire message`() = runTest {
-        val outcome = withTimeoutOrNull(1000) {
-            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+    @Test fun `Presenter emits Failed UNEXPECTED_EVENT when Host_Aborted driven by wire message`() = runTest {
+        dispatcher.presentV2().test {
             runnerEventsFlow.emit(
                 transition(
                     from = ExchangeV2State.Host.Confirming,
@@ -947,20 +918,20 @@ class RealSyncCodeDispatcherTest {
                     trigger = ExchangeV2Message.RecoveryCodeResponse(rawJson = "{}"),
                 ),
             )
-            job.await()
+            assertEquals(UNEXPECTED_EVENT.code, (awaitItem() as DispatchOutcome.Failed).code)
+            cancelAndIgnoreRemainingEvents()
         }
-        assertEquals(UNEXPECTED_EVENT.code, (outcome as DispatchOutcome.Failed).code)
     }
 
-    @Test fun `presentV2 calls runner_startPresent when Flow is collected`() = runTest {
+    @Test fun `Presenter calls runner_startPresent when Flow is collected`() = runTest {
         val flow = dispatcher.presentV2()
         verify(runner, never()).startPresent()
 
-        withTimeoutOrNull(50) { flow.first() }
+        flow.test { cancelAndIgnoreRemainingEvents() }
         verify(runner).startPresent()
     }
 
-    @Test fun `presentV2 cancels runner when collecting coroutine is cancelled`() = runTest {
+    @Test fun `Presenter cancels runner when collecting coroutine is cancelled`() = runTest {
         val flow = dispatcher.presentV2()
         val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
             flow.collect { /* no-op */ }
@@ -973,10 +944,10 @@ class RealSyncCodeDispatcherTest {
         verify(runner).cancel()
     }
 
-    @Test fun `driveV2Linking cancels runner when collecting coroutine is cancelled`() = runTest {
-        setV2(true)
+    @Test fun `Scanner cancels runner when collecting coroutine is cancelled`() = runTest {
+        configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
-            com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult.LinkingV2(
+            ExchangeV2CodeParseResult.LinkingV2(
                 channelId = "c",
                 publicKey = "k",
                 version = "2",
@@ -994,30 +965,26 @@ class RealSyncCodeDispatcherTest {
         verify(runner).cancel()
     }
 
-    @Test fun `presentV2 terminates silently when another SessionStarted with different channel arrives`() = runTest {
-        val outcomes = mutableListOf<DispatchOutcome>()
-        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
-            dispatcher.presentV2().toList(outcomes)
+    @Test fun `Presenter terminates silently when another SessionStarted with different channel arrives`() = runTest {
+        dispatcher.presentV2().test {
+            runnerEventsFlow.emit(sessionStarted(linkingCode = "code-for-own-channel"))
+            runnerEventsFlow.emit(
+                ExchangeV2Event.SessionStarted(
+                    timestampMs = System.currentTimeMillis(),
+                    pairingRole = PairingRole.Scanner,
+                    ownChannelId = "other-channel",
+                    linkingCode = null,
+                ),
+            )
+            assertEquals(DispatchOutcome.LinkingCodeReady("code-for-own-channel"), awaitItem())
+            awaitComplete()
         }
-        runnerEventsFlow.emit(sessionStarted(linkingCode = "code-for-own-channel"))
-        runnerEventsFlow.emit(
-            ExchangeV2Event.SessionStarted(
-                timestampMs = System.currentTimeMillis(),
-                pairingRole = PairingRole.Scanner,
-                ownChannelId = "other-channel",
-                linkingCode = null,
-            ),
-        )
-        job.join()
-
-        assertEquals(1, outcomes.size)
-        assertEquals(DispatchOutcome.LinkingCodeReady("code-for-own-channel"), outcomes.single())
     }
 
-    @Test fun `driveV2Linking terminates silently when another SessionStarted with different channel arrives`() = runTest {
-        setV2(true)
+    @Test fun `Scanner terminates silently when another SessionStarted with different channel arrives`() = runTest {
+        configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
-            com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult.LinkingV2(
+            ExchangeV2CodeParseResult.LinkingV2(
                 channelId = "peer-channel",
                 publicKey = "k",
                 version = "2",
@@ -1025,59 +992,51 @@ class RealSyncCodeDispatcherTest {
         )
         val decision = dispatcher.route("v2-url") as RouteDecision.V2InProgress
 
-        val outcomes = mutableListOf<DispatchOutcome>()
-        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
-            decision.outcomes.toList(outcomes)
+        decision.outcomes.test {
+            runnerEventsFlow.emit(
+                ExchangeV2Event.SessionStarted(
+                    timestampMs = System.currentTimeMillis(),
+                    pairingRole = PairingRole.Scanner,
+                    ownChannelId = "scanner-own-channel",
+                    linkingCode = null,
+                ),
+            )
+            runnerEventsFlow.emit(
+                ExchangeV2Event.SessionStarted(
+                    timestampMs = System.currentTimeMillis(),
+                    pairingRole = PairingRole.Presenter,
+                    ownChannelId = "different-channel",
+                    linkingCode = "code",
+                ),
+            )
+            awaitComplete()
         }
-        runnerEventsFlow.emit(
-            ExchangeV2Event.SessionStarted(
-                timestampMs = System.currentTimeMillis(),
-                pairingRole = PairingRole.Scanner,
-                ownChannelId = "scanner-own-channel",
-                linkingCode = null,
-            ),
-        )
-        runnerEventsFlow.emit(
-            ExchangeV2Event.SessionStarted(
-                timestampMs = System.currentTimeMillis(),
-                pairingRole = PairingRole.Presenter,
-                ownChannelId = "different-channel",
-                linkingCode = "code",
-            ),
-        )
-        job.join()
-
-        assertTrue("expected no outcomes, got $outcomes", outcomes.isEmpty())
     }
 
-    @Test fun `presentV2 emits Failed when runner reaches Aborted (hello during negotiating)`() = runTest {
-        val outcomes = mutableListOf<DispatchOutcome>()
-        val job = launch(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
-            dispatcher.presentV2().take(1).collect { outcomes += it }
+    @Test fun `Presenter emits Failed when runner reaches Aborted (hello during negotiating)`() = runTest {
+        dispatcher.presentV2().test {
+            runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Aborted))
+            val outcome = awaitItem()
+            assertTrue("expected Failed, got $outcome", outcome is DispatchOutcome.Failed)
+            cancelAndIgnoreRemainingEvents()
         }
-        runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Aborted))
-        job.join()
-
-        assertTrue("expected Failed, got ${outcomes.single()}", outcomes.single() is DispatchOutcome.Failed)
     }
 
-    @Test fun `linking flow emits Failed when runner reaches Aborted (hello during negotiating)`() = runTest {
-        setV2(true)
+    @Test fun `Scanner emits Failed when runner reaches Aborted (hello during negotiating)`() = runTest {
+        configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
             ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
         )
         val decision = dispatcher.route("v2-url") as RouteDecision.V2InProgress
-        val outcome = withTimeoutOrNull(1000) {
-            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) {
-                decision.outcomes.first { it is DispatchOutcome.Failed }
-            }
+        decision.outcomes.test {
             runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Aborted))
-            job.await()
+            val outcome = awaitItem()
+            assertTrue("expected Failed, got $outcome", outcome is DispatchOutcome.Failed)
+            cancelAndIgnoreRemainingEvents()
         }
-        assertTrue("expected Failed, got $outcome", outcome is DispatchOutcome.Failed)
     }
 
-    @Test fun `presentV2 filters out events from before session start`() = runTest {
+    @Test fun `Presenter filters out events from before session start`() = runTest {
         val staleFlow = MutableSharedFlow<ExchangeV2Event>(replay = 10)
         staleFlow.tryEmit(
             ExchangeV2Event.Transition(
@@ -1094,21 +1053,22 @@ class RealSyncCodeDispatcherTest {
             staleFlow.filter { it.timestampMs >= since }
         }
 
-        val outcome = withTimeoutOrNull(100) { dispatcher.presentV2().first() }
-        assertEquals(null, outcome)
+        dispatcher.presentV2().test {
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     private fun startLinking(): kotlinx.coroutines.flow.Flow<DispatchOutcome> {
-        setV2(true)
+        configureFeatureFlag(canUseV2Code = true)
         whenever(qrCode.parse(any())).thenReturn(
             ExchangeV2CodeParseResult.LinkingV2(channelId = "c", publicKey = "k", version = "2"),
         )
         return (dispatcher.route("v2-url") as RouteDecision.V2InProgress).outcomes
     }
 
-    @Test fun `linking - AbortedByHost with RecoveryCodeDenied maps to Failed PAIRING_REJECTED`() = runTest {
-        val outcome = withTimeoutOrNull(1000) {
-            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+    @Test fun `Scanner - Joiner_AbortedByHost with RecoveryCodeDenied maps to Failed PAIRING_REJECTED`() = runTest {
+        startLinking().test {
             runnerEventsFlow.emit(
                 transition(
                     from = ExchangeV2State.Joiner.Confirming,
@@ -1116,15 +1076,15 @@ class RealSyncCodeDispatcherTest {
                     trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
                 ),
             )
-            job.await()
+            val outcome = awaitItem()
+            assertTrue("expected Failed, got $outcome", outcome is DispatchOutcome.Failed)
+            assertEquals(PAIRING_REJECTED.code, (outcome as DispatchOutcome.Failed).code)
+            cancelAndIgnoreRemainingEvents()
         }
-        assertTrue("expected Failed, got $outcome", outcome is DispatchOutcome.Failed)
-        assertEquals(PAIRING_REJECTED.code, (outcome as DispatchOutcome.Failed).code)
     }
 
-    @Test fun `linking - AbortedByHost with RecoveryCodeUnavailable maps to Failed PAIRING_UNAVAILABLE`() = runTest {
-        val outcome = withTimeoutOrNull(1000) {
-            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+    @Test fun `Scanner - Joiner_AbortedByHost with RecoveryCodeUnavailable maps to Failed PAIRING_UNAVAILABLE`() = runTest {
+        startLinking().test {
             runnerEventsFlow.emit(
                 transition(
                     from = ExchangeV2State.Joiner.Confirming,
@@ -1132,14 +1092,13 @@ class RealSyncCodeDispatcherTest {
                     trigger = ExchangeV2Message.RecoveryCodeUnavailable(rawJson = "{}"),
                 ),
             )
-            job.await()
+            assertEquals(PAIRING_UNAVAILABLE.code, (awaitItem() as DispatchOutcome.Failed).code)
+            cancelAndIgnoreRemainingEvents()
         }
-        assertEquals(PAIRING_UNAVAILABLE.code, (outcome as DispatchOutcome.Failed).code)
     }
 
-    @Test fun `linking - Joiner AbortedLocal with UserDeniedJoiner maps to Failed PAIRING_CANCELLED`() = runTest {
-        val outcome = withTimeoutOrNull(1000) {
-            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+    @Test fun `Scanner - Joiner_AbortedLocal with UserDeniedJoiner maps to Failed PAIRING_CANCELLED`() = runTest {
+        startLinking().test {
             runnerEventsFlow.emit(
                 transition(
                     from = ExchangeV2State.Joiner.Confirming,
@@ -1147,14 +1106,13 @@ class RealSyncCodeDispatcherTest {
                     localTrigger = LocalTrigger.UserDeniedJoiner,
                 ),
             )
-            job.await()
+            assertEquals(PAIRING_CANCELLED.code, (awaitItem() as DispatchOutcome.Failed).code)
+            cancelAndIgnoreRemainingEvents()
         }
-        assertEquals(PAIRING_CANCELLED.code, (outcome as DispatchOutcome.Failed).code)
     }
 
-    @Test fun `linking - Joiner AbortedLocal driven by wire message maps to Failed UNEXPECTED_EVENT`() = runTest {
-        val outcome = withTimeoutOrNull(1000) {
-            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+    @Test fun `Scanner - Joiner_AbortedLocal driven by wire message maps to Failed UNEXPECTED_EVENT`() = runTest {
+        startLinking().test {
             runnerEventsFlow.emit(
                 transition(
                     from = ExchangeV2State.Joiner.Waiting,
@@ -1162,14 +1120,13 @@ class RealSyncCodeDispatcherTest {
                     trigger = ExchangeV2Message.Hello(rawJson = "{}"),
                 ),
             )
-            job.await()
+            assertEquals(UNEXPECTED_EVENT.code, (awaitItem() as DispatchOutcome.Failed).code)
+            cancelAndIgnoreRemainingEvents()
         }
-        assertEquals(UNEXPECTED_EVENT.code, (outcome as DispatchOutcome.Failed).code)
     }
 
-    @Test fun `linking - Host Aborted driven by wire message maps to Failed UNEXPECTED_EVENT`() = runTest {
-        val outcome = withTimeoutOrNull(1000) {
-            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+    @Test fun `Scanner - Host_Aborted driven by wire message maps to Failed UNEXPECTED_EVENT`() = runTest {
+        startLinking().test {
             runnerEventsFlow.emit(
                 transition(
                     from = ExchangeV2State.Host.Confirming,
@@ -1177,50 +1134,45 @@ class RealSyncCodeDispatcherTest {
                     trigger = ExchangeV2Message.Hello(rawJson = "{}"),
                 ),
             )
-            job.await()
+            assertEquals(UNEXPECTED_EVENT.code, (awaitItem() as DispatchOutcome.Failed).code)
+            cancelAndIgnoreRemainingEvents()
         }
-        assertEquals(UNEXPECTED_EVENT.code, (outcome as DispatchOutcome.Failed).code)
     }
 
-    @Test fun `linking - Aborted maps to Failed NEGOTIATION_ABORTED`() = runTest {
-        val outcome = withTimeoutOrNull(1000) {
-            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+    @Test fun `Scanner - Aborted maps to Failed NEGOTIATION_ABORTED`() = runTest {
+        startLinking().test {
             runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Aborted))
-            job.await()
+            assertEquals(NEGOTIATION_ABORTED.code, (awaitItem() as DispatchOutcome.Failed).code)
+            cancelAndIgnoreRemainingEvents()
         }
-        assertEquals(NEGOTIATION_ABORTED.code, (outcome as DispatchOutcome.Failed).code)
     }
 
-    @Test fun `linking - Joiner Done without recovery code maps to Failed NO_RECOVERY_CODE`() = runTest {
-        val outcome = withTimeoutOrNull(1000) {
-            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+    @Test fun `Scanner - Joiner_Done without recovery code maps to Failed NO_RECOVERY_CODE`() = runTest {
+        startLinking().test {
             runnerEventsFlow.emit(transition(from = ExchangeV2State.Joiner.Waiting, to = ExchangeV2State.Joiner.Done))
-            job.await()
+            assertEquals(NO_RECOVERY_CODE.code, (awaitItem() as DispatchOutcome.Failed).code)
+            cancelAndIgnoreRemainingEvents()
         }
-        assertEquals(NO_RECOVERY_CODE.code, (outcome as DispatchOutcome.Failed).code)
     }
 
-    @Test fun `linking - SessionError maps to Failed PAIRING_FAILED`() = runTest {
-        val outcome = withTimeoutOrNull(1000) {
-            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+    @Test fun `Scanner - SessionError maps to Failed PAIRING_FAILED`() = runTest {
+        startLinking().test {
             runnerEventsFlow.emit(ExchangeV2Event.SessionError(timestampMs = System.currentTimeMillis(), message = "channel 500"))
-            job.await()
+            assertEquals(PAIRING_FAILED.code, (awaitItem() as DispatchOutcome.Failed).code)
+            cancelAndIgnoreRemainingEvents()
         }
-        assertEquals(PAIRING_FAILED.code, (outcome as DispatchOutcome.Failed).code)
     }
 
-    @Test fun `linking - Host Aborted maps to Failed NEGOTIATION_ABORTED`() = runTest {
-        val outcome = withTimeoutOrNull(1000) {
-            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+    @Test fun `Scanner - Host_Aborted maps to Failed NEGOTIATION_ABORTED`() = runTest {
+        startLinking().test {
             runnerEventsFlow.emit(transition(from = ExchangeV2State.Host.Confirming, to = ExchangeV2State.Host.Aborted))
-            job.await()
+            assertEquals(NEGOTIATION_ABORTED.code, (awaitItem() as DispatchOutcome.Failed).code)
+            cancelAndIgnoreRemainingEvents()
         }
-        assertEquals(NEGOTIATION_ABORTED.code, (outcome as DispatchOutcome.Failed).code)
     }
 
-    @Test fun `present - AbortedByHost with RecoveryCodeDenied maps to Failed PAIRING_REJECTED`() = runTest {
-        val outcome = withTimeoutOrNull(1000) {
-            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+    @Test fun `Presenter - Joiner_AbortedByHost with RecoveryCodeDenied maps to Failed PAIRING_REJECTED`() = runTest {
+        dispatcher.presentV2().test {
             runnerEventsFlow.emit(
                 transition(
                     from = ExchangeV2State.Joiner.Confirming,
@@ -1228,17 +1180,80 @@ class RealSyncCodeDispatcherTest {
                     trigger = ExchangeV2Message.RecoveryCodeDenied(rawJson = "{}"),
                 ),
             )
-            job.await()
+            assertEquals(PAIRING_REJECTED.code, (awaitItem() as DispatchOutcome.Failed).code)
+            cancelAndIgnoreRemainingEvents()
         }
-        assertEquals(PAIRING_REJECTED.code, (outcome as DispatchOutcome.Failed).code)
     }
 
-    @Test fun `present - Host Aborted with no localTrigger maps to Failed NEGOTIATION_ABORTED`() = runTest {
-        val outcome = withTimeoutOrNull(1000) {
-            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+    @Test fun `Presenter - Host_Aborted with no localTrigger maps to Failed NEGOTIATION_ABORTED`() = runTest {
+        dispatcher.presentV2().test {
             runnerEventsFlow.emit(transition(from = ExchangeV2State.Host.Confirming, to = ExchangeV2State.Host.Aborted))
-            job.await()
+            assertEquals(NEGOTIATION_ABORTED.code, (awaitItem() as DispatchOutcome.Failed).code)
+            cancelAndIgnoreRemainingEvents()
         }
-        assertEquals(NEGOTIATION_ABORTED.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `Scanner - Joiner_AbortedByHost with an unrecognised trigger maps to Failed PAIRING_REJECTED (peer_aborted)`() = runTest {
+        startLinking().test {
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedByHost,
+                    trigger = ExchangeV2Message.Hello(rawJson = "{}"),
+                ),
+            )
+            val outcome = awaitItem() as DispatchOutcome.Failed
+            assertEquals(PAIRING_REJECTED.code, outcome.code)
+            assertEquals("peer_aborted", outcome.reason)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `Scanner - Joiner_AbortedLocal with no trigger maps to Failed PAIRING_FAILED (joiner_local_aborted)`() = runTest {
+        startLinking().test {
+            runnerEventsFlow.emit(
+                transition(from = ExchangeV2State.Joiner.Confirming, to = ExchangeV2State.Joiner.AbortedLocal),
+            )
+            val outcome = awaitItem() as DispatchOutcome.Failed
+            assertEquals(PAIRING_FAILED.code, outcome.code)
+            assertEquals("joiner_local_aborted", outcome.reason)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `Presenter emits Failed when Joiner_Done carries a recovery code with unknown cid`() = runTest {
+        val recoveryJson = JSONObject().apply {
+            put(
+                "recovery",
+                JSONObject().apply {
+                    put("user_id", "u-1")
+                    put("secret", "s-1")
+                    put("cid", "future-credential")
+                    put("v", "2.0")
+                },
+            )
+        }.toString()
+        val b64 = android.util.Base64.encodeToString(
+            recoveryJson.toByteArray(Charsets.UTF_8),
+            android.util.Base64.URL_SAFE or android.util.Base64.NO_PADDING or android.util.Base64.NO_WRAP,
+        )
+        val responseMessage = ExchangeV2Message.RecoveryCodeResponse(rawJson = "{}", recoveryCode = b64)
+
+        dispatcher.presentV2().test {
+            runnerEventsFlow.emit(
+                ExchangeV2Event.Transition(
+                    timestampMs = System.currentTimeMillis(),
+                    from = ExchangeV2State.Joiner.Waiting,
+                    to = ExchangeV2State.Joiner.Done,
+                    trigger = responseMessage,
+                    localTrigger = null,
+                ),
+            )
+            val outcome = awaitItem() as DispatchOutcome.Failed
+            assertTrue("expected reason to mention the unknown cid, got '${outcome.reason}'", outcome.reason.contains("future-credential"))
+            cancelAndIgnoreRemainingEvents()
+        }
+        verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
+        verify(syncAccountRepository, never()).joinAccountFromThirdPartyRecoveryCode(any())
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
 import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
 import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_UNAVAILABLE
+import com.duckduckgo.sync.impl.AccountErrorCodes.UNEXPECTED_EVENT
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
@@ -802,7 +803,7 @@ class RealSyncCodeDispatcherTest {
         }
         assertEquals(
             DispatchOutcome.Failed(
-                "Pairing completed without a recovery code",
+                "joiner_done_missing_recovery_code",
                 NO_RECOVERY_CODE.code,
                 path = SetupPath.PAIRING,
                 myRole = SetupRole.JOINER,
@@ -898,7 +899,7 @@ class RealSyncCodeDispatcherTest {
         verify(syncAccountRepository, never()).processCode(any(), anyOrNull())
     }
 
-    @Test fun `presentV2 emits Failed with cancelled-on-this-device reason when Joiner reaches AbortedLocal`() = runTest {
+    @Test fun `presentV2 emits Failed PAIRING_CANCELLED when Joiner AbortedLocal driven by UserDeniedJoiner`() = runTest {
         val outcome = withTimeoutOrNull(1000) {
             val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
             runnerEventsFlow.emit(
@@ -912,13 +913,43 @@ class RealSyncCodeDispatcherTest {
         }
         assertEquals(
             DispatchOutcome.Failed(
-                "Pairing cancelled on this device",
+                "user_denied_joiner",
                 PAIRING_CANCELLED.code,
                 path = SetupPath.PAIRING,
                 myRole = SetupRole.JOINER,
             ),
             outcome,
         )
+    }
+
+    @Test fun `presentV2 emits Failed UNEXPECTED_EVENT when Joiner AbortedLocal driven by wire message`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Waiting,
+                    to = ExchangeV2State.Joiner.AbortedLocal,
+                    trigger = ExchangeV2Message.Hello(rawJson = "{}"),
+                ),
+            )
+            job.await()
+        }
+        assertEquals(UNEXPECTED_EVENT.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `presentV2 emits Failed UNEXPECTED_EVENT when Host Aborted driven by wire message`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { dispatcher.presentV2().first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Host.Confirming,
+                    to = ExchangeV2State.Host.Aborted,
+                    trigger = ExchangeV2Message.RecoveryCodeResponse(rawJson = "{}"),
+                ),
+            )
+            job.await()
+        }
+        assertEquals(UNEXPECTED_EVENT.code, (outcome as DispatchOutcome.Failed).code)
     }
 
     @Test fun `presentV2 calls runner_startPresent when Flow is collected`() = runTest {
@@ -1106,13 +1137,49 @@ class RealSyncCodeDispatcherTest {
         assertEquals(PAIRING_UNAVAILABLE.code, (outcome as DispatchOutcome.Failed).code)
     }
 
-    @Test fun `linking - Joiner AbortedLocal maps to Failed PAIRING_CANCELLED`() = runTest {
+    @Test fun `linking - Joiner AbortedLocal with UserDeniedJoiner maps to Failed PAIRING_CANCELLED`() = runTest {
         val outcome = withTimeoutOrNull(1000) {
             val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
-            runnerEventsFlow.emit(transition(from = ExchangeV2State.Joiner.Confirming, to = ExchangeV2State.Joiner.AbortedLocal))
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Confirming,
+                    to = ExchangeV2State.Joiner.AbortedLocal,
+                    localTrigger = LocalTrigger.UserDeniedJoiner,
+                ),
+            )
             job.await()
         }
         assertEquals(PAIRING_CANCELLED.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `linking - Joiner AbortedLocal driven by wire message maps to Failed UNEXPECTED_EVENT`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Joiner.Waiting,
+                    to = ExchangeV2State.Joiner.AbortedLocal,
+                    trigger = ExchangeV2Message.Hello(rawJson = "{}"),
+                ),
+            )
+            job.await()
+        }
+        assertEquals(UNEXPECTED_EVENT.code, (outcome as DispatchOutcome.Failed).code)
+    }
+
+    @Test fun `linking - Host Aborted driven by wire message maps to Failed UNEXPECTED_EVENT`() = runTest {
+        val outcome = withTimeoutOrNull(1000) {
+            val job = async(start = kotlinx.coroutines.CoroutineStart.UNDISPATCHED) { startLinking().first() }
+            runnerEventsFlow.emit(
+                transition(
+                    from = ExchangeV2State.Host.Confirming,
+                    to = ExchangeV2State.Host.Aborted,
+                    trigger = ExchangeV2Message.Hello(rawJson = "{}"),
+                ),
+            )
+            job.await()
+        }
+        assertEquals(UNEXPECTED_EVENT.code, (outcome as DispatchOutcome.Failed).code)
     }
 
     @Test fun `linking - Aborted maps to Failed NEGOTIATION_ABORTED`() = runTest {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachineTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2StateMachineTest.kt
@@ -59,7 +59,7 @@ class ExchangeV2StateMachineTest {
         assertTrue(transition.trigger is Hello)
     }
 
-    @Test fun `when non-hello known message received in Bootstrapped then aborts`() {
+    @Test fun `when non-hello known message received in Bootstrapped then aborts to terminal Aborted`() {
         val known: List<ExchangeV2Message> = listOf(
             availableFromPeer(),
             requestFromPeer(),
@@ -74,6 +74,11 @@ class ExchangeV2StateMachineTest {
             val result = machine.receive(msg)
             assertTrue("expected abort for $msg, got ${result.outcome}", result.outcome is TransitionOutcome.Aborted)
             assertEquals(RejectReason.ImplicitAbort, (result.outcome as TransitionOutcome.Aborted).reason)
+            assertSame("recv $msg should drive to Aborted", ExchangeV2State.Aborted, machine.currentState)
+            val transition = result.event as ExchangeV2Event.Transition
+            assertSame(ExchangeV2State.Bootstrapped, transition.from)
+            assertSame(ExchangeV2State.Aborted, transition.to)
+            assertSame(msg, transition.trigger)
         }
     }
 
@@ -87,10 +92,15 @@ class ExchangeV2StateMachineTest {
         assertEquals(RejectReason.UnknownMessageDropped, event.reason)
     }
 
-    @Test fun `when out-of-sequence local trigger in Bootstrapped then aborts`() {
+    @Test fun `when out-of-sequence local trigger in Bootstrapped then aborts to terminal Aborted`() {
         val machine = sm()
         val result = machine.localTrigger(LocalTrigger.UserConfirmedHost)
         assertTrue(result.outcome is TransitionOutcome.Aborted)
+        assertSame(ExchangeV2State.Aborted, machine.currentState)
+        val transition = result.event as ExchangeV2Event.Transition
+        assertSame(ExchangeV2State.Bootstrapped, transition.from)
+        assertSame(ExchangeV2State.Aborted, transition.to)
+        assertSame(LocalTrigger.UserConfirmedHost, transition.localTrigger)
     }
 
     @Test fun `when presenter receives second hello in Negotiating then aborts to terminal Aborted`() {
@@ -170,7 +180,7 @@ class ExchangeV2StateMachineTest {
         assertSame(ExchangeV2State.Negotiating, machine.currentState)
     }
 
-    @Test fun `when finalise-phase message received in Negotiating then aborts`() {
+    @Test fun `when finalise-phase message received in Negotiating then aborts to terminal Aborted`() {
         val finalise: List<ExchangeV2Message> = listOf(
             RecoveryCodeAwaitingConfirmation("{}"),
             RecoveryCodeConfirmed("{}"),
@@ -183,6 +193,11 @@ class ExchangeV2StateMachineTest {
             machine.receive(Hello("{}"))
             val result = machine.receive(msg)
             assertTrue("expected abort for $msg in Negotiating, got ${result.outcome}", result.outcome is TransitionOutcome.Aborted)
+            assertSame("recv $msg in Negotiating should drive to Aborted", ExchangeV2State.Aborted, machine.currentState)
+            val transition = result.event as ExchangeV2Event.Transition
+            assertSame(ExchangeV2State.Negotiating, transition.from)
+            assertSame(ExchangeV2State.Aborted, transition.to)
+            assertSame(msg, transition.trigger)
         }
     }
 
@@ -239,10 +254,10 @@ class ExchangeV2StateMachineTest {
         assertSame(ExchangeV2State.Host.Done, machine.currentState)
     }
 
-    @Test fun `when wire message received in Host states then aborts`() {
-        val hostStateBuilders: List<Pair<String, () -> ExchangeV2StateMachine>> = listOf(
-            "Host.Confirming" to ::inHostConfirming,
-            "Host.Sending" to {
+    @Test fun `when wire message received in Host states then aborts to terminal Host Aborted`() {
+        val hostStateBuilders: List<Pair<ExchangeV2State, () -> ExchangeV2StateMachine>> = listOf(
+            ExchangeV2State.Host.Confirming to ::inHostConfirming,
+            ExchangeV2State.Host.Sending to {
                 inHostConfirming().also { it.localTrigger(LocalTrigger.UserConfirmedHost) }
             },
         )
@@ -252,11 +267,16 @@ class ExchangeV2StateMachineTest {
             requestFromPeer(),
             RecoveryCodeResponse("{}"),
         )
-        for ((label, build) in hostStateBuilders) {
+        for ((from, build) in hostStateBuilders) {
             for (msg in knownIncoming) {
                 val machine = build()
                 val result = machine.receive(msg)
-                assertTrue("$label recv $msg should abort, got ${result.outcome}", result.outcome is TransitionOutcome.Aborted)
+                assertTrue("$from recv $msg should abort, got ${result.outcome}", result.outcome is TransitionOutcome.Aborted)
+                assertSame("$from recv $msg should drive to Host.Aborted", ExchangeV2State.Host.Aborted, machine.currentState)
+                val transition = result.event as ExchangeV2Event.Transition
+                assertSame(from, transition.from)
+                assertSame(ExchangeV2State.Host.Aborted, transition.to)
+                assertSame(msg, transition.trigger)
             }
         }
     }
@@ -301,7 +321,7 @@ class ExchangeV2StateMachineTest {
         assertSame(ExchangeV2State.Joiner.AbortedByHost, machine.currentState)
     }
 
-    @Test fun `when host success-phase message received in Joiner Confirming then aborts and stays put`() {
+    @Test fun `when host success-phase message received in Joiner Confirming then aborts to terminal Joiner AbortedLocal`() {
         val hostSuccessPhase: List<ExchangeV2Message> = listOf(
             RecoveryCodeAwaitingConfirmation("{}"),
             RecoveryCodeConfirmed("{}"),
@@ -312,11 +332,15 @@ class ExchangeV2StateMachineTest {
             val result = machine.receive(msg)
             assertTrue("recv $msg in Joiner.Confirming should abort, got ${result.outcome}", result.outcome is TransitionOutcome.Aborted)
             assertEquals(RejectReason.ImplicitAbort, (result.outcome as TransitionOutcome.Aborted).reason)
-            assertSame("recv $msg should leave the SM in Joiner.Confirming", ExchangeV2State.Joiner.Confirming, machine.currentState)
+            assertSame("recv $msg should drive to Joiner.AbortedLocal", ExchangeV2State.Joiner.AbortedLocal, machine.currentState)
+            val transition = result.event as ExchangeV2Event.Transition
+            assertSame(ExchangeV2State.Joiner.Confirming, transition.from)
+            assertSame(ExchangeV2State.Joiner.AbortedLocal, transition.to)
+            assertSame(msg, transition.trigger)
         }
     }
 
-    @Test fun `when negotiation-phase message received in Joiner Confirming then aborts`() {
+    @Test fun `when negotiation-phase message received in Joiner Confirming then aborts to terminal Joiner AbortedLocal`() {
         val negotiationPhase: List<ExchangeV2Message> = listOf(
             Hello("{}"),
             availableFromPeer(),
@@ -326,6 +350,7 @@ class ExchangeV2StateMachineTest {
             val machine = inJoinerConfirming()
             val result = machine.receive(msg)
             assertTrue("recv $msg in Joiner.Confirming should abort, got ${result.outcome}", result.outcome is TransitionOutcome.Aborted)
+            assertSame(ExchangeV2State.Joiner.AbortedLocal, machine.currentState)
         }
     }
 
@@ -377,7 +402,7 @@ class ExchangeV2StateMachineTest {
         assertSame(ExchangeV2State.Joiner.Done, machine.currentState)
     }
 
-    @Test fun `when negotiation-phase message received in Joiner Waiting then aborts`() {
+    @Test fun `when negotiation-phase message received in Joiner Waiting then aborts to terminal Joiner AbortedLocal`() {
         val negotiationPhase: List<ExchangeV2Message> = listOf(
             Hello("{}"),
             availableFromPeer(),
@@ -387,6 +412,11 @@ class ExchangeV2StateMachineTest {
             val machine = inJoinerWaiting()
             val result = machine.receive(msg)
             assertTrue("recv $msg in Joiner.Waiting should abort, got ${result.outcome}", result.outcome is TransitionOutcome.Aborted)
+            assertSame("recv $msg should drive to Joiner.AbortedLocal", ExchangeV2State.Joiner.AbortedLocal, machine.currentState)
+            val transition = result.event as ExchangeV2Event.Transition
+            assertSame(ExchangeV2State.Joiner.Waiting, transition.from)
+            assertSame(ExchangeV2State.Joiner.AbortedLocal, transition.to)
+            assertSame(msg, transition.trigger)
         }
     }
 
@@ -465,6 +495,57 @@ class ExchangeV2StateMachineTest {
         val denying = inJoinerConfirming()
         val denied = denying.localTrigger(LocalTrigger.UserDeniedJoiner)
         assertTrue(denied.sideEffects.isEmpty())
+    }
+
+    @Test fun `when out-of-sequence local trigger in Host Confirming then aborts to terminal Host Aborted`() {
+        val machine = inHostConfirming()
+        val result = machine.localTrigger(LocalTrigger.UserConfirmedJoiner)
+
+        assertTrue(result.outcome is TransitionOutcome.Aborted)
+        assertSame(ExchangeV2State.Host.Aborted, machine.currentState)
+        val transition = result.event as ExchangeV2Event.Transition
+        assertSame(ExchangeV2State.Host.Confirming, transition.from)
+        assertSame(ExchangeV2State.Host.Aborted, transition.to)
+        assertSame(LocalTrigger.UserConfirmedJoiner, transition.localTrigger)
+    }
+
+    @Test fun `when out-of-sequence local trigger in Joiner Confirming then aborts to terminal Joiner AbortedLocal`() {
+        val machine = inJoinerConfirming()
+        val result = machine.localTrigger(LocalTrigger.UserConfirmedHost)
+
+        assertTrue(result.outcome is TransitionOutcome.Aborted)
+        assertSame(ExchangeV2State.Joiner.AbortedLocal, machine.currentState)
+    }
+
+    @Test fun `when out-of-sequence local trigger in Joiner Waiting then aborts to terminal Joiner AbortedLocal`() {
+        val machine = inJoinerWaiting()
+        val result = machine.localTrigger(LocalTrigger.UserConfirmedJoiner)
+
+        assertTrue(result.outcome is TransitionOutcome.Aborted)
+        assertSame(ExchangeV2State.Joiner.AbortedLocal, machine.currentState)
+    }
+
+    @Test fun `when message received in Host Done then state unchanged and outcome is Aborted`() {
+        val machine = inHostConfirming().also {
+            it.localTrigger(LocalTrigger.UserConfirmedHost)
+            it.localTrigger(LocalTrigger.HostSendComplete)
+        }
+        assertSame(ExchangeV2State.Host.Done, machine.currentState)
+
+        val result = machine.receive(RecoveryCodeResponse("{}"))
+
+        assertTrue(result.outcome is TransitionOutcome.Aborted)
+        assertSame(ExchangeV2State.Host.Done, machine.currentState)
+    }
+
+    @Test fun `when message received in Joiner Done then state unchanged and outcome is Aborted`() {
+        val machine = inJoinerWaiting().also { it.receive(RecoveryCodeResponse("{}")) }
+        assertSame(ExchangeV2State.Joiner.Done, machine.currentState)
+
+        val result = machine.receive(Hello("{}"))
+
+        assertTrue(result.outcome is TransitionOutcome.Aborted)
+        assertSame(ExchangeV2State.Joiner.Done, machine.currentState)
     }
 
     private fun inHostConfirming(): ExchangeV2StateMachine =

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
@@ -74,6 +74,7 @@ import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.Logi
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.ShowError
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.ShowV2Error
 import com.duckduckgo.sync.impl.ui.SyncWithAnotherActivityViewModel.Command.SwitchAccountSuccess
+import com.duckduckgo.sync.impl.ui.setup.EnterCodeContract.EnterCodeContractOutput
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -791,6 +792,38 @@ class SyncWithAnotherDeviceViewModelTest {
             val command = awaitItem()
             assertTrue("expected ShowV2Error, got $command", command is ShowV2Error)
             assertEquals(PAIRING_REJECTED.code.toV2PairingError(), (command as ShowV2Error).content)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenEnterCodeReturnsErrorThenFinishWithError() = runTest {
+        testee.onEnterCodeResult(EnterCodeContractOutput.Error)
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected FinishWithError, got $command", command is Command.FinishWithError)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenEnterCodeReturnsCancelledThenNoCommand() = runTest {
+        testee.onEnterCodeResult(EnterCodeContractOutput.Cancelled)
+
+        testee.commands().test {
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenEnterCodeReturnsLoginSuccessThenLoginSuccessCommand() = runTest {
+        testee.onEnterCodeResult(EnterCodeContractOutput.LoginSuccess)
+
+        testee.commands().test {
+            val command = awaitItem()
+            assertTrue("expected LoginSuccess, got $command", command is LoginSuccess)
             cancelAndIgnoreRemainingEvents()
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203822806345703/task/1215724271421988?focus=true

### Description

Per the Transport Tech Design ("other error/incompatibility/bug in the other party is detected" → tear down), implicit aborts in the v2 SM now drive to a terminal state instead of leaving the session in a non-terminal one. Previously the runner only tore down on `isTerminal()`, so out-of-sequence messages let sessions linger until the 5-min client timed out.

Now, if the peer sends an unexpected/out-of-sequence message then treated as `UNEXPECTED_EVENT` rather than the generic `PAIRING_FAILED`

Finally, if there is a terminal error in the manual code entry screen, after the user sees the error message they are taken back to sync settings screen (instead of returned only to the barcode scanning screen on a bad session).

### Steps to test this PR

> [!NOTE]
> Requires the Python pairing reference client

For each scenario below, start with no existing sync account before testing.

#### 1. `response-without-hello` — exercises the new `Bootstrapped → Aborted` path

**Direction:** Android = Presenter (shows code), Python = Scanner (pastes Android's code).

- [x] On Android: Sync settings → Sync With Another Device → **Copy Text Code** (Android presents).
- [x] In a terminal, run the broken Scanner:
    
```
      poetry run pairing-client \
        --server-url https://sync.duckduckgo.com/ \
        --broken-mode response-without-hello \
        --kind 3party
```

- [x] When Python prompts `Paste the other device's code:`, paste Android's code
- [x] Expected on Android: dialog "Sync failed. Please try again." immediately (no 5-min wait)

#### 2. `duplicate-hello` — sanity check on second-hello-in-Negotiating teardown

**Direction:** Android = Presenter, Python = Scanner.

- [x] Android: same as scenario 1 (copy code from Android and paste into python companion).
- [x] Python:
     
```
      poetry run pairing-client \
        --server-url https://sync.duckduckgo.com/ \
        --broken-mode duplicate-hello \
        --kind 3party
 ```

- [x] Paste Android's code into Python when prompted.
- [x] Expected on Android: dialog "Sync failed. Please try again."

#### 3. `hello-from-presenter` — same teardown contract, opposite role assignment

**Direction:** Android = Scanner (pastes Python's code), Python = Presenter (shows code).

- [x] In a terminal, run the broken Presenter:
     
```
      poetry run pairing-client \
        --server-url https://sync.duckduckgo.com/ \
        --broken-mode hello-from-presenter \
        --kind 3party --has-account 3party
```

- [x] Python prints `https://duckduckgo.com/sync/pairing/#&code2=…` — copy this URL.
- [x] On Android: Sync settings → Sync With Another Device → **Manually Enter Code** and paste Python's URL.
- [x] Expected on Android: dialog "Sync failed. Please try again."


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sync v2 pairing session teardown and user-visible error classification; impact is limited to the connect/pairing path but wrong mapping would confuse users or leave sessions uncleared.
> 
> **Overview**
> **V2 exchange state machine** now moves **implicit aborts** and **out-of-sequence local triggers** into **terminal states** (`Aborted`, `Host.Aborted`, `Joiner.AbortedLocal`) instead of leaving the session stuck in non-terminal states, so the runner can tear down per session lifecycle. Late messages on **already-terminal** states stay defensive (state unchanged).
> 
> **`RealSyncCodeDispatcher`** maps those terminals more precisely: **`Joiner.AbortedLocal`** and **`Host.Aborted`** use **`PAIRING_CANCELLED`** only when the user explicitly denied; **wire-driven protocol errors** use **`PAIRING_FAILED`** (generic "Sync failed" copy) instead of cancellation messaging.
> 
> Tests in **`ExchangeV2StateMachineTest`** and **`RealSyncCodeDispatcherTest`** assert terminal transitions and the new outcome codes for present/linking flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a41c40158080f02290c855f03418bcf8c615311. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->