### PR TITLE
Add translations for disabling AI

### DIFF
--- a/duckchat/duckchat-impl/src/main/res/values-bg/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-bg/strings-duckchat.xml
@@ -95,6 +95,24 @@
     <string name="duckAiHideAiGeneratedImagesTitle">Скриване на изображения, генерирани от изкуствен интелект</string>
     <string name="duckAiHideAiGeneratedImagesDescription">Филтрира в резултатите от търсенето изображенията, генерирани от изкуствен интелект</string>
 
+    <!-- Search Assist Visibility -->
+    <string name="duckAiSearchAssistVisibilityTitle">Видимост на Search Assist</string>
+    <string name="duckAiSearchAssistVisibilitySubtitle">Изберете колко често искате да се появяват отговори, подпомагани от изкуствен интелект, в търсенето.</string>
+    <string name="duckAiSearchAssistVisibilityNever">Никога</string>
+    <string name="duckAiSearchAssistVisibilityOnDemand">При поискване</string>
+    <string name="duckAiSearchAssistVisibilitySometimes">Понякога</string>
+    <string name="duckAiSearchAssistVisibilityOften">Често</string>
+
+    <!-- Duck AI Use Without AI Settings Option -->
+    <string name="duckAiUseWithoutAiTitle">Използвайте DuckDuckGo без AI</string>
+    <string name="duckAiUseWithoutAiDescription">Деактивира Duck.ai, скрива подпомогнатите от AI отговори в търсенето и филтрира известни спам AI сайтове в резултатите от търсенето на изображения.</string>
+    <string name="duckAiUseWithoutAiDisabledDescription">AI в момента е деактивиран в браузъра, затова вече няма да виждате подпомогнати от AI отговори и ще виждате по-малко генерирани от AI изображения в резултатите от търсенето на изображения.</string>
+
+    <!-- Duck AI Section in AI Feature Screen -->
+    <string name="input_screen_user_pref_toggle_between_search_and_ai">Превключвайте между\nТърсене и Duck.ai</string>
+    <string name="duckAiDialogHideAiGeneratedImagesTitle">Скриване на изображения, генерирани от изкуствен интелект</string>
+    <string name="duckAiDialogHideAiGeneratedImagesDescription">Филтрира известни спам AI сайтове в резултатите от търсенето на изображения. <annotation link="learn_more">Научете повече</annotation></string>
+
     <!-- Duck AI Paid Settings -->
     <string name="duck_ai_paid_settings_enable_in_settings">Активиране в настройките на AI функции</string>
     <string name="duck_ai_paid_settings_manage_in_settings">Управление на настройките на AI функциите</string>

--- a/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
@@ -202,10 +202,4 @@
     <string name="duck_ai_chat_history_download_view">Zobrazit</string>
     <string name="duck_ai_chat_history_download_error">Nepodařilo se exportovat chat</string>
     <string name="duck_ai_chat_history_bulk_download_error">Nepodařilo se exportovat chaty</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
@@ -95,6 +95,24 @@
     <string name="duckAiHideAiGeneratedImagesTitle">Skrýt obrázky vygenerované umělou inteligencí</string>
     <string name="duckAiHideAiGeneratedImagesDescription">Odstraní obrázky vytvořené umělou inteligencí z výsledků vyhledávání obrázků</string>
 
+    <!-- Search Assist Visibility -->
+    <string name="duckAiSearchAssistVisibilityTitle">Viditelnost Search Assist</string>
+    <string name="duckAiSearchAssistVisibilitySubtitle">Vyber, jak často chceš, aby se odpovědi s podporou umělé inteligence zobrazovaly ve tvých vyhledáváních.</string>
+    <string name="duckAiSearchAssistVisibilityNever">Nikdy</string>
+    <string name="duckAiSearchAssistVisibilityOnDemand">Na vyžádání</string>
+    <string name="duckAiSearchAssistVisibilitySometimes">Někdy</string>
+    <string name="duckAiSearchAssistVisibilityOften">Často</string>
+
+    <!-- Duck AI Use Without AI Settings Option -->
+    <string name="duckAiUseWithoutAiTitle">Používat DuckDuckGo bez umělé inteligence</string>
+    <string name="duckAiUseWithoutAiDescription">Zakáže Duck.ai, skryje ve vyhledávání odpovědi generované AI a vyfiltruje známé weby s AI spamem z výsledků vyhledávání obrázků.</string>
+    <string name="duckAiUseWithoutAiDisabledDescription">AI je v prohlížeči momentálně zakázaná. Proto v něm neuvidíš odpovědi, které generovala umělá inteligence, a zobrazí se ti méně obrázků generovaných umělou inteligencí ve výsledcích vyhledávání obrázků.</string>
+
+    <!-- Duck AI Section in AI Feature Screen -->
+    <string name="input_screen_user_pref_toggle_between_search_and_ai">Přepínání mezi vyhledáváním a Duck.ai</string>
+    <string name="duckAiDialogHideAiGeneratedImagesTitle">Skrýt obrázky vygenerované AI</string>
+    <string name="duckAiDialogHideAiGeneratedImagesDescription">Vyfiltruje známé weby s AI spamem z výsledků vyhledávání obrázků. <annotation link="learn_more">Další informace</annotation></string>
+
     <!-- Duck AI Paid Settings -->
     <string name="duck_ai_paid_settings_enable_in_settings">Povolit v nastavení funkcí AI</string>
     <string name="duck_ai_paid_settings_manage_in_settings">Spravovat v nastavení funkcí AI</string>
@@ -184,4 +202,10 @@
     <string name="duck_ai_chat_history_download_view">Zobrazit</string>
     <string name="duck_ai_chat_history_download_error">Nepodařilo se exportovat chat</string>
     <string name="duck_ai_chat_history_bulk_download_error">Nepodařilo se exportovat chaty</string>
+
+    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
+         users, so these are not localized (translatable="false"). Delete with the example. -->
+    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
+    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
+    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-da/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-da/strings-duckchat.xml
@@ -200,10 +200,4 @@
     <string name="duck_ai_chat_history_download_view">Vis</string>
     <string name="duck_ai_chat_history_download_error">Kunne ikke eksportere chat</string>
     <string name="duck_ai_chat_history_bulk_download_error">Kunne ikke eksportere chats</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-da/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-da/strings-duckchat.xml
@@ -95,6 +95,24 @@
     <string name="duckAiHideAiGeneratedImagesTitle">Skjul AI-genererede billeder</string>
     <string name="duckAiHideAiGeneratedImagesDescription">Filtrerer AI-genererede billeder fra billedsøgeresultater</string>
 
+    <!-- Search Assist Visibility -->
+    <string name="duckAiSearchAssistVisibilityTitle">Synlighed i Search Assist</string>
+    <string name="duckAiSearchAssistVisibilitySubtitle">Vælg, hvor ofte du vil have AI-assisterede svar til at optræde i dine søgninger.</string>
+    <string name="duckAiSearchAssistVisibilityNever">Aldrig</string>
+    <string name="duckAiSearchAssistVisibilityOnDemand">On demand</string>
+    <string name="duckAiSearchAssistVisibilitySometimes">Nogle gange</string>
+    <string name="duckAiSearchAssistVisibilityOften">Ofte</string>
+
+    <!-- Duck AI Use Without AI Settings Option -->
+    <string name="duckAiUseWithoutAiTitle">Brug DuckDuckGo uden AI</string>
+    <string name="duckAiUseWithoutAiDescription">Deaktiverer Duck.ai, skjuler AI-assisterede svar i søgninger og filtrerer kendte AI-spamsider fra i billedsøgeresultater.</string>
+    <string name="duckAiUseWithoutAiDisabledDescription">AI er i øjeblikket deaktiveret i browseren, så du ikke længere får vist AI-assisterede svar og vil se færre AI-genererede billeder i billedsøgeresultater.</string>
+
+    <!-- Duck AI Section in AI Feature Screen -->
+    <string name="input_screen_user_pref_toggle_between_search_and_ai">Skift mellem\nSøgning og Duck.ai</string>
+    <string name="duckAiDialogHideAiGeneratedImagesTitle">Skjul AI-genererede billeder</string>
+    <string name="duckAiDialogHideAiGeneratedImagesDescription">Filtrerer kendte AI-spamsider fra billedsøgeresultater. <annotation link="learn_more">Læs mere</annotation></string>
+
     <!-- Duck AI Paid Settings -->
     <string name="duck_ai_paid_settings_enable_in_settings">Aktivér i indstillinger for AI-funktioner</string>
     <string name="duck_ai_paid_settings_manage_in_settings">Administrer i indstillinger for AI-funktioner</string>
@@ -182,4 +200,10 @@
     <string name="duck_ai_chat_history_download_view">Vis</string>
     <string name="duck_ai_chat_history_download_error">Kunne ikke eksportere chat</string>
     <string name="duck_ai_chat_history_bulk_download_error">Kunne ikke eksportere chats</string>
+
+    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
+         users, so these are not localized (translatable="false"). Delete with the example. -->
+    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
+    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
+    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-de/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-de/strings-duckchat.xml
@@ -200,10 +200,4 @@
     <string name="duck_ai_chat_history_download_view">Anzeigen</string>
     <string name="duck_ai_chat_history_download_error">Chat konnte nicht exportiert werden</string>
     <string name="duck_ai_chat_history_bulk_download_error">Chats konnten nicht exportiert werden</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-de/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-de/strings-duckchat.xml
@@ -95,6 +95,24 @@
     <string name="duckAiHideAiGeneratedImagesTitle">AI-generierte Bilder ausblenden</string>
     <string name="duckAiHideAiGeneratedImagesDescription">Filtert KI-generierte Bilder aus den Ergebnissen der Bildersuche</string>
 
+    <!-- Search Assist Visibility -->
+    <string name="duckAiSearchAssistVisibilityTitle">Sichtbarkeit von Search Assist</string>
+    <string name="duckAiSearchAssistVisibilitySubtitle">Du kannst auswählen, wie oft KI-gestützte Antworten in deinen Suchergebnissen angezeigt werden sollen.</string>
+    <string name="duckAiSearchAssistVisibilityNever">Nie</string>
+    <string name="duckAiSearchAssistVisibilityOnDemand">Auf Anfrage</string>
+    <string name="duckAiSearchAssistVisibilitySometimes">Manchmal</string>
+    <string name="duckAiSearchAssistVisibilityOften">Häufig</string>
+
+    <!-- Duck AI Use Without AI Settings Option -->
+    <string name="duckAiUseWithoutAiTitle">DuckDuckGo ohne KI verwenden</string>
+    <string name="duckAiUseWithoutAiDescription">Deaktiviert Duck.ai, verbirgt KI-gestützte Antworten in der Suche und filtert bekannte KI-Spam-Websites in den Ergebnissen der Bildsuche.</string>
+    <string name="duckAiUseWithoutAiDisabledDescription">KI ist im Browser derzeit deaktiviert, sodass dir keine KI-gestützten Antworten mehr angezeigt werden und du in den Bildersuchergebnissen weniger von der KI generierte Bilder siehst.</string>
+
+    <!-- Duck AI Section in AI Feature Screen -->
+    <string name="input_screen_user_pref_toggle_between_search_and_ai">Wechseln zwischen Suche und Duck.ai</string>
+    <string name="duckAiDialogHideAiGeneratedImagesTitle">KI-generierte Bilder ausblenden</string>
+    <string name="duckAiDialogHideAiGeneratedImagesDescription">Filtert bekannte KI-Spam-Websites aus den Bildersuchergebnissen heraus. <annotation link="learn_more">Mehr erfahren</annotation></string>
+
     <!-- Duck AI Paid Settings -->
     <string name="duck_ai_paid_settings_enable_in_settings">In Einstellungen für KI-Funktionen aktivieren</string>
     <string name="duck_ai_paid_settings_manage_in_settings">In Einstellungen für KI-Funktionen verwalten</string>
