### PR TITLE
Sync exchange v2: Ensure legacy timeout doesn't apply to v2

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
@@ -115,10 +115,12 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
         if (sessionStarted) return
         sessionStarted = true
         viewModelScope.launch(dispatchers.io()) {
+            // On the deep-link receive path, routing is owned by onDeepLinkCodeReceived → onQRCodeScanned
+            // → codeDispatcher.route(). This VM is the scanner here, so neither showQRCode() (presenter
+            // QR) nor the legacy presenter-side acknowledgement polling loop below should run.
+            if (isDeepLink) return@launch
             if (shouldUseV2()) {
-                if (!isDeepLink) {
-                    startV2Present()
-                }
+                startV2Present()
                 return@launch
             }
             showQRCode()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
@@ -115,9 +115,7 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
         if (sessionStarted) return
         sessionStarted = true
         viewModelScope.launch(dispatchers.io()) {
-            // On the deep-link receive path, routing is owned by onDeepLinkCodeReceived → onQRCodeScanned
-            // → codeDispatcher.route(). This VM is the scanner here, so neither showQRCode() (presenter
-            // QR) nor the legacy presenter-side acknowledgement polling loop below should run.
+            // If deep-linking, neither showQRCode() nor legacy polling should run
             if (isDeepLink) return@launch
             if (shouldUseV2()) {
                 startV2Present()

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
@@ -738,10 +738,7 @@ class SyncWithAnotherDeviceViewModelTest {
     }
 
     @Test
-    fun whenIsDeepLinkAndV2MasterOnButDisplayOffThenLegacyPresenterPollingDoesNotStart() = runTest {
-        // Reproduces the deep-link timeout bug: canUseV2ConnectFlow=true (so codeDispatcher routes V2)
-        // but canShowV2ConnectCode=false (so the old shouldUseV2() gate fell through to legacy showQRCode()
-        // + pollSecondDeviceExchangeAcknowledgement, which fired ShowError over V2's confirmation dialog).
+    fun `when deep linking with main v2 flag enabled and ability to show v2 barcode disabled, then legacy polling not started`() = runTest {
         enableV2(displayOn = false)
 
         testee.viewState(isDeepLink = true).test {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherDeviceViewModelTest.kt
@@ -738,6 +738,40 @@ class SyncWithAnotherDeviceViewModelTest {
     }
 
     @Test
+    fun whenIsDeepLinkAndV2MasterOnButDisplayOffThenLegacyPresenterPollingDoesNotStart() = runTest {
+        // Reproduces the deep-link timeout bug: canUseV2ConnectFlow=true (so codeDispatcher routes V2)
+        // but canShowV2ConnectCode=false (so the old shouldUseV2() gate fell through to legacy showQRCode()
+        // + pollSecondDeviceExchangeAcknowledgement, which fired ShowError over V2's confirmation dialog).
+        enableV2(displayOn = false)
+
+        testee.viewState(isDeepLink = true).test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        verify(runner, never()).startPresent()
+        verify(syncRepository, never()).generateExchangeInvitationCode()
+        verify(syncRepository, never()).getRecoveryCode()
+        verify(syncRepository, never()).pollSecondDeviceExchangeAcknowledgement()
+    }
+
+    @Test
+    fun whenIsDeepLinkAndV2MasterOffThenLegacyPresenterPollingDoesNotStart() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+        syncFeature.canShowV2ConnectCode().setRawStoredState(State(false))
+
+        testee.viewState(isDeepLink = true).test {
+            awaitItem()
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        verify(runner, never()).startPresent()
+        verify(syncRepository, never()).generateExchangeInvitationCode()
+        verify(syncRepository, never()).getRecoveryCode()
+        verify(syncRepository, never()).pollSecondDeviceExchangeAcknowledgement()
+    }
+
+    @Test
     fun whenV2PairingRejectedByPeerThenShowError() = runTest {
         syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
         whenever(syncRepository.getAccountInfo()).thenReturn(accountA)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203822806345703/task/1215999266926800?focus=true
Tech Design URL (if applicable): 

### Description
When deep-linking to set up sync (scanning from system camera app when we're the default browser) we jump straight into the sync set up flow. This set up flow can be either exchange v1 or exchange v2 depending on which code type is scanned. Right now, if processing v2 then the legacy v1 timeout can kick in and interrupt the pairing (if you don't accept usre confirmation within 10s)

This PR ensures the v1 timeout mechanism isn't running during a deep-linked v2 exchange.

### Steps to test this PR
> [!NOTE]
> QA optional. the following is the full test matrix to ensure it's working correctly if desired.

#### Setup
- **Emulator** = presenter (shows QR).
- **Device** = scanner. Two scan paths:
  - **in-app** (`isDeepLink=false`) — scan from inside the app.
  - **system camera → tap URL** (`isDeepLink=true`) — the deep-link path this PR targets.

#### Flag shorthand
- `U` = `canUseV2ConnectFlow`
- `S` = `canShowV2ConnectCode`

On **Emulator**, `S` decides which QR is generated (V2 vs Legacy). On **Device**, `U` decides whether V2 codes can be processed; `S` is irrelevant on the scanner side after this fix (that coupling was the bug).

#### Matrix

| # | Emulator flags | Device flags | Scan path | Expected |
|---|---|---|---|---|
| 1 | `U=on, S=on` (V2 QR) | `U=on, S=off` (default) | **deep link** | **Bug repro.** With fix: host-confirm dialog stays up, allow → success. |
| 2 | `U=on, S=on` (V2 QR) | `U=on, S=on` | deep link | Success (already worked pre-fix). |
| 3 | `U=on, S=off` (Legacy QR) | `U=on, S=off` | **deep link** | Legacy deep-link receiver path. Success via `pollForRecoveryKey`. |
| 4 | `U=off` (Legacy QR) | `U=off` | **deep link** | Pure legacy deep link. Success. |
| 5 | `U=on, S=on` (V2 QR) | `U=on, S=on` | in-app scan | V2 happy path. |
| 6 | `U=on, S=on` (V2 QR) | `U=on, S=off` | in-app scan | V2 happy path (display-off scanner combo). |
| 7 | `U=on, S=off` (Legacy QR) | `U=on, S=off` | in-app scan | Legacy happy path. |
| 8 | `U=off` (Legacy QR) | `U=off` | in-app scan | Pure legacy in-app. |

#### Negative check (optional)
Revert the `if (isDeepLink) return@launch` line, rerun scenario `#1` — dialog should show then be replaced by an error after ~10s. Re-apply the fix and rerun — should now stay up without being interrupted.

#### Logcat filter
```
message~:"Sync-setup|Sync-CodeDispatch|Sync-ExchangeV2"
```
On deep-link scenarios (`#1`–`#4`), watch for the **absence** of `Sync-setup: can timeout = true. time since start: …` lines — those indicate the legacy presenter polling loop is incorrectly running.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Targets sync pairing flow timing and feature-flag combinations; scope is small but user-visible during device linking.
> 
> **Overview**
> Fixes a **deep-link sync pairing bug** where the legacy presenter path (QR generation plus `pollSecondDeviceExchangeAcknowledgement` with a ~10s timeout) could still run while the device was acting as the **joiner/scanner**, causing a spurious `ShowError` on top of an in-progress V2 confirmation dialog.
> 
> **`startExchangeProcess`** now **returns immediately when `isDeepLink` is true**, so neither V2 present nor legacy presenter QR/polling runs on the deep-link receive path; pairing stays on **`onDeepLinkCodeReceived` → `codeDispatcher.route()`**. The V2-present branch no longer needs a separate `!isDeepLink` guard because deep links exit earlier.
> 
> Adds tests that deep-link `viewState` never starts legacy acknowledgement polling when V2 master is on but display is off, or when V2 master is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1442737d51bc8c00ea5b1b3dfe074136517963b4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
