### PR TITLE
Add Ask about tab/page items to the Duck.ai attach menu

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -284,6 +284,12 @@ interface DuckChatInternal : DuckChat {
     fun isNativeChatInputEnabled(): Boolean
 
     /**
+     * Returns whether the Duck.ai contextual sheet's INPUT mode should use the native unified input.
+     * True only when [isNativeChatInputEnabled] is true AND the [contextualNativeInput] toggle is on.
+     */
+    fun isContextualNativeInputEnabled(): Boolean
+
+    /**
      * Returns whether Duck.ai in contextual mode should attach more than one content
      */
     fun areMultipleContentAttachmentsEnabled(): Boolean
@@ -449,6 +455,7 @@ class RealDuckChat @Inject constructor(
     private var areMultipleContentAttachmentsEnabled: Boolean = false
     private var isNativeInputFieldEnabled: Boolean = false
     private var isNativeChatInputEnabled: Boolean = false
+    private var isContextualNativeInputEnabled: Boolean = false
 
     init {
         if (isMainProcess) {
@@ -523,6 +530,8 @@ class RealDuckChat @Inject constructor(
     override fun isNativeStorageEnabled(): Boolean = duckAiNativeStorage
 
     override fun isNativeChatInputEnabled(): Boolean = isNativeChatInputEnabled
+
+    override fun isContextualNativeInputEnabled(): Boolean = isContextualNativeInputEnabled
 
     override fun areMultipleContentAttachmentsEnabled(): Boolean = areMultipleContentAttachmentsEnabled
 
@@ -940,6 +949,9 @@ class RealDuckChat @Inject constructor(
             isNativeInputFieldEnabled = _nativeInputFieldEnabled.value
             isNativeChatInputEnabled = isNativeInputFieldEnabled && duckChatFeature.nativeChatInput().isEnabled()
             _nativeChatInputEnabled.value = isNativeChatInputEnabled
+            // Contextual native INPUT mode is gated by nativeChatInput AND the contextualNativeInput flag.
+            // Read synchronously via isContextualNativeInputEnabled() — no flow needed (static per session).
+            isContextualNativeInputEnabled = isNativeChatInputEnabled && duckChatFeature.contextualNativeInput().isEnabled()
             _nativeInputNavBarEnabled.value = duckChatFeature.nativeInputNavBar().isEnabled()
             val inputScreenUserSettingEnabled = duckChatFeatureRepository.isInputScreenUserSettingEnabled()
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
@@ -83,6 +83,14 @@ interface ContextualNativeInputManager {
      * widget wrote during its lifetime.
      */
     fun onContextualClosed(tabId: String)
+
+    /**
+     * Called when the contextual sheet is reopened for a tab that was previously closed. Restores the
+     * per-tab [NativeInputState] to the contextual (DUCK_AI) values that [onContextualClosed] reverted,
+     * so the widget's plugin controls (attach, model picker, tools — gated on toggleSelection == DUCK_AI)
+     * reappear. Without this the reused widget keeps the browser/search state and renders without them.
+     */
+    fun onContextualReopened(tabId: String)
 }
 
 @ContributesBinding(FragmentScope::class)
@@ -135,6 +143,17 @@ class RealContextualNativeInputManager @Inject constructor(
             it.copy(
                 inputContext = browser,
                 toggleSelection = NativeInputState.defaultToggleFor(browser),
+            )
+        }
+    }
+
+    override fun onContextualReopened(tabId: String) {
+        if (tabId.isBlank()) return
+        val contextual = NativeInputState.InputContext.DUCK_AI_CONTEXTUAL
+        nativeInputStatePublisher.update(tabId) {
+            it.copy(
+                inputContext = contextual,
+                toggleSelection = NativeInputState.defaultToggleFor(contextual),
             )
         }
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
@@ -23,9 +23,9 @@ import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.di.scopes.FragmentScope
-import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
+import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.helper.RealDuckChatJSHelper
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.NativeInputModeWidget
 import com.duckduckgo.js.messaging.api.JsMessaging
@@ -95,11 +95,12 @@ interface ContextualNativeInputManager {
 
 @ContributesBinding(FragmentScope::class)
 class RealContextualNativeInputManager @Inject constructor(
-    private val duckChat: DuckChat,
+    private val duckChatInternal: DuckChatInternal,
     private val nativeInputStatePublisher: NativeInputStatePublisher,
 ) : ContextualNativeInputManager {
 
     private var isNativeInputEnabled = false
+    private var isContextualNativeInputEnabled = false
     private var card: MaterialCardView? = null
     private var jsMessaging: JsMessaging? = null
     private var widget: NativeInputModeWidget? = null
@@ -172,13 +173,13 @@ class RealContextualNativeInputManager @Inject constructor(
 
     override fun onInputMode() {
         lastMode = Mode.INPUT
-        if (isNativeInputEnabled) {
+        if (isContextualNativeInputEnabled) {
             // The unified input widget is the composer for the initial sheet.
             card?.show()
             // INPUT mode is a new chat: restore the picker so the user can pick a model before starting.
             modelPickerEnabled.value = true
         } else {
-            // Flag off: the legacy EditText composer is shown instead, so keep the widget card hidden.
+            // contextualNativeInput off: the legacy EditText composer is shown instead, so keep the card hidden.
             card?.gone()
         }
     }
@@ -248,12 +249,10 @@ class RealContextualNativeInputManager @Inject constructor(
     }
 
     private fun observeNativeInputSetting(lifecycleOwner: LifecycleOwner) {
-        duckChat.observeNativeChatInputEnabled()
+        isContextualNativeInputEnabled = duckChatInternal.isContextualNativeInputEnabled()
+        duckChatInternal.observeNativeChatInputEnabled()
             .onEach { isEnabled ->
                 isNativeInputEnabled = isEnabled
-                // Re-apply the current mode so the card shows/hides immediately when the flag
-                // flips at runtime — otherwise a card left over from WEBVIEW mode would overlap
-                // the web input after the flag turns off.
                 when (lastMode) {
                     Mode.WEBVIEW -> onWebViewMode()
                     Mode.INPUT -> onInputMode()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
@@ -41,9 +41,9 @@ import org.json.JSONObject
 import javax.inject.Inject
 
 /**
- * A prompt submitted from the unified input widget while the contextual sheet is in its initial
- * (INPUT) state. Carries the widget's current model/reasoning/tool/attachment selections so the
- * new chat starts with everything the user configured.
+ * A prompt submitted from the unified input widget in the contextual sheet, in either the initial
+ * (INPUT) state or a running chat (WEBVIEW). Carries the widget's current model/reasoning/tool/
+ * attachment selections so the chat is submitted with everything the user configured.
  */
 data class NativeInputPrompt(
     val prompt: String,
@@ -65,9 +65,9 @@ interface ContextualNativeInputManager {
         onSearchSubmitted: (String) -> Unit,
         onCameraCaptureRequested: (ValueCallback<Array<Uri>>) -> Unit = {},
         onFilePickerRequested: (ValueCallback<Array<Uri>>, List<String>) -> Unit = { _, _ -> },
-        // Invoked when the widget submits a prompt while the sheet is in INPUT mode: starts a new chat.
-        // WEBVIEW-mode submissions keep going through the in-chat JS event path (see setupWidget).
-        onNewPromptSubmitted: (NativeInputPrompt) -> Unit = {},
+        // Invoked when the widget submits a prompt, in both INPUT and WEBVIEW modes. Routing every submit
+        // through the ViewModel keeps prompt-building (and page-context attachment) in one place.
+        onPromptSubmitted: (NativeInputPrompt) -> Unit = {},
         onAskAboutTab: () -> Unit = {},
         onAskAboutPage: () -> Unit = {},
         onPageContextRemoved: () -> Unit = {},
@@ -110,7 +110,7 @@ class RealContextualNativeInputManager @Inject constructor(
         onSearchSubmitted: (String) -> Unit,
         onCameraCaptureRequested: (ValueCallback<Array<Uri>>) -> Unit,
         onFilePickerRequested: (ValueCallback<Array<Uri>>, List<String>) -> Unit,
-        onNewPromptSubmitted: (NativeInputPrompt) -> Unit,
+        onPromptSubmitted: (NativeInputPrompt) -> Unit,
         onAskAboutTab: () -> Unit,
         onAskAboutPage: () -> Unit,
         onPageContextRemoved: () -> Unit,
@@ -123,7 +123,7 @@ class RealContextualNativeInputManager @Inject constructor(
         setupWidget(
             tabId, widget, chatIdFlow, onSearchSubmitted,
             onCameraCaptureRequested, onFilePickerRequested,
-            onNewPromptSubmitted, onAskAboutTab, onAskAboutPage, onPageContextRemoved,
+            onPromptSubmitted, onAskAboutTab, onAskAboutPage, onPageContextRemoved,
         )
         observeNativeInputSetting(lifecycleOwner)
     }
@@ -182,7 +182,7 @@ class RealContextualNativeInputManager @Inject constructor(
         onSearchSubmitted: (String) -> Unit,
         onCameraCaptureRequested: (ValueCallback<Array<Uri>>) -> Unit,
         onFilePickerRequested: (ValueCallback<Array<Uri>>, List<String>) -> Unit,
-        onNewChatPromptSubmitted: (NativeInputPrompt) -> Unit,
+        onPromptSubmitted: (NativeInputPrompt) -> Unit,
         onAskAboutTab: () -> Unit,
         onAskAboutPage: () -> Unit,
         onPageContextRemoved: () -> Unit,
@@ -213,14 +213,15 @@ class RealContextualNativeInputManager @Inject constructor(
                 val reasoningEffort = widget.getResolvedReasoningEffort()
                 val selectedTool = widget.getSelectedTool()
                 widget.clearAttachments()
-                if (lastMode != Mode.WEBVIEW) {
-                    onNewChatPromptSubmitted(
-                        NativeInputPrompt(prompt, modelId, reasoningEffort, selectedTool, imagesJson, filesJson),
-                    )
-                } else {
-                    // Chat already in progress: submit into the running chat via the JS event.
-                    sendPrompt(prompt, modelId, reasoningEffort, selectedTool, imagesJson, filesJson)
-                }
+                // Both the initial submit (INPUT) and follow-ups in a running chat (WEBVIEW) go through the
+                // ViewModel so the prompt is built in one place (generateContextPrompt). That single path is
+                // what attaches any page context the user added from the "+" menu; the previous WEBVIEW
+                // shortcut built its own JS event and silently dropped that context. onPromptSent starts a
+                // new chat from INPUT and appends to the active chat from WEBVIEW — the web page decides
+                // which, based on its own state, not on the native caller.
+                onPromptSubmitted(
+                    NativeInputPrompt(prompt, modelId, reasoningEffort, selectedTool, imagesJson, filesJson),
+                )
                 widget.clearSelectedTool()
                 widget.text = ""
             },
@@ -241,49 +242,6 @@ class RealContextualNativeInputManager @Inject constructor(
                 }
             }
             .launchIn(lifecycleOwner.lifecycleScope)
-    }
-
-    private fun sendPrompt(
-        prompt: String,
-        modelId: String? = null,
-        reasoningEffort: String? = null,
-        selectedTool: String? = null,
-        imagesJson: JSONArray? = null,
-        filesJson: JSONArray? = null,
-    ) {
-        val params = JSONObject().apply {
-            put("platform", "android")
-            put("tool", "query")
-            put(
-                "query",
-                JSONObject().apply {
-                    put("prompt", prompt)
-                    put("autoSubmit", true)
-                    if (modelId != null) {
-                        put("modelId", modelId)
-                    }
-                    if (reasoningEffort != null) {
-                        put("reasoningEffort", reasoningEffort)
-                    }
-                    if (selectedTool != null) {
-                        put("toolChoice", JSONArray().apply { put(selectedTool) })
-                    }
-                    if (imagesJson != null) {
-                        put("images", imagesJson)
-                    }
-                    if (filesJson != null) {
-                        put("files", filesJson)
-                    }
-                },
-            )
-        }
-        jsMessaging?.sendSubscriptionEvent(
-            SubscriptionEventData(
-                featureName = RealDuckChatJSHelper.DUCK_CHAT_FEATURE_NAME,
-                subscriptionName = "submitAIChatNativePrompt",
-                params = params,
-            ),
-        )
     }
 
     private fun sendStopEvent() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
@@ -68,6 +68,9 @@ interface ContextualNativeInputManager {
         // Invoked when the widget submits a prompt while the sheet is in INPUT mode: starts a new chat.
         // WEBVIEW-mode submissions keep going through the in-chat JS event path (see setupWidget).
         onNewPromptSubmitted: (NativeInputPrompt) -> Unit = {},
+        onAskAboutTab: () -> Unit = {},
+        onAskAboutPage: () -> Unit = {},
+        onPageContextRemoved: () -> Unit = {},
     )
 
     fun onWebViewMode()
@@ -108,13 +111,20 @@ class RealContextualNativeInputManager @Inject constructor(
         onCameraCaptureRequested: (ValueCallback<Array<Uri>>) -> Unit,
         onFilePickerRequested: (ValueCallback<Array<Uri>>, List<String>) -> Unit,
         onNewPromptSubmitted: (NativeInputPrompt) -> Unit,
+        onAskAboutTab: () -> Unit,
+        onAskAboutPage: () -> Unit,
+        onPageContextRemoved: () -> Unit,
     ) {
         this.card = card
         this.jsMessaging = jsMessaging
         this.widget = widget
 
         applyCardShape(card)
-        setupWidget(tabId, widget, chatIdFlow, onSearchSubmitted, onCameraCaptureRequested, onFilePickerRequested, onNewPromptSubmitted)
+        setupWidget(
+            tabId, widget, chatIdFlow, onSearchSubmitted,
+            onCameraCaptureRequested, onFilePickerRequested,
+            onNewPromptSubmitted, onAskAboutTab, onAskAboutPage, onPageContextRemoved,
+        )
         observeNativeInputSetting(lifecycleOwner)
     }
 
@@ -173,6 +183,9 @@ class RealContextualNativeInputManager @Inject constructor(
         onCameraCaptureRequested: (ValueCallback<Array<Uri>>) -> Unit,
         onFilePickerRequested: (ValueCallback<Array<Uri>>, List<String>) -> Unit,
         onNewChatPromptSubmitted: (NativeInputPrompt) -> Unit,
+        onAskAboutTab: () -> Unit,
+        onAskAboutPage: () -> Unit,
+        onPageContextRemoved: () -> Unit,
     ) {
         widget.configureContextual(tabId)
         widget.bindChatIdSource(chatIdFlow)
@@ -182,6 +195,11 @@ class RealContextualNativeInputManager @Inject constructor(
         widget.bindAttachmentCallbacks(
             onCameraCaptureRequested = onCameraCaptureRequested,
             onFilePickerRequested = onFilePickerRequested,
+        )
+        widget.setContextualAttachmentActions(
+            onAskAboutTab = onAskAboutTab,
+            onAskAboutPage = onAskAboutPage,
+            onPageContextRemoved = onPageContextRemoved,
         )
         widget.bindInputEvents(
             onSearchTextChanged = { },

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -478,7 +478,7 @@ class DuckChatContextualFragment :
             onFilePickerRequested = { callback, mimeTypes ->
                 launchNativeFilePicker(callback, mimeTypes)
             },
-            onNewPromptSubmitted = { submitted ->
+            onPromptSubmitted = { submitted ->
                 viewModel.onPromptSent(
                     prompt = submitted.prompt,
                     modelId = submitted.modelId,
@@ -672,6 +672,10 @@ class DuckChatContextualFragment :
                     is DuckChatContextualViewModel.Command.LaunchChatHistory -> {
                         viewModel.onContextualClose()
                         globalActivityStarter.start(requireContext(), DuckChatHistoryNoParams)
+                    }
+
+                    is DuckChatContextualViewModel.Command.FocusInput -> {
+                        binding.contextualNativeInputWidget.focusInput(activity)
                     }
                 }
             }.launchIn(lifecycleScope)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -73,6 +73,7 @@ import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.FragmentViewModelFactory
 import com.duckduckgo.common.utils.extensions.hideKeyboard
+import com.duckduckgo.common.utils.extensions.showKeyboard
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.downloads.api.DOWNLOAD_SNACKBAR_DELAY
@@ -676,7 +677,14 @@ class DuckChatContextualFragment :
                     }
 
                     is DuckChatContextualViewModel.Command.FocusInput -> {
-                        binding.contextualNativeInputWidget.focusInput(activity)
+                        if (viewModel.viewState.value.nativeChatInputEnabled) {
+                            binding.contextualNativeInputWidget.focusInput(activity)
+                        } else {
+                            binding.legacyInputField.let {
+                                it.requestFocus()
+                                activity?.showKeyboard(it)
+                            }
+                        }
                     }
                 }
             }.launchIn(lifecycleScope)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -235,7 +235,7 @@ class DuckChatContextualFragment :
                 val imeVisible = heightDiff > threshold
                 if (imeVisible != isKeyboardVisible) {
                     isKeyboardVisible = imeVisible
-                    val composerHasFocus = if (viewModel.viewState.value.nativeChatInputEnabled) {
+                    val composerHasFocus = if (viewModel.viewState.value.contextualNativeInputEnabled) {
                         binding.contextualNativeInputWidget.hasFocus()
                     } else {
                         binding.contextualModeNativeContent.hasFocus()
@@ -599,7 +599,7 @@ class DuckChatContextualFragment :
             viewModel.addPageContext(fromPlaceholderTap = true)
         }
         binding.contextualPromptQuickAction.setOnClickListener {
-            val currentInput = if (viewModel.viewState.value.nativeChatInputEnabled) {
+            val currentInput = if (viewModel.viewState.value.contextualNativeInputEnabled) {
                 binding.contextualNativeInputWidget.text
             } else {
                 binding.legacyInputField.text.toString()
@@ -677,7 +677,7 @@ class DuckChatContextualFragment :
                     }
 
                     is DuckChatContextualViewModel.Command.FocusInput -> {
-                        if (viewModel.viewState.value.nativeChatInputEnabled) {
+                        if (viewModel.viewState.value.contextualNativeInputEnabled) {
                             binding.contextualNativeInputWidget.focusInput(activity)
                         } else {
                             binding.legacyInputField.let {
@@ -759,8 +759,8 @@ class DuckChatContextualFragment :
                 }
                 binding.contextualFire.gone()
 
-                if (viewState.nativeChatInputEnabled) {
-                    // The unified input widget is the composer; ContextualNativeInputManager.onInputMode()
+                if (viewState.contextualNativeInputEnabled) {
+                    // The unified input widget is the INPUT composer; ContextualNativeInputManager.onInputMode()
                     // shows its card. Hide the legacy EditText composer and its context chip/placeholder.
                     binding.contextualModeNativeContent.gone()
                 } else {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -488,6 +488,9 @@ class DuckChatContextualFragment :
                     filesJson = submitted.filesJson,
                 )
             },
+            onAskAboutTab = { viewModel.onAskAboutTabClicked() },
+            onAskAboutPage = { viewModel.onAskAboutPageClicked() },
+            onPageContextRemoved = { viewModel.removePageContext() },
         )
         observeViewModel()
 
@@ -786,6 +789,16 @@ class DuckChatContextualFragment :
                 if (viewState.isFireButtonEnabled) binding.contextualFire.show() else binding.contextualFire.gone()
                 contextualNativeInputManager.onWebViewMode()
             }
+        }
+
+        if (viewState.showContext && viewState.contextTitle.isNotEmpty()) {
+            binding.contextualNativeInputWidget.setPageContext(
+                title = viewState.contextTitle,
+                url = viewState.contextUrl,
+                faviconUrl = null,
+            )
+        } else {
+            binding.contextualNativeInputWidget.clearPageContext()
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -650,6 +650,7 @@ class DuckChatContextualFragment :
 
                     is DuckChatContextualViewModel.Command.ChangeSheetState -> {
                         command.prefillNativeInput?.let { binding.contextualNativeInputWidget.text = it }
+                        if (command.hideKeyboard) activity?.hideKeyboard()
                         bottomSheetBehavior.state = command.newState
                     }
                     is DuckChatContextualViewModel.Command.RequestPageContext -> {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -759,6 +759,8 @@ class DuckChatContextualViewModel @Inject constructor(
             return
         }
         addPageContext()
+        commandChannel.trySend(Command.FocusInput)
+        _viewState.update { it.copy(quickActionState = QuickActionState.SUBMIT_SUMMARIZE) }
     }
 
     fun onAskAboutPageClicked() {
@@ -766,6 +768,7 @@ class DuckChatContextualViewModel @Inject constructor(
             // Context not attached; nothing to ask about.
             return
         }
+        commandChannel.trySend(Command.FocusInput)
         onPromptSent(prompt = context.getString(R.string.duckChatContextualAskAboutPage))
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -624,21 +624,19 @@ class DuckChatContextualViewModel @Inject constructor(
 
     fun removePageContext() {
         logcat { "Duck.ai Contextual: removePageContext" }
-        viewModelScope.launch {
-            _viewState.update { current ->
-                current.copy(
-                    showContext = false,
-                    userRemovedContext = true,
-                    quickActionState = if (current.quickActionState == QuickActionState.SUBMIT_SUMMARIZE) {
-                        QuickActionState.ASK_ABOUT_PAGE
-                    } else {
-                        current.quickActionState
-                    },
-                )
-            }
-            if (_viewState.value.showsAttachContextPlaceholder()) {
-                duckChatPixels.reportContextualPlaceholderContextShown()
-            }
+        _viewState.update { current ->
+            current.copy(
+                showContext = false,
+                userRemovedContext = true,
+                quickActionState = if (current.quickActionState == QuickActionState.SUBMIT_SUMMARIZE) {
+                    QuickActionState.ASK_ABOUT_PAGE
+                } else {
+                    current.quickActionState
+                },
+            )
+        }
+        if (_viewState.value.showsAttachContextPlaceholder()) {
+            duckChatPixels.reportContextualPlaceholderContextShown()
         }
         duckChatPixels.reportContextualPageContextRemovedNative()
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -271,6 +271,8 @@ class DuckChatContextualViewModel @Inject constructor(
     fun onSheetReopened() {
         logcat { "Duck.ai: onSheetReopened" }
 
+        contextualNativeInputManager.onContextualReopened(sheetTabId)
+
         viewModelScope.launch(dispatchers.io()) {
             withContext(dispatchers.main()) {
                 logcat { "Duck.ai: requesting page context after sheet reopened" }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -139,6 +139,7 @@ class DuckChatContextualViewModel @Inject constructor(
             val sourceTabId: String,
         ) : Command()
         data object LaunchChatHistory : Command()
+        data object FocusInput : Command()
     }
 
     private val _viewState: MutableStateFlow<ViewState> =
@@ -409,6 +410,10 @@ class DuckChatContextualViewModel @Inject constructor(
                     _viewState.value.copy(
                         sheetMode = SheetMode.WEBVIEW,
                         prompt = "",
+                        // The context has already been captured in contextPrompt above, so drop the
+                        // page-context chip from the input once the prompt is sent — mirroring how image
+                        // attachments are cleared on submit.
+                        showContext = false,
                     )
                 _subscriptionEventDataChannel.trySend(contextPrompt)
                 prefillEvent?.let { _subscriptionEventDataChannel.trySend(it) }
@@ -720,6 +725,9 @@ class DuckChatContextualViewModel @Inject constructor(
                 }
                 duckChatPixels.reportContextualAskAboutPageSelected()
                 addPageContext()
+                // Focus the input in the same tap so the keyboard and the (focus-gated) tools row come
+                // up without the user needing a second tap.
+                commandChannel.trySend(Command.FocusInput)
                 viewModelScope.launch {
                     _viewState.update { it.copy(quickActionState = QuickActionState.SUBMIT_SUMMARIZE) }
                 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -740,8 +740,10 @@ class DuckChatContextualViewModel @Inject constructor(
     }
 
     fun onAskAboutTabClicked() {
-        // Attaches the current page as context (shows the native input's page-context chip via the
-        // showContext observer). Sends no prompt. addPageContext() is a no-op if context is invalid.
+        if (!isContextValid(updatedPageContext)) {
+            // Page context not ready/valid; do nothing (and don't fire invalid-context pixels).
+            return
+        }
         addPageContext()
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -733,8 +733,6 @@ class DuckChatContextualViewModel @Inject constructor(
                 }
                 duckChatPixels.reportContextualAskAboutPageSelected()
                 addPageContext()
-                // Focus the input in the same tap so the keyboard and the (focus-gated) tools row come
-                // up without the user needing a second tap.
                 commandChannel.trySend(Command.FocusInput)
                 viewModelScope.launch {
                     _viewState.update { it.copy(quickActionState = QuickActionState.SUBMIT_SUMMARIZE) }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -127,6 +127,10 @@ class DuckChatContextualViewModel @Inject constructor(
         data class ChangeSheetState(
             val newState: Int,
             val prefillNativeInput: String? = null,
+            // Hide the soft keyboard as part of this transition (e.g. leaving the initial input state for
+            // the chat). Folded into this command rather than a separate one because commandChannel is a
+            // capacity-1 DROP_OLDEST channel: two commands emitted in the same burst would lose the older.
+            val hideKeyboard: Boolean = false,
         ) : Command()
         data object RequestPageContext : Command()
         data object ShowFireConfirmation : Command()
@@ -406,6 +410,9 @@ class DuckChatContextualViewModel @Inject constructor(
             val prefillText = followUpPrefill?.takeIf { it.isNotEmpty() }
             val prefillEvent = prefillText?.let { generatePrefillEvent(it) }
             withContext(dispatchers.main()) {
+                // Sending from the initial input state leaves the sheet in the chat; hide the keyboard so
+                // the user sees the streaming reply instead of the composer.
+                val wasInInputMode = _viewState.value.sheetMode == SheetMode.INPUT
                 _viewState.value =
                     _viewState.value.copy(
                         sheetMode = SheetMode.WEBVIEW,
@@ -423,6 +430,7 @@ class DuckChatContextualViewModel @Inject constructor(
                     Command.ChangeSheetState(
                         newState = BottomSheetBehavior.STATE_EXPANDED,
                         prefillNativeInput = prefillText.orEmpty(),
+                        hideKeyboard = wasInInputMode,
                     ),
                 )
             }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -739,6 +739,20 @@ class DuckChatContextualViewModel @Inject constructor(
         }
     }
 
+    fun onAskAboutTabClicked() {
+        // Attaches the current page as context (shows the native input's page-context chip via the
+        // showContext observer). Sends no prompt. addPageContext() is a no-op if context is invalid.
+        addPageContext()
+    }
+
+    fun onAskAboutPageClicked() {
+        if (!_viewState.value.showContext) {
+            // Context not attached; nothing to ask about.
+            return
+        }
+        onPromptSent(prompt = context.getString(R.string.duckChatContextualAskAboutPage))
+    }
+
     fun onPromptCleared() {
         logcat { "Duck.ai Contextual: onPromptCleared" }
         viewModelScope.launch {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -160,6 +160,7 @@ class DuckChatContextualViewModel @Inject constructor(
                 prompt = "",
                 isFireButtonEnabled = false,
                 quickActionState = QuickActionState.LEGACY_SUMMARIZE,
+                contextualNativeInputEnabled = duckChatInternal.isContextualNativeInputEnabled(),
             ),
         )
     val viewState: StateFlow<ViewState> = _viewState.asStateFlow()
@@ -263,9 +264,8 @@ class DuckChatContextualViewModel @Inject constructor(
         // When true, the legacy "+" icon is replaced by the chats icon and shown regardless of sheet mode.
         val showChatsIcon: Boolean = false,
         val recentChats: List<ChatHistoryItem> = emptyList(),
-        // When true, the initial (INPUT) sheet uses the unified input widget as its composer instead
-        // of the legacy EditText. Mirrors duckChat.observeNativeChatInputEnabled().
         val nativeChatInputEnabled: Boolean = false,
+        val contextualNativeInputEnabled: Boolean = false,
     )
 
     fun onSheetReopened() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -319,4 +319,14 @@ interface DuckChatFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun removeChatHistory(): Toggle
+
+    /**
+     * @return `true` when the Duck.ai contextual sheet's initial INPUT state should use the native
+     * unified input widget as its composer. Gated together with [nativeChatInput] (and
+     * [nativeInputField]): when this is off but native chat input is on, the contextual sheet uses
+     * the legacy input for INPUT mode while still using the native widget in WEBVIEW (in-chat) mode.
+     * When native chat input is off, this has no effect (everything falls back to legacy/web input).
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun contextualNativeInput(): Toggle
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/AttachmentViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/AttachmentViewModel.kt
@@ -39,6 +39,7 @@ import com.duckduckgo.duckchat.impl.models.ImageLimits
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.ImageAttachment
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.LimitsHandler
+import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.PageContextAttachment
 import com.duckduckgo.duckchat.impl.ui.nativeinput.file.FileAttachment
 import com.duckduckgo.duckchat.impl.ui.nativeinput.file.FileAttachmentProcessor
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -79,6 +80,7 @@ class AttachmentViewModel @Inject constructor(
     data class AttachmentState(
         val images: List<ImageAttachment> = emptyList(),
         val files: List<FileAttachment> = emptyList(),
+        val pageContext: PageContextAttachment? = null,
         val imageLimitError: String? = null,
         val fileLimitError: String? = null,
         val fileSizeError: String? = null,
@@ -88,7 +90,7 @@ class AttachmentViewModel @Inject constructor(
         val supportsImageUpload: Boolean = false,
         val supportedFileTypes: List<String> = emptyList(),
     ) {
-        val hasAttachments: Boolean get() = images.isNotEmpty() || files.isNotEmpty()
+        val hasAttachments: Boolean get() = images.isNotEmpty() || files.isNotEmpty() || pageContext != null
         val acceptedMimeTypes: List<String> get() {
             val types = mutableListOf<String>()
             if (supportedFileTypes.isNotEmpty()) types.addAll(supportedFileTypes)
@@ -100,17 +102,20 @@ class AttachmentViewModel @Inject constructor(
     @VisibleForTesting
     internal val imageAttachments = MutableStateFlow<List<ImageAttachment>>(emptyList())
     private val _fileAttachments = MutableStateFlow<List<FileAttachment>>(emptyList())
+    private val _pageContextAttachment = MutableStateFlow<PageContextAttachment?>(null)
 
     private val isDuckAiModeFlow: StateFlow<Boolean> = nativeInputStateProvider.state
         .map { it.inputContext != NativeInputState.InputContext.BROWSER }
         .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
     val attachmentState: StateFlow<AttachmentState> = combine(
-        combine(imageAttachments, _fileAttachments) { images, files -> Pair(images, files) },
+        combine(imageAttachments, _fileAttachments, _pageContextAttachment) { images, files, pageContext ->
+            Triple(images, files, pageContext)
+        },
         modelManager.modelState,
         combine(limitsHandler.conversationImagesSent, limitsHandler.conversationFilesUsed) { imgSent, filesUsed -> Pair(imgSent, filesUsed) },
         isDuckAiModeFlow,
-    ) { (images, files), modelState, (conversationImagesSent, conversationFilesUsed), isDuckAiMode ->
+    ) { (images, files, pageContext), modelState, (conversationImagesSent, conversationFilesUsed), isDuckAiMode ->
         val conversationFilesSent = conversationFilesUsed.count
         val conversationFileSizeSentBytes = conversationFilesUsed.sizeBytes
         val model = modelState.models.find { it.id == modelState.selectedModelId }
@@ -126,6 +131,7 @@ class AttachmentViewModel @Inject constructor(
         AttachmentState(
             images = images,
             files = files,
+            pageContext = pageContext,
             imageLimitError = computeImageLimitError(currentImageCount, totalImages, imageLimits),
             fileLimitError = computeFileLimitError(totalFiles, fileLimits.maxPerConversation),
             fileSizeError = computeFileSizeError(files, fileLimits.maxFileSizeBytes),
@@ -270,10 +276,21 @@ class AttachmentViewModel @Inject constructor(
         if (removed) duckChatPixels.fireFileRemoved()
     }
 
+    fun setPageContext(attachment: PageContextAttachment) {
+        _pageContextAttachment.value = attachment
+    }
+
+    fun removePageContext() {
+        _pageContextAttachment.value = null
+    }
+
+    fun getPageContext(): PageContextAttachment? = _pageContextAttachment.value
+
     fun clearAttachments() {
         val toRecycle = imageAttachments.value
         imageAttachments.value = emptyList()
         _fileAttachments.value = emptyList()
+        _pageContextAttachment.value = null
         viewModelScope.launch { toRecycle.forEach { it.bitmap.recycle() } }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/attachment/PageContextAttachment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/attachment/PageContextAttachment.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.nativeinput.attachment
+
+/**
+ * Display-only token representing the current page attached to the unified input as a chip.
+ * The page content itself is held by the contextual layer; this carries only what the chip needs.
+ */
+data class PageContextAttachment(
+    val title: String,
+    val url: String,
+    val faviconUrl: String?,
+)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
@@ -43,6 +43,7 @@ import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.ui.AttachmentViewModel
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.ImageAttachment
+import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.PageContextAttachment
 import com.duckduckgo.duckchat.impl.ui.nativeinput.file.FileAttachment
 import com.duckduckgo.duckchat.impl.ui.nativeinput.file.FileAttachmentsContainerView
 import kotlinx.coroutines.CoroutineScope
@@ -69,6 +70,7 @@ class AttachmentView(
     private var thumbnailsLayout: LinearLayout? = null
     private var imageAttachmentsContainer: ImageAttachmentsContainerView? = null
     private var fileAttachmentsContainer: FileAttachmentsContainerView? = null
+    private var pageContextContainer: PageContextAttachmentView? = null
     private var limitErrorView: TextView? = null
 
     init {
@@ -110,6 +112,12 @@ class AttachmentView(
     fun clearAttachments() = viewModel?.clearAttachments()
 
     fun clearAttachmentsForNewChat() = viewModel?.clearAttachmentsForNewChat()
+
+    fun setPageContext(attachment: PageContextAttachment) = viewModel?.setPageContext(attachment)
+
+    fun clearPageContext() = viewModel?.removePageContext()
+
+    fun getPageContext(): PageContextAttachment? = viewModel?.getPageContext()
 
     private fun buildAttachButton(): ImageView {
         val iconSize = context.resources.getDimensionPixelSize(R.dimen.nativeInputButtonSize)
@@ -158,6 +166,10 @@ class AttachmentView(
         }
         scroll.addView(row)
 
+        val pageContext = PageContextAttachmentView(context)
+        row.addView(pageContext)
+        pageContextContainer = pageContext
+
         val imagesContainer = ImageAttachmentsContainerView(context).also {
             it.onAttachmentRemoved = { id -> vm.removeImageAttachment(id) }
         }
@@ -185,6 +197,7 @@ class AttachmentView(
         val imagesView = imageAttachmentsContainer ?: return
         syncImages(imagesView, state)
         syncFiles(state)
+        syncPageContext(state)
         val errorMessage =
             state.imageLimitError
                 ?: state.fileLimitError
@@ -215,6 +228,16 @@ class AttachmentView(
         }
         (stateFileIds - containerFileIds).forEach { id ->
             state.files.find { it.id == id }?.let { filesView.addAttachment(it) }
+        }
+    }
+
+    private fun syncPageContext(state: AttachmentViewModel.AttachmentState) {
+        val view = pageContextContainer ?: return
+        val next = state.pageContext
+        if (next == null) {
+            view.hide()
+        } else if (view.current() != next) {
+            view.show(next) { viewModel?.removePageContext() }
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
@@ -61,6 +61,10 @@ class AttachmentView(
     var host: NativeInputHost? = null
     var onCameraCaptureRequested: ((ValueCallback<Array<Uri>>) -> Unit)? = null
     var onFilePickerRequested: ((ValueCallback<Array<Uri>>, List<String>) -> Unit)? = null
+    var isContextual: Boolean = false
+    var onAskAboutTab: (() -> Unit)? = null
+    var onAskAboutPage: (() -> Unit)? = null
+    var onPageContextRemoved: (() -> Unit)? = null
 
     private var viewModel: AttachmentViewModel? = null
     private var supportsUpload: Boolean = false
@@ -96,7 +100,7 @@ class AttachmentView(
     }
 
     private fun updateButtonVisibility() {
-        val show = supportsUpload && lastNativeInputState?.shouldShowPluginControls() == true
+        val show = (supportsUpload || isContextual) && lastNativeInputState?.shouldShowPluginControls() == true
         isVisible = show
         (parent as? View)?.isVisible = show
     }
@@ -237,7 +241,10 @@ class AttachmentView(
         if (next == null) {
             view.hide()
         } else if (view.current() != next) {
-            view.show(next) { viewModel?.removePageContext() }
+            view.show(next) {
+                viewModel?.removePageContext()
+                onPageContextRemoved?.invoke()
+            }
         }
     }
 
@@ -275,7 +282,7 @@ class AttachmentView(
         val supportedFileTypes = state?.supportedFileTypes.orEmpty()
         val supportsImages = state?.supportsImageUpload == true
 
-        if (!supportsImages && supportedFileTypes.isEmpty()) return
+        if (!supportsImages && supportedFileTypes.isEmpty() && !isContextual) return
 
         val container = LinearLayout(context).apply {
             orientation = LinearLayout.VERTICAL
@@ -326,6 +333,22 @@ class AttachmentView(
                 popup.dismiss()
                 host?.showAttachmentChooser(true)
                 onFilePickerRequested?.invoke(buildFilePickerCallback(), supportedFileTypes)
+            }
+        }
+
+        if (isContextual) {
+            val pageContextAttached = viewModel?.getPageContext() != null
+            addMenuItem(
+                container = container,
+                iconRes = R.drawable.ic_page_content_attach_24,
+                titleRes = if (pageContextAttached) {
+                    R.string.duckChatContextualAskAboutPage
+                } else {
+                    R.string.duckChatContextualAskAboutTab
+                },
+            ) {
+                popup.dismiss()
+                if (pageContextAttached) onAskAboutPage?.invoke() else onAskAboutTab?.invoke()
             }
         }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -332,6 +332,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private var pendingAskAboutTab: (() -> Unit)? = null
     private var pendingAskAboutPage: (() -> Unit)? = null
     private var pendingOnPageContextRemoved: (() -> Unit)? = null
+    private var pendingPageContext: PageContextAttachment? = null
 
     // True when this widget instance hosts the contextual sheet. Set in configureContextual();
     // never reset. Used to prevent the shared per-tab NativeInputStateProvider from leaking
@@ -443,6 +444,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
             pluginView.onAskAboutPage = pendingAskAboutPage
             pluginView.onPageContextRemoved = pendingOnPageContextRemoved
             pluginView.bind(scope, viewModelFactory, nativeInputStateProvider)
+            pendingPageContext?.let { pluginView.setPageContext(it) }
         }
         (pluginView as? ModelPicker)?.let { picker ->
             picker.onMenuShown = { isModelMenuVisible = true }
@@ -1212,10 +1214,13 @@ class NativeInputModeWidget @JvmOverloads constructor(
     override fun getFileAttachmentsJson(): JSONArray? = attachmentView?.getFileAttachmentsJson()
 
     override fun setPageContext(title: String, url: String, faviconUrl: String?) {
-        attachmentView?.setPageContext(PageContextAttachment(title = title, url = url, faviconUrl = faviconUrl))
+        val attachment = PageContextAttachment(title = title, url = url, faviconUrl = faviconUrl)
+        pendingPageContext = attachment
+        attachmentView?.setPageContext(attachment)
     }
 
     override fun clearPageContext() {
+        pendingPageContext = null
         attachmentView?.clearPageContext()
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -145,6 +145,11 @@ interface NativeInputWidget {
     fun setPageContext(title: String, url: String, faviconUrl: String?)
     fun clearPageContext()
     fun getPageContext(): PageContextAttachment?
+    fun setContextualAttachmentActions(
+        onAskAboutTab: () -> Unit,
+        onAskAboutPage: () -> Unit,
+        onPageContextRemoved: () -> Unit,
+    )
     fun storePendingPrompt(query: String)
     fun configure(tabId: String, isDuckAiMode: Boolean, isBottom: Boolean)
     fun configureContextual(tabId: String)
@@ -323,6 +328,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     private var pendingCameraCaptureCallback: ((ValueCallback<Array<Uri>>) -> Unit)? = null
     private var pendingFilePickerCallback: ((ValueCallback<Array<Uri>>, List<String>) -> Unit)? = null
+    private var pendingIsContextual: Boolean = false
+    private var pendingAskAboutTab: (() -> Unit)? = null
+    private var pendingAskAboutPage: (() -> Unit)? = null
+    private var pendingOnPageContextRemoved: (() -> Unit)? = null
 
     // True when this widget instance hosts the contextual sheet. Set in configureContextual();
     // never reset. Used to prevent the shared per-tab NativeInputStateProvider from leaking
@@ -429,6 +438,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
             attachmentView = pluginView
             pluginView.onCameraCaptureRequested = pendingCameraCaptureCallback
             pluginView.onFilePickerRequested = pendingFilePickerCallback
+            pluginView.isContextual = pendingIsContextual
+            pluginView.onAskAboutTab = pendingAskAboutTab
+            pluginView.onAskAboutPage = pendingAskAboutPage
+            pluginView.onPageContextRemoved = pendingOnPageContextRemoved
             pluginView.bind(scope, viewModelFactory, nativeInputStateProvider)
         }
         (pluginView as? ModelPicker)?.let { picker ->
@@ -1207,6 +1220,23 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     override fun getPageContext(): PageContextAttachment? = attachmentView?.getPageContext()
+
+    override fun setContextualAttachmentActions(
+        onAskAboutTab: () -> Unit,
+        onAskAboutPage: () -> Unit,
+        onPageContextRemoved: () -> Unit,
+    ) {
+        pendingIsContextual = true
+        pendingAskAboutTab = onAskAboutTab
+        pendingAskAboutPage = onAskAboutPage
+        pendingOnPageContextRemoved = onPageContextRemoved
+        attachmentView?.let { view ->
+            view.isContextual = true
+            view.onAskAboutTab = onAskAboutTab
+            view.onAskAboutPage = onAskAboutPage
+            view.onPageContextRemoved = onPageContextRemoved
+        }
+    }
 
     override fun clearAttachments() {
         attachmentView?.clearAttachments()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -67,6 +67,7 @@ import com.duckduckgo.duckchat.impl.inputscreen.ui.view.InputScreenButtons
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import com.duckduckgo.duckchat.impl.ui.NativeInputModeWidgetViewModel
+import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.PageContextAttachment
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.tabs.TabLayout
 import kotlinx.coroutines.CoroutineScope
@@ -141,6 +142,9 @@ interface NativeInputWidget {
     fun getImageAttachmentsJson(): JSONArray?
     fun getFileAttachmentsJson(): JSONArray?
     fun clearAttachments()
+    fun setPageContext(title: String, url: String, faviconUrl: String?)
+    fun clearPageContext()
+    fun getPageContext(): PageContextAttachment?
     fun storePendingPrompt(query: String)
     fun configure(tabId: String, isDuckAiMode: Boolean, isBottom: Boolean)
     fun configureContextual(tabId: String)
@@ -1193,6 +1197,16 @@ class NativeInputModeWidget @JvmOverloads constructor(
     override fun getImageAttachmentsJson(): JSONArray? = attachmentView?.getImageAttachmentsJson()
 
     override fun getFileAttachmentsJson(): JSONArray? = attachmentView?.getFileAttachmentsJson()
+
+    override fun setPageContext(title: String, url: String, faviconUrl: String?) {
+        attachmentView?.setPageContext(PageContextAttachment(title = title, url = url, faviconUrl = faviconUrl))
+    }
+
+    override fun clearPageContext() {
+        attachmentView?.clearPageContext()
+    }
+
+    override fun getPageContext(): PageContextAttachment? = attachmentView?.getPageContext()
 
     override fun clearAttachments() {
         attachmentView?.clearAttachments()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/PageContextAttachmentView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/PageContextAttachmentView.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.ui.nativeinput.views
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.widget.ImageView
+import android.widget.LinearLayout
+import com.duckduckgo.common.ui.view.gone
+import com.duckduckgo.common.ui.view.show
+import com.duckduckgo.common.ui.view.text.DaxTextView
+import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.PageContextAttachment
+
+class PageContextAttachmentView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+) : LinearLayout(context, attrs, defStyleAttr) {
+
+    private var attachment: PageContextAttachment? = null
+
+    init {
+        orientation = HORIZONTAL
+        clipChildren = false
+        clipToPadding = false
+        gone()
+    }
+
+    fun current(): PageContextAttachment? = attachment
+
+    fun show(attachment: PageContextAttachment, onRemoved: () -> Unit) {
+        this.attachment = attachment
+        removeAllViews()
+        val itemView = LayoutInflater.from(context).inflate(R.layout.view_page_context_attachment_item, this, false)
+        itemView.findViewById<DaxTextView>(R.id.pageContextTitle).text = attachment.title
+        itemView.findViewById<ImageView>(R.id.pageContextRemove).setOnClickListener { onRemoved() }
+        addView(itemView)
+        show()
+    }
+
+    fun hide() {
+        attachment = null
+        removeAllViews()
+        gone()
+    }
+}

--- a/duckchat/duckchat-impl/src/main/res/layout/view_page_context_attachment_item.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_page_context_attachment_item.xml
@@ -53,7 +53,7 @@
         android:layout_width="@dimen/keyline_4"
         android:layout_height="@dimen/keyline_4"
         android:layout_marginStart="@dimen/keyline_2"
-        android:contentDescription="@string/duckChatFileAttachmentRemoveContentDescription"
+        android:contentDescription="@string/duckChatPageContextRemoveContentDescription"
         android:scaleType="center"
         app:srcCompat="@drawable/ic_close_16"
         app:tint="?attr/daxColorSecondaryIcon" />

--- a/duckchat/duckchat-impl/src/main/res/layout/view_page_context_attachment_item.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_page_context_attachment_item.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="@dimen/keyline_1"
+    android:background="@drawable/background_image_attachment_chip"
+    android:clickable="true"
+    android:focusable="true"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingStart="@dimen/keyline_2"
+    android:paddingEnd="@dimen/keyline_3"
+    android:paddingTop="@dimen/keyline_1"
+    android:paddingBottom="@dimen/keyline_1">
+
+    <ImageView
+        android:id="@+id/pageContextFavicon"
+        android:layout_width="@dimen/keyline_6"
+        android:layout_height="@dimen/keyline_6"
+        android:importantForAccessibility="no"
+        app:srcCompat="@drawable/ic_page_content_attach_24" />
+
+    <com.duckduckgo.common.ui.view.text.DaxTextView
+        android:id="@+id/pageContextTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/keyline_1"
+        android:ellipsize="end"
+        android:maxWidth="120dp"
+        android:maxLines="1"
+        app:textType="primary"
+        app:typography="body2_bold" />
+
+    <ImageView
+        android:id="@+id/pageContextRemove"
+        android:layout_width="@dimen/keyline_4"
+        android:layout_height="@dimen/keyline_4"
+        android:layout_marginStart="@dimen/keyline_2"
+        android:contentDescription="@string/duckChatFileAttachmentRemoveContentDescription"
+        android:scaleType="center"
+        app:srcCompat="@drawable/ic_close_16"
+        app:tint="?attr/daxColorSecondaryIcon" />
+
+</LinearLayout>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -23,4 +23,7 @@
     <string name="duckChatContextualAskAboutTab">Ask about tab</string>
     <string name="duckChatContextualAskAboutPage">Ask about page</string>
 
+    <!-- Page context attachment -->
+    <string name="duckChatPageContextRemoveContentDescription">Remove page context</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -19,4 +19,8 @@
     <!-- Remove chat history suggestion -->
     <string name="duck_chat_remove_chat_suggestion_content_description">Delete chat</string>
 
+    <!-- File/image attachment menu options -->
+    <string name="duckChatContextualAskAboutTab">Ask about tab</string>
+    <string name="duckChatContextualAskAboutPage">Ask about page</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -232,6 +232,9 @@
     <string name="attachmentAttachPhoto">Add Image</string>
     <string name="attachmentAttachFile">Add File</string>
 
+    <!-- Page context attachment -->
+    <string name="duckChatPageContextRemoveContentDescription">Remove page context</string>
+
     <!-- File attachment -->
     <string name="duckChatFileAttachmentRemoveContentDescription">Remove file</string>
     <string name="duckChatFileAttachmentLimitPerConversation" instruction="%1$d is the maximum number of files allowed in a single conversation.">You can only attach %1$d files per conversation.</string>

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -232,9 +232,6 @@
     <string name="attachmentAttachPhoto">Add Image</string>
     <string name="attachmentAttachFile">Add File</string>
 
-    <!-- Page context attachment -->
-    <string name="duckChatPageContextRemoveContentDescription">Remove page context</string>
-
     <!-- File attachment -->
     <string name="duckChatFileAttachmentRemoveContentDescription">Remove file</string>
     <string name="duckChatFileAttachmentLimitPerConversation" instruction="%1$d is the maximum number of files allowed in a single conversation.">You can only attach %1$d files per conversation.</string>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -380,6 +380,42 @@ class RealDuckChatTest {
     }
 
     @Test
+    fun whenNativeChatInputAndContextualNativeInputEnabledThenObserveContextualNativeInputEmitsTrue() = runTest {
+        duckChatFeature.nativeInputField().setRawStoredState(State(enable = true))
+        duckChatFeature.nativeChatInput().setRawStoredState(State(enable = true))
+        duckChatFeature.contextualNativeInput().setRawStoredState(State(enable = true))
+
+        testee.onPrivacyConfigDownloaded()
+        advanceUntilIdle()
+
+        assertTrue(testee.isContextualNativeInputEnabled())
+    }
+
+    @Test
+    fun whenNativeChatInputEnabledButContextualNativeInputDisabledThenObserveContextualNativeInputEmitsFalse() = runTest {
+        duckChatFeature.nativeInputField().setRawStoredState(State(enable = true))
+        duckChatFeature.nativeChatInput().setRawStoredState(State(enable = true))
+        duckChatFeature.contextualNativeInput().setRawStoredState(State(enable = false))
+
+        testee.onPrivacyConfigDownloaded()
+        advanceUntilIdle()
+
+        assertFalse(testee.isContextualNativeInputEnabled())
+    }
+
+    @Test
+    fun whenContextualNativeInputEnabledButNativeChatInputDisabledThenObserveContextualNativeInputEmitsFalse() = runTest {
+        duckChatFeature.nativeInputField().setRawStoredState(State(enable = true))
+        duckChatFeature.nativeChatInput().setRawStoredState(State(enable = false))
+        duckChatFeature.contextualNativeInput().setRawStoredState(State(enable = true))
+
+        testee.onPrivacyConfigDownloaded()
+        advanceUntilIdle()
+
+        assertFalse(testee.isContextualNativeInputEnabled())
+    }
+
+    @Test
     fun whenSetChatSuggestionsUserSettingThenRepositorySetCalled() = runTest {
         testee.setChatSuggestionsUserSetting(true)
         verify(mockDuckChatFeatureRepository).setChatSuggestionsUserSetting(true)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -1111,6 +1111,34 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
+    fun `when prompt sent from input state then sheet state change hides keyboard`() = runTest {
+        val testee = buildViewModel()
+
+        testee.commands.test {
+            testee.onPromptSent(prompt = "hello")
+            val command = expectMostRecentItem()
+            assertTrue(command is DuckChatContextualViewModel.Command.ChangeSheetState)
+            assertTrue((command as DuckChatContextualViewModel.Command.ChangeSheetState).hideKeyboard)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when prompt sent while already in chat then keyboard is not hidden`() = runTest {
+        val testee = buildViewModel()
+        testee.onPromptSent(prompt = "first") // INPUT -> WEBVIEW
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.commands.test {
+            testee.onPromptSent(prompt = "second") // already in WEBVIEW
+            val command = expectMostRecentItem()
+            assertTrue(command is DuckChatContextualViewModel.Command.ChangeSheetState)
+            assertFalse((command as DuckChatContextualViewModel.Command.ChangeSheetState).hideKeyboard)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `when replace prompt with previous input then prompt is appended`() =
         runTest {
             testee.viewState.test {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -1078,6 +1078,39 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
+    fun `when ask about page quick action clicked then focus input command emitted`() = runTest {
+        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        val pageContext = """{"title":"Page","url":"https://example.com","content":"text"}"""
+        testee.onPageContextReceived("tab-1", pageContext)
+
+        testee.commands.test {
+            testee.onQuickActionClicked("") // ASK_ABOUT_PAGE with valid context
+            assertTrue(expectMostRecentItem() is DuckChatContextualViewModel.Command.FocusInput)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when prompt sent then attached page context is cleared from input`() = runTest {
+        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        testee.onPageContextReceived("tab-1", """{"title":"Page","url":"https://example.com","content":"text"}""")
+        testee.addPageContext()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        assertTrue(testee.viewState.value.showContext)
+
+        testee.onPromptSent(prompt = "hello")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        assertFalse(testee.viewState.value.showContext)
+    }
+
+    @Test
     fun `when replace prompt with previous input then prompt is appended`() =
         runTest {
             testee.viewState.test {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -2444,6 +2444,51 @@ class DuckChatContextualViewModelTest {
         }
 
     @Test
+    fun `when ask about tab clicked with valid context then quick action transitions to SUBMIT_SUMMARIZE`() =
+        runTest {
+            val tabId = "tab-1"
+            val serializedPageData =
+                """
+                {
+                    "title": "Page Title",
+                    "url": "https://example.com",
+                    "content": "Extracted DOM text..."
+                }
+                """.trimIndent()
+            testee.onSheetOpened(tabId)
+            testee.onPageContextReceived(tabId, serializedPageData)
+
+            testee.onAskAboutTabClicked()
+
+            assertEquals(
+                DuckChatContextualViewModel.QuickActionState.SUBMIT_SUMMARIZE,
+                testee.viewState.value.quickActionState,
+            )
+        }
+
+    @Test
+    fun `when ask about tab clicked with valid context then focus input command emitted`() =
+        runTest {
+            val tabId = "tab-1"
+            val serializedPageData =
+                """
+                {
+                    "title": "Page Title",
+                    "url": "https://example.com",
+                    "content": "Extracted DOM text..."
+                }
+                """.trimIndent()
+            testee.onSheetOpened(tabId)
+            testee.onPageContextReceived(tabId, serializedPageData)
+
+            testee.commands.test {
+                testee.onAskAboutTabClicked()
+                assertTrue(expectMostRecentItem() is DuckChatContextualViewModel.Command.FocusInput)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
     fun `when ask about page clicked with context then submits ask about page prompt with pageContext`() =
         runTest {
             val tabId = "tab-1"

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -2346,6 +2346,86 @@ class DuckChatContextualViewModelTest {
         assertEquals("current", testee.chatId.value)
     }
 
+    @Test
+    fun `when ask about tab clicked with valid context then showContext true and no prompt sent`() =
+        runTest {
+            val tabId = "tab-1"
+            val serializedPageData =
+                """
+                {
+                    "title": "Page Title",
+                    "url": "https://example.com",
+                    "content": "Extracted DOM text...",
+                    "truncated": false,
+                    "fullContentLength": 1234
+                }
+                """.trimIndent()
+            testee.onSheetOpened(tabId)
+            testee.onPageContextReceived(tabId, serializedPageData)
+
+            testee.subscriptionEventDataFlow.test {
+                testee.onAskAboutTabClicked()
+                expectNoEvents()
+                cancelAndIgnoreRemainingEvents()
+            }
+            assertTrue(testee.viewState.value.showContext)
+        }
+
+    @Test
+    fun `when ask about tab clicked without valid context then showContext stays false`() =
+        runTest {
+            testee.onSheetOpened("tab-1")
+            testee.updatedPageContext = ""
+
+            testee.onAskAboutTabClicked()
+
+            assertFalse(testee.viewState.value.showContext)
+        }
+
+    @Test
+    fun `when ask about page clicked with context then submits ask about page prompt with pageContext`() =
+        runTest {
+            val tabId = "tab-1"
+            val serializedPageData =
+                """
+                {
+                    "title": "Page Title",
+                    "url": "https://example.com",
+                    "content": "Extracted DOM text...",
+                    "truncated": false,
+                    "fullContentLength": 1234
+                }
+                """.trimIndent()
+            testee.onSheetOpened(tabId)
+            testee.onPageContextReceived(tabId, serializedPageData)
+            testee.addPageContext()
+
+            testee.subscriptionEventDataFlow.test {
+                testee.onAskAboutPageClicked()
+
+                val event = awaitItem()
+                assertEquals("submitAIChatNativePrompt", event.subscriptionName)
+                val params = event.params
+                val query = params.getJSONObject("query")
+                assertEquals(context.getString(R.string.duckChatContextualAskAboutPage), query.getString("prompt"))
+                val pageContext = params.getJSONObject("pageContext")
+                assertEquals("https://example.com", pageContext.getString("url"))
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `when ask about page clicked without context then no prompt sent`() =
+        runTest {
+            testee.onSheetOpened("tab-1")
+
+            testee.subscriptionEventDataFlow.test {
+                testee.onAskAboutPageClicked()
+                expectNoEvents()
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
     private fun fakeChat(id: String, title: String, lastEditMillis: Long): ChatHistoryItem =
         ChatHistoryItem(
             chatId = id,

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealContextualNativeInputManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealContextualNativeInputManagerTest.kt
@@ -37,7 +37,6 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -221,7 +220,7 @@ class RealContextualNativeInputManagerTest {
             lifecycleOwner = lifecycleOwner(),
             chatIdFlow = emptyFlow(),
             onSearchSubmitted = {},
-            onNewPromptSubmitted = { submitted = it },
+            onPromptSubmitted = { submitted = it },
         )
         testee.onInputMode()
 
@@ -236,10 +235,11 @@ class RealContextualNativeInputManagerTest {
     }
 
     @Test
-    fun `when web view mode and chat submitted then sends in-chat prompt event and skips new chat callback`() {
+    fun `when web view mode and chat submitted then routes to prompt callback and does not send event directly`() {
         val enabled = MutableStateFlow(true)
         whenever(duckChat.observeNativeChatInputEnabled()).thenReturn(enabled)
         val widget = mock<NativeInputModeWidget>()
+        whenever(widget.getSelectedModelId()).thenReturn("model-1")
         val jsMessaging = mock<JsMessaging>()
         var submitted: NativeInputPrompt? = null
         testee.init(
@@ -250,7 +250,7 @@ class RealContextualNativeInputManagerTest {
             lifecycleOwner = lifecycleOwner(),
             chatIdFlow = emptyFlow(),
             onSearchSubmitted = {},
-            onNewPromptSubmitted = { submitted = it },
+            onPromptSubmitted = { submitted = it },
         )
         testee.onWebViewMode()
 
@@ -258,8 +258,11 @@ class RealContextualNativeInputManagerTest {
         verify(widget).bindInputEvents(any(), any(), captor.capture(), any())
         captor.firstValue.invoke("hello")
 
-        assertNull(submitted)
-        verify(jsMessaging).sendSubscriptionEvent(any())
+        // Follow-ups in a running chat now route through the ViewModel too, so page context is attached
+        // in one place; the manager no longer builds and sends its own in-chat event.
+        assertEquals("hello", submitted?.prompt)
+        assertEquals("model-1", submitted?.modelId)
+        verify(jsMessaging, never()).sendSubscriptionEvent(any())
     }
 
     @Test
@@ -277,7 +280,7 @@ class RealContextualNativeInputManagerTest {
             lifecycleOwner = lifecycleOwner(),
             chatIdFlow = emptyFlow(),
             onSearchSubmitted = {},
-            onNewPromptSubmitted = { submitted = it },
+            onPromptSubmitted = { submitted = it },
         )
         // Submit before onInputMode/onWebViewMode runs (lastMode still null): must start a new chat,
         // not fall through to the in-chat JS path.

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealContextualNativeInputManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealContextualNativeInputManagerTest.kt
@@ -23,9 +23,9 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
-import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
+import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.NativeInputModeWidget
 import com.duckduckgo.js.messaging.api.JsMessaging
 import com.google.android.material.card.MaterialCardView
@@ -54,9 +54,9 @@ class RealContextualNativeInputManagerTest {
     @get:Rule
     val coroutineRule = CoroutineTestRule()
 
-    private val duckChat: DuckChat = mock()
+    private val duckChatInternal: DuckChatInternal = mock()
     private val publisher: NativeInputStatePublisher = mock()
-    private val testee = RealContextualNativeInputManager(duckChat, publisher)
+    private val testee = RealContextualNativeInputManager(duckChatInternal, publisher)
 
     @Test
     fun `when onContextualClosed called with blank tabId then publisher is not touched`() {
@@ -106,7 +106,8 @@ class RealContextualNativeInputManagerTest {
     @Test
     fun `when webview mode then input mode modelPickerEnabled emits false then true`() = runTest {
         val enabled = MutableStateFlow(true)
-        whenever(duckChat.observeNativeChatInputEnabled()).thenReturn(enabled)
+        whenever(duckChatInternal.observeNativeChatInputEnabled()).thenReturn(enabled)
+        whenever(duckChatInternal.isContextualNativeInputEnabled()).thenReturn(true)
         val widget = mock<NativeInputModeWidget>()
         val pickerFlowCaptor = argumentCaptor<Flow<Boolean>>()
         testee.init(
@@ -137,7 +138,7 @@ class RealContextualNativeInputManagerTest {
     @Test
     fun `when native chat input flips off in web view mode then card is hidden`() {
         val enabled = MutableStateFlow(true)
-        whenever(duckChat.observeNativeChatInputEnabled()).thenReturn(enabled)
+        whenever(duckChatInternal.observeNativeChatInputEnabled()).thenReturn(enabled)
         val card = mockCard()
         val widget = mock<NativeInputModeWidget>()
         testee.init(
@@ -157,9 +158,10 @@ class RealContextualNativeInputManagerTest {
     }
 
     @Test
-    fun `when native chat input enabled and onInputMode then card shown`() {
+    fun `when contextual native input enabled and onInputMode then card shown`() {
         val enabled = MutableStateFlow(true)
-        whenever(duckChat.observeNativeChatInputEnabled()).thenReturn(enabled)
+        whenever(duckChatInternal.observeNativeChatInputEnabled()).thenReturn(enabled)
+        whenever(duckChatInternal.isContextualNativeInputEnabled()).thenReturn(true)
         val card = mockCard()
         // View.show() only writes visibility when it isn't already VISIBLE; a mock defaults to 0
         // (VISIBLE), so start it GONE to observe the transition.
@@ -185,7 +187,7 @@ class RealContextualNativeInputManagerTest {
     @Test
     fun `when native chat input disabled and onInputMode then card hidden`() {
         val enabled = MutableStateFlow(false)
-        whenever(duckChat.observeNativeChatInputEnabled()).thenReturn(enabled)
+        whenever(duckChatInternal.observeNativeChatInputEnabled()).thenReturn(enabled)
         val card = mockCard()
         val widget = mock<NativeInputModeWidget>()
         testee.init(
@@ -206,7 +208,7 @@ class RealContextualNativeInputManagerTest {
     @Test
     fun `when input mode and chat submitted then routes to new chat callback with widget selections`() {
         val enabled = MutableStateFlow(true)
-        whenever(duckChat.observeNativeChatInputEnabled()).thenReturn(enabled)
+        whenever(duckChatInternal.observeNativeChatInputEnabled()).thenReturn(enabled)
         val widget = mock<NativeInputModeWidget>()
         whenever(widget.getSelectedModelId()).thenReturn("model-1")
         whenever(widget.getResolvedReasoningEffort()).thenReturn("high")
@@ -237,7 +239,7 @@ class RealContextualNativeInputManagerTest {
     @Test
     fun `when web view mode and chat submitted then routes to prompt callback and does not send event directly`() {
         val enabled = MutableStateFlow(true)
-        whenever(duckChat.observeNativeChatInputEnabled()).thenReturn(enabled)
+        whenever(duckChatInternal.observeNativeChatInputEnabled()).thenReturn(enabled)
         val widget = mock<NativeInputModeWidget>()
         whenever(widget.getSelectedModelId()).thenReturn("model-1")
         val jsMessaging = mock<JsMessaging>()
@@ -268,7 +270,7 @@ class RealContextualNativeInputManagerTest {
     @Test
     fun `when chat submitted before any mode set then routes to new chat callback`() {
         val enabled = MutableStateFlow(true)
-        whenever(duckChat.observeNativeChatInputEnabled()).thenReturn(enabled)
+        whenever(duckChatInternal.observeNativeChatInputEnabled()).thenReturn(enabled)
         val widget = mock<NativeInputModeWidget>()
         val jsMessaging = mock<JsMessaging>()
         var submitted: NativeInputPrompt? = null

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -181,6 +181,8 @@ class FakeDuckChatInternal(
     override fun isNativeStorageEnabled(): Boolean = false
     override fun isNativeChatInputEnabled(): Boolean = false
 
+    override fun isContextualNativeInputEnabled(): Boolean = false
+
     override fun keepSessionIntervalInMinutes(): Int = 30
 
     override fun isInputScreenFeatureAvailable(): Boolean = false

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/AttachmentViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/AttachmentViewModelTest.kt
@@ -40,6 +40,7 @@ import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.ConversationFileUsage
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.ImageAttachment
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.LimitsHandler
+import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.PageContextAttachment
 import com.duckduckgo.duckchat.impl.ui.nativeinput.file.FileAttachment
 import com.duckduckgo.duckchat.impl.ui.nativeinput.file.FileAttachmentProcessor
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -968,5 +969,51 @@ class AttachmentViewModelTest {
         }
 
         override suspend fun processFile(context: Context, uri: Uri): FileAttachment? = responses[uri]
+    }
+
+    @Test
+    fun whenSetPageContextThenAttachmentStateAndGetterReflectIt() = runTest {
+        val pageContext = PageContextAttachment(title = "Example", url = "https://example.com", faviconUrl = null)
+
+        viewModel.setPageContext(pageContext)
+
+        assertEquals(pageContext, viewModel.attachmentState.value.pageContext)
+        assertEquals(pageContext, viewModel.getPageContext())
+    }
+
+    @Test
+    fun whenSetPageContextTwiceThenLatestReplaces() = runTest {
+        viewModel.setPageContext(PageContextAttachment("First", "https://first.com", null))
+        val latest = PageContextAttachment("Second", "https://second.com", "https://second.com/fav.ico")
+
+        viewModel.setPageContext(latest)
+
+        assertEquals(latest, viewModel.attachmentState.value.pageContext)
+    }
+
+    @Test
+    fun whenRemovePageContextThenStateIsNull() = runTest {
+        viewModel.setPageContext(PageContextAttachment("Example", "https://example.com", null))
+
+        viewModel.removePageContext()
+
+        assertNull(viewModel.attachmentState.value.pageContext)
+        assertNull(viewModel.getPageContext())
+    }
+
+    @Test
+    fun whenOnlyPageContextPresentThenHasAttachmentsIsTrue() = runTest {
+        viewModel.setPageContext(PageContextAttachment("Example", "https://example.com", null))
+
+        assertTrue(viewModel.attachmentState.value.hasAttachments)
+    }
+
+    @Test
+    fun whenClearAttachmentsThenPageContextCleared() = runTest {
+        viewModel.setPageContext(PageContextAttachment("Example", "https://example.com", null))
+
+        viewModel.clearAttachments()
+
+        assertNull(viewModel.attachmentState.value.pageContext)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216113532784490
Tech Design URL (if applicable):

> Draft — stacked on `feature/david/contextual_sheet_changes` (Page Context attachment) → `feature/david/native_chat_input_flag` (#8946). Asana task to be added later.

### Description

Adds a contextual-mode-only item to the Duck.ai unified input's attach (paper-clip) menu, chosen by whether page context is attached:

- **No context → "Ask about tab"**: attaches the current page as the Page Context chip (from the stacked Page Context PR); sends no prompt.
- **Context attached → "Ask about page"**: submits the prompt "Ask about page" with the page-context JSON, reusing the existing `onPromptSent` / `generateContextPrompt` path.

`DuckChatContextualViewModel` is the single source of truth (`showContext`); the fragment bridges it to the unified input's chip (observe `showContext` → `setPageContext`/`clearPageContext`; chip-remove → `removePageContext`). `isContextual` defaults false so omnibar / new-tab attach menus are unchanged.

Note: this PR only adds the attach-menu items. Making the unified input the contextual sheet's initial-state composer was explored and intentionally **not** included here (the bottom-sheet sizing needs a different approach) — to be revisited separately.

### Steps to test this PR

_Ask about tab / page (internal build, contextual mode)_
- [x] Open Duck.ai contextual sheet on a web page, start a chat so the unified input shows
- [x] Tap the paper-clip → with no page context attached, the menu shows **Ask about tab**; tapping it adds the page-context chip (no prompt sent)
- [x] Tap the paper-clip again → menu now shows **Ask about page**; tapping it submits "Ask about page" and Duck.ai answers using the page context
- [x] Remove the chip → menu reverts to **Ask about tab**
- [ ] Omnibar / new-tab attach menu is unchanged (no context item)

### UI changes
| Before  | After |
| ------ | ----- |
|(Upload before screenshot)|(Upload after screenshot)|

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches contextual sheet UX, feature-flag gating, and the JS prompt subscription path for in-chat follow-ups; regressions could affect page-context attachment or composer visibility, but changes are flag-gated and covered by new unit tests.
> 
> **Overview**
> Introduces a **`contextualNativeInput`** feature flag (gated on native chat input) so the contextual sheet’s initial **INPUT** state can use the unified native composer instead of the legacy `EditText`, while **WEBVIEW** mode still follows **`nativeChatInput`**.
> 
> **Attach menu & page context:** In contextual mode only, the paper-clip menu gains **Ask about tab** / **Ask about page** (depending on whether page context is attached). Page context is shown as a chip in the unified input via `PageContextAttachment` / `AttachmentViewModel`, with the fragment syncing `showContext` to `setPageContext` / `clearPageContext`.
> 
> **Prompt path:** All native widget submits (INPUT and WEBVIEW) now go through `onPromptSubmitted` → `onPromptSent` / `generateContextPrompt`, removing the manager’s direct JS `submitAIChatNativePrompt` path so page context is not dropped on in-chat follow-ups. Sending a prompt clears the attached context chip and, when leaving INPUT for chat, hides the keyboard via `ChangeSheetState.hideKeyboard`.
> 
> **Sheet lifecycle:** `onContextualReopened` restores per-tab `NativeInputState` for contextual plugin controls; `FocusInput` and `onAskAboutTabClicked` / `onAskAboutPageClicked` wire attach-menu and quick-action flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 040516169bdd998fc644b8528091e6bf41c21f20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->