### PR TITLE
Add setting to hide the Return To Last Tab hatch after idl

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
@@ -152,9 +152,18 @@ class ShowOnAppLaunchActivity : DuckDuckGoActivity() {
                     setTitle(R.string.afterInactivityOptionTitle)
                     binding.afterInactivityTimeoutRow.setSecondaryText(viewState.selectedIdleThresholdSeconds.toTimeoutLabel())
                     binding.afterInactivityTimeoutRow.visibility = View.VISIBLE
+                    binding.afterInactivityTimeoutDivider.visibility = View.VISIBLE
                 } else {
                     setTitle(R.string.showOnAppLaunchOptionTitle)
                     binding.afterInactivityTimeoutRow.visibility = View.GONE
+                    binding.afterInactivityTimeoutDivider.visibility = View.GONE
+                }
+
+                val showReturnToLastTabToggle = viewState.showNTPAfterIdleReturn && viewState.selectedOption == NewTabPage
+                binding.returnToLastTabDivider.visibility = if (showReturnToLastTabToggle) View.VISIBLE else View.GONE
+                binding.returnToLastTabToggle.visibility = if (showReturnToLastTabToggle) View.VISIBLE else View.GONE
+                binding.returnToLastTabToggle.quietlySetIsChecked(viewState.returnToLastTabEnabled) { _, isChecked ->
+                    viewModel.onReturnToLastTabToggled(isChecked)
                 }
 
                 if (binding.specificPageUrlInput.text.isBlank()) {

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModel.kt
@@ -56,6 +56,7 @@ class ShowOnAppLaunchViewModel @Inject constructor(
         val showNTPAfterIdleReturn: Boolean = false,
         val selectedIdleThresholdSeconds: Long = FirstScreenHandlerImpl.DEFAULT_IDLE_THRESHOLD_SECONDS,
         val idleThresholdOptions: List<Long> = FirstScreenHandlerImpl.DEFAULT_IDLE_THRESHOLD_OPTIONS,
+        val returnToLastTabEnabled: Boolean = true,
     )
 
     sealed class Command {
@@ -80,7 +81,8 @@ class ShowOnAppLaunchViewModel @Inject constructor(
             showOnAppLaunchOptionDataStore.specificPageUrlFlow,
             androidBrowserConfigFeature.showNTPAfterIdleReturn().enabled(),
             userSelectedThreshold,
-        ) { option, specificPageUrl, showNTPAfterIdleReturn, userThreshold ->
+            ntpAfterIdleManager.returnToLastTabEnabled,
+        ) { option, specificPageUrl, showNTPAfterIdleReturn, userThreshold, returnToLastTabEnabled ->
             val effectiveThreshold = userThreshold
                 ?: FirstScreenHandlerImpl.parseDefaultIdleThresholdSeconds(
                     androidBrowserConfigFeature.showNTPAfterIdleReturn().getSettings(),
@@ -91,6 +93,7 @@ class ShowOnAppLaunchViewModel @Inject constructor(
                 specificPageUrl = specificPageUrl,
                 showNTPAfterIdleReturn = showNTPAfterIdleReturn,
                 selectedIdleThresholdSeconds = effectiveThreshold,
+                returnToLastTabEnabled = returnToLastTabEnabled,
             )
         }.flowOn(dispatcherProvider.io())
             .launchIn(viewModelScope)
@@ -122,6 +125,12 @@ class ShowOnAppLaunchViewModel @Inject constructor(
             userSelectedThreshold.value = seconds
             pixel.fire(SETTINGS_AFTER_INACTIVITY_TIMEOUT_CHANGED, mapOf("selectedSeconds" to seconds.toString()))
             ntpAfterIdleManager.onIdleTimeoutSelected(seconds)
+        }
+    }
+
+    fun onReturnToLastTabToggled(enabled: Boolean) {
+        viewModelScope.launch(dispatcherProvider.io()) {
+            ntpAfterIdleManager.setReturnToLastTabEnabled(enabled)
         }
     }
 }

--- a/app/src/main/res/layout/activity_show_on_app_launch_setting.xml
+++ b/app/src/main/res/layout/activity_show_on_app_launch_setting.xml
@@ -46,6 +46,13 @@
                 tools:secondaryText="5 minutes"
                 tools:visibility="visible" />
 
+            <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+                android:id="@+id/afterInactivityTimeoutDivider"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                tools:visibility="visible" />
+
             <com.duckduckgo.common.ui.view.text.DaxTextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -87,6 +94,23 @@
                 android:paddingBottom="@dimen/keyline_2"
                 app:type="single_line"
                 tools:ignore="HardcodedText" />
+
+            <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+                android:id="@+id/returnToLastTabDivider"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                tools:visibility="visible" />
+
+            <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                android:id="@+id/returnToLastTabToggle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                app:primaryText="@string/returnToLastTabSettingTitle"
+                app:secondaryText="@string/returnToLastTabSettingSubtitle"
+                app:showSwitch="true"
+                tools:visibility="visible" />
 
         </LinearLayout>
     </ScrollView>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -145,4 +145,7 @@
     <string name="preOnboardingDaxDialog3ButtonCustomAi">Start AI Chat</string>
     <!-- Pre-onboarding: input demo screen -->
     <string name="preOnboardingInputModeDemoTitleCustomAi">Now, try a private AI chat!</string>
+    <!-- After Inactivity: return-to-last-tab hatch setting -->
+    <string name="returnToLastTabSettingTitle">Return To Last Tab</string>
+    <string name="returnToLastTabSettingSubtitle">Show a link to your last tab on the New Tab Page when you reopen the app</string>
 </resources>

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModelTest.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -57,6 +58,7 @@ class ShowOnAppLaunchViewModelTest {
     @Before
     fun setup() {
         whenever(settingsDataStore.userSelectedIdleThresholdSeconds).thenReturn(null)
+        whenever(ntpAfterIdleManager.returnToLastTabEnabled).thenReturn(flowOf(true))
         fakeDataStore = FakeShowOnAppLaunchOptionDataStore(LastOpenedTab)
         testee = ShowOnAppLaunchViewModel(
             dispatcherProvider,
@@ -212,6 +214,14 @@ class ShowOnAppLaunchViewModelTest {
         coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
 
         verify(ntpAfterIdleManager).onIdleTimeoutSelected(300L)
+    }
+
+    @Test
+    fun whenReturnToLastTabToggledThenSettingPersisted() = runTest {
+        testee.onReturnToLastTabToggled(false)
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(ntpAfterIdleManager).setReturnToLastTabEnabled(false)
     }
 
     @Test

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchView.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchView.kt
@@ -162,6 +162,9 @@ class NewTabReturnHatchView @JvmOverloads constructor(
         popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.hatchMenuCloseTab)) {
             viewModel.closeTab()
         }
+        popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.hatchMenuDontShowThis)) {
+            viewModel.onDontShowThisPressed()
+        }
         popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.hatchMenuAfterInactivity)) {
             viewModel.onAfterInactivityPressed()
             hatchHatchListener?.onAfterInactivityPressed()

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModel.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModel.kt
@@ -106,8 +106,9 @@ class NewTabReturnHatchViewModel @Inject constructor(
         pendingClose,
         tabRepository.flowTabs,
         duckChat.observeNativeInputFieldUserSettingEnabled(),
-    ) { tab, closed, tabs, nativeInputEnabled ->
-        if (tab != null && !closed && tabs.any { it.tabId == tab.tabId }) {
+        ntpAfterIdleManager.returnToLastTabEnabled,
+    ) { tab, closed, tabs, nativeInputEnabled, returnToLastTabEnabled ->
+        if (tab != null && !closed && returnToLastTabEnabled && tabs.any { it.tabId == tab.tabId }) {
             val url = tab.url.orEmpty()
             ViewState(
                 tabTitle = tab.title.orEmpty(),
@@ -183,5 +184,12 @@ class NewTabReturnHatchViewModel @Inject constructor(
     fun onAfterInactivityPressed() {
         pixel.fire(NewTabReturnHatchPixelName.OPTION_SELECTED_AFTER_INACTIVITY, type = Count)
         pixel.fire(NewTabReturnHatchPixelName.OPTION_SELECTED_AFTER_INACTIVITY_DAILY, type = Daily())
+    }
+
+    fun onDontShowThisPressed() {
+        // Disable the hatch for future idle returns.
+        viewModelScope.launch(dispatchers.io()) {
+            ntpAfterIdleManager.setReturnToLastTabEnabled(false)
+        }
     }
 }

--- a/browser/browser-ui/src/main/res/layout/popup_hatch_menu.xml
+++ b/browser/browser-ui/src/main/res/layout/popup_hatch_menu.xml
@@ -31,7 +31,7 @@
     <com.duckduckgo.common.ui.view.divider.HorizontalDivider
         app:defaultPadding="false"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="wrap_content"/>
 
     <com.duckduckgo.common.ui.view.PopupMenuItemView
         android:id="@+id/hatchMenuCloseTab"
@@ -45,7 +45,7 @@
     <com.duckduckgo.common.ui.view.divider.HorizontalDivider
         app:defaultPadding="false"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="wrap_content"/>
 
     <com.duckduckgo.common.ui.view.PopupMenuItemView
         android:id="@+id/hatchMenuDontShowThis"
@@ -57,7 +57,7 @@
     <com.duckduckgo.common.ui.view.divider.HorizontalDivider
         app:defaultPadding="false"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"/>
+        android:layout_height="wrap_content"/>
 
     <com.duckduckgo.common.ui.view.PopupMenuItemView
         android:id="@+id/hatchMenuAfterInactivity"

--- a/browser/browser-ui/src/main/res/layout/popup_hatch_menu.xml
+++ b/browser/browser-ui/src/main/res/layout/popup_hatch_menu.xml
@@ -48,6 +48,18 @@
         android:layout_height="match_parent"/>
 
     <com.duckduckgo.common.ui.view.PopupMenuItemView
+        android:id="@+id/hatchMenuDontShowThis"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:leadingIcon="@drawable/ic_eye_closed_24"
+        app:primaryText="@string/hatchMenuDontShowThis" />
+
+    <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+        app:defaultPadding="false"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+
+    <com.duckduckgo.common.ui.view.PopupMenuItemView
         android:id="@+id/hatchMenuAfterInactivity"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/browser/browser-ui/src/main/res/values/donottranslate.xml
+++ b/browser/browser-ui/src/main/res/values/donottranslate.xml
@@ -27,6 +27,7 @@
     <string name="hatchMenuAfterInactivitySettings">After Inactivity</string>
     <string name="hatchMenuCloseTab">Close Tab</string>
     <string name="hatchMenuBurnTab">Delete Tab</string>
+    <string name="hatchMenuDontShowThis">Don\'t Show This</string>
     <string name="newTabReturnHatchTabClosed">Tab closed</string>
     <string name="newTabReturnHatchUndo">Undo</string>
     <string name="browserMenuChats">Chats</string>

--- a/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModelTest.kt
+++ b/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModelTest.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -60,6 +61,7 @@ class NewTabReturnHatchViewModelTest {
     // Starts false so each test controls the idle-return rising edge that captures the snapshot.
     private val afterIdleReturnFlow = MutableStateFlow(false)
     private val nativeInputEnabledFlow = MutableStateFlow(true)
+    private val returnToLastTabEnabledFlow = MutableStateFlow(true)
 
     private lateinit var testee: NewTabReturnHatchViewModel
 
@@ -67,6 +69,7 @@ class NewTabReturnHatchViewModelTest {
     fun setup() {
         whenever(mockTabRepository.flowTabs).thenReturn(tabsFlow)
         whenever(mockNtpAfterIdleManager.isAfterIdleReturn).thenReturn(afterIdleReturnFlow)
+        whenever(mockNtpAfterIdleManager.returnToLastTabEnabled).thenReturn(returnToLastTabEnabledFlow)
         whenever(mockDuckChat.observeNativeInputFieldUserSettingEnabled()).thenReturn(nativeInputEnabledFlow)
 
         testee = NewTabReturnHatchViewModel(
@@ -112,6 +115,27 @@ class NewTabReturnHatchViewModelTest {
 
             assertFalse(expectMostRecentItem().shouldShow)
         }
+    }
+
+    @Test
+    fun whenReturnToLastTabDisabledThenHatchHiddenEvenWithTab() = runTest {
+        val tab = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
+        returnToLastTabEnabledFlow.value = false
+
+        testee.viewState.test {
+            returnFromIdleWith(tab)
+
+            assertFalse(expectMostRecentItem().shouldShow)
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun whenDontShowThisPressedThenReturnToLastTabDisabled() = runTest {
+        testee.onDontShowThisPressed()
+        advanceUntilIdle()
+
+        verify(mockNtpAfterIdleManager).setReturnToLastTabEnabled(false)
     }
 
     @Test

--- a/new-tab-page/new-tab-page-api/src/main/java/com/duckduckgo/newtabpage/api/NtpAfterIdleManager.kt
+++ b/new-tab-page/new-tab-page-api/src/main/java/com/duckduckgo/newtabpage/api/NtpAfterIdleManager.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.newtabpage.api
 
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
 /**
@@ -42,4 +43,10 @@ interface NtpAfterIdleManager {
 
     /** Emits true when the current NTP was shown as a result of an idle return, false otherwise. */
     val isAfterIdleReturn: StateFlow<Boolean>
+
+    /** Emits whether the return-to-last-tab hatch is enabled (user setting, defaults to true). */
+    val returnToLastTabEnabled: Flow<Boolean>
+
+    /** Persists whether the return-to-last-tab hatch is enabled. */
+    suspend fun setReturnToLastTabEnabled(enabled: Boolean)
 }

--- a/new-tab-page/new-tab-page-impl/build.gradle
+++ b/new-tab-page/new-tab-page-impl/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     implementation "com.squareup.logcat:logcat:_"
 
     testImplementation Testing.junit4
+    testImplementation AndroidX.test.ext.junit
     testImplementation "org.mockito.kotlin:mockito-kotlin:_"
     testImplementation project(path: ':common-test')
     testImplementation CashApp.turbine

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/NtpAfterIdleManagerImpl.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/NtpAfterIdleManagerImpl.kt
@@ -37,6 +37,7 @@ import com.duckduckgo.newtabpage.impl.pixels.NtpAfterIdlePixels
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -50,11 +51,19 @@ class NtpAfterIdleManagerImpl @Inject constructor(
     private val pixel: Pixel,
     private val hatchPixels: HatchPixels,
     private val hatchInteractionsPlugins: PluginPoint<HatchInteractionsPlugin>,
+    private val returnToLastTabStore: ReturnToLastTabStore,
 ) : NtpAfterIdleManager, BrowserLifecycleObserver {
 
     private val pendingAfterIdle = AtomicBoolean(false)
     private val _isAfterIdleReturn = MutableStateFlow(false)
     override val isAfterIdleReturn: StateFlow<Boolean> = _isAfterIdleReturn.asStateFlow()
+
+    override val returnToLastTabEnabled: Flow<Boolean>
+        get() = returnToLastTabStore.isEnabled
+
+    override suspend fun setReturnToLastTabEnabled(enabled: Boolean) {
+        returnToLastTabStore.setEnabled(enabled)
+    }
 
     override fun onOpen(isFreshLaunch: Boolean) {
         // pendingAfterIdle is intentionally NOT reset: FirstScreenHandlerImpl.onOpen may

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/ReturnToLastTabStore.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/ReturnToLastTabStore.kt
@@ -25,6 +25,7 @@ import androidx.datastore.preferences.preferencesDataStore
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.newtabpage.impl.RealReturnToLastTabStore.Keys.RETURN_TO_LAST_TAB_ENABLED
 import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
@@ -44,6 +45,7 @@ private val Context.returnToLastTabStore: DataStore<Preferences> by preferencesD
     name = "return_to_last_tab_store",
 )
 
+@SingleInstanceIn(AppScope::class)
 @ContributesBinding(AppScope::class)
 class RealReturnToLastTabStore @Inject constructor(
     private val context: Context,

--- a/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/ReturnToLastTabStore.kt
+++ b/new-tab-page/new-tab-page-impl/src/main/java/com/duckduckgo/newtabpage/impl/ReturnToLastTabStore.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.newtabpage.impl
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.newtabpage.impl.RealReturnToLastTabStore.Keys.RETURN_TO_LAST_TAB_ENABLED
+import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+/**
+ * Persists whether the return-to-last-tab hatch should be shown on the NTP after an idle return.
+ * Defaults to enabled, so existing users keep seeing the hatch.
+ */
+interface ReturnToLastTabStore {
+    val isEnabled: Flow<Boolean>
+
+    suspend fun setEnabled(enabled: Boolean)
+}
+
+private val Context.returnToLastTabStore: DataStore<Preferences> by preferencesDataStore(
+    name = "return_to_last_tab_store",
+)
+
+@ContributesBinding(AppScope::class)
+class RealReturnToLastTabStore @Inject constructor(
+    private val context: Context,
+) : ReturnToLastTabStore {
+
+    override val isEnabled: Flow<Boolean>
+        get() = context.returnToLastTabStore.data
+            .map { prefs -> prefs[RETURN_TO_LAST_TAB_ENABLED] ?: true }
+            .distinctUntilChanged()
+
+    override suspend fun setEnabled(enabled: Boolean) {
+        context.returnToLastTabStore.edit { prefs -> prefs[RETURN_TO_LAST_TAB_ENABLED] = enabled }
+    }
+
+    internal object Keys {
+        val RETURN_TO_LAST_TAB_ENABLED = booleanPreferencesKey(name = "RETURN_TO_LAST_TAB_ENABLED")
+    }
+}

--- a/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/NtpAfterIdleManagerImplTest.kt
+++ b/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/NtpAfterIdleManagerImplTest.kt
@@ -34,6 +34,10 @@ import com.duckduckgo.newtabpage.impl.pixels.NtpAfterIdlePixelName.TIMEOUT_SELEC
 import com.duckduckgo.newtabpage.impl.pixels.NtpAfterIdlePixelName.TIMEOUT_SELECTED_60_DAILY
 import com.duckduckgo.newtabpage.impl.pixels.NtpAfterIdlePixelName.TIMEOUT_SELECTED_ALWAYS
 import com.duckduckgo.newtabpage.impl.pixels.NtpAfterIdlePixelName.TIMEOUT_SELECTED_ALWAYS_DAILY
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
@@ -47,12 +51,29 @@ class NtpAfterIdleManagerImplTest {
     private val pixel: Pixel = mock()
     private val hatchPixels: HatchPixels = mock()
     private val hatchInteractionsPlugins: PluginPoint<HatchInteractionsPlugin> = mock()
+    private val returnToLastTabStore: ReturnToLastTabStore = mock()
 
     private lateinit var testee: NtpAfterIdleManagerImpl
 
     @Before
     fun setup() {
-        testee = NtpAfterIdleManagerImpl(pixel, hatchPixels, hatchInteractionsPlugins)
+        testee = NtpAfterIdleManagerImpl(pixel, hatchPixels, hatchInteractionsPlugins, returnToLastTabStore)
+    }
+
+    // --- return-to-last-tab setting ---
+
+    @Test
+    fun returnToLastTabEnabledReflectsStore() = runTest {
+        whenever(returnToLastTabStore.isEnabled).thenReturn(flowOf(false))
+
+        assertFalse(testee.returnToLastTabEnabled.first())
+    }
+
+    @Test
+    fun setReturnToLastTabEnabledWritesToStore() = runTest {
+        testee.setReturnToLastTabEnabled(false)
+
+        verify(returnToLastTabStore).setEnabled(false)
     }
 
     // --- onNtpShown classification ---

--- a/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/RealReturnToLastTabStoreTest.kt
+++ b/new-tab-page/new-tab-page-impl/src/test/java/com/duckduckgo/newtabpage/impl/RealReturnToLastTabStoreTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.newtabpage.impl
+
+import android.content.Context
+import androidx.datastore.preferences.preferencesDataStoreFile
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RealReturnToLastTabStoreTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val testee = RealReturnToLastTabStore(context)
+
+    @After
+    fun after() {
+        context.preferencesDataStoreFile("return_to_last_tab_store").delete()
+    }
+
+    @Test
+    fun emptyStoreDefaultsToEnabledThenPersistsUpdates() = runTest {
+        // Empty store: existing users keep seeing the hatch.
+        assertTrue(testee.isEnabled.first())
+
+        testee.setEnabled(false)
+        assertFalse(testee.isEnabled.first())
+
+        testee.setEnabled(true)
+        assertTrue(testee.isEnabled.first())
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1216003755360875?focus=true 
Tech Design URL (if applicable): Not tech design but API proposal: https://app.asana.com/1/137249556945/project/1212810093780571/task/1216003755360869?focus=true

### Description

Lets users turn off the escape hatch ("return to last tab") that appears on the New Tab Page after returning from inactivity.

- A new **"Return To Last Tab"** toggle on the *After Inactivity* settings page. Visible only when the after-idle feature is on **and** "New Tab Page" is the selected return option.
- A new **"Don't Show This"** item in the hatch's overflow menu. Tapping it hides the hatch and turns the setting off; it stays off until re-enabled from settings.

When off, the after-idle NTP still appears as before just without the hatch link.

**Implementation notes**
- The setting is persisted in a DataStore in `new-tab-page-impl` and exposed through `NtpAfterIdleManager` (`new-tab-page-api`) as `returnToLastTabEnabled: Flow<Boolean>` + `suspend fun setReturnToLastTabEnabled(...)`
- `NewTabReturnHatchViewModel.shouldShow` now also requires the setting on

**Follow-ups (not in this PR)**
- Pixels/telemetry for the toggle and "Don't Show This".
- New strings are in `donottranslate` for now.

### Steps to test this PR

_Settings toggle_
- [ ] With NTP-after-idle enabled, open *After Inactivity* settings and select "New Tab Page" → the "Return To Last Tab" toggle is visible and ON by default. Select another return option → the toggle hides.
- [ ] Turn the toggle OFF, background the app past the idle threshold, reopen → the NTP shows after idle with **no** hatch. Turn it back ON → the hatch reappears after the next idle return.

_Hatch menu_
- [ ] When the hatch is showing, open its overflow (⋮) menu → "Don't Show This" appears below "Close Tab". Tap it → the hatch disappears and you remain on the NTP.
- [ ] Return from idle again → the hatch no longer shows. Go to *After Inactivity* settings → the toggle is OFF → turn it ON → the hatch shows again after the next idle return.

### UI changes
| Before  | After |
| ------ | ----- |
|  <img width="1080" height="2063" alt="rn_image_picker_lib_temp_df267d92-ab83-46c9-8b5d-d7ab97dd35d7" src="https://github.com/user-attachments/assets/56e8c314-7340-4711-8982-d6d1c1e18c1e" /> | <img width="1080" height="2094" alt="share_1150669119304190926" src="https://github.com/user-attachments/assets/6d38e8cb-0897-4c9a-b632-e9d60f79b90a" /> |
| <img width="1080" height="455" alt="rn_image_picker_lib_temp_71b29753-69c8-4564-87a4-46f1086374b4" src="https://github.com/user-attachments/assets/891766f3-4c46-4a5f-8928-3e08928f5229" /> | <img width="1080" height="627" alt="rn_image_picker_lib_temp_f80e8bc0-219c-4732-8dd0-b72cfb638360" src="https://github.com/user-attachments/assets/a181c8b2-e9c1-4b81-8fd0-74ed6e85ed2f" /> |



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized NTP/after-idle UX and a boolean preference with default true; no auth, security, or core navigation changes beyond gating hatch visibility.
> 
> **Overview**
> Adds a **persisted preference** (DataStore via `ReturnToLastTabStore`, wired through `NtpAfterIdleManager`) that controls whether the post-idle **return-to-last-tab hatch** appears on the NTP. **Default is on** so existing behavior is unchanged.
> 
> On **After Inactivity** settings, a **Return To Last Tab** switch is shown only when after-idle is enabled and **New Tab Page** is the selected launch option; toggling it calls `setReturnToLastTabEnabled`. The hatch overflow menu gains **Don't Show This**, which turns the same setting off in one tap.
> 
> `NewTabReturnHatchViewModel` now requires `returnToLastTabEnabled` for `shouldShow`, so after-idle NTP still shows but the hatch can be hidden. Unit tests cover settings, hatch visibility, store persistence, and manager delegation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6640b56f53ff3b8a3c11c13a95da3a9b03ea8c1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->