@@ -182,4 +200,10 @@
     <string name="duck_ai_chat_history_download_view">Anzeigen</string>
     <string name="duck_ai_chat_history_download_error">Chat konnte nicht exportiert werden</string>
     <string name="duck_ai_chat_history_bulk_download_error">Chats konnten nicht exportiert werden</string>
+
+    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
+         users, so these are not localized (translatable="false"). Delete with the example. -->
+    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
+    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
+    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-el/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-el/strings-duckchat.xml
@@ -95,6 +95,24 @@
     <string name="duckAiHideAiGeneratedImagesTitle">Απόκρυψη εικόνων που δημιουργήθηκαν με τεχνητή νοημοσύνη</string>
     <string name="duckAiHideAiGeneratedImagesDescription">Φιλτράρει τις εικόνες που δημιουργούνται με τεχνητή νοημοσύνη από τα αποτελέσματα αναζήτησης εικόνων</string>
 
+    <!-- Search Assist Visibility -->
+    <string name="duckAiSearchAssistVisibilityTitle">Ορατότητα Search Assist</string>
+    <string name="duckAiSearchAssistVisibilitySubtitle">Επιλέξτε πόσο συχνά θέλετε να εμφανίζονται οι απαντήσεις που υποστηρίζονται από τεχνητή νοημοσύνη στις αναζητήσεις σας.</string>
+    <string name="duckAiSearchAssistVisibilityNever">Ποτέ</string>
+    <string name="duckAiSearchAssistVisibilityOnDemand">Κατ\' απαίτηση</string>
+    <string name="duckAiSearchAssistVisibilitySometimes">Μερικές φορές</string>
+    <string name="duckAiSearchAssistVisibilityOften">Συχνά</string>
+
+    <!-- Duck AI Use Without AI Settings Option -->
+    <string name="duckAiUseWithoutAiTitle">Χρησιμοποιήστε το DuckDuckGo χωρίς AI</string>
+    <string name="duckAiUseWithoutAiDescription">Απενεργοποιεί το Duck.ai, αποκρύπτει από την αναζήτηση απαντήσεις που υποβοηθούνται από τεχνητή νοημοσύνη και φιλτράρει γνωστούς ιστότοπους με απατηλό περιεχόμενο τεχνητής νοημοσύνης στα αποτελέσματα αναζήτησης εικόνων.</string>
+    <string name="duckAiUseWithoutAiDisabledDescription">Η τεχνητή νοημοσύνη είναι προς το παρόν απενεργοποιημένη στο πρόγραμμα περιήγησης, επομένως δεν θα βλέπετε πλέον απαντήσεις που υποβοηθούνται από τεχνητή νοημοσύνη και θα βλέπετε λιγότερες εικόνες που δημιουργούνται από τεχνητή νοημοσύνη στα αποτελέσματα αναζήτησης εικόνων.</string>
+
+    <!-- Duck AI Section in AI Feature Screen -->
+    <string name="input_screen_user_pref_toggle_between_search_and_ai">Εναλλαγή μεταξύ Αναζήτησης και Duck.ai</string>
+    <string name="duckAiDialogHideAiGeneratedImagesTitle">Απόκρυψη εικόνων που δημιουργήθηκαν με τεχνητή νοημοσύνη</string>
+    <string name="duckAiDialogHideAiGeneratedImagesDescription">Αποκλείει γνωστούς ιστότοπους με απατηλό περιεχόμενο τεχνητής νοημοσύνης από τα αποτελέσματα αναζήτησης εικόνων. <annotation link="learn_more">Μάθετε περισσότερα</annotation></string>
+
     <!-- Duck AI Paid Settings -->
     <string name="duck_ai_paid_settings_enable_in_settings">Ενεργοποίηση στις Ρυθμίσεις λειτουργιών τεχνητής νοημοσύνης</string>
     <string name="duck_ai_paid_settings_manage_in_settings">Διαχείριση στις Ρυθμίσεις λειτουργιών τεχνητής νοημοσύνης</string>
@@ -182,4 +200,10 @@
     <string name="duck_ai_chat_history_download_view">Εμφάνιση</string>
     <string name="duck_ai_chat_history_download_error">Δεν ήταν δυνατή η εξαγωγή της συνομιλίας</string>
     <string name="duck_ai_chat_history_bulk_download_error">Δεν ήταν δυνατή η εξαγωγή των συνομιλιών</string>
+
+    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
+         users, so these are not localized (translatable="false"). Delete with the example. -->
+    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
+    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
+    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-el/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-el/strings-duckchat.xml
@@ -200,10 +200,4 @@
     <string name="duck_ai_chat_history_download_view">Εμφάνιση</string>
     <string name="duck_ai_chat_history_download_error">Δεν ήταν δυνατή η εξαγωγή της συνομιλίας</string>
     <string name="duck_ai_chat_history_bulk_download_error">Δεν ήταν δυνατή η εξαγωγή των συνομιλιών</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
@@ -200,10 +200,4 @@
     <string name="duck_ai_chat_history_download_view">Mostrar</string>
     <string name="duck_ai_chat_history_download_error">No se pudo exportar el chat</string>
     <string name="duck_ai_chat_history_bulk_download_error">No se pudieron exportar los chats</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
@@ -95,6 +95,24 @@
     <string name="duckAiHideAiGeneratedImagesTitle">Ocultar imágenes generadas por IA</string>
     <string name="duckAiHideAiGeneratedImagesDescription">Filtra las imágenes generadas por IA de los resultados de búsqueda de imágenes</string>
 
+    <!-- Search Assist Visibility -->
+    <string name="duckAiSearchAssistVisibilityTitle">Visibilidad de Search Assist</string>
+    <string name="duckAiSearchAssistVisibilitySubtitle">Elige con qué frecuencia deseas que las respuestas asistidas por IA aparezcan en tus búsquedas.</string>
+    <string name="duckAiSearchAssistVisibilityNever">Nunca</string>
+    <string name="duckAiSearchAssistVisibilityOnDemand">A la carta</string>
+    <string name="duckAiSearchAssistVisibilitySometimes">A veces</string>
+    <string name="duckAiSearchAssistVisibilityOften">A menudo</string>
+
+    <!-- Duck AI Use Without AI Settings Option -->
+    <string name="duckAiUseWithoutAiTitle">Usar DuckDuckGo sin IA</string>
+    <string name="duckAiUseWithoutAiDescription">Desactiva Duck.ai, oculta las respuestas asistidas por IA en las búsquedas y filtra los sitios de spam de IA conocidos en los resultados de búsqueda de imágenes.</string>
+    <string name="duckAiUseWithoutAiDisabledDescription">La IA está actualmente deshabilitada en el navegador, por lo que ya no verás respuestas asistidas por IA y menos imágenes generadas por IA en los resultados de búsqueda de imágenes.</string>
+
+    <!-- Duck AI Section in AI Feature Screen -->
+    <string name="input_screen_user_pref_toggle_between_search_and_ai">Alterna entre la búsqueda y Duck.ai</string>
+    <string name="duckAiDialogHideAiGeneratedImagesTitle">Ocultar imágenes generadas por IA</string>
+    <string name="duckAiDialogHideAiGeneratedImagesDescription">Filtra los sitios de spam de IA conocidos de los resultados de búsqueda de imágenes. <annotation link="learn_more">Más información</annotation></string>
+
     <!-- Duck AI Paid Settings -->
     <string name="duck_ai_paid_settings_enable_in_settings">Habilitar en la configuración de funciones de IA</string>
     <string name="duck_ai_paid_settings_manage_in_settings">Administrar en la configuración de funciones de IA</string>
@@ -182,4 +200,10 @@
     <string name="duck_ai_chat_history_download_view">Mostrar</string>
     <string name="duck_ai_chat_history_download_error">No se pudo exportar el chat</string>
     <string name="duck_ai_chat_history_bulk_download_error">No se pudieron exportar los chats</string>
+
+    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
+         users, so these are not localized (translatable="false"). Delete with the example. -->
+    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
+    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
+    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
@@ -200,10 +200,4 @@
     <string name="duck_ai_chat_history_download_view">Kuva</string>
     <string name="duck_ai_chat_history_download_error">Vestlust ei õnnestunud eksportida</string>
     <string name="duck_ai_chat_history_bulk_download_error">Vestlusi ei õnnestunud eksportida</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
@@ -95,6 +95,24 @@
     <string name="duckAiHideAiGeneratedImagesTitle">Peida AI loodud pildid</string>
     <string name="duckAiHideAiGeneratedImagesDescription">Eemaldab tehisintellekti loodud pildid pildiotsingu tulemustest</string>
 
+    <!-- Search Assist Visibility -->
+    <string name="duckAiSearchAssistVisibilityTitle">Search Assisti nähtavus</string>
+    <string name="duckAiSearchAssistVisibilitySubtitle">Vali, kui tihti soovid tehisintellekti abil saadud vastuseid oma otsingutes kuvada.</string>
+    <string name="duckAiSearchAssistVisibilityNever">Mitte kunagi</string>
+    <string name="duckAiSearchAssistVisibilityOnDemand">Nõudmisel</string>
+    <string name="duckAiSearchAssistVisibilitySometimes">Mõnikord</string>
+    <string name="duckAiSearchAssistVisibilityOften">Sageli</string>
+
+    <!-- Duck AI Use Without AI Settings Option -->
+    <string name="duckAiUseWithoutAiTitle">Kasuta DuckDuckGo-d ilma tehisintellektita</string>
+    <string name="duckAiUseWithoutAiDescription">Keelab Duck.ai, peidab otsingus tehisintellektiga toetatud vastused ja filtreerib pildiotsingu tulemustest teadaolevaid tehisintellekti rämpsposti saite.</string>
+    <string name="duckAiUseWithoutAiDisabledDescription">Tehisintellekt on brauseris praegu keelatud, seega sa ei näe enam tehisintellekti abil saadud vastuseid ja näed pildiotsingu tulemustes vähem tehisintellekti loodud pilte.</string>
+
+    <!-- Duck AI Section in AI Feature Screen -->
+    <string name="input_screen_user_pref_toggle_between_search_and_ai">Lülita otsingu ja Duck.ai vahel</string>
+    <string name="duckAiDialogHideAiGeneratedImagesTitle">Peida tehisintellekti loodud pildid</string>
+    <string name="duckAiDialogHideAiGeneratedImagesDescription">Filtreerib pildiotsingu tulemustest välja teadaolevad tehisintellekti rämpsposti saidid. <annotation link="learn_more">Lisateave</annotation></string>
+
     <!-- Duck AI Paid Settings -->
     <string name="duck_ai_paid_settings_enable_in_settings">Luba tehisintellekti funktsioonide seadetes</string>
     <string name="duck_ai_paid_settings_manage_in_settings">Halda tehisintellekti funktsioonide seadetes</string>
@@ -182,4 +200,10 @@
     <string name="duck_ai_chat_history_download_view">Kuva</string>
     <string name="duck_ai_chat_history_download_error">Vestlust ei õnnestunud eksportida</string>
     <string name="duck_ai_chat_history_bulk_download_error">Vestlusi ei õnnestunud eksportida</string>
