### PR TITLE
Add chat sync promo dismiss animation

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinder.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinder.kt
@@ -136,7 +136,9 @@ class NativeInputChatSuggestionsBinder @Inject constructor(
             val commit = { onCommit(hasChat || inputModeState.inputQuery.value.isNotEmpty() || pluginHasContent()) }
             recomputeOverlay = commit
 
-            chatSuggestionsAdapter.submitList(suggestions.chatHistory) { commit() }
+            chatSuggestionsAdapter.submitList(suggestions.chatHistory) {
+                commit()
+            }
             if (showUrl) {
                 urlAdapter.updateData(suggestions.urlSuggestions.query, suggestions.urlSuggestions.suggestions)
             } else {

--- a/duckchat/duckchat-impl/src/main/res/values-bg/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-bg/strings-duckchat.xml
@@ -182,10 +182,4 @@
     <string name="duck_ai_chat_history_download_view">Показване</string>
     <string name="duck_ai_chat_history_download_error">Неуспешно експортиране на чата</string>
     <string name="duck_ai_chat_history_bulk_download_error">Неуспешно експортиране на чатове</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
@@ -184,10 +184,4 @@
     <string name="duck_ai_chat_history_download_view">Zobrazit</string>
     <string name="duck_ai_chat_history_download_error">Nepodařilo se exportovat chat</string>
     <string name="duck_ai_chat_history_bulk_download_error">Nepodařilo se exportovat chaty</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-da/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-da/strings-duckchat.xml
@@ -182,10 +182,4 @@
     <string name="duck_ai_chat_history_download_view">Vis</string>
     <string name="duck_ai_chat_history_download_error">Kunne ikke eksportere chat</string>
     <string name="duck_ai_chat_history_bulk_download_error">Kunne ikke eksportere chats</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-de/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-de/strings-duckchat.xml
@@ -182,10 +182,4 @@
     <string name="duck_ai_chat_history_download_view">Anzeigen</string>
     <string name="duck_ai_chat_history_download_error">Chat konnte nicht exportiert werden</string>
     <string name="duck_ai_chat_history_bulk_download_error">Chats konnten nicht exportiert werden</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-el/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-el/strings-duckchat.xml
@@ -182,10 +182,4 @@
     <string name="duck_ai_chat_history_download_view">Εμφάνιση</string>
     <string name="duck_ai_chat_history_download_error">Δεν ήταν δυνατή η εξαγωγή της συνομιλίας</string>
     <string name="duck_ai_chat_history_bulk_download_error">Δεν ήταν δυνατή η εξαγωγή των συνομιλιών</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
@@ -182,10 +182,4 @@
     <string name="duck_ai_chat_history_download_view">Mostrar</string>
     <string name="duck_ai_chat_history_download_error">No se pudo exportar el chat</string>
     <string name="duck_ai_chat_history_bulk_download_error">No se pudieron exportar los chats</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
@@ -182,10 +182,4 @@
     <string name="duck_ai_chat_history_download_view">Kuva</string>
     <string name="duck_ai_chat_history_download_error">Vestlust ei õnnestunud eksportida</string>
     <string name="duck_ai_chat_history_bulk_download_error">Vestlusi ei õnnestunud eksportida</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-fi/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fi/strings-duckchat.xml
@@ -182,10 +182,4 @@
     <string name="duck_ai_chat_history_download_view">Näytä</string>
     <string name="duck_ai_chat_history_download_error">Keskustelua ei voitu viedä</string>
     <string name="duck_ai_chat_history_bulk_download_error">Keskusteluja ei voitu viedä</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
@@ -182,10 +182,4 @@
     <string name="duck_ai_chat_history_download_view">Afficher</string>
     <string name="duck_ai_chat_history_download_error">Impossible d\'exporter la discussion</string>
     <string name="duck_ai_chat_history_bulk_download_error">Impossible d\'exporter les discussions</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-hr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hr/strings-duckchat.xml
@@ -184,10 +184,4 @@
     <string name="duck_ai_chat_history_download_view">Prikaži</string>
     <string name="duck_ai_chat_history_download_error">Izvoz čavrljanja nije moguć</string>
     <string name="duck_ai_chat_history_bulk_download_error">Izvoz čavrljanja nije uspio</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
@@ -182,10 +182,4 @@
     <string name="duck_ai_chat_history_download_view">Megjelenítés</string>
     <string name="duck_ai_chat_history_download_error">Nem sikerült exportálni a csevegést</string>
     <string name="duck_ai_chat_history_bulk_download_error">Nem sikerült exportálni a csevegéseket</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
@@ -182,10 +182,4 @@
     <string name="duck_ai_chat_history_download_view">Mostra</string>
     <string name="duck_ai_chat_history_download_error">Non è possibile esportare la chat</string>
     <string name="duck_ai_chat_history_bulk_download_error">Non è stato possibile esportare le chat</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
@@ -184,10 +184,4 @@
     <string name="duck_ai_chat_history_download_view">Rodyti</string>
     <string name="duck_ai_chat_history_download_error">Nepavyko eksportuoti pokalbio</string>
     <string name="duck_ai_chat_history_bulk_download_error">Nepavyko eksportuoti pokalbių</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
@@ -183,10 +183,4 @@
     <string name="duck_ai_chat_history_download_view">Rādīt</string>
     <string name="duck_ai_chat_history_download_error">Nevarēja eksportēt tērzēšanu</string>
     <string name="duck_ai_chat_history_bulk_download_error">Neizdevās eksportēt tērzēšanas</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
@@ -182,10 +182,4 @@
     <string name="duck_ai_chat_history_download_view">Vis</string>
     <string name="duck_ai_chat_history_download_error">Kunne ikke eksportere chatten</string>
     <string name="duck_ai_chat_history_bulk_download_error">Kunne ikke eksportere chattene</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
@@ -182,10 +182,4 @@
     <string name="duck_ai_chat_history_download_view">Tonen</string>
     <string name="duck_ai_chat_history_download_error">Kan chat niet exporteren</string>
     <string name="duck_ai_chat_history_bulk_download_error">Kan chats niet exporteren</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-pl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pl/strings-duckchat.xml
@@ -184,10 +184,4 @@
     <string name="duck_ai_chat_history_download_view">Pokaż</string>
     <string name="duck_ai_chat_history_download_error">Nie udało się wyeksportować czatu</string>
     <string name="duck_ai_chat_history_bulk_download_error">Nie udało się wyeksportować czatów</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
@@ -182,10 +182,4 @@
     <string name="duck_ai_chat_history_download_view">Mostrar</string>
     <string name="duck_ai_chat_history_download_error">Não foi possível exportar a conversa</string>
     <string name="duck_ai_chat_history_bulk_download_error">Não foi possível exportar as conversas</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-ro/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ro/strings-duckchat.xml
@@ -183,10 +183,4 @@
     <string name="duck_ai_chat_history_download_view">Afișează</string>
     <string name="duck_ai_chat_history_download_error">Nu s-a putut exporta chatul</string>
     <string name="duck_ai_chat_history_bulk_download_error">Nu s-au putut exporta chaturile</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
@@ -184,10 +184,4 @@
     <string name="duck_ai_chat_history_download_view">Показать</string>
     <string name="duck_ai_chat_history_download_error">Не удалось экспортировать чат</string>
     <string name="duck_ai_chat_history_bulk_download_error">Не удалось экспортировать чаты</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
@@ -184,10 +184,4 @@
     <string name="duck_ai_chat_history_download_view">Zobraziť</string>
     <string name="duck_ai_chat_history_download_error">Nepodarilo sa exportovať chat</string>
     <string name="duck_ai_chat_history_bulk_download_error">Nepodarilo sa exportovať čety</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
@@ -184,10 +184,4 @@
     <string name="duck_ai_chat_history_download_view">Prikaži</string>
     <string name="duck_ai_chat_history_download_error">Klepeta ni bilo mogoče izvoziti</string>
     <string name="duck_ai_chat_history_bulk_download_error">Klepetov ni bilo mogoče izvoziti</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
@@ -182,10 +182,4 @@
     <string name="duck_ai_chat_history_download_view">Visa</string>
     <string name="duck_ai_chat_history_download_error">Kunde inte exportera chatt</string>
     <string name="duck_ai_chat_history_bulk_download_error">Kunde inte exportera chattar</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
@@ -182,10 +182,4 @@
     <string name="duck_ai_chat_history_download_view">Göster</string>
     <string name="duck_ai_chat_history_download_error">Sohbet dışa aktarılamadı</string>
     <string name="duck_ai_chat_history_bulk_download_error">Sohbetler dışa aktarılamadı</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/chat/ChatSyncPromoAdapter.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/chat/ChatSyncPromoAdapter.kt
@@ -82,7 +82,13 @@ internal class ChatSyncPromoAdapter(
                     notifyItemRemoved(0)
                 }
             }
-            State.Dismissed, State.Dismissing -> Unit
+            State.Dismissing -> {
+                if (!shouldAnimate) {
+                    state = State.Dismissed
+                    notifyItemRemoved(0)
+                }
+            }
+            State.Dismissed -> Unit
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/chat/ChatSyncPromoAdapter.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/chat/ChatSyncPromoAdapter.kt
@@ -16,15 +16,25 @@
 
 package com.duckduckgo.sync.impl.promotion.chat
 
+import android.animation.ValueAnimator
+import android.os.Handler
+import android.os.Looper
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import android.view.ViewGroup.LayoutParams
+import androidx.core.animation.doOnEnd
+import androidx.core.view.doOnLayout
 import androidx.core.view.doOnPreDraw
+import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
+import androidx.interpolator.view.animation.FastOutSlowInInterpolator
 import androidx.recyclerview.widget.RecyclerView.Adapter
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import com.duckduckgo.common.ui.view.MessageCta
 import com.duckduckgo.sync.impl.R.drawable
 import com.duckduckgo.sync.impl.R.string
 import com.duckduckgo.sync.impl.databinding.ItemChatSyncPromoBinding
+import kotlin.math.roundToInt
 
 internal class ChatSyncPromoAdapter(
     private val listener: Listener,
@@ -37,23 +47,50 @@ internal class ChatSyncPromoAdapter(
         fun onBannerShown(adapter: ChatSyncPromoAdapter)
     }
 
-    private var isVisible = false
+    private enum class State {
+        Dismissed,
+        Dismissing,
+        Shown,
+    }
+
+    private var state = State.Dismissed
+
+    private val mainHandler = Handler(Looper.getMainLooper())
 
     fun show() {
-        if (!isVisible) {
-            isVisible = true
-            notifyItemInserted(0)
+        when (state) {
+            State.Dismissed -> {
+                state = State.Shown
+                notifyItemInserted(0)
+            }
+            State.Dismissing -> {
+                state = State.Shown
+                notifyItemChanged(0)
+            }
+            State.Shown -> Unit
         }
     }
 
-    fun dismiss() {
-        if (isVisible) {
-            isVisible = false
-            notifyItemRemoved(0)
+    fun dismiss(shouldAnimate: Boolean) {
+        when (state) {
+            State.Shown -> {
+                if (shouldAnimate) {
+                    state = State.Dismissing
+                    notifyItemChanged(0)
+                } else {
+                    state = State.Dismissed
+                    notifyItemRemoved(0)
+                }
+            }
+            State.Dismissed, State.Dismissing -> Unit
         }
     }
 
-    override fun getItemCount() = if (isVisible) 1 else 0
+    override fun getItemCount(): Int = when (state) {
+        State.Dismissed -> 0
+        State.Dismissing -> 1
+        State.Shown -> 1
+    }
 
     override fun onCreateViewHolder(
         parent: ViewGroup,
@@ -72,7 +109,24 @@ internal class ChatSyncPromoAdapter(
         holder: ChatSyncPromoViewHolder,
         position: Int,
     ) {
-        holder.show()
+        when (state) {
+            State.Dismissed -> holder.hide()
+            State.Dismissing -> holder.animateOut {
+                // Defer the removal a frame: notifyItemRemoved() can't run during the RecyclerView
+                // layout/animation pass. By the time this runs the banner may have been re-shown, so
+                // re-check the state before removing.
+                mainHandler.post {
+                    if (state != State.Dismissing) return@post
+                    state = State.Dismissed
+                    notifyItemRemoved(0)
+                }
+            }
+            State.Shown -> holder.show()
+        }
+    }
+
+    override fun onViewRecycled(holder: ChatSyncPromoViewHolder) {
+        holder.cancelAnimation()
     }
 }
 
@@ -82,6 +136,9 @@ internal class ChatSyncPromoViewHolder(
     private val onDismissClicked: () -> Unit,
     private val onShown: () -> Unit,
 ) : ViewHolder(binding.root) {
+    private var knownHeight: Int? = null
+    private var dismissAnimator: ValueAnimator? = null
+
     init {
         binding.syncPromotion.apply {
             setMessage(
@@ -97,6 +154,51 @@ internal class ChatSyncPromoViewHolder(
     }
 
     fun show() {
-        binding.root.doOnPreDraw { onShown() }
+        cancelAnimation()
+        binding.root.apply {
+            alpha = 1f
+            isVisible = true
+            updateLayoutParams { height = LayoutParams.WRAP_CONTENT }
+            doOnLayout { view -> knownHeight = view.height }
+            doOnPreDraw { onShown() }
+        }
+    }
+
+    fun hide() {
+        cancelAnimation()
+        binding.root.isVisible = false
+    }
+
+    // We collapse the row (height + alpha) ourselves instead of letting RecyclerView's
+    // ItemAnimator animate the removal: the lists that host this banner disable their
+    // ItemAnimator (e.g. autoCompleteList.itemAnimator = null in NativeInputManager), so a
+    // plain notifyItemRemoved() would just make the row disappear with no animation.
+    fun animateOut(onComplete: () -> Unit) {
+        if (dismissAnimator != null) return
+        val startHeight = knownHeight ?: return
+
+        cancelAnimation()
+        dismissAnimator = ValueAnimator.ofFloat(1f, 0f).apply {
+            duration = EXIT_ANIM_DURATION
+            interpolator = FastOutSlowInInterpolator()
+            addUpdateListener { animation ->
+                val progress = animation.animatedValue as Float
+                binding.root.alpha = progress
+                binding.root.updateLayoutParams { height = (startHeight * progress).roundToInt() }
+            }
+            doOnEnd {
+                dismissAnimator = null
+                onComplete()
+            }
+            start()
+        }
+    }
+
+    fun cancelAnimation() {
+        dismissAnimator?.cancel()
+    }
+
+    private companion object {
+        const val EXIT_ANIM_DURATION = 300L
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/chat/ChatSyncPromoAdapter.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/chat/ChatSyncPromoAdapter.kt
@@ -181,9 +181,15 @@ internal class ChatSyncPromoViewHolder(
     // plain notifyItemRemoved() would just make the row disappear with no animation.
     fun animateOut(onComplete: () -> Unit) {
         if (dismissAnimator != null) return
-        val startHeight = knownHeight ?: return
 
-        cancelAnimation()
+        val startHeight = knownHeight
+        if (startHeight == null) {
+            // Never measured, so there's nothing to collapse. Complete immediately rather than
+            // leaving the adapter stuck in Dismissing with the row still counted.
+            onComplete()
+            return
+        }
+
         dismissAnimator = ValueAnimator.ofFloat(1f, 0f).apply {
             duration = EXIT_ANIM_DURATION
             interpolator = FastOutSlowInInterpolator()
@@ -202,6 +208,7 @@ internal class ChatSyncPromoViewHolder(
 
     fun cancelAnimation() {
         dismissAnimator?.cancel()
+        dismissAnimator = null
     }
 
     private companion object {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/chat/ChatSyncPromoChatTabItemPlugin.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/chat/ChatSyncPromoChatTabItemPlugin.kt
@@ -57,7 +57,7 @@ class ChatSyncPromoChatTabItemPlugin @Inject constructor(
     private fun CoroutineScope.hideBannerOnInput(adapter: ChatSyncPromoAdapter) {
         launch {
             duckChatInput.inputQuery.firstOrNull(String::isNotEmpty) ?: return@launch
-            adapter.dismiss()
+            adapter.dismiss(shouldAnimate = false)
         }
     }
 }
@@ -72,11 +72,11 @@ private class ChatTabPluginAdapterListener : ChatSyncPromoAdapter.Listener {
     private var didBannerShow = false
 
     override fun onSyncWithDeviceClicked(adapter: ChatSyncPromoAdapter) {
-        adapter.dismiss()
+        adapter.dismiss(shouldAnimate = true)
     }
 
     override fun onDismissClicked(adapter: ChatSyncPromoAdapter) {
-        adapter.dismiss()
+        adapter.dismiss(shouldAnimate = true)
     }
 
     override fun onBannerShown(adapter: ChatSyncPromoAdapter) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1215321458176118/task/1215745708977852?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1215321458176118/task/1215842375041298?focus=true

### Description

This adds a hide animation to the chat sync banner. It runs only when tapping the "X" or the CTA button. Typing in hides the banner without animation as it leads to glitches due to input suggestions overtaking the UI.

### Steps to test this PR

Dismiss animation
- [ ] Make sure that `nativeInputField` and `pluginChatSyncPromoChatTabItemPlugin` are enabled in the FF inventory (should be default).
- [ ] In AI Features settings make sure that "Search & Duck.ai" is enabled.
- [ ] Go to the main screen.
- [ ] Tap the search bar.
- [ ] Switch to the chat tab.
- [ ] Tap "X" on the banner.
- [ ] The banner should animate out.
- [ ] Reopen the native input and switch to chat tab.
- [ ] Tap "Sync With Another Device" on the banner.
- [ ] The banner should animate out.
- [ ] Reopen the native input and switch to chat tab.
- [ ] Type something in.
- [ ] The banner should hide without an animation.

### UI changes
| Before  | After |
| ------ | ----- |
| <video src="https://github.com/user-attachments/assets/1d8db287-7190-4286-bacb-de470ad4ba54" /> | <video src="https://github.com/user-attachments/assets/b21dd899-bd17-4f39-ab39-04691d9f1e60"/> |



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only promo banner animation with explicit instant-dismiss on input; no auth, data, or security impact.
> 
> **Overview**
> Adds a **300ms collapse animation** (alpha + height) when the chat sync promo banner is dismissed via the close button or **Sync With Another Device** CTA. Because the native input list disables `ItemAnimator`, removal is driven manually in `ChatSyncPromoAdapter` with a `Dismissed` / `Dismissing` / `Shown` state machine and deferred `notifyItemRemoved` after the animation.
> 
> **Typing in the chat field** still hides the banner immediately (`dismiss(shouldAnimate = false)`) to avoid glitches when suggestions take over the UI.
> 
> Also removes duplicate **example message card** string entries from many localized `strings-duckchat.xml` files (internal-only, non-translatable). `NativeInputChatSuggestionsBinder` only has a formatting change to a `submitList` callback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca73cfbedc717f55fbb61e5b4cf8da7df55c8cc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->