### PR TITLE
Enable duckAiOnboarding and fix onboarding Maestro tests

### DIFF
--- a/.maestro/fire_button/dimiss_fire_during_onboarding.yaml
+++ b/.maestro/fire_button/dimiss_fire_during_onboarding.yaml
@@ -13,8 +13,10 @@ tags:
 
       - runFlow: ../shared/pre_onboarding.yaml
 
+      # pre_onboarding ends on a search result page; type the test URL into the omnibar
+      # (the native input field only exists on the new-tab page).
       - tapOn:
-          id: "inputField"
+          id: "omnibarTextInput"
       - inputText: "https://privacy-test-pages.site"
       - pressKey: Enter
       - assertVisible:

--- a/.maestro/fire_button/fire_during_onboarding.yaml
+++ b/.maestro/fire_button/fire_during_onboarding.yaml
@@ -14,7 +14,7 @@ tags:
       - runFlow: ../shared/pre_onboarding.yaml
 
       - tapOn:
-          id: "inputField"
+          id: "omnibarTextInput"
       - inputText: "https://privacy-test-pages.site"
       - pressKey: Enter
       - assertVisible:

--- a/.maestro/onboarding/onboarding_dismiss_all_dialogs.yaml
+++ b/.maestro/onboarding/onboarding_dismiss_all_dialogs.yaml
@@ -12,12 +12,10 @@ tags:
       - launchApp:
           clearState: true
       - runFlow: ../shared/pre_onboarding.yaml
-      - assertVisible:
-          id: "daxDialogDismissButton|brandDesignDismissButton"
       - tapOn:
-          id: "daxDialogDismissButton|brandDesignDismissButton"
-      - assertVisible:
-          id: ddgLogo
+          id: "daxDialogDismissButton|contextualBrandDesignDismissButton"
+      - tapOn:
+          id: "omnibarTextInput"
       - inputText: "https://www.search-company.site/#ad-id-14"
       - pressKey: Enter
       - assertVisible:

--- a/.maestro/onboarding/onboarding_dismiss_try_a_search_dialog.yaml
+++ b/.maestro/onboarding/onboarding_dismiss_try_a_search_dialog.yaml
@@ -11,9 +11,9 @@ tags:
       - launchApp:
           clearState: true
       - runFlow: ../shared/pre_onboarding.yaml
-      - assertVisible:
-          id: "daxDialogDismissButton|brandDesignDismissButton"
       - tapOn:
-          id: "daxDialogDismissButton|brandDesignDismissButton"
+          id: "daxDialogDismissButton|contextualBrandDesignDismissButton"
+      - assertNotVisible:
+          text: ".*That's DuckDuckGo Search!.*"
       - assertVisible:
-          id: ddgLogo
+          id: "omnibarTextInput"

--- a/.maestro/shared/pre_onboarding.yaml
+++ b/.maestro/shared/pre_onboarding.yaml
@@ -31,6 +31,13 @@ appId: com.duckduckgo.mobile.android
 - tapOn: "next"
 - assertVisible:
     text: ".*want easy access to private AI chat?.*"
+# Tapping next opens the new Duck.ai onboarding preview. Search is the default mode, so tap a
+# search suggestion to run a demo search — this completes onboarding and lands in the browser
+# on the in-context "That's DuckDuckGo Search!" CTA.
 - tapOn: "next"
 - assertVisible:
-    text: ".*Try a search!.*"
+    id: "suggestion1"
+- tapOn:
+    id: "suggestion1"
+- assertVisible:
+    text: ".*That's DuckDuckGo Search!.*"

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/extendedonboarding/ExtendedOnboardingFeatureToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/extendedonboarding/ExtendedOnboardingFeatureToggles.kt
@@ -50,6 +50,6 @@ interface ExtendedOnboardingFeatureToggles {
     @Experiment
     fun freeTrialCopy(): Toggle
 
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun duckAiOnboarding(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205648422731273/task/1216032811593479?focus=true
Tech Design URL (if applicable):

### Description

Enables the `duckAiOnboarding` feature flag (default `FALSE` → `TRUE`). When on (together with its co-gates `aiChat` + `singleTabFireDialog`, already enabled in production config), it adds the Duck.ai input-screen **preview** step to new-user onboarding: after the "Want easy access to private AI chat?" screen, tapping **Next** opens the preview (Search is the default tab); submitting a query completes onboarding via a search and lands in the browser on the in-context **"That's DuckDuckGo Search!"** CTA.

Updates the Maestro flows that run full onboarding to account for the new step. The shared `pre_onboarding.yaml` now drives the preview (taps a search suggestion) and asserts the in-context CTA; flows that continue from there dismiss the CTA and use the loaded-page omnibar.

Changes:
- `shared/pre_onboarding.yaml` — tap a search suggestion, then assert "That's DuckDuckGo Search!".
- `fire_button/fire_during_onboarding.yaml`, `fire_button/dimiss_fire_during_onboarding.yaml` — retarget the address-bar tap to `omnibarTextInput` (the result-page address bar; `inputField` only exists on the new-tab page). The in-context CTA is just ignored, like the previous flow ignored "Try a search!".
- `onboarding/onboarding_dismiss_all_dialogs.yaml`, `onboarding/onboarding_dismiss_try_a_search_dialog.yaml` — drop the now-gone "Try a search!" / `ddgLogo` home assumptions; dismiss the CTA and continue via the omnibar.
- `custom_tabs` / `sync` flows need no changes — they inherit `pre_onboarding` and their menu navigation is unaffected.

Note: the post-preview state is a search result page, so the native input field (`inputField`, #9016) is intentionally not used in these flows.

### Steps to test this PR

QA-optional

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default onboarding UX for all new installs via a remote feature toggle; Maestro-only test updates limit production code risk.
> 
> **Overview**
> Turns on **`duckAiOnboarding`** by default (`FALSE` → `TRUE`), so new users see the Duck.ai onboarding preview after the private AI chat step and finish onboarding via a demo search on the **"That's DuckDuckGo Search!"** in-context CTA.
> 
> **Maestro** is updated to match: **`pre_onboarding.yaml`** taps a search suggestion instead of expecting **"Try a search!"** on the home/new-tab screen. Flows that continue after onboarding dismiss that CTA and use **`omnibarTextInput`** (SERP address bar) instead of **`inputField`** (new-tab only). Onboarding dismiss tests drop home/`ddgLogo` assumptions and align dismiss targets with **`contextualBrandDesignDismissButton`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c38293f85de6a21167d8cb99501d504c60b0542. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->