### PR TITLE
Restrict data clearing shortcut to launchers only

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -405,6 +405,12 @@
             android:theme="@style/Theme.DuckDuckGo.Dark"
             android:process="@string/fireProcessName" />
         <activity
+            android:name="com.duckduckgo.app.global.shortcut.FireShortcutTrampolineActivity"
+            android:exported="false"
+            android:excludeFromRecents="true"
+            android:noHistory="true"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+        <activity
             android:name="com.duckduckgo.app.icon.ui.ChangeIconActivity"
             android:exported="false"
             android:label="@string/changeIconActivityTitle"

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -77,16 +77,13 @@ import com.duckduckgo.app.browser.tabs.adapter.TabPagerAdapter
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.dispatchers.ExternalIntentProcessingState
 import com.duckduckgo.app.feedback.ui.common.FeedbackActivity
+import com.duckduckgo.app.fire.AppShortcutDataClearer
 import com.duckduckgo.app.fire.DataClearer
 import com.duckduckgo.app.fire.DataClearerForegroundAppRestartPixel
-import com.duckduckgo.app.fire.ManualDataClearing
-import com.duckduckgo.app.fire.store.FireDataStore
-import com.duckduckgo.app.fire.wideevents.DataClearingWideEvent
 import com.duckduckgo.app.global.ApplicationClearDataState
 import com.duckduckgo.app.global.intentText
 import com.duckduckgo.app.global.rating.PromptCount
 import com.duckduckgo.app.global.sanitize
-import com.duckduckgo.app.global.view.ClearDataAction
 import com.duckduckgo.app.global.view.ORIGIN_DUCK_AI_CONTEXTUAL_CHAT
 import com.duckduckgo.app.global.view.ORIGIN_HATCH
 import com.duckduckgo.app.global.view.renderIfChanged
@@ -96,7 +93,6 @@ import com.duckduckgo.app.onboarding.ui.page.DefaultBrowserPage
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppPixelName.FIRE_DIALOG_CANCEL
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
-import com.duckduckgo.app.settings.clear.ClearWhatOption
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelParameter
@@ -167,16 +163,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
     lateinit var settingsDataStore: SettingsDataStore
 
     @Inject
-    lateinit var clearDataAction: ClearDataAction
-
-    @Inject
-    lateinit var dataClearing: ManualDataClearing
-
-    @Inject
-    lateinit var fireDataStore: FireDataStore
-
-    @Inject
-    lateinit var dataClearingWideEvent: DataClearingWideEvent
+    lateinit var appShortcutDataClearer: AppShortcutDataClearer
 
     @Inject
     lateinit var androidBrowserConfigFeature: AndroidBrowserConfigFeature
@@ -788,35 +775,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
                     return@launch
                 }
                 logcat(INFO) { "Clearing everything as a result of $PERFORM_FIRE_ON_ENTRY_EXTRA flag being set" }
