### PR TITLE
Add Duck Chat history enabled to the public API

### DIFF
--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
@@ -165,6 +165,11 @@ interface DuckChat {
     suspend fun isChatHistoryAvailable(): Boolean
 
     /**
+     * Returns `true` when the user enabled Duck.ai chat history in settings.
+     */
+    suspend fun hasUserEnabledChatHistory(): Boolean
+
+    /**
      * Records that the user selected the "Search + Duck.ai" option on the new address bar picker, so the
      * first prompt submitted from the Duck.ai toggle input field within the attribution window can be
      * attributed back to the picker.

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -822,6 +822,10 @@ class RealDuckChat @Inject constructor(
             duckChatFeature.historyScreen().isEnabled()
     }
 
+    override suspend fun hasUserEnabledChatHistory(): Boolean {
+        return duckChatFeatureRepository.isAIChatHistoryEnabled()
+    }
+
     override fun buildChatUrl(chatId: String): String {
         return appendParameters(mapOf(CHAT_ID_QUERY_NAME to chatId) + nativeChatInputParameters(), getDuckChatLink())
     }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -1832,6 +1832,13 @@ class RealDuckChatTest {
         }
     }
 
+    @Test
+    fun whenHasUserEnabledChatHistoryThenDelegatesToRepository() = runTest {
+        testee.hasUserEnabledChatHistory()
+
+        verify(mockDuckChatFeatureRepository).isAIChatHistoryEnabled()
+    }
+
     private suspend fun enableChatHistoryFlags() {
         duckChatFeature.self().setRawStoredState(State(enable = true))
         duckChatFeature.useNativeStorageChatData().setRawStoredState(State(enable = true))

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -1834,8 +1834,9 @@ class RealDuckChatTest {
 
     @Test
     fun whenHasUserEnabledChatHistoryThenDelegatesToRepository() = runTest {
-        testee.hasUserEnabledChatHistory()
+        whenever(mockDuckChatFeatureRepository.isAIChatHistoryEnabled()).thenReturn(true)
 
+        assertTrue(testee.hasUserEnabledChatHistory())
         verify(mockDuckChatFeatureRepository).isAIChatHistoryEnabled()
     }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -2355,6 +2355,7 @@ class DuckChatContextualViewModelTest {
         override fun observeTriggerVoiceChatSessionEnd(): Flow<String> = kotlinx.coroutines.flow.emptyFlow()
         override fun endVoiceChatSession(tabId: String) { }
         override suspend fun isChatHistoryAvailable(): Boolean = false
+        override suspend fun hasUserEnabledChatHistory(): Boolean = false
         override suspend fun onAddressBarPickerDuckAiSelected() = Unit
     }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
@@ -120,6 +120,8 @@ class FakeDuckChat(
 
     override suspend fun isChatHistoryAvailable(): Boolean = false
 
+    override suspend fun hasUserEnabledChatHistory(): Boolean = false
+
     override suspend fun onAddressBarPickerDuckAiSelected() { }
 
     fun setEnabled(enabled: Boolean) {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -209,6 +209,8 @@ class FakeDuckChatInternal(
 
     override suspend fun isChatHistoryAvailable(): Boolean = false
 
+    override suspend fun hasUserEnabledChatHistory(): Boolean = false
+
     override suspend fun onAddressBarPickerDuckAiSelected() { }
 
     override fun buildChatUrl(chatId: String): String = "https://duck.ai?chatID=$chatId"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212087397361015/task/1216015637040027?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1212087397361015/task/1215842375041298?focus=true

### Description

Adds `DuckChat.hasUserEnabledChatHistory()` so that the chat sync promotion can decide based on it whether to show itself.

### Steps to test this PR

Code review the change.

### UI changes
N/A


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small API addition with a thin read-through to existing persisted user preference; no new storage or gating logic.
> 
> **Overview**
> Adds **`DuckChat.hasUserEnabledChatHistory()`** so callers outside duckchat-impl can read whether the user turned on Duck.ai chat history in settings, without going through internal repositories.
> 
> **`RealDuckChat`** implements it by delegating to **`DuckChatFeatureRepository.isAIChatHistoryEnabled()`**. This is intentionally separate from **`isChatHistoryAvailable()`**, which still gates on product/feature flags for the native history UI.
> 
> Test fakes and a **`RealDuckChatTest`** case verify the repository delegation; no behavior changes to how the setting is stored.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08a3149ea0c4d3a5c3f58fa9afa2fea6a4bb8e54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->