### PR TITLE
Update content scope scripts to version 15.8.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -8344,9 +8344,16 @@
     /**
      * Register a captcha provider
      * @param {import('./providers/provider.interface').CaptchaProvider} provider - The provider to register
+     * @param {Object} [options] - The optional provider options
+     * @param {Array<string>} [options.aliases] - An optional list of aliases for that provider
      */
-    registerProvider(provider) {
+    registerProvider(provider, options) {
       this.providers.set(provider.getType(), provider);
+      if (options?.aliases) {
+        options?.aliases.forEach((alias) => {
+          this.providers.set(alias, provider);
+        });
+      }
     }
     /**
      * Get a provider by type
@@ -8379,7 +8386,7 @@
      * @returns {Array<import('./providers/provider.interface').CaptchaProvider>}
      */
     _getAllProviders() {
-      return Array.from(this.providers.values());
+      return Array.from(new Set(this.providers.values()));
     }
   };
 
@@ -8823,7 +8830,7 @@
     })
   );
   captchaFactory.registerProvider(new CloudFlareTurnstileProvider());
-  captchaFactory.registerProvider(new ImageProvider());
+  captchaFactory.registerProvider(new ImageProvider(), { aliases: ["red-circle", "basic-math"] });
 
   // src/features/broker-protection/captcha-services/get-captcha-provider.js
   function getCaptchaProvider(root, captchaContainer, captchaType) {
@@ -8993,11 +9000,12 @@
     if (PirError.isError(captchaIdentifier)) {
       return createError(captchaIdentifier.error.message);
     }
+    const reportedType = captchaFactory.getProviderByType(captchaType) === captchaProvider ? captchaType : captchaProvider.getType();
     const response = {
       url: removeUrlQueryParams(window.location.href),
       // query params (which may include PII)
       siteKey: captchaIdentifier,
-      type: captchaProvider.getType()
+      type: reportedType
     };
     return SuccessResponse.create({ actionID, actionType, response });
   }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -8313,9 +8313,16 @@
     /**
      * Register a captcha provider
      * @param {import('./providers/provider.interface').CaptchaProvider} provider - The provider to register
+     * @param {Object} [options] - The optional provider options
+     * @param {Array<string>} [options.aliases] - An optional list of aliases for that provider
      */
-    registerProvider(provider) {
+    registerProvider(provider, options) {
       this.providers.set(provider.getType(), provider);
+      if (options?.aliases) {
+        options?.aliases.forEach((alias) => {
+          this.providers.set(alias, provider);
+        });
+      }
     }
     /**
      * Get a provider by type
@@ -8348,7 +8355,7 @@
      * @returns {Array<import('./providers/provider.interface').CaptchaProvider>}
      */
     _getAllProviders() {
-      return Array.from(this.providers.values());
+      return Array.from(new Set(this.providers.values()));
     }
   };
 
@@ -8792,7 +8799,7 @@
     })
   );
   captchaFactory.registerProvider(new CloudFlareTurnstileProvider());
-  captchaFactory.registerProvider(new ImageProvider());
+  captchaFactory.registerProvider(new ImageProvider(), { aliases: ["red-circle", "basic-math"] });
 
   // src/features/broker-protection/captcha-services/get-captcha-provider.js
   function getCaptchaProvider(root, captchaContainer, captchaType) {
@@ -8962,11 +8969,12 @@
     if (PirError.isError(captchaIdentifier)) {
       return createError(captchaIdentifier.error.message);
     }
+    const reportedType = captchaFactory.getProviderByType(captchaType) === captchaProvider ? captchaType : captchaProvider.getType();
     const response = {
       url: removeUrlQueryParams(window.location.href),
       // query params (which may include PII)
       siteKey: captchaIdentifier,
-      type: captchaProvider.getType()
+      type: reportedType
     };
     return SuccessResponse.create({ actionID, actionType, response });
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.95.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.7.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.8.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#79f92b48fafa783528227adac0adcee29709ff42",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#b08079e6b77c160fcc9a3ad1237c1338cb76e984",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -678,18 +678,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.4.tgz",
-      "integrity": "sha512-vwVLJVvvpslm7vqAH7+XNj/neA/Ynq7DT2EEcMuwc5YzN5XaMyRAqxwU+uX3azZ1FQtB2gvrvnLnAEkvYlVdfg==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.5.tgz",
+      "integrity": "sha512-pGrwzZDvPwKe+7NNUqAunb6rqTfynr0VOUhCMdqbu5xlvNiszsAJygRzwvpVycdzejlbpY+SWJOn+s75Og7FEA==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.4.4.tgz",
-      "integrity": "sha512-L1xvJQNZQFrhjyAFmFlOoijmd9lSOvK6bGs0+z8Nz91UCAIyVIShwOsPPStuQH4XCFwif5Hlmcr6DnEz7Ag7Xw==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.4.5.tgz",
+      "integrity": "sha512-bwtTTTg5YJVFwpoxqO1Xtggkmia84oKfXCGMvz6ta1JEJ5S+MJ5n7hyYFzXVNh9GFg6zisd90iPTFzhe5bMQwg==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.4.4"
+        "tldts-core": "^7.4.5"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.95.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.7.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.8.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1216100734459361

- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [x] All tests must pass
- [x] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches broker-protection captcha resolution and reporting in injected scripts; behavior changes for alias captcha types could affect PIR flows, though scope is limited to the dependency bump.
> 
> **Overview**
> Bumps **`@duckduckgo/content-scope-scripts`** from **15.7.0** to **15.8.0** in `package.json` / `package-lock.json` and refreshes the vendored Android bundles under `node_modules/.../build/android/` (including `autofillImport.js` and `brokerProtection.js`).
> 
> The upstream broker-protection captcha changes add **provider aliases** on `CaptchaFactory.registerProvider` (e.g. `ImageProvider` is also reachable as `red-circle` and `basic-math`), dedupe providers in `_getAllProviders`, and report the **requested captcha type** when it resolves via an alias instead of always using the provider’s canonical type. Lockfile also picks up a minor **`tldts-*`** **7.4.4 → 7.4.5** transitive bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb421c22e51cded31d03c958f2560f1e7ae1439e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->