### PR TITLE
Add pixels for the hide hatch settings

### DIFF
--- a/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
+++ b/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
@@ -288,5 +288,26 @@
         "triggers": ["other"],
         "suffixes": ["form_factor"],
         "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_escape_hatch_hidden_from_menu": {
+        "description": "User tapped the 'Don't Show This' menu item in the NTP escape hatch card menu",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_last_tab_shortcut_setting_enabled": {
+        "description": "User enabled the Return To Last Tab shortcut from the After Inactivity settings toggle",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_last_tab_shortcut_setting_disabled": {
+        "description": "User disabled the Return To Last Tab shortcut from the After Inactivity settings toggle",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": ["appVersion"]
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchPixelName.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch
+
+import com.duckduckgo.app.statistics.pixels.Pixel
+
+/** Pixels fired from the After Inactivity (show-on-app-launch) settings screen. */
+enum class ShowOnAppLaunchPixelName(override val pixelName: String) : Pixel.PixelName {
+    // Return To Last Tab settings toggle pixels
+    LAST_TAB_SHORTCUT_SETTING_ENABLED("m_ntp_after_idle_last_tab_shortcut_setting_enabled_count"),
+    LAST_TAB_SHORTCUT_SETTING_ENABLED_DAILY("m_ntp_after_idle_last_tab_shortcut_setting_enabled_daily"),
+    LAST_TAB_SHORTCUT_SETTING_DISABLED("m_ntp_after_idle_last_tab_shortcut_setting_disabled_count"),
+    LAST_TAB_SHORTCUT_SETTING_DISABLED_DAILY("m_ntp_after_idle_last_tab_shortcut_setting_disabled_daily"),
+}

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchPixelParamRemovalPlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchPixelParamRemovalPlugin.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch
+
+import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin
+import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class ShowOnAppLaunchPixelParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin {
+    override fun names(): List<Pair<String, Set<PixelParameter>>> {
+        return ShowOnAppLaunchPixelName.entries.map { it.pixelName to PixelParameter.removeAtb() }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModel.kt
@@ -25,6 +25,8 @@ import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_AFTER_INACTIVITY_TIMEOUT_
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
@@ -131,6 +133,13 @@ class ShowOnAppLaunchViewModel @Inject constructor(
     fun onReturnToLastTabToggled(enabled: Boolean) {
         viewModelScope.launch(dispatcherProvider.io()) {
             ntpAfterIdleManager.setReturnToLastTabEnabled(enabled)
+            if (enabled) {
+                pixel.fire(ShowOnAppLaunchPixelName.LAST_TAB_SHORTCUT_SETTING_ENABLED, type = Count)
+                pixel.fire(ShowOnAppLaunchPixelName.LAST_TAB_SHORTCUT_SETTING_ENABLED_DAILY, type = Daily())
+            } else {
+                pixel.fire(ShowOnAppLaunchPixelName.LAST_TAB_SHORTCUT_SETTING_DISABLED, type = Count)
+                pixel.fire(ShowOnAppLaunchPixelName.LAST_TAB_SHORTCUT_SETTING_DISABLED_DAILY, type = Daily())
+            }
         }
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModelTest.kt
@@ -25,6 +25,8 @@ import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_AFTER_INACTIVITY_TIMEOUT_
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Count
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
@@ -217,11 +219,23 @@ class ShowOnAppLaunchViewModelTest {
     }
 
     @Test
-    fun whenReturnToLastTabToggledThenSettingPersisted() = runTest {
+    fun whenReturnToLastTabToggledOffThenSettingPersistedAndDisabledPixelsFired() = runTest {
         testee.onReturnToLastTabToggled(false)
         coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
 
         verify(ntpAfterIdleManager).setReturnToLastTabEnabled(false)
+        verify(pixel).fire(ShowOnAppLaunchPixelName.LAST_TAB_SHORTCUT_SETTING_DISABLED, type = Count)
+        verify(pixel).fire(ShowOnAppLaunchPixelName.LAST_TAB_SHORTCUT_SETTING_DISABLED_DAILY, type = Daily())
+    }
+
+    @Test
+    fun whenReturnToLastTabToggledOnThenSettingPersistedAndEnabledPixelsFired() = runTest {
+        testee.onReturnToLastTabToggled(true)
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(ntpAfterIdleManager).setReturnToLastTabEnabled(true)
+        verify(pixel).fire(ShowOnAppLaunchPixelName.LAST_TAB_SHORTCUT_SETTING_ENABLED, type = Count)
+        verify(pixel).fire(ShowOnAppLaunchPixelName.LAST_TAB_SHORTCUT_SETTING_ENABLED_DAILY, type = Daily())
     }
 
     @Test

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchPixelName.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchPixelName.kt
@@ -29,4 +29,6 @@ enum class NewTabReturnHatchPixelName(override val pixelName: String) : Pixel.Pi
     OPTION_SELECTED_AFTER_INACTIVITY_DAILY("m_ntp_after_idle_escape_hatch_after_inactivity_tapped_daily"),
     OPTION_SELECTED_TAB_SWITCHER("m_ntp_after_idle_escape_hatch_tab_switcher_tapped_after_idle"),
     OPTION_SELECTED_TAB_SWITCHER_DAILY("m_ntp_after_idle_escape_hatch_tab_switcher_tapped_after_idle_daily"),
+    HIDDEN_FROM_MENU("m_ntp_after_idle_escape_hatch_hidden_from_menu_count"),
+    HIDDEN_FROM_MENU_DAILY("m_ntp_after_idle_escape_hatch_hidden_from_menu_daily"),
 }

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModel.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModel.kt
@@ -187,6 +187,8 @@ class NewTabReturnHatchViewModel @Inject constructor(
     }
 
     fun onDontShowThisPressed() {
+        pixel.fire(NewTabReturnHatchPixelName.HIDDEN_FROM_MENU, type = Count)
+        pixel.fire(NewTabReturnHatchPixelName.HIDDEN_FROM_MENU_DAILY, type = Daily())
         // Disable the hatch for future idle returns.
         viewModelScope.launch(dispatchers.io()) {
             ntpAfterIdleManager.setReturnToLastTabEnabled(false)

--- a/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModelTest.kt
+++ b/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModelTest.kt
@@ -131,11 +131,13 @@ class NewTabReturnHatchViewModelTest {
 
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun whenDontShowThisPressedThenReturnToLastTabDisabled() = runTest {
+    fun whenDontShowThisPressedThenReturnToLastTabDisabledAndPixelsFired() = runTest {
         testee.onDontShowThisPressed()
         advanceUntilIdle()
 
         verify(mockNtpAfterIdleManager).setReturnToLastTabEnabled(false)
+        verify(mockPixel).fire(NewTabReturnHatchPixelName.HIDDEN_FROM_MENU, type = Count)
+        verify(mockPixel).fire(NewTabReturnHatchPixelName.HIDDEN_FROM_MENU_DAILY, type = Daily())
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1216007250221705?focus=true 
Tech Design URL (if applicable): N/A

### Description

Adds telemetry for the "hide the Return To Last Tab hatch" feature (the feature itself is in #8998 this is the pixels/telemetry follow-up).

**Note:** I did not remove the m_ prefix to stay consistent with the existing iOS pixels

Three user actions are now measured, each fired as a **count + daily** pair:

- Toggled "Return To Last Tab" in *After Inactivity* settings ON/OFF
- Tapped "Don't Show This" in the hatch menu

### Steps to test this PR

_Settings toggle pixels_
- [ ] On an internal build with Android Studio logcat (or `adb logcat` filtered for `Pixel sent:`)
- [ ] Open *After Inactivity* settings with NTP-after-idle enabled and "New Tab Page" selected.
- [ ] Turn the "Return To Last Tab" toggle **off** → `m_ntp_after_idle_last_tab_shortcut_setting_disabled_count_*` and `..._disabled_daily_*` fire.
- [ ] Turn it back **on** → `m_ntp_after_idle_last_tab_shortcut_setting_enabled_count_*` and `..._enabled_daily_*` fire.

_Hatch menu pixel_
- [ ] With the hatch showing after an idle return, open its overflow (⋮) menu and tap **"Don't Show This"** → `m_ntp_after_idle_escape_hatch_hidden_from_menu_count_*` and `..._hidden_from_menu_daily_*` fire.


### UI changes

No UI changes 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only wiring around existing user actions; no new product behavior beyond firing pixels alongside current persistence calls.
> 
> **Overview**
> Adds **count + daily** analytics for how users dismiss or control the NTP “Return To Last Tab” hatch, aligned with existing `m_ntp_after_idle_*` pixel naming.
> 
> **After Inactivity settings:** toggling “Return To Last Tab” now fires enable/disable pixels from `ShowOnAppLaunchViewModel`, backed by new `ShowOnAppLaunchPixelName` constants and a `PixelParamRemovalPlugin` that strips ATB from those events.
> 
> **Hatch overflow menu:** choosing **Don’t Show This** now fires `hidden_from_menu` count/daily pixels in `NewTabReturnHatchViewModel` (still disables the hatch via `NtpAfterIdleManager` as before).
> 
> Pixel registry entries were added in `ntp_after_idle.json5`; unit tests assert the new `pixel.fire` calls on toggle and menu dismiss.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdc61536c36802aa40f345aa84e524aa302b5eb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->