### PR TITLE
Add chat sync promo pixels

### DIFF
--- a/PixelDefinitions/pixels/definitions/sync_promotion.json
+++ b/PixelDefinitions/pixels/definitions/sync_promotion.json
@@ -1,0 +1,50 @@
+{
+    "sync_promotion_displayed": {
+        "description": "Fired when a Sync promotion is shown to the user.",
+        "owners": ["MiSikora"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The surface where the Sync promotion was shown",
+                "enum": ["bookmarks", "passwords", "ai_chat"]
+            }
+        ]
+    },
+    "sync_promotion_confirmed": {
+        "description": "Fired when the user taps a Sync promotion to start setting up Sync.",
+        "owners": ["MiSikora"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The surface where the Sync promotion was shown",
+                "enum": ["bookmarks", "passwords", "ai_chat"]
+            }
+        ]
+    },
+    "sync_promotion_dismissed": {
+        "description": "Fired when a Sync promotion is dismissed by the user or after its impression cap is reached.",
+        "owners": ["MiSikora"],
+        "triggers": ["other"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "source",
+                "type": "string",
+                "description": "The surface where the Sync promotion was shown",
+                "enum": ["bookmarks", "passwords", "ai_chat"]
+            },
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Why the Sync promotion was dismissed. Sent for the ai_chat source only",
+                "enum": ["user_tapped", "impression_cap"]
+            }
+        ]
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -776,6 +776,7 @@ object SyncPixelParameters {
     const val ERROR_REASON = "reason"
     const val ERROR = "error"
     const val SYNC_FEATURE_PROMOTION_SOURCE = "source"
+    const val SYNC_FEATURE_PROMOTION_DISMISS_REASON = "reason"
     const val GET_OTHER_DEVICES_SCREEN_LAUNCH_SOURCE = "source"
     const val SYNC_SETUP_SCREEN_TYPE = "source"
     const val SYNC_SETUP_FLOW_VERSION = "flow_version"

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/chat/ChatSyncPromotion.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/chat/ChatSyncPromotion.kt
@@ -16,10 +16,14 @@
 
 package com.duckduckgo.sync.impl.promotion.chat
 
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.sync.api.DeviceSyncState
+import com.duckduckgo.sync.impl.pixels.SyncPixelName
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters
 import com.duckduckgo.sync.impl.promotion.SyncPromotionDataStore
 import com.duckduckgo.sync.impl.promotion.SyncPromotionDataStore.PromotionType.ChatTabPage
 import com.squareup.anvil.annotations.ContributesBinding
@@ -42,6 +46,7 @@ class RealChatSyncPromotion @Inject constructor(
     private val promotionDataStore: SyncPromotionDataStore,
     private val syncState: DeviceSyncState,
     private val duckChat: DuckChat,
+    private val pixel: Pixel,
     private val dispatchers: DispatcherProvider,
 ) : ChatSyncPromotion {
     override suspend fun canShowPromotion(): Boolean = coroutineScope {
@@ -52,19 +57,41 @@ class RealChatSyncPromotion @Inject constructor(
 
     override suspend fun incrementImpressionCount() {
         promotionDataStore.recordPromoImpression(ChatTabPage)
+        pixel.fire(SyncPixelName.SYNC_FEATURE_PROMOTION_DISPLAYED, pixelParms())
     }
 
     override suspend fun recordPromotionAccepted() {
         promotionDataStore.recordPromoDismissed(ChatTabPage)
+        pixel.fire(SyncPixelName.SYNC_FEATURE_PROMOTION_CONFIRMED, pixelParms())
     }
 
     override suspend fun recordPromotionDismissed() {
         promotionDataStore.recordPromoDismissed(ChatTabPage)
+        pixel.fire(
+            pixel = SyncPixelName.SYNC_FEATURE_PROMOTION_DISMISSED,
+            parameters = pixelParms {
+                put(SyncPixelParameters.SYNC_FEATURE_PROMOTION_DISMISS_REASON, PIXEL_DISMISS_REASON_USER_TAPPED)
+            },
+        )
     }
 
     private suspend fun isPromoExhausted(): Boolean {
-        return promotionDataStore.hasPromoBeenDismissed(ChatTabPage) ||
-            promotionDataStore.getPromoImpressionCount(ChatTabPage) >= MAX_IMPRESSION_COUNT
+        val isDismissedByUser = promotionDataStore.hasPromoBeenDismissed(ChatTabPage)
+        if (isDismissedByUser) {
+            return true
+        }
+
+        val isImpressionCapReached = promotionDataStore.getPromoImpressionCount(ChatTabPage) >= MAX_IMPRESSION_COUNT
+        if (isImpressionCapReached) {
+            pixel.fire(
+                pixel = SyncPixelName.SYNC_FEATURE_PROMOTION_DISMISSED,
+                parameters = pixelParms {
+                    put(SyncPixelParameters.SYNC_FEATURE_PROMOTION_DISMISS_REASON, PIXEL_DISMISS_REASON_IMPRESSION_CAP)
+                },
+                type = Unique(MAX_IMPRESSION_CAP_PIXEL_TAG),
+            )
+        }
+        return isImpressionCapReached
     }
 
     private suspend fun isEligibleForPromo() = coroutineScope {
@@ -86,7 +113,28 @@ class RealChatSyncPromotion @Inject constructor(
 
     private suspend fun hasChatSuggestions(): Boolean = duckChat.observeHasChatSuggestions().firstOrNull() == true
 
+    private fun pixelParms(
+        customParams: (MutableMap<String, String>.() -> Unit)? = null,
+    ): Map<String, String> = buildMap {
+        put(SyncPixelParameters.SYNC_FEATURE_PROMOTION_SOURCE, PIXEL_SOURCE)
+        customParams?.invoke(this)
+    }
+
     companion object {
         const val MAX_IMPRESSION_COUNT = 3
+
+        private const val PIXEL_SOURCE = "ai_chat"
+        private const val PIXEL_DISMISS_REASON_USER_TAPPED = "user_tapped"
+        private const val PIXEL_DISMISS_REASON_IMPRESSION_CAP = "impression_cap"
+
+        private val MAX_IMPRESSION_CAP_PIXEL_TAG = buildString {
+            append(SyncPixelName.SYNC_FEATURE_PROMOTION_DISMISSED.pixelName)
+            append('_')
+            append(PIXEL_SOURCE)
+            append('_')
+            append(PIXEL_DISMISS_REASON_IMPRESSION_CAP)
+            append('_')
+            append(MAX_IMPRESSION_COUNT)
+        }
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/chat/ChatSyncPromotion.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/chat/ChatSyncPromotion.kt
@@ -57,19 +57,19 @@ class RealChatSyncPromotion @Inject constructor(
 
     override suspend fun incrementImpressionCount() {
         promotionDataStore.recordPromoImpression(ChatTabPage)
-        pixel.fire(SyncPixelName.SYNC_FEATURE_PROMOTION_DISPLAYED, pixelParms())
+        pixel.fire(SyncPixelName.SYNC_FEATURE_PROMOTION_DISPLAYED, pixelParmas())
     }
 
     override suspend fun recordPromotionAccepted() {
         promotionDataStore.recordPromoDismissed(ChatTabPage)
-        pixel.fire(SyncPixelName.SYNC_FEATURE_PROMOTION_CONFIRMED, pixelParms())
+        pixel.fire(SyncPixelName.SYNC_FEATURE_PROMOTION_CONFIRMED, pixelParmas())
     }
 
     override suspend fun recordPromotionDismissed() {
         promotionDataStore.recordPromoDismissed(ChatTabPage)
         pixel.fire(
             pixel = SyncPixelName.SYNC_FEATURE_PROMOTION_DISMISSED,
-            parameters = pixelParms {
+            parameters = pixelParmas {
                 put(SyncPixelParameters.SYNC_FEATURE_PROMOTION_DISMISS_REASON, PIXEL_DISMISS_REASON_USER_TAPPED)
             },
         )
@@ -85,7 +85,7 @@ class RealChatSyncPromotion @Inject constructor(
         if (isImpressionCapReached) {
             pixel.fire(
                 pixel = SyncPixelName.SYNC_FEATURE_PROMOTION_DISMISSED,
-                parameters = pixelParms {
+                parameters = pixelParmas {
                     put(SyncPixelParameters.SYNC_FEATURE_PROMOTION_DISMISS_REASON, PIXEL_DISMISS_REASON_IMPRESSION_CAP)
                 },
                 type = Unique(MAX_IMPRESSION_CAP_PIXEL_TAG),
@@ -113,7 +113,7 @@ class RealChatSyncPromotion @Inject constructor(
 
     private suspend fun hasChatSuggestions(): Boolean = duckChat.observeHasChatSuggestions().firstOrNull() == true
 
-    private fun pixelParms(
+    private fun pixelParmas(
         customParams: (MutableMap<String, String>.() -> Unit)? = null,
     ): Map<String, String> = buildMap {
         put(SyncPixelParameters.SYNC_FEATURE_PROMOTION_SOURCE, PIXEL_SOURCE)

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/promotion/chat/RealChatSyncPromotionTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/promotion/chat/RealChatSyncPromotionTest.kt
@@ -50,7 +50,6 @@ class RealChatSyncPromotionTest {
     // DuckChat properties
     private var isChatHistoryEnabled = false
     private val hasChatSuggestions = MutableStateFlow(false)
-    
 
     private val testee = RealChatSyncPromotion(
         promotionDataStore = dataStore,
@@ -177,7 +176,7 @@ class RealChatSyncPromotionTest {
     }
 
     @Test
-    fun `when promotion is checked then fire confirmed pixel`() = runTest {
+    fun `when promotion is accepted then fire confirmed pixel`() = runTest {
         testee.recordPromotionAccepted()
 
         assertEquals(

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/promotion/chat/RealChatSyncPromotionTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/promotion/chat/RealChatSyncPromotionTest.kt
@@ -204,7 +204,7 @@ class RealChatSyncPromotionTest {
     }
 
     @Test
-    fun `when can't show promotion due to cap limit then fire user_tapped dismissed pixel`() = runTest {
+    fun `when can't show promotion due to cap limit then fire impression_cap dismissed pixel`() = runTest {
         configurePromotionToShow()
         repeat(RealChatSyncPromotion.MAX_IMPRESSION_COUNT) {
             testee.incrementImpressionCount()

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/promotion/chat/RealChatSyncPromotionTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/promotion/chat/RealChatSyncPromotionTest.kt
@@ -16,9 +16,14 @@
 
 package com.duckduckgo.sync.impl.promotion.chat
 
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelName
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.sync.impl.promotion.FakeSyncPromotionDataStore
 import com.duckduckgo.sync.impl.promotion.SyncPromotionDataStore.PromotionType
+import com.duckduckgo.sync.impl.promotion.chat.FakePixel.Measurement
 import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
@@ -35,6 +40,7 @@ class RealChatSyncPromotionTest {
     val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
 
     private val dataStore = FakeSyncPromotionDataStore()
+    private val pixel = FakePixel()
 
     // DeviceSyncState properties
     private var isSyncEnabled = false
@@ -44,6 +50,7 @@ class RealChatSyncPromotionTest {
     // DuckChat properties
     private var isChatHistoryEnabled = false
     private val hasChatSuggestions = MutableStateFlow(false)
+    
 
     private val testee = RealChatSyncPromotion(
         promotionDataStore = dataStore,
@@ -56,6 +63,7 @@ class RealChatSyncPromotionTest {
             onBlocking { hasUserEnabledChatHistory() } doAnswer { isChatHistoryEnabled }
             on { observeHasChatSuggestions() } doReturn hasChatSuggestions
         },
+        pixel = pixel,
         dispatchers = coroutineTestRule.testDispatcherProvider,
     )
 
@@ -156,6 +164,78 @@ class RealChatSyncPromotionTest {
         assertTrue(dataStore.hasPromoBeenDismissed(PromotionType.ChatTabPage))
     }
 
+    @Test
+    fun `when promotion impression count is increased then fire displayed pixel`() = runTest {
+        testee.incrementImpressionCount()
+
+        assertEquals(
+            listOf(
+                Measurement("sync_promotion_displayed", mapOf("source" to "ai_chat")),
+            ),
+            pixel.firedPixels,
+        )
+    }
+
+    @Test
+    fun `when promotion is checked then fire confirmed pixel`() = runTest {
+        testee.recordPromotionAccepted()
+
+        assertEquals(
+            listOf(
+                Measurement("sync_promotion_confirmed", mapOf("source" to "ai_chat")),
+            ),
+            pixel.firedPixels,
+        )
+    }
+
+    @Test
+    fun `when promotion is dismissed then fire user_tapped dismissed pixel`() = runTest {
+        testee.recordPromotionDismissed()
+
+        assertEquals(
+            listOf(
+                Measurement(
+                    name = "sync_promotion_dismissed",
+                    params = mapOf("source" to "ai_chat", "reason" to "user_tapped"),
+                ),
+            ),
+            pixel.firedPixels,
+        )
+    }
+
+    @Test
+    fun `when can't show promotion due to cap limit then fire user_tapped dismissed pixel`() = runTest {
+        configurePromotionToShow()
+        repeat(RealChatSyncPromotion.MAX_IMPRESSION_COUNT) {
+            testee.incrementImpressionCount()
+        }
+        pixel.clear()
+
+        testee.canShowPromotion()
+
+        assertEquals(
+            listOf(
+                Measurement(
+                    name = "sync_promotion_dismissed",
+                    params = mapOf("source" to "ai_chat", "reason" to "impression_cap"),
+                    type = Unique("sync_promotion_dismissed_ai_chat_impression_cap_3"),
+                ),
+            ),
+            pixel.firedPixels,
+        )
+    }
+
+    @Test
+    fun `when can't show promotion due to it being dismissed then fire no pixels`() = runTest {
+        configurePromotionToShow()
+        testee.recordPromotionDismissed()
+        pixel.clear()
+
+        testee.canShowPromotion()
+
+        assertTrue(pixel.firedPixels.isEmpty())
+    }
+
     private suspend fun configurePromotionToShow() {
         dataStore.clearPromoHistory(PromotionType.ChatTabPage)
         isSyncEnabled = true
@@ -164,4 +244,48 @@ class RealChatSyncPromotionTest {
         isChatHistoryEnabled = true
         hasChatSuggestions.value = true
     }
+}
+
+private class FakePixel : Pixel {
+    private val _firedPixels = mutableListOf<Measurement>()
+    val firedPixels get() = _firedPixels.toList()
+
+    fun clear() = _firedPixels.clear()
+
+    override fun fire(
+        pixelName: String,
+        parameters: Map<String, String>,
+        encodedParameters: Map<String, String>,
+        type: PixelType,
+    ) {
+        _firedPixels.add(Measurement(pixelName, parameters, encodedParameters, type))
+    }
+
+    override fun fire(
+        pixel: PixelName,
+        parameters: Map<String, String>,
+        encodedParameters: Map<String, String>,
+        type: PixelType,
+    ) = fire(pixel.pixelName, parameters, encodedParameters, type)
+
+    override fun enqueueFire(
+        pixelName: String,
+        parameters: Map<String, String>,
+        encodedParameters: Map<String, String>,
+        type: PixelType,
+    ) = fire(pixelName, parameters, encodedParameters, type)
+
+    override fun enqueueFire(
+        pixel: PixelName,
+        parameters: Map<String, String>,
+        encodedParameters: Map<String, String>,
+        type: PixelType,
+    ) = fire(pixel, parameters, encodedParameters, type)
+
+    data class Measurement(
+        val name: String,
+        val params: Map<String, String> = emptyMap(),
+        val encodedParams: Map<String, String> = emptyMap(),
+        val type: PixelType = PixelType.Count,
+    )
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1215321458176118/task/1215746356945813?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1215321458176118/task/1215842375041298?focus=true

### Description

Adds Chat Sync promo measurements:
- `sync_promotion_displayed with params: {source=ai_chat}`
- `sync_promotion_confirmed with params: {source=ai_chat}` 
- `sync_promotion_dismissed with params: {source=ai_chat, reason=user_tapped}`
- `sync_promotion_dismissed with params: {source=ai_chat, reason=impression_cap}`

### Steps to test this PR

_Setup_
- [ ] Install the `internalDebug` app variant.
- [ ] Start log monitoring by running `adb logcat -s RxBasedPixel:V | grep -E "sync_promotion"`.
- [ ] In the FF inventory, confirm `nativeInputField` and `pluginChatSyncPromoChatTabItemPlugin` are enabled (this is the default).
- [ ] In AI Features settings, confirm "Search & Duck.ai" is enabled (this is the default).

> [!TIP]
> Use Menu -> Sync Dev Settings -> "Clear history (chat tab page)" button (at the bottom) to reset the promo's impression count and dismissed state between runs.

_Pixels_
- [ ] Start a Duck.ai chat.
- [ ] Return to the chat tab.
- [ ] Confirm the logs show `Pixel sent: sync_promotion_displayed with params: {source=ai_chat}`.
- [ ] Return to the chat tab.
- [ ] Tap "Continue With Another Device".
- [ ] Confirm the logs show `Pixel sent: sync_promotion_confirmed with params: {source=ai_chat}`.
- [ ] Reset the promo state in dev settings.
- [ ] Tap "X" to dismiss the promo.
- [ ] Confirm the logs show `Pixel sent: sync_promotion_dismissed with params: {source=ai_chat, reason=user_tapped}`.
- [ ] Reset the promo state in dev settings.
- [ ] Trigger the promo impression cap: open the native input, switch to the chat tab, and collapse the input. Repeat this 2 more times.
- [ ] Try to trigger the promo for the fourth time: open the native input, switch to the chat tab.
- [ ] Confirm the logs show `Pixel sent: sync_promotion_dismissed with params: {source=ai_chat, reason=impression_cap}`.
- [ ] Confirm the logs do not show `sync_promotion_displayed with params: {source=ai_chat}`.
- [ ] Collapse the native input.
- [ ] Open the native input.
- [ ] Switch to the chat tab.
- [ ] Confirm the logs show `Pixel ignored: sync_promotion_dismissed with params: {source=ai_chat, reason=impression_cap}`.

### UI changes
N/A


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes to promotion lifecycle hooks; no sync auth, data, or UI behavior changes beyond firing pixels.
> 
> **Overview**
> Adds **telemetry** for the Duck.ai chat tab Sync promotion by registering three pixels in `sync_promotion.json` and firing them from `RealChatSyncPromotion`.
> 
> **Impressions and engagement:** each impression increment sends `sync_promotion_displayed` with `source=ai_chat`. Accept and explicit dismiss send `sync_promotion_confirmed` and `sync_promotion_dismissed` with `reason=user_tapped`, respectively.
> 
> **Impression cap:** when eligibility is checked and the promo is exhausted only because the impression cap (3) was hit—not because the user dismissed—`sync_promotion_dismissed` fires once with `reason=impression_cap` using a `Unique` pixel tag so repeat checks do not spam events. User-dismissed promos no longer trigger cap-dismiss pixels on later `canShowPromotion()` calls.
> 
> Adds `SYNC_FEATURE_PROMOTION_DISMISS_REASON` for the dismiss `reason` param and unit tests that assert pixel names, params, and unique firing for the cap case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5c71140526258303e931c40be5126c2e4ad6bbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->