### PR TITLE
Migrate Autofill E2E flows to the native input field

### DIFF
--- a/.maestro/autofill/3_autofill_prompted_to_save_creds_on_form.yaml
+++ b/.maestro/autofill/3_autofill_prompted_to_save_creds_on_form.yaml
@@ -13,8 +13,7 @@ tags:
         - runFlow: ../shared/skip_all_onboarding.yaml
 
         - tapOn:
-            id: "omnibarTextInput"
-        - eraseText
+            id: "inputField"
         - inputText: "fill.dev/form/login-simple"
         - pressKey: enter
 

--- a/.maestro/autofill/backfillingUsername/multi_step_login_username_backfilled.yaml
+++ b/.maestro/autofill/backfillingUsername/multi_step_login_username_backfilled.yaml
@@ -17,7 +17,7 @@ tags:
 
       # get to autofill form
       - tapOn:
-          id: "omnibarTextInput"
+          id: "inputField"
       - inputText: "https://autofill.me/form/login-simple"
       - pressKey: Enter
 

--- a/.maestro/autofill/backfillingUsername/multi_step_login_username_backfilled_for_an_update.yaml
+++ b/.maestro/autofill/backfillingUsername/multi_step_login_username_backfilled_for_an_update.yaml
@@ -20,7 +20,7 @@ tags:
 
       # get to autofill form
       - tapOn:
-          id: "omnibarTextInput"
+          id: "inputField"
       - inputText: "https://autofill.me/form/login-simple"
       - pressKey: Enter
       - runFlow: ../steps/decline_autofill_prompt.yaml

--- a/.maestro/autofill/backfillingUsername/multi_step_login_username_not_backfilled_if_provided_explicitly.yaml
+++ b/.maestro/autofill/backfillingUsername/multi_step_login_username_not_backfilled_if_provided_explicitly.yaml
@@ -17,7 +17,7 @@ tags:
 
       # get to autofill form
       - tapOn:
-          id: "omnibarTextInput"
+          id: "inputField"
       - inputText: "https://autofill.me/form/login-simple"
       - pressKey: Enter
 

--- a/.maestro/autofill/backfillingUsername/multi_step_registration_username_backfilled_password_autogenerated.yaml
+++ b/.maestro/autofill/backfillingUsername/multi_step_registration_username_backfilled_password_autogenerated.yaml
@@ -17,7 +17,7 @@ tags:
 
       # get to autofill form
       - tapOn:
-          id: "omnibarTextInput"
+          id: "inputField"
       - inputText: "https://autofill.me/form/registration-username"
       - pressKey: Enter
 

--- a/.maestro/autofill/backfillingUsername/multi_step_registration_username_backfilled_password_manually_entered.yaml
+++ b/.maestro/autofill/backfillingUsername/multi_step_registration_username_backfilled_password_manually_entered.yaml
@@ -17,7 +17,7 @@ tags:
 
       # get to autofill form
       - tapOn:
-          id: "omnibarTextInput"
+          id: "inputField"
       - inputText: "https://autofill.me/form/registration-username"
       - pressKey: Enter
 

--- a/.maestro/autofill/backfillingUsername/password_reset_flow_autogenerated_password.yaml
+++ b/.maestro/autofill/backfillingUsername/password_reset_flow_autogenerated_password.yaml
@@ -17,7 +17,7 @@ tags:
 
       # get to autofill login form
       - tapOn:
-          id: "omnibarTextInput"
+          id: "inputField"
       - inputText: "https://autofill.me/form/login-simple"
       - pressKey: Enter
 
@@ -35,7 +35,8 @@ tags:
 
       # get to password reset form
       - tapOn:
-          id: "com.duckduckgo.mobile.android:id/omnibarTextInput"
+          id: "com.duckduckgo.mobile.android:id/omnibarTextInputClickCatcher"
+      - eraseText
       - inputText: "https://autofill.me/form/change-password"
       - pressKey: Enter
       - runFlow: ../steps/decline_autofill_prompt.yaml

--- a/.maestro/autofill/backfillingUsername/password_reset_flow_for_existing_credential_generated_password.yaml
+++ b/.maestro/autofill/backfillingUsername/password_reset_flow_for_existing_credential_generated_password.yaml
@@ -17,7 +17,7 @@ tags:
 
       # get to autofill login form
       - tapOn:
-          id: "omnibarTextInput"
+          id: "inputField"
       - inputText: "https://autofill.me/form/login-simple"
       - pressKey: Enter
 
@@ -35,7 +35,8 @@ tags:
 
       # get to password reset form
       - tapOn:
