### PR TITLE
Handle chat sync storage capabilities

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/SyncPromotionDataStore.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/SyncPromotionDataStore.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.sync.impl.di.SyncPromotion
 import com.duckduckgo.sync.impl.promotion.SyncPromotionDataStore.PromotionType
 import com.duckduckgo.sync.impl.promotion.SyncPromotionDataStore.PromotionType.BookmarkAddedDialog
 import com.duckduckgo.sync.impl.promotion.SyncPromotionDataStore.PromotionType.BookmarksScreen
+import com.duckduckgo.sync.impl.promotion.SyncPromotionDataStore.PromotionType.ChatTabPage
 import com.duckduckgo.sync.impl.promotion.SyncPromotionDataStore.PromotionType.PasswordsScreen
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.flow.firstOrNull
@@ -34,12 +35,15 @@ import javax.inject.Inject
 interface SyncPromotionDataStore {
     suspend fun hasPromoBeenDismissed(promotionType: PromotionType): Boolean
     suspend fun recordPromoDismissed(promotionType: PromotionType)
+    suspend fun getPromoImpressionCount(promotionType: PromotionType): Long
+    suspend fun recordPromoImpression(promotionType: PromotionType)
     suspend fun clearPromoHistory(promotionType: PromotionType)
 
     sealed interface PromotionType {
         object BookmarksScreen : PromotionType
         object PasswordsScreen : PromotionType
         object BookmarkAddedDialog : PromotionType
+        object ChatTabPage : PromotionType
     }
 }
 
