### PR TITLE
Implement Disable All AI and Reset to Default

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsActivity.kt
@@ -174,13 +174,18 @@ class DuckChatSettingsActivity : DuckDuckGoActivity() {
         }
 
         binding.duckAINoAiItem.isVisible = viewState.isNativeControlsEnabled
-        // Greyed out and non-tappable while Duck.ai is turned off, with a description explaining why.
-        binding.duckAINoAiItem.isEnabled = viewState.isDuckChatUserEnabled
+        // The item represents "turn everything off". Once Duck.ai is off, Search Assist is Never and
+        // AI-generated images are hidden, there is nothing left to do, so it's greyed out, non-tappable,
+        // and explains why. Re-enabling any of the three makes it actionable again.
+        val isAlreadyWithoutAi = !viewState.isDuckChatUserEnabled &&
+            viewState.searchAssistVisibility == SearchAssistVisibility.NEVER &&
+            viewState.hideAiGeneratedImages == HideAiGeneratedImages.ON
+        binding.duckAINoAiItem.isEnabled = !isAlreadyWithoutAi
         binding.duckAINoAiItem.setSecondaryText(
-            if (viewState.isDuckChatUserEnabled) {
-                getString(R.string.duckAiUseWithoutAiDescription)
-            } else {
+            if (isAlreadyWithoutAi) {
                 getString(R.string.duckAiUseWithoutAiDisabledDescription)
+            } else {
+                getString(R.string.duckAiUseWithoutAiDescription)
             },
         )
         binding.duckAINoAiItem.setOnClickListener {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsActivity.kt
@@ -173,6 +173,8 @@ class DuckChatSettingsActivity : DuckDuckGoActivity() {
             moveInputScreenSettingsToEnd()
         }
 
+        binding.duckAINoAiItem.isVisible = viewState.isNativeControlsEnabled
+
         // The Duck.ai section header and its top divider are only shown when the block lives at the end of the
         // layout (native controls enabled) and Duck.ai is enabled by the user.
         val showDuckAiSectionHeader = viewState.isNativeControlsEnabled && viewState.isDuckChatUserEnabled
@@ -271,6 +273,13 @@ class DuckChatSettingsActivity : DuckDuckGoActivity() {
         val parent = container.parent as? ViewGroup ?: return
         parent.removeView(container)
         parent.addView(container)
+        // Keep the "Use DuckDuckGo Without AI" item as the very last item after the input screen
+        // settings block has been moved to the end.
+        val noAiItem = binding.duckAINoAiItem
+        (noAiItem.parent as? ViewGroup)?.let { noAiParent ->
+            noAiParent.removeView(noAiItem)
+            noAiParent.addView(noAiItem)
+        }
         inputScreenSettingsMovedToEnd = true
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsActivity.kt
@@ -183,6 +183,9 @@ class DuckChatSettingsActivity : DuckDuckGoActivity() {
                 getString(R.string.duckAiUseWithoutAiDisabledDescription)
             },
         )
+        binding.duckAINoAiItem.setOnClickListener {
+            viewModel.onUseWithoutAiClicked()
+        }
 
         // The Duck.ai section header and its top divider are only shown when the block lives at the end of the
         // layout (native controls enabled) and Duck.ai is enabled by the user.

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsActivity.kt
@@ -177,15 +177,12 @@ class DuckChatSettingsActivity : DuckDuckGoActivity() {
         // The item represents "turn everything off". Once Duck.ai is off, Search Assist is Never and
         // AI-generated images are hidden, there is nothing left to do, so it's greyed out, non-tappable,
         // and explains why. Re-enabling any of the three makes it actionable again.
-        val isAlreadyWithoutAi = !viewState.isDuckChatUserEnabled &&
-            viewState.searchAssistVisibility == SearchAssistVisibility.NEVER &&
-            viewState.hideAiGeneratedImages == HideAiGeneratedImages.ON
-        binding.duckAINoAiItem.isEnabled = !isAlreadyWithoutAi
+        binding.duckAINoAiItem.isEnabled = viewState.isUseWithoutAiActionEnabled
         binding.duckAINoAiItem.setSecondaryText(
-            if (isAlreadyWithoutAi) {
-                getString(R.string.duckAiUseWithoutAiDisabledDescription)
-            } else {
+            if (viewState.isUseWithoutAiActionEnabled) {
                 getString(R.string.duckAiUseWithoutAiDescription)
+            } else {
+                getString(R.string.duckAiUseWithoutAiDisabledDescription)
             },
         )
         binding.duckAINoAiItem.setOnClickListener {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsActivity.kt
@@ -174,6 +174,15 @@ class DuckChatSettingsActivity : DuckDuckGoActivity() {
         }
 
         binding.duckAINoAiItem.isVisible = viewState.isNativeControlsEnabled
+        // Greyed out and non-tappable while Duck.ai is turned off, with a description explaining why.
+        binding.duckAINoAiItem.isEnabled = viewState.isDuckChatUserEnabled
+        binding.duckAINoAiItem.setSecondaryText(
+            if (viewState.isDuckChatUserEnabled) {
+                getString(R.string.duckAiUseWithoutAiDescription)
+            } else {
+                getString(R.string.duckAiUseWithoutAiDisabledDescription)
+            },
+        )
 
         // The Duck.ai section header and its top divider are only shown when the block lives at the end of the
         // layout (native controls enabled) and Duck.ai is enabled by the user.

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModel.kt
@@ -192,6 +192,14 @@ class DuckChatSettingsViewModel @AssistedInject constructor(
         }
     }
 
+    fun onUseWithoutAiClicked() {
+        // Turn off Duck.ai, silence Search Assist, and hide AI-generated images in one tap.
+        // The item disables itself reactively once isDuckChatUserEnabled flips to false.
+        onDuckChatUserEnabledToggled(checked = false)
+        onSearchAssistVisibilitySelected(SearchAssistVisibility.NEVER)
+        onHideAiGeneratedImagesSelected(HideAiGeneratedImages.ON)
+    }
+
     fun onAutomaticContextAttachmentToggled(checked: Boolean) {
         viewModelScope.launch {
             duckChat.setAutomaticPageContextUserSetting(checked)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModel.kt
@@ -85,6 +85,7 @@ class DuckChatSettingsViewModel @AssistedInject constructor(
         val isNativeControlsEnabled: Boolean = false,
         val searchAssistVisibility: SearchAssistVisibility = DEFAULT_SEARCH_ASSIST_VISIBILITY,
         val hideAiGeneratedImages: HideAiGeneratedImages = HideAiGeneratedImages.OFF,
+        val isUseWithoutAiActionEnabled: Boolean = true,
     )
 
     private data class FeatureState(
@@ -136,6 +137,12 @@ class DuckChatSettingsViewModel @AssistedInject constructor(
         ) { featureState, featureVisibility, defaultTogglePosition, searchAssistVisibility, hideAiGeneratedImages ->
             val isDuckChatUserEnabled = featureState.isDuckChatUserEnabled
             val isInputScreenEnabled = featureState.isCosmeticInputScreenEnabled ?: featureState.isInputScreenEnabled
+            val resolvedSearchAssistVisibility = searchAssistVisibility ?: DEFAULT_SEARCH_ASSIST_VISIBILITY
+            // The "Use DuckDuckGo Without AI" action turns everything off at once; once Duck.ai is off,
+            // Search Assist is Never and AI-generated images are hidden, there's nothing left to do.
+            val isAlreadyWithoutAi = !isDuckChatUserEnabled &&
+                resolvedSearchAssistVisibility == SearchAssistVisibility.NEVER &&
+                hideAiGeneratedImages == HideAiGeneratedImages.ON
             ViewState(
                 isDuckChatUserEnabled = isDuckChatUserEnabled,
                 isInputScreenEnabled = isInputScreenEnabled,
@@ -149,8 +156,9 @@ class DuckChatSettingsViewModel @AssistedInject constructor(
                     duckChat.isInputScreenFeatureAvailable() && featureVisibility.isRememberTogglePositionVisible,
                 defaultTogglePosition = defaultTogglePosition,
                 isNativeControlsEnabled = featureVisibility.isNativeControlsEnabled,
-                searchAssistVisibility = searchAssistVisibility ?: DEFAULT_SEARCH_ASSIST_VISIBILITY,
+                searchAssistVisibility = resolvedSearchAssistVisibility,
                 hideAiGeneratedImages = hideAiGeneratedImages,
+                isUseWithoutAiActionEnabled = !isAlreadyWithoutAi,
             )
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), ViewState())
 

--- a/duckchat/duckchat-impl/src/main/res/layout/activity_duck_chat_settings.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/activity_duck_chat_settings.xml
@@ -119,6 +119,14 @@
                 app:secondaryText="@string/duckAiHideAiGeneratedImagesDescription"
                 app:showSwitch="false" />
 
+            <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                android:id="@+id/duckAINoAiItem"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                app:primaryText="@string/duckAiUseWithoutAiTitle"
+                app:secondaryText="@string/duckAiUseWithoutAiDescription" />
+
         </LinearLayout>
     </ScrollView>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -80,4 +80,8 @@
     <string name="duckAiSearchAssistVisibilitySometimes">Sometimes</string>
     <string name="duckAiSearchAssistVisibilityOften">Often</string>
 
+    <!-- Duck AI Use Without AI Settings Option -->
+    <string name="duckAiUseWithoutAiTitle">Use DuckDuckGo Without AI</string>
+    <string name="duckAiUseWithoutAiDescription">Disables Duck.ai, hides AI-assisted answers in search, and hides AI-generated images in image search results.</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -83,5 +83,6 @@
     <!-- Duck AI Use Without AI Settings Option -->
     <string name="duckAiUseWithoutAiTitle">Use DuckDuckGo Without AI</string>
     <string name="duckAiUseWithoutAiDescription">Disables Duck.ai, hides AI-assisted answers in search, and hides AI-generated images in image search results.</string>
+    <string name="duckAiUseWithoutAiDisabledDescription">AI is currently disabled in the Browser so you\'ll no longer see AI-assisted answers or AI-generated images in image search results.</string>
 
 </resources>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModelTest.kt
@@ -699,6 +699,34 @@ class DuckChatSettingsViewModelTest {
         }
 
     @Test
+    fun `when onUseWithoutAiClicked then duck chat user setting disabled`() =
+        runTest {
+            testee.onUseWithoutAiClicked()
+            verify(duckChat).setEnableDuckChatUserSetting(false)
+        }
+
+    @Test
+    fun `when onUseWithoutAiClicked then disabled pixel fired`() =
+        runTest {
+            testee.onUseWithoutAiClicked()
+            verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_USER_DISABLED)
+        }
+
+    @Test
+    fun `when onUseWithoutAiClicked then search assist visibility set to never in SERP settings`() =
+        runTest {
+            testee.onUseWithoutAiClicked()
+            verify(serpSettingsDataProvider).setSetting(SearchAssistVisibility.SERP_SETTINGS_KEY, SearchAssistVisibility.NEVER.serpCode)
+        }
+
+    @Test
+    fun `when onUseWithoutAiClicked then hide ai generated images set to on in SERP settings`() =
+        runTest {
+            testee.onUseWithoutAiClicked()
+            verify(serpSettingsDataProvider).setSetting(HideAiGeneratedImages.SERP_SETTINGS_KEY, HideAiGeneratedImages.ON.serpCode)
+        }
+
+    @Test
     fun whenAutomaticContextAttachmentToggledThenSetUserSetting() =
         runTest {
             testee.onAutomaticContextAttachmentToggled(true)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModelTest.kt
@@ -727,6 +727,110 @@ class DuckChatSettingsViewModelTest {
         }
 
     @Test
+    fun `when duck chat off and search assist never and images hidden then use without ai action disabled`() =
+        runTest {
+            whenever(duckChat.observeEnableDuckChatUserSetting()).thenReturn(flowOf(false))
+            whenever(serpSettingsDataProvider.observeSetting(SearchAssistVisibility.SERP_SETTINGS_KEY))
+                .thenReturn(flowOf(SearchAssistVisibility.NEVER.serpCode))
+            whenever(serpSettingsDataProvider.observeSetting(HideAiGeneratedImages.SERP_SETTINGS_KEY))
+                .thenReturn(flowOf(HideAiGeneratedImages.ON.serpCode))
+            testee = DuckChatSettingsViewModel(
+                duckChatActivityParams = DuckChatSettingsNoParams,
+                duckChat = duckChat,
+                pixel = mockPixel,
+                inputScreenDiscoveryFunnel = mockInputScreenDiscoveryFunnel,
+                settingsPageFeature = settingsPageFeature,
+                duckChatPixels = mockDuckChatPixels,
+                dispatcherProvider = coroutineRule.testDispatcherProvider,
+                duckChatFeature = duckChatFeature,
+                serpSettingsDataProvider = serpSettingsDataProvider,
+            )
+
+            testee.viewState.test {
+                assertFalse(awaitItem().isUseWithoutAiActionEnabled)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `when duck chat on but search assist never and images hidden then use without ai action enabled`() =
+        runTest {
+            whenever(duckChat.observeEnableDuckChatUserSetting()).thenReturn(flowOf(true))
+            whenever(serpSettingsDataProvider.observeSetting(SearchAssistVisibility.SERP_SETTINGS_KEY))
+                .thenReturn(flowOf(SearchAssistVisibility.NEVER.serpCode))
+            whenever(serpSettingsDataProvider.observeSetting(HideAiGeneratedImages.SERP_SETTINGS_KEY))
+                .thenReturn(flowOf(HideAiGeneratedImages.ON.serpCode))
+            testee = DuckChatSettingsViewModel(
+                duckChatActivityParams = DuckChatSettingsNoParams,
+                duckChat = duckChat,
+                pixel = mockPixel,
+                inputScreenDiscoveryFunnel = mockInputScreenDiscoveryFunnel,
+                settingsPageFeature = settingsPageFeature,
+                duckChatPixels = mockDuckChatPixels,
+                dispatcherProvider = coroutineRule.testDispatcherProvider,
+                duckChatFeature = duckChatFeature,
+                serpSettingsDataProvider = serpSettingsDataProvider,
+            )
+
+            testee.viewState.test {
+                assertTrue(awaitItem().isUseWithoutAiActionEnabled)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `when duck chat off but search assist not never then use without ai action enabled`() =
+        runTest {
+            whenever(duckChat.observeEnableDuckChatUserSetting()).thenReturn(flowOf(false))
+            whenever(serpSettingsDataProvider.observeSetting(SearchAssistVisibility.SERP_SETTINGS_KEY))
+                .thenReturn(flowOf(SearchAssistVisibility.OFTEN.serpCode))
+            whenever(serpSettingsDataProvider.observeSetting(HideAiGeneratedImages.SERP_SETTINGS_KEY))
+                .thenReturn(flowOf(HideAiGeneratedImages.ON.serpCode))
+            testee = DuckChatSettingsViewModel(
+                duckChatActivityParams = DuckChatSettingsNoParams,
+                duckChat = duckChat,
+                pixel = mockPixel,
+                inputScreenDiscoveryFunnel = mockInputScreenDiscoveryFunnel,
+                settingsPageFeature = settingsPageFeature,
+                duckChatPixels = mockDuckChatPixels,
+                dispatcherProvider = coroutineRule.testDispatcherProvider,
+                duckChatFeature = duckChatFeature,
+                serpSettingsDataProvider = serpSettingsDataProvider,
+            )
+
+            testee.viewState.test {
+                assertTrue(awaitItem().isUseWithoutAiActionEnabled)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `when duck chat off and search assist never but images not hidden then use without ai action enabled`() =
+        runTest {
+            whenever(duckChat.observeEnableDuckChatUserSetting()).thenReturn(flowOf(false))
+            whenever(serpSettingsDataProvider.observeSetting(SearchAssistVisibility.SERP_SETTINGS_KEY))
+                .thenReturn(flowOf(SearchAssistVisibility.NEVER.serpCode))
+            whenever(serpSettingsDataProvider.observeSetting(HideAiGeneratedImages.SERP_SETTINGS_KEY))
+                .thenReturn(flowOf(HideAiGeneratedImages.OFF.serpCode))
+            testee = DuckChatSettingsViewModel(
+                duckChatActivityParams = DuckChatSettingsNoParams,
+                duckChat = duckChat,
+                pixel = mockPixel,
+                inputScreenDiscoveryFunnel = mockInputScreenDiscoveryFunnel,
+                settingsPageFeature = settingsPageFeature,
+                duckChatPixels = mockDuckChatPixels,
+                dispatcherProvider = coroutineRule.testDispatcherProvider,
+                duckChatFeature = duckChatFeature,
+                serpSettingsDataProvider = serpSettingsDataProvider,
+            )
+
+            testee.viewState.test {
+                assertTrue(awaitItem().isUseWithoutAiActionEnabled)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
     fun whenAutomaticContextAttachmentToggledThenSetUserSetting() =
         runTest {
             testee.onAutomaticContextAttachmentToggled(true)

--- a/settings/settings-impl/src/main/java/com/duckduckgo/settings/impl/serpsettings/messaging/SerpSettingsSubscriptionEventPlugin.kt
+++ b/settings/settings-impl/src/main/java/com/duckduckgo/settings/impl/serpsettings/messaging/SerpSettingsSubscriptionEventPlugin.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.settings.impl.serpsettings.messaging
+
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.contentscopescripts.api.ContentScopeScriptsSubscriptionEventPlugin
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.js.messaging.api.SubscriptionEventData
+import com.duckduckgo.settings.impl.serpsettings.store.SerpSettingsDataStore
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import org.json.JSONObject
+import javax.inject.Inject
+
+/**
+ * Pushes the current native SERP settings snapshot to an open SERP via a content-scope subscription event, so a
+ * SERP page that is already loaded picks up native changes live, without a full re-bootstrap.
+ *
+ * This is the native half of the SERP frontend's generic `nativeSync` mechanism (`NativeStorageForSettings`). The
+ * `serpSettings` bridge has three messages: `getNativeSettings` (FE→native request, see [GetNativeSettingsHandler]),
+ * `updateNativeSettings` (FE→native notify, see [UpdateNativeSettingsHandler]), and `nativeSettingsDidChange`
+ * (native→FE subscribe, emitted here).
+ *
+ * Per the frontend contract, the live channel always emits the **full current state** of every native-synced
+ * setting (e.g. `{ "kbe": "...", "kbj": "..." }`) and the receiver reconciles against that snapshot — a key absent
+ * from the snapshot is read as that key's default. We therefore push the stored blob verbatim (native only stores
+ * the allowlisted nativeSync keys) and never the `{noNativeSettings: true}` form, which is `getNativeSettings`-only.
+ *
+ * The pipeline is already wired: [BrowserTabViewModel.onViewResumed] iterates every
+ * [ContentScopeScriptsSubscriptionEventPlugin] and sends each event via `contentScopeScripts.sendSubscriptionEvent`.
+ * That callback is not a suspend function, so we keep a synchronous snapshot of the blob, collected from the store
+ * for app lifetime (`@SingleInstanceIn` so there's a single collector). `@Volatile`: written on the IO collector,
+ * read on whatever thread the subscription-event fan-out runs on.
+ *
+ * NOTE: inert until the SERP frontend re-subscribes `nativeSettingsDidChange` (removed in a Nov 2025 refactor, being
+ * restored by the frontend `nativeSync` work).
+ */
+@ContributesMultibinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
+class SerpSettingsSubscriptionEventPlugin @Inject constructor(
+    serpSettingsDataStore: SerpSettingsDataStore,
+    dispatcherProvider: DispatcherProvider,
+    @AppCoroutineScope appCoroutineScope: CoroutineScope,
+) : ContentScopeScriptsSubscriptionEventPlugin {
+
+    @Volatile
+    private var cachedBlob: String? = null
+
+    init {
+        serpSettingsDataStore.observeSerpSettings()
+            .onEach { cachedBlob = it }
+            .flowOn(dispatcherProvider.io())
+            .launchIn(appCoroutineScope)
+    }
+
+    override fun getSubscriptionEventData(): SubscriptionEventData =
+        SubscriptionEventData(
+            featureName = FEATURE_NAME,
+            subscriptionName = SUBSCRIPTION_NAME,
+            params = cachedBlob.toSnapshot(),
+        )
+
+    // Full-state snapshot of native-owned settings. Empty/malformed storage → empty object (every key absent,
+    // which the SERP reconciles as "all defaults"), never a partial diff and never noNativeSettings.
+    private fun String?.toSnapshot(): JSONObject {
+        if (this.isNullOrEmpty()) return JSONObject()
+        return runCatching { JSONObject(this) }.getOrElse { JSONObject() }
+    }
+
+    companion object {
+        private const val FEATURE_NAME = "serpSettings"
+        private const val SUBSCRIPTION_NAME = "nativeSettingsDidChange"
+    }
+}

--- a/settings/settings-impl/src/test/java/com/duckduckgo/settings/impl/serpsettings/messaging/SerpSettingsSubscriptionEventPluginTest.kt
+++ b/settings/settings-impl/src/test/java/com/duckduckgo/settings/impl/serpsettings/messaging/SerpSettingsSubscriptionEventPluginTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.settings.impl.serpsettings.messaging
+
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.settings.impl.serpsettings.fakes.FakeSerpSettingsDataStore
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Rule
+import org.junit.Test
+
+class SerpSettingsSubscriptionEventPluginTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val dataStore = FakeSerpSettingsDataStore()
+
+    private val testee = SerpSettingsSubscriptionEventPlugin(
+        serpSettingsDataStore = dataStore,
+        dispatcherProvider = coroutineRule.testDispatcherProvider,
+        appCoroutineScope = coroutineRule.testScope,
+    )
+
+    @Test
+    fun whenBlobHasSettingsThenEmitsSerpSettingsNativeSettingsDidChangeSnapshot() = runTest {
+        dataStore.setSerpSettings("""{"kbe":"0","kbj":"1"}""")
+
+        val event = testee.getSubscriptionEventData()
+
+        assertEquals("serpSettings", event.featureName)
+        assertEquals("nativeSettingsDidChange", event.subscriptionName)
+        assertEquals("0", event.params.getString("kbe"))
+        assertEquals("1", event.params.getString("kbj"))
+    }
+
+    @Test
+    fun whenNoBlobStoredThenEmitsEmptySnapshotNotNoNativeSettings() = runTest {
+        val event = testee.getSubscriptionEventData()
+
+        // The live channel always emits a full-state snapshot; noNativeSettings is a getNativeSettings-only form.
+        assertFalse(event.params.has("noNativeSettings"))
+        assertEquals(0, event.params.length())
+    }
+
+    @Test
+    fun whenBlobMalformedThenEmitsEmptySnapshot() = runTest {
+        dataStore.setSerpSettings("not-json")
+
+        val event = testee.getSubscriptionEventData()
+
+        assertFalse(event.params.has("noNativeSettings"))
+        assertEquals(0, event.params.length())
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200581511062568/task/1215808956430404?focus=true
Tech Design URL (if applicable):

### Description

  Adds native (in-app) controls to the Duck.ai settings screen, gated behind the aiFeaturesNativeControls feature flag. Previously these settings opened the SERP webview; now they're surfaced and editable natively, kept in sync with the SERP via SerpSettingsDataProvider.

  When aiFeaturesNativeControls is enabled:
  - Search Assist Visibility — tapping the row opens a native dialog (Never / On demand / Sometimes / Often) instead of the webview; the row's subtitle reflects the current selection.
  - Hide AI-Generated Images — tapping the row opens a native On/Off dialog; the subtitle reflects the current state.
  - Use DuckDuckGo Without AI — a new item at the very end of the screen. Tapping it disables Duck.ai, sets Search Assist to Never, and sets Hide AI-Generated Images to On in one action. The
  item is greyed out and non-tappable when Duck.ai is off and Search Assist is Never and Hide AI-Generated Images is On (i.e. there's nothing left to turn off); re-enabling any of the three makes it actionable again. Its subtitle changes to explain when AI is already fully disabled.

  All settings reads/writes go through the SERP blob as the single source of truth, so native changes are reflected on the web's next getNativeSettings and vice versa.


### Steps to test this PR

  1. Enable the aiFeaturesNativeControls flag (DuckChat feature flags) — for SERP-backed rows also ensure showHideAiGeneratedImages is enabled.
  2. Open Settings → AI Features
  3. Search Assist Visibility: tap the row → confirm the native dialog appears, change the value → confirm the subtitle updates and the choice persists across reopening the screen.
  4. Hide AI-Generated Images: tap the row → confirm the native On/Off dialog appears, toggle it → confirm the subtitle updates and persists.
  5. Use DuckDuckGo Without AI (last item):
    - With Duck.ai on (or any of the three not in its "off" state), confirm the item is enabled/tappable.
    - Tap it → confirm the Duck.ai toggle turns off, Search Assist shows Never, Hide AI-Generated Images shows On, and the item becomes greyed out / non-tappable with the "AI is currently
  disabled…" subtitle.
    - Re-enable any one of the three → confirm the item becomes tappable again and its subtitle reverts.
  6. With the flag off, confirm the screen behaves as before (rows open the SERP webview; the "Use DuckDuckGo Without AI" item is not shown).

### UI changes

| Before | After (some AI enabled) | After (all AI disabled)|
| --- | --- | --- |
|<img width="1080" height="2424" alt="Screenshot_20260624_192715" src="https://github.com/user-attachments/assets/a0e2bf5a-ff8b-4a76-b5ea-ed5d73653a37" />|<img width="1080" height="2424" alt="Screenshot_20260624_192630" src="https://github.com/user-attachments/assets/45a13d8e-9dc1-4f41-84bd-8ad73a4009e1" />|<img width="1080" height="2424" alt="Screenshot_20260624_192636" src="https://github.com/user-attachments/assets/63fee964-708a-4b58-a622-28a01a9b126e" />|



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bulk AI preference changes touch Duck.ai, Search Assist, and SERP blob keys; the new subscription plugin will push settings to live SERPs once the frontend listens again.
> 
> **Overview**
> Adds a **Use DuckDuckGo Without AI** row on Duck.ai settings when `aiFeaturesNativeControls` is on. One tap turns off Duck.ai, sets Search Assist to **Never**, and hides AI-generated images via existing `SerpSettingsDataProvider` writes. `ViewState.isUseWithoutAiActionEnabled` greys the row when all three are already off; copy switches between actionable and disabled subtitles. Layout reorder keeps that row last after the input-screen block moves to the end.
> 
> Introduces **`SerpSettingsSubscriptionEventPlugin`**, which caches the SERP settings blob and emits `serpSettings` / `nativeSettingsDidChange` full snapshots on tab resume so an open SERP can pick up native changes without reload (pending frontend resubscribe).
> 
> ViewModel tests cover the bulk action and enabled/disabled logic; settings-impl tests cover snapshot emission edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6066ec917779491747712d8f74989b0471eed0c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->