### PR TITLE
Remove wrong Duck Player query

### DIFF
--- a/.maestro/duckplayer/common/load_youtube_video.yaml
+++ b/.maestro/duckplayer/common/load_youtube_video.yaml
@@ -6,7 +6,6 @@ androidWebViewHierarchy: devtools
 - runFlow: ../../shared/dismiss_native_input.yaml
 - tapOn:
     id: "omnibarTextInput"
-- inputText: "https://m.youtube.com/@duckduckgo2597/search?query=DuckDuckGo%20vs%20Google%3A%205%20Reasons%20You%20Should%20Switch"
 - inputText: "https://m.youtube.com/@duckduckgo/search?query=DuckDuckGo%20vs%20Google%3A%205%20Reasons%20You%20Should%20Switch"
 - pressKey: Enter
 - runFlow: handle_youtube_cookies.yaml


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1216104666009314?focus=true
Tech Design URL (if applicable): 

### Description

### Steps to test this PR

_Feature 1_
- [ ] Check [job](https://github.com/duckduckgo/Android/actions/runs/28362424763/job/84020015230) passes 

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Maestro test-only URL change with no production app or runtime behavior impact.
> 
> **Overview**
> Updates the shared Maestro **`load_youtube_video`** flow so Duck Player UI tests open YouTube via **`@duckduckgo`** instead of **`@duckduckgo2597`**, keeping the same search query for the “DuckDuckGo vs Google” video.
> 
> That URL is reused by several Duck Player flows (always/never/ask modes), so fixing the channel should stop tests from navigating to the wrong channel or missing the expected result tap target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae36fa24bfb812fca75fafa538b0eb71cf246ffb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->