### PR TITLE
Fire Mode: Fix the UI glitch when switching modes

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -1345,7 +1345,11 @@ open class BrowserActivity : DuckDuckGoActivity() {
                 .flowWithLifecycle(lifecycle, Lifecycle.State.RESUMED)
                 .collect { mode ->
                     if (mode != currentBrowserMode) {
-                        modeSwitchRecreateSignal.markPending()
+                        // Only needed on the old path: with recreateAwareLifecycle on,
+                        // the recreate's onOpen is suppressed so FirstScreenHandler never runs
+                        if (!androidBrowserConfigFeature.recreateAwareLifecycle().isEnabled()) {
+                            modeSwitchRecreateSignal.markPending()
+                        }
                         recreate()
                     }
                 }

--- a/app/src/main/java/com/duckduckgo/app/browser/state/BrowserApplicationStateInfo.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/state/BrowserApplicationStateInfo.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.browser.state
 import android.app.Activity
 import android.os.Bundle
 import com.duckduckgo.app.browser.BrowserActivity
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.browser.api.ActivityLifecycleCallbacks
 import com.duckduckgo.browser.api.BrowserLifecycleObserver
 import com.duckduckgo.di.DaggerSet
@@ -31,6 +32,7 @@ import javax.inject.Inject
 @SingleInstanceIn(AppScope::class)
 class BrowserApplicationStateInfo @Inject constructor(
     private val observers: DaggerSet<BrowserLifecycleObserver>,
+    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
 ) : ActivityLifecycleCallbacks {
     private var created = 0
     private var started = 0
@@ -75,8 +77,8 @@ class BrowserApplicationStateInfo @Inject constructor(
     override fun onActivityStopped(activity: Activity) {
         if (started > 0) (--started)
         if (started == 0) {
-            if (activity.isChangingConfigurations) {
-                // recreate()/rotation, not a real background
+            if (activity.isChangingConfigurations && androidBrowserConfigFeature.recreateAwareLifecycle().isEnabled()) {
+                // recreate()/rotation, not a real background (kill switch: recreateAwareLifecycle)
                 stoppedForRecreate = true
             } else {
                 observers.forEach { it.onClose() }

--- a/app/src/main/java/com/duckduckgo/app/browser/state/BrowserApplicationStateInfo.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/state/BrowserApplicationStateInfo.kt
@@ -39,6 +39,10 @@ class BrowserApplicationStateInfo @Inject constructor(
     private var isFreshLaunch: Boolean = false
     private var overrideIsFreshLaunch: Boolean = false
 
+    // True when the started-count hit 0 due to a config-change recreate (rotation / Activity.recreate()),
+    // not a real background->foreground; suppresses onClose()/onOpen() so the fg pipeline doesn't run on it.
+    private var stoppedForRecreate = false
+
     override fun onActivityCreated(
         activity: Activity,
         savedInstanceState: Bundle?,
@@ -48,8 +52,13 @@ class BrowserApplicationStateInfo @Inject constructor(
 
     override fun onActivityStarted(activity: Activity) {
         if (started++ == 0) {
-            observers.forEach { it.onOpen(isFreshLaunch) }
-            isFreshLaunch = false
+            if (stoppedForRecreate) {
+                // The recreated instance came back; this is not a real foreground.
+                stoppedForRecreate = false
+            } else {
+                observers.forEach { it.onOpen(isFreshLaunch) }
+                isFreshLaunch = false
+            }
         }
     }
 
@@ -65,7 +74,14 @@ class BrowserApplicationStateInfo @Inject constructor(
 
     override fun onActivityStopped(activity: Activity) {
         if (started > 0) (--started)
-        if (started == 0) observers.forEach { it.onClose() }
+        if (started == 0) {
+            if (activity.isChangingConfigurations) {
+                // recreate()/rotation, not a real background
+                stoppedForRecreate = true
+            } else {
+                observers.forEach { it.onClose() }
+            }
+        }
     }
 
     override fun onActivityDestroyed(activity: Activity) {

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -396,4 +396,12 @@ interface AndroidBrowserConfigFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun webViewSessionPersistence(): Toggle
+
+    /**
+     * Kill switch: when enabled, an Activity.recreate() (mode switch / config change) is not treated as an
+     * app background->foreground, so BrowserApplicationStateInfo skips the onClose()/onOpen() pipeline for it.
+     * Disable to restore firing the full lifecycle pipeline on every recreate. Defaults to `true`.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun recreateAwareLifecycle(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/BrowserModeToggleView.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/BrowserModeToggleView.kt
@@ -53,7 +53,7 @@ class BrowserModeToggleView @JvmOverloads constructor(
 
     private val touchSlop: Int = ViewConfiguration.get(context).scaledTouchSlop
 
-    private var listener: ((BrowserMode) -> Unit)? = null
+    private var listener: ((BrowserMode, fromDrag: Boolean) -> Unit)? = null
     private var currentMode: BrowserMode? = null
 
     private var dragging = false
@@ -96,7 +96,7 @@ class BrowserModeToggleView @JvmOverloads constructor(
         }
     }
 
-    fun setOnModeChangedListener(listener: (BrowserMode) -> Unit) {
+    fun setOnModeChangedListener(listener: (BrowserMode, fromDrag: Boolean) -> Unit) {
         this.listener = listener
     }
 
@@ -137,7 +137,7 @@ class BrowserModeToggleView @JvmOverloads constructor(
                     // Let the ViewModel publish the change; setMode arrives via the flow
                     // and finishes the animation. Don't pre-animate here — keeps a single
                     // source of truth and avoids a snap-and-jump if the switch is vetoed.
-                    listener?.invoke(snappedMode)
+                    listener?.invoke(snappedMode, true)
                 } else {
                     // No mode change — snap the indicator back to the current segment.
                     animateIndicatorTo(snappedMode, animated = true)
@@ -174,7 +174,7 @@ class BrowserModeToggleView @JvmOverloads constructor(
             BrowserMode.FIRE -> BrowserMode.REGULAR
             BrowserMode.REGULAR, null -> BrowserMode.FIRE
         }
-        listener?.invoke(target)
+        listener?.invoke(target, false)
     }
 
     private companion object {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -252,6 +252,7 @@ class TabSwitcherActivity :
     private var fadingOutForRecreate = false
     private var fadingInAfterRecreate = false
     private var fadeInAnimationStarted = false
+    private var switchedModeFromDrag = false
 
     private var lastSnackbar: DefaultSnackbar? = null
 
@@ -295,6 +296,7 @@ class TabSwitcherActivity :
         setContentView(binding.root)
 
         fadingInAfterRecreate = savedInstanceState?.getBoolean(KEY_FADE_IN_AFTER_RECREATE) == true
+        switchedModeFromDrag = savedInstanceState?.getBoolean(KEY_MODE_SWITCH_FROM_DRAG) == true
 
         tabsAdapter.setAnimationTileCloseClickListener {
             viewModel.onTrackerAnimationInfoPanelClicked()
@@ -320,6 +322,7 @@ class TabSwitcherActivity :
         super.onSaveInstanceState(outState)
         if (fadingOutForRecreate) {
             outState.putBoolean(KEY_FADE_IN_AFTER_RECREATE, true)
+            outState.putBoolean(KEY_MODE_SWITCH_FROM_DRAG, switchedModeFromDrag)
         }
     }
 
@@ -499,11 +502,11 @@ class TabSwitcherActivity :
                 Gravity.START or Gravity.CENTER_VERTICAL,
             ),
         )
-        toggle.setOnModeChangedListener { mode ->
-            fadeOutTabsThenRecreate(mode)
+        toggle.setOnModeChangedListener { mode, fromDrag ->
+            fadeOutTabsThenRecreate(mode, fromDrag = fromDrag)
         }
 
-        if (fadingInAfterRecreate) {
+        if (fadingInAfterRecreate && !switchedModeFromDrag) {
             val previousMode = when (currentBrowserMode) {
                 BrowserMode.FIRE -> BrowserMode.REGULAR
                 BrowserMode.REGULAR -> BrowserMode.FIRE
@@ -521,12 +524,14 @@ class TabSwitcherActivity :
     private fun fadeOutTabsThenRecreate(
         newMode: BrowserMode,
         fromUser: Boolean = true,
+        fromDrag: Boolean = false,
     ) {
         if (fadingOutForRecreate) return
         // Ignore user taps while the previous switch is still settling on the recreated activity, so we don't
         // stack recreate()/overlapping fades (which freezes the UI). Programmatic switches are mandatory and bypass.
         if (fromUser && fadingInAfterRecreate) return
         fadingOutForRecreate = true
+        switchedModeFromDrag = fromDrag
 
         // In the Fire tabs empty state the recycler is hidden and empty, so there is nothing to
         // fade out. Animate nothing and just switch mode and recreate immediately; the recreated
@@ -1202,5 +1207,6 @@ class TabSwitcherActivity :
 
         private const val ANCHOR_REPIN_WINDOW_MS = 1000L
         private const val KEY_FADE_IN_AFTER_RECREATE = "fadeInAfterModeSwitchRecreate"
+        private const val KEY_MODE_SWITCH_FROM_DRAG = "modeSwitchFromDrag"
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -604,7 +604,7 @@ class TabSwitcherActivity :
                 if (it.showFireTabsEmptyState && !fadingOutForRecreate) {
                     binding.fireTabsEmptyState.root.show()
                     tabsRecycler.gone()
-                    
+
                     // No fade-in runs in the empty state, so settle the post-recreate flags here; otherwise
                     // fadingInAfterRecreate stays true forever and the mode toggle (guarded on it) is stuck disabled.
                     if (fadingInAfterRecreate) {

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -323,6 +323,22 @@ class TabSwitcherActivity :
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+
+        // Safety net: a recreate()/animation race must never leave the tabs recycler permanently hidden.
+        // If we're "fading in" but no fade-in is running and tabs exist, force it back to visible.
+        val hasTabs = tabsAdapter.itemCount > 0
+        val recyclerNotVisible = tabsRecycler.visibility != View.VISIBLE || tabsRecycler.alpha < 1f
+        if (fadingInAfterRecreate && !fadeInAnimationStarted && hasTabs && recyclerNotVisible) {
+            fadingInAfterRecreate = false
+            tabsRecycler.animate().cancel()
+            tabsRecycler.alpha = 1f
+            tabsRecycler.show()
+            tabsRecycler.itemAnimator = DefaultItemAnimator()
+        }
+    }
+
     private fun configureEdgeToEdgeInsets() {
         edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
         applyDisplayCutoutMode(resources.configuration.orientation)
@@ -502,8 +518,14 @@ class TabSwitcherActivity :
         updateToolbarTitle(state.mode, state.tabs.size)
     }
 
-    private fun fadeOutTabsThenRecreate(newMode: BrowserMode) {
+    private fun fadeOutTabsThenRecreate(
+        newMode: BrowserMode,
+        fromUser: Boolean = true,
+    ) {
         if (fadingOutForRecreate) return
+        // Ignore user taps while the previous switch is still settling on the recreated activity, so we don't
+        // stack recreate()/overlapping fades (which freezes the UI). Programmatic switches are mandatory and bypass.
+        if (fromUser && fadingInAfterRecreate) return
         fadingOutForRecreate = true
 
         // In the Fire tabs empty state the recycler is hidden and empty, so there is nothing to
@@ -582,6 +604,14 @@ class TabSwitcherActivity :
                 if (it.showFireTabsEmptyState && !fadingOutForRecreate) {
                     binding.fireTabsEmptyState.root.show()
                     tabsRecycler.gone()
+                    
+                    // No fade-in runs in the empty state, so settle the post-recreate flags here; otherwise
+                    // fadingInAfterRecreate stays true forever and the mode toggle (guarded on it) is stuck disabled.
+                    if (fadingInAfterRecreate) {
+                        fadingInAfterRecreate = false
+                        fadeInAnimationStarted = false
+                        tabsRecycler.itemAnimator = DefaultItemAnimator()
+                    }
                 } else {
                     binding.fireTabsEmptyState.root.gone()
 
@@ -811,7 +841,7 @@ class TabSwitcherActivity :
             DismissAnimatedTileDismissalDialog -> tabSwitcherAnimationTileRemovalDialog!!.dismiss()
             Command.ShowFireBottomSheet -> onFireButtonClicked()
             Command.DismissSnackbar -> lastSnackbar?.dismiss()
-            Command.SwitchToRegularMode -> fadeOutTabsThenRecreate(BrowserMode.REGULAR)
+            Command.SwitchToRegularMode -> fadeOutTabsThenRecreate(BrowserMode.REGULAR, fromUser = false)
         }
     }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/state/BrowserApplicationStateInfoTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/state/BrowserApplicationStateInfoTest.kt
@@ -18,7 +18,9 @@ package com.duckduckgo.app.browser.state
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.browser.BrowserActivity
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.browser.api.BrowserLifecycleObserver
+import com.duckduckgo.feature.toggles.api.Toggle
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -30,6 +32,8 @@ class BrowserApplicationStateInfoTest {
     private lateinit var browserApplicationStateInfo: BrowserApplicationStateInfo
     private val observer: BrowserLifecycleObserver = mock()
     private val activity = FakeBrowserActivity()
+    private val recreateAwareToggle: Toggle = mock()
+    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature = mock()
 
     class FakeBrowserActivity : BrowserActivity() {
         var isConfigChange = false
@@ -42,7 +46,9 @@ class BrowserApplicationStateInfoTest {
     @Before
     fun setup() {
         activity.destroyedByBackPress = false
-        browserApplicationStateInfo = BrowserApplicationStateInfo(setOf(observer))
+        whenever(recreateAwareToggle.isEnabled()).thenReturn(true)
+        whenever(androidBrowserConfigFeature.recreateAwareLifecycle()).thenReturn(recreateAwareToggle)
+        browserApplicationStateInfo = BrowserApplicationStateInfo(setOf(observer), androidBrowserConfigFeature)
     }
 
     @Test
@@ -193,6 +199,23 @@ class BrowserApplicationStateInfoTest {
         verify(observer).onClose()
 
         // A genuine foreground afterwards must fire onOpen() again (recreate flag not stuck).
+        browserApplicationStateInfo.onActivityStarted(activity)
+        verify(observer).onOpen(false)
+    }
+
+    @Test
+    fun whenConfigChangeButRecreateAwareLifecycleDisabledThenNotifyCloseAndOpen() {
+        // Kill switch off => behave exactly as before the fix: a recreate fires onClose()/onOpen().
+        whenever(recreateAwareToggle.isEnabled()).thenReturn(false)
+
+        browserApplicationStateInfo.onActivityCreated(activity, null)
+        browserApplicationStateInfo.onActivityStarted(activity)
+        verify(observer).onOpen(true)
+
+        activity.isConfigChange = true
+        browserApplicationStateInfo.onActivityStopped(activity)
+        verify(observer).onClose()
+
         browserApplicationStateInfo.onActivityStarted(activity)
         verify(observer).onOpen(false)
     }

--- a/app/src/test/java/com/duckduckgo/app/browser/state/BrowserApplicationStateInfoTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/state/BrowserApplicationStateInfoTest.kt
@@ -132,7 +132,7 @@ class BrowserApplicationStateInfoTest {
     }
 
     @Test
-    fun whenAllActivitiesAreDestroyedByConfigChangeAndRecreatedThenDoNotNotifyFreshAppLaunch() {
+    fun whenActivitiesStopAndRestartForConfigChangeThenDoNotNotifyCloseOrOpen() {
         activity.isConfigChange = true
 
         browserApplicationStateInfo.onActivityCreated(activity, null)
@@ -143,16 +143,56 @@ class BrowserApplicationStateInfoTest {
 
         verify(observer).onOpen(true)
 
+        // A config-change recreate stops then restarts the activities, but it is not a real
+        // background->foreground, so neither onClose() nor onOpen() should fire again.
         browserApplicationStateInfo.onActivityStopped(activity)
         browserApplicationStateInfo.onActivityStopped(activity)
-        verify(observer).onClose()
+        verify(observer, never()).onClose()
 
         browserApplicationStateInfo.onActivityDestroyed(activity)
         browserApplicationStateInfo.onActivityDestroyed(activity)
-        verify(observer).onClose()
         verify(observer, never()).onExit()
 
         browserApplicationStateInfo.onActivityStarted(activity)
+        browserApplicationStateInfo.onActivityStarted(activity)
+        // only the initial onOpen(true); the recreate restart must not fire a second onOpen
+        verify(observer, times(1)).onOpen(any())
+    }
+
+    @Test
+    fun whenConfigChangeRecreateThenSubsequentRealBackgroundThenNotifyClose() {
+        browserApplicationStateInfo.onActivityCreated(activity, null)
+        browserApplicationStateInfo.onActivityStarted(activity)
+        verify(observer).onOpen(true)
+
+        // Config-change recreate: stop + restart must not fire onClose()/onOpen().
+        activity.isConfigChange = true
+        browserApplicationStateInfo.onActivityStopped(activity)
+        browserApplicationStateInfo.onActivityStarted(activity)
+        verify(observer, never()).onClose()
+        verify(observer, times(1)).onOpen(any())
+
+        // The recreate flag must be consumed, not stuck, so a genuine background still fires onClose().
+        activity.isConfigChange = false
+        browserApplicationStateInfo.onActivityStopped(activity)
+        verify(observer).onClose()
+    }
+
+    @Test
+    fun whenConfigChangeRecreateThenRealBackgroundAndForegroundThenNotifyOpen() {
+        browserApplicationStateInfo.onActivityCreated(activity, null)
+        browserApplicationStateInfo.onActivityStarted(activity)
+        verify(observer).onOpen(true)
+
+        // Config-change recreate (no onClose()/onOpen()), then a genuine background.
+        activity.isConfigChange = true
+        browserApplicationStateInfo.onActivityStopped(activity)
+        browserApplicationStateInfo.onActivityStarted(activity)
+        activity.isConfigChange = false
+        browserApplicationStateInfo.onActivityStopped(activity)
+        verify(observer).onClose()
+
+        // A genuine foreground afterwards must fire onOpen() again (recreate flag not stuck).
         browserApplicationStateInfo.onActivityStarted(activity)
         verify(observer).onOpen(false)
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1216049501259336?focus=true

### Description

This PR fixes 2 bugs that happen while switching modes in the Tab switcher:

1. While [rapidly switching between modes](https://github.com/duckduckgo/Android/pull/8748#pullrequestreview-4504401491), the app eventually freezes. This caused by app trying to recreate the activity multiple times. User is no prevented from doing that.
2. Sometimes when switching modes, there is lag lasting a few seconds. Because switching modes in the tab switcher and changing the omnibar position recreate the activity via `Activity.recreate()`, it briefly drops the started-activity count to 0. Previously this fired the full app foreground/background pipeline (`BrowserLifecycleObserver.onClose()`/`onOpen()` — e.g. `AutomaticDataClearer`, ANR-supervisor teardown, session pixels) on every switch. Running the foreground pipeline on every switch intermittently stalled the main thread ~0.6–1.6s (observed `Davey! duration=1647ms`), which is the switcher lag/"freeze". After the fix, `BrowserApplicationStateInfo` now treats a stop→start caused by a configuration-change recreate (`Activity.isChangingConfigurations`) as *not* a real background→foreground transition, and skips `onClose()`/`onOpen()` for it. A genuine background still reports `isChangingConfigurations == false`, so `onClose()`/`onOpen()` fire exactly as before — verified on-device across HOME, screen-off, and app-switch (see table).

<img width="1324" height="199" alt="image" src="https://github.com/user-attachments/assets/5e0bc4a2-4bfe-48ae-afba-27875c7c4b76" />

### Steps to test this PR

**Setup**
- Internal build. Enable the `fireTabs` flag, then force-stop and relaunch

**Mode-switch responsiveness (freeze/lag fix)**
- [ ] Open the tab switcher and rapidly toggle Regular↔Fire many times (tap-storm). The toggle stays responsive and the switcher never freezes, blanks, or leaves the tab grid hidden.
- [ ] Toggle into the Fire empty state (no Fire tabs) and back to Regular. The toggle is still responsive in the empty state.
- [ ] Switching modes is smooth, with no multi-second stall/jank on the switch.

**Auto data-clearing still fires on a real background (key regression check — this PR changes the onClose/onOpen path)**
- [ ] Settings → set automatic clearing to "Tabs and data" with a short "when" (e.g. 5s).
- [ ] Browse, then background the app via HOME / app-switch / screen-off, wait past the timer, and reopen. Data is cleared as configured (fresh state).
- [ ] "Show on app launch" and any after-inactivity screen still trigger after a genuine background for the configured duration.

**Mode switch must NOT behave like a background**
- [ ] With auto-clearing configured, switch Regular↔Fire in the tab switcher: it must NOT clear data or restart the app (a switch is not a real background→foreground).
- [ ] Rotate the device / change system font size while browsing: no spurious data-clear, no freeze.

**Automated**
- [ ] `./gradlew :app:testPlayDebugUnitTest --tests "com.duckduckgo.app.browser.state.BrowserApplicationStateInfoTest"` (8/8 pass).



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global activity lifecycle signaling used by auto data-clear and related observers; mitigated by isChangingConfigurations gating, a remote kill switch, and expanded unit tests, but real-background regression testing is important.
> 
> **Overview**
> Fixes tab switcher lag/freezes when toggling **Fire ↔ Regular** by treating `Activity.recreate()` (mode switch, rotation) as **not** a real background→foreground in `BrowserApplicationStateInfo`, so `BrowserLifecycleObserver` **`onClose()` / `onOpen()`** no longer run on every switch. Adds remote kill switch **`recreateAwareLifecycle`** (default on); when off, behavior reverts to firing the full pipeline on recreate.
> 
> **Tab switcher hardening:** blocks overlapping user mode switches while post-recreate fade-in is settling; **`BrowserModeToggleView`** reports tap vs drag; drag switches skip a misleading toggle “reverse” animation; **`onResume`** forces the tab grid visible if fade-in races leave it hidden; Fire empty state clears stuck post-recreate flags so the toggle stays usable.
> 
> **BrowserActivity** only calls **`modeSwitchRecreateSignal.markPending()`** when **`recreateAwareLifecycle`** is disabled (legacy path). Unit tests cover recreate vs real background/foreground and the kill switch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09708c473c70200d5a2e38aa4605aa7636497efb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->