### PR TITLE
Keep input field query in sync across tab changes

### DIFF
--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChatInputModeState.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChatInputModeState.kt
@@ -37,14 +37,17 @@ interface DuckChatInputModeState {
     val displayedMode: StateFlow<InputMode>
 
     /**
-     * The current Chat-tab query — the text typed while the Chat tab is the input target.
+     * The live input query — the trimmed text in the shared input field, updated per keystroke
+     * regardless of the selected tab (the field is shared between Search and Chat, so the query is the
+     * same on both).
      *
-     * High-frequency (updates per keystroke), kept as its own flow so it doesn't churn
-     * [displayedMode] consumers. Holds [""] when the Chat tab isn't the target (Search tab selected
-     * or no widget attached), mirroring how [displayedMode] resets to [InputMode.SEARCH]. A sibling
-     * `searchQuery` can follow the same pattern for the Search tab.
+     * High-frequency, kept as its own flow so it doesn't churn [displayedMode] consumers. Holds [""]
+     * only when the field is blank or no widget is attached. Deliberately NOT reset to [""] on the
+     * Search tab: a chat-tab item that derives its visibility from this (e.g. a zero-state card) would
+     * otherwise go stale while Search is active and flash when the Chat tab re-renders. Pair it with
+     * [displayedMode] when you also need to know which tab is showing.
      */
-    val chatQuery: StateFlow<String>
+    val inputQuery: StateFlow<String>
 }
 
 /**

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/inputscreen/NativeInputChatTabItemPlugin.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/inputscreen/NativeInputChatTabItemPlugin.kt
@@ -62,7 +62,7 @@ interface NativeInputChatTabItemPlugin : ActivePlugin {
  * view holders, and the host only positions them.
  *
  * Input state the item needs to decide its rows — the current query, the displayed mode — is read from
- * the shared state in this module (e.g. [com.duckduckgo.duckchat.api.DuckChatInputModeState.chatQuery]
+ * the shared state in this module (e.g. [com.duckduckgo.duckchat.api.DuckChatInputModeState.inputQuery]
  * and `displayedMode`), not pushed in here. An item observes that state (combining it with its own
  * async data) and updates its adapter(s); an item with no rows contributes no content and does not keep
  * the suggestions overlay open. For the common single-view card see [SingleViewChatTabItem].

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/inputscreen/SingleViewChatTabItem.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/inputscreen/SingleViewChatTabItem.kt
@@ -30,7 +30,7 @@ import kotlinx.coroutines.launch
  *
  * Provide the view in [onCreateView] and a [visible] flow that drives whether the row is shown. The
  * flow is the single knob: compose it from whatever state the item cares about — e.g.
- * `chatQuery.map { it.isEmpty() }` for a zero-state card that hides while the user types, the item's
+ * `inputQuery.map { it.isEmpty() }` for a zero-state card that hides while the user types, the item's
  * own data for a state-driven card, both combined, or `flowOf(true)` to always show. [hide] is a
  * sticky override (e.g. on dismiss) that wins over [visible] for the rest of the presentation.
  *

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -127,11 +127,10 @@ interface DuckChatInternal : DuckChat {
     fun setSelectedMode(mode: InputMode)
 
     /**
-     * Updates the live Chat-tab query. Called by [InputModeWidget] as the user types on the Chat tab,
-     * and reset to [""] when the Chat tab isn't the target, to keep [DuckChatInputModeState.chatQuery]
-     * in sync with the actual widget state.
+     * Updates the live input query. Called by [InputModeWidget] as the user types (on either tab) and
+     * on attach/detach, to keep [DuckChatInputModeState.inputQuery] in sync with the shared input field.
      */
-    fun setChatQuery(query: String)
+    fun setInputQuery(query: String)
 
     /**
      * Observes whether DuckChat is user enabled or disabled.
@@ -404,7 +403,7 @@ class RealDuckChat @Inject constructor(
     private val _showContextualMode = MutableStateFlow(false)
     private val _allowDuckAiAsDigitalAssistant = MutableStateFlow(false)
     private val _displayedMode = MutableStateFlow(InputMode.SEARCH)
-    private val _chatQuery = MutableStateFlow("")
+    private val _inputQuery = MutableStateFlow("")
 
     private val jsonAdapter: JsonAdapter<DuckChatSettingJson> by lazy {
         moshi.adapter(DuckChatSettingJson::class.java)
@@ -835,10 +834,10 @@ class RealDuckChat @Inject constructor(
         _displayedMode.value = mode
     }
 
-    override val chatQuery: StateFlow<String> = _chatQuery.asStateFlow()
+    override val inputQuery: StateFlow<String> = _inputQuery.asStateFlow()
 
-    override fun setChatQuery(query: String) {
-        _chatQuery.value = query
+    override fun setInputQuery(query: String) {
+        _inputQuery.value = query
     }
 
     private suspend fun hasActiveSession(): Boolean {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/example/ExampleMessageCardPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/suggestions/example/ExampleMessageCardPlugin.kt
@@ -39,9 +39,9 @@ import javax.inject.Inject
  * - implement [NativeInputChatTabItemPlugin] in your own module, gated by [ContributesActivePlugin]
  *   (here `INTERNAL`, so it only appears in internal/dev builds),
  * - return a [SingleViewChatTabItem] for a single static view — no adapter to write,
- * - drive visibility from the shared input state: here `chatQuery.map { it.isEmpty() }` makes it a
+ * - drive visibility from the shared input state: here `inputQuery.map { it.isEmpty() }` makes it a
  *   zero-state card (hidden once the user types). A card that should stay while typing would simply
- *   not include `chatQuery` in its `visible` flow.
+ *   not include `inputQuery` in its `visible` flow.
  * - `priority` picks the slot from [NativeInputChatTabItemPlugin]'s constants.
  *
  * This is a showcase — delete it (and its strings) once real consumers exist.
@@ -66,7 +66,7 @@ private class ExampleMessageCardItem(
     inputModeState: DuckChatInputModeState,
     scope: CoroutineScope,
 ) : SingleViewChatTabItem(
-    visible = inputModeState.chatQuery.map { it.isEmpty() }, // zero-state: shown only on empty query
+    visible = inputModeState.inputQuery.map { it.isEmpty() }, // zero-state: shown only on empty query
     scope = scope,
 ) {
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
@@ -343,7 +343,12 @@ open class InputModeWidget @JvmOverloads constructor(
                 // Keep inputQuery in sync with the shared input field on every keystroke, regardless of
                 // the active tab, so a chat-tab item driven by it settles while the Search tab is
                 // active and is already correct when the Chat tab re-renders (no flash on switch-back).
-                duckChatInternal.setInputQuery(liveQuery)
+                // Guard on attach: duckChatInternal is injected in onAttachedToWindow, but the field can
+                // be set before then (e.g. omnibar prefill); onAttachedToWindow publishes the initial
+                // query, so nothing is lost by skipping the pre-attach changes here.
+                if (isAttachedToWindow) {
+                    duckChatInternal.setInputQuery(liveQuery)
+                }
                 when (inputModeSwitch.selectedTabPosition) {
                     0 -> onSearchTextChanged?.invoke(liveQuery)
                     1 -> {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
@@ -172,7 +172,11 @@ open class InputModeWidget @JvmOverloads constructor(
             override fun onTabSelected(tab: TabLayout.Tab) {
                 val mode = if (tab.position == 0) InputMode.SEARCH else InputMode.DUCK_AI
                 duckChatInternal.setSelectedMode(mode)
-                duckChatInternal.setChatQuery(if (mode == InputMode.DUCK_AI) currentChatQuery() else "")
+                // inputQuery tracks the shared input field, not the selected tab — the field is shared
+                // between Search and Chat, so the query is the same on both. Don't reset to "" on the
+                // Search tab: a chat-tab item driven by inputQuery would then go stale while Search is
+                // active and flash on switch-back. displayedMode carries the tab; inputQuery the text.
+                duckChatInternal.setInputQuery(currentInputQuery())
             }
             override fun onTabUnselected(tab: TabLayout.Tab?) {}
             override fun onTabReselected(tab: TabLayout.Tab?) {}
@@ -210,13 +214,13 @@ open class InputModeWidget @JvmOverloads constructor(
         inputModeSwitch.addOnTabSelectedListener(duckChatTabSelectedListener)
         val mode = if (inputModeSwitch.selectedTabPosition == 0) InputMode.SEARCH else InputMode.DUCK_AI
         duckChatInternal.setSelectedMode(mode)
-        duckChatInternal.setChatQuery(if (mode == InputMode.DUCK_AI) currentChatQuery() else "")
+        duckChatInternal.setInputQuery(currentInputQuery())
     }
 
     override fun onDetachedFromWindow() {
         inputModeSwitch.removeOnTabSelectedListener(duckChatTabSelectedListener)
         duckChatInternal.setSelectedMode(InputMode.SEARCH)
-        duckChatInternal.setChatQuery("")
+        duckChatInternal.setInputQuery("")
         super.onDetachedFromWindow()
     }
 
@@ -335,12 +339,15 @@ open class InputModeWidget @JvmOverloads constructor(
                 onSubmitMessageAvailable?.invoke(textToSubmit != null)
                 onVoiceInputAllowed?.invoke(!hasTextChangedFromOriginal || inputField.text.isBlank())
 
+                val liveQuery = textToSubmit?.toString().orEmpty()
+                // Keep inputQuery in sync with the shared input field on every keystroke, regardless of
+                // the active tab, so a chat-tab item driven by it settles while the Search tab is
+                // active and is already correct when the Chat tab re-renders (no flash on switch-back).
+                duckChatInternal.setInputQuery(liveQuery)
                 when (inputModeSwitch.selectedTabPosition) {
-                    0 -> onSearchTextChanged?.invoke(textToSubmit?.toString().orEmpty())
+                    0 -> onSearchTextChanged?.invoke(liveQuery)
                     1 -> {
-                        val chatQuery = textToSubmit?.toString().orEmpty()
-                        onChatTextChanged?.invoke(chatQuery)
-                        duckChatInternal.setChatQuery(chatQuery)
+                        onChatTextChanged?.invoke(liveQuery)
                         if (tabAttachmentsEnabled) {
                             onChatTagTextChanged?.invoke(
                                 inputField.text.toString(),
@@ -494,7 +501,7 @@ open class InputModeWidget @JvmOverloads constructor(
 
     fun isChatTabSelected(): Boolean = inputModeSwitch.selectedTabPosition == 1
 
-    private fun currentChatQuery(): String = inputField.text.getTextToSubmit()?.toString().orEmpty()
+    private fun currentInputQuery(): String = inputField.text.getTextToSubmit()?.toString().orEmpty()
 
     fun setScrollPosition(
         position: Int,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinder.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinder.kt
@@ -130,10 +130,10 @@ class NativeInputChatSuggestionsBinder @Inject constructor(
 
             // hasContent counts the live plugin rows (a plugin item with any rows keeps the overlay open
             // even with no chat/typing). The recompute reads the LIVE query, not this submit's captured
-            // one: a zero-state item hides as soon as the user types (chatQuery updates before the typed
+            // one: a zero-state item hides as soon as the user types (inputQuery updates before the typed
             // query's fetch submits), and recomputing with a stale isTyping=false would wrongly close the
-            // overlay for a frame. The live chatQuery still distinguishes a genuine empty-state dismiss.
-            val commit = { onCommit(hasChat || inputModeState.chatQuery.value.isNotEmpty() || pluginHasContent()) }
+            // overlay for a frame. The live inputQuery still distinguishes a genuine empty-state dismiss.
+            val commit = { onCommit(hasChat || inputModeState.inputQuery.value.isNotEmpty() || pluginHasContent()) }
             recomputeOverlay = commit
 
             chatSuggestionsAdapter.submitList(suggestions.chatHistory) { commit() }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -254,13 +254,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
     // Outlives a single suggestions presentation (survives clear() on tab switches); handed to chat-item
     // plugins so they can collect into their adapters. Cancelled in tearDownChatSuggestions().
     private var chatItemPluginScope: CoroutineScope? = null
-
-    // Creates the chat-suggestions binding and loads its chat-item plugins. Captured from
-    // bindChatSuggestions and invoked at attach so plugins are live for the whole presentation,
-    // independent of which tab is selected (they must react while the Search tab is showing, and
-    // their rows must already exist before the Chat tab first renders — otherwise a late insert on
-    // first Chat-tab show flashes). The built-in sections stay lazy, populated via submit().
-    private var ensureChatSuggestionsBinding: (() -> Unit)? = null
     private var onShowSuggestions: ((RecyclerView.Adapter<*>) -> Unit)? = null
     private var onClearSuggestions: ((Boolean) -> Unit)? = null
     private var voiceSearchAvailable: Boolean = false
@@ -335,9 +328,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
         applyNativeStyling()
         observeChatState()
         observeChatSuggestionsEnabled()
-        // Create the binding and load chat-item plugins now (not on first Chat-tab show), so plugins
-        // are live regardless of the selected tab and their rows exist before the Chat tab renders.
-        ensureChatSuggestionsBinding?.invoke()
         observeNativeInputState()
         observeSubmitEnabled()
         observeOpenModelPicker()
@@ -1265,10 +1255,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
             showSuggestions(text)
         }
 
-        // Load plugins eagerly: at attach if we're not attached yet (the usual case — this runs
-        // pre-attach), or right now if bind happened after attach. ensureBinding() is idempotent.
-        ensureChatSuggestionsBinding = { ensureBinding() }
-        if (isAttachedToWindow) ensureChatSuggestionsBinding?.invoke()
+        // Load plugins at attach (or now, if already attached) rather than on the first Chat-tab show,
+        // so they're live regardless of the selected tab and their rows exist before the Chat tab first
+        // renders (otherwise a late insert flashes). ensureBinding() is idempotent.
+        doOnAttach { ensureBinding() }
     }
 
     private fun tearDownChatSuggestions() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -254,6 +254,13 @@ class NativeInputModeWidget @JvmOverloads constructor(
     // Outlives a single suggestions presentation (survives clear() on tab switches); handed to chat-item
     // plugins so they can collect into their adapters. Cancelled in tearDownChatSuggestions().
     private var chatItemPluginScope: CoroutineScope? = null
+
+    // Creates the chat-suggestions binding and loads its chat-item plugins. Captured from
+    // bindChatSuggestions and invoked at attach so plugins are live for the whole presentation,
+    // independent of which tab is selected (they must react while the Search tab is showing, and
+    // their rows must already exist before the Chat tab first renders — otherwise a late insert on
+    // first Chat-tab show flashes). The built-in sections stay lazy, populated via submit().
+    private var ensureChatSuggestionsBinding: (() -> Unit)? = null
     private var onShowSuggestions: ((RecyclerView.Adapter<*>) -> Unit)? = null
     private var onClearSuggestions: ((Boolean) -> Unit)? = null
     private var voiceSearchAvailable: Boolean = false
@@ -328,6 +335,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
         applyNativeStyling()
         observeChatState()
         observeChatSuggestionsEnabled()
+        // Create the binding and load chat-item plugins now (not on first Chat-tab show), so plugins
+        // are live regardless of the selected tab and their rows exist before the Chat tab renders.
+        ensureChatSuggestionsBinding?.invoke()
         observeNativeInputState()
         observeSubmitEnabled()
         observeOpenModelPicker()
@@ -1195,7 +1205,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
         this.onClearSuggestions = onClearSuggestions
 
         // Lazy: bindChatSuggestions runs before attach, so @Inject fields and the ViewModel
-        // aren't ready yet. showSuggestions() only fires post-attach.
+        // aren't ready yet. The binding is created at attach (see onAttachedToWindow) or on the
+        // first showSuggestions(), whichever comes first — both run post-attach.
         fun ensureBinding(): NativeInputChatSuggestionsBinder.Binding {
             return chatSuggestionsBinding ?: chatSuggestionsBinder.create(
                 onChatSuggestionSelected = { suggestion ->
@@ -1253,6 +1264,11 @@ class NativeInputModeWidget @JvmOverloads constructor(
         this.onChatTextChanged = { text ->
             showSuggestions(text)
         }
+
+        // Load plugins eagerly: at attach if we're not attached yet (the usual case — this runs
+        // pre-attach), or right now if bind happened after attach. ensureBinding() is idempotent.
+        ensureChatSuggestionsBinding = { ensureBinding() }
+        if (isAttachedToWindow) ensureChatSuggestionsBinding?.invoke()
     }
 
     private fun tearDownChatSuggestions() {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -231,12 +231,12 @@ class FakeDuckChatInternal(
         _displayedMode.value = mode
     }
 
-    private val _chatQuery = MutableStateFlow("")
+    private val _inputQuery = MutableStateFlow("")
 
-    override val chatQuery: StateFlow<String> = _chatQuery.asStateFlow()
+    override val inputQuery: StateFlow<String> = _inputQuery.asStateFlow()
 
-    override fun setChatQuery(query: String) {
-        _chatQuery.value = query
+    override fun setInputQuery(query: String) {
+        _inputQuery.value = query
     }
 
     fun setDuckChatUserEnabled(enabled: Boolean) {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinderTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinderTest.kt
@@ -287,7 +287,7 @@ class NativeInputChatSuggestionsBinderTest {
 
         // The user types: the live query updates before the typed query's fetch submits, and the
         // zero-state card drops its rows in response.
-        chatQueryFlow.value = "a"
+        inputQueryFlow.value = "a"
         adapter.setCount(0)
 
         // The recompute must read the live query (typing) and keep the overlay open, not close it.
@@ -321,10 +321,10 @@ class NativeInputChatSuggestionsBinderTest {
 
     private val scope = CoroutineScope(SupervisorJob())
 
-    private val chatQueryFlow = MutableStateFlow("")
+    private val inputQueryFlow = MutableStateFlow("")
     private val inputModeState = object : DuckChatInputModeState {
         override val displayedMode: StateFlow<InputMode> = MutableStateFlow(InputMode.SEARCH)
-        override val chatQuery: StateFlow<String> = chatQueryFlow
+        override val inputQuery: StateFlow<String> = inputQueryFlow
     }
 
     private fun binderWith(vararg plugins: NativeInputChatTabItemPlugin): NativeInputChatSuggestionsBinder =


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215998257028347
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/481882893211075/task/1215906519502283

### Description

Follow-up to the Chat-tab plugin architecture (#8948), fixing a flash of plugin-contributed items reported by Michal during implementation.

The shared input field is used by both the Search and Chat tabs, but `inputQuery` (was `chatQuery`) was only updated while the Chat tab was selected and reset to `""` on the switch to Search. So a chat-tab item driven by it — e.g. the example zero-state card — never saw the input change while the Search tab was active, and only corrected itself after the Chat tab had already re-rendered with the stale value, producing a visible flash on switch-back.

Changes:
- `inputQuery` now tracks the live shared input field on every keystroke regardless of the selected tab, resetting to `""` only when no widget is attached (no longer on the Search tab). The item settles while Search is active — invisibly, as the chat list is hidden — so the Chat tab renders already-correct. `displayedMode` remains the signal for which tab is showing; `inputQuery` is just the text.
- Chat-item plugins are now loaded at attach instead of on the first Chat-tab show, so they're live regardless of the selected tab and their rows exist before the first Chat render, removing a separate first-render pop-in.
- Renamed `chatQuery` → `inputQuery` since it now represents the whole shared input field rather than a chat-specific value; KDocs updated.

### Steps to test this PR

_No flash on tab switch (internal build, `ExampleMessageCardPlugin` is enabled)_
- [ ] Focus the omnibar to open the native input, switch to the Duck.ai tab — the "Example message card" shows immediately at the top (no late pop-in).
- [ ] Switch to the Search tab, type something, switch back to Duck.ai — the card is already hidden, no flash.
- [ ] Clear the field on the Search tab, switch back to Duck.ai — the card is shown again.
- [ ] On the Duck.ai tab, type to confirm the card hides, clear to confirm it returns, and tap the card's close (✕) to confirm sticky dismiss still closes the overlay.

### UI changes
| Before  | After |
| ------ | ----- |
|(card flashes on switch back to Chat)|(no flash)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared input state and native input widget lifecycle; behavior change is localized to Duck.ai input UI but affects all Chat-tab plugin consumers.
> 
> **Overview**
> Fixes a **flash of Chat-tab plugin UI** (e.g. zero-state cards) when switching back from Search to Duck.ai after typing on the shared omnibar field.
> 
> **`chatQuery` → `inputQuery`:** The shared field’s trimmed text is published on **every keystroke on either tab**, and is **no longer cleared when Search is selected**—only when the widget detaches. Tab selection stays on **`displayedMode`**. **`InputModeWidget`** centralizes updates in the text watcher (with an attach guard) and stops resetting query on tab select.
> 
> **Earlier plugin load:** **`NativeInputModeWidget`** calls **`ensureBinding()`** at attach so Chat-tab plugins are active before the first Chat render, avoiding late pop-in.
> 
> **Overlay logic:** **`NativeInputChatSuggestionsBinder`** uses live **`inputQuery`** when deciding whether the suggestions overlay stays open during typing. Tests and fakes follow the rename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97a711486dd62b10fc468da32d53f176187e8a22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->