### PR TITLE
Hide the Duck.ai tier indicator during the onboarding lock

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -6027,6 +6027,7 @@ class BrowserTabFragment :
                     },
                 )
                 nativeInputManager.setDuckAiFireButtonHighlighted(highlighted = viewState.fireButton.isHighlighted())
+                nativeInputManager.setDuckAiTierVisible(visible = !viewState.isOmnibarLockedForOnboarding)
 
                 renderBrowserMenu(viewState)
 

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -132,6 +132,9 @@ interface NativeInputManager {
 
     /** Show pulse animation around the Duck.ai fire button. */
     fun setDuckAiFireButtonHighlighted(highlighted: Boolean)
+
+    /** Hide/show the subscription-tier indicator in the Duck.ai header (hidden during the onboarding lock). */
+    fun setDuckAiTierVisible(visible: Boolean)
 }
 
 @ContributesBinding(FragmentScope::class)
@@ -732,6 +735,10 @@ class RealNativeInputManager @Inject constructor(
 
     override fun setDuckAiFireButtonHighlighted(highlighted: Boolean) {
         duckAiFireButtonHighlightSource.value = highlighted
+    }
+
+    override fun setDuckAiTierVisible(visible: Boolean) {
+        if (::omnibarController.isInitialized) omnibarController.setTierVisible(visible)
     }
 
     private fun suppressShadow(view: View) {

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
@@ -60,6 +60,9 @@ interface NativeInputOmnibarController : OmnibarState {
     fun restore()
     fun forceToTop()
     fun updateTierTitle(tier: DuckAiTier, onUpgradeClicked: () -> Unit)
+
+    /** Hide/show the subscription-tier indicator (Free pill / paid title) in the Duck.ai header. */
+    fun setTierVisible(visible: Boolean)
 }
 
 class RealNativeInputOmnibarController(
@@ -150,6 +153,7 @@ class RealNativeInputOmnibarController(
 
     private var currentTier: DuckAiTier = DuckAiTier.Unknown
     private var currentUpgradeClick: (() -> Unit)? = null
+    private var tierVisible: Boolean = true
 
     private fun showDuckAiTitle(omnibarView: View) {
         val header = omnibarView.findViewById<android.widget.LinearLayout?>(R.id.duckAIHeader)
@@ -167,9 +171,20 @@ class RealNativeInputOmnibarController(
         applyTierText(omnibarView)
     }
 
+    override fun setTierVisible(visible: Boolean) {
+        tierVisible = visible
+        (omnibar.omnibarView as? View)?.let { applyTierText(it) }
+    }
+
     private fun applyTierText(omnibarView: View) {
         val aiTitle = omnibarView.findViewById<TextView?>(R.id.aiTitle)
         val freePill = omnibarView.findViewById<View?>(R.id.duckAIFreePill)
+        if (!tierVisible) {
+            aiTitle?.gone()
+            freePill?.gone()
+            freePill?.setOnClickListener(null)
+            return
+        }
         if (nativeInputStateBugKillSwitch.self().isEnabled() && !overlayActive) {
             freePill?.gone()
             freePill?.setOnClickListener(null)
@@ -219,6 +234,7 @@ class RealNativeInputOmnibarController(
         overlayActive = false
         currentTier = DuckAiTier.Unknown
         currentUpgradeClick = null
+        tierVisible = true
         (omnibar.omnibarView as? View)?.let { removeLayoutListener(it) }
         restoreOmnibarColors()
         restoreOmnibarContent()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1205648422731273/task/1216069993070136?focus=true
Tech Design URL (if applicable): 

### Description

Hides the Duck.ai subscription-tier indicator in the omnibar's Duck.ai header during the Duck.ai onboarding flow.

The tier indicator is rendered imperatively by `NativeInputOmnibarController.applyTierText()` (and re-applied on every layout pass), so an omnibar-`ViewState` approach can't hide it. Instead a `tierVisible` flag is honoured inside `applyTierText()` (hiding both the Free pill and the paid title), driven from `NativeInputManager.setDuckAiTierVisible(...)` off the existing `isOmnibarLockedForOnboarding` signal, and reset in `restore()` so it can't leak across Duck.ai sessions.

### Steps to test this PR
- [ ] Ensure bot `nativeInputField` and `duckAiOnboarding` flags are enabled
- [ ] During the locked onboarding window, confirm the Duck.ai header shows only the Duck.ai icon — no "Free plan"/upgrade pill and no paid tier title.
- [ ] Finish onboarding, open Duck.ai normally, and confirm the tier indicator shows again (Free pill, or the paid title for a Plus account).

### UI changes
| Before  | After |
| ------ | ----- |
|<img width="1080" height="2400" alt="Screenshot_20260626_192112" src="https://github.com/user-attachments/assets/f58dc900-0b4c-4f31-9796-35354a4a77d0" />|<img width="1080" height="2400" alt="Screenshot_20260626_191642" src="https://github.com/user-attachments/assets/ca868668-b66c-44da-bc9c-383d9e631f7e" />|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, onboarding-only UI visibility change with no auth, data, or subscription logic changes; state is reset in `restore()` to avoid leaking across sessions.
> 
> **Overview**
> Hides the Duck.ai **Free pill** and **paid tier title** in the native-input omnibar header while Duck.ai onboarding has the omnibar locked, so onboarding shows only the Duck.ai icon alongside the existing interaction lock and fire-button highlight.
> 
> Adds **`setDuckAiTierVisible`** on `NativeInputManager` (forwarded to the omnibar controller when initialized), driven from **`BrowserTabFragment`** with `visible = !isOmnibarLockedForOnboarding` next to the existing onboarding lock wiring. **`NativeInputOmnibarController`** gains a **`tierVisible`** flag honored inside **`applyTierText()`** (including on layout re-applies), and **`restore()`** resets **`tierVisible`** to true so tier UI cannot stay hidden after Duck.ai exits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 484437661bd3205972f1f5ad7058cd0fadf7f86b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->