### PR TITLE
Fix YouTube video URL in load_youtube_video.yaml

### DIFF
--- a/.maestro/duckplayer/common/load_youtube_video.yaml
+++ b/.maestro/duckplayer/common/load_youtube_video.yaml
@@ -7,6 +7,7 @@ androidWebViewHierarchy: devtools
 - tapOn:
     id: "omnibarTextInput"
 - inputText: "https://m.youtube.com/@duckduckgo2597/search?query=DuckDuckGo%20vs%20Google%3A%205%20Reasons%20You%20Should%20Switch"
+- inputText: "https://m.youtube.com/@duckduckgo/search?query=DuckDuckGo%20vs%20Google%3A%205%20Reasons%20You%20Should%20Switch"
 - pressKey: Enter
 - runFlow: handle_youtube_cookies.yaml
 - tapOn:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1216107310155097?focus=true
Tech Design URL (if applicable): 

### Description
Fix broken Duck Player tests due to URL not found

### Steps to test this PR
n/a

### UI changes
n/a

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Maestro YAML change with no production app or runtime impact.
> 
> **Overview**
> Updates the Duck Player Maestro flow **`load_youtube_video.yaml`** so omnibar navigation uses **`https://m.youtube.com/@duckduckgo/...`** instead of **`@duckduckgo2597`**, matching a channel that no longer resolves and was causing “URL not found” / failed video taps in Duck Player E2E.
> 
> Also normalizes indentation on the **`tapOn`** step that selects the **“DuckDuckGo vs Google.*”** search result; behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34988cc2639ef7ef97e2eec2bb6c1a552fcdd23e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->