### PR TITLE
enable Custom AI onboarding for all languages

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.app.onboarding
 
 import androidx.core.content.edit
 import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
-import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.data.store.api.SharedPreferencesProvider
 import com.duckduckgo.di.scopes.AppScope
@@ -36,7 +35,6 @@ import kotlinx.coroutines.withTimeoutOrNull
 import logcat.LogPriority.INFO
 import logcat.LogPriority.WARN
 import logcat.logcat
-import java.util.Locale
 import javax.inject.Inject
 
 interface CustomAiOnboardingStore {
@@ -87,7 +85,6 @@ class CustomAiOnboardingStoreImpl @Inject constructor(
     private val customAiOnboardingFeature: CustomAiOnboardingFeature,
     private val orchestratorFeature: LinearOnboardingOrchestratorFeature,
     private val brandDesignUpdateToggles: OnboardingBrandDesignUpdateToggles,
-    private val appBuildConfig: AppBuildConfig,
 ) : CustomAiOnboardingStore, CustomAiOnboardingResolver, ReferrerParserPlugin {
 
     private val preferences by lazy { sharedPreferencesProvider.getSharedPreferences(PREFS_FILENAME) }
@@ -112,10 +109,8 @@ class CustomAiOnboardingStoreImpl @Inject constructor(
             val customAiOnboardingEnabled = customAiOnboardingFeature.self().isEnabled()
             val orchestratorEnabled = orchestratorFeature.self().isEnabled()
             val brandDesignEnabled = brandDesignUpdateToggles.brandDesignUpdate().isEnabled()
-            // Only English strings exist for the custom AI onboarding, so restrict it to English locales for now.
-            val englishLocale = appBuildConfig.deviceLocale.language == Locale.ENGLISH.language
 
-            val resolution = referrerExists && customAiOnboardingEnabled && orchestratorEnabled && brandDesignEnabled && englishLocale
+            val resolution = referrerExists && customAiOnboardingEnabled && orchestratorEnabled && brandDesignEnabled
             preferences.edit { putBoolean(PREFS_KEY_ENABLED, resolution) }
 
             return@withContext resolution

--- a/app/src/test/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStoreImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStoreImplTest.kt
@@ -17,7 +17,6 @@
 package com.duckduckgo.app.onboarding
 
 import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
-import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.test.api.InMemorySharedPreferences
 import com.duckduckgo.data.store.api.SharedPreferencesProvider
@@ -36,7 +35,6 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import java.util.Locale
 
 class CustomAiOnboardingStoreImplTest {
 
@@ -53,7 +51,6 @@ class CustomAiOnboardingStoreImplTest {
     private val customAiOnboardingFeature: CustomAiOnboardingFeature = mock()
     private val orchestratorFeature: LinearOnboardingOrchestratorFeature = mock()
     private val brandDesignUpdateToggles: OnboardingBrandDesignUpdateToggles = mock()
-    private val appBuildConfig: AppBuildConfig = mock()
 
     private val resolvedListener = object : AppInstallationReferrerStateListener {
         override fun initialiseReferralRetrieval() {}
@@ -72,7 +69,6 @@ class CustomAiOnboardingStoreImplTest {
             customAiOnboardingFeature = customAiOnboardingFeature,
             orchestratorFeature = orchestratorFeature,
             brandDesignUpdateToggles = brandDesignUpdateToggles,
-            appBuildConfig = appBuildConfig,
         )
 
     @Before
@@ -80,7 +76,6 @@ class CustomAiOnboardingStoreImplTest {
         whenever(customAiOnboardingFeature.self()).thenReturn(enabledToggle)
         whenever(orchestratorFeature.self()).thenReturn(enabledToggle)
         whenever(brandDesignUpdateToggles.brandDesignUpdate()).thenReturn(enabledToggle)
-        whenever(appBuildConfig.deviceLocale).thenReturn(Locale.US)
     }
 
     @Test
@@ -112,22 +107,6 @@ class CustomAiOnboardingStoreImplTest {
         val store = store()
         store.process(mapOf("origin" to "funnel_playstore", "onboarding" to "ai"))
         assertFalse(store.resolve())
-    }
-
-    @Test
-    fun `when referrer ai but non-english locale then resolves false`() = runTest {
-        whenever(appBuildConfig.deviceLocale).thenReturn(Locale.FRANCE)
-        val store = store()
-        store.process(mapOf("origin" to "funnel_playstore", "onboarding" to "ai"))
-        assertFalse(store.resolve())
-    }
-
-    @Test
-    fun `when referrer ai and non-us english locale then resolves true`() = runTest {
-        whenever(appBuildConfig.deviceLocale).thenReturn(Locale.UK)
-        val store = store()
-        store.process(mapOf("origin" to "funnel_playstore", "onboarding" to "ai"))
-        assertTrue(store.resolve())
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1216068431861591?focus=true
Tech Design URL (if applicable): 

### Description
Enable Custom AI onboarding for all languages.

### Steps to test this PR
QA optional.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small onboarding eligibility change with no auth or data-path impact; main risk is showing AI onboarding where localized copy may still be incomplete.
> 
> **Overview**
> **Custom AI onboarding** no longer requires an English device locale when `CustomAiOnboardingStoreImpl.resolve()` decides whether to engage the plan.
> 
> The resolution gate is unchanged otherwise: Play referrer `onboarding=ai` must still be present and the custom AI, linear orchestrator, and brand design feature toggles must be on. **`AppBuildConfig`** is removed from the store constructor and related imports>
> tests that asserted locale behavior are deleted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c639ba06335cebc2b5231a72a5229a940b122b82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->