-          id: "com.duckduckgo.mobile.android:id/omnibarTextInput"
+          id: "com.duckduckgo.mobile.android:id/omnibarTextInputClickCatcher"
+      - eraseText
       - inputText: "https://autofill.me/form/change-password"
       - pressKey: Enter
 

--- a/.maestro/autofill/backfillingUsername/password_reset_flow_for_existing_credential_manual_password.yaml
+++ b/.maestro/autofill/backfillingUsername/password_reset_flow_for_existing_credential_manual_password.yaml
@@ -20,7 +20,7 @@ tags:
 
       # get to autofill login form
       - tapOn:
-          id: "com.duckduckgo.mobile.android:id/omnibarTextInput"
+          id: "com.duckduckgo.mobile.android:id/inputField"
       - inputText: "https://autofill.me/form/login-simple"
       - pressKey: Enter
       - runFlow: ../steps/decline_autofill_prompt.yaml
@@ -36,7 +36,8 @@ tags:
 
       # get to password reset form
       - tapOn:
-          id: "com.duckduckgo.mobile.android:id/omnibarTextInput"
+          id: "com.duckduckgo.mobile.android:id/omnibarTextInputClickCatcher"
+      - eraseText
       - inputText: "https://autofill.me/form/change-password"
       - pressKey: Enter
       - runFlow: ../steps/decline_autofill_prompt.yaml

--- a/.maestro/autofill/passwordGeneration/autosaves_credential_when_password_generated_with_username.yaml
+++ b/.maestro/autofill/passwordGeneration/autosaves_credential_when_password_generated_with_username.yaml
@@ -17,7 +17,7 @@ tags:
 
       # get to autofill form
       - tapOn:
-          id: "omnibarTextInput"
+          id: "inputField"
       - inputText: "https://autofill.me/form/registration-username"
       - pressKey: Enter
 

--- a/.maestro/autofill/passwordGeneration/autosaves_credential_when_password_generated_without_username.yaml
+++ b/.maestro/autofill/passwordGeneration/autosaves_credential_when_password_generated_without_username.yaml
@@ -17,7 +17,7 @@ tags:
 
       # get to autofill form
       - tapOn:
-          id: "omnibarTextInput"
+          id: "inputField"
       - inputText: "https://autofill.me/form/registration-username"
       - pressKey: Enter
 


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/project/1200905986587319/task/1216050397312126?focus=true
Tech Design URL (if applicable):

### Description

Migrates the autofill Maestro E2E flows to the native unified input field, following the same pattern as #9016. When the privacy config enables native input, the legacy omnibarTextInput is
replaced by inputField on the new-tab page and becomes a disabled view behind an omnibarTextInputClickCatcher overlay on loaded pages, so flows driving omnibarTextInput directly failed with
Element not found.

Selector mapping applied:

- NTP / new tab (input widget auto-open) → tap inputField
- Loaded page, edit the URL → tap omnibarTextInputClickCatcher, then eraseText (field opens pre-filled), then type the new URL

Flows migrated (11):

- 3_autofill_prompted_to_save_creds_on_form
- passwordGeneration/ (×2)
- backfillingUsername/multi_step_* (×6)
- backfillingUsername/password_reset_flow_* (×3) — NTP first-tap plus the loaded-page URL edit when navigating to the change-password form

Left unchanged: steps/search_logins.yaml — its omnibarTextInput references are the password-manager's own search field (tapped after searchLogins), not the browser omnibar, so the

### Steps to test this PR

Cloud maestro tests should pass against this branch. 
OR
Running these locally should pass:
`./gradlew assemblePlayRelease -Pforce-default-variant -Pskip-onboarding -x lint -Pautofill-disable-auth-requirement`
`maestro test .maestro/autofill`

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Maestro YAML changes with no production or app logic impact.
> 
> **Overview**
> Updates **11 autofill Maestro flows** so they work with the **native unified omnibar** instead of the legacy `omnibarTextInput`, which is no longer tappable when native input is enabled.
> 
> **New-tab navigation** now taps `inputField` (and drops the extra `eraseText` where it was only needed for the old field). **In-page URL edits** (password-reset flows) tap `omnibarTextInputClickCatcher`, then **`eraseText`** before entering the change-password URL. One flow uses the fully qualified `com.duckduckgo.mobile.android:id/inputField` id.
> 
> Autofill test behavior is unchanged; only selectors and omnibar interaction steps were adjusted. Password-manager search steps were left alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49841555c1240660a8eb94819ff541737406c103. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->