+
+    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
+         users, so these are not localized (translatable="false"). Delete with the example. -->
+    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
+    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
+    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-fi/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fi/strings-duckchat.xml
@@ -95,6 +95,24 @@
     <string name="duckAiHideAiGeneratedImagesTitle">Piilota tekoälyn luomat kuvat</string>
     <string name="duckAiHideAiGeneratedImagesDescription">Suodattaa pois tekoälyn luomat kuvat kuvahaun tuloksista</string>
 
+    <!-- Search Assist Visibility -->
+    <string name="duckAiSearchAssistVisibilityTitle">Search Assist -näkyvyys</string>
+    <string name="duckAiSearchAssistVisibilitySubtitle">Valitse, kuinka usein haluat tekoälyavusteisten vastausten näkyvän hauissasi.</string>
+    <string name="duckAiSearchAssistVisibilityNever">Ei koskaan</string>
+    <string name="duckAiSearchAssistVisibilityOnDemand">Pyynnöstä</string>
+    <string name="duckAiSearchAssistVisibilitySometimes">Joskus</string>
+    <string name="duckAiSearchAssistVisibilityOften">Usein</string>
+
+    <!-- Duck AI Use Without AI Settings Option -->
+    <string name="duckAiUseWithoutAiTitle">Käytä DuckDuckGo:ta ilman tekoälyä</string>
+    <string name="duckAiUseWithoutAiDescription">Poistaa Duck.ai:n käytöstä, piilottaa tekoälyavusteiset vastaukset haussa ja suodattaa tunnetut tekoälyroskapostisivustot kuvahaun tuloksista.</string>
+    <string name="duckAiUseWithoutAiDisabledDescription">Tekoäly on tällä hetkellä poistettu käytöstä selaimessa, joten et enää näe tekoälyavusteisia vastauksia ja näet vähemmän tekoälyn luomia kuvia kuvahaun tuloksissa.</string>
+
+    <!-- Duck AI Section in AI Feature Screen -->
+    <string name="input_screen_user_pref_toggle_between_search_and_ai">Vaihda haun ja Duck.ai:n välillä</string>
+    <string name="duckAiDialogHideAiGeneratedImagesTitle">Piilota tekoälyn luomat kuvat</string>
+    <string name="duckAiDialogHideAiGeneratedImagesDescription">Suodattaa pois tunnetut tekoälyroskapostisivustot kuvahaun tuloksista. <annotation link="learn_more">Lue lisää</annotation></string>
+
     <!-- Duck AI Paid Settings -->
     <string name="duck_ai_paid_settings_enable_in_settings">Ota käyttöön tekoälyominaisuuksien asetuksissa</string>
     <string name="duck_ai_paid_settings_manage_in_settings">Hallinnoi tekoälyominaisuuksien asetuksissa</string>

--- a/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
@@ -200,10 +200,4 @@
     <string name="duck_ai_chat_history_download_view">Afficher</string>
     <string name="duck_ai_chat_history_download_error">Impossible d\'exporter la discussion</string>
     <string name="duck_ai_chat_history_bulk_download_error">Impossible d\'exporter les discussions</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
@@ -95,6 +95,24 @@
     <string name="duckAiHideAiGeneratedImagesTitle">Masquer les images générées par l\'IA</string>
     <string name="duckAiHideAiGeneratedImagesDescription">Filtre les images générées par l\'IA des résultats de recherche d\'images</string>
 
+    <!-- Search Assist Visibility -->
+    <string name="duckAiSearchAssistVisibilityTitle">Visibilité de Search Assist</string>
+    <string name="duckAiSearchAssistVisibilitySubtitle">Choisissez la fréquence à laquelle vous souhaitez que les réponses assistées par l\'IA apparaissent dans vos recherches.</string>
+    <string name="duckAiSearchAssistVisibilityNever">Jamais</string>
+    <string name="duckAiSearchAssistVisibilityOnDemand">À la demande</string>
+    <string name="duckAiSearchAssistVisibilitySometimes">Parfois</string>
+    <string name="duckAiSearchAssistVisibilityOften">Souvent</string>
+
+    <!-- Duck AI Use Without AI Settings Option -->
+    <string name="duckAiUseWithoutAiTitle">Utiliser DuckDuckGo sans IA</string>
+    <string name="duckAiUseWithoutAiDescription">Désactive Duck.ai, masque les réponses assistées par l\'IA dans la recherche et filtre les sites de spam liés à l\'IA dans les résultats de recherche d\'images.</string>
+    <string name="duckAiUseWithoutAiDisabledDescription">L\'IA est actuellement désactivée dans le navigateur, vous ne verrez donc plus de réponses assistées par l\'IA et vous verrez moins d\'images générées par l\'IA dans les résultats de recherche d\'images.</string>
+
+    <!-- Duck AI Section in AI Feature Screen -->
+    <string name="input_screen_user_pref_toggle_between_search_and_ai">Basculer entre la recherche et Duck.ai</string>
+    <string name="duckAiDialogHideAiGeneratedImagesTitle">Masquer les images générées par l\'IA</string>
+    <string name="duckAiDialogHideAiGeneratedImagesDescription">Filtre les sites de spam IA connus dans les résultats de recherche d\'images. <annotation link="learn_more">En savoir plus</annotation></string>
+
     <!-- Duck AI Paid Settings -->
     <string name="duck_ai_paid_settings_enable_in_settings">Activer dans les réglages des fonctionnalités d\'IA</string>
     <string name="duck_ai_paid_settings_manage_in_settings">Gérer dans les réglages des fonctionnalités d\'IA</string>
@@ -182,4 +200,10 @@
     <string name="duck_ai_chat_history_download_view">Afficher</string>
     <string name="duck_ai_chat_history_download_error">Impossible d\'exporter la discussion</string>
     <string name="duck_ai_chat_history_bulk_download_error">Impossible d\'exporter les discussions</string>
+
+    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
+         users, so these are not localized (translatable="false"). Delete with the example. -->
+    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
+    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
+    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-hr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hr/strings-duckchat.xml
@@ -95,6 +95,24 @@
     <string name="duckAiHideAiGeneratedImagesTitle">Sakrij slike generirane umjetnom inteligencijom</string>
     <string name="duckAiHideAiGeneratedImagesDescription">Filtrira slike generirane umjetnom inteligencijom iz rezultata pretraživanja slika</string>
 
+    <!-- Search Assist Visibility -->
+    <string name="duckAiSearchAssistVisibilityTitle">Vidljivost Search Assista</string>
+    <string name="duckAiSearchAssistVisibilitySubtitle">Odaberi koliko često želiš da se odgovori potpomognuti umjetnom inteligencijom pojavljuju u tvojim pretraživanjima.</string>
+    <string name="duckAiSearchAssistVisibilityNever">Nikada</string>
+    <string name="duckAiSearchAssistVisibilityOnDemand">Na zahtjev</string>
+    <string name="duckAiSearchAssistVisibilitySometimes">Ponekad</string>
+    <string name="duckAiSearchAssistVisibilityOften">Često</string>
+
+    <!-- Duck AI Use Without AI Settings Option -->
+    <string name="duckAiUseWithoutAiTitle">Koristi DuckDuckGo bez AI</string>
+    <string name="duckAiUseWithoutAiDescription">Onemogućuje Duck.ai, skriva odgovore potpomognute umjetnom inteligencijom u pretraživanju i filtrira poznata web-mjesta s neželjenom umjetnom inteligencijom u rezultatima pretraživanja slika.</string>
+    <string name="duckAiUseWithoutAiDisabledDescription">Umjetna inteligencija trenutno je onemogućena u pregledniku pa više nećeš vidjeti odgovore potpomognute umjetnom inteligencijom i vidjet ćeš manje slika generiranih umjetnom inteligencijom u rezultatima pretraživanja slika.</string>
+
+    <!-- Duck AI Section in AI Feature Screen -->
+    <string name="input_screen_user_pref_toggle_between_search_and_ai">Prebacuj se između pretraživanja i Duck.ai</string>
+    <string name="duckAiDialogHideAiGeneratedImagesTitle">Sakrij slike generirane umjetnom inteligencijom</string>
+    <string name="duckAiDialogHideAiGeneratedImagesDescription">Filtrira poznata neželjena web-mjesta s AI-jem iz rezultata pretraživanja slika. <annotation link="learn_more">Saznaj više</annotation></string>
+
     <!-- Duck AI Paid Settings -->
     <string name="duck_ai_paid_settings_enable_in_settings">Omogući u postavkama AI značajki</string>
     <string name="duck_ai_paid_settings_manage_in_settings">Upravljaj u postavkama AI značajki</string>

--- a/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
@@ -124,6 +124,13 @@
     <string name="duckAIContextualAutomaticContextMessage">Az oldal tartalmának automatikus küldése a Duck.ai részére</string>
     <string name="duckAIContextualAttachPageContent">Oldal tartalmának csatolása</string>
 
+    <!-- Contextual sheet quick action -->
+    <string name="duckAIContextualPromptAskAboutPage">Kérdezz az oldalról</string>
+
+    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
+    <string name="contextualSheetImprovedHint">Kérdezz bármit privátban</string>
+    <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Legutóbbi csevegések</string>
+
     <!-- duck.ai contextual fire button -->
     <string name="duckAIContextualFireButtonContentDescription">Csevegés törlése</string>
 
@@ -143,6 +150,12 @@
 
     <!-- Duck AI Chat Suggestions -->
     <string name="duckAiChatHistoryViewAllChats">Összes csevegés megtekintése</string>
+
+    <!-- Duck.ai onboarding end CTA -->
+    <string name="duckAiEndCtaTitle">Menni fog!</string>
+    <string name="duckAiEndCtaDescription"><![CDATA[A címsávban kereshetsz, webhelyeket nyithatsz meg, vagy átválthatsz a Duck.ai-ra privát MI-beszélgetéshez.<br/><br/>A Duck.ai-t bárhol használhatod, ahol látod a beszélgetés ikonját]]></string>
+    <string name="duckAiEndCtaButton">Pacsi!</string>
+    <string name="duckAiEndCtaDescriptionCustomAi"><![CDATA[Indíts privát MI-beszélgetést a Duck.ai-jal, vagy válts a Keresésre a védett böngészéshez.<br/><br/>A Duck.ai-t bárhol használhatod, ahol látod a beszélgetés ikonját]]></string>
 
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Csevegések</string>
@@ -187,10 +200,4 @@
     <string name="duck_ai_chat_history_download_view">Megjelenítés</string>
     <string name="duck_ai_chat_history_download_error">Nem sikerült exportálni a csevegést</string>
     <string name="duck_ai_chat_history_bulk_download_error">Nem sikerült exportálni a csevegéseket</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
@@ -95,6 +95,24 @@
     <string name="duckAiHideAiGeneratedImagesTitle">AI által generált képek elrejtése</string>
     <string name="duckAiHideAiGeneratedImagesDescription">Kiszűri az AI által generált képeket a képkeresési találatokból</string>
 