-                if (androidBrowserConfigFeature.singleTabFireDialog().isEnabled()) {
-                    val clearOptions = fireDataStore.getManualClearOptions()
-                    dataClearingWideEvent.start(
-                        entryPoint = DataClearingWideEvent.EntryPoint.APP_SHORTCUT,
-                        clearOptions = clearOptions,
-                    )
-                    try {
-                        dataClearing.clearDataUsingManualFireOptions(shouldRestartIfRequired = true, browserMode = currentBrowserMode)
-                        dataClearingWideEvent.finishSuccess()
-                    } catch (e: Exception) {
-                        dataClearingWideEvent.finishFailure(e)
-                        throw e
-                    }
-                } else {
-                    dataClearingWideEvent.startLegacy(
-                        entryPoint = DataClearingWideEvent.EntryPoint.LEGACY_APP_SHORTCUT,
-                        clearWhatOption = ClearWhatOption.CLEAR_TABS_AND_DATA,
-                        clearDuckAiData = settingsDataStore.clearDuckAiData,
-                    )
-                    try {
-                        clearDataAction.clearTabsAndAllDataAsync(appInForeground = true, shouldFireDataClearPixel = true)
-                        clearDataAction.setAppUsedSinceLastClearFlag(false)
-                        dataClearingWideEvent.finishSuccess()
-                    } catch (e: Exception) {
-                        dataClearingWideEvent.finishFailure(e)
-                        throw e
-                    }
-                    clearDataAction.killAndRestartProcess(notifyDataCleared = false)
-                }
+                appShortcutDataClearer.clearFromAppShortcut(currentBrowserMode)
             }
             return
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -779,8 +779,15 @@ open class BrowserActivity : DuckDuckGoActivity() {
         }
 
         if (intent.getBooleanExtra(PERFORM_FIRE_ON_ENTRY_EXTRA, false)) {
-            logcat(INFO) { "Clearing everything as a result of $PERFORM_FIRE_ON_ENTRY_EXTRA flag being set" }
             appCoroutineScope.launch(dispatcherProvider.io()) {
+                // The legitimate shortcut goes through [FireShortcutTrampolineActivity]; this legacy handler is only active if FF disabled.
+                if (androidBrowserConfigFeature.useFireAppShortcutTrampoline().isEnabled()) {
+                    logcat(INFO) {
+                        "$PERFORM_FIRE_ON_ENTRY_EXTRA received but fireShortcutTrampoline kill switch is on; ignoring"
+                    }
+                    return@launch
+                }
+                logcat(INFO) { "Clearing everything as a result of $PERFORM_FIRE_ON_ENTRY_EXTRA flag being set" }
                 if (androidBrowserConfigFeature.singleTabFireDialog().isEnabled()) {
                     val clearOptions = fireDataStore.getManualClearOptions()
                     dataClearingWideEvent.start(
@@ -811,7 +818,6 @@ open class BrowserActivity : DuckDuckGoActivity() {
                     clearDataAction.killAndRestartProcess(notifyDataCleared = false)
                 }
             }
-
             return
         }
 

--- a/app/src/main/java/com/duckduckgo/app/fire/AppShortcutDataClearer.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/AppShortcutDataClearer.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.fire
+
+import com.duckduckgo.app.fire.store.FireDataStore
+import com.duckduckgo.app.fire.wideevents.DataClearingWideEvent
+import com.duckduckgo.app.global.view.ClearDataAction
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.app.settings.clear.ClearWhatOption
+import com.duckduckgo.app.settings.db.SettingsDataStore
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+interface AppShortcutDataClearer {
+    suspend fun clearFromAppShortcut(browserMode: BrowserMode)
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealAppShortcutDataClearer @Inject constructor(
+    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
+    private val fireDataStore: FireDataStore,
+    private val dataClearingWideEvent: DataClearingWideEvent,
+    private val dataClearing: ManualDataClearing,
+    private val clearDataAction: ClearDataAction,
+    private val settingsDataStore: SettingsDataStore,
+) : AppShortcutDataClearer {
+
+    override suspend fun clearFromAppShortcut(browserMode: BrowserMode) {
+        if (androidBrowserConfigFeature.singleTabFireDialog().isEnabled()) {
+            val clearOptions = fireDataStore.getManualClearOptions()
+            dataClearingWideEvent.start(
+                entryPoint = DataClearingWideEvent.EntryPoint.APP_SHORTCUT,
+                clearOptions = clearOptions,
+            )
+            try {
+                dataClearing.clearDataUsingManualFireOptions(shouldRestartIfRequired = true, browserMode = browserMode)
+                dataClearingWideEvent.finishSuccess()
+            } catch (e: Exception) {
+                dataClearingWideEvent.finishFailure(e)
+                throw e
+            }
+        } else {
+            dataClearingWideEvent.startLegacy(
+                entryPoint = DataClearingWideEvent.EntryPoint.LEGACY_APP_SHORTCUT,
+                clearWhatOption = ClearWhatOption.CLEAR_TABS_AND_DATA,
+                clearDuckAiData = settingsDataStore.clearDuckAiData,
+            )
+            try {
+                clearDataAction.clearTabsAndAllDataAsync(appInForeground = true, shouldFireDataClearPixel = true)
+                clearDataAction.setAppUsedSinceLastClearFlag(false)
+                dataClearingWideEvent.finishSuccess()
+            } catch (e: Exception) {
+                dataClearingWideEvent.finishFailure(e)
+                throw e
+            }
+            clearDataAction.killAndRestartProcess(notifyDataCleared = false)
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/global/shortcut/AppShortcutCreator.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/shortcut/AppShortcutCreator.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.app.browser.mode.AppShortcutNewTab
 import com.duckduckgo.app.browser.mode.FireRestart
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
@@ -84,6 +85,7 @@ class AppShortcutCreator @Inject constructor(
     private val duckChat: DuckChat,
     private val duckAiFeatureState: DuckAiFeatureState,
     private val dispatchers: DispatcherProvider,
+    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
 ) {
 
     init {
@@ -95,10 +97,12 @@ class AppShortcutCreator @Inject constructor(
 
     fun refreshAppShortcuts() {
         appCoroutineScope.launch(dispatchers.io()) {
+            val trampolineEnabled = androidBrowserConfigFeature.useFireAppShortcutTrampoline().isEnabled()
+
             val shortcutList = mutableListOf<ShortcutInfo>()
 
             shortcutList.add(buildNewTabShortcut(context))
-            shortcutList.add(buildClearDataShortcut(context))
+            shortcutList.add(buildClearDataShortcut(context, trampolineEnabled))
             shortcutList.add(buildBookmarksShortcut(context))
 
             if (duckAiFeatureState.showPopupMenuShortcut.value) {
@@ -135,16 +139,21 @@ class AppShortcutCreator @Inject constructor(
             .build().toShortcutInfo()
     }
 
-    private fun buildClearDataShortcut(context: Context): ShortcutInfo {
+    private fun buildClearDataShortcut(context: Context, trampolineEnabled: Boolean): ShortcutInfo {
+        val intent = if (trampolineEnabled) {
+            Intent(context, FireShortcutTrampolineActivity::class.java).apply {
+                action = Intent.ACTION_VIEW
+            }
+        } else {
+            BrowserActivity.intent(context, launchSource = FireRestart).also {
+                it.action = Intent.ACTION_VIEW
+                it.putExtra(BrowserActivity.PERFORM_FIRE_ON_ENTRY_EXTRA, true)
+            }
+        }
         return ShortcutInfoCompat.Builder(context, SHORTCUT_ID_CLEAR_DATA)
             .setShortLabel(context.getString(R.string.fireMenu))
             .setIcon(IconCompat.createWithResource(context, R.drawable.ic_app_shortcut_fire_adaptive))
-            .setIntent(
-                BrowserActivity.intent(context, launchSource = FireRestart).also {
-                    it.action = Intent.ACTION_VIEW
-                    it.putExtra(BrowserActivity.PERFORM_FIRE_ON_ENTRY_EXTRA, true)
-                },
-            )
+            .setIntent(intent)
             .build().toShortcutInfo()
     }
 

--- a/app/src/main/java/com/duckduckgo/app/global/shortcut/FireShortcutTrampolineActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/shortcut/FireShortcutTrampolineActivity.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.global.shortcut
+
+import android.content.Intent
+import android.os.Bundle
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.app.browser.BrowserActivity
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.fire.ManualDataClearing
+import com.duckduckgo.app.fire.store.FireDataStore
+import com.duckduckgo.app.fire.wideevents.DataClearingWideEvent
+import com.duckduckgo.app.global.view.ClearDataAction
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.app.settings.clear.ClearWhatOption
+import com.duckduckgo.app.settings.db.SettingsDataStore
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.ActivityScope
+import dev.zacsweers.metro.HasMemberInjections
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import logcat.LogPriority.INFO
+import logcat.logcat
+import javax.inject.Inject
+
+/**
+ * Entry point for the "Clear Data" launcher shortcut. `exported=false`.
+ * Reachable only via the system ShortcutService.
+ */
+@HasMemberInjections
+@InjectWith(ActivityScope::class)
+class FireShortcutTrampolineActivity : DuckDuckGoActivity() {
+
+    @Inject
+    @AppCoroutineScope
+    lateinit var appCoroutineScope: CoroutineScope
+
+    @Inject lateinit var dispatcherProvider: DispatcherProvider
+
+    @Inject lateinit var androidBrowserConfigFeature: AndroidBrowserConfigFeature
+
+    @Inject lateinit var fireDataStore: FireDataStore
+
+    @Inject lateinit var dataClearingWideEvent: DataClearingWideEvent
+
+    @Inject lateinit var dataClearing: ManualDataClearing
+
+    @Inject lateinit var clearDataAction: ClearDataAction
+
+    @Inject lateinit var settingsDataStore: SettingsDataStore
+
+    @Inject lateinit var currentBrowserMode: BrowserMode
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        logcat(INFO) { "Clearing everything as a result of the Clear Data launcher shortcut" }
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            try {
+                // Kill switch off: delegate to BrowserActivity so already-migrated pinned shortcuts still honor the data clearing.
+                if (!androidBrowserConfigFeature.useFireAppShortcutTrampoline().isEnabled()) {
+                    logcat(INFO) { "useFireAppShortcutTrampoline kill switch is off; delegating Clear Data shortcut to BrowserActivity" }
+                    val delegate = Intent(this@FireShortcutTrampolineActivity, BrowserActivity::class.java).apply {
+                        action = Intent.ACTION_VIEW
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        putExtra(BrowserActivity.PERFORM_FIRE_ON_ENTRY_EXTRA, true)
+                    }
+                    startActivity(delegate)
+                    return@launch
+                }
+                if (androidBrowserConfigFeature.singleTabFireDialog().isEnabled()) {
+                    val clearOptions = fireDataStore.getManualClearOptions()
+                    dataClearingWideEvent.start(
+                        entryPoint = DataClearingWideEvent.EntryPoint.APP_SHORTCUT,
+                        clearOptions = clearOptions,
+                    )
+                    try {
+                        dataClearing.clearDataUsingManualFireOptions(shouldRestartIfRequired = true, browserMode = currentBrowserMode)
+                        dataClearingWideEvent.finishSuccess()
+                    } catch (e: Exception) {
+                        dataClearingWideEvent.finishFailure(e)
+                        throw e
+                    }
+                } else {
+                    dataClearingWideEvent.startLegacy(
+                        entryPoint = DataClearingWideEvent.EntryPoint.LEGACY_APP_SHORTCUT,
+                        clearWhatOption = ClearWhatOption.CLEAR_TABS_AND_DATA,
+                        clearDuckAiData = settingsDataStore.clearDuckAiData,
+                    )
+                    try {
+                        clearDataAction.clearTabsAndAllDataAsync(appInForeground = true, shouldFireDataClearPixel = true)
+                        clearDataAction.setAppUsedSinceLastClearFlag(false)
+                        dataClearingWideEvent.finishSuccess()
+                    } catch (e: Exception) {
+                        dataClearingWideEvent.finishFailure(e)
+                        throw e
+                    }
+                    clearDataAction.killAndRestartProcess(notifyDataCleared = false)
+                }
+            } finally {
+                finish()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/global/shortcut/FireShortcutTrampolineActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/shortcut/FireShortcutTrampolineActivity.kt
@@ -21,13 +21,8 @@ import android.os.Bundle
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.BrowserActivity
 import com.duckduckgo.app.di.AppCoroutineScope
-import com.duckduckgo.app.fire.ManualDataClearing
-import com.duckduckgo.app.fire.store.FireDataStore
-import com.duckduckgo.app.fire.wideevents.DataClearingWideEvent
-import com.duckduckgo.app.global.view.ClearDataAction
+import com.duckduckgo.app.fire.AppShortcutDataClearer
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
-import com.duckduckgo.app.settings.clear.ClearWhatOption
-import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -55,15 +50,7 @@ class FireShortcutTrampolineActivity : DuckDuckGoActivity() {
 
     @Inject lateinit var androidBrowserConfigFeature: AndroidBrowserConfigFeature
 
-    @Inject lateinit var fireDataStore: FireDataStore
-
-    @Inject lateinit var dataClearingWideEvent: DataClearingWideEvent
-
-    @Inject lateinit var dataClearing: ManualDataClearing
-
-    @Inject lateinit var clearDataAction: ClearDataAction
-
-    @Inject lateinit var settingsDataStore: SettingsDataStore
+    @Inject lateinit var appShortcutDataClearer: AppShortcutDataClearer
 
     @Inject lateinit var currentBrowserMode: BrowserMode
 
@@ -83,35 +70,7 @@ class FireShortcutTrampolineActivity : DuckDuckGoActivity() {
                     startActivity(delegate)
                     return@launch
                 }
-                if (androidBrowserConfigFeature.singleTabFireDialog().isEnabled()) {
-                    val clearOptions = fireDataStore.getManualClearOptions()
-                    dataClearingWideEvent.start(
-                        entryPoint = DataClearingWideEvent.EntryPoint.APP_SHORTCUT,
-                        clearOptions = clearOptions,
-                    )
-                    try {
-                        dataClearing.clearDataUsingManualFireOptions(shouldRestartIfRequired = true, browserMode = currentBrowserMode)
-                        dataClearingWideEvent.finishSuccess()
-                    } catch (e: Exception) {
-                        dataClearingWideEvent.finishFailure(e)
-                        throw e
-                    }
-                } else {
-                    dataClearingWideEvent.startLegacy(
-                        entryPoint = DataClearingWideEvent.EntryPoint.LEGACY_APP_SHORTCUT,
-                        clearWhatOption = ClearWhatOption.CLEAR_TABS_AND_DATA,
-                        clearDuckAiData = settingsDataStore.clearDuckAiData,
-                    )
-                    try {
-                        clearDataAction.clearTabsAndAllDataAsync(appInForeground = true, shouldFireDataClearPixel = true)
-                        clearDataAction.setAppUsedSinceLastClearFlag(false)
-                        dataClearingWideEvent.finishSuccess()
-                    } catch (e: Exception) {
-                        dataClearingWideEvent.finishFailure(e)
-                        throw e
-                    }
-                    clearDataAction.killAndRestartProcess(notifyDataCleared = false)
-                }
+                appShortcutDataClearer.clearFromAppShortcut(currentBrowserMode)
             } finally {
                 finish()
             }

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -404,4 +404,13 @@ interface AndroidBrowserConfigFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun recreateAwareLifecycle(): Toggle
+
+    /**
+     * Kill switch for the trampoline-activity based Clear Data shortcut implementation.
+     * When enabled (default), the Clear Data shortcut routes through a non-exported trampoline activity,
+     * and the legacy PERFORM_FIRE_ON_ENTRY_EXTRA handler on BrowserActivity is suppressed.
+     * When disabled, falls back to the legacy BrowserActivity + PERFORM_FIRE_ON_ENTRY_EXTRA intent surface.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun useFireAppShortcutTrampoline(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1216118716787351?focus=true 
Tech Design URL (if applicable): 

### Description
Introduces a trampoline activity for externally-triggered data clearing, namely, for App Shortcuts.

If there are no problems with this approach, will do a follow-up to remove the FF and legacy data clearing paths.

### Steps to test this PR

Follow steps in [Testing instructions](https://app.asana.com/1/137249556945/task/1216212828806092?focus=true)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches full data-clearing and process restart behavior for app shortcuts, but logic is largely duplicated from BrowserActivity with a rollback path via feature flag; primary change is reducing intent-redirection risk on exported BrowserActivity.
> 
> **Overview**
> Routes the **Clear Data** launcher shortcut through a new **`FireShortcutTrampolineActivity`** (`exported=false`, translucent, no history) instead of launching **`BrowserActivity`** with **`PERFORM_FIRE_ON_ENTRY_EXTRA`**, so external apps cannot trigger a full clear via the exported browser entry point.
> 
> **`AppShortcutCreator`** points dynamic shortcuts at the trampoline when **`useFireAppShortcutTrampoline`** is on (default); otherwise it keeps the legacy **`BrowserActivity`** intent. **`BrowserActivity.processIntent`** ignores **`PERFORM_FIRE_ON_ENTRY_EXTRA`** when that flag is enabled. The trampoline runs the same manual/legacy clearing paths as before and can delegate back to **`BrowserActivity`** if the kill switch is off (e.g. old pinned shortcuts). Remote config adds **`useFireAppShortcutTrampoline`** on **`AndroidBrowserConfigFeature`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d38b696bb8316f842f1b80b8a2791717b42ce133. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->