### PR TITLE
Update notification for free trial cancelation reminder

### DIFF
--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/notification/SubscriptionExpirationReminderNotification.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/notification/SubscriptionExpirationReminderNotification.kt
@@ -29,10 +29,11 @@ import com.duckduckgo.common.ui.view.getColorFromAttr
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
-import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionsSettingsScreenWithEmptyParams
 import com.duckduckgo.subscriptions.api.SubscriptionStatus
 import com.duckduckgo.subscriptions.api.Subscriptions
 import com.duckduckgo.subscriptions.impl.R
+import com.duckduckgo.subscriptions.impl.internal.SubscriptionsUrlProvider
+import com.duckduckgo.subscriptions.impl.ui.SubscriptionsWebViewActivityWithParams
 import com.squareup.anvil.annotations.ContributesMultibinding
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -42,6 +43,7 @@ class SubscriptionExpirationReminderNotification @Inject constructor(
     private val context: Context,
     private val subscriptions: Subscriptions,
     private val dispatcherProvider: DispatcherProvider,
+    private val reminderStore: SubscriptionExpirationReminderStore,
 ) : SchedulableNotification {
 
     override val id = "com.duckduckgo.subscriptions.expiration.reminder"
@@ -61,11 +63,17 @@ class SubscriptionExpirationReminderNotification @Inject constructor(
     }
 
     override suspend fun buildSpecification(): NotificationSpec {
-        return SubscriptionExpirationReminderNotificationSpecification(context)
+        return SubscriptionExpirationReminderNotificationSpecification(
+            context = context,
+            daysBeforeCancel = reminderStore.daysBeforeCancel ?: 0,
+        )
     }
 }
 
-class SubscriptionExpirationReminderNotificationSpecification(context: Context) : NotificationSpec {
+class SubscriptionExpirationReminderNotificationSpecification(
+    context: Context,
+    daysBeforeCancel: Int,
+) : NotificationSpec {
 
     override val channel = Channel(
         id = "com.duckduckgo.subscriptions.expiration.reminder",
@@ -75,7 +83,11 @@ class SubscriptionExpirationReminderNotificationSpecification(context: Context) 
     override val systemId = NOTIFICATION_SYSTEM_ID
     override val name = "Subscription Expiration Reminder"
     override val icon = com.duckduckgo.mobile.android.R.drawable.notification_logo
-    override val title: String = context.getString(R.string.subscriptionExpirationReminderNotificationTitle)
+    override val title: String = context.resources.getQuantityString(
+        R.plurals.subscriptionExpirationReminderNotificationTitle,
+        daysBeforeCancel,
+        daysBeforeCancel,
+    )
     override val description: String = context.getString(R.string.subscriptionExpirationReminderNotificationDescription)
     override val launchButton: String? = null
     override val closeButton: String? = null
@@ -96,6 +108,7 @@ class SubscriptionExpirationReminderNotificationPlugin @Inject constructor(
     private val schedulableNotification: SubscriptionExpirationReminderNotification,
     private val globalActivityStarter: GlobalActivityStarter,
     private val pixel: Pixel,
+    private val subscriptionsUrlProvider: SubscriptionsUrlProvider,
 ) : SchedulableNotificationPlugin {
 
     override fun getSchedulableNotification(): SchedulableNotification = schedulableNotification
@@ -115,7 +128,10 @@ class SubscriptionExpirationReminderNotificationPlugin @Inject constructor(
     }
 
     override suspend fun getLaunchIntent(): Intent? {
-        return globalActivityStarter.startIntent(context, SubscriptionsSettingsScreenWithEmptyParams)
+        return globalActivityStarter.startIntent(
+            context,
+            SubscriptionsWebViewActivityWithParams(url = subscriptionsUrlProvider.buyUrl),
+        )
     }
 
     companion object {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/notification/SubscriptionExpirationReminderScheduler.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/notification/SubscriptionExpirationReminderScheduler.kt
@@ -42,6 +42,7 @@ class SubscriptionExpirationReminderSchedulerImpl @Inject constructor(
     private val workManager: WorkManager,
     private val notificationManager: NotificationManagerCompat,
     private val subscriptionsManager: SubscriptionsManager,
+    private val reminderStore: SubscriptionExpirationReminderStore,
 ) : SubscriptionExpirationReminderScheduler {
 
     override suspend fun scheduleReminderNotification(daysBeforeCancel: Int) {
@@ -54,6 +55,8 @@ class SubscriptionExpirationReminderSchedulerImpl @Inject constructor(
         val delayMillis = expiresOrRenewsAt - TimeUnit.DAYS.toMillis(daysBeforeCancel.toLong()) - System.currentTimeMillis()
         if (delayMillis <= 0) return
 
+        reminderStore.daysBeforeCancel = daysBeforeCancel
+
         val request = OneTimeWorkRequestBuilder<SubscriptionExpirationReminderWorker>()
             .addTag(EXPIRATION_REMINDER_WORK_TAG)
             .setInitialDelay(delayMillis, TimeUnit.MILLISECONDS)
@@ -64,6 +67,7 @@ class SubscriptionExpirationReminderSchedulerImpl @Inject constructor(
 
     override fun cancelScheduledNotification() {
         workManager.cancelAllWorkByTag(EXPIRATION_REMINDER_WORK_TAG)
+        reminderStore.daysBeforeCancel = null
     }
 
     companion object {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/notification/SubscriptionExpirationReminderStore.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/notification/SubscriptionExpirationReminderStore.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.notification
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
+import com.duckduckgo.di.scopes.AppScope
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+@SingleInstanceIn(AppScope::class)
+class SubscriptionExpirationReminderStore @Inject constructor(
+    private val sharedPreferencesProvider: SharedPreferencesProvider,
+) {
+    private val preferences: SharedPreferences by lazy {
+        sharedPreferencesProvider.getSharedPreferences(FILENAME)
+    }
+
+    var daysBeforeCancel: Int?
+        get() = preferences.getInt(KEY_DAYS_BEFORE_CANCEL, -1).takeIf { it >= 0 }
+        set(value) {
+            preferences.edit {
+                if (value != null) {
+                    putInt(KEY_DAYS_BEFORE_CANCEL, value)
+                } else {
+                    remove(KEY_DAYS_BEFORE_CANCEL)
+                }
+            }
+        }
+
+    companion object {
+        const val FILENAME = "com.duckduckgo.subscriptions.expiration.reminder"
+        const val KEY_DAYS_BEFORE_CANCEL = "KEY_DAYS_BEFORE_CANCEL"
+    }
+}

--- a/subscriptions/subscriptions-impl/src/main/res/values/donottranslate.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values/donottranslate.xml
@@ -34,8 +34,8 @@
     <!-- Subscription Expiration Reminder Notification -->
     <string name="subscriptionExpirationReminderNotificationChannelName">Subscription Reminders</string>
     <plurals name="subscriptionExpirationReminderNotificationTitle" tools:ignore="ImpliedQuantity">
-        <item quantity="one">Your free trial ends in 1 day</item>
-        <item quantity="other" instruction="Placeholder is the number of days until the free trial ends">Your free trial ends in %1$d days</item>
+        <item quantity="one">Your trial ends in 1 day</item>
+        <item quantity="other" instruction="Placeholder is the number of days until the free trial ends">Your trial ends in %1$d days</item>
     </plurals>
     <string name="subscriptionExpirationReminderNotificationDescription">Try all your new premium protections before your trial ends!</string>
 

--- a/subscriptions/subscriptions-impl/src/main/res/values/donottranslate.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values/donottranslate.xml
@@ -14,7 +14,7 @@
   ~ limitations under the License.
   -->
 
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Personal Information Removal -->
     <string name="pirStorageUnavailableDialogTitle">Temporary issue with Personal Information Removal</string>
@@ -33,9 +33,9 @@
 
     <!-- Subscription Expiration Reminder Notification -->
     <string name="subscriptionExpirationReminderNotificationChannelName">Subscription Reminders</string>
-    <plurals name="subscriptionExpirationReminderNotificationTitle">
-        <item quantity="one">Your free trial ends in %d day</item>
-        <item quantity="other">Your free trial ends in %d days</item>
+    <plurals name="subscriptionExpirationReminderNotificationTitle" tools:ignore="ImpliedQuantity">
+        <item quantity="one">Your free trial ends in 1 day</item>
+        <item quantity="other" instruction="Placeholder is the number of days until the free trial ends">Your free trial ends in %1$d days</item>
     </plurals>
     <string name="subscriptionExpirationReminderNotificationDescription">Try all your new premium protections before your trial ends!</string>
 

--- a/subscriptions/subscriptions-impl/src/main/res/values/donottranslate.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values/donottranslate.xml
@@ -33,7 +33,10 @@
 
     <!-- Subscription Expiration Reminder Notification -->
     <string name="subscriptionExpirationReminderNotificationChannelName">Subscription Reminders</string>
-    <string name="subscriptionExpirationReminderNotificationTitle">Your Privacy Pro subscription is ending soon</string>
-    <string name="subscriptionExpirationReminderNotificationDescription">Tap to review your subscription and stay protected.</string>
+    <plurals name="subscriptionExpirationReminderNotificationTitle">
+        <item quantity="one">Your free trial ends in %d day</item>
+        <item quantity="other">Your free trial ends in %d days</item>
+    </plurals>
+    <string name="subscriptionExpirationReminderNotificationDescription">Try all your new premium protections before your trial ends!</string>
 
 </resources>

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/notification/SubscriptionExpirationReminderSchedulerImplTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/notification/SubscriptionExpirationReminderSchedulerImplTest.kt
@@ -37,6 +37,7 @@ class SubscriptionExpirationReminderSchedulerImplTest {
     private val workManager: WorkManager = mock()
     private val notificationManager: NotificationManagerCompat = mock()
     private val subscriptionsManager: SubscriptionsManager = mock()
+    private val reminderStore: SubscriptionExpirationReminderStore = mock()
 
     private lateinit var testee: SubscriptionExpirationReminderSchedulerImpl
 
@@ -46,6 +47,7 @@ class SubscriptionExpirationReminderSchedulerImplTest {
             workManager,
             notificationManager,
             subscriptionsManager,
+            reminderStore,
         )
     }
 
@@ -68,20 +70,22 @@ class SubscriptionExpirationReminderSchedulerImplTest {
     }
 
     @Test
-    fun whenAllConditionsMetThenNotificationScheduled() = runTest {
+    fun whenAllConditionsMetThenNotificationScheduledAndDaysBeforeCancelStored() = runTest {
         whenever(notificationManager.areNotificationsEnabled()).thenReturn(true)
         whenever(subscriptionsManager.getSubscription()).thenReturn(activeSubscriptionExpiringIn(days = 30))
 
         testee.scheduleReminderNotification(7)
 
+        verify(reminderStore).daysBeforeCancel = 7
         verify(workManager).enqueue(any<WorkRequest>())
     }
 
     @Test
-    fun whenCancelScheduledNotificationThenWorkCancelled() {
+    fun whenCancelScheduledNotificationThenWorkCancelledAndStoreCleared() {
         testee.cancelScheduledNotification()
 
         verify(workManager).cancelAllWorkByTag(SubscriptionExpirationReminderSchedulerImpl.EXPIRATION_REMINDER_WORK_TAG)
+        verify(reminderStore).daysBeforeCancel = null
     }
 
     private fun activeSubscriptionExpiringIn(days: Int): Subscription = Subscription(

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/notification/SubscriptionExpirationReminderStoreTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/notification/SubscriptionExpirationReminderStoreTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.notification
+
+import android.content.SharedPreferences
+import android.content.SharedPreferences.Editor
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class SubscriptionExpirationReminderStoreTest {
+
+    private val sharedPreferencesProvider: SharedPreferencesProvider = mock()
+    private val sharedPreferences: SharedPreferences = mock()
+    private val editor: Editor = mock()
+
+    private lateinit var testee: SubscriptionExpirationReminderStore
+
+    @Before
+    fun before() {
+        whenever(sharedPreferencesProvider.getSharedPreferences(SubscriptionExpirationReminderStore.FILENAME)).thenReturn(sharedPreferences)
+        whenever(sharedPreferences.edit()).thenReturn(editor)
+        whenever(editor.putInt(any(), any())).thenReturn(editor)
+        whenever(editor.remove(any())).thenReturn(editor)
+        testee = SubscriptionExpirationReminderStore(sharedPreferencesProvider)
+    }
+
+    @Test
+    fun whenDaysBeforeCancelNotStoredThenGetReturnsNull() {
+        whenever(sharedPreferences.getInt(SubscriptionExpirationReminderStore.KEY_DAYS_BEFORE_CANCEL, -1)).thenReturn(-1)
+
+        assertNull(testee.daysBeforeCancel)
+    }
+
+    @Test
+    fun whenDaysBeforeCancelStoredThenGetReturnsValue() {
+        whenever(sharedPreferences.getInt(SubscriptionExpirationReminderStore.KEY_DAYS_BEFORE_CANCEL, -1)).thenReturn(7)
+
+        assertEquals(7, testee.daysBeforeCancel)
+    }
+
+    @Test
+    fun whenSetDaysBeforeCancelThenEditorPutsValue() {
+        testee.daysBeforeCancel = 3
+
+        verify(editor).putInt(SubscriptionExpirationReminderStore.KEY_DAYS_BEFORE_CANCEL, 3)
+    }
+
+    @Test
+    fun whenSetDaysBeforeCancelToNullThenEditorRemovesKey() {
+        testee.daysBeforeCancel = null
+
+        verify(editor).remove(SubscriptionExpirationReminderStore.KEY_DAYS_BEFORE_CANCEL)
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215276633328686?focus=true
Tech Design URL (if applicable): 

### Description
Add latests spect to notification reminder for users that opt-in during purchase flow
1. Latest copy
2. Add daysBeforeCancel to notification title

### Steps to test this PR

_Pre steps_
- [x] Host index.html attached to https://app.asana.com/1/137249556945/project/1207260194172075/task/1215276633328686?focus=true (instructions in the next step)
- [x] Apply patch on https://app.asana.com/1/137249556945/project/1207260194172075/task/1215276633328686?focus=true. 
      - This will apply the staging environment for subscriptions
      - The subscription paywall will be redirected to a local test site that serves custom JS messages for testing notifications
      - To host the test site locally, put the provided `index.html` file in a folder on your laptop and run this command from that folder: `python3 -m http.server 8080`
      - Then replace the local URL (http://YOUR_IP:8080) in SubscriptionsWebViewActivity.kt line 300 so when subscription paywall is selected, the test site is loaded.
      - Make sure your laptop and Android device are connected to the same Wi-Fi network

_Notification updates_
- [x] Fresh install
- [x] Grant notification permissions in the first prompt
- [x] Skip onboarding
- [x] Go to Susbcriptions landing page -> will redirect to the custom site
- [x] Verify notification permissions will appear as granted
- [x] In section 2. Verify "Request notifications permissions" is disabled
- [x] In section 3 tap on 'Fire subscriptionSelected'
- [ ] Verify that notification is scheduled and fired in 10 seconds (or whatever you selected in section 2)
- [ ] Verify in the notification you see the Int you selected in section 1 (10, 20, etc)

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: notification UX, copy, and deep-link target only; scheduling logic is extended with persisted days-before-cancel without touching payment or auth flows.
> 
> **Overview**
> Updates the **subscription expiration reminder** for users who opt in during the purchase flow so it matches the free-trial cancelation spec: new title/description copy and a **dynamic title** that reflects how many days remain before the trial ends.
> 
> **`daysBeforeCancel`** is persisted when the reminder is scheduled via a new **`SubscriptionExpirationReminderStore`** (SharedPreferences) so the notification can still show the correct day count when WorkManager fires later; the store is cleared when scheduling is cancelled.
> 
> The notification **tap action** now opens the subscriptions **buy URL** in **`SubscriptionsWebViewActivityWithParams`** instead of subscription settings. Title strings move from a fixed string to **`R.plurals.subscriptionExpirationReminderNotificationTitle` with trial-focused wording (“Your trial ends in N days”); description is updated to the trial messaging as well.
> 
> Scheduler and store behavior is covered by extended unit tests; new **`SubscriptionExpirationReminderStoreTest`** and updated scheduler tests assert persistence and cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98be615aa60bc9e3b3d56fc66ca9c5005c6dee8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->