### PR TITLE
Other changes from Ship Review

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/pixels/EnqueuedPixelWorker.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/EnqueuedPixelWorker.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.browser.api.WebViewVersionProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.customtabs.api.CustomTabDetector
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.impl.pixel.AiFeaturesStateReporter
 import com.duckduckgo.verifiedinstallation.IsVerifiedPlayStoreInstall
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
@@ -65,6 +66,7 @@ class EnqueuedPixelWorker @Inject constructor(
     private val appBuildConfig: AppBuildConfig,
     private val dispatchers: DispatcherProvider,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val aiFeaturesStateReporter: AiFeaturesStateReporter,
 ) : MainProcessLifecycleObserver {
 
     private var launchedByFireAction: Boolean = false
@@ -123,6 +125,9 @@ class EnqueuedPixelWorker @Inject constructor(
                 parameters = paramsMap,
             )
         }
+
+        // daily snapshot of the AI-features settings state
+        aiFeaturesStateReporter.reportDailyState()
     }
 
     private fun isDuckDuckGoAppPackage(applicationId: String): String {

--- a/app/src/main/java/com/duckduckgo/app/pixels/EnqueuedPixelWorker.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/EnqueuedPixelWorker.kt
@@ -35,7 +35,6 @@ import com.duckduckgo.browser.api.WebViewVersionProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.customtabs.api.CustomTabDetector
 import com.duckduckgo.di.scopes.AppScope
-import com.duckduckgo.duckchat.impl.pixel.AiFeaturesStateReporter
 import com.duckduckgo.verifiedinstallation.IsVerifiedPlayStoreInstall
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
@@ -66,7 +65,6 @@ class EnqueuedPixelWorker @Inject constructor(
     private val appBuildConfig: AppBuildConfig,
     private val dispatchers: DispatcherProvider,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
-    private val aiFeaturesStateReporter: AiFeaturesStateReporter,
 ) : MainProcessLifecycleObserver {
 
     private var launchedByFireAction: Boolean = false
@@ -125,9 +123,6 @@ class EnqueuedPixelWorker @Inject constructor(
                 parameters = paramsMap,
             )
         }
-
-        // daily snapshot of the AI-features settings state
-        aiFeaturesStateReporter.reportDailyState()
     }
 
     private fun isDuckDuckGoAppPackage(applicationId: String): String {

--- a/app/src/test/java/com/duckduckgo/app/pixels/EnqueuedPixelWorkerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/pixels/EnqueuedPixelWorkerTest.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.browser.api.WebViewVersionProvider
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.customtabs.api.CustomTabDetector
+import com.duckduckgo.duckchat.impl.pixel.AiFeaturesStateReporter
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.verifiedinstallation.IsVerifiedPlayStoreInstall
@@ -52,6 +53,7 @@ class EnqueuedPixelWorkerTest {
     private val androidBrowserConfigFeature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
     private val isVerifiedPlayStoreInstall: IsVerifiedPlayStoreInstall = mock()
     private val appBuildConfig: AppBuildConfig = mock()
+    private val aiFeaturesStateReporter: AiFeaturesStateReporter = mock()
 
     private lateinit var enqueuedPixelWorker: EnqueuedPixelWorker
 
@@ -67,8 +69,9 @@ class EnqueuedPixelWorkerTest {
             androidBrowserConfigFeature,
             isVerifiedPlayStoreInstall,
             appBuildConfig,
-            appCoroutineScope = coroutineRule.testScope,
             dispatchers = coroutineRule.testDispatcherProvider,
+            appCoroutineScope = coroutineRule.testScope,
+            aiFeaturesStateReporter = aiFeaturesStateReporter,
         )
         setupRemoteConfig(browserEnabled = false, collectFullWebViewVersionEnabled = false)
     }

--- a/app/src/test/java/com/duckduckgo/app/pixels/EnqueuedPixelWorkerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/pixels/EnqueuedPixelWorkerTest.kt
@@ -28,7 +28,6 @@ import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.browser.api.WebViewVersionProvider
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.customtabs.api.CustomTabDetector
-import com.duckduckgo.duckchat.impl.pixel.AiFeaturesStateReporter
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.verifiedinstallation.IsVerifiedPlayStoreInstall
@@ -53,7 +52,6 @@ class EnqueuedPixelWorkerTest {
     private val androidBrowserConfigFeature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
     private val isVerifiedPlayStoreInstall: IsVerifiedPlayStoreInstall = mock()
     private val appBuildConfig: AppBuildConfig = mock()
-    private val aiFeaturesStateReporter: AiFeaturesStateReporter = mock()
 
     private lateinit var enqueuedPixelWorker: EnqueuedPixelWorker
 
@@ -71,7 +69,6 @@ class EnqueuedPixelWorkerTest {
             appBuildConfig,
             dispatchers = coroutineRule.testDispatcherProvider,
             appCoroutineScope = coroutineRule.testScope,
-            aiFeaturesStateReporter = aiFeaturesStateReporter,
         )
         setupRemoteConfig(browserEnabled = false, collectFullWebViewVersionEnabled = false)
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -292,8 +292,8 @@ interface DuckChatFeature {
 
     /**
      * @return `true` when the native controls for AI Features are enabled in the app.
-     * If the remote feature is not present defaults to `internal`
+     * If the remote feature is not present defaults to `true`
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun aiFeaturesNativeControls(): Toggle
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -292,8 +292,8 @@ interface DuckChatFeature {
 
     /**
      * @return `true` when the native controls for AI Features are enabled in the app.
-     * If the remote feature is not present defaults to `true`
+     * If the remote feature is not present defaults to `internal`
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun aiFeaturesNativeControls(): Toggle
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/AiFeaturesStateReporter.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/AiFeaturesStateReporter.kt
@@ -16,42 +16,34 @@
 
 package com.duckduckgo.duckchat.impl.pixel
 
-import com.duckduckgo.app.di.AppCoroutineScope
-import com.duckduckgo.app.statistics.api.AtbLifecyclePlugin
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.store.HideAiGeneratedImages
 import com.duckduckgo.duckchat.impl.store.SearchAssistVisibility
 import com.duckduckgo.settings.api.SerpSettingsDataProvider
-import com.squareup.anvil.annotations.ContributesMultibinding
-import kotlinx.coroutines.CoroutineScope
+import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-/**
- * On each daily-active day, samples the AI-features settings and fires [DuckChatPixelName.AI_FEATURES_STATE_DAILY]
- * so we can see the distribution across the whole active base. If a stored SERP value can't decode to its native
- * enum, also fires [DuckChatPixelName.SERP_SETTINGS_UNRECOGNIZED_VALUE].
- */
-@ContributesMultibinding(AppScope::class)
-class AiFeaturesStateDauPlugin @Inject constructor(
+interface AiFeaturesStateReporter {
+    /**
+     * Samples the AI-features settings and fires [DuckChatPixelName.AI_FEATURES_STATE_DAILY] so we can see the
+     * distribution across the whole active base. If a stored SERP value can't decode to its native enum, also fires
+     * [DuckChatPixelName.SERP_SETTINGS_UNRECOGNIZED_VALUE]. The fired pixel is a daily pixel, so it is deduped per
+     * calendar day regardless of how often this is called.
+     */
+    suspend fun reportDailyState()
+}
+
+@ContributesBinding(AppScope::class)
+class RealAiFeaturesStateReporter @Inject constructor(
     private val duckChat: DuckChatInternal,
     private val serpSettingsDataProvider: SerpSettingsDataProvider,
     private val pixel: Pixel,
-    @AppCoroutineScope private val coroutineScope: CoroutineScope,
-    private val dispatcherProvider: DispatcherProvider,
-) : AtbLifecyclePlugin {
+) : AiFeaturesStateReporter {
 
-    override fun onAppRetentionAtbRefreshed(oldAtb: String, newAtb: String) {
-        coroutineScope.launch(dispatcherProvider.io()) {
-            fireStatePixel()
-        }
-    }
-
-    private suspend fun fireStatePixel() {
+    override suspend fun reportDailyState() {
         val duckAiOn = duckChat.observeEnableDuckChatUserSetting().firstOrNull() ?: false
 
         val rawKbe = serpSettingsDataProvider.observeSetting(SearchAssistVisibility.SERP_SETTINGS_KEY).firstOrNull()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatDailyPixelSender.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatDailyPixelSender.kt
@@ -40,6 +40,7 @@ class DuckChatDailyPixelSender @Inject constructor(
     private val pixel: Pixel,
     private val duckChatInternal: DuckChatInternal,
     private val duckChatFeatureRepository: DuckChatFeatureRepository,
+    private val aiFeaturesStateReporter: AiFeaturesStateReporter,
     private val dispatcherProvider: DispatcherProvider,
     @AppCoroutineScope private val coroutineScope: CoroutineScope,
 ) : MainProcessLifecycleObserver {
@@ -72,6 +73,8 @@ class DuckChatDailyPixelSender @Inject constructor(
                 parameters = mapOf(PixelParameter.IS_ENABLED to duckChatInternal.isAutomaticContextAttachmentEnabled().toString()),
                 type = Daily(),
             )
+
+            aiFeaturesStateReporter.reportDailyState()
         }
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsActivity.kt
@@ -259,7 +259,9 @@ class DuckChatSettingsActivity : DuckDuckGoActivity() {
         }
         inputScreenSettingsBinding.duckAiDefaultTogglePosition.updatePadding(left = offset)
 
-        inputScreenSettingsBinding.duckAiInputScreenDescription.isVisible = viewState.shouldShowInputScreenToggle
+        // The input screen description is hidden entirely once native controls are enabled.
+        inputScreenSettingsBinding.duckAiInputScreenDescription.isVisible =
+            viewState.shouldShowInputScreenToggle && !viewState.isNativeControlsEnabled
         inputScreenSettingsBinding.duckAiInputScreenDescription.addClickableSpan(
             textSequence = getText(R.string.input_screen_user_pref_description),
             spans =

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsActivity.kt
@@ -311,6 +311,13 @@ class DuckChatSettingsActivity : DuckDuckGoActivity() {
             if (viewState.isSearchSectionVisible) {
                 with(showDuckChatSearchSettingsLink) {
                     isVisible = true
+                    setPrimaryText(
+                        if (viewState.isNativeControlsEnabled) {
+                            getString(R.string.duckAiSearchAssistSettingsTitle)
+                        } else {
+                            getString(R.string.duck_chat_assist_settings_title)
+                        },
+                    )
                     setSecondaryText(
                         if (viewState.isNativeControlsEnabled) {
                             getString(viewState.searchAssistVisibility.toDisplayNameRes())

--- a/duckchat/duckchat-impl/src/main/res/values-bg/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-bg/strings-duckchat.xml
@@ -96,7 +96,6 @@
     <string name="duckAiHideAiGeneratedImagesDescription">Филтрира в резултатите от търсенето изображенията, генерирани от изкуствен интелект</string>
 
     <!-- Search Assist Visibility -->
-    <string name="duckAiSearchAssistVisibilityTitle">Видимост на Search Assist</string>
     <string name="duckAiSearchAssistVisibilitySubtitle">Изберете колко често искате да се появяват отговори, подпомагани от изкуствен интелект, в търсенето.</string>
     <string name="duckAiSearchAssistVisibilityNever">Никога</string>
     <string name="duckAiSearchAssistVisibilityOnDemand">При поискване</string>

--- a/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
@@ -96,7 +96,6 @@
     <string name="duckAiHideAiGeneratedImagesDescription">Odstraní obrázky vytvořené umělou inteligencí z výsledků vyhledávání obrázků</string>
 
     <!-- Search Assist Visibility -->
-    <string name="duckAiSearchAssistVisibilityTitle">Viditelnost Search Assist</string>
     <string name="duckAiSearchAssistVisibilitySubtitle">Vyber, jak často chceš, aby se odpovědi s podporou umělé inteligence zobrazovaly ve tvých vyhledáváních.</string>
     <string name="duckAiSearchAssistVisibilityNever">Nikdy</string>
     <string name="duckAiSearchAssistVisibilityOnDemand">Na vyžádání</string>

--- a/duckchat/duckchat-impl/src/main/res/values-da/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-da/strings-duckchat.xml
@@ -96,7 +96,6 @@
     <string name="duckAiHideAiGeneratedImagesDescription">Filtrerer AI-genererede billeder fra billedsøgeresultater</string>
 
     <!-- Search Assist Visibility -->
-    <string name="duckAiSearchAssistVisibilityTitle">Synlighed i Search Assist</string>
     <string name="duckAiSearchAssistVisibilitySubtitle">Vælg, hvor ofte du vil have AI-assisterede svar til at optræde i dine søgninger.</string>
     <string name="duckAiSearchAssistVisibilityNever">Aldrig</string>
     <string name="duckAiSearchAssistVisibilityOnDemand">On demand</string>

--- a/duckchat/duckchat-impl/src/main/res/values-de/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-de/strings-duckchat.xml
@@ -96,7 +96,6 @@
     <string name="duckAiHideAiGeneratedImagesDescription">Filtert KI-generierte Bilder aus den Ergebnissen der Bildersuche</string>
 
     <!-- Search Assist Visibility -->
-    <string name="duckAiSearchAssistVisibilityTitle">Sichtbarkeit von Search Assist</string>
     <string name="duckAiSearchAssistVisibilitySubtitle">Du kannst auswählen, wie oft KI-gestützte Antworten in deinen Suchergebnissen angezeigt werden sollen.</string>
     <string name="duckAiSearchAssistVisibilityNever">Nie</string>
     <string name="duckAiSearchAssistVisibilityOnDemand">Auf Anfrage</string>

--- a/duckchat/duckchat-impl/src/main/res/values-el/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-el/strings-duckchat.xml
@@ -96,7 +96,6 @@
     <string name="duckAiHideAiGeneratedImagesDescription">Φιλτράρει τις εικόνες που δημιουργούνται με τεχνητή νοημοσύνη από τα αποτελέσματα αναζήτησης εικόνων</string>
 
     <!-- Search Assist Visibility -->
-    <string name="duckAiSearchAssistVisibilityTitle">Ορατότητα Search Assist</string>
     <string name="duckAiSearchAssistVisibilitySubtitle">Επιλέξτε πόσο συχνά θέλετε να εμφανίζονται οι απαντήσεις που υποστηρίζονται από τεχνητή νοημοσύνη στις αναζητήσεις σας.</string>
     <string name="duckAiSearchAssistVisibilityNever">Ποτέ</string>
     <string name="duckAiSearchAssistVisibilityOnDemand">Κατ\' απαίτηση</string>

--- a/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
@@ -96,7 +96,6 @@
     <string name="duckAiHideAiGeneratedImagesDescription">Filtra las imágenes generadas por IA de los resultados de búsqueda de imágenes</string>
 
     <!-- Search Assist Visibility -->
-    <string name="duckAiSearchAssistVisibilityTitle">Visibilidad de Search Assist</string>
     <string name="duckAiSearchAssistVisibilitySubtitle">Elige con qué frecuencia deseas que las respuestas asistidas por IA aparezcan en tus búsquedas.</string>
     <string name="duckAiSearchAssistVisibilityNever">Nunca</string>
     <string name="duckAiSearchAssistVisibilityOnDemand">A la carta</string>

--- a/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
@@ -96,7 +96,6 @@
     <string name="duckAiHideAiGeneratedImagesDescription">Eemaldab tehisintellekti loodud pildid pildiotsingu tulemustest</string>
 
     <!-- Search Assist Visibility -->
-    <string name="duckAiSearchAssistVisibilityTitle">Search Assisti nähtavus</string>
     <string name="duckAiSearchAssistVisibilitySubtitle">Vali, kui tihti soovid tehisintellekti abil saadud vastuseid oma otsingutes kuvada.</string>
     <string name="duckAiSearchAssistVisibilityNever">Mitte kunagi</string>
     <string name="duckAiSearchAssistVisibilityOnDemand">Nõudmisel</string>

--- a/duckchat/duckchat-impl/src/main/res/values-fi/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fi/strings-duckchat.xml
@@ -96,7 +96,6 @@
     <string name="duckAiHideAiGeneratedImagesDescription">Suodattaa pois tekoälyn luomat kuvat kuvahaun tuloksista</string>
 
     <!-- Search Assist Visibility -->
-    <string name="duckAiSearchAssistVisibilityTitle">Search Assist -näkyvyys</string>
     <string name="duckAiSearchAssistVisibilitySubtitle">Valitse, kuinka usein haluat tekoälyavusteisten vastausten näkyvän hauissasi.</string>
     <string name="duckAiSearchAssistVisibilityNever">Ei koskaan</string>
     <string name="duckAiSearchAssistVisibilityOnDemand">Pyynnöstä</string>

--- a/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
@@ -96,7 +96,6 @@
     <string name="duckAiHideAiGeneratedImagesDescription">Filtre les images générées par l\'IA des résultats de recherche d\'images</string>
 
     <!-- Search Assist Visibility -->
-    <string name="duckAiSearchAssistVisibilityTitle">Visibilité de Search Assist</string>
     <string name="duckAiSearchAssistVisibilitySubtitle">Choisissez la fréquence à laquelle vous souhaitez que les réponses assistées par l\'IA apparaissent dans vos recherches.</string>
     <string name="duckAiSearchAssistVisibilityNever">Jamais</string>
     <string name="duckAiSearchAssistVisibilityOnDemand">À la demande</string>

--- a/duckchat/duckchat-impl/src/main/res/values-hr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hr/strings-duckchat.xml
@@ -96,7 +96,6 @@
     <string name="duckAiHideAiGeneratedImagesDescription">Filtrira slike generirane umjetnom inteligencijom iz rezultata pretraživanja slika</string>
 
     <!-- Search Assist Visibility -->
-    <string name="duckAiSearchAssistVisibilityTitle">Vidljivost Search Assista</string>
     <string name="duckAiSearchAssistVisibilitySubtitle">Odaberi koliko često želiš da se odgovori potpomognuti umjetnom inteligencijom pojavljuju u tvojim pretraživanjima.</string>
     <string name="duckAiSearchAssistVisibilityNever">Nikada</string>
     <string name="duckAiSearchAssistVisibilityOnDemand">Na zahtjev</string>

--- a/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
@@ -96,7 +96,6 @@
     <string name="duckAiHideAiGeneratedImagesDescription">Kiszűri az AI által generált képeket a képkeresési találatokból</string>
 
     <!-- Search Assist Visibility -->
-    <string name="duckAiSearchAssistVisibilityTitle">Search Assist láthatósága</string>
     <string name="duckAiSearchAssistVisibilitySubtitle">Válaszd ki, milyen gyakran szeretnél mesterséges intelligenciával generált válaszokat látni a kereséseid során.</string>
     <string name="duckAiSearchAssistVisibilityNever">Soha</string>
     <string name="duckAiSearchAssistVisibilityOnDemand">Igény esetén</string>

--- a/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
@@ -96,7 +96,6 @@
     <string name="duckAiHideAiGeneratedImagesDescription">Filtra le immagini generate dall\'intelligenza artificiale dai risultati di ricerca delle immagini</string>
 
     <!-- Search Assist Visibility -->
-    <string name="duckAiSearchAssistVisibilityTitle">Visibilità di Search Assist</string>
     <string name="duckAiSearchAssistVisibilitySubtitle">Scegli la frequenza con cui vuoi che le risposte assistite dall\'AI appaiano nelle tue ricerche.</string>
     <string name="duckAiSearchAssistVisibilityNever">Mai</string>
     <string name="duckAiSearchAssistVisibilityOnDemand">Su richiesta</string>

--- a/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
@@ -96,7 +96,6 @@
     <string name="duckAiHideAiGeneratedImagesDescription">Vaizdų paieškos rezultatuose nepalieka Di sukurtų vaizdų</string>
 
     <!-- Search Assist Visibility -->
-    <string name="duckAiSearchAssistVisibilityTitle">„Search Assist“ matomumas</string>
     <string name="duckAiSearchAssistVisibilitySubtitle">Pasirink, kaip dažnai paieškose nori matyti „AI-Assisted Answers“.</string>
     <string name="duckAiSearchAssistVisibilityNever">Niekada</string>
     <string name="duckAiSearchAssistVisibilityOnDemand">Pagal poreikį</string>

--- a/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
@@ -96,7 +96,6 @@
     <string name="duckAiHideAiGeneratedImagesDescription">Filtrē MI radītus attēlus no attēlu meklēšanas rezultātiem</string>
 
     <!-- Search Assist Visibility -->
-    <string name="duckAiSearchAssistVisibilityTitle">Search Assist redzamība</string>
     <string name="duckAiSearchAssistVisibilitySubtitle">Izvēlies, cik bieži vēlies redzēt ar MI atbalstītas atbildes savos meklējumos.</string>
     <string name="duckAiSearchAssistVisibilityNever">Nekad</string>
     <string name="duckAiSearchAssistVisibilityOnDemand">Pēc pieprasījuma</string>

--- a/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
@@ -96,7 +96,6 @@
     <string name="duckAiHideAiGeneratedImagesDescription">Filtrerer ut AI-genererte bilder fra bildesøkresultater</string>
 
     <!-- Search Assist Visibility -->
-    <string name="duckAiSearchAssistVisibilityTitle">Synlighet for Search Assist</string>
     <string name="duckAiSearchAssistVisibilitySubtitle">Velg hvor ofte du vil at AI-assisterte svar skal vises i søkene dine.</string>
     <string name="duckAiSearchAssistVisibilityNever">Aldri</string>
     <string name="duckAiSearchAssistVisibilityOnDemand">På forespørsel</string>

--- a/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
@@ -96,7 +96,6 @@
     <string name="duckAiHideAiGeneratedImagesDescription">Filtert AI-gegenereerde afbeeldingen uit de zoekresultaten van afbeeldingen.</string>
 
     <!-- Search Assist Visibility -->
-    <string name="duckAiSearchAssistVisibilityTitle">Zichtbaarheid van Search Assist</string>
     <string name="duckAiSearchAssistVisibilitySubtitle">Kies hoe vaak antwoorden op basis van AI in je zoekresultaten moeten worden weergegeven.</string>
     <string name="duckAiSearchAssistVisibilityNever">Nooit</string>
     <string name="duckAiSearchAssistVisibilityOnDemand">Op aanvraag</string>

--- a/duckchat/duckchat-impl/src/main/res/values-pl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pl/strings-duckchat.xml
@@ -96,7 +96,6 @@
     <string name="duckAiHideAiGeneratedImagesDescription">Filtruje obrazy generowane przez AI z wyników wyszukiwania obrazów</string>
 
     <!-- Search Assist Visibility -->
-    <string name="duckAiSearchAssistVisibilityTitle">Widoczność Search Assist</string>
     <string name="duckAiSearchAssistVisibilitySubtitle">Wybierz, jak często w wyszukiwaniach mają pojawiać się odpowiedzi wspomagane przez sztuczną inteligencję.</string>
     <string name="duckAiSearchAssistVisibilityNever">Nigdy</string>
     <string name="duckAiSearchAssistVisibilityOnDemand">Na żądanie</string>

--- a/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
@@ -96,7 +96,6 @@
     <string name="duckAiHideAiGeneratedImagesDescription">Filtra imagens geradas por IA dos resultados de pesquisa de imagens</string>
 
     <!-- Search Assist Visibility -->
-    <string name="duckAiSearchAssistVisibilityTitle">Visibilidade do Search Assist</string>
     <string name="duckAiSearchAssistVisibilitySubtitle">Escolhe a frequência com que queres que as respostas assistidas por IA apareçam nas tuas pesquisas.</string>
     <string name="duckAiSearchAssistVisibilityNever">Nunca</string>
     <string name="duckAiSearchAssistVisibilityOnDemand">A pedido</string>

--- a/duckchat/duckchat-impl/src/main/res/values-ro/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ro/strings-duckchat.xml
@@ -96,7 +96,6 @@
     <string name="duckAiHideAiGeneratedImagesDescription">Filtrează imaginile generate de IA din rezultatele căutării de imagini</string>
 
     <!-- Search Assist Visibility -->
-    <string name="duckAiSearchAssistVisibilityTitle">Vizibilitate Search Assist</string>
     <string name="duckAiSearchAssistVisibilitySubtitle">Alege cât de des dorești să apară răspunsurile asistate de IA în căutările tale.</string>
     <string name="duckAiSearchAssistVisibilityNever">Niciodată</string>
     <string name="duckAiSearchAssistVisibilityOnDemand">La cerere</string>

--- a/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
@@ -96,7 +96,6 @@
     <string name="duckAiHideAiGeneratedImagesDescription">Исключает из результатов поиска изображения, созданные нейросетью</string>
 
     <!-- Search Assist Visibility -->
-    <string name="duckAiSearchAssistVisibilityTitle">Параметры Search Assist</string>
     <string name="duckAiSearchAssistVisibilitySubtitle">Выберите, как часто вы хотите видеть ответы от ИИ в результатах поиска.</string>
     <string name="duckAiSearchAssistVisibilityNever">Никогда</string>
     <string name="duckAiSearchAssistVisibilityOnDemand">По запросу</string>

--- a/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
@@ -96,7 +96,6 @@
     <string name="duckAiHideAiGeneratedImagesDescription">Odstraňuje obrázky vytvorené umelou inteligenciou z výsledkov vyhľadávania obrázkov</string>
 
     <!-- Search Assist Visibility -->
-    <string name="duckAiSearchAssistVisibilityTitle">Viditeľnosť funkcie Search Assist</string>
     <string name="duckAiSearchAssistVisibilitySubtitle">Vyber, ako často chceš, aby sa vo vyhľadávaní zobrazovali odpovede podporované AI.</string>
     <string name="duckAiSearchAssistVisibilityNever">Nikdy</string>
     <string name="duckAiSearchAssistVisibilityOnDemand">Na požiadanie</string>

--- a/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
@@ -96,7 +96,6 @@
     <string name="duckAiHideAiGeneratedImagesDescription">Iz rezultatov iskanja slik odstrani slike, ki jih je ustvarila umetna inteligenca</string>
 
     <!-- Search Assist Visibility -->
-    <string name="duckAiSearchAssistVisibilityTitle">Vidnost pomoči pri iskanju Search Assist</string>
     <string name="duckAiSearchAssistVisibilitySubtitle">Izberite, kako pogosto želite, da se v vaših iskanjih prikazujejo odgovori s pomočjo umetne inteligence.</string>
     <string name="duckAiSearchAssistVisibilityNever">Nikoli</string>
     <string name="duckAiSearchAssistVisibilityOnDemand">Na zahtevo</string>

--- a/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
@@ -96,7 +96,6 @@
     <string name="duckAiHideAiGeneratedImagesDescription">Filtrerar bort AI-genererade bilder från bildsökningsresultaten</string>
 
     <!-- Search Assist Visibility -->
-    <string name="duckAiSearchAssistVisibilityTitle">Search Assist-synlighet</string>
     <string name="duckAiSearchAssistVisibilitySubtitle">Välj hur ofta du vill att AI-assisterade svar ska visas i dina sökningar.</string>
     <string name="duckAiSearchAssistVisibilityNever">Aldrig</string>
     <string name="duckAiSearchAssistVisibilityOnDemand">På begäran</string>

--- a/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
@@ -96,7 +96,6 @@
     <string name="duckAiHideAiGeneratedImagesDescription">Görsel arama sonuçlarından yapay zeka tarafından üretilmiş görselleri filtreler</string>
 
     <!-- Search Assist Visibility -->
-    <string name="duckAiSearchAssistVisibilityTitle">Search Assist Görünürlüğü</string>
     <string name="duckAiSearchAssistVisibilitySubtitle">Yapay zeka destekli yanıtların aramalarınızda ne sıklıkta görünmesini istediğinizi seçin.</string>
     <string name="duckAiSearchAssistVisibilityNever">Hiçbir zaman</string>
     <string name="duckAiSearchAssistVisibilityOnDemand">Talep Üzerine</string>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -72,4 +72,6 @@
     <!-- Duck AI Duck.ai Section Header -->
     <string name="duckAiDuckAiSectionHeader">Duck.ai</string>
 
+    <!-- Search Assist Visibility -->
+    <string name="duckAiSearchAssistVisibilityTitle">Search Assist</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -74,4 +74,5 @@
 
     <!-- Search Assist Visibility -->
     <string name="duckAiSearchAssistVisibilityTitle">Search Assist</string>
+    <string name="duckAiSearchAssistSettingsTitle">Search Assist</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -48,7 +48,7 @@
     <string name="duck_ai_shortcut_settings_description">Choose which Duck.ai shortcuts to display</string>
 
     <!-- Default Toggle Position -->
-    <string name="duckAiDefaultTogglePositionTitle" instruction="'Toggle' refers to the UI tab switcher component (Search/Duck.ai), not the verb 'to toggle'.">New Tab Toggle Position</string>
+    <string name="duckAiDefaultTogglePositionTitle" instruction="'Toggle' refers to the UI tab switcher component (Search/Duck.ai), not the verb 'to toggle'.">Toggle Position</string>
     <string name="duckAiDefaultTogglePositionSearch">Search</string>
     <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
     <string name="duckAiDefaultTogglePositionLastUsed">Last Used</string>

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -48,7 +48,7 @@
     <string name="duck_ai_shortcut_settings_description">Choose which Duck.ai shortcuts to display</string>
 
     <!-- Default Toggle Position -->
-    <string name="duckAiDefaultTogglePositionTitle" instruction="'Toggle' refers to the UI tab switcher component (Search/Duck.ai), not the verb 'to toggle'.">Toggle Position</string>
+    <string name="duckAiDefaultTogglePositionTitle" instruction="'Toggle' refers to the UI tab switcher component (Search/Duck.ai), not the verb 'to toggle'.">New Tab Toggle Position</string>
     <string name="duckAiDefaultTogglePositionSearch">Search</string>
     <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
     <string name="duckAiDefaultTogglePositionLastUsed">Last Used</string>

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -95,7 +95,6 @@
     <string name="duckAiHideAiGeneratedImagesDescription">Filters out AI-generated images from image search results</string>
 
     <!-- Search Assist Visibility -->
-    <string name="duckAiSearchAssistVisibilityTitle">Search Assist Visibility</string>
     <string name="duckAiSearchAssistVisibilitySubtitle">Choose how often you want AI-assisted answers to appear in your searches.</string>
     <string name="duckAiSearchAssistVisibilityNever">Never</string>
     <string name="duckAiSearchAssistVisibilityOnDemand">On demand</string>

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -48,7 +48,7 @@
     <string name="duck_ai_shortcut_settings_description">Choose which Duck.ai shortcuts to display</string>
 
     <!-- Default Toggle Position -->
-    <string name="duckAiDefaultTogglePositionTitle" instruction="'Toggle' refers to the UI tab switcher component (Search/Duck.ai), not the verb 'to toggle'.">New tab toggle position</string>
+    <string name="duckAiDefaultTogglePositionTitle" instruction="'Toggle' refers to the UI tab switcher component (Search/Duck.ai), not the verb 'to toggle'.">New Tab Toggle Position</string>
     <string name="duckAiDefaultTogglePositionSearch">Search</string>
     <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
     <string name="duckAiDefaultTogglePositionLastUsed">Last Used</string>
@@ -104,7 +104,7 @@
     <!-- Duck AI Use Without AI Settings Option -->
     <string name="duckAiUseWithoutAiTitle">Use DuckDuckGo Without AI</string>
     <string name="duckAiUseWithoutAiDescription">Disables Duck.ai, hides AI-assisted answers in search, and filters known AI spam sites in image search results.</string>
-    <string name="duckAiUseWithoutAiDisabledDescription">AI is currently disabled in the Browser so you’ll no longer see AI-assisted answers and see fewer AI-generated images in image search results.</string>
+    <string name="duckAiUseWithoutAiDisabledDescription">AI is currently disabled in the browser so you’ll no longer see AI-assisted answers and see fewer AI-generated images in image search results.</string>
 
     <!-- Duck AI Section in AI Feature Screen -->
     <string name="input_screen_user_pref_toggle_between_search_and_ai">Toggle between Search and Duck.ai</string>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/DuckChatDailyPixelSenderTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/DuckChatDailyPixelSenderTest.kt
@@ -43,6 +43,7 @@ class DuckChatDailyPixelSenderTest {
     private val mockDuckChatFeatureRepository: DuckChatFeatureRepository = mock()
     private val mockLifecycleOwner: LifecycleOwner = mock()
     private val duckChatInternal: DuckChatInternal = mock()
+    private val aiFeaturesStateReporter: AiFeaturesStateReporter = mock()
 
     private lateinit var testee: DuckChatDailyPixelSender
 
@@ -51,6 +52,7 @@ class DuckChatDailyPixelSenderTest {
         testee = DuckChatDailyPixelSender(
             pixel = mockPixel,
             duckChatFeatureRepository = mockDuckChatFeatureRepository,
+            aiFeaturesStateReporter = aiFeaturesStateReporter,
             dispatcherProvider = coroutineRule.testDispatcherProvider,
             coroutineScope = coroutineRule.testScope,
             duckChatInternal = duckChatInternal,
@@ -94,5 +96,19 @@ class DuckChatDailyPixelSenderTest {
             parameters = mapOf(PixelParameter.IS_ENABLED to "false"),
             type = Daily(),
         )
+    }
+
+    @Test
+    fun `when onStart then reports ai features state`() = runTest {
+        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(false)
+        whenever(mockDuckChatFeatureRepository.shouldShowInBrowserMenu()).thenReturn(false)
+        whenever(mockDuckChatFeatureRepository.shouldShowInAddressBar()).thenReturn(false)
+        whenever(mockDuckChatFeatureRepository.isInputScreenUserSettingEnabled()).thenReturn(false)
+
+        testee.onStart(mockLifecycleOwner)
+
+        advanceUntilIdle()
+
+        verify(aiFeaturesStateReporter).reportDailyState()
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealAiFeaturesStateReporterTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealAiFeaturesStateReporterTest.kt
@@ -17,16 +17,13 @@
 package com.duckduckgo.duckchat.impl.pixel
 
 import com.duckduckgo.app.statistics.pixels.Pixel
-import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.store.HideAiGeneratedImages
 import com.duckduckgo.duckchat.impl.store.SearchAssistVisibility
 import com.duckduckgo.settings.api.SerpSettingsDataProvider
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
@@ -36,21 +33,16 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class AiFeaturesStateDauPluginTest {
-
-    @get:Rule
-    val coroutineRule = CoroutineTestRule()
+class RealAiFeaturesStateReporterTest {
 
     private val duckChat: DuckChatInternal = mock()
     private val serpSettingsDataProvider: SerpSettingsDataProvider = mock()
     private val pixel: Pixel = mock()
 
-    private val testee = AiFeaturesStateDauPlugin(
+    private val testee = RealAiFeaturesStateReporter(
         duckChat = duckChat,
         serpSettingsDataProvider = serpSettingsDataProvider,
         pixel = pixel,
-        coroutineScope = coroutineRule.testScope,
-        dispatcherProvider = coroutineRule.testDispatcherProvider,
     )
 
     private fun stubSettings(duckAiOn: Boolean, kbe: String?, kbj: String?) {
@@ -63,8 +55,7 @@ class AiFeaturesStateDauPluginTest {
     fun `when fully without ai then state pixel reports no_ai true`() = runTest {
         stubSettings(duckAiOn = false, kbe = "0", kbj = "1")
 
-        testee.onAppRetentionAtbRefreshed(oldAtb = "v100-1", newAtb = "v100-2")
-        advanceUntilIdle()
+        testee.reportDailyState()
 
         verify(pixel).fire(
             DuckChatPixelName.AI_FEATURES_STATE_DAILY,
@@ -82,8 +73,7 @@ class AiFeaturesStateDauPluginTest {
     fun `when duck ai on then no_ai false`() = runTest {
         stubSettings(duckAiOn = true, kbe = "0", kbj = "1")
 
-        testee.onAppRetentionAtbRefreshed(oldAtb = "v100-1", newAtb = "v100-2")
-        advanceUntilIdle()
+        testee.reportDailyState()
 
         verify(pixel).fire(
             DuckChatPixelName.AI_FEATURES_STATE_DAILY,
@@ -101,8 +91,7 @@ class AiFeaturesStateDauPluginTest {
     fun `when search assist not synced then defaults to 2 and not no_ai`() = runTest {
         stubSettings(duckAiOn = false, kbe = null, kbj = "1")
 
-        testee.onAppRetentionAtbRefreshed(oldAtb = "v100-1", newAtb = "v100-2")
-        advanceUntilIdle()
+        testee.reportDailyState()
 
         verify(pixel).fire(
             DuckChatPixelName.AI_FEATURES_STATE_DAILY,
@@ -121,8 +110,7 @@ class AiFeaturesStateDauPluginTest {
     fun `when stored kbe value is unrecognized then unrecognized pixel fired and default used`() = runTest {
         stubSettings(duckAiOn = false, kbe = "9", kbj = "1")
 
-        testee.onAppRetentionAtbRefreshed(oldAtb = "v100-1", newAtb = "v100-2")
-        advanceUntilIdle()
+        testee.reportDailyState()
 
         verify(pixel).fire(DuckChatPixelName.SERP_SETTINGS_UNRECOGNIZED_VALUE, type = Pixel.PixelType.Daily())
         verify(pixel).fire(
@@ -141,8 +129,7 @@ class AiFeaturesStateDauPluginTest {
     fun `when stored kbj value is unrecognized then unrecognized pixel fired and treated as off`() = runTest {
         stubSettings(duckAiOn = false, kbe = "0", kbj = "7")
 
-        testee.onAppRetentionAtbRefreshed(oldAtb = "v100-1", newAtb = "v100-2")
-        advanceUntilIdle()
+        testee.reportDailyState()
 
         verify(pixel).fire(DuckChatPixelName.SERP_SETTINGS_UNRECOGNIZED_VALUE, type = Pixel.PixelType.Daily())
         verify(pixel).fire(


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200581511062568/task/1216122666748045?focus=true
Tech Design URL (if applicable):

### Description

Small UI and string refinements to the AI Features native controls screen (gated by aiFeaturesNativeControls).

- Hide the input-screen description when native controls are enabled. duckAiInputScreenDescription is now only shown when shouldShowInputScreenToggle && !isNativeControlsEnabled, so it no longer appears in the native-controls layout.
- Search Assist row title under native controls. When the flag is on, the Search Assist row (showDuckChatSearchSettingsLink) now shows primary text "Search Assist" (duckAiSearchAssistSettingsTitle); when off it keeps its original duck_chat_assist_settings_title.
- String cleanup for the Search Assist title. Moved duckAiSearchAssistVisibilityTitle out of the translatable strings-duckchat.xml into donottranslate.xml and renamed its value from "Search Assist Visibility" → "Search Assist", dropping the now-stale translated entries from all locale files. Added a new duckAiSearchAssistSettingsTitle ("Search Assist") in donottranslate.xml for the row title above.
- Rebase fixup commit.

No behaviour change when the flag is off.

### Steps to test this PR

Native controls ON (enable the aiFeaturesNativeControls flag):

1. Open Settings → AI Features and confirm the input-screen description text is not shown.
2. Confirm the Search Assist row's primary text reads "Search Assist", with its secondary text reflecting the current selection (Never / On demand / Sometimes / Often).
3. Tap the row and confirm the Search Assist dialog opens with the title "Search Assist".

Native controls OFF:
4\. Open Settings → AI Features and confirm the input-screen description is still visible and the Search Assist row keeps its original title and description.

Translations:
5\. Switch the device to a non-English locale (e.g. French) and confirm the Search Assist title renders as "Search Assist" (no longer translated / no missing-string crash).

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly UI copy and telemetry trigger relocation; daily pixel deduping should limit double-firing risk. No auth or data-path changes.
> 
> **Overview**
> Ship-review tweaks for **AI Features** when native controls are on, plus a refactor of how the **AI features state** daily pixel is sent.
> 
> **Settings UI (native controls):** The input-screen description is hidden when `isNativeControlsEnabled` is true. The Search Assist entry row uses the **"Search Assist"** title (`duckAiSearchAssistSettingsTitle`) under native controls instead of the legacy assist settings title.
> 
> **Strings:** `duckAiSearchAssistVisibilityTitle` is renamed to **"Search Assist"**, moved to `donottranslate.xml`, and removed from locale files so the label stays English. Minor English copy fixes (e.g. toggle position capitalization, browser casing).
> 
> **Telemetry:** `AiFeaturesStateDauPlugin` is replaced by **`AiFeaturesStateReporter`** / **`RealAiFeaturesStateReporter`**. **`AI_FEATURES_STATE_DAILY`** (and unrecognized SERP value handling) now runs from **`DuckChatDailyPixelSender.onStart`** via `reportDailyState()`, not on ATB retention refresh. Tests follow the new types and wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aad392d3b4440e9f14ca0f1916a6d648a3703b58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->