### PR TITLE
Update content scope scripts to version 15.7.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -7897,6 +7897,7 @@
     let target;
     if (el.tagName === "INPUT") target = window.HTMLInputElement;
     if (el.tagName === "SELECT") target = window.HTMLSelectElement;
+    if (el.tagName === "TEXTAREA") target = window.HTMLTextAreaElement;
     if (!target) {
       return { result: false, error: `input type was not supported: ${el.tagName}` };
     }
@@ -7905,7 +7906,7 @@
       return { result: false, error: "cannot access original value setter" };
     }
     try {
-      if (el.tagName === "INPUT") {
+      if (el.tagName === "INPUT" || el.tagName === "TEXTAREA") {
         el.dispatchEvent(new Event("keydown", { bubbles: true }));
         originalSet.call(el, val);
         const events = [

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -7866,6 +7866,7 @@
     let target;
     if (el.tagName === "INPUT") target = window.HTMLInputElement;
     if (el.tagName === "SELECT") target = window.HTMLSelectElement;
+    if (el.tagName === "TEXTAREA") target = window.HTMLTextAreaElement;
     if (!target) {
       return { result: false, error: `input type was not supported: ${el.tagName}` };
     }
@@ -7874,7 +7875,7 @@
       return { result: false, error: "cannot access original value setter" };
     }
     try {
-      if (el.tagName === "INPUT") {
+      if (el.tagName === "INPUT" || el.tagName === "TEXTAREA") {
         el.dispatchEvent(new Event("keydown", { bubbles: true }));
         originalSet.call(el, val);
         const events = [

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.95.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.6.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.7.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#752e8a7503f618f04743ef63add5d1cc65dbac19",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#79f92b48fafa783528227adac0adcee29709ff42",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -280,9 +280,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
-      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -415,9 +415,9 @@
       }
     },
     "node_modules/immutable-json-patch": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/immutable-json-patch/-/immutable-json-patch-6.0.2.tgz",
-      "integrity": "sha512-KwCA5DXJiyldda8SPha1zB+6+vbEi5/jRRcYii/6yFXlyu9ZjiSH/wPq8Ri2Hk8iGjjTMcHW3Z21S4MOpl7sOw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/immutable-json-patch/-/immutable-json-patch-6.0.3.tgz",
+      "integrity": "sha512-qFLRzQLjteiTGy5tRJcYqvuu0r/GdQ1fE27IyNBrJ/k7yGSO0xFr6QX62TtmIqSvjQF3afcNFUHsGPYW7ydaHQ==",
       "license": "ISC"
     },
     "node_modules/is-builtin-module": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.95.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.6.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.7.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1216063953891872

- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes injected page scripts used for autofill and broker protection; incorrect event/value handling on sites could affect form filling, though the change is narrowly scoped to TEXTAREA support.
> 
> **Overview**
> Bumps **`@duckduckgo/content-scope-scripts`** from **15.6.0** to **15.7.0** in `package.json` and refreshes the lockfile (including the resolved git commit and minor transitive bumps such as `@types/node` and `immutable-json-patch`).
> 
> The updated Android bundles **`autofillImport.js`** and **`brokerProtection.js`** extend **`setValueForInput`** so **`TEXTAREA`** fields are supported: it uses `HTMLTextAreaElement`’s native value setter and runs the same keydown/input/keyup/change dispatch path as **`INPUT`**, instead of failing as an unsupported tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a221c04f522d89515d6b58dc0d940158ac9bddd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->