### PR TITLE
Android/VoiceChat: Ensure that Private Voice Chat setting takes effect right away

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -340,6 +340,26 @@ class OmnibarLayoutViewModel @Inject constructor(
             }
         }.launchIn(viewModelScope)
 
+        // Re-evaluate the voice-search icon reactively when the user toggles "Private Voice Search",
+        // so it appears/disappears immediately even while the omnibar is unfocused, rather than only
+        // on the next focus or page-load event.
+        voiceSearchAvailability.isVoiceSearchAvailableFlow()
+            .onEach {
+                _viewState.update { state ->
+                    state.copy(
+                        showVoiceSearch = shouldShowVoiceSearch(
+                            viewMode = state.viewMode,
+                            hasFocus = state.hasFocus,
+                            query = state.omnibarText,
+                            hasQueryChanged = false,
+                            urlLoaded = state.url,
+                        ),
+                    )
+                }
+            }
+            .flowOn(dispatcherProvider.io())
+            .launchIn(viewModelScope)
+
         voiceActiveOnSelectedTab.onEach { voiceActive ->
             _viewState.update {
                 it.copy(showDuckAISidebar = shouldShowDuckAiSidebar(it.viewMode, it.hasFocus, voiceActive))

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -357,7 +357,6 @@ class OmnibarLayoutViewModel @Inject constructor(
                     )
                 }
             }
