### PR TITLE
[Android Maintenance] Allow reasoning mode values in unified input prompt_submitted reasoning_effort pixel

### DIFF
--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -1000,8 +1000,8 @@
             {
                 "key": "reasoning_effort",
                 "type": "string",
-                "description": "The resolved reasoning effort level used for the prompt",
-                "enum": ["none", "minimal", "low", "medium", "high"]
+                "description": "The reasoning level used for the prompt (resolved effort level or selected reasoning mode)",
+                "enum": ["none", "minimal", "low", "medium", "high", "fast", "reasoning", "extended_reasoning"]
             },
             { "key": "has_image_attachment", "type": "boolean", "description": "Whether the prompt included an image attachment" },
             { "key": "has_file_attachment", "type": "boolean", "description": "Whether the prompt included a file attachment" },
@@ -1025,8 +1025,8 @@
             {
                 "key": "reasoning_effort",
                 "type": "string",
-                "description": "The resolved reasoning effort level used for the prompt",
-                "enum": ["none", "minimal", "low", "medium", "high"]
+                "description": "The reasoning level used for the prompt (resolved effort level or selected reasoning mode)",
+                "enum": ["none", "minimal", "low", "medium", "high", "fast", "reasoning", "extended_reasoning"]
             },
             { "key": "has_image_attachment", "type": "boolean", "description": "Whether the prompt included an image attachment" },
             { "key": "has_file_attachment", "type": "boolean", "description": "Whether the prompt included a file attachment" },


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1215891186389639
Tech Design URL (if applicable):

### Description

The pixels `m_aichat_unified_input_prompt_submitted_count` and `m_aichat_unified_input_prompt_submitted_daily` failed live validation with:

> `/reasoning_effort must be equal to one of the allowed values`

**Root cause:** the `reasoning_effort` parameter on these pixels was declared with the `enum` `["none", "minimal", "low", "medium", "high"]` (the `ReasoningEffort` rawValues). However, the Duck.ai reasoning feature has a second, user-facing vocabulary — the `ReasoningMode` rawValues `fast` / `reasoning` / `extended_reasoning` (see `Reasoning.kt`). That same mode vocabulary is what the sibling pixel `m_aichat_unified_input_reasoning_effort_selected` already documents for its `effort_level` parameter, and what the `firePromptSubmitted` unit test passes for `reasoningEffort` (`"fast"`). The only reasoning vocabularies in the feature are these two, so the live values failing the effort-only enum are the reasoning mode values.

**Fix:** widen the `reasoning_effort` enum on both pixels to the union of the effort and mode values (`["none", "minimal", "low", "medium", "high", "fast", "reasoning", "extended_reasoning"]`) and update the description accordingly, so field data from all app versions validates.

This is a pixel-definition (JSON5) change only — no Kotlin/app code is touched, so there is no behaviour change. Adding values to a validation enum is non-breaking: it only widens what validation accepts and cannot affect any currently-valid pixels.

🤖 Android Maintenance Worker

### Steps to test this PR

_Pixel definition validation_
- [ ] `cd PixelDefinitions && npm ci`
- [ ] `npm run validate-defs-without-formatting` — schema validation
- [ ] `npm run lint` — Prettier formatting check

_Note:_ `npm run lint` (Prettier) passes locally. `validate-defs-without-formatting` could not complete in the sandbox because it fetches the product target version over the network (`ERROR in product.json target version: fetch failed`) — an infrastructure/firewall limitation unrelated to this change, which occurs before any definition is validated. CI runs this check with network access. No Gradle/spotless/unit-test changes apply because no Kotlin sources were modified.

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |




> [!NOTE]
> <details>
> <summary><b>🔒 Integrity filter blocked 17 items</b></summary>
>
> The following items were blocked because they don't meet the GitHub integrity level.
>
> - [#8942](https://github.com/duckduckgo/Android/pull/8942) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#8860](https://github.com/duckduckgo/Android/pull/8860) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#8844](https://github.com/duckduckgo/Android/pull/8844) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#7961](https://github.com/duckduckgo/Android/pull/7961) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#7835](https://github.com/duckduckgo/Android/pull/7835) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#7825](https://github.com/duckduckgo/Android/pull/7825) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#7785](https://github.com/duckduckgo/Android/pull/7785) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#7744](https://github.com/duckduckgo/Android/pull/7744) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#7462](https://github.com/duckduckgo/Android/pull/7462) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#7446](https://github.com/duckduckgo/Android/pull/7446) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#7433](https://github.com/duckduckgo/Android/pull/7433) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#7264](https://github.com/duckduckgo/Android/pull/7264) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#7085](https://github.com/duckduckgo/Android/pull/7085) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#6890](https://github.com/duckduckgo/Android/pull/6890) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#6870](https://github.com/duckduckgo/Android/pull/6870) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#5621](https://github.com/duckduckgo/Android/pull/5621) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - ... and 1 more item
>
> To allow these resources, lower `min-integrity` in your GitHub frontmatter:
>
> ```yaml
> tools:
>   github:
>     min-integrity: approved  # merged | approved | unapproved | none
> ```
>
> </details>


> Generated by [Android Maintenance Worker](https://github.com/duckduckgo/Android/actions/runs/28221126013/agentic_workflow) · [◷](https://github.com/search?q=repo%3Aduckduckgo%2FAndroid+%22gh-aw-workflow-id%3A+android-maintenance-worker%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: Android Maintenance Worker, engine: claude, model: auto, id: 28221126013, workflow_id: android-maintenance-worker, run: https://github.com/duckduckgo/Android/actions/runs/28221126013 -->

<!-- gh-aw-workflow-id: android-maintenance-worker -->