### PR TITLE
Add breakageData key to broken site report pixel definitions

### DIFF
--- a/PixelDefinitions/pixels/definitions/broken_site_report.json
+++ b/PixelDefinitions/pixels/definitions/broken_site_report.json
@@ -205,6 +205,11 @@
                 "key": "urlParametersRemoved",
                 "description": "Whether URL parameters were removed.",
                 "enum": ["0", "1"]
+            },
+            {
+                "key": "breakageData",
+                "description": "Specific website breakage types (e.g., adwalls or captchas) detected by C-S-S.",
+                "type": "string"
             }
         ]
     },
@@ -343,6 +348,11 @@
             {
                 "key": "wvVersion",
                 "description": "User's runtime WebView version",
+                "type": "string"
+            },
+            {
+                "key": "breakageData",
+                "description": "Specific website breakage types (e.g., adwalls or captchas) detected by C-S-S.",
                 "type": "string"
             }
         ]


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1215471539618648?focus=true
Tech Design URL (if applicable): 

### Description

Added missing definition for `breakageData` key on site breakage report pixels