-            .flowOn(dispatcherProvider.io())
             .launchIn(viewModelScope)
 
         voiceActiveOnSelectedTab.onEach { voiceActive ->
@@ -602,7 +601,7 @@ class OmnibarLayoutViewModel @Inject constructor(
         hasQueryChanged: Boolean = false,
         urlLoaded: String = "",
     ): Boolean {
-        return if (viewMode == ViewMode.DuckAI) {
+        return if (viewMode == ViewMode.DuckAI || viewMode is CustomTab) {
             false
         } else {
             voiceSearchAvailability.shouldShowVoiceSearch(

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -343,7 +343,7 @@ class OmnibarLayoutViewModel @Inject constructor(
         // Re-evaluate the voice-search icon reactively when the user toggles "Private Voice Search",
         // so it appears/disappears immediately even while the omnibar is unfocused, rather than only
         // on the next focus or page-load event.
-        voiceSearchAvailability.isVoiceSearchAvailableFlow()
+        voiceSearchAvailability.observeVoiceSearchAvailability()
             .onEach {
                 _viewState.update { state ->
                     state.copy(

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -53,6 +53,7 @@ import com.duckduckgo.serp.logos.api.SerpLogo
 import com.duckduckgo.voice.api.VoiceSearchAvailability
 import com.duckduckgo.voice.api.VoiceSearchAvailabilityPixelLogger
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
@@ -139,6 +140,7 @@ class OmnibarLayoutViewModelTest {
         whenever(tabRepository.flowTabs).thenReturn(flowOf(emptyList()))
         whenever(tabRepository.flowSelectedTab).thenReturn(selectedTabFlow)
         whenever(voiceSearchAvailability.shouldShowVoiceSearch(any(), any(), any(), any())).thenReturn(true)
+        whenever(voiceSearchAvailability.isVoiceSearchAvailableFlow()).thenReturn(emptyFlow())
         whenever(duckPlayer.isDuckPlayerUri(DUCK_PLAYER_URL)).thenReturn(true)
         whenever(duckAiFeatureState.showOmnibarShortcutOnNtpAndOnFocus).thenReturn(duckAiShowOmnibarShortcutOnNtpAndOnFocusFlow)
         whenever(duckAiFeatureState.showOmnibarShortcutInAllStates).thenReturn(duckAiShowOmnibarShortcutInAllStatesFlow)

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -401,6 +401,25 @@ class OmnibarLayoutViewModelTest {
     }
 
     @Test
+    fun whenVoiceSearchAvailabilityEmitsWhileInCustomTabThenVoiceSearchStaysHidden() = runTest {
+        val voiceSearchAvailabilityFlow = MutableStateFlow(false)
+        whenever(voiceSearchAvailability.observeVoiceSearchAvailability()).thenReturn(voiceSearchAvailabilityFlow)
+        initializeViewModel()
+
+        testee.onViewModeChanged(ViewMode.CustomTab(100, "example", "example.com", showDuckPlayerIcon = false))
+
+        // User toggles "Private Voice Search" on while a custom tab is active.
+        voiceSearchAvailabilityFlow.value = true
+
+        testee.viewState.test {
+            val viewState = expectMostRecentItem()
+            assertTrue(viewState.viewMode is ViewMode.CustomTab)
+            assertFalse(viewState.showVoiceSearch)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `when custom tab title updates, update view mode state`() = runTest {
         val expectedTitle = "newTitle"
         val initialUrl = "https://example.com/page"

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -13,7 +13,6 @@ import com.duckduckgo.app.browser.menu.BrowserMenuHighlight
 import com.duckduckgo.app.browser.menu.BrowserViewMode
 import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode
 import com.duckduckgo.app.browser.omnibar.OmnibarLayoutViewModel.Command
-import com.duckduckgo.app.browser.omnibar.OmnibarLayoutViewModel.Command.CopyUrlToClipboard
 import com.duckduckgo.app.browser.omnibar.OmnibarLayoutViewModel.Command.LaunchInputScreen
 import com.duckduckgo.app.browser.omnibar.OmnibarLayoutViewModel.EnabledState
 import com.duckduckgo.app.browser.omnibar.OmnibarLayoutViewModel.LeadingIconState
@@ -140,7 +139,7 @@ class OmnibarLayoutViewModelTest {
         whenever(tabRepository.flowTabs).thenReturn(flowOf(emptyList()))
         whenever(tabRepository.flowSelectedTab).thenReturn(selectedTabFlow)
         whenever(voiceSearchAvailability.shouldShowVoiceSearch(any(), any(), any(), any())).thenReturn(true)
-        whenever(voiceSearchAvailability.isVoiceSearchAvailableFlow()).thenReturn(emptyFlow())
+        whenever(voiceSearchAvailability.observeVoiceSearchAvailability()).thenReturn(emptyFlow())
         whenever(duckPlayer.isDuckPlayerUri(DUCK_PLAYER_URL)).thenReturn(true)
         whenever(duckAiFeatureState.showOmnibarShortcutOnNtpAndOnFocus).thenReturn(duckAiShowOmnibarShortcutOnNtpAndOnFocusFlow)
         whenever(duckAiFeatureState.showOmnibarShortcutInAllStates).thenReturn(duckAiShowOmnibarShortcutInAllStatesFlow)

--- a/voice-search/voice-search-api/build.gradle
+++ b/voice-search/voice-search-api/build.gradle
@@ -23,6 +23,7 @@ apply from: "$rootProject.projectDir/gradle/android-library.gradle"
 
 dependencies {
     implementation AndroidX.appCompat
+    implementation KotlinX.coroutines.core
 }
 android {
   namespace 'com.duckduckgo.voice.api'

--- a/voice-search/voice-search-api/src/main/java/com/duckduckgo/voice/api/VoiceSearchAvailability.kt
+++ b/voice-search/voice-search-api/src/main/java/com/duckduckgo/voice/api/VoiceSearchAvailability.kt
@@ -16,9 +16,18 @@
 
 package com.duckduckgo.voice.api
 
+import kotlinx.coroutines.flow.Flow
+
 interface VoiceSearchAvailability {
     val isVoiceSearchSupported: Boolean
     val isVoiceSearchAvailable: Boolean
+
+    /**
+     * Emits [isVoiceSearchAvailable] now and again whenever the user toggles "Private Voice Search",
+     * so consumers can re-evaluate visibility immediately instead of waiting for the next focus or
+     * page-load event.
+     */
+    fun isVoiceSearchAvailableFlow(): Flow<Boolean>
     fun shouldShowVoiceSearch(
         hasFocus: Boolean = false,
         query: String = "",

--- a/voice-search/voice-search-api/src/main/java/com/duckduckgo/voice/api/VoiceSearchAvailability.kt
+++ b/voice-search/voice-search-api/src/main/java/com/duckduckgo/voice/api/VoiceSearchAvailability.kt
@@ -27,7 +27,7 @@ interface VoiceSearchAvailability {
      * so consumers can re-evaluate visibility immediately instead of waiting for the next focus or
      * page-load event.
      */
-    fun isVoiceSearchAvailableFlow(): Flow<Boolean>
+    fun observeVoiceSearchAvailability(): Flow<Boolean>
     fun shouldShowVoiceSearch(
         hasFocus: Boolean = false,
         query: String = "",

--- a/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/RealVoiceSearchAvailability.kt
+++ b/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/RealVoiceSearchAvailability.kt
@@ -23,6 +23,9 @@ import com.duckduckgo.voice.impl.remoteconfig.VoiceSearchFeature
 import com.duckduckgo.voice.impl.remoteconfig.VoiceSearchFeatureRepository
 import com.duckduckgo.voice.store.VoiceSearchRepository
 import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 @ContributesBinding(AppScope::class)
@@ -49,6 +52,11 @@ class RealVoiceSearchAvailability @Inject constructor(
 
     override val isVoiceSearchAvailable: Boolean
         get() = isVoiceSearchSupported && voiceSearchRepository.isVoiceSearchUserEnabled(voiceSearchRepository.getHasAcceptedRationaleDialog())
+
+    override fun isVoiceSearchAvailableFlow(): Flow<Boolean> =
+        voiceSearchRepository.voiceSearchUserEnabledFlow(voiceSearchRepository.getHasAcceptedRationaleDialog())
+            .map { userEnabled -> isVoiceSearchSupported && userEnabled }
+            .distinctUntilChanged()
 
     private fun hasValidVersion(sdkInt: Int) = voiceSearchFeatureRepository.minVersion?.let { minVersion ->
         sdkInt >= minVersion

--- a/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/RealVoiceSearchAvailability.kt
+++ b/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/RealVoiceSearchAvailability.kt
@@ -53,7 +53,7 @@ class RealVoiceSearchAvailability @Inject constructor(
     override val isVoiceSearchAvailable: Boolean
         get() = isVoiceSearchSupported && voiceSearchRepository.isVoiceSearchUserEnabled(voiceSearchRepository.getHasAcceptedRationaleDialog())
 
-    override fun isVoiceSearchAvailableFlow(): Flow<Boolean> =
+    override fun observeVoiceSearchAvailability(): Flow<Boolean> =
         voiceSearchRepository.voiceSearchUserEnabledFlow(voiceSearchRepository.getHasAcceptedRationaleDialog())
             .map { userEnabled -> isVoiceSearchSupported && userEnabled }
             .distinctUntilChanged()

--- a/voice-search/voice-search-store/build.gradle
+++ b/voice-search/voice-search-store/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     ksp AndroidX.room.compiler
 
     implementation AndroidX.core.ktx
+    implementation KotlinX.coroutines.core
     implementation Square.moshi
     implementation "com.squareup.moshi:moshi-kotlin:_"
     implementation "com.squareup.moshi:moshi-adapters:_"

--- a/voice-search/voice-search-store/src/main/java/com/duckduckgo/voice/store/VoiceSearchDataStore.kt
+++ b/voice-search/voice-search-store/src/main/java/com/duckduckgo/voice/store/VoiceSearchDataStore.kt
@@ -20,6 +20,9 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import com.duckduckgo.voice.api.VoiceSearchLauncher.VoiceSearchMode
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
 
 interface VoiceSearchDataStore {
     var permissionDeclinedForever: Boolean
@@ -30,6 +33,9 @@ interface VoiceSearchDataStore {
 
     fun isVoiceSearchEnabled(default: Boolean): Boolean
     fun setVoiceSearchEnabled(value: Boolean)
+
+    /** Emits the current enabled value immediately, then again on every change to the enabled flag. */
+    fun voiceSearchEnabledFlow(default: Boolean): Flow<Boolean>
 }
 
 class SharedPreferencesVoiceSearchDataStore constructor(
@@ -71,6 +77,17 @@ class SharedPreferencesVoiceSearchDataStore constructor(
 
     override fun setVoiceSearchEnabled(value: Boolean) {
         updateValue(KEY_VOICE_SEARCH_ENABLED, value)
+    }
+
+    override fun voiceSearchEnabledFlow(default: Boolean): Flow<Boolean> = callbackFlow {
+        val listener = SharedPreferences.OnSharedPreferenceChangeListener { prefs, key ->
+            if (key == KEY_VOICE_SEARCH_ENABLED) {
+                trySend(prefs.getBoolean(KEY_VOICE_SEARCH_ENABLED, default))
+            }
+        }
+        trySend(preferences.getBoolean(KEY_VOICE_SEARCH_ENABLED, default))
+        preferences.registerOnSharedPreferenceChangeListener(listener)
+        awaitClose { preferences.unregisterOnSharedPreferenceChangeListener(listener) }
     }
 
     override var countVoiceSearchDismissed: Int

--- a/voice-search/voice-search-store/src/main/java/com/duckduckgo/voice/store/VoiceSearchRepository.kt
+++ b/voice-search/voice-search-store/src/main/java/com/duckduckgo/voice/store/VoiceSearchRepository.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.voice.store
 
 import com.duckduckgo.voice.api.VoiceSearchLauncher.VoiceSearchMode
 import com.duckduckgo.voice.api.VoiceSearchStatusListener
+import kotlinx.coroutines.flow.Flow
 
 interface VoiceSearchRepository {
     fun declinePermissionForever()
@@ -27,6 +28,7 @@ interface VoiceSearchRepository {
     fun getHasAcceptedRationaleDialog(): Boolean
     fun getHasLoggedAvailability(): Boolean
     fun isVoiceSearchUserEnabled(default: Boolean): Boolean
+    fun voiceSearchUserEnabledFlow(default: Boolean): Flow<Boolean>
     fun setVoiceSearchUserEnabled(enabled: Boolean)
     fun countVoiceSearchDismissed(): Int
     fun dismissVoiceSearch()
@@ -58,6 +60,8 @@ class RealVoiceSearchRepository constructor(
     override fun getHasLoggedAvailability(): Boolean = dataStore.availabilityLogged
 
     override fun isVoiceSearchUserEnabled(default: Boolean): Boolean = dataStore.isVoiceSearchEnabled(default)
+
+    override fun voiceSearchUserEnabledFlow(default: Boolean): Flow<Boolean> = dataStore.voiceSearchEnabledFlow(default)
 
     override fun setVoiceSearchUserEnabled(enabled: Boolean) {
         dataStore.setVoiceSearchEnabled(enabled)

--- a/voice-search/voice-search-store/src/test/java/com/duckduckgo/voice/store/RealVoiceSearchRepositoryTest.kt
+++ b/voice-search/voice-search-store/src/test/java/com/duckduckgo/voice/store/RealVoiceSearchRepositoryTest.kt
@@ -18,6 +18,8 @@ package com.duckduckgo.voice.store
 
 import com.duckduckgo.voice.api.VoiceSearchLauncher.VoiceSearchMode
 import com.duckduckgo.voice.api.VoiceSearchStatusListener
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -104,15 +106,17 @@ class FakeVoiceSearchDataStore : VoiceSearchDataStore {
     override var countVoiceSearchDismissed: Int = 0
     override var lastSelectedMode: VoiceSearchMode = VoiceSearchMode.SEARCH
 
-    private var _voiceSearchEnabled = false
+    private val _voiceSearchEnabled = MutableStateFlow(false)
 
     override fun isVoiceSearchEnabled(default: Boolean): Boolean {
-        return _voiceSearchEnabled
+        return _voiceSearchEnabled.value
     }
 
     override fun setVoiceSearchEnabled(value: Boolean) {
-        _voiceSearchEnabled = value
+        _voiceSearchEnabled.value = value
     }
+
+    override fun voiceSearchEnabledFlow(default: Boolean): Flow<Boolean> = _voiceSearchEnabled
 }
 
 class FakeVoiceSearchStatusListener : VoiceSearchStatusListener {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1215970033685400?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/481882893211075/task/1215970033685402?focus=true

### Description
The Omnibar mic icon only re-evaluated on focus/page-load events, so enabling Private Voice Search while unfocused didn't show the icon until the next such event. This makes availability observable so the Omnibar reacts immediately.

Key changes
  
  - VoiceSearchAvailability (-api): add observeVoiceSearchAvailability(): Flow<Boolean> — emits current availability, then on every setting change.
  - RealVoiceSearchAvailability: implemented via voiceSearchUserEnabledFlow → map { supported && enabled }.distinctUntilChanged().
  - VoiceSearchDataStore: add voiceSearchEnabledFlow(default) — a callbackFlow over OnSharedPreferenceChangeListener.
  - VoiceSearchRepository: add voiceSearchUserEnabledFlow(default) passthrough.
  - OmnibarLayoutViewModel: collect the flow and re-run shouldShowVoiceSearch(...) into view state.
  - Added kotlinx-coroutines-core to voice-search-api and voice-search-store.
  
### Steps to test this PR
- [x] Fresh install internal build
- [x] Verify that voice icon is NOT visible in focused / unfocused state of the input/omnibar
- [x] Go to Settings > General or Accessibility > Enable Private Voice Search
- [x] Go back to Browser
- [x] Verify that voice icon IS visible in focused AND unfocused state of the input/omnibar
- [x] Go to Settings > General or Accessibility > Disable Private Voice Search
- [x] Go back to Browser
- [x] Verify that voice icon IS NOT visible in focused AND unfocused state of the input/omnibar
- [x] Smoke test opening tabs (SERP and articles) via search tab, duck-ai tab and only search tab and verify no weird behaviors


### UI changes
Before: 
https://github.com/user-attachments/assets/b1344c58-b5a3-42e6-94cd-536e044fccab
After:
https://github.com/user-attachments/assets/c4b2aea5-5624-4ce1-9d87-e0a7098da5ba




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only omnibar visibility with a small API extension to voice-search modules; custom tabs are guarded so the mic does not appear incorrectly.
> 
> **Overview**
> The omnibar mic icon now updates as soon as the user toggles **Private Voice Search**, instead of waiting for focus or navigation.
> 
> Voice search adds **`observeVoiceSearchAvailability()`**, backed by a SharedPreferences **`callbackFlow`** on the enabled flag (repository passthrough, combined with device support in **`RealVoiceSearchAvailability`**). **`OmnibarLayoutViewModel`** collects that flow and refreshes **`showVoiceSearch`** via existing **`shouldShowVoiceSearch`** logic. **Custom tab** view modes are explicitly excluded from showing voice search when availability turns on. Tests cover the custom-tab case and mock the new observer in omnibar tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f94b0424107ad41cc93588ceb27d45d48ce3f3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->