### PR TITLE
Set the chat sync feature flag to disabled by default

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/chat/ChatSyncPromoChatTabItemPlugin.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/chat/ChatSyncPromoChatTabItemPlugin.kt
@@ -40,7 +40,7 @@ import javax.inject.Inject
 @ContributesActivePlugin(
     scope = AppScope::class,
     boundType = NativeInputChatTabItemPlugin::class,
-    defaultActiveValue = DefaultFeatureValue.INTERNAL,
+    defaultActiveValue = DefaultFeatureValue.FALSE,
     priority = NativeInputChatTabItemPlugin.PRIORITY_PROMO,
     featureName = "pluginChatSyncPromoChatTabItemPlugin",
     parentFeatureName = "pluginPointNativeInputChatTabItemPlugin",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216069544570447?focus=true
Tech Design URL (if applicable): 

### Description

Disable the feature flag by default until the dismiss logic is merged and doesn't interfere with the onboarding.

### Steps to test this PR

Feature flag state
- [ ] In AI Features settings make sure that "Search & Duck.ai" is enabled.
- [ ] Go to the main screen.
- [ ] Tap the search bar.
- [ ] Switch to the chat tab.
- [ ] You should not see the chat sync promo.

### UI changes
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single annotation default change; no runtime logic changes, only whether the promo plugin is active by default.
> 
> **Overview**
> Sets **`defaultActiveValue`** on `ChatSyncPromoChatTabItemPlugin` from **`INTERNAL`** to **`FALSE`**, so the chat-tab sync promo is off by default for all users (including internal) until the plugin is explicitly enabled.
> 
> This keeps the promo from appearing during chat onboarding until dismiss behavior is ready and can be re-enabled remotely when appropriate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e71bc8b5e6f0b52ebde5b8e6552a9ebd9514e4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->