### PR TITLE
Fix favorites not shown on second omnibar tap with native input enabled

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -5836,7 +5836,6 @@ class BrowserTabFragment :
                 lastSeenAutoCompleteViewState = null
                 return
             }
-
             renderIfChanged(viewState, lastSeenAutoCompleteViewState) {
                 lastSeenAutoCompleteViewState = viewState
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -5836,6 +5836,7 @@ class BrowserTabFragment :
                 lastSeenAutoCompleteViewState = null
                 return
             }
+
             renderIfChanged(viewState, lastSeenAutoCompleteViewState) {
                 lastSeenAutoCompleteViewState = viewState
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -2928,7 +2928,6 @@ class BrowserTabViewModel @Inject constructor(
      */
     fun restoreOmnibarAutocomplete(forQuery: String): AutoCompleteResult? {
         val cached = omnibarAutocompleteCache.value
-        if (cached.query != forQuery || cached.suggestions.isEmpty()) return null
         val current = autoCompleteViewState.value ?: return null
         val restored = current.copy(
             searchResults = cached,
@@ -2937,7 +2936,11 @@ class BrowserTabViewModel @Inject constructor(
         )
         autoCompleteViewState.value = restored
         lastAutoCompleteState = restored
-        return cached
+        return if (cached.query != forQuery || cached.suggestions.isEmpty()) {
+            null
+        } else {
+            cached
+        }
     }
 
     fun onBookmarkMenuClicked() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1216106240185123

### Description

- Fixes a bug where favorites were not visible the second time the address bar was tapped on a browser tab with the native input field enabled
- Root cause: `restoreOmnibarAutocomplete` had an early return on cache miss before resetting `showFocusedView = false`, leaving the renderer's cached state stale — `renderIfChanged` skipped re-rendering on the second tap
- Fix: move the cache-miss check to after the state update so `showFocusedView = false` is always applied on widget dismiss, regardless of cache hit or miss

### Steps to test this PR

- [ ] Have at least one favorite saved
- [ ] Open a browser tab and navigate to any website
- [ ] Tap the address bar — confirm favorites are visible
- [ ] Press Back to dismiss
- [ ] Tap the address bar again — confirm favorites are visible this time too
- [ ] Repeat a third time to confirm the fix is stable across multiple open/close cycles
- [ ] Changes in PR https://github.com/duckduckgo/Android/pull/8669 should be unaffected

### UI changes

| Before  | After |
| ------ | ----- |
https://github.com/user-attachments/assets/08170ab1-1c4b-4e6d-aa37-dff540bbefcd|https://github.com/user-attachments/assets/531ec6a4-2c97-416a-9e7e-d2f46bf5877a|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single control-flow reorder in omnibar autocomplete restore; no auth, data, or API changes.
> 
> **Overview**
> Fixes favorites not appearing on the **second** address-bar tap when the native omnibar input is enabled.
> 
> **`restoreOmnibarAutocomplete`** no longer returns early when the autocomplete cache does not match the current query or is empty. It always writes autocomplete view state with **`showSuggestions`** and **`showFocusedView`** set to **false** (as documented for widget dismiss), then returns the cached result only on a hit. Previously, a cache miss skipped that update, so the omnibar renderer’s **`renderIfChanged`** could keep stale focused-view state and skip re-showing favorites on the next tap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0d8a86bcd467ef32876796d7ac0b441cbe750f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->