### PR TITLE
Remove noBrowserCtas feature flag

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabPageViewModel.kt
@@ -26,7 +26,6 @@ import com.duckduckgo.app.browser.remotemessage.CommandActionMapper
 import com.duckduckgo.app.cta.db.DismissedCtaDao
 import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.app.cta.ui.CtaViewModel
-import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardingFeatureToggles
 import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -71,7 +70,6 @@ class NewTabPageViewModel @AssistedInject constructor(
     private val syncEngine: SyncEngine,
     private val commandActionMapper: CommandActionMapper,
     private val dismissedCtaDao: DismissedCtaDao,
-    private val extendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles,
     private val settingsDataStore: SettingsDataStore,
     private val lowPriorityMessagingModel: LowPriorityMessagingModel,
     private val appTrackingProtection: AppTrackingProtection,
@@ -190,14 +188,12 @@ class NewTabPageViewModel @AssistedInject constructor(
     // We only want to show New Tab when the Home CTAs from Onboarding has finished
     // https://app.asana.com/0/1157893581871903/1207769731595075/f
     private suspend fun isHomeOnboardingComplete(): Boolean {
-        val noBrowserCtaExperiment = extendedOnboardingFeatureToggles.noBrowserCtas().isEnabled()
         val lastDialogShown = if (onboardingBrandDesignUpdateToggles.brandDesignUpdate().isEnabled()) {
             ctaViewModel.areBubbleDaxDialogsCompleted()
         } else {
             dismissedCtaDao.exists(CtaId.DAX_END)
         }
         return lastDialogShown ||
-            noBrowserCtaExperiment ||
             settingsDataStore.hideTips ||
             dismissedCtaDao.exists(CtaId.ADD_WIDGET)
     }

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -259,7 +259,7 @@ class CtaViewModel @Inject constructor(
 
     suspend fun prepareAndMarkDuckAiEndCtaForInputScreen(): DuckAiOnboardingEndCtaVariant {
         return withContext(dispatchers.io()) {
-            val shouldShow = canShowDuckAiEndCta() && !extendedOnboardingFeatureToggles.noBrowserCtas().isEnabled() && !settingsDataStore.hideTips
+            val shouldShow = canShowDuckAiEndCta() && !settingsDataStore.hideTips
             if (!shouldShow) return@withContext DuckAiOnboardingEndCtaVariant.NONE
 
             dismissedCtaDao.insert(DismissedCta(CtaId.DAX_DUCK_AI_END))
@@ -370,15 +370,8 @@ class CtaViewModel @Inject constructor(
 
     private suspend fun getHomeCta(): Cta? {
         return when {
-            // Onboarding disabled
-            canShowDaxIntroCta() && extendedOnboardingFeatureToggles.noBrowserCtas().isEnabled() -> {
-                settingsDataStore.hideTips = true
-                userStageStore.stageCompleted(AppStage.DAX_ONBOARDING)
-                null
-            }
-
             // Duck.ai onboarding end
-            canShowDuckAiEndCta() && !extendedOnboardingFeatureToggles.noBrowserCtas().isEnabled() -> {
+            canShowDuckAiEndCta() -> {
                 if (isInputScreenEnabled()) {
                     // Legacy path: the input screen auto-launches with the end CTA. Suppress home
                     // CTAs until that flow runs (see prepareAndMarkDuckAiEndCtaForInputScreen).
@@ -397,7 +390,7 @@ class CtaViewModel @Inject constructor(
             }
 
             // Search suggestions
-            canShowDaxIntroCta() && !extendedOnboardingFeatureToggles.noBrowserCtas().isEnabled() -> {
+            canShowDaxIntroCta() -> {
                 if (isBrandDesignUpdateEnabled()) {
                     DaxTryASearchBrandDesignUpdateBubbleCta(onboardingStore, appInstallStore, appTheme.isLightModeEnabled(), deviceInfo)
                 } else {
@@ -406,7 +399,7 @@ class CtaViewModel @Inject constructor(
             }
 
             // Site suggestions
-            canShowDaxIntroVisitSiteCta() && !extendedOnboardingFeatureToggles.noBrowserCtas().isEnabled() -> {
+            canShowDaxIntroVisitSiteCta() -> {
                 if (isBrandDesignUpdateEnabled()) {
                     DaxVisitSiteOptionsBrandDesignUpdateBubbleCta(
                         onboardingStore,
@@ -421,7 +414,7 @@ class CtaViewModel @Inject constructor(
             }
 
             // End
-            canShowDaxCtaEndOfJourney() && !extendedOnboardingFeatureToggles.noBrowserCtas().isEnabled() -> {
+            canShowDaxCtaEndOfJourney() -> {
                 if (isBrandDesignUpdateEnabled()) {
                     DaxEndBrandDesignUpdateBubbleCta(
                         onboardingStore,
@@ -672,25 +665,23 @@ class CtaViewModel @Inject constructor(
 
     suspend fun areBubbleDaxDialogsCompleted(): Boolean {
         return withContext(dispatchers.io()) {
-            val noBrowserCtaExperiment = extendedOnboardingFeatureToggles.noBrowserCtas().isEnabled()
             val isLastContextDialogShown = when {
                 onboardingStore.isDuckAiOnboardingFlow() -> duckAiEndShown()
                 isSubscriptionCtaAvailable() -> daxDialogSubscriptionShown()
                 else -> daxDialogEndShown()
             }
-            noBrowserCtaExperiment || isLastContextDialogShown || hideTips() || !userStageStore.daxOnboardingActive()
+            isLastContextDialogShown || hideTips() || !userStageStore.daxOnboardingActive()
         }
     }
 
     suspend fun areInContextDaxDialogsCompleted(): Boolean {
         return withContext(dispatchers.io()) {
-            val noBrowserCtaExperiment = extendedOnboardingFeatureToggles.noBrowserCtas().isEnabled()
             val inContextDaxCtasShown = if (onboardingStore.isDuckAiOnboardingFlow()) {
                 duckAiFireButtonShown() && duckAiEndShown()
             } else {
                 daxDialogSerpShown() && daxDialogTrackersFoundShown() && daxDialogFireEducationShown() && daxDialogEndShown()
             }
-            noBrowserCtaExperiment || inContextDaxCtasShown || hideTips() || !userStageStore.daxOnboardingActive()
+            inContextDaxCtasShown || hideTips() || !userStageStore.daxOnboardingActive()
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingFlowCheckerImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingFlowCheckerImpl.kt
@@ -20,7 +20,6 @@ import com.duckduckgo.app.cta.db.DismissedCtaDao
 import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.app.onboarding.store.AppStage
 import com.duckduckgo.app.onboarding.store.UserStageStore
-import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardingFeatureToggles
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
@@ -33,7 +32,6 @@ import javax.inject.Inject
 @SingleInstanceIn(AppScope::class)
 class OnboardingFlowCheckerImpl @Inject constructor(
     private val dismissedCtaDao: DismissedCtaDao,
-    private val extendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles,
     private val settingsDataStore: SettingsDataStore,
     private val userStageStore: UserStageStore,
     private val dispatcher: DispatcherProvider,
@@ -43,9 +41,7 @@ class OnboardingFlowCheckerImpl @Inject constructor(
         // TODO Consider adding allOnboardingCtasShown() in the future.
         //  See https://app.asana.com/1/137249556945/project/414730916066338/task/1212406513605392
         return withContext(dispatcher.io()) {
-            val noBrowserCtaExperiment = extendedOnboardingFeatureToggles.noBrowserCtas().isEnabled()
-            noBrowserCtaExperiment ||
-                settingsDataStore.hideTips ||
+            settingsDataStore.hideTips ||
                 dismissedCtaDao.exists(CtaId.ADD_WIDGET) ||
                 userStageStore.getUserAppStage() == AppStage.ESTABLISHED
         }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/extendedonboarding/ExtendedOnboardingFeatureToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/extendedonboarding/ExtendedOnboardingFeatureToggles.kt
@@ -31,9 +31,6 @@ interface ExtendedOnboardingFeatureToggles {
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
-    fun noBrowserCtas(): Toggle
-
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun privacyProCta(): Toggle
 

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -797,7 +797,6 @@ class BrowserTabViewModelTest {
             whenever(subscriptions.isEligible()).thenReturn(false)
             whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCta()).thenReturn(mockDisabledToggle)
             whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCtaExistingUsers()).thenReturn(mockDisabledToggle)
-            whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
             whenever(mockExtendedOnboardingFeatureToggles.freeTrialCopy()).thenReturn(mockDisabledToggle)
             whenever(mockOnboardingBrandDesignUpdateToggles.self()).thenReturn(mockDisabledToggle)
             whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockDisabledToggle)
@@ -1083,7 +1082,6 @@ class BrowserTabViewModelTest {
     @Test
     fun whenViewBecomesVisibleAndHomeShowingThenKeyboardShown() =
         runTest {
-            whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
             whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(true)
 
             setBrowserShowing(false)
@@ -1096,7 +1094,6 @@ class BrowserTabViewModelTest {
     @Test
     fun whenViewBecomesVisibleAndMaliciousSiteBlockedThenKeyboardNotShown() =
         runTest {
-            whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
             whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(true)
             testee.browserViewState.value = browserViewState().copy(maliciousSiteBlocked = true)
 
@@ -1108,7 +1105,6 @@ class BrowserTabViewModelTest {
     @Test
     fun whenOmnibarTypeSplitThenThenKeyboardShownOnlyTheFirstTimeNtpIsVisible() =
         runTest {
-            whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
             whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(true)
             testee.browserViewState.value = browserViewState().copy(browserShowing = false)
             whenever(mockSettingsDataStore.omnibarType).thenReturn(OmnibarType.SPLIT)
@@ -1125,7 +1121,6 @@ class BrowserTabViewModelTest {
     @Test
     fun whenOmnibarTypeNotSplitThenThenKeyboardNotHiddenWhenOpenedMultipleTimes() =
         runTest {
-            whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
             whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(true)
             testee.browserViewState.value = browserViewState().copy(browserShowing = false)
             whenever(mockSettingsDataStore.omnibarType).thenReturn(OmnibarType.SINGLE_TOP)
@@ -1142,7 +1137,6 @@ class BrowserTabViewModelTest {
     @Test
     fun whenViewBecomesVisibleAndDuckAIPoCIsEnabledThenKeyboardNotShown() =
         runTest {
-            whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
             whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(true)
             whenever(mockDuckAiFeatureState.showInputScreen).thenReturn(MutableStateFlow(true))
 
@@ -1163,7 +1157,6 @@ class BrowserTabViewModelTest {
     fun whenViewBecomesVisibleAndHomeShowingThenRefreshCtaIsCalled() {
         runTest {
             setBrowserShowing(false)
-            whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
             val observer = ValueCaptorObserver<CtaViewState>()
             testee.ctaViewState.observeForever(observer)
 
@@ -3465,7 +3458,6 @@ class BrowserTabViewModelTest {
     @Test
     fun whenCtaRefreshedAndOnlyStandardAddSupportedAndWidgetAlreadyInstalledThenCtaIsNull() =
         runTest {
-            whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
             whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(false)
             whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(true)
             testee.refreshCta()
@@ -3476,7 +3468,6 @@ class BrowserTabViewModelTest {
     fun whenCtaRefreshedAndIsNewTabIsFalseThenReturnNull() =
         runTest {
             setBrowserShowing(true)
-            whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
             whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
             whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(false)
             testee.refreshCta()
@@ -3486,7 +3477,6 @@ class BrowserTabViewModelTest {
     @Test
     fun whenCtaRefreshedAndOnboardingCompleteThenViewStateUpdated() =
         runTest {
-            whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
             whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(false)
             whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(true)
             whenever(mockDismissedCtaDao.exists(DAX_END)).thenReturn(true)
@@ -3501,7 +3491,6 @@ class BrowserTabViewModelTest {
     fun whenCtaRefreshedAndBrowserShowingThenViewStateUpdated() =
         runTest {
             setBrowserShowing(true)
-            whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
             whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(false)
             whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(true)
             whenever(mockDismissedCtaDao.exists(DAX_END)).thenReturn(true)
@@ -3515,7 +3504,6 @@ class BrowserTabViewModelTest {
     @Test
     fun whenCtaRefreshedAndMaliciousSiteBlockedThenViewStateUpdated() =
         runTest {
-            whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
             testee.browserViewState.value =
                 browserViewState().copy(
                     browserShowing = false,
@@ -3531,7 +3519,6 @@ class BrowserTabViewModelTest {
     fun whenCtaRefreshedGetUserRefreshesCalled() =
         runTest {
             setBrowserShowing(true)
-            whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
             whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(false)
             whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(true)
             val expectedRefreshPatterns = setOf(RefreshPattern.THRICE_IN_20_SECONDS)
@@ -7779,7 +7766,6 @@ class BrowserTabViewModelTest {
     fun whenRefreshCtaAndPatternsDetectedThenSendBreakageRefreshPixels() =
         runTest {
             setBrowserShowing(true)
-            whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
             val refreshPatterns = setOf(RefreshPattern.TWICE_IN_12_SECONDS, RefreshPattern.THRICE_IN_20_SECONDS)
             whenever(mockBrokenSitePrompt.getUserRefreshPatterns()).thenReturn(refreshPatterns)
             testee.refreshCta()
@@ -9747,7 +9733,6 @@ class BrowserTabViewModelTest {
     }
 
     private suspend fun givenFireButtonPulsing() {
-        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockEnabledToggle)
         whenever(mockUserStageStore.getUserAppStage()).thenReturn(AppStage.DAX_ONBOARDING)
         dismissedCtaDaoChannel.send(listOf(DismissedCta(DAX_DIALOG_TRACKERS_FOUND)))
     }

--- a/app/src/test/java/com/duckduckgo/app/browser/newtab/NewTabPageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/newtab/NewTabPageViewModelTest.kt
@@ -23,7 +23,6 @@ import com.duckduckgo.app.browser.remotemessage.CommandActionMapper
 import com.duckduckgo.app.cta.db.DismissedCtaDao
 import com.duckduckgo.app.cta.model.CtaId.DAX_END
 import com.duckduckgo.app.cta.ui.CtaViewModel
-import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardingFeatureToggles
 import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -72,7 +71,6 @@ class NewTabPageViewModelTest {
     private var mockPlaystoreUtils: PlayStoreUtils = mock()
     private var mockRemoteMessageModel: RemoteMessageModel = mock()
     private var mockDismissedCtaDao: DismissedCtaDao = mock()
-    private val mockExtendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles = mock()
     private val mockSettingsDataStore: SettingsDataStore = mock()
     private val mockLowPriorityMessagingModel: LowPriorityMessagingModel = mock()
     private val mockAppTrackingProtection: AppTrackingProtection = mock()
@@ -85,7 +83,6 @@ class NewTabPageViewModelTest {
     @Before
     fun setUp() = runTest {
         val mockDisabledToggle: Toggle = mock { on { it.isEnabled() } doReturn false }
-        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
         whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockDisabledToggle)
         whenever(mockSavedSitesRepository.getFavorites()).thenReturn(flowOf(emptyList()))
         whenever(mockRemoteMessageModel.observeActiveMessages()).thenReturn(flowOf(null))
@@ -107,7 +104,6 @@ class NewTabPageViewModelTest {
             syncEngine = mockSyncEngine,
             commandActionMapper = mockCommandActionMapper,
             dismissedCtaDao = mockDismissedCtaDao,
-            extendedOnboardingFeatureToggles = mockExtendedOnboardingFeatureToggles,
             settingsDataStore = mockSettingsDataStore,
             lowPriorityMessagingModel = mockLowPriorityMessagingModel,
             appTrackingProtection = mockAppTrackingProtection,

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -176,7 +176,6 @@ class CtaViewModelTest {
             .build()
 
         val mockDisabledToggle: Toggle = mock { on { it.isEnabled() } doReturn false }
-        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
         whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCta()).thenReturn(mockDisabledToggle)
         whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCtaExistingUsers()).thenReturn(mockDisabledToggle)
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1))
@@ -837,47 +836,10 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun givenNoBrowserCtasExperimentWhenRefreshCtaOnHomeTabThenSkipOnboardingHomeCtas() = runTest {
-        givenDaxOnboardingActive()
-        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockEnabledToggle)
-        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(false)
-        whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
-
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
-        assertFalse(value is DaxBubbleCta.DaxIntroSearchOptionsCta)
-    }
-
-    @Test
-    fun givenNoBrowserCtasExperimentWhenFirstRefreshCtaOnHomeTabThenDontReturnWidgetCta() = runTest {
-        givenDaxOnboardingActive()
-        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockEnabledToggle)
-        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(false)
-
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
-        assertFalse(value is HomePanelCta.AddWidgetAutoOnboarding)
-    }
-
-    @Test
-    fun givenNoBrowserCtasExperimentWhenRefreshCtaWhileBrowsingThenReturnNull() = runTest {
-        givenDaxOnboardingActive()
-        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockEnabledToggle)
-        val site = site(url = "http://www.facebook.com", entity = TdsEntity("Facebook", "Facebook", 9.0))
-
-        val value = testee.refreshCta(
-            coroutineRule.testDispatcher,
-            isBrowserShowing = true,
-            site = site,
-            detectedRefreshPatterns = detectedRefreshPatterns,
-        )
-        assertNull(value)
-    }
-
-    @Test
     fun givenSubscriptionCtaExperimentWhenRefreshCtaOnHomeTabThenReturnSubscriptionCta() = runTest {
         givenDaxOnboardingActive()
         whenever(mockSubscriptions.isEligible()).thenReturn(true)
         whenever(mockSubscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
-        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockEnabledToggle)
         whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
         whenever(mockExtendedOnboardingFeatureToggles.freeTrialCopy()).thenReturn(mockDisabledToggle)
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
@@ -894,7 +856,6 @@ class CtaViewModelTest {
         givenDaxOnboardingActive()
         whenever(mockSubscriptions.isEligible()).thenReturn(true)
         whenever(mockSubscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
-        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockEnabledToggle)
         whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
         whenever(mockExtendedOnboardingFeatureToggles.freeTrialCopy()).thenReturn(mockEnabledToggle)
         whenever(mockSubscriptions.isFreeTrialEligible()).thenReturn(true)
@@ -980,7 +941,6 @@ class CtaViewModelTest {
     @Test
     fun givenSubscriptionCtaExperimentDisabledWhenRefreshCtaOnHomeTabThenDontReturnSubscriptionCta() = runTest {
         givenDaxOnboardingActive()
-        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_VISIT_SITE)).thenReturn(true)
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_END)).thenReturn(true)
@@ -1198,7 +1158,6 @@ class CtaViewModelTest {
         givenDaxOnboardingActive()
         whenever(mockSubscriptions.isEligible()).thenReturn(true)
         whenever(mockSubscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
-        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockEnabledToggle)
         whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
         whenever(mockExtendedOnboardingFeatureToggles.freeTrialCopy()).thenReturn(mockDisabledToggle)
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
@@ -1216,7 +1175,6 @@ class CtaViewModelTest {
         givenDaxOnboardingActive()
         whenever(mockSubscriptions.isEligible()).thenReturn(true)
         whenever(mockSubscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
-        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockEnabledToggle)
         whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
         whenever(mockExtendedOnboardingFeatureToggles.freeTrialCopy()).thenReturn(mockDisabledToggle)
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO)).thenReturn(true)
@@ -1431,18 +1389,6 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenPrepareDuckAiEndCtaAndNoBrowserCtasEnabledThenReturnsNoneAndNoSideEffects() = runTest {
-        givenCanShowDuckAiEndCta()
-        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockEnabledToggle)
-
-        val result = testee.prepareAndMarkDuckAiEndCtaForInputScreen()
-
-        assertEquals(DuckAiOnboardingEndCtaVariant.NONE, result)
-        verify(mockPixel, never()).fire(eq(ONBOARDING_DAX_CTA_SHOWN), any(), any(), eq(Count))
-        verify(mockDismissedCtaDao, never()).insert(DismissedCta(CtaId.DAX_DUCK_AI_END))
-    }
-
-    @Test
     fun whenPrepareDuckAiEndCtaAndAlreadyShownThenReturnsNoneAndNoSideEffects() = runTest {
         givenCanShowDuckAiEndCta()
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_DUCK_AI_END)).thenReturn(true)
@@ -1496,18 +1442,6 @@ class CtaViewModelTest {
         givenDaxOnboardingActive()
         givenCanShowDuckAiEndCta()
         showInputScreenFlow.value = true
-
-        val cta = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
-
-        assertNull(cta)
-    }
-
-    @Test
-    fun whenNativeInputActiveAndCanShowDuckAiEndCtaButNoBrowserCtasEnabledThenHomeCtaIsNull() = runTest {
-        givenDaxOnboardingActive()
-        givenCanShowDuckAiEndCta()
-        showInputScreenFlow.value = false
-        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockEnabledToggle)
 
         val cta = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
 

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxDuckAiFireButtonBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxDuckAiFireButtonBrandDesignUpdateContextualCtaTest.kt
@@ -129,7 +129,6 @@ class DaxDuckAiFireButtonBrandDesignUpdateContextualCtaTest {
 
     @Before
     fun before() = runTest {
-        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(disabledToggle)
         whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCta()).thenReturn(disabledToggle)
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1))
         whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateContextualCtaTest.kt
@@ -127,7 +127,6 @@ class DaxEndBrandDesignUpdateContextualCtaTest {
             .allowMainThreadQueries()
             .build()
 
-        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
         whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCta()).thenReturn(mockDisabledToggle)
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1))
         whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxFireButtonBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxFireButtonBrandDesignUpdateContextualCtaTest.kt
@@ -121,7 +121,6 @@ class DaxFireButtonBrandDesignUpdateContextualCtaTest {
 
     @Before
     fun before() = runTest {
-        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(disabledToggle)
         whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCta()).thenReturn(disabledToggle)
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1))
         whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCtaTest.kt
@@ -141,7 +141,6 @@ class DaxMainNetworkBrandDesignUpdateContextualCtaTest {
             .allowMainThreadQueries()
             .build()
 
-        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
         whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCta()).thenReturn(mockDisabledToggle)
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1))
         whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxNoTrackersBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxNoTrackersBrandDesignUpdateContextualCtaTest.kt
@@ -133,7 +133,6 @@ class DaxNoTrackersBrandDesignUpdateContextualCtaTest {
             .allowMainThreadQueries()
             .build()
 
-        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
         whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCta()).thenReturn(mockDisabledToggle)
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1))
         whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxSerpBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxSerpBrandDesignUpdateContextualCtaTest.kt
@@ -135,7 +135,6 @@ class DaxSerpBrandDesignUpdateContextualCtaTest {
             .allowMainThreadQueries()
             .build()
 
-        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(disabledToggle)
         whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCta()).thenReturn(disabledToggle)
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1))
         whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxSiteSuggestionsBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxSiteSuggestionsBrandDesignUpdateContextualCtaTest.kt
@@ -146,7 +146,6 @@ class DaxSiteSuggestionsBrandDesignUpdateContextualCtaTest {
             .allowMainThreadQueries()
             .build()
 
-        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
         whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCta()).thenReturn(mockDisabledToggle)
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1))
         whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxTrackersBlockedBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxTrackersBlockedBrandDesignUpdateContextualCtaTest.kt
@@ -126,7 +126,6 @@ class DaxTrackersBlockedBrandDesignUpdateContextualCtaTest {
 
     @Before
     fun before() = runTest {
-        whenever(mockExtendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
         whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCta()).thenReturn(mockDisabledToggle)
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1))
         whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/OnboardingDaxDialogTests.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/OnboardingDaxDialogTests.kt
@@ -100,7 +100,6 @@ class OnboardingDaxDialogTests {
 
     @Before
     fun before() = runTest {
-        whenever(extendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockDisabledToggle)
         whenever(extendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockDisabledToggle)
         whenever(extendedOnboardingFeatureToggles.subscriptionPromoModalCta()).thenReturn(mockDisabledToggle)
         whenever(extendedOnboardingFeatureToggles.subscriptionPromoModalCtaExistingUsers()).thenReturn(mockDisabledToggle)
@@ -138,13 +137,6 @@ class OnboardingDaxDialogTests {
             },
             mock(DuckAiFeatureState::class.java).also { whenever(it.showInputScreen).thenReturn(MutableStateFlow(true)) },
         )
-    }
-
-    @Test
-    fun whenNoOnboardingExperimentEnabledThenOnboardingComplete() = runTest {
-        whenever(extendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(mockEnabledToggle)
-        val onboardingComplete = testee.areBubbleDaxDialogsCompleted()
-        assertTrue(onboardingComplete)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/onboarding/OnboardingFlowCheckerImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/OnboardingFlowCheckerImplTest.kt
@@ -20,10 +20,8 @@ import com.duckduckgo.app.cta.db.DismissedCtaDao
 import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.app.onboarding.store.AppStage
 import com.duckduckgo.app.onboarding.store.UserStageStore
-import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardingFeatureToggles
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.common.test.CoroutineTestRule
-import com.duckduckgo.feature.toggles.api.Toggle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -39,21 +37,17 @@ class OnboardingFlowCheckerImplTest {
     var coroutineTestRule = CoroutineTestRule()
 
     private val dismissedCtaDao: DismissedCtaDao = mock()
-    private val extendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles = mock()
     private val settingsDataStore: SettingsDataStore = mock()
     private val userStageStore: UserStageStore = mock()
-    private val noBrowserCtasToggle: Toggle = mock()
 
     private lateinit var testee: OnboardingFlowCheckerImpl
 
     @Before
     fun setup() = runTest {
-        whenever(extendedOnboardingFeatureToggles.noBrowserCtas()).thenReturn(noBrowserCtasToggle)
         whenever(userStageStore.getUserAppStage()).thenReturn(AppStage.DAX_ONBOARDING)
 
         testee = OnboardingFlowCheckerImpl(
             dismissedCtaDao = dismissedCtaDao,
-            extendedOnboardingFeatureToggles = extendedOnboardingFeatureToggles,
             settingsDataStore = settingsDataStore,
             userStageStore = userStageStore,
             dispatcher = coroutineTestRule.testDispatcherProvider,
@@ -61,19 +55,7 @@ class OnboardingFlowCheckerImplTest {
     }
 
     @Test
-    fun whenNoBrowserCtasExperimentIsEnabledThenOnboardingIsComplete() = runTest {
-        whenever(noBrowserCtasToggle.isEnabled()).thenReturn(true)
-        whenever(settingsDataStore.hideTips).thenReturn(false)
-        whenever(dismissedCtaDao.exists(CtaId.ADD_WIDGET)).thenReturn(false)
-
-        val result = testee.isOnboardingComplete()
-
-        assertTrue(result)
-    }
-
-    @Test
     fun whenHideTipsIsTrueThenOnboardingIsComplete() = runTest {
-        whenever(noBrowserCtasToggle.isEnabled()).thenReturn(false)
         whenever(settingsDataStore.hideTips).thenReturn(true)
         whenever(dismissedCtaDao.exists(CtaId.ADD_WIDGET)).thenReturn(false)
 
@@ -84,7 +66,6 @@ class OnboardingFlowCheckerImplTest {
 
     @Test
     fun whenAddWidgetCtaIsDismissedThenOnboardingIsComplete() = runTest {
-        whenever(noBrowserCtasToggle.isEnabled()).thenReturn(false)
         whenever(settingsDataStore.hideTips).thenReturn(false)
         whenever(dismissedCtaDao.exists(CtaId.ADD_WIDGET)).thenReturn(true)
 
@@ -95,7 +76,6 @@ class OnboardingFlowCheckerImplTest {
 
     @Test
     fun whenAppStageIsEstablishedThenOnboardingIsComplete() = runTest {
-        whenever(noBrowserCtasToggle.isEnabled()).thenReturn(false)
         whenever(settingsDataStore.hideTips).thenReturn(false)
         whenever(dismissedCtaDao.exists(CtaId.ADD_WIDGET)).thenReturn(false)
         whenever(userStageStore.getUserAppStage()).thenReturn(AppStage.ESTABLISHED)
@@ -107,7 +87,6 @@ class OnboardingFlowCheckerImplTest {
 
     @Test
     fun whenAppStageIsNewThenOnboardingIsNotComplete() = runTest {
-        whenever(noBrowserCtasToggle.isEnabled()).thenReturn(false)
         whenever(settingsDataStore.hideTips).thenReturn(false)
         whenever(dismissedCtaDao.exists(CtaId.ADD_WIDGET)).thenReturn(false)
         whenever(userStageStore.getUserAppStage()).thenReturn(AppStage.NEW)
@@ -119,7 +98,6 @@ class OnboardingFlowCheckerImplTest {
 
     @Test
     fun whenAppStageIsDaxOnboardingThenOnboardingIsNotComplete() = runTest {
-        whenever(noBrowserCtasToggle.isEnabled()).thenReturn(false)
         whenever(settingsDataStore.hideTips).thenReturn(false)
         whenever(dismissedCtaDao.exists(CtaId.ADD_WIDGET)).thenReturn(false)
         whenever(userStageStore.getUserAppStage()).thenReturn(AppStage.DAX_ONBOARDING)
@@ -131,7 +109,6 @@ class OnboardingFlowCheckerImplTest {
 
     @Test
     fun whenNoCompletionConditionsAreMetThenOnboardingIsNotComplete() = runTest {
-        whenever(noBrowserCtasToggle.isEnabled()).thenReturn(false)
         whenever(settingsDataStore.hideTips).thenReturn(false)
         whenever(dismissedCtaDao.exists(CtaId.ADD_WIDGET)).thenReturn(false)
 
@@ -142,7 +119,6 @@ class OnboardingFlowCheckerImplTest {
 
     @Test
     fun whenMultipleCompletionConditionsAreMetThenOnboardingIsComplete() = runTest {
-        whenever(noBrowserCtasToggle.isEnabled()).thenReturn(true)
         whenever(settingsDataStore.hideTips).thenReturn(true)
         whenever(dismissedCtaDao.exists(CtaId.ADD_WIDGET)).thenReturn(true)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1216029167343883?focus=true
Tech Design URL (if applicable): 

### Description
The `extendedOnboarding.noBrowserCtas` toggle is no longer needed. Bake in the disabled behavior: drop the dead onboarding- disabled branch in `getHomeCta`, remove the flag guards from the remaining home CTA branches and onboarding-completion checks, and delete the now-unused toggle injection from `OnboardingFlowCheckerImpl` and `NewTabPageViewModel`.

### Steps to test this PR

QA optional, code review for the right is enough since there's no behavior change.

Optional:
- [ ] Clean install the app
- [ ] Go through onboarding and verify all dialogs are shown
- [ ] Clean install the app
- [ ] Skip onboarding and verify no dialogs are shown

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cleanup of a retired experiment with no intended user-facing change when the flag was disabled; scope is onboarding CTA gating only.
> 
> **Overview**
> Removes the **`extendedOnboarding.noBrowserCtas`** remote feature toggle and standardizes on the previous “flag off” behavior everywhere.
> 
> **Production:** Deletes `noBrowserCtas()` from `ExtendedOnboardingFeatureToggles`. **`CtaViewModel`** drops the branch that auto-completed DAX onboarding and hid tips when the experiment was on, and removes `noBrowserCtas` guards from home CTA selection, Duck.ai end CTA prep, and bubble/in-context completion checks. **`NewTabPageViewModel`** and **`OnboardingFlowCheckerImpl`** no longer inject the toggles or short-circuit “home onboarding complete” / **`isOnboardingComplete()`** via that flag.
> 
> **Tests:** Strips mocks and tests that covered the experiment-only paths across browser tab, new tab, CTA, onboarding flow, and brand-design contextual CTA test classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 843f76ca8a401879860419ce6c7acb290a1f3b2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->