### PR TITLE
Open the full AI Features from SERP Settings

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModel.kt
@@ -148,7 +148,7 @@ class DuckChatSettingsViewModel @AssistedInject constructor(
                 isInputScreenEnabled = isInputScreenEnabled,
                 shouldShowShortcuts = isDuckChatUserEnabled,
                 shouldShowInputScreenToggle = isDuckChatUserEnabled && duckChat.isInputScreenFeatureAvailable(),
-                isSearchSectionVisible = isSearchSectionVisible(duckChatActivityParams),
+                isSearchSectionVisible = isSearchSectionVisible(duckChatActivityParams, featureVisibility.isNativeControlsEnabled),
                 isHideGeneratedImagesOptionVisible = featureVisibility.isHideGeneratedImagesOptionVisible,
                 isAutomaticContextEnabled = featureState.isAutomaticContextEnabled,
                 isAutomaticContextVisible = isDuckChatUserEnabled && duckChatFeature.automaticContextAttachment().isEnabled(),
@@ -402,10 +402,17 @@ class DuckChatSettingsViewModel @AssistedInject constructor(
         }
     }
 
-    private fun isSearchSectionVisible(duckChatActivityParams: GlobalActivityStarter.ActivityParams): Boolean = when (duckChatActivityParams) {
-        is DuckChatSettingsNoParams -> true
-        is DuckChatNativeSettingsNoParams -> false
-        else -> throw IllegalArgumentException("Unknown params type: $duckChatActivityParams")
+    private fun isSearchSectionVisible(
+        duckChatActivityParams: GlobalActivityStarter.ActivityParams,
+        isNativeControlsEnabled: Boolean,
+    ): Boolean {
+        // With native controls the search section is always shown, regardless of how settings were launched.
+        if (isNativeControlsEnabled) return true
+        return when (duckChatActivityParams) {
+            is DuckChatSettingsNoParams -> true
+            is DuckChatNativeSettingsNoParams -> false
+            else -> throw IllegalArgumentException("Unknown params type: $duckChatActivityParams")
+        }
     }
 
     @AssistedFactory

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModelTest.kt
@@ -613,6 +613,8 @@ class DuckChatSettingsViewModelTest {
     @Test
     fun `when DuckChatNativeSettingsNoParams passed then viewState shows search section hidden`() =
         runTest {
+            @Suppress("DenyListedApi")
+            duckChatFeature.aiFeaturesNativeControls().setRawStoredState(State(enable = false))
             testee = DuckChatSettingsViewModel(
                 duckChatActivityParams = DuckChatNativeSettingsNoParams,
                 duckChat = duckChat,

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModelTest.kt
@@ -632,6 +632,29 @@ class DuckChatSettingsViewModelTest {
         }
 
     @Test
+    fun `when DuckChatNativeSettingsNoParams passed and aiFeaturesNativeControls enabled then viewState shows search section visible`() =
+        runTest {
+            @Suppress("DenyListedApi")
+            duckChatFeature.aiFeaturesNativeControls().setRawStoredState(State(enable = true))
+            testee = DuckChatSettingsViewModel(
+                duckChatActivityParams = DuckChatNativeSettingsNoParams,
+                duckChat = duckChat,
+                pixel = mockPixel,
+                inputScreenDiscoveryFunnel = mockInputScreenDiscoveryFunnel,
+                settingsPageFeature = settingsPageFeature,
+                duckChatPixels = mockDuckChatPixels,
+                dispatcherProvider = coroutineRule.testDispatcherProvider,
+                duckChatFeature = duckChatFeature,
+                serpSettingsDataProvider = serpSettingsDataProvider,
+            )
+
+            testee.viewState.test {
+                val state = awaitItem()
+                assertTrue(state.isSearchSectionVisible)
+            }
+        }
+
+    @Test
     fun `when onDuckAiHideAiGeneratedImagesClicked and native controls disabled then SERP open pixel is fired`() =
         runTest {
             testee.onDuckAiHideAiGeneratedImagesClicked()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200581511062568/task/1216109204910246?focus=true
Tech Design URL (if applicable):

### Description

When AI Features settings are opened from the SERP (via DuckChatNativeSettingsNoParams), the search section is normally hidden.
(aiFeaturesNativeControls) is enabled, the search section should always be shown — the search-related settings (Search Assist, Hide AI-
hiding them no longer makes sense regardless of how the screen was launched.

This change gates the section's visibility behind the aiFeaturesNativeControls flag: when the flag is enabled, isSearchSectionVisible always
unchanged (the section is hidden when launched via DuckChatNativeSettingsNoParams and shown otherwise).

Added unit test coverage for the new flag-override behavior.

### Steps to test this PR

With aiFeaturesNativeControls enabled:

1. Open the SERP AI Features settings (which launches DuckChat settings via DuckChatNativeSettingsNoParams): navigate to [duckduckgo.com](http://duckduckgo.com), tap on the hamburger menu from the website (not the app!), tap on Settings just under SEARCH, tap on "AI Features", tap on "Open Duck.ai Settings"
2. Verify the search settings section is shown
3. Open DuckChat settings normally (e.g. from in-app settings)
4. Verify the search settings section is shown

With aiFeaturesNativeControls disabled:

1. Open the SERP AI Features settings: navigate to [duckduckgo.com](http://duckduckgo.com), tap on the hamburger menu from the website (not the app!), tap on Settings just under SEARCH, tap on "AI Features", tap on "Open Duck.ai Settings"
2. Verify the search settings section is hidden
3. Open DuckChat settings normally
4. Verify the search settings section is shown

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small visibility-gating change behind a feature flag; no auth or data-path changes.
> 
> **Overview**
> When **aiFeaturesNativeControls** is enabled, Duck.ai settings opened from the SERP (`DuckChatNativeSettingsNoParams`) now **always show the search settings section** (Search Assist, hide AI-generated images, etc.). Previously that entry path hid the section even though native controls expect those options in-app.
> 
> `isSearchSectionVisible` in `DuckChatSettingsViewModel` now takes the native-controls flag and returns visible when it is on; with the flag off, behavior is unchanged (hidden for SERP native launch, visible for normal in-app settings).
> 
> Unit tests pin the disabled-flag case and add coverage for SERP launch + native controls enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f00bda3e22e90eafe20828305f543dfe111ad107. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->