### PR TITLE
Added form factor to VPN entry point pixels

### DIFF
--- a/PixelDefinitions/pixels/definitions/network_protection.json5
+++ b/PixelDefinitions/pixels/definitions/network_protection.json5
@@ -3,21 +3,21 @@
         "description": "Fired when the VPN access revoked dialog is shown",
         "owners": ["nalcalag"],
         "triggers": ["other"],
-        "suffixes": ["daily_count_short"],
+        "suffixes": ["daily_count_short", "form_factor"],
         "parameters": ["appVersion"]
     },
     "m_netp_ev_vpn_access_revoked_dialog_subscribe_clicked": {
         "description": "Fired when the user taps the 'Subscribe' button on the VPN access revoked dialog",
         "owners": ["nalcalag"],
         "triggers": ["other"],
-        "suffixes": ["daily_count_short"],
+        "suffixes": ["daily_count_short", "form_factor"],
         "parameters": ["appVersion"]
     },
     "m_netp_ev_vpn_access_revoked_dialog_dismiss_clicked": {
         "description": "Fired when the user taps the 'Dismiss' button on the VPN access revoked dialog",
         "owners": ["nalcalag"],
         "triggers": ["other"],
-        "suffixes": ["daily_count_short"],
+        "suffixes": ["daily_count_short", "form_factor"],
         "parameters": ["appVersion"]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215886819037224?focus=true
Tech Design URL (if applicable): 

### Description
Update pixel definition from VPN entry point pixels to add form_factor

### Steps to test this PR
- [ ] N/A

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics definition-only change with no runtime logic, auth, or data-handling impact; no secrets in the diff.
> 
> **Overview**
> Adds the **`form_factor`** analytics suffix to all three VPN access revoked dialog pixels in `network_protection.json5` (`shown`, **Subscribe** click, **Dismiss** click), alongside the existing **`daily_count_short`** suffix.
> 
> This aligns those NetP entry-point events with other pixels that already segment by device form factor, so reporting can distinguish phone vs tablet (or equivalent) without changing app UI or event parameters beyond the generated pixel names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7c1eda7d3fff96b35ff0d5079f47daee49012ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->