### PR TITLE
Update Copy and UI to reflect the latest changes

### DIFF
--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/dialog/RadioListAlertDialogBuilder.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/dialog/RadioListAlertDialogBuilder.kt
@@ -17,7 +17,16 @@
 package com.duckduckgo.common.ui.view.dialog
 
 import android.content.Context
+import android.text.Annotation
+import android.text.SpannableString
+import android.text.Spanned
+import android.text.SpannedString
+import android.text.method.LinkMovementMethod
+import android.text.style.ClickableSpan
+import android.text.style.ForegroundColorSpan
+import android.text.style.UnderlineSpan
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.RadioGroup
@@ -26,6 +35,7 @@ import androidx.appcompat.app.AlertDialog
 import com.duckduckgo.common.ui.view.button.ButtonType
 import com.duckduckgo.common.ui.view.button.DaxButton
 import com.duckduckgo.common.ui.view.button.RadioButton
+import com.duckduckgo.common.ui.view.getColorFromAttr
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.mobile.android.R
 import com.duckduckgo.mobile.android.databinding.DialogSingleChoiceAlertBinding
@@ -49,6 +59,7 @@ class RadioListAlertDialogBuilder(val context: Context) : DaxAlertDialog {
     private var listener: EventListener = DefaultEventListener()
     private var titleText: CharSequence = ""
     private var messageText: CharSequence = ""
+    private var messageClickable: Boolean = false
     private var positiveButtonText: CharSequence = ""
     private var positiveButtonType: ButtonType = ButtonType.PRIMARY
     private var negativeButtonText: CharSequence = ""
@@ -74,6 +85,47 @@ class RadioListAlertDialogBuilder(val context: Context) : DaxAlertDialog {
 
     fun setMessage(text: CharSequence): RadioListAlertDialogBuilder {
         messageText = text
+        return this
+    }
+
+    fun setClickableMessage(textSequence: CharSequence, annotation: String, onClick: () -> Unit): RadioListAlertDialogBuilder {
+        val fullText = textSequence as SpannedString
+        val spannableString = SpannableString(fullText)
+        val annotations = fullText.getSpans(0, fullText.length, Annotation::class.java)
+        val clickableSpan = object : ClickableSpan() {
+            override fun onClick(widget: View) {
+                onClick()
+            }
+        }
+
+        annotations?.find { it.value == annotation }?.let {
+            spannableString.apply {
+                setSpan(
+                    clickableSpan,
+                    fullText.getSpanStart(it),
+                    fullText.getSpanEnd(it),
+                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE,
+                )
+                setSpan(
+                    UnderlineSpan(),
+                    fullText.getSpanStart(it),
+                    fullText.getSpanEnd(it),
+                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE,
+                )
+                setSpan(
+                    ForegroundColorSpan(
+                        context.getColorFromAttr(R.attr.daxColorAccentBlue),
+                    ),
+                    fullText.getSpanStart(it),
+                    fullText.getSpanEnd(it),
+                    Spanned.SPAN_EXCLUSIVE_EXCLUSIVE,
+                )
+            }
+        }
+
+        messageText = spannableString
+        messageClickable = true
+
         return this
     }
 
@@ -170,6 +222,9 @@ class RadioListAlertDialogBuilder(val context: Context) : DaxAlertDialog {
             binding.radioListDialogMessage.gone()
         } else {
             binding.radioListDialogMessage.text = messageText
+            if (messageClickable) {
+                binding.radioListDialogMessage.movementMethod = LinkMovementMethod.getInstance()
+            }
         }
 
         optionList.forEachIndexed { index, option ->

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsActivity.kt
@@ -485,8 +485,13 @@ class DuckChatSettingsActivity : DuckDuckGoActivity() {
     private fun showHideAiGeneratedImagesDialog(current: HideAiGeneratedImages) {
         val options = hideAiGeneratedImagesOptions
         RadioListAlertDialogBuilder(this)
-            .setTitle(R.string.duckAiHideAiGeneratedImagesTitle)
-            .setMessage(R.string.duckAiHideAiGeneratedImagesDescription)
+            .setTitle(R.string.duckAiDialogHideAiGeneratedImagesTitle)
+            .setClickableMessage(
+                getText(R.string.duckAiDialogHideAiGeneratedImagesDescription),
+                "learn_more",
+            ) {
+                viewModel.onHideAiGeneratedImagesLearnMoreClicked()
+            }
             .setOptions(
                 options.map { it.toDisplayNameRes() },
                 options.indexOf(current).takeIf { index -> index >= 0 }?.plus(1),

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsActivity.kt
@@ -234,6 +234,13 @@ class DuckChatSettingsActivity : DuckDuckGoActivity() {
         )
 
         inputScreenSettingsBinding.duckAiInputScreenToggleContainer.isVisible = viewState.shouldShowInputScreenToggle
+        inputScreenSettingsBinding.duckAiInputScreenToggleWithAiText.text = getString(
+            if (viewState.isNativeControlsEnabled) {
+                R.string.input_screen_user_pref_toggle_between_search_and_ai
+            } else {
+                R.string.input_screen_user_pref_with_ai
+            },
+        )
         configureInputScreenToggle(
             withoutAi = InputScreenToggleButton.WithoutAi(isActive = !viewState.isInputScreenEnabled, appTheme.isLightModeEnabled()),
             withAi = InputScreenToggleButton.WithAi(isActive = viewState.isInputScreenEnabled, appTheme.isLightModeEnabled()),

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModel.kt
@@ -291,6 +291,17 @@ class DuckChatSettingsViewModel @AssistedInject constructor(
         }
     }
 
+    fun onHideAiGeneratedImagesLearnMoreClicked() {
+        viewModelScope.launch {
+            commandChannel.send(
+                OpenLink(
+                    link = DUCK_CHAT_HIDE_GENERATED_IMAGES_LEARN_MORE_LINK,
+                    titleRes = R.string.duckAiDialogHideAiGeneratedImagesTitle,
+                ),
+            )
+        }
+    }
+
     fun onHideAiGeneratedImagesSelected(option: HideAiGeneratedImages) {
         // Only report a value change; re-selecting the current option is a no-op for telemetry.
         if (option != viewState.value.hideAiGeneratedImages) {
@@ -412,5 +423,7 @@ class DuckChatSettingsViewModel @AssistedInject constructor(
             "https://duckduckgo.com/settings?ko=-1&embedded=1&highlight=kbe&hideduckai=1#aifeatures"
         const val DUCK_CHAT_HIDE_GENERATED_IMAGES_LINK_EMBEDDED =
             "https://duckduckgo.com/settings?ko=-1&embedded=1&highlight=kbj&hideduckai=1#aifeatures"
+        const val DUCK_CHAT_HIDE_GENERATED_IMAGES_LEARN_MORE_LINK =
+            "https://duckduckgo.com/duckduckgo-help-pages/results/how-to-filter-out-ai-images-in-duckduckgo-search-results"
     }
 }

--- a/duckchat/duckchat-impl/src/main/res/layout/include_duck_ai_input_screen_settings.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/include_duck_ai_input_screen_settings.xml
@@ -115,6 +115,7 @@
                 android:orientation="horizontal">
 
                 <com.duckduckgo.common.ui.view.text.DaxTextView
+                    android:id="@+id/duckAiInputScreenToggleWithAiText"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:gravity="center"

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -82,7 +82,7 @@
 
     <!-- Duck AI Use Without AI Settings Option -->
     <string name="duckAiUseWithoutAiTitle">Use DuckDuckGo Without AI</string>
-    <string name="duckAiUseWithoutAiDescription">Disables Duck.ai, hides AI-assisted answers in search, and hides AI-generated images in image search results.</string>
+    <string name="duckAiUseWithoutAiDescription">Disables Duck.ai, hides AI-assisted answers in search, and filters known AI spam sites in image search results.</string>
     <string name="duckAiUseWithoutAiDisabledDescription">AI is currently disabled in the Browser so you\'ll no longer see AI-assisted answers or AI-generated images in image search results.</string>
 
     <!-- Duck AI Section in AI Feature Screen -->

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -87,5 +87,7 @@
 
     <!-- Duck AI Section in AI Feature Screen -->
     <string name="input_screen_user_pref_toggle_between_search_and_ai">Toggle between Search and Duck.ai</string>
+    <string name="duckAiDialogHideAiGeneratedImagesTitle">Hide AI-Generated Images</string>
+    <string name="duckAiDialogHideAiGeneratedImagesDescription">Filters out known AI spam sites from image search results. <annotation link="learn_more">Learn more</annotation></string>
 
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -85,4 +85,7 @@
     <string name="duckAiUseWithoutAiDescription">Disables Duck.ai, hides AI-assisted answers in search, and hides AI-generated images in image search results.</string>
     <string name="duckAiUseWithoutAiDisabledDescription">AI is currently disabled in the Browser so you\'ll no longer see AI-assisted answers or AI-generated images in image search results.</string>
 
+    <!-- Duck AI Section in AI Feature Screen -->
+    <string name="input_screen_user_pref_toggle_between_search_and_ai">Toggle between Search and Duck.ai</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -83,7 +83,7 @@
     <!-- Duck AI Use Without AI Settings Option -->
     <string name="duckAiUseWithoutAiTitle">Use DuckDuckGo Without AI</string>
     <string name="duckAiUseWithoutAiDescription">Disables Duck.ai, hides AI-assisted answers in search, and filters known AI spam sites in image search results.</string>
-    <string name="duckAiUseWithoutAiDisabledDescription">AI is currently disabled in the Browser so you\'ll no longer see AI-assisted answers or AI-generated images in image search results.</string>
+    <string name="duckAiUseWithoutAiDisabledDescription">AI is currently disabled in the Browser so you’ll no longer see AI-assisted answers and see fewer AI-generated images in image search results.</string>
 
     <!-- Duck AI Section in AI Feature Screen -->
     <string name="input_screen_user_pref_toggle_between_search_and_ai">Toggle between Search and Duck.ai</string>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModelTest.kt
@@ -657,6 +657,24 @@ class DuckChatSettingsViewModelTest {
         }
 
     @Test
+    fun `when onHideAiGeneratedImagesLearnMoreClicked then OpenLink command with learn more link is emitted`() =
+        runTest {
+            testee.onHideAiGeneratedImagesLearnMoreClicked()
+
+            testee.commands.test {
+                val command = awaitItem()
+                assertTrue(command is OpenLink)
+                command as OpenLink
+                assertEquals(
+                    DuckChatSettingsViewModel.DUCK_CHAT_HIDE_GENERATED_IMAGES_LEARN_MORE_LINK,
+                    command.link,
+                )
+                assertEquals(R.string.duckAiDialogHideAiGeneratedImagesTitle, command.titleRes)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
     fun `when onDuckAiHideAiGeneratedImagesClicked and native controls enabled then ShowHideAiGeneratedImagesDialog emitted`() =
         runTest {
             @Suppress("DenyListedApi")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200581511062568/task/1216049683101111?focus=true
Tech Design URL (if applicable):

### Description

Updates [Duck.ai](http://Duck.ai) settings copy and UI to reflect the latest changes:

- Input screen toggle label — When the aiFeaturesNativeControls flag is enabled, the "with AI" toggle option now reads "Toggle between Search and [Duck.ai](http://Duck.ai)". When the flag is off, it keeps the existing "Search & [Duck.ai](http://Duck.ai)" label.
- "Use DuckDuckGo Without AI" copy — Reworded the enabled- and disabled-state descriptions to clarify that image search now filters known AI spam sites (rather than hiding all AI-generated images).
- "Hide AI-Generated Images" dialog — The description now ends with a tappable "Learn more" hyperlink that opens the help page in a WebView: https://duckduckgo.com/duckduckgo-help-pages/results/how-to-filter-out-ai-images-in-duckduckgo-search-results
This required adding setClickableMessage(...) support to the shared RadioListAlertDialogBuilder (mirroring the existing TextAlertDialogBuilder API), since the radio-list dialog previously had no way to render a clickable link in its message.

Added a unit test covering the new "Learn more" command emission.

### Steps to test this PR

1. Open Settings → AI Features
2. Toggle label (flag ON): With aiFeaturesNativeControls enabled, confirm the input-screen toggle shows "Toggle between Search and [Duck.ai](http://Duck.ai)". With the flag disabled, confirm it shows "Search & [Duck.ai](http://Duck.ai)".
3. "Use Without AI" copy: Verify the "Use DuckDuckGo Without AI" item description reads "…and filters known AI spam sites in image search results." Disable AI and confirm the disabled-state description reads "…and see fewer AI-generated images in image search results."
4. Learn more link: With aiFeaturesNativeControls enabled, tap Hide AI-Generated Images to open the native dialog. Confirm "Learn more" appears as a blue underlined link at the end of the description, and tapping it opens the help page in a WebView.
5. Confirm the rest of the dialog (ON/OFF radio options, Save/Cancel) still behaves correctly.

### UI changes

| Webpage opened from "Learn More" | New copy and "Learn More" link |
| --- | --- |
|<img width="1080" height="2424" alt="Screenshot_20260626_162728" src="https://github.com/user-attachments/assets/14b067e7-70c3-4285-9dba-f6e15c49383e" />|<img width="1080" height="2424" alt="Screenshot_20260626_162722" src="https://github.com/user-attachments/assets/ace79a5f-c08b-4e74-bfc4-ef0fe0c48b06" />|

|New copy for "Toggle Between Search and Duck.ai. New copy for Use DuckDuckGo Without AI (enabled) | New copy for Use DuckDuckGo Without AI (disabled) |
| --- | --- |
|<img width="1080" height="2424" alt="Screenshot_20260626_162648" src="https://github.com/user-attachments/assets/5656ce76-f5dd-498c-97d6-44e76df607e4" />|<img width="1080" height="2424" alt="Screenshot_20260626_162702" src="https://github.com/user-attachments/assets/61d61128-ba4f-4f51-8d17-1bb3670c60ae" />|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly strings, layout IDs, and a shared dialog helper patterned after existing TextAlertDialogBuilder; no auth, persistence, or SERP setting logic changes beyond opening a help URL.
> 
> **Overview**
> Updates **Duck.ai / AI Features** settings strings and UI to match current product messaging around image search filtering and the input-screen toggle.
> 
> **Shared dialog:** `RadioListAlertDialogBuilder` gains **`setClickableMessage(...)`** (annotation-based spans, accent styling, `LinkMovementMethod`) so radio-list dialogs can show tappable links like `TextAlertDialogBuilder` already does.
> 
> **Hide AI-Generated Images:** The native dialog uses new title/description strings; description includes a **Learn more** link that opens a help-page `OpenLink` via `onHideAiGeneratedImagesLearnMoreClicked()`.
> 
> **Input screen toggle:** When `aiFeaturesNativeControls` is on, the “with AI” caption is set at runtime to **“Toggle between Search and Duck.ai”** (layout exposes `duckAiInputScreenToggleWithAiText` for this).
> 
> **Copy:** “Use DuckDuckGo Without AI” enabled/disabled descriptions now describe **filtering known AI spam sites** / **fewer AI-generated images** rather than hiding all AI images.
> 
> A ViewModel unit test covers Learn more link command emission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fd3abf0b1b59769d800babaedd0baa0370794de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->