### PR TITLE
Force recycled webview re-composite when onPageCommitVisible doesn't fire

### DIFF
--- a/PixelDefinitions/pixels/definitions/force_web_view_recomposite.json5
+++ b/PixelDefinitions/pixels/definitions/force_web_view_recomposite.json5
@@ -1,0 +1,8 @@
+{
+    "m_web_view_forced_recomposite": {
+        "description": "A recycled WebView finished loading but onPageCommitVisible never fired, so a re-composite (onPause/onResume) was forced to present the new content and clear the stale frame. Fired once per day.",
+        "owners": ["laghee"],
+        "triggers": ["page_load"],
+        "suffixes": ["first_daily_count"]
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -143,6 +143,7 @@ class BrowserWebViewClient @Inject constructor(
     private var lastPageStarted: String? = null
     private var start: Long? = null
     private var lastInterceptedAppSchemeUrl: String? = null
+    private var lastCommitVisibleUrl: String? = null
 
     private val isAppSchemeInterceptionEnabled = AtomicBoolean(true)
 
@@ -461,6 +462,7 @@ class BrowserWebViewClient @Inject constructor(
         url: String,
     ) {
         logcat(VERBOSE) { "onPageCommitVisible webViewUrl: ${webView.url} URL: $url progress: ${webView.progress}" }
+        lastCommitVisibleUrl = url
         // Show only when the commit matches the tab state
         if (webView.url == url) {
             val navigationList = webView.safeCopyBackForwardList() ?: return
@@ -508,6 +510,7 @@ class BrowserWebViewClient @Inject constructor(
         }
 
         lastInterceptedAppSchemeUrl = null
+        lastCommitVisibleUrl = null
 
         url?.let {
             // See https://app.asana.com/0/0/1206159443951489/f (WebView limitations)
@@ -607,6 +610,14 @@ class BrowserWebViewClient @Inject constructor(
 
         // See https://app.asana.com/0/0/1206159443951489/f (WebView limitations)
         if (webView.progress == 100) {
+            // FALLBACK (recycled-WebView stale frame): the load finished, but if onPageCommitVisible
+            // never fired for this url the recycled WebView keeps drawing the previous navigation's
+            // frame until a re-composite (e.g. tab switch). Force it to present the new content.
+            if (url != null && url != ABOUT_BLANK && lastCommitVisibleUrl != url) {
+                logcat(VERBOSE) { "onPageCommitVisible never fired for $url; forcing present" }
+                forceWebViewPresent(webView)
+            }
+
             jsPlugins.getPlugins().forEach {
                 it.onPageFinished(
                     webView,
@@ -677,6 +688,13 @@ class BrowserWebViewClient @Inject constructor(
         val scope = webView.findViewTreeLifecycleOwner()?.lifecycleScope ?: return
         scope.launch(dispatcherProvider.io()) {
             cookieManagerProvider.get()?.flush()
+        }
+    }
+
+    private fun forceWebViewPresent(webView: WebView) {
+        webView.post {
+            webView.onPause()
+            webView.onResume()
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -137,15 +137,17 @@ class BrowserWebViewClient @Inject constructor(
     private val duckChat: DuckChat,
     private val contentScopeExperiments: ContentScopeExperiments,
     private val appSchemeInterceptionFeature: AppSchemeInterceptionFeature,
+    private val forceWebViewRecompositeFeature: ForceWebViewRecompositeFeature,
 ) : WebViewClient() {
     var webViewClientListener: WebViewClientListener? = null
     var clientProvider: ClientBrandHintProvider? = null
     private var lastPageStarted: String? = null
     private var start: Long? = null
     private var lastInterceptedAppSchemeUrl: String? = null
-    private var lastCommitVisibleUrl: String? = null
+    private var pageCommitVisibleFired: Boolean = false
 
     private val isAppSchemeInterceptionEnabled = AtomicBoolean(true)
+    private val isForceRecompositeEnabled = AtomicBoolean(true)
 
     init {
         appCoroutineScope.launch(dispatcherProvider.io()) {
@@ -153,6 +155,13 @@ class BrowserWebViewClient @Inject constructor(
                 .distinctUntilChanged()
                 .collect { enabled ->
                     isAppSchemeInterceptionEnabled.set(enabled)
+                }
+        }
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            forceWebViewRecompositeFeature.self().enabled()
+                .distinctUntilChanged()
+                .collect { enabled ->
+                    isForceRecompositeEnabled.set(enabled)
                 }
         }
     }
@@ -462,7 +471,7 @@ class BrowserWebViewClient @Inject constructor(
         url: String,
     ) {
         logcat(VERBOSE) { "onPageCommitVisible webViewUrl: ${webView.url} URL: $url progress: ${webView.progress}" }
-        lastCommitVisibleUrl = url
+        pageCommitVisibleFired = true
         // Show only when the commit matches the tab state
         if (webView.url == url) {
             val navigationList = webView.safeCopyBackForwardList() ?: return
@@ -510,7 +519,7 @@ class BrowserWebViewClient @Inject constructor(
         }
 
         lastInterceptedAppSchemeUrl = null
-        lastCommitVisibleUrl = null
+        pageCommitVisibleFired = false
 
         url?.let {
             // See https://app.asana.com/0/0/1206159443951489/f (WebView limitations)
@@ -610,12 +619,14 @@ class BrowserWebViewClient @Inject constructor(
 
         // See https://app.asana.com/0/0/1206159443951489/f (WebView limitations)
         if (webView.progress == 100) {
-            // FALLBACK (recycled-WebView stale frame): the load finished, but if onPageCommitVisible
-            // never fired for this url the recycled WebView keeps drawing the previous navigation's
-            // frame until a re-composite (e.g. tab switch). Force it to present the new content.
-            if (url != null && url != ABOUT_BLANK && lastCommitVisibleUrl != url) {
-                logcat(VERBOSE) { "onPageCommitVisible never fired for $url; forcing present" }
-                forceWebViewPresent(webView)
+            // Without onPageCommitVisible a recycled WebView keeps drawing the previous
+            // navigation's frame until a re-composite. Only worth doing for a foreground tab.
+            if (url != null && url != ABOUT_BLANK && !pageCommitVisibleFired) {
+                if (isForceRecompositeEnabled.get() && webViewClientListener?.isTabInForeground() == true) {
+                    logcat(VERBOSE) { "onPageCommitVisible never fired for $url; forcing present" }
+                    pixel.fire(WebViewPixelName.WEB_VIEW_FORCED_RECOMPOSITE, type = Pixel.PixelType.Daily())
+                    forceWebViewPresent(webView)
+                }
             }
 
             jsPlugins.getPlugins().forEach {
@@ -972,6 +983,7 @@ enum class WebViewPixelName(override val pixelName: String) : Pixel.PixelName {
     WEB_RENDERER_GONE_KILLED("m_web_view_renderer_gone_killed"),
     WEB_PAGE_LOADED("m_web_view_page_loaded"),
     WEB_PAGE_PAINTED("m_web_view_page_painted"),
+    WEB_VIEW_FORCED_RECOMPOSITE("m_web_view_forced_recomposite"),
 }
 
 enum class WebViewErrorResponse(

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -145,6 +145,7 @@ class BrowserWebViewClient @Inject constructor(
     private var start: Long? = null
     private var lastInterceptedAppSchemeUrl: String? = null
     private var pageCommitVisibleFired: Boolean = false
+    private var recompositeScheduled: Boolean = false
 
     private val isAppSchemeInterceptionEnabled = AtomicBoolean(true)
     private val isForceRecompositeEnabled = AtomicBoolean(true)
@@ -513,6 +514,7 @@ class BrowserWebViewClient @Inject constructor(
         logcat { "onPageStarted webViewUrl: ${webView.url} URL: $url lastPageStarted $lastPageStarted" }
 
         pageCommitVisibleFired = false
+        recompositeScheduled = false
 
         // Handle app-scheme URLs that bypass shouldOverrideUrlLoading (e.g., window.open with intent:// URLs)
         if (url != null && interceptAppSchemeUrl(webView, url)) {
@@ -622,10 +624,12 @@ class BrowserWebViewClient @Inject constructor(
         if (webView.progress == 100) {
             // Without onPageCommitVisible a recycled WebView keeps drawing the previous
             // navigation's frame until a re-composite. Only worth doing for a foreground tab.
-            if (url != null && url != ABOUT_BLANK && !pageCommitVisibleFired) {
+            // onPageFinished can fire more than once per load (redirects, subframes), so latch
+            // to force at most one re-composite per navigation (reset in onPageStarted).
+            if (url != null && url != ABOUT_BLANK && !pageCommitVisibleFired && !recompositeScheduled) {
                 if (isForceRecompositeEnabled.get() && webViewClientListener?.isTabInForeground() == true) {
                     logcat(VERBOSE) { "onPageCommitVisible never fired for $url; forcing present" }
-                    pixel.fire(WebViewPixelName.WEB_VIEW_FORCED_RECOMPOSITE, type = Pixel.PixelType.Daily())
+                    recompositeScheduled = true
                     forceWebViewPresent(webView)
                 }
             }
@@ -705,8 +709,16 @@ class BrowserWebViewClient @Inject constructor(
 
     private fun forceWebViewPresent(webView: WebView) {
         webView.post {
-            webView.onPause()
-            webView.onResume()
+            // The foreground state checked when this was scheduled can go stale before the
+            // posted runnable runs: the user may switch tabs or move to a PDF / new-tab view,
+            // all of which pause (and hide) the WebView via the fragment lifecycle. Re-check
+            // here so we never resume a WebView the fragment intended to keep paused, which
+            // would leave it running JS/timers/media while hidden.
+            if (webView.isShown && webViewClientListener?.isTabInForeground() == true) {
+                pixel.fire(WebViewPixelName.WEB_VIEW_FORCED_RECOMPOSITE, type = Pixel.PixelType.Daily())
+                webView.onPause()
+                webView.onResume()
+            }
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -512,6 +512,8 @@ class BrowserWebViewClient @Inject constructor(
     ) {
         logcat { "onPageStarted webViewUrl: ${webView.url} URL: $url lastPageStarted $lastPageStarted" }
 
+        pageCommitVisibleFired = false
+
         // Handle app-scheme URLs that bypass shouldOverrideUrlLoading (e.g., window.open with intent:// URLs)
         if (url != null && interceptAppSchemeUrl(webView, url)) {
             logcat { "interceptAppSchemeUrl: intercepted $url in onPageStarted, returning early" }
@@ -519,7 +521,6 @@ class BrowserWebViewClient @Inject constructor(
         }
 
         lastInterceptedAppSchemeUrl = null
-        pageCommitVisibleFired = false
 
         url?.let {
             // See https://app.asana.com/0/0/1206159443951489/f (WebView limitations)

--- a/app/src/main/java/com/duckduckgo/app/browser/ForceWebViewRecompositeFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/ForceWebViewRecompositeFeature.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+
+/**
+ * Kill switch for forcing a WebView re-composite (onPause/onResume) when onPageCommitVisible
+ * never fired, to clear a stale frame left by a recycled WebView.
+ */
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "forceWebViewRecomposite",
+)
+interface ForceWebViewRecompositeFeature {
+
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun self(): Toggle
+}

--- a/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/api/PixelParamRemovalInterceptor.kt
@@ -117,6 +117,7 @@ object PixelInterceptorPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
             AppPixelName.EMAIL_COPIED_TO_CLIPBOARD.pixelName to PixelParameter.removeAll(),
             WebViewPixelName.WEB_PAGE_LOADED.pixelName to PixelParameter.removeAll(),
             WebViewPixelName.WEB_PAGE_PAINTED.pixelName to PixelParameter.removeAll(),
+            WebViewPixelName.WEB_VIEW_FORCED_RECOMPOSITE.pixelName to PixelParameter.removeAtb(),
             AppPixelName.REFERRAL_INSTALL_UTM_CAMPAIGN.pixelName to PixelParameter.removeAtb(),
             HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_400_DAILY.pixelName to PixelParameter.removeAtb(),
             HttpErrorPixelName.WEBVIEW_RECEIVED_HTTP_ERROR_4XX_DAILY.pixelName to PixelParameter.removeAtb(),

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -1265,12 +1265,44 @@ class BrowserWebViewClientTest {
         whenever(mockWebView.progress).thenReturn(100)
         whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())
         whenever(mockWebView.settings).thenReturn(mock())
+        whenever(mockWebView.isShown).thenReturn(true)
         whenever(listener.isTabInForeground()).thenReturn(true)
         testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
         testee.onPageFinished(mockWebView, EXAMPLE_URL)
         verify(mockWebView).onPause()
         verify(mockWebView).onResume()
         verify(pixel).fire(WebViewPixelName.WEB_VIEW_FORCED_RECOMPOSITE, type = Pixel.PixelType.Daily())
+    }
+
+    @Test
+    fun whenPageFinishesMultipleTimesAndCommitVisibleNeverFiredThenWebViewRecompositedOnlyOnce() {
+        val mockWebView = getImmediatelyInvokedMockWebView()
+        whenever(mockWebView.progress).thenReturn(100)
+        whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())
+        whenever(mockWebView.settings).thenReturn(mock())
+        whenever(mockWebView.isShown).thenReturn(true)
+        whenever(listener.isTabInForeground()).thenReturn(true)
+        testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
+        testee.onPageFinished(mockWebView, EXAMPLE_URL)
+        testee.onPageFinished(mockWebView, EXAMPLE_URL)
+        verify(mockWebView, times(1)).onPause()
+        verify(mockWebView, times(1)).onResume()
+        verify(pixel, times(1)).fire(WebViewPixelName.WEB_VIEW_FORCED_RECOMPOSITE, type = Pixel.PixelType.Daily())
+    }
+
+    @Test
+    fun whenPageFinishesAndCommitVisibleNeverFiredButWebViewNotShownThenWebViewNotRecomposited() {
+        val mockWebView = getImmediatelyInvokedMockWebView()
+        whenever(mockWebView.progress).thenReturn(100)
+        whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())
+        whenever(mockWebView.settings).thenReturn(mock())
+        whenever(mockWebView.isShown).thenReturn(false)
+        whenever(listener.isTabInForeground()).thenReturn(true)
+        testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
+        testee.onPageFinished(mockWebView, EXAMPLE_URL)
+        verify(mockWebView, never()).onPause()
+        verify(mockWebView, never()).onResume()
+        verify(pixel, never()).fire(eq(WebViewPixelName.WEB_VIEW_FORCED_RECOMPOSITE), any(), any(), any())
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -179,6 +179,8 @@ class BrowserWebViewClientTest {
     private val pageLoadWideEvent: PageLoadWideEvent = mock()
     private val mockAppSchemeInterceptionFeature: AppSchemeInterceptionFeature = mock()
     private val appSchemeInterceptionEnabledFlow = MutableStateFlow(true)
+    private val mockForceWebViewRecompositeFeature: ForceWebViewRecompositeFeature = mock()
+    private val forceRecompositeEnabledFlow = MutableStateFlow(true)
 
     @Before
     fun setup() =
@@ -191,6 +193,10 @@ class BrowserWebViewClientTest {
             whenever(enabledToggle.isEnabled()).thenReturn(true)
             whenever(enabledToggle.enabled()).thenReturn(appSchemeInterceptionEnabledFlow)
             whenever(mockAppSchemeInterceptionFeature.self()).thenReturn(enabledToggle)
+            val forceRecompositeToggle: Toggle = mock()
+            whenever(forceRecompositeToggle.isEnabled()).thenReturn(true)
+            whenever(forceRecompositeToggle.enabled()).thenReturn(forceRecompositeEnabledFlow)
+            whenever(mockForceWebViewRecompositeFeature.self()).thenReturn(forceRecompositeToggle)
             testee =
                 BrowserWebViewClient(
                     webViewHttpAuthStore,
@@ -226,6 +232,7 @@ class BrowserWebViewClientTest {
                     mockDuckChat,
                     mockContentScopeExperiments,
                     mockAppSchemeInterceptionFeature,
+                    mockForceWebViewRecompositeFeature,
                 )
             testee.webViewClientListener = listener
             whenever(webResourceRequest.url).thenReturn(Uri.EMPTY)
@@ -1251,6 +1258,65 @@ class BrowserWebViewClientTest {
             verify(listener).onSiteVisited(eq(EXAMPLE_URL), eq(null))
         }
     }
+
+    @Test
+    fun whenPageFinishesAndCommitVisibleNeverFiredAndTabInForegroundThenWebViewRecomposited() {
+        val mockWebView = getImmediatelyInvokedMockWebView()
+        whenever(mockWebView.progress).thenReturn(100)
+        whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())
+        whenever(mockWebView.settings).thenReturn(mock())
+        whenever(listener.isTabInForeground()).thenReturn(true)
+        testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
+        testee.onPageFinished(mockWebView, EXAMPLE_URL)
+        verify(mockWebView).onPause()
+        verify(mockWebView).onResume()
+        verify(pixel).fire(WebViewPixelName.WEB_VIEW_FORCED_RECOMPOSITE, type = Pixel.PixelType.Daily())
+    }
+
+    @Test
+    fun whenPageFinishesAndCommitVisibleFiredThenWebViewNotRecomposited() {
+        val mockWebView = getImmediatelyInvokedMockWebView()
+        whenever(mockWebView.progress).thenReturn(100)
+        whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())
+        whenever(mockWebView.settings).thenReturn(mock())
+        whenever(listener.isTabInForeground()).thenReturn(true)
+        testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
+        testee.onPageCommitVisible(mockWebView, EXAMPLE_URL)
+        testee.onPageFinished(mockWebView, EXAMPLE_URL)
+        verify(mockWebView, never()).onPause()
+        verify(mockWebView, never()).onResume()
+        verify(pixel, never()).fire(eq(WebViewPixelName.WEB_VIEW_FORCED_RECOMPOSITE), any(), any(), any())
+    }
+
+    @Test
+    fun whenPageFinishesAndCommitVisibleNeverFiredButTabNotInForegroundThenWebViewNotRecomposited() {
+        val mockWebView = getImmediatelyInvokedMockWebView()
+        whenever(mockWebView.progress).thenReturn(100)
+        whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())
+        whenever(mockWebView.settings).thenReturn(mock())
+        whenever(listener.isTabInForeground()).thenReturn(false)
+        testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
+        testee.onPageFinished(mockWebView, EXAMPLE_URL)
+        verify(mockWebView, never()).onPause()
+        verify(mockWebView, never()).onResume()
+        verify(pixel, never()).fire(eq(WebViewPixelName.WEB_VIEW_FORCED_RECOMPOSITE), any(), any(), any())
+    }
+
+    @Test
+    fun whenPageFinishesAndCommitVisibleNeverFiredButFeatureDisabledThenWebViewNotRecomposited() =
+        runTest {
+            forceRecompositeEnabledFlow.emit(false)
+            val mockWebView = getImmediatelyInvokedMockWebView()
+            whenever(mockWebView.progress).thenReturn(100)
+            whenever(mockWebView.safeCopyBackForwardList()).thenReturn(TestBackForwardList())
+            whenever(mockWebView.settings).thenReturn(mock())
+            whenever(listener.isTabInForeground()).thenReturn(true)
+            testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
+            testee.onPageFinished(mockWebView, EXAMPLE_URL)
+            verify(mockWebView, never()).onPause()
+            verify(mockWebView, never()).onResume()
+            verify(pixel, never()).fire(eq(WebViewPixelName.WEB_VIEW_FORCED_RECOMPOSITE), any(), any(), any())
+        }
 
     @Test
     fun whenPageStartedMoreThanOnceThenStartTimeIsNotUpdated() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1209253361096901/task/1215945203156353?focus=true
Tech Design URL (if applicable): 

### Description

We have an existing bug coming from site breakage where navigating within a tab (i.e., with a recycled view) on certain sites leaves the previous page's pixels on screen (or goes white after a touch or scroll), even though the new page has fully loaded. The recycled WebView never commits/presents a visible frame for the new page for some reason, so we're adding a forcing mechanism for when this is detected on a visible tab, gated behind a feature flag and firing a daily count pixel.

### Steps to test this PR

- [x] With the feature flag disabled, visit the following sites and attempt to tap on link (to open a full article or otherwise navigate to a new page within the same domain) -- some immediately go blank, some you may need to tap or scroll the page if it still shows the stale previous page.
  - [x] theatlantic.com
  - [x] ilfattoquotidiano.it (must accept all cookies first)
  - [x] 3bmeteo.it (same)
- [x] Toggle the feature flag back on, revisit the sites and verify that the same navigation works as expected.
- [x] Navigate to a couple top news sites and verify that similar navigations seem suddenly broken.

### UI changes
None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes run on the main WebView page-load path and manipulate lifecycle (pause/resume), which could affect rendering or background tabs if guards fail; remote kill switch mitigates rollout risk.
> 
> **Overview**
> Fixes **stale or blank frames** when a recycled tab WebView finishes loading but **`onPageCommitVisible` never runs**, by forcing a one-time **`onPause` / `onResume`** re-composite on the foreground tab.
> 
> **`BrowserWebViewClient`** tracks whether commit-visible fired per navigation (reset in **`onPageStarted`**). At **`onPageFinished`** with progress 100, if commit-visible did not fire and a re-composite is not already scheduled, it schedules **`forceWebViewPresent`** when the remote **`forceWebViewRecomposite`** toggle is on and the tab is in the foreground. The posted runnable re-checks **`isShown`** and foreground before pausing/resuming so hidden WebViews are not resumed. A daily pixel **`m_web_view_forced_recomposite`** records occurrences; pixel definitions and ATB stripping for that pixel are added.
> 
> Unit tests cover happy path, single-fire latch, hidden WebView, commit-visible present, background tab, and disabled feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0fd55b176700502f6a083c0ea91a37bc65d2e04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->