@@ -49,31 +53,60 @@ class SyncPromotionDataStoreImpl @Inject constructor(
 ) : SyncPromotionDataStore {
 
     override suspend fun hasPromoBeenDismissed(promotionType: PromotionType): Boolean {
-        val key = promotionType.key()
+        val key = promotionType.dismissKey()
         return dataStore.data.map { it[key] }.firstOrNull() != null
     }
 
     override suspend fun recordPromoDismissed(promotionType: PromotionType) {
-        val key = promotionType.key()
+        val key = promotionType.dismissKey()
         dataStore.edit { it[key] = System.currentTimeMillis() }
     }
 
-    override suspend fun clearPromoHistory(promotionType: PromotionType) {
-        val key = promotionType.key()
-        dataStore.edit { it.remove(key) }
+    override suspend fun getPromoImpressionCount(promotionType: PromotionType): Long {
+        val key = promotionType.impressionsKey()
+        return dataStore.data.map { it[key] }.firstOrNull() ?: 0
     }
 
-    private fun PromotionType.key(): Preferences.Key<Long> {
+    override suspend fun recordPromoImpression(promotionType: PromotionType) {
+        val key = promotionType.impressionsKey()
+        dataStore.edit { it[key] = (it[key] ?: 0) + 1 }
+    }
+
+    override suspend fun clearPromoHistory(promotionType: PromotionType) {
+        val dismissKey = promotionType.dismissKey()
+        val impressionKey = promotionType.impressionsKey()
+        dataStore.edit {
+            it.remove(dismissKey)
+            it.remove(impressionKey)
+        }
+    }
+
+    private fun PromotionType.dismissKey(): Preferences.Key<Long> {
         return when (this) {
             BookmarkAddedDialog -> bookmarkAddedDialogPromoDismissedKey
             BookmarksScreen -> bookmarksScreenPromoDismissedKey
             PasswordsScreen -> passwordsPromoDismissedKey
+            ChatTabPage -> chatTabPagePromoDismissedKey
+        }
+    }
+
+    private fun PromotionType.impressionsKey(): Preferences.Key<Long> {
+        return when (this) {
+            BookmarkAddedDialog -> bookmarkAddedDialogPromoImpressionsKey
+            BookmarksScreen -> bookmarksScreenPromoImpressionsKey
+            PasswordsScreen -> passwordsPromoImpressionsKey
+            ChatTabPage -> chatTabPagePromoImpressionsKey
         }
     }
 
     companion object {
         private val bookmarksScreenPromoDismissedKey = longPreferencesKey("bookmarks_promo_dismissed")
+        private val bookmarksScreenPromoImpressionsKey = longPreferencesKey("bookmarks_promo_impressions")
         private val bookmarkAddedDialogPromoDismissedKey = longPreferencesKey("bookmark_added_dialog_promo_dismissed")
+        private val bookmarkAddedDialogPromoImpressionsKey = longPreferencesKey("bookmark_added_dialog_promo_impressions")
         private val passwordsPromoDismissedKey = longPreferencesKey("passwords_promo_dismissed")
+        private val passwordsPromoImpressionsKey = longPreferencesKey("passwords_promo_impressions")
+        private val chatTabPagePromoDismissedKey = longPreferencesKey("chat_tab_page_promo_dismissed")
+        private val chatTabPagePromoImpressionsKey = longPreferencesKey("chat_tab_page_promo_impressions")
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/promotion/SyncPromotionDataStoreImplTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/promotion/SyncPromotionDataStoreImplTest.kt
@@ -6,6 +6,7 @@ import androidx.datastore.preferences.core.Preferences
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.sync.impl.promotion.SyncPromotionDataStore.PromotionType.BookmarkAddedDialog
 import com.duckduckgo.sync.impl.promotion.SyncPromotionDataStore.PromotionType.BookmarksScreen
+import com.duckduckgo.sync.impl.promotion.SyncPromotionDataStore.PromotionType.ChatTabPage
 import com.duckduckgo.sync.impl.promotion.SyncPromotionDataStore.PromotionType.PasswordsScreen
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
@@ -59,5 +60,72 @@ class SyncPromotionDataStoreImplTest {
     fun whenBookmarkAddedPromoRecordedThenPromoHasBeenDismissed() = runTest {
         testee.recordPromoDismissed(BookmarkAddedDialog)
         assertTrue(testee.hasPromoBeenDismissed(BookmarkAddedDialog))
+    }
+
+    @Test
+    fun whenInitializedThenChatTabPromoHasNotBeenDismissed() = runTest {
+        assertFalse(testee.hasPromoBeenDismissed(ChatTabPage))
+    }
+
+    @Test
+    fun whenChatTabPromoRecordedThenPromoHasBeenDismissed() = runTest {
+        testee.recordPromoDismissed(ChatTabPage)
+        assertTrue(testee.hasPromoBeenDismissed(ChatTabPage))
+    }
+
+    @Test
+    fun whenInitializedThenBookmarksScreenPromoHasNoImpressions() = runTest {
+        assertEquals(0L, testee.getPromoImpressionCount(BookmarksScreen))
+    }
+
+    @Test
+    fun whenBookmarksPromoImpressionRecordedThenBookmarksImpressionCounterIncreases() = runTest {
+        testee.recordPromoImpression(BookmarksScreen)
+        assertEquals(1L, testee.getPromoImpressionCount(BookmarksScreen))
+
+        testee.recordPromoImpression(BookmarksScreen)
+        assertEquals(2L, testee.getPromoImpressionCount(BookmarksScreen))
+    }
+
+    @Test
+    fun whenInitializedThenPasswordsPromoHasNoImpressions() = runTest {
+        assertEquals(0L, testee.getPromoImpressionCount(PasswordsScreen))
+    }
+
+    @Test
+    fun whenPasswordsPromoImpressionRecordedThenPasswordsImpressionCounterIncreases() = runTest {
+        testee.recordPromoImpression(PasswordsScreen)
+        assertEquals(1L, testee.getPromoImpressionCount(PasswordsScreen))
+
+        testee.recordPromoImpression(PasswordsScreen)
+        assertEquals(2L, testee.getPromoImpressionCount(PasswordsScreen))
+    }
+
+    @Test
+    fun whenInitializedThenBookmarkAddedPromoHasNoImpressions() = runTest {
+        assertEquals(0L, testee.getPromoImpressionCount(BookmarkAddedDialog))
+    }
+
+    @Test
+    fun whenBookmarkAddedPromoImpressionRecordedThenImpressionCounterIncreases() = runTest {
+        testee.recordPromoImpression(BookmarkAddedDialog)
+        assertEquals(1L, testee.getPromoImpressionCount(BookmarkAddedDialog))
+
+        testee.recordPromoImpression(BookmarkAddedDialog)
+        assertEquals(2L, testee.getPromoImpressionCount(BookmarkAddedDialog))
+    }
+
+    @Test
+    fun whenInitializedThenChatTabPromoHasNoImpressions() = runTest {
+        assertEquals(0L, testee.getPromoImpressionCount(ChatTabPage))
+    }
+
+    @Test
+    fun whenChatTabPromoImpressionRecordedThenImpressionCounterIncreases() = runTest {
+        testee.recordPromoImpression(ChatTabPage)
+        assertEquals(1L, testee.getPromoImpressionCount(ChatTabPage))
+
+        testee.recordPromoImpression(ChatTabPage)
+        assertEquals(2L, testee.getPromoImpressionCount(ChatTabPage))
     }
 }

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
@@ -144,6 +144,7 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         binding.clearHistoryBookmarkAddedDialogPromo.setOnClickListener { viewModel.onClearHistoryBookmarkAddedDialogPromoClicked() }
         binding.clearHistoryBookmarkScreenPromo.setOnClickListener { viewModel.onClearHistoryBookmarkScreenPromoClicked() }
         binding.clearHistoryPasswordScreenPromo.setOnClickListener { viewModel.onClearHistoryPasswordScreenPromoClicked() }
+        binding.clearHistoryChatTabPagePromo.setOnClickListener { viewModel.onClearHistoryChatTabPagePromoClicked() }
         binding.userIdTextView.setOnClickListener { copyToClipboard("User ID", binding.userIdTextView.text.toString()) }
         binding.deviceNameTextView.setOnClickListener { copyToClipboard("Device Name", binding.deviceNameTextView.text.toString()) }
         binding.deviceIdTextView.setOnClickListener { copyToClipboard("Device ID", binding.deviceIdTextView.text.toString()) }

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
@@ -44,6 +44,7 @@ import com.duckduckgo.sync.impl.internal.SyncInternalEnvDataStore
 import com.duckduckgo.sync.impl.promotion.SyncPromotionDataStore
 import com.duckduckgo.sync.impl.promotion.SyncPromotionDataStore.PromotionType.BookmarkAddedDialog
 import com.duckduckgo.sync.impl.promotion.SyncPromotionDataStore.PromotionType.BookmarksScreen
+import com.duckduckgo.sync.impl.promotion.SyncPromotionDataStore.PromotionType.ChatTabPage
 import com.duckduckgo.sync.impl.promotion.SyncPromotionDataStore.PromotionType.PasswordsScreen
 import com.duckduckgo.sync.internal.ui.SyncInternalSettingsViewModel.Command.ReadConnectQR
 import com.duckduckgo.sync.internal.ui.SyncInternalSettingsViewModel.Command.ReadQR
@@ -454,6 +455,13 @@ constructor(
         viewModelScope.launch {
             syncPromotionDataStore.clearPromoHistory(PasswordsScreen)
             command.send(ShowMessage("'Password screen' promo history cleared"))
+        }
+    }
+
+    fun onClearHistoryChatTabPagePromoClicked() {
+        viewModelScope.launch {
+            syncPromotionDataStore.clearPromoHistory(ChatTabPage)
+            command.send(ShowMessage("'Chat tab page' promo history cleared"))
         }
     }
 

--- a/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
+++ b/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
@@ -663,5 +663,12 @@
             android:layout_margin="10dp"
             android:text="@string/sync_internal_promotions_clear_history_password_screen_promo" />
 
+        <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+            android:id="@+id/clearHistoryChatTabPagePromo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:text="@string/sync_internal_promotions_clear_history_chat_tab_page_promo" />
+
     </LinearLayout>
 </ScrollView>

--- a/sync/sync-internal/src/main/res/values/donottranslate.xml
+++ b/sync/sync-internal/src/main/res/values/donottranslate.xml
@@ -38,6 +38,7 @@
     <string name="sync_internal_promotions_clear_history_bookmark_added_promo">Clear history (bookmark added dialog)</string>
     <string name="sync_internal_promotions_clear_history_bookmark_screen_promo">Clear history (bookmark screen)</string>
     <string name="sync_internal_promotions_clear_history_password_screen_promo">Clear history (password screen)</string>
+    <string name="sync_internal_promotions_clear_history_chat_tab_page_promo">Clear history (chat tab page)</string>
 
     <string name="sync_internal_launch_recover_data_screen">Launch Recover Data Screen</string>
     <string name="sync_internal_block_store_write_recovery_code">Save account recovery code &amp; device ID to Block Store</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215965303418144?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/481882893211075/task/1215842375041298?focus=true

### Description

Introduces `PromotionType.ChatTabPage` and adds impression-counting functions to `SyncPromotionDataStore`. This functionality will be used later to manage the Chat Sync banner state and to decide whether it should be displayed. I'm doing it as a separate step so it also includes dev tools for easier future testing.

### Steps to test this PR

Dev settings
- [ ] Go to Settings.
- [ ] Go to "Sync Dev Settings".
- [ ] Scroll to the bottom.
- [ ] You should see the "Clear history (chat tab page)" button.

### UI changes
| Before  | After |
| ------ | ----- |
| <img width="540" alt="image" src="https://github.com/user-attachments/assets/d6bf8feb-ac4a-4cba-b976-3ac389044a84" />  | <img width="540" alt="image" src="https://github.com/user-attachments/assets/d25931ba-dcc7-4e77-aac8-f3ac3b15d4c4" /> |


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local promo preference DataStore changes and internal dev settings only; no sync auth or production promo display logic yet.
> 
> **Overview**
> Extends **sync promotion persistence** for an upcoming Chat Sync banner: adds **`PromotionType.ChatTabPage`**, plus **`getPromoImpressionCount`** / **`recordPromoImpression`** on `SyncPromotionDataStore` for every promo type (including existing bookmark/password promos).
> 
> Dismiss and impression state are stored under **separate DataStore keys**; **`clearPromoHistory`** now wipes both dismiss and impression entries. Sync Dev Settings gains **Clear history (chat tab page)** wired like the other promo reset buttons.
> 
> Unit tests cover Chat tab dismiss/impression behavior and impression counting for all promotion types. No user-facing chat banner logic in this diff—storage and dev tooling only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47333f14e785afcce151839bdec7e5ebd8fd62a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->