+    <!-- Search Assist Visibility -->
+    <string name="duckAiSearchAssistVisibilityTitle">Search Assist láthatósága</string>
+    <string name="duckAiSearchAssistVisibilitySubtitle">Válaszd ki, milyen gyakran szeretnél mesterséges intelligenciával generált válaszokat látni a kereséseid során.</string>
+    <string name="duckAiSearchAssistVisibilityNever">Soha</string>
+    <string name="duckAiSearchAssistVisibilityOnDemand">Igény esetén</string>
+    <string name="duckAiSearchAssistVisibilitySometimes">Néha</string>
+    <string name="duckAiSearchAssistVisibilityOften">Gyakran</string>
+
+    <!-- Duck AI Use Without AI Settings Option -->
+    <string name="duckAiUseWithoutAiTitle">DuckDuckGo használata AI nélkül</string>
+    <string name="duckAiUseWithoutAiDescription">Kikapcsolja a Duck.ai-t, elrejti az AI segítségével létrehozott válaszokat a keresésben, és kiszűri az ismert AI-spam-webhelyeket a képkeresési eredmények közül.</string>
+    <string name="duckAiUseWithoutAiDisabledDescription">Az AI jelenleg ki van kapcsolva a böngészőben, így a továbbiakban nem fogsz AI segítségével létrehozott válaszokat látni, és kevesebb AI által generált kép jelenik meg a képkeresési találatok között.</string>
+
+    <!-- Duck AI Section in AI Feature Screen -->
+    <string name="input_screen_user_pref_toggle_between_search_and_ai">Váltás a keresés és a Duck.ai között</string>
+    <string name="duckAiDialogHideAiGeneratedImagesTitle">AI által generált képek elrejtése</string>
+    <string name="duckAiDialogHideAiGeneratedImagesDescription">Kiszűri az ismert AI-spam-webhelyeket a képkeresési találatok közül. <annotation link="learn_more">További információk</annotation></string>
+
     <!-- Duck AI Paid Settings -->
     <string name="duck_ai_paid_settings_enable_in_settings">Engedélyezés az AI-funkciók beállításaiban</string>
     <string name="duck_ai_paid_settings_manage_in_settings">Kezelés az AI-funkciók beállításaiban</string>
@@ -105,13 +123,6 @@
     <string name="duckAIContextualAutomaticContextTitle">Oldal tartalmának automatikus küldése</string>
     <string name="duckAIContextualAutomaticContextMessage">Az oldal tartalmának automatikus küldése a Duck.ai részére</string>
     <string name="duckAIContextualAttachPageContent">Oldal tartalmának csatolása</string>
-
-    <!-- Contextual sheet quick action -->
-    <string name="duckAIContextualPromptAskAboutPage">Kérdezz az oldalról</string>
-
-    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
-    <string name="contextualSheetImprovedHint">Kérdezz bármit privátban</string>
-    <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Legutóbbi csevegések</string>
 
     <!-- duck.ai contextual fire button -->
     <string name="duckAIContextualFireButtonContentDescription">Csevegés törlése</string>
@@ -132,12 +143,6 @@
 
     <!-- Duck AI Chat Suggestions -->
     <string name="duckAiChatHistoryViewAllChats">Összes csevegés megtekintése</string>
-
-    <!-- Duck.ai onboarding end CTA -->
-    <string name="duckAiEndCtaTitle">Menni fog!</string>
-    <string name="duckAiEndCtaDescription"><![CDATA[A címsávban kereshetsz, webhelyeket nyithatsz meg, vagy átválthatsz a Duck.ai-ra privát MI-beszélgetéshez.<br/><br/>A Duck.ai-t bárhol használhatod, ahol látod a beszélgetés ikonját]]></string>
-    <string name="duckAiEndCtaButton">Pacsi!</string>
-    <string name="duckAiEndCtaDescriptionCustomAi"><![CDATA[Indíts privát MI-beszélgetést a Duck.ai-jal, vagy válts a Keresésre a védett böngészéshez.<br/><br/>A Duck.ai-t bárhol használhatod, ahol látod a beszélgetés ikonját]]></string>
 
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Csevegések</string>
@@ -182,4 +187,10 @@
     <string name="duck_ai_chat_history_download_view">Megjelenítés</string>
     <string name="duck_ai_chat_history_download_error">Nem sikerült exportálni a csevegést</string>
     <string name="duck_ai_chat_history_bulk_download_error">Nem sikerült exportálni a csevegéseket</string>
+
+    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
+         users, so these are not localized (translatable="false"). Delete with the example. -->
+    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
+    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
+    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
@@ -124,6 +124,13 @@
     <string name="duckAIContextualAutomaticContextMessage">Invia automaticamente il contenuto della pagina a Duck.ai</string>
     <string name="duckAIContextualAttachPageContent">Allega il contenuto della pagina</string>
 
+    <!-- Contextual sheet quick action -->
+    <string name="duckAIContextualPromptAskAboutPage">Richiedi informazioni sulla pagina</string>
+
+    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
+    <string name="contextualSheetImprovedHint">Chiedi qualsiasi cosa in privato</string>
+    <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Chat recenti</string>
+
     <!-- duck.ai contextual fire button -->
     <string name="duckAIContextualFireButtonContentDescription">Cancella chat</string>
 
@@ -143,6 +150,12 @@
 
     <!-- Duck AI Chat Suggestions -->
     <string name="duckAiChatHistoryViewAllChats">Visualizza tutte le chat</string>
+
+    <!-- Duck.ai onboarding end CTA -->
+    <string name="duckAiEndCtaTitle">Ben fatto!</string>
+    <string name="duckAiEndCtaDescription"><![CDATA[Usa la barra degli indirizzi per cercare e visitare siti o passa a Duck.ai per una chat AI privata.<br/><br/>Puoi utilizzare Duck.ai da qualsiasi punto in cui vedi l\'icona della chat]]></string>
+    <string name="duckAiEndCtaButton">Batti il cinque!</string>
+    <string name="duckAiEndCtaDescriptionCustomAi"><![CDATA[Avvia una chat privata con l\'AI con Duck.ai oppure attiva la Ricerca per navigazione protetta.<br/><br/>Puoi utilizzare Duck.ai da qualsiasi punto in cui vedi l\'icona della chat]]></string>
 
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Chat</string>
@@ -187,10 +200,4 @@
     <string name="duck_ai_chat_history_download_view">Mostra</string>
     <string name="duck_ai_chat_history_download_error">Non è possibile esportare la chat</string>
     <string name="duck_ai_chat_history_bulk_download_error">Non è stato possibile esportare le chat</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
@@ -95,6 +95,24 @@
     <string name="duckAiHideAiGeneratedImagesTitle">Nascondi le immagini generate dall\'IA</string>
     <string name="duckAiHideAiGeneratedImagesDescription">Filtra le immagini generate dall\'intelligenza artificiale dai risultati di ricerca delle immagini</string>
 
+    <!-- Search Assist Visibility -->
+    <string name="duckAiSearchAssistVisibilityTitle">Visibilità di Search Assist</string>
+    <string name="duckAiSearchAssistVisibilitySubtitle">Scegli la frequenza con cui vuoi che le risposte assistite dall\'AI appaiano nelle tue ricerche.</string>
+    <string name="duckAiSearchAssistVisibilityNever">Mai</string>
+    <string name="duckAiSearchAssistVisibilityOnDemand">Su richiesta</string>
+    <string name="duckAiSearchAssistVisibilitySometimes">A volte</string>
+    <string name="duckAiSearchAssistVisibilityOften">Spesso</string>
+
+    <!-- Duck AI Use Without AI Settings Option -->
+    <string name="duckAiUseWithoutAiTitle">Usa DuckDuckGo senza AI</string>
+    <string name="duckAiUseWithoutAiDescription">Disattiva Duck.ai, nasconde le risposte formulate dall\'AI nei risultati di ricerca e filtra i siti di spam noti generati dall\'AI nei risultati della ricerca per immagini.</string>
+    <string name="duckAiUseWithoutAiDisabledDescription">Attualmente l\'AI è disattivata nel browser, quindi non vedrai più risposte formulate con l\'aiuto dell\'AI e vedrai meno immagini generate dall\'AI nei risultati di ricerca delle immagini.</string>
+
+    <!-- Duck AI Section in AI Feature Screen -->
+    <string name="input_screen_user_pref_toggle_between_search_and_ai">Alterna tra\nCerca e Duck.ai</string>
+    <string name="duckAiDialogHideAiGeneratedImagesTitle">Nascondi le immagini generate dall\'AI</string>
+    <string name="duckAiDialogHideAiGeneratedImagesDescription">Filtra i siti di spam AI noti dai risultati di ricerca delle immagini. <annotation link="learn_more">Ulteriori informazioni</annotation></string>
+
     <!-- Duck AI Paid Settings -->
     <string name="duck_ai_paid_settings_enable_in_settings">Abilita nelle impostazioni delle funzionalità AI</string>
     <string name="duck_ai_paid_settings_manage_in_settings">Gestisci nelle impostazioni delle funzionalità AI</string>
@@ -105,13 +123,6 @@
     <string name="duckAIContextualAutomaticContextTitle">Invia automaticamente il contenuto della pagina</string>
     <string name="duckAIContextualAutomaticContextMessage">Invia automaticamente il contenuto della pagina a Duck.ai</string>
     <string name="duckAIContextualAttachPageContent">Allega il contenuto della pagina</string>
-
-    <!-- Contextual sheet quick action -->
-    <string name="duckAIContextualPromptAskAboutPage">Richiedi informazioni sulla pagina</string>
-
-    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
-    <string name="contextualSheetImprovedHint">Chiedi qualsiasi cosa in privato</string>
-    <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Chat recenti</string>
 
     <!-- duck.ai contextual fire button -->
     <string name="duckAIContextualFireButtonContentDescription">Cancella chat</string>
@@ -132,12 +143,6 @@
 
     <!-- Duck AI Chat Suggestions -->
     <string name="duckAiChatHistoryViewAllChats">Visualizza tutte le chat</string>
-
-    <!-- Duck.ai onboarding end CTA -->
-    <string name="duckAiEndCtaTitle">Ben fatto!</string>
-    <string name="duckAiEndCtaDescription"><![CDATA[Usa la barra degli indirizzi per cercare e visitare siti o passa a Duck.ai per una chat AI privata.<br/><br/>Puoi utilizzare Duck.ai da qualsiasi punto in cui vedi l\'icona della chat]]></string>
-    <string name="duckAiEndCtaButton">Batti il cinque!</string>
-    <string name="duckAiEndCtaDescriptionCustomAi"><![CDATA[Avvia una chat privata con l\'AI con Duck.ai oppure attiva la Ricerca per navigazione protetta.<br/><br/>Puoi utilizzare Duck.ai da qualsiasi punto in cui vedi l\'icona della chat]]></string>
 
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Chat</string>
@@ -182,4 +187,10 @@
     <string name="duck_ai_chat_history_download_view">Mostra</string>
     <string name="duck_ai_chat_history_download_error">Non è possibile esportare la chat</string>
     <string name="duck_ai_chat_history_bulk_download_error">Non è stato possibile esportare le chat</string>
+
+    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
+         users, so these are not localized (translatable="false"). Delete with the example. -->
+    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
+    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
+    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
@@ -202,10 +202,4 @@
     <string name="duck_ai_chat_history_download_view">Rodyti</string>
     <string name="duck_ai_chat_history_download_error">Nepavyko eksportuoti pokalbio</string>
     <string name="duck_ai_chat_history_bulk_download_error">Nepavyko eksportuoti pokalbių</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
@@ -95,6 +95,24 @@
     <string name="duckAiHideAiGeneratedImagesTitle">Slėpti DI generuotus vaizdus</string>
     <string name="duckAiHideAiGeneratedImagesDescription">Vaizdų paieškos rezultatuose nepalieka Di sukurtų vaizdų</string>
 
+    <!-- Search Assist Visibility -->
+    <string name="duckAiSearchAssistVisibilityTitle">„Search Assist“ matomumas</string>
+    <string name="duckAiSearchAssistVisibilitySubtitle">Pasirink, kaip dažnai paieškose nori matyti „AI-Assisted Answers“.</string>
+    <string name="duckAiSearchAssistVisibilityNever">Niekada</string>
+    <string name="duckAiSearchAssistVisibilityOnDemand">Pagal poreikį</string>
+    <string name="duckAiSearchAssistVisibilitySometimes">Kartais</string>
+    <string name="duckAiSearchAssistVisibilityOften">Dažnai</string>
+
+    <!-- Duck AI Use Without AI Settings Option -->
+    <string name="duckAiUseWithoutAiTitle">Naudok „DuckDuckGo“ be DI</string>
+    <string name="duckAiUseWithoutAiDescription">Išjungia „Duck.ai“, paieškoje paslepia DI parengtus atsakymus ir iš vaizdų paieškos rezultatų pašalina žinomas DI brukalų svetaines.</string>
+    <string name="duckAiUseWithoutAiDisabledDescription">Šiuo metu naršyklėje DI išjungtas, todėl nebematysi DI parengtų atsakymų, o vaizdų paieškos rezultatuose matysi mažiau DI sukurtų vaizdų.</string>
+
+    <!-- Duck AI Section in AI Feature Screen -->
+    <string name="input_screen_user_pref_toggle_between_search_and_ai">Perjungti paiešką ir „Duck.ai“</string>
+    <string name="duckAiDialogHideAiGeneratedImagesTitle">Slėpti DI sugeneruotus vaizdus</string>
+    <string name="duckAiDialogHideAiGeneratedImagesDescription">Iš vaizdų paieškos rezultatų pašalina žinomas DI brukalų svetaines. <annotation link="learn_more">Sužinok daugiau</annotation></string>
+
     <!-- Duck AI Paid Settings -->
     <string name="duck_ai_paid_settings_enable_in_settings">Įgalinti DI funkcijų nustatymuose</string>
     <string name="duck_ai_paid_settings_manage_in_settings">Tvarkyti DI funkcijų nustatymuose</string>
@@ -184,4 +202,10 @@
     <string name="duck_ai_chat_history_download_view">Rodyti</string>
     <string name="duck_ai_chat_history_download_error">Nepavyko eksportuoti pokalbio</string>
     <string name="duck_ai_chat_history_bulk_download_error">Nepavyko eksportuoti pokalbių</string>
+
+    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
+         users, so these are not localized (translatable="false"). Delete with the example. -->
+    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
+    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
+    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
@@ -95,6 +95,24 @@
     <string name="duckAiHideAiGeneratedImagesTitle">Paslēpt MI ģenerētus attēlus</string>
     <string name="duckAiHideAiGeneratedImagesDescription">Filtrē MI radītus attēlus no attēlu meklēšanas rezultātiem</string>
 
+    <!-- Search Assist Visibility -->
+    <string name="duckAiSearchAssistVisibilityTitle">Search Assist redzamība</string>
+    <string name="duckAiSearchAssistVisibilitySubtitle">Izvēlies, cik bieži vēlies redzēt ar MI atbalstītas atbildes savos meklējumos.</string>
+    <string name="duckAiSearchAssistVisibilityNever">Nekad</string>
+    <string name="duckAiSearchAssistVisibilityOnDemand">Pēc pieprasījuma</string>
+    <string name="duckAiSearchAssistVisibilitySometimes">Dažreiz</string>
+    <string name="duckAiSearchAssistVisibilityOften">Bieži</string>
+
+    <!-- Duck AI Use Without AI Settings Option -->
+    <string name="duckAiUseWithoutAiTitle">Lieto DuckDuckGo bez MI</string>
+    <string name="duckAiUseWithoutAiDescription">Atspējo Duck.ai, paslēpj mākslīgā intelekta atbildes meklēšanā un filtrē zināmas MI spama vietnes attēlu meklēšanas rezultātos.</string>
+    <string name="duckAiUseWithoutAiDisabledDescription">Mākslīgais intelekts (MI) pašlaik pārlūkā ir atspējots, tāpēc vairs neredzēsi MI atbildes un attēlu meklēšanas rezultātos redzēsi mazāk ar MI ģenerētu attēlu.</string>
+
+    <!-- Duck AI Section in AI Feature Screen -->
+    <string name="input_screen_user_pref_toggle_between_search_and_ai">Pārslēdzies starp meklēšanu un Duck.ai</string>
+    <string name="duckAiDialogHideAiGeneratedImagesTitle">Paslēpt ar MI ģenerētus attēlus</string>
+    <string name="duckAiDialogHideAiGeneratedImagesDescription">Izfiltrē zināmas mākslīgā intelekta spama vietnes no attēlu meklēšanas rezultātiem. <annotation link="learn_more">Uzzināt vairāk</annotation></string>
+
     <!-- Duck AI Paid Settings -->
     <string name="duck_ai_paid_settings_enable_in_settings">Ieslēgt MI funkciju iestatījumos</string>
     <string name="duck_ai_paid_settings_manage_in_settings">Pārvaldīt MI funkciju iestatījumos</string>
@@ -183,4 +201,10 @@
     <string name="duck_ai_chat_history_download_view">Rādīt</string>
     <string name="duck_ai_chat_history_download_error">Nevarēja eksportēt tērzēšanu</string>
     <string name="duck_ai_chat_history_bulk_download_error">Neizdevās eksportēt tērzēšanas</string>
+
+    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
+         users, so these are not localized (translatable="false"). Delete with the example. -->
+    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
+    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
+    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
@@ -201,10 +201,4 @@
     <string name="duck_ai_chat_history_download_view">Rādīt</string>
     <string name="duck_ai_chat_history_download_error">Nevarēja eksportēt tērzēšanu</string>
     <string name="duck_ai_chat_history_bulk_download_error">Neizdevās eksportēt tērzēšanas</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
@@ -200,10 +200,4 @@
     <string name="duck_ai_chat_history_download_view">Vis</string>
     <string name="duck_ai_chat_history_download_error">Kunne ikke eksportere chatten</string>
     <string name="duck_ai_chat_history_bulk_download_error">Kunne ikke eksportere chattene</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
@@ -95,6 +95,24 @@
     <string name="duckAiHideAiGeneratedImagesTitle">Skjul AI-genererte bilder</string>
     <string name="duckAiHideAiGeneratedImagesDescription">Filtrerer ut AI-genererte bilder fra bildesøkresultater</string>
 
+    <!-- Search Assist Visibility -->
+    <string name="duckAiSearchAssistVisibilityTitle">Synlighet for Search Assist</string>
+    <string name="duckAiSearchAssistVisibilitySubtitle">Velg hvor ofte du vil at AI-assisterte svar skal vises i søkene dine.</string>
+    <string name="duckAiSearchAssistVisibilityNever">Aldri</string>
+    <string name="duckAiSearchAssistVisibilityOnDemand">På forespørsel</string>
+    <string name="duckAiSearchAssistVisibilitySometimes">Noen ganger</string>
+    <string name="duckAiSearchAssistVisibilityOften">Ofte</string>
+
+    <!-- Duck AI Use Without AI Settings Option -->
+    <string name="duckAiUseWithoutAiTitle">Bruk DuckDuckGo uten AI</string>
+    <string name="duckAiUseWithoutAiDescription">Deaktiverer Duck.ai, skjuler AI-assisterte svar i søk og filtrerer ut kjente AI-søppelnettsteder i bildesøkresultatene.</string>
+    <string name="duckAiUseWithoutAiDisabledDescription">AI er for øyeblikket deaktivert i nettleseren, så du ser ikke lenger AI-assisterte svar, og du ser færre AI-genererte bilder i bildesøkresultatene.</string>
+
+    <!-- Duck AI Section in AI Feature Screen -->
+    <string name="input_screen_user_pref_toggle_between_search_and_ai">Bytt mellom søk og Duck.ai</string>
+    <string name="duckAiDialogHideAiGeneratedImagesTitle">Skjul AI-genererte bilder</string>
+    <string name="duckAiDialogHideAiGeneratedImagesDescription">Filtrerer ut kjente AI-søppelnettsteder fra bildesøkresultater. <annotation link="learn_more">Finn ut mer</annotation></string>
+
     <!-- Duck AI Paid Settings -->
     <string name="duck_ai_paid_settings_enable_in_settings">Aktiver i innstillingene for AI-funksjoner</string>
     <string name="duck_ai_paid_settings_manage_in_settings">Administrer i innstillingene for AI-funksjoner</string>
@@ -182,4 +200,10 @@
     <string name="duck_ai_chat_history_download_view">Vis</string>
     <string name="duck_ai_chat_history_download_error">Kunne ikke eksportere chatten</string>
     <string name="duck_ai_chat_history_bulk_download_error">Kunne ikke eksportere chattene</string>
+
+    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
+         users, so these are not localized (translatable="false"). Delete with the example. -->
+    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
+    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
+    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
@@ -200,10 +200,4 @@
     <string name="duck_ai_chat_history_download_view">Tonen</string>
     <string name="duck_ai_chat_history_download_error">Kan chat niet exporteren</string>
     <string name="duck_ai_chat_history_bulk_download_error">Kan chats niet exporteren</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
@@ -95,6 +95,24 @@
     <string name="duckAiHideAiGeneratedImagesTitle">Verberg AI-gegenereerde afbeeldingen.</string>
     <string name="duckAiHideAiGeneratedImagesDescription">Filtert AI-gegenereerde afbeeldingen uit de zoekresultaten van afbeeldingen.</string>
 
+    <!-- Search Assist Visibility -->
+    <string name="duckAiSearchAssistVisibilityTitle">Zichtbaarheid van Search Assist</string>
+    <string name="duckAiSearchAssistVisibilitySubtitle">Kies hoe vaak antwoorden op basis van AI in je zoekresultaten moeten worden weergegeven.</string>
+    <string name="duckAiSearchAssistVisibilityNever">Nooit</string>
+    <string name="duckAiSearchAssistVisibilityOnDemand">Op aanvraag</string>
+    <string name="duckAiSearchAssistVisibilitySometimes">Soms</string>
+    <string name="duckAiSearchAssistVisibilityOften">Vaak</string>
+
+    <!-- Duck AI Use Without AI Settings Option -->
+    <string name="duckAiUseWithoutAiTitle">DuckDuckGo zonder AI gebruiken</string>
+    <string name="duckAiUseWithoutAiDescription">Hiermee schakel je Duck.ai uit, verberg je antwoorden op basis van AI in zoekresultaten en filter je bekende AI-spamsites in zoekresultaten voor afbeeldingen.</string>
+    <string name="duckAiUseWithoutAiDisabledDescription">AI is momenteel uitgeschakeld in de browser, dus je ziet geen antwoorden op basis van AI meer en minder door AI gegenereerde afbeeldingen in de zoekresultaten voor afbeeldingen.</string>
+
+    <!-- Duck AI Section in AI Feature Screen -->
+    <string name="input_screen_user_pref_toggle_between_search_and_ai">Schakelen tussen zoeken en Duck.ai</string>
+    <string name="duckAiDialogHideAiGeneratedImagesTitle">Door AI gegenereerde afbeeldingen verbergen</string>
+    <string name="duckAiDialogHideAiGeneratedImagesDescription">Hiermee filter je bekende AI-spamsites uit de zoekresultaten voor afbeeldingen. <annotation link="learn_more">Meer informatie</annotation></string>
+
     <!-- Duck AI Paid Settings -->
     <string name="duck_ai_paid_settings_enable_in_settings">Inschakelen in de instellingen voor AI-functies</string>
     <string name="duck_ai_paid_settings_manage_in_settings">Beheren in de instellingen voor AI-functies</string>
@@ -182,4 +200,10 @@
     <string name="duck_ai_chat_history_download_view">Tonen</string>
     <string name="duck_ai_chat_history_download_error">Kan chat niet exporteren</string>
     <string name="duck_ai_chat_history_bulk_download_error">Kan chats niet exporteren</string>
+
+    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
+         users, so these are not localized (translatable="false"). Delete with the example. -->
+    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
+    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
+    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-pl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pl/strings-duckchat.xml
@@ -95,6 +95,24 @@
     <string name="duckAiHideAiGeneratedImagesTitle">Ukryj obrazy generowane przez AI</string>
     <string name="duckAiHideAiGeneratedImagesDescription">Filtruje obrazy generowane przez AI z wyników wyszukiwania obrazów</string>
 
+    <!-- Search Assist Visibility -->
+    <string name="duckAiSearchAssistVisibilityTitle">Widoczność Search Assist</string>
+    <string name="duckAiSearchAssistVisibilitySubtitle">Wybierz, jak często w wyszukiwaniach mają pojawiać się odpowiedzi wspomagane przez sztuczną inteligencję.</string>
+    <string name="duckAiSearchAssistVisibilityNever">Nigdy</string>
+    <string name="duckAiSearchAssistVisibilityOnDemand">Na żądanie</string>
+    <string name="duckAiSearchAssistVisibilitySometimes">Czasami</string>
+    <string name="duckAiSearchAssistVisibilityOften">Często</string>
+
+    <!-- Duck AI Use Without AI Settings Option -->
+    <string name="duckAiUseWithoutAiTitle">Korzystaj z DuckDuckGo bez AI</string>
+    <string name="duckAiUseWithoutAiDescription">Wyłącza Duck.ai, ukrywa odpowiedzi wspomagane sztuczną inteligencją w wyszukiwaniu i odfiltrowuje znane strony ze spamem AI w wynikach wyszukiwania obrazów.</string>
+    <string name="duckAiUseWithoutAiDisabledDescription">Sztuczna inteligencja jest obecnie wyłączona w przeglądarce, więc nie zobaczysz już odpowiedzi wspomaganych sztuczną inteligencją oraz uzyskasz mniej obrazów generowanych przez sztuczną inteligencję w wynikach wyszukiwania obrazów.</string>
+
+    <!-- Duck AI Section in AI Feature Screen -->
+    <string name="input_screen_user_pref_toggle_between_search_and_ai">Przełącz między wyszukiwaniem a Duck.ai</string>
+    <string name="duckAiDialogHideAiGeneratedImagesTitle">Ukryj obrazy generowane przez AI</string>
+    <string name="duckAiDialogHideAiGeneratedImagesDescription">Odfiltrowuje znane strony ze spamem AI z wyników wyszukiwania obrazów. <annotation link="learn_more">Dowiedz się więcej</annotation></string>
+
     <!-- Duck AI Paid Settings -->
     <string name="duck_ai_paid_settings_enable_in_settings">Włącz w ustawieniach funkcji AI</string>
     <string name="duck_ai_paid_settings_manage_in_settings">Zarządzaj w ustawieniach funkcji AI</string>

--- a/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
@@ -200,10 +200,4 @@
     <string name="duck_ai_chat_history_download_view">Mostrar</string>
     <string name="duck_ai_chat_history_download_error">Não foi possível exportar a conversa</string>
     <string name="duck_ai_chat_history_bulk_download_error">Não foi possível exportar as conversas</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
@@ -95,6 +95,24 @@
     <string name="duckAiHideAiGeneratedImagesTitle">Ocultar Imagens Geradas por IA</string>
     <string name="duckAiHideAiGeneratedImagesDescription">Filtra imagens geradas por IA dos resultados de pesquisa de imagens</string>
 
+    <!-- Search Assist Visibility -->
+    <string name="duckAiSearchAssistVisibilityTitle">Visibilidade do Search Assist</string>
+    <string name="duckAiSearchAssistVisibilitySubtitle">Escolhe a frequência com que queres que as respostas assistidas por IA apareçam nas tuas pesquisas.</string>
+    <string name="duckAiSearchAssistVisibilityNever">Nunca</string>
+    <string name="duckAiSearchAssistVisibilityOnDemand">A pedido</string>
+    <string name="duckAiSearchAssistVisibilitySometimes">Às vezes</string>
+    <string name="duckAiSearchAssistVisibilityOften">Frequentemente</string>
+
+    <!-- Duck AI Use Without AI Settings Option -->
+    <string name="duckAiUseWithoutAiTitle">Usar o DuckDuckGo sem IA</string>
+    <string name="duckAiUseWithoutAiDescription">Desativa o Duck.ai, esconde as respostas assistidas por IA nos resultados de pesquisa e filtra os sites conhecidos de spam gerado por IA nos resultados da pesquisa de imagens.</string>
+    <string name="duckAiUseWithoutAiDisabledDescription">A IA está atualmente desativada no navegador, pelo que deixarás de ver respostas assistidas por IA e verás menos imagens geradas por IA nos resultados de pesquisa de imagens.</string>
+
+    <!-- Duck AI Section in AI Feature Screen -->
+    <string name="input_screen_user_pref_toggle_between_search_and_ai">Alternar entre Pesquisa e Duck.ai</string>
+    <string name="duckAiDialogHideAiGeneratedImagesTitle">Ocultar imagens geradas por IA</string>
+    <string name="duckAiDialogHideAiGeneratedImagesDescription">Filtra sites conhecidos de spam gerado por IA nos resultados de pesquisa de imagens. <annotation link="learn_more">Sabe mais</annotation></string>
+
     <!-- Duck AI Paid Settings -->
     <string name="duck_ai_paid_settings_enable_in_settings">Ativar nas definições das Funcionalidades de IA</string>
     <string name="duck_ai_paid_settings_manage_in_settings">Gerir nas definições das Funcionalidades de IA</string>
@@ -182,4 +200,10 @@
     <string name="duck_ai_chat_history_download_view">Mostrar</string>
     <string name="duck_ai_chat_history_download_error">Não foi possível exportar a conversa</string>
     <string name="duck_ai_chat_history_bulk_download_error">Não foi possível exportar as conversas</string>
+
+    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
+         users, so these are not localized (translatable="false"). Delete with the example. -->
+    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
+    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
+    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-ro/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ro/strings-duckchat.xml
@@ -201,10 +201,4 @@
     <string name="duck_ai_chat_history_download_view">Afișează</string>
     <string name="duck_ai_chat_history_download_error">Nu s-a putut exporta chatul</string>
     <string name="duck_ai_chat_history_bulk_download_error">Nu s-au putut exporta chaturile</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-ro/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ro/strings-duckchat.xml
@@ -95,6 +95,24 @@
     <string name="duckAiHideAiGeneratedImagesTitle">Ascunde imaginile generate de IA</string>
     <string name="duckAiHideAiGeneratedImagesDescription">Filtrează imaginile generate de IA din rezultatele căutării de imagini</string>
 
+    <!-- Search Assist Visibility -->
+    <string name="duckAiSearchAssistVisibilityTitle">Vizibilitate Search Assist</string>
+    <string name="duckAiSearchAssistVisibilitySubtitle">Alege cât de des dorești să apară răspunsurile asistate de IA în căutările tale.</string>
+    <string name="duckAiSearchAssistVisibilityNever">Niciodată</string>
+    <string name="duckAiSearchAssistVisibilityOnDemand">La cerere</string>
+    <string name="duckAiSearchAssistVisibilitySometimes">Uneori</string>
+    <string name="duckAiSearchAssistVisibilityOften">Adesea</string>
+
+    <!-- Duck AI Use Without AI Settings Option -->
+    <string name="duckAiUseWithoutAiTitle">Folosește DuckDuckGo fără IA</string>
+    <string name="duckAiUseWithoutAiDescription">Dezactivează Duck.ai, ascunde răspunsurile asistate de IA în căutare și filtrează site-urile de spam cunoscute bazate pe IA din rezultatele căutării de imagini.</string>
+    <string name="duckAiUseWithoutAiDisabledDescription">IA este în prezent dezactivată în browser, așa că nu vei mai vedea răspunsuri asistate de IA și vei vedea mai puține imagini generate de IA în rezultatele căutării de imagini.</string>
+
+    <!-- Duck AI Section in AI Feature Screen -->
+    <string name="input_screen_user_pref_toggle_between_search_and_ai">Comută între Căutare și Duck.ai</string>
+    <string name="duckAiDialogHideAiGeneratedImagesTitle">Ascunde imaginile generate de IA</string>
+    <string name="duckAiDialogHideAiGeneratedImagesDescription">Filtrează site-urile spam cunoscute, bazate pe IA, din rezultatele căutării de imagini. <annotation link="learn_more">Află mai multe</annotation></string>
+
     <!-- Duck AI Paid Settings -->
     <string name="duck_ai_paid_settings_enable_in_settings">Activează în setările funcțiilor IA</string>
     <string name="duck_ai_paid_settings_manage_in_settings">Gestionează în setările funcțiilor IA</string>
@@ -183,4 +201,10 @@
     <string name="duck_ai_chat_history_download_view">Afișează</string>
     <string name="duck_ai_chat_history_download_error">Nu s-a putut exporta chatul</string>
     <string name="duck_ai_chat_history_bulk_download_error">Nu s-au putut exporta chaturile</string>
+
+    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
+         users, so these are not localized (translatable="false"). Delete with the example. -->
+    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
+    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
+    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
@@ -124,6 +124,13 @@
     <string name="duckAIContextualAutomaticContextMessage">Автоматически отправлять содержимое страницы в Duck.ai</string>
     <string name="duckAIContextualAttachPageContent">Добавить содержимое страницы</string>
 
+    <!-- Contextual sheet quick action -->
+    <string name="duckAIContextualPromptAskAboutPage">Задайте вопрос о странице</string>
+
+    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
+    <string name="contextualSheetImprovedHint">Задавайте любые вопросы, сохраняя конфиденциальность</string>
+    <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Последние чаты</string>
+
     <!-- duck.ai contextual fire button -->
     <string name="duckAIContextualFireButtonContentDescription">Стереть чат</string>
 
@@ -143,6 +150,12 @@
 
     <!-- Duck AI Chat Suggestions -->
     <string name="duckAiChatHistoryViewAllChats">Показать все чаты</string>
+
+    <!-- Duck.ai onboarding end CTA -->
+    <string name="duckAiEndCtaTitle">Проще некуда!</string>
+    <string name="duckAiEndCtaDescription"><![CDATA[Ищите и открывайте сайты в адресной строке или переключитесь на приватный чат с ИИ.<br/><br/>Duck.ai можно использовать везде, где есть значок чата]]></string>
+    <string name="duckAiEndCtaButton">Дай пять!</string>
+    <string name="duckAiEndCtaDescriptionCustomAi"><![CDATA[Начните приватный чат с ИИ через Duck.ai или переключитесь на поиск для защищенного просмотра веб-страниц.<br/><br/>Duck.ai можно использовать везде, где есть значок чата]]></string>
 
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Чаты</string>
@@ -189,10 +202,4 @@
     <string name="duck_ai_chat_history_download_view">Показать</string>
     <string name="duck_ai_chat_history_download_error">Не удалось экспортировать чат</string>
     <string name="duck_ai_chat_history_bulk_download_error">Не удалось экспортировать чаты</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
@@ -95,6 +95,24 @@
     <string name="duckAiHideAiGeneratedImagesTitle">Скрыть ИИ-картинки</string>
     <string name="duckAiHideAiGeneratedImagesDescription">Исключает из результатов поиска изображения, созданные нейросетью</string>
 
+    <!-- Search Assist Visibility -->
+    <string name="duckAiSearchAssistVisibilityTitle">Параметры Search Assist</string>
+    <string name="duckAiSearchAssistVisibilitySubtitle">Выберите, как часто вы хотите видеть ответы от ИИ в результатах поиска.</string>
+    <string name="duckAiSearchAssistVisibilityNever">Никогда</string>
+    <string name="duckAiSearchAssistVisibilityOnDemand">По запросу</string>
+    <string name="duckAiSearchAssistVisibilitySometimes">Иногда</string>
+    <string name="duckAiSearchAssistVisibilityOften">Часто</string>
+
+    <!-- Duck AI Use Without AI Settings Option -->
+    <string name="duckAiUseWithoutAiTitle">Использовать DuckDuckGo без ИИ</string>
+    <string name="duckAiUseWithoutAiDescription">Отключает Duck.ai, скрывает ответы с использованием ИИ в поиске и фильтрует известные сайты с ИИ-спамом в результатах поиска изображений.</string>
+    <string name="duckAiUseWithoutAiDisabledDescription">ИИ сейчас отключен в браузере, поэтому ответы с использованием ИИ больше не будут отображаться, а в результатах поиска изображений будет меньше изображений, созданных ИИ.</string>
+
+    <!-- Duck AI Section in AI Feature Screen -->
+    <string name="input_screen_user_pref_toggle_between_search_and_ai">Переключайтесь между обычным поиском и Duck.ai</string>
+    <string name="duckAiDialogHideAiGeneratedImagesTitle">Скрыть изображения, сгенерированные ИИ</string>
+    <string name="duckAiDialogHideAiGeneratedImagesDescription">Исключает из результатов поиска изображений известные сайты с ИИ-спамом. <annotation link="learn_more">Подробнее</annotation></string>
+
     <!-- Duck AI Paid Settings -->
     <string name="duck_ai_paid_settings_enable_in_settings">Посетить «Настройки функций ИИ»</string>
     <string name="duck_ai_paid_settings_manage_in_settings">Настроить функции ИИ</string>
@@ -105,13 +123,6 @@
     <string name="duckAIContextualAutomaticContextTitle">Автоматически отправлять содержимое страницы</string>
     <string name="duckAIContextualAutomaticContextMessage">Автоматически отправлять содержимое страницы в Duck.ai</string>
     <string name="duckAIContextualAttachPageContent">Добавить содержимое страницы</string>
-
-    <!-- Contextual sheet quick action -->
-    <string name="duckAIContextualPromptAskAboutPage">Задайте вопрос о странице</string>
-
-    <!-- Contextual sheet input hint (contextualSheetImprovements flag) -->
-    <string name="contextualSheetImprovedHint">Задавайте любые вопросы, сохраняя конфиденциальность</string>
-    <string name="contextualSheetChatsPopupRecentSection" instruction="Section header above the list of recent Duck.ai chats in the contextual sheet overflow menu.">Последние чаты</string>
 
     <!-- duck.ai contextual fire button -->
     <string name="duckAIContextualFireButtonContentDescription">Стереть чат</string>
@@ -132,12 +143,6 @@
 
     <!-- Duck AI Chat Suggestions -->
     <string name="duckAiChatHistoryViewAllChats">Показать все чаты</string>
-
-    <!-- Duck.ai onboarding end CTA -->
-    <string name="duckAiEndCtaTitle">Проще некуда!</string>
-    <string name="duckAiEndCtaDescription"><![CDATA[Ищите и открывайте сайты в адресной строке или переключитесь на приватный чат с ИИ.<br/><br/>Duck.ai можно использовать везде, где есть значок чата]]></string>
-    <string name="duckAiEndCtaButton">Дай пять!</string>
-    <string name="duckAiEndCtaDescriptionCustomAi"><![CDATA[Начните приватный чат с ИИ через Duck.ai или переключитесь на поиск для защищенного просмотра веб-страниц.<br/><br/>Duck.ai можно использовать везде, где есть значок чата]]></string>
 
     <!-- Native Duck.ai chat history -->
     <string name="duck_ai_chat_history_title">Чаты</string>
@@ -184,4 +189,10 @@
     <string name="duck_ai_chat_history_download_view">Показать</string>
     <string name="duck_ai_chat_history_download_error">Не удалось экспортировать чат</string>
     <string name="duck_ai_chat_history_bulk_download_error">Не удалось экспортировать чаты</string>
+
+    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
+         users, so these are not localized (translatable="false"). Delete with the example. -->
+    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
+    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
+    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
@@ -95,6 +95,24 @@
     <string name="duckAiHideAiGeneratedImagesTitle">Skryť obrázky generované umelou inteligenciou</string>
     <string name="duckAiHideAiGeneratedImagesDescription">Odstraňuje obrázky vytvorené umelou inteligenciou z výsledkov vyhľadávania obrázkov</string>
 
+    <!-- Search Assist Visibility -->
+    <string name="duckAiSearchAssistVisibilityTitle">Viditeľnosť funkcie Search Assist</string>
+    <string name="duckAiSearchAssistVisibilitySubtitle">Vyber, ako často chceš, aby sa vo vyhľadávaní zobrazovali odpovede podporované AI.</string>
+    <string name="duckAiSearchAssistVisibilityNever">Nikdy</string>
+    <string name="duckAiSearchAssistVisibilityOnDemand">Na požiadanie</string>
+    <string name="duckAiSearchAssistVisibilitySometimes">Niekedy</string>
+    <string name="duckAiSearchAssistVisibilityOften">Často</string>
+
+    <!-- Duck AI Use Without AI Settings Option -->
+    <string name="duckAiUseWithoutAiTitle">Používaj DuckDuckGo bez AI</string>
+    <string name="duckAiUseWithoutAiDescription">Zakáže Duck.ai, skryje odpovede s podporou umelej inteligencie vo vyhľadávaní a filtruje známe spamové stránky s umelou inteligenciou vo výsledkoch vyhľadávania obrázkov.</string>
+    <string name="duckAiUseWithoutAiDisabledDescription">Umelá inteligencia je momentálne v prehliadači vypnutá, takže sa ti už nebudú zobrazovať odpovede s pomocou umelej inteligencie a vo výsledkoch vyhľadávania obrázkov sa bude zobrazovať menej obrázkov vygenerovaných umelou inteligenciou.</string>
+
+    <!-- Duck AI Section in AI Feature Screen -->
+    <string name="input_screen_user_pref_toggle_between_search_and_ai">Prepínať medzi vyhľadávaním a Duck.ai</string>
+    <string name="duckAiDialogHideAiGeneratedImagesTitle">Skryť obrázky generované umelou inteligenciou</string>
+    <string name="duckAiDialogHideAiGeneratedImagesDescription">Filtruje známe spamové stránky generované umelou inteligenciou vo výsledkoch vyhľadávania obrázkov. <annotation link="learn_more">Zisti viac</annotation></string>
+
     <!-- Duck AI Paid Settings -->
     <string name="duck_ai_paid_settings_enable_in_settings">Povoliť v nastaveniach funkcií AI</string>
     <string name="duck_ai_paid_settings_manage_in_settings">Spravovať v nastaveniach funkcií AI</string>
@@ -184,4 +202,10 @@
     <string name="duck_ai_chat_history_download_view">Zobraziť</string>
     <string name="duck_ai_chat_history_download_error">Nepodarilo sa exportovať chat</string>
     <string name="duck_ai_chat_history_bulk_download_error">Nepodarilo sa exportovať čety</string>
+
+    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
+         users, so these are not localized (translatable="false"). Delete with the example. -->
+    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
+    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
+    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
@@ -202,10 +202,4 @@
     <string name="duck_ai_chat_history_download_view">Zobraziť</string>
     <string name="duck_ai_chat_history_download_error">Nepodarilo sa exportovať chat</string>
     <string name="duck_ai_chat_history_bulk_download_error">Nepodarilo sa exportovať čety</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
@@ -95,6 +95,24 @@
     <string name="duckAiHideAiGeneratedImagesTitle">Skrij slike, ki jih ustvari umetna inteligenca</string>
     <string name="duckAiHideAiGeneratedImagesDescription">Iz rezultatov iskanja slik odstrani slike, ki jih je ustvarila umetna inteligenca</string>
 
+    <!-- Search Assist Visibility -->
+    <string name="duckAiSearchAssistVisibilityTitle">Vidnost pomoči pri iskanju Search Assist</string>
+    <string name="duckAiSearchAssistVisibilitySubtitle">Izberite, kako pogosto želite, da se v vaših iskanjih prikazujejo odgovori s pomočjo umetne inteligence.</string>
+    <string name="duckAiSearchAssistVisibilityNever">Nikoli</string>
+    <string name="duckAiSearchAssistVisibilityOnDemand">Na zahtevo</string>
+    <string name="duckAiSearchAssistVisibilitySometimes">Občasno</string>
+    <string name="duckAiSearchAssistVisibilityOften">Pogosto</string>
+
+    <!-- Duck AI Use Without AI Settings Option -->
+    <string name="duckAiUseWithoutAiTitle">Uporabljajte DuckDuckGo brez umetne inteligence</string>
+    <string name="duckAiUseWithoutAiDescription">Onemogoči Duck.ai, skrije odgovore z uporabo umetne inteligence v rezultatih iskanja in iz rezultatov iskanja slik izloči znana spletna mesta z neželeno vsebino, ustvarjeno z umetno inteligenco.</string>
+    <string name="duckAiUseWithoutAiDisabledDescription">Umetna inteligenca je v brskalniku trenutno onemogočena. Odgovori, ustvarjeni z umetno inteligenco, ne bodo več prikazani, med rezultati iskanja slik pa bo manj slik, ustvarjenih z umetno inteligenco.</string>
+
+    <!-- Duck AI Section in AI Feature Screen -->
+    <string name="input_screen_user_pref_toggle_between_search_and_ai">Preklopite med\niskanjem in Duck.ai</string>
+    <string name="duckAiDialogHideAiGeneratedImagesTitle">Skrij slike, ustvarjene z umetno inteligenco</string>
+    <string name="duckAiDialogHideAiGeneratedImagesDescription">Iz rezultatov iskanja slik izloči znana spletna mesta z neželeno vsebino, ustvarjeno z umetno inteligenco. <annotation link="learn_more">Več o tem</annotation></string>
+
     <!-- Duck AI Paid Settings -->
     <string name="duck_ai_paid_settings_enable_in_settings">Omogočite v nastavitvah funkcij umetne inteligence</string>
     <string name="duck_ai_paid_settings_manage_in_settings">Upravljajte v nastavitvah funkcij umetne inteligence</string>
@@ -184,4 +202,10 @@
     <string name="duck_ai_chat_history_download_view">Prikaži</string>
     <string name="duck_ai_chat_history_download_error">Klepeta ni bilo mogoče izvoziti</string>
     <string name="duck_ai_chat_history_bulk_download_error">Klepetov ni bilo mogoče izvoziti</string>
+
+    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
+         users, so these are not localized (translatable="false"). Delete with the example. -->
+    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
+    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
+    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
@@ -202,10 +202,4 @@
     <string name="duck_ai_chat_history_download_view">Prikaži</string>
     <string name="duck_ai_chat_history_download_error">Klepeta ni bilo mogoče izvoziti</string>
     <string name="duck_ai_chat_history_bulk_download_error">Klepetov ni bilo mogoče izvoziti</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
@@ -200,10 +200,4 @@
     <string name="duck_ai_chat_history_download_view">Visa</string>
     <string name="duck_ai_chat_history_download_error">Kunde inte exportera chatt</string>
     <string name="duck_ai_chat_history_bulk_download_error">Kunde inte exportera chattar</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
@@ -95,6 +95,24 @@
     <string name="duckAiHideAiGeneratedImagesTitle">Dölj AI-genererade bilder</string>
     <string name="duckAiHideAiGeneratedImagesDescription">Filtrerar bort AI-genererade bilder från bildsökningsresultaten</string>
 
+    <!-- Search Assist Visibility -->
+    <string name="duckAiSearchAssistVisibilityTitle">Search Assist-synlighet</string>
+    <string name="duckAiSearchAssistVisibilitySubtitle">Välj hur ofta du vill att AI-assisterade svar ska visas i dina sökningar.</string>
+    <string name="duckAiSearchAssistVisibilityNever">Aldrig</string>
+    <string name="duckAiSearchAssistVisibilityOnDemand">På begäran</string>
+    <string name="duckAiSearchAssistVisibilitySometimes">Ibland</string>
+    <string name="duckAiSearchAssistVisibilityOften">Ofta</string>
+
+    <!-- Duck AI Use Without AI Settings Option -->
+    <string name="duckAiUseWithoutAiTitle">Använd DuckDuckGo utan AI</string>
+    <string name="duckAiUseWithoutAiDescription">Inaktiverar Duck.ai, döljer AI-assisterade svar i sökningen och filtrerar bort kända webbplatser för AI-spam från sökresultaten för bilder.</string>
+    <string name="duckAiUseWithoutAiDisabledDescription">AI är för närvarande inaktiverat i webbläsaren, så du kommer inte längre att se AI-assisterade svar eller AI-genererade bilder i sökresultaten för bilder.</string>
+
+    <!-- Duck AI Section in AI Feature Screen -->
+    <string name="input_screen_user_pref_toggle_between_search_and_ai">Växla mellan\nsökning och Duck.ai</string>
+    <string name="duckAiDialogHideAiGeneratedImagesTitle">Dölj AI-genererade bilder</string>
+    <string name="duckAiDialogHideAiGeneratedImagesDescription">Filtrerar bort kända webbplatser för AI-spam från sökresultaten för bilder. <annotation link="learn_more">Läs mer</annotation></string>
+
     <!-- Duck AI Paid Settings -->
     <string name="duck_ai_paid_settings_enable_in_settings">Aktivera i inställningarna för AI-funktioner</string>
     <string name="duck_ai_paid_settings_manage_in_settings">Hantera i inställningarna för AI-funktioner</string>
@@ -182,4 +200,10 @@
     <string name="duck_ai_chat_history_download_view">Visa</string>
     <string name="duck_ai_chat_history_download_error">Kunde inte exportera chatt</string>
     <string name="duck_ai_chat_history_bulk_download_error">Kunde inte exportera chattar</string>
+
+    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
+         users, so these are not localized (translatable="false"). Delete with the example. -->
+    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
+    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
+    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
@@ -95,6 +95,24 @@
     <string name="duckAiHideAiGeneratedImagesTitle">Yapay Zeka Tarafından Oluşturulan Görselleri Gizle</string>
     <string name="duckAiHideAiGeneratedImagesDescription">Görsel arama sonuçlarından yapay zeka tarafından üretilmiş görselleri filtreler</string>
 
+    <!-- Search Assist Visibility -->
+    <string name="duckAiSearchAssistVisibilityTitle">Search Assist Görünürlüğü</string>
+    <string name="duckAiSearchAssistVisibilitySubtitle">Yapay zeka destekli yanıtların aramalarınızda ne sıklıkta görünmesini istediğinizi seçin.</string>
+    <string name="duckAiSearchAssistVisibilityNever">Hiçbir zaman</string>
+    <string name="duckAiSearchAssistVisibilityOnDemand">Talep Üzerine</string>
+    <string name="duckAiSearchAssistVisibilitySometimes">Bazen</string>
+    <string name="duckAiSearchAssistVisibilityOften">Sıklıkla</string>
+
+    <!-- Duck AI Use Without AI Settings Option -->
+    <string name="duckAiUseWithoutAiTitle">DuckDuckGo\'yu AI Olmadan Kullanın</string>
+    <string name="duckAiUseWithoutAiDescription">Duck.ai\'yi devre dışı bırakır, aramalarda yapay zeka destekli yanıtları gizler ve görsel arama sonuçlarında bilinen yapay zeka spam sitelerini filtreler.</string>
+    <string name="duckAiUseWithoutAiDisabledDescription">Tarayıcıda yapay zeka şimdilik devre dışı bırakıldı. Bu nedenle artık yapay zeka destekli yanıtları göremeyecek ve görsel arama sonuçlarında yapay zeka tarafından oluşturulmuş daha az görsel göreceksiniz.</string>
+
+    <!-- Duck AI Section in AI Feature Screen -->
+    <string name="input_screen_user_pref_toggle_between_search_and_ai">Arama ile\nDuck.ai arasında geçiş yapın</string>
+    <string name="duckAiDialogHideAiGeneratedImagesTitle">Yapay Zeka Tarafından Oluşturulan Görselleri Gizle</string>
+    <string name="duckAiDialogHideAiGeneratedImagesDescription">Görsel arama sonuçlarından bilinen yapay zeka spam sitelerini filtreler. <annotation link="learn_more">Daha fazla bilgi</annotation></string>
+
     <!-- Duck AI Paid Settings -->
     <string name="duck_ai_paid_settings_enable_in_settings">AI Özellikleri Ayarlarında etkinleştir</string>
     <string name="duck_ai_paid_settings_manage_in_settings">AI Özellikleri Ayarlarında Yönet</string>
@@ -182,4 +200,10 @@
     <string name="duck_ai_chat_history_download_view">Göster</string>
     <string name="duck_ai_chat_history_download_error">Sohbet dışa aktarılamadı</string>
     <string name="duck_ai_chat_history_bulk_download_error">Sohbetler dışa aktarılamadı</string>
+
+    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
+         users, so these are not localized (translatable="false"). Delete with the example. -->
+    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
+    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
+    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
@@ -200,10 +200,4 @@
     <string name="duck_ai_chat_history_download_view">Göster</string>
     <string name="duck_ai_chat_history_download_error">Sohbet dışa aktarılamadı</string>
     <string name="duck_ai_chat_history_bulk_download_error">Sohbetler dışa aktarılamadı</string>
-
-    <!-- Example message card: internal-only showcase of NativeInputChatTabItemPlugin, not shipped to
-         users, so these are not localized (translatable="false"). Delete with the example. -->
-    <string name="duckChatExampleMessageCardTitle" translatable="false">Example message card</string>
-    <string name="duckChatExampleMessageCardSubtitle" translatable="false">Contributed by an ActivePlugin to show how other modules can add items to the Chat tab. Dismiss it to see the card remove itself.</string>
-    <string name="duckChatExampleMessageCardAction" translatable="false">Got it</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -72,22 +72,4 @@
     <!-- Duck AI Duck.ai Section Header -->
     <string name="duckAiDuckAiSectionHeader">Duck.ai</string>
 
-    <!-- Search Assist Visibility -->
-    <string name="duckAiSearchAssistVisibilityTitle">Search Assist Visibility</string>
-    <string name="duckAiSearchAssistVisibilitySubtitle">Choose how often you want AI-assisted answers to appear in your searches.</string>
-    <string name="duckAiSearchAssistVisibilityNever">Never</string>
-    <string name="duckAiSearchAssistVisibilityOnDemand">On demand</string>
-    <string name="duckAiSearchAssistVisibilitySometimes">Sometimes</string>
-    <string name="duckAiSearchAssistVisibilityOften">Often</string>
-
-    <!-- Duck AI Use Without AI Settings Option -->
-    <string name="duckAiUseWithoutAiTitle">Use DuckDuckGo Without AI</string>
-    <string name="duckAiUseWithoutAiDescription">Disables Duck.ai, hides AI-assisted answers in search, and filters known AI spam sites in image search results.</string>
-    <string name="duckAiUseWithoutAiDisabledDescription">AI is currently disabled in the Browser so you’ll no longer see AI-assisted answers and see fewer AI-generated images in image search results.</string>
-
-    <!-- Duck AI Section in AI Feature Screen -->
-    <string name="input_screen_user_pref_toggle_between_search_and_ai">Toggle between Search and Duck.ai</string>
-    <string name="duckAiDialogHideAiGeneratedImagesTitle">Hide AI-Generated Images</string>
-    <string name="duckAiDialogHideAiGeneratedImagesDescription">Filters out known AI spam sites from image search results. <annotation link="learn_more">Learn more</annotation></string>
-
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -94,6 +94,24 @@
     <string name="duckAiHideAiGeneratedImagesTitle">Hide AI-Generated Images</string>
     <string name="duckAiHideAiGeneratedImagesDescription">Filters out AI-generated images from image search results</string>
 
+    <!-- Search Assist Visibility -->
+    <string name="duckAiSearchAssistVisibilityTitle">Search Assist Visibility</string>
+    <string name="duckAiSearchAssistVisibilitySubtitle">Choose how often you want AI-assisted answers to appear in your searches.</string>
+    <string name="duckAiSearchAssistVisibilityNever">Never</string>
+    <string name="duckAiSearchAssistVisibilityOnDemand">On demand</string>
+    <string name="duckAiSearchAssistVisibilitySometimes">Sometimes</string>
+    <string name="duckAiSearchAssistVisibilityOften">Often</string>
+
+    <!-- Duck AI Use Without AI Settings Option -->
+    <string name="duckAiUseWithoutAiTitle">Use DuckDuckGo Without AI</string>
+    <string name="duckAiUseWithoutAiDescription">Disables Duck.ai, hides AI-assisted answers in search, and filters known AI spam sites in image search results.</string>
+    <string name="duckAiUseWithoutAiDisabledDescription">AI is currently disabled in the Browser so you’ll no longer see AI-assisted answers and see fewer AI-generated images in image search results.</string>
+
+    <!-- Duck AI Section in AI Feature Screen -->
+    <string name="input_screen_user_pref_toggle_between_search_and_ai">Toggle between Search and Duck.ai</string>
+    <string name="duckAiDialogHideAiGeneratedImagesTitle">Hide AI-Generated Images</string>
+    <string name="duckAiDialogHideAiGeneratedImagesDescription">Filters out known AI spam sites from image search results. <annotation link="learn_more">Learn more</annotation></string>
+
     <!-- Duck AI Paid Settings -->
     <string name="duck_ai_paid_settings_enable_in_settings">Enable in AI Features Settings</string>
     <string name="duck_ai_paid_settings_manage_in_settings">Manage in AI Features Settings</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200581511062568/task/1215998626402639?focus=true
Tech Design URL (if applicable):

### Description

Translations for disable AI feature.

### Steps to test this PR

QA optional.

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only localization with no Kotlin or behavior changes; main risk is translation or copy mismatches in settings UI.
> 
> **Overview**
> Adds **localized copy** for the disable-AI / “use without AI” experience and related AI search settings by moving strings out of `donottranslate.xml` into `values/strings-duckchat.xml` and filling **~20 locale** `strings-duckchat.xml` files.
> 
> New or relocated user-facing keys include **Search Assist visibility** (title, subtitle, Never / On demand / Sometimes / Often), **Use DuckDuckGo without AI** (title, active description, disabled-state description), **toggle between Search and Duck.ai**, and **hide AI-generated images** dialog strings (with learn-more annotation). English defaults now live in the main duckchat strings file alongside existing SERP AI settings; non-English users get matching translations instead of English-only `donottranslate` entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b4cd0cfea89c3d3e9e88b434605830355ac3b4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->