### PR TITLE
Updated Tab Switcher Info Panel icon

### DIFF
--- a/app/src/main/res/layout/item_tab_switcher_animation_info_panel.xml
+++ b/app/src/main/res/layout/item_tab_switcher_animation_info_panel.xml
@@ -66,7 +66,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:srcCompat="@drawable/ic_info_16"
+        app:srcCompat="@drawable/ic_close_16"
         app:tint="?attr/daxColorSecondaryIcon" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_tab_switcher_animation_info_panel.xml
+++ b/app/src/main/res/layout/item_tab_switcher_animation_info_panel.xml
@@ -61,7 +61,7 @@
         android:id="@+id/closeIcon"
         android:layout_width="16dp"
         android:layout_height="16dp"
-        android:layout_marginEnd="@dimen/keyline_4"
+        android:layout_marginEnd="14dp"
         android:importantForAccessibility="no"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/main/res/layout/item_tab_switcher_animation_info_panel.xml
+++ b/app/src/main/res/layout/item_tab_switcher_animation_info_panel.xml
@@ -49,7 +49,7 @@
         android:layout_marginBottom="@dimen/keyline_4"
         android:fontFeatureSettings="tnum"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/infoIcon"
+        app:layout_constraintEnd_toStartOf="@+id/closeIcon"
         app:layout_constraintStart_toEndOf="@+id/infoPanelAnimatedImage"
         app:layout_constraintTop_toTopOf="parent"
         app:textType="primary"
@@ -58,7 +58,7 @@
         tools:text="396 trackers blocked in the last 7 days" />
 
     <ImageView
-        android:id="@+id/infoIcon"
+        android:id="@+id/closeIcon"
         android:layout_width="16dp"
         android:layout_height="16dp"
         android:layout_marginEnd="@dimen/keyline_4"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1176956903599313/task/1215857978064235?focus=true
Tech Design URL (if applicable): 

### Description
Update info icon to a close one in tab switcher info panel

### Steps to test this PR

- [x] Install from branch
- [x] Open tabs
- [x] Go tab switcher
- [x] Check info panel icon is now X instead of an info icon

### UI changes
| Before  | After |
| ------ | ----- |
<img width="389" height="843" alt="Screenshot 2026-06-26 at 13 49 16" src="https://github.com/user-attachments/assets/8f4321bd-878a-4317-a9c8-3b1900e4c629" />|<img width="391" height="846" alt="Screenshot 2026-06-26 at 13 35 58" src="https://github.com/user-attachments/assets/83d7572f-e7d1-409d-9bd6-67381d4c0197" />|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only visual change with no logic updates; low risk unless other code still references the old `infoIcon` id (none found in this PR).
> 
> **Overview**
> Updates the tab switcher **tracker animation info panel** so the trailing control reads as **dismiss** instead of **more info**.
> 
> In `item_tab_switcher_animation_info_panel.xml`, the end `ImageView` is renamed from `infoIcon` to `closeIcon`, its drawable switches from `ic_info_16` to `ic_close_16`, and the end margin is set to **14dp** (was `@dimen/keyline_4`). The info text constraint is wired to `closeIcon` instead of `infoIcon`. Dismiss behavior is unchanged—the panel still uses the existing root click handler in `TabSwitcherAdapter`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac83f0c4caecb7b396b2333ca82057619f8e6309. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->