### PR TITLE
Restore experimental_omnibar pixels on the native input path

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -471,6 +471,7 @@ class RealNativeInputManager @Inject constructor(
         widget.bindInputEvents(
             onSearchTextChanged = onSearchTextChanged,
             onSearchSubmitted = { query ->
+                duckChatPixels.fireOmnibarQuerySubmitted(query)
                 hideNativeInput(isNavigation = true)
                 callbacks.onSearchSubmitted(query)
             },

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -50,6 +50,7 @@ import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.InputMode
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InteractionLock
 import com.duckduckgo.duckchat.api.toChatIdOrNull
+import com.duckduckgo.duckchat.impl.inputscreen.ui.metrics.usage.InputScreenSessionUsageMetric
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.NativeInputWidget
 import com.duckduckgo.navigation.api.GlobalActivityStarter
@@ -146,6 +147,7 @@ class RealNativeInputManager @Inject constructor(
     private val pixel: Pixel,
     private val nativeInputStateBugKillSwitch: NativeInputStateBugKillSwitch,
     private val duckChatPixels: DuckChatPixels,
+    private val inputScreenSessionUsageMetric: InputScreenSessionUsageMetric,
 ) : NativeInputManager {
     private lateinit var omnibarController: NativeInputOmnibarController
     private lateinit var rootView: ViewGroup
@@ -472,6 +474,7 @@ class RealNativeInputManager @Inject constructor(
             onSearchTextChanged = onSearchTextChanged,
             onSearchSubmitted = { query ->
                 duckChatPixels.fireOmnibarQuerySubmitted(query)
+                inputScreenSessionUsageMetric.onSearchSubmitted()
                 hideNativeInput(isNavigation = true)
                 callbacks.onSearchSubmitted(query)
             },
@@ -494,6 +497,7 @@ class RealNativeInputManager @Inject constructor(
                     )
                     widget.clearSelectedTool()
                     widget.onPromptSubmitted()
+                    inputScreenSessionUsageMetric.onPromptSubmitted()
                 } else if (queryUrlPredictor.isUrl(query)) {
                     // Not in a Duck.ai chat (e.g. on the NTP with the Duck.ai toggle selected): a
                     // URL is an address, so navigate to it exactly like Search mode rather than
@@ -519,6 +523,7 @@ class RealNativeInputManager @Inject constructor(
                         hideNtp()
                     }
                     isExiting = false
+                    inputScreenSessionUsageMetric.onPromptSubmitted()
                     callbacks.onDuckAiQuerySubmitted(query)
                 }
             },

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -50,6 +50,7 @@ import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.InputMode
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InteractionLock
 import com.duckduckgo.duckchat.api.toChatIdOrNull
+import com.duckduckgo.duckchat.impl.inputscreen.ui.metrics.discovery.InputScreenDiscoveryFunnel
 import com.duckduckgo.duckchat.impl.inputscreen.ui.metrics.usage.InputScreenSessionUsageMetric
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.NativeInputWidget
@@ -148,6 +149,7 @@ class RealNativeInputManager @Inject constructor(
     private val nativeInputStateBugKillSwitch: NativeInputStateBugKillSwitch,
     private val duckChatPixels: DuckChatPixels,
     private val inputScreenSessionUsageMetric: InputScreenSessionUsageMetric,
+    private val inputScreenDiscoveryFunnel: InputScreenDiscoveryFunnel,
 ) : NativeInputManager {
     private lateinit var omnibarController: NativeInputOmnibarController
     private lateinit var rootView: ViewGroup
@@ -453,6 +455,8 @@ class RealNativeInputManager @Inject constructor(
         } else {
             showNtp()
         }
+        inputScreenDiscoveryFunnel.onNativeInputActive()
+        inputScreenDiscoveryFunnel.onInputScreenOpened()
         duckChatPixels.fireOmnibarShown()
         val landscape = rootView.resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
         duckChatPixels.fireOmnibarTextAreaFocused(landscape = landscape)
@@ -475,6 +479,7 @@ class RealNativeInputManager @Inject constructor(
             onSearchSubmitted = { query ->
                 duckChatPixels.fireOmnibarQuerySubmitted(query)
                 inputScreenSessionUsageMetric.onSearchSubmitted()
+                inputScreenDiscoveryFunnel.onSearchSubmitted()
                 hideNativeInput(isNavigation = true)
                 callbacks.onSearchSubmitted(query)
             },
@@ -498,6 +503,7 @@ class RealNativeInputManager @Inject constructor(
                     widget.clearSelectedTool()
                     widget.onPromptSubmitted()
                     inputScreenSessionUsageMetric.onPromptSubmitted()
+                    inputScreenDiscoveryFunnel.onPromptSubmitted()
                 } else if (queryUrlPredictor.isUrl(query)) {
                     // Not in a Duck.ai chat (e.g. on the NTP with the Duck.ai toggle selected): a
                     // URL is an address, so navigate to it exactly like Search mode rather than
@@ -524,6 +530,7 @@ class RealNativeInputManager @Inject constructor(
                     }
                     isExiting = false
                     inputScreenSessionUsageMetric.onPromptSubmitted()
+                    inputScreenDiscoveryFunnel.onPromptSubmitted()
                     callbacks.onDuckAiQuerySubmitted(query)
                 }
             },

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -50,6 +50,7 @@ import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.InputMode
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InteractionLock
 import com.duckduckgo.duckchat.api.toChatIdOrNull
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.NativeInputWidget
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionPurchase
@@ -144,6 +145,7 @@ class RealNativeInputManager @Inject constructor(
     private val duckAiFeatureState: DuckAiFeatureState,
     private val pixel: Pixel,
     private val nativeInputStateBugKillSwitch: NativeInputStateBugKillSwitch,
+    private val duckChatPixels: DuckChatPixels,
 ) : NativeInputManager {
     private lateinit var omnibarController: NativeInputOmnibarController
     private lateinit var rootView: ViewGroup
@@ -449,6 +451,9 @@ class RealNativeInputManager @Inject constructor(
         } else {
             showNtp()
         }
+        duckChatPixels.fireOmnibarShown()
+        val landscape = rootView.resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE
+        duckChatPixels.fireOmnibarTextAreaFocused(landscape = landscape)
     }
 
     private fun bindSearchCallbacks(

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
@@ -37,6 +37,9 @@ import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.impl.inputscreen.ui.metrics.discovery.InputScreenDiscoveryFunnel
+import com.duckduckgo.duckchat.impl.inputscreen.ui.metrics.usage.InputScreenSessionUsageMetric
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.voice.api.VoiceSearchAvailability
@@ -71,6 +74,9 @@ class RealNativeInputManagerTest {
     private val queryUrlPredictor: QueryUrlPredictor = mock()
     private val duckAiFeatureState: DuckAiFeatureState = mock()
     private val pixel: Pixel = mock()
+    private val duckChatPixels: DuckChatPixels = mock()
+    private val inputScreenSessionUsageMetric: InputScreenSessionUsageMetric = mock()
+    private val inputScreenDiscoveryFunnel: InputScreenDiscoveryFunnel = mock()
     private val nativeInputStateBugKillSwitch = FakeFeatureToggleFactory.create(NativeInputStateBugKillSwitch::class.java)
 
     private val context: Context = ApplicationProvider.getApplicationContext()
@@ -91,6 +97,9 @@ class RealNativeInputManagerTest {
             duckAiFeatureState,
             pixel,
             nativeInputStateBugKillSwitch,
+            duckChatPixels,
+            inputScreenSessionUsageMetric,
+            inputScreenDiscoveryFunnel,
         )
     }
 

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckAiFeatureState.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckAiFeatureState.kt
@@ -94,4 +94,10 @@ interface DuckAiFeatureState {
      * Indicates whether Duck.ai should be used as digital assistant
      */
     val allowDuckAiAsDigitalAssistant: StateFlow<Boolean>
+
+    /**
+     * True when the native input field is the active input surface. Mutually exclusive with
+     * [showInputScreen] (which is computed with `&& !isNativeInputFieldEnabled`).
+     */
+    val nativeInputFieldEnabled: StateFlow<Boolean>
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -625,6 +625,8 @@ class RealDuckChat @Inject constructor(
 
     override val allowDuckAiAsDigitalAssistant: StateFlow<Boolean> = _allowDuckAiAsDigitalAssistant.asStateFlow()
 
+    override val nativeInputFieldEnabled: StateFlow<Boolean> = _nativeInputFieldEnabled.asStateFlow()
+
     override val chatState: StateFlow<ChatState> = _chatState.asStateFlow()
 
     override fun isImageUploadEnabled(): Boolean = isImageUploadEnabled

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/metrics/discovery/InputScreenDiscoveryFunnel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/metrics/discovery/InputScreenDiscoveryFunnel.kt
@@ -41,6 +41,9 @@ interface InputScreenDiscoveryFunnel {
     fun onDuckAiSettingsSeen()
     fun onInputScreenEnabled()
     fun onInputScreenDisabled()
+
+    /** Records SettingsSeen + FeatureEnabled for native-input users who never toggle the Input Screen setting. */
+    fun onNativeInputActive()
     fun onInputScreenOpened()
     fun onSearchSubmitted()
     fun onPromptSubmitted()
@@ -68,6 +71,11 @@ class InputScreenDiscoveryFunnelImpl @Inject constructor(
 
     override fun onInputScreenDisabled() {
         resetFunnel()
+    }
+
+    override fun onNativeInputActive() {
+        onStep(SettingsSeen)
+        onStep(FeatureEnabled)
     }
 
     override fun onInputScreenOpened() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/metrics/retention/InputScreenRetentionMonitor.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/metrics/retention/InputScreenRetentionMonitor.kt
@@ -73,7 +73,7 @@ class InputScreenRetentionMonitor @Inject constructor(
                         if (nowMinus24hET > lastCheckET) {
                             val wasFeatureEnabled = persistedData[Key.LAST_ENABLED_STATE]
                             if (wasFeatureEnabled == true) {
-                                val isStillEnabled = duckAiFeatureState.showInputScreen.value
+                                val isStillEnabled = duckAiFeatureState.nativeInputFieldEnabled.value
                                 pixel.fire(
                                     pixel = DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_DAILY_RETENTION,
                                     parameters = mapOf("still_enabled" to isStillEnabled.toString()),
@@ -100,7 +100,7 @@ class InputScreenRetentionMonitor @Inject constructor(
 
     private suspend fun persistCurrentState() {
         val currentTimeETString = timeProvider.nowInEasternTime().toString()
-        val isFeatureEnabled = duckAiFeatureState.showInputScreen.value
+        val isFeatureEnabled = duckAiFeatureState.nativeInputFieldEnabled.value
         retentionMonitorDataStore.edit { preferences ->
             preferences[Key.LAST_CHECK_DATE_TIME_ET] = currentTimeETString
             preferences[Key.LAST_ENABLED_STATE] = isFeatureEnabled

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/metrics/usage/InputScreenSessionUsageMetric.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/metrics/usage/InputScreenSessionUsageMetric.kt
@@ -22,9 +22,11 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 
@@ -45,6 +47,7 @@ interface InputScreenSessionUsageMetric {
 class InputScreenSessionUsageMetricImpl @Inject constructor(
     private val pixel: Pixel,
     private val duckAiFeatureState: DuckAiFeatureState,
+    private val duckChatPixels: DuckChatPixels,
 ) : MainProcessLifecycleObserver, InputScreenSessionUsageMetric {
 
     private companion object {
@@ -54,13 +57,15 @@ class InputScreenSessionUsageMetricImpl @Inject constructor(
 
     private val searchCounter: AtomicInteger = AtomicInteger()
     private val promptCounter: AtomicInteger = AtomicInteger()
+    private val bothModesFired: AtomicBoolean = AtomicBoolean(false)
 
     override fun onStop(owner: LifecycleOwner) {
-        if (!duckAiFeatureState.showInputScreen.value) {
+        if (!duckAiFeatureState.nativeInputFieldEnabled.value) {
             return
         }
         val searchCount = searchCounter.getAndSet(0)
         val promptCount = promptCounter.getAndSet(0)
+        bothModesFired.set(false)
         val params = mapOf(
             PIXEL_PARAM_SEARCH_COUNT to searchCount.toString(),
             PIXEL_PARAM_PROMPT_COUNT to promptCount.toString(),
@@ -73,9 +78,17 @@ class InputScreenSessionUsageMetricImpl @Inject constructor(
 
     override fun onSearchSubmitted() {
         searchCounter.incrementAndGet()
+        maybeFireBothModes()
     }
 
     override fun onPromptSubmitted() {
         promptCounter.incrementAndGet()
+        maybeFireBothModes()
+    }
+
+    private fun maybeFireBothModes() {
+        if (searchCounter.get() > 0 && promptCounter.get() > 0 && bothModesFired.compareAndSet(false, true)) {
+            duckChatPixels.fireOmnibarSessionBothModes()
+        }
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -189,6 +189,16 @@ interface DuckChatPixels {
     fun fireDuckAiChatHistorySuggestionClicked()
     fun fireDuckAiSearchDuckDuckGoSuggestionClicked()
     fun fireCustomizeResponsesSelected()
+    fun fireOmnibarShown()
+    fun fireOmnibarTextAreaFocused(landscape: Boolean)
+    fun fireOmnibarQuerySubmitted(query: String)
+    fun fireOmnibarModeSwitched(directionToSearch: Boolean, hadText: Boolean)
+    fun fireOmnibarClearButtonPressed(isSearchMode: Boolean)
+    fun fireOmnibarBackButtonPressed(isSearchMode: Boolean)
+    fun fireOmnibarKeyboardGoPressed(isSearchMode: Boolean)
+    fun fireOmnibarFloatingSubmitPressed(isSearchMode: Boolean)
+    fun fireOmnibarFloatingReturnPressed()
+    fun fireOmnibarSessionBothModes()
 }
 
 @ContributesBinding(AppScope::class)
@@ -674,6 +684,79 @@ class RealDuckChatPixels @Inject constructor(
             pixel.fire(DuckChatPixelName.AUTOCOMPLETE_DUCKAI_CLICK_SEARCH_DUCKDUCKGO)
         }
     }
+
+    override fun fireOmnibarShown() = fireCountAndDaily(
+        DUCK_CHAT_EXPERIMENTAL_OMNIBAR_SHOWN_COUNT,
+        DUCK_CHAT_EXPERIMENTAL_OMNIBAR_SHOWN_DAILY,
+    )
+
+    override fun fireOmnibarTextAreaFocused(landscape: Boolean) {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            pixel.fire(
+                pixel = DUCK_CHAT_EXPERIMENTAL_OMNIBAR_TEXT_AREA_FOCUSED,
+                parameters = mapOf("orientation" to if (landscape) "landscape" else "portrait"),
+            )
+        }
+    }
+
+    override fun fireOmnibarQuerySubmitted(query: String) {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            pixel.fire(
+                pixel = DUCK_CHAT_EXPERIMENTAL_OMNIBAR_QUERY_SUBMITTED,
+                parameters = mapOf(DuckChatPixelParameters.TEXT_LENGTH_BUCKET to toQueryLengthBucket(query.length)),
+            )
+            pixel.fire(DUCK_CHAT_EXPERIMENTAL_OMNIBAR_QUERY_SUBMITTED_DAILY, type = Pixel.PixelType.Daily())
+        }
+    }
+
+    override fun fireOmnibarModeSwitched(directionToSearch: Boolean, hadText: Boolean) {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            pixel.fire(
+                pixel = DUCK_CHAT_EXPERIMENTAL_OMNIBAR_MODE_SWITCHED,
+                parameters = mapOf(
+                    "direction" to if (directionToSearch) "to_search" else "to_duckai",
+                    "had_text" to hadText.toString(),
+                ),
+            )
+        }
+    }
+
+    override fun fireOmnibarClearButtonPressed(isSearchMode: Boolean) = fireModeParam(
+        DUCK_CHAT_EXPERIMENTAL_OMNIBAR_CLEAR_BUTTON_PRESSED,
+        isSearchMode,
+    )
+
+    override fun fireOmnibarBackButtonPressed(isSearchMode: Boolean) = fireModeParam(
+        DUCK_CHAT_EXPERIMENTAL_OMNIBAR_BACK_BUTTON_PRESSED,
+        isSearchMode,
+    )
+
+    override fun fireOmnibarKeyboardGoPressed(isSearchMode: Boolean) = fireModeParam(
+        DUCK_CHAT_EXPERIMENTAL_OMNIBAR_KEYBOARD_GO_PRESSED,
+        isSearchMode,
+    )
+
+    override fun fireOmnibarFloatingSubmitPressed(isSearchMode: Boolean) = fireModeParam(
+        DUCK_CHAT_EXPERIMENTAL_OMNIBAR_FLOATING_SUBMIT_PRESSED,
+        isSearchMode,
+    )
+
+    override fun fireOmnibarFloatingReturnPressed() {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            pixel.fire(DUCK_CHAT_EXPERIMENTAL_OMNIBAR_FLOATING_RETURN_PRESSED)
+        }
+    }
+
+    override fun fireOmnibarSessionBothModes() = fireCountAndDaily(
+        DUCK_CHAT_EXPERIMENTAL_OMNIBAR_SESSION_BOTH_MODES,
+        DUCK_CHAT_EXPERIMENTAL_OMNIBAR_SESSION_BOTH_MODES_DAILY,
+    )
+
+    private fun fireModeParam(name: DuckChatPixelName, isSearchMode: Boolean) {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            pixel.fire(pixel = name, parameters = inputScreenPixelsModeParam(isSearchMode))
+        }
+    }
 }
 
 enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
@@ -1145,3 +1228,11 @@ internal fun inputScreenPixelsModeParam(isSearchMode: Boolean) = mapOf(
         "aiChat"
     },
 )
+
+internal fun toQueryLengthBucket(length: Int): String =
+    when {
+        length <= 15 -> "short"
+        length <= 40 -> "medium"
+        length <= 100 -> "long"
+        else -> "very_long"
+    }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -245,6 +245,12 @@ class NativeInputModeWidgetViewModel @Inject constructor(
 
     fun fireStopGenerationTapped() = duckChatPixels.fireStopGenerationTapped()
 
+    fun fireClearPressed(isSearchMode: Boolean) = duckChatPixels.fireOmnibarClearButtonPressed(isSearchMode)
+    fun fireKeyboardGoPressed(isSearchMode: Boolean) = duckChatPixels.fireOmnibarKeyboardGoPressed(isSearchMode)
+    fun fireFloatingSubmitPressed(isSearchMode: Boolean) = duckChatPixels.fireOmnibarFloatingSubmitPressed(isSearchMode)
+    fun fireFloatingReturnPressed() = duckChatPixels.fireOmnibarFloatingReturnPressed()
+    fun fireModeSwitched(directionToSearch: Boolean, hadText: Boolean) = duckChatPixels.fireOmnibarModeSwitched(directionToSearch, hadText)
+
     private data class WidgetConfig(
         val inputContext: NativeInputState.InputContext = NativeInputState.InputContext.BROWSER,
         val inputPosition: NativeInputState.InputPosition = NativeInputState.InputPosition.TOP,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -24,6 +24,7 @@ import android.text.InputType
 import android.transition.AutoTransition
 import android.transition.TransitionManager
 import android.util.AttributeSet
+import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
@@ -497,6 +498,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
             .launchIn(findViewTreeLifecycleOwner()?.lifecycleScope ?: return)
     }
 
+    private fun isSearchMode() = !isChatTabSelected()
+
     private fun applyNativeStyling() {
         setBackgroundColor(Color.TRANSPARENT)
         hideInputFieldBackground()
@@ -505,10 +508,54 @@ class NativeInputModeWidget @JvmOverloads constructor(
         prepareSubmitButtons()
         configureMainButtonsVisibility()
         configureBottomRowFocusVisibility()
+        hookClearButtonPixel()
+        hookEditorActionPixels()
         inputField.doOnTextChanged { _, _, _, _ ->
             updateSendButtonVisibility()
             updateVoiceButtonVisibility()
             updateNewLineButtonVisibility()
+        }
+    }
+
+    /**
+     * Re-wraps the clear-button click listener (originally set by the base class in init) to also
+     * fire the omnibar clear pixel. We replace rather than stack because [View.setOnClickListener]
+     * replaces existing listeners; preserving base-class behaviour manually keeps the contract clear.
+     */
+    private fun hookClearButtonPixel() {
+        val clearBtn = findViewById<View>(R.id.inputFieldClearText) ?: return
+        clearBtn.setOnClickListener {
+            inputField.text.clear()
+            inputField.setSelection(0)
+            inputField.scrollTo(0, 0)
+            onClearTextTapped?.invoke()
+            viewModel.fireClearPressed(isSearchMode())
+        }
+    }
+
+    /**
+     * Re-wraps the IME editor-action listener (originally set by the base class in init) to also
+     * fire omnibar keyboard-go and floating-return pixels. The submit path is unchanged: we call
+     * [submitMessage] and return true exactly when the base class would, so downstream behaviour
+     * (onSearchSent / onChatSent / submission pixels) is not affected.
+     */
+    private fun hookEditorActionPixels() {
+        inputField.setOnEditorActionListener { _, actionId, keyEvent ->
+            val isHardwareEnter =
+                (keyEvent?.keyCode == KeyEvent.KEYCODE_ENTER || keyEvent?.keyCode == KeyEvent.KEYCODE_NUMPAD_ENTER) &&
+                    keyEvent.action == KeyEvent.ACTION_DOWN
+
+            if (actionId == EditorInfo.IME_ACTION_GO) {
+                submitMessage()
+                viewModel.fireKeyboardGoPressed(isSearchMode())
+                true
+            } else if (isHardwareEnter && shouldSubmitOnHardwareEnter()) {
+                submitMessage()
+                viewModel.fireFloatingReturnPressed()
+                true
+            } else {
+                false
+            }
         }
     }
 
@@ -775,6 +822,14 @@ class NativeInputModeWidget @JvmOverloads constructor(
             object : TabLayout.OnTabSelectedListener {
                 override fun onTabSelected(tab: TabLayout.Tab) {
                     applyTabUi()
+                    // Only fire mode_switched when the toggle is visible (i.e. user-driven); programmatic
+                    // tab changes via applyState / selectChatTab / selectSearchTab run while toggleVisible
+                    // is false and must not fire the pixel. This mirrors pushToggleSelectionIfUserDriven().
+                    if (nativeInputState?.toggleVisible == true) {
+                        val directionToSearch = tab.position == 0
+                        val hadText = inputField.text?.isNotBlank() == true
+                        viewModel.fireModeSwitched(directionToSearch, hadText)
+                    }
                     pushToggleSelectionIfUserDriven()
                     refreshTabDependentButtons()
                 }
@@ -1455,7 +1510,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
                 useTopBar = false,
                 layoutResId = R.layout.view_native_input_screen_buttons,
             ).apply {
-                onSendClick = { submitMessage() }
+                onSendClick = {
+                    submitMessage()
+                    viewModel.fireFloatingSubmitPressed(isSearchMode())
+                }
                 onStopClick = { this@NativeInputModeWidget.stop() }
                 onVoiceChatClick = voiceChatClickWithPixel
                 setSendButtonVisible(false)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/inputscreen/ui/metrics/discovery/InputScreenDiscoveryFunnelImplTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/inputscreen/ui/metrics/discovery/InputScreenDiscoveryFunnelImplTest.kt
@@ -329,6 +329,23 @@ class InputScreenDiscoveryFunnelImplTest {
     }
 
     @Test
+    fun `when native active then interaction and submissions then full conversion fires`() = runTest {
+        testee.onNativeInputActive()
+        advanceUntilIdle()
+        testee.onInputScreenOpened()
+        advanceUntilIdle()
+        testee.onSearchSubmitted()
+        advanceUntilIdle()
+        testee.onPromptSubmitted()
+        advanceUntilIdle()
+
+        verify(mockPixel).fire(DUCK_CHAT_EXPERIMENTAL_OMNIBAR_FIRST_INTERACTION)
+        verify(mockPixel).fire(DUCK_CHAT_EXPERIMENTAL_OMNIBAR_FIRST_SEARCH_SUBMISSION)
+        verify(mockPixel).fire(DUCK_CHAT_EXPERIMENTAL_OMNIBAR_FIRST_PROMPT_SUBMISSION)
+        verify(mockPixel).fire(DUCK_CHAT_EXPERIMENTAL_OMNIBAR_FULL_CONVERSION_USER)
+    }
+
+    @Test
     fun `when complete funnel flow is executed then all individual step pixels are fired in correct order`() = runTest {
         // Set input screen as disabled initially
         showInputScreenFlow.value = false

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/inputscreen/ui/metrics/retention/InputScreenRetentionMonitorTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/inputscreen/ui/metrics/retention/InputScreenRetentionMonitorTest.kt
@@ -59,12 +59,14 @@ class InputScreenRetentionMonitorTest {
     private val mockTimeProvider: TimeProvider = mock()
 
     private val showInputScreenFlow = MutableStateFlow(true)
+    private val nativeInputFlow = MutableStateFlow(true)
 
     private lateinit var testee: InputScreenRetentionMonitor
 
     @Before
     fun setup() {
         whenever(mockDuckAiFeatureState.showInputScreen).thenReturn(showInputScreenFlow)
+        whenever(mockDuckAiFeatureState.nativeInputFieldEnabled).thenReturn(nativeInputFlow)
 
         testee = InputScreenRetentionMonitor(
             coroutineScope = coroutineTestRule.testScope,
@@ -82,7 +84,7 @@ class InputScreenRetentionMonitorTest {
 
         // First call - feature was enabled in a previous session
         whenever(mockTimeProvider.nowInEasternTime()).thenReturn(initialTime)
-        showInputScreenFlow.value = true
+        nativeInputFlow.value = true
         testee.onResume(mockLifecycleOwner)
 
         // Second call - feature is still enabled after 24+ hours (mock time has advanced)
@@ -104,12 +106,12 @@ class InputScreenRetentionMonitorTest {
 
         // First call - feature was enabled in a previous session
         whenever(mockTimeProvider.nowInEasternTime()).thenReturn(initialTime)
-        showInputScreenFlow.value = true
+        nativeInputFlow.value = true
         testee.onResume(mockLifecycleOwner)
 
         // Second call - feature is now disabled after 24+ hours (mock time has advanced)
         whenever(mockTimeProvider.nowInEasternTime()).thenReturn(laterTime)
-        showInputScreenFlow.value = false
+        nativeInputFlow.value = false
         testee.onResume(mockLifecycleOwner)
 
         verify(mockPixel).fire(
@@ -127,12 +129,12 @@ class InputScreenRetentionMonitorTest {
         // First call - feature was disabled in a previous session
         whenever(mockTimeProvider.nowInEasternTime()).thenReturn(initialTime)
         val laterTime = initialTime.plusHours(25)
-        showInputScreenFlow.value = false
+        nativeInputFlow.value = false
         testee.onResume(mockLifecycleOwner)
 
         // Second call - feature is now enabled after 24+ hours, but was disabled initially
         whenever(mockTimeProvider.nowInEasternTime()).thenReturn(laterTime)
-        showInputScreenFlow.value = true
+        nativeInputFlow.value = true
         testee.onResume(mockLifecycleOwner)
 
         // Third call - feature is now enabled for more than 24+ hours
@@ -155,7 +157,7 @@ class InputScreenRetentionMonitorTest {
 
         // First call - feature was enabled in a previous session
         whenever(mockTimeProvider.nowInEasternTime()).thenReturn(initialTime)
-        showInputScreenFlow.value = true
+        nativeInputFlow.value = true
         testee.onResume(mockLifecycleOwner)
 
         // Second call - still enabled but less than 24 hours have passed
@@ -166,7 +168,7 @@ class InputScreenRetentionMonitorTest {
 
         // Third call - feature is still enabled after 24+ hours, send the pixel
         whenever(mockTimeProvider.nowInEasternTime()).thenReturn(laterTime)
-        showInputScreenFlow.value = true
+        nativeInputFlow.value = true
         testee.onResume(mockLifecycleOwner)
 
         verify(mockPixel).fire(
@@ -194,7 +196,7 @@ class InputScreenRetentionMonitorTest {
 
         // Second call - feature is now disabled
         whenever(mockTimeProvider.nowInEasternTime()).thenReturn(laterTime)
-        showInputScreenFlow.value = false
+        nativeInputFlow.value = false
         testee.onResume(mockLifecycleOwner)
 
         // No pixel should be fired due to parsing error

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/inputscreen/ui/metrics/usage/InputScreenSessionUsageMetricTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/inputscreen/ui/metrics/usage/InputScreenSessionUsageMetricTest.kt
@@ -20,10 +20,13 @@ import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -31,21 +34,22 @@ import org.mockito.kotlin.whenever
 class InputScreenSessionUsageMetricTest {
 
     private val pixel: Pixel = mock()
+    private val duckChatPixels: DuckChatPixels = mock()
     private val duckAiFeatureState: DuckAiFeatureState = mock()
     private val lifecycleOwner: LifecycleOwner = mock()
-    private val showInputScreenFlow = MutableStateFlow(true)
+    private val nativeInputFieldEnabledFlow = MutableStateFlow(true)
 
     private lateinit var testee: InputScreenSessionUsageMetricImpl
 
     @Before
     fun setup() {
-        whenever(duckAiFeatureState.showInputScreen).thenReturn(showInputScreenFlow)
-        testee = InputScreenSessionUsageMetricImpl(pixel, duckAiFeatureState)
+        whenever(duckAiFeatureState.nativeInputFieldEnabled).thenReturn(nativeInputFieldEnabledFlow)
+        testee = InputScreenSessionUsageMetricImpl(pixel, duckAiFeatureState, duckChatPixels)
     }
 
     @Test
     fun `when onStop called with feature enabled and no searches or prompts then pixel fired with zero counts`() {
-        showInputScreenFlow.value = true
+        nativeInputFieldEnabledFlow.value = true
 
         testee.onStop(lifecycleOwner)
 
@@ -61,7 +65,7 @@ class InputScreenSessionUsageMetricTest {
 
     @Test
     fun `when onStop called with feature disabled then no pixel fired`() {
-        showInputScreenFlow.value = false
+        nativeInputFieldEnabledFlow.value = false
 
         testee.onSearchSubmitted()
         testee.onPromptSubmitted()
@@ -72,7 +76,7 @@ class InputScreenSessionUsageMetricTest {
 
     @Test
     fun `when onSearchSubmitted called once and feature enabled then counter increments`() {
-        showInputScreenFlow.value = true
+        nativeInputFieldEnabledFlow.value = true
 
         testee.onSearchSubmitted()
         testee.onStop(lifecycleOwner)
@@ -89,7 +93,7 @@ class InputScreenSessionUsageMetricTest {
 
     @Test
     fun `when onPromptSubmitted called once and feature enabled then counter increments`() {
-        showInputScreenFlow.value = true
+        nativeInputFieldEnabledFlow.value = true
 
         testee.onPromptSubmitted()
         testee.onStop(lifecycleOwner)
@@ -106,7 +110,7 @@ class InputScreenSessionUsageMetricTest {
 
     @Test
     fun `when multiple searches and prompts submitted and feature enabled then counters increment correctly`() {
-        showInputScreenFlow.value = true
+        nativeInputFieldEnabledFlow.value = true
 
         testee.onSearchSubmitted()
         testee.onSearchSubmitted()
@@ -128,7 +132,7 @@ class InputScreenSessionUsageMetricTest {
 
     @Test
     fun `when onStop called multiple times with feature enabled then counters reset after each call`() {
-        showInputScreenFlow.value = true
+        nativeInputFieldEnabledFlow.value = true
 
         // First session
         testee.onSearchSubmitted()
@@ -160,7 +164,7 @@ class InputScreenSessionUsageMetricTest {
 
     @Test
     fun `when counters increment but onStop never called then no pixel fired`() {
-        showInputScreenFlow.value = true
+        nativeInputFieldEnabledFlow.value = true
 
         testee.onSearchSubmitted()
         testee.onPromptSubmitted()
@@ -170,7 +174,7 @@ class InputScreenSessionUsageMetricTest {
 
     @Test
     fun `when thread safety is required then atomic counters handle concurrent access`() {
-        showInputScreenFlow.value = true
+        nativeInputFieldEnabledFlow.value = true
 
         // Simulate concurrent access
         val threads = mutableListOf<Thread>()
@@ -203,5 +207,71 @@ class InputScreenSessionUsageMetricTest {
             pixel = DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_SESSION_SUMMARY,
             parameters = expectedParams,
         )
+    }
+
+    @Test
+    fun `when native input enabled and both modes used then both-modes pixel fired once and summary on stop`() = runTest {
+        nativeInputFieldEnabledFlow.value = true
+
+        testee.onSearchSubmitted()
+        testee.onPromptSubmitted()
+
+        verify(duckChatPixels).fireOmnibarSessionBothModes()
+
+        testee.onStop(lifecycleOwner)
+        verify(pixel).enqueueFire(
+            pixel = DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_SESSION_SUMMARY,
+            parameters = mapOf("searches_in_session" to "1", "prompts_in_session" to "1"),
+        )
+    }
+
+    @Test
+    fun `when both modes used in one session then both-modes fires once only`() = runTest {
+        nativeInputFieldEnabledFlow.value = true
+
+        testee.onSearchSubmitted()
+        testee.onPromptSubmitted()
+        testee.onSearchSubmitted()
+        testee.onPromptSubmitted()
+
+        verify(duckChatPixels).fireOmnibarSessionBothModes()
+    }
+
+    @Test
+    fun `when only search submitted then both-modes pixel not fired`() = runTest {
+        nativeInputFieldEnabledFlow.value = true
+
+        testee.onSearchSubmitted()
+        testee.onStop(lifecycleOwner)
+
+        verifyNoInteractions(duckChatPixels)
+    }
+
+    @Test
+    fun `when only prompt submitted then both-modes pixel not fired`() = runTest {
+        nativeInputFieldEnabledFlow.value = true
+
+        testee.onPromptSubmitted()
+        testee.onStop(lifecycleOwner)
+
+        verifyNoInteractions(duckChatPixels)
+    }
+
+    @Test
+    fun `when both modes used across two sessions then both-modes fires once per session`() = runTest {
+        nativeInputFieldEnabledFlow.value = true
+
+        // First session
+        testee.onSearchSubmitted()
+        testee.onPromptSubmitted()
+        testee.onStop(lifecycleOwner)
+
+        // Second session - bothModesFired should be reset
+        testee.onSearchSubmitted()
+        testee.onPromptSubmitted()
+        testee.onStop(lifecycleOwner)
+
+        // Should be called exactly twice (once per session)
+        verify(duckChatPixels, times(2)).fireOmnibarSessionBothModes()
     }
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
@@ -409,4 +409,56 @@ class RealDuckChatPixelsTest {
         verify(mockTermsOfServiceHandler).userAcceptedTerms()
         verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_USER_ACCEPTED_TERMS_AND_CONDITIONS, parameters = emptyMap())
     }
+
+    @Test
+    fun whenFireOmnibarShownThenCountAndDailyFired() = runTest {
+        testee.fireOmnibarShown()
+
+        advanceUntilIdle()
+
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_SHOWN_COUNT)
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_SHOWN_DAILY, type = Pixel.PixelType.Daily())
+    }
+
+    @Test
+    fun whenFireOmnibarQuerySubmittedThenCountCarriesLengthBucketAndDailyHasNoParams() = runTest {
+        testee.fireOmnibarQuerySubmitted("hi") // 2 chars -> "short"
+
+        advanceUntilIdle()
+
+        verify(mockPixel).fire(
+            pixel = DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_QUERY_SUBMITTED,
+            parameters = mapOf(DuckChatPixelParameters.TEXT_LENGTH_BUCKET to "short"),
+        )
+        verify(mockPixel).fire(
+            pixel = DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_QUERY_SUBMITTED_DAILY,
+            parameters = emptyMap(),
+            encodedParameters = emptyMap(),
+            type = Pixel.PixelType.Daily(),
+        )
+    }
+
+    @Test
+    fun whenFireOmnibarModeSwitchedToSearchThenDirectionAndHadTextParamsFired() = runTest {
+        testee.fireOmnibarModeSwitched(directionToSearch = true, hadText = true)
+
+        advanceUntilIdle()
+
+        verify(mockPixel).fire(
+            pixel = DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_MODE_SWITCHED,
+            parameters = mapOf("direction" to "to_search", "had_text" to "true"),
+        )
+    }
+
+    @Test
+    fun whenFireOmnibarBackButtonPressedInSearchModeThenModeParamFired() = runTest {
+        testee.fireOmnibarBackButtonPressed(isSearchMode = true)
+
+        advanceUntilIdle()
+
+        verify(mockPixel).fire(
+            pixel = DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_BACK_BUTTON_PRESSED,
+            parameters = mapOf(DuckChatPixelParameters.INPUT_SCREEN_MODE to "search"),
+        )
+    }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216108452227332
Tech Design URL (if applicable):

### Description

After the Unified Input rollout, a set of `m_aichat_experimental_omnibar_*` pixels declined because they were fired only from the legacy Input Screen path (`InputScreenActivity` / `InputScreenFragment` / `InputScreenViewModel` and its metric observers), which is bypassed once the native input field is shown.

This restores those metrics by firing the **same pixel names** from the native input path. Native-only, no dual-firing, no discriminator param.

**Scope: 17 pixels** (not 19). Investigation found `back_button_pressed` and `keyboard_go_pressed` already fire for native — `NativeInputModeWidget` extends the shared base `InputModeWidget`, whose `init` wires the back button and IME listener that fire those pixels regardless of the bypassed Input Screen path. They were therefore left alone.

What changed:
- New `fireOmnibar*` helpers on `DuckChatPixels` (reusing existing enums; no pixel-definition JSON changes).
- UI pixels fired from `NativeInputManager` / `NativeInputModeWidget`: `shown`, `text_area_focused`, `query_submitted`, `clear_button_pressed`, `floating_submit_pressed`, `floating_return_pressed`, `mode_switched`.
- New `DuckAiFeatureState.nativeInputFieldEnabled` flag; `InputScreenRetentionMonitor` and `InputScreenSessionUsageMetric` re-gated on it (was `showInputScreen`, always false for native), fed from native submit callbacks. `session_both_modes` ported via a per-session guard.
- Discovery funnel driven from native via `onNativeInputActive()` (records the `SettingsSeen`/`FeatureEnabled` preconditions so the chain isn't blocked for default-on native users) plus interaction/submission feeds.

**⚠️ Telemetry coordination (for data/dashboard owners) before rollout:**
- `first_settings_viewed` + `first_enabled` will show a one-time spike (funnel preconditions recorded on first native activation).
- `daily_retention`'s `still_enabled` param is now ≈ always true — its meaning shifts to "input experience active."
- Confirm at runtime that `shown` / `shown_count` fire once per presentation (not inflated by repeated `showNativeInput`).

### Steps to test this PR

_Native input enabled (internal build)_
- [ ] Tap the omnibar → verify `m_aichat_experimental_omnibar_shown_count` + `..._text_area_focused` fire once.
- [ ] Submit a search → `..._query_submitted_count` fires (and NOT when submitting a Duck.ai prompt).
- [ ] Tap clear, tap floating submit, press keyboard return, switch the search/Duck.ai toggle → `..._clear_button_pressed`, `..._floating_submit_pressed`, `..._floating_return_pressed`, `..._mode_switched` fire.
- [ ] Use both search and Duck.ai in one session → `..._session_both_modes_*` fires once; background the app → `..._session_summary` fires with counts.
- [ ] After 24h of native input being active → `..._daily_retention` fires with `still_enabled=true`.
- [ ] First interaction + a search + a prompt → funnel pixels (`first_interaction`, `first_search_submission`, `first_prompt_submission`, `full_conversion_user`) fire.

### UI changes

None — telemetry only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only changes with no auth, payment, or data-model impact; main operational risk is dashboard interpretation (one-time funnel spike, daily_retention semantics shift) called out in the PR.
> 
> **Overview**
> Restores **`m_aichat_experimental_omnibar_*`** telemetry on the **native unified input** path so metrics no longer drop when the legacy Input Screen is bypassed. Same pixel names, native-only wiring—no dual-firing.
> 
> **`DuckChatPixels`** gains **`fireOmnibar*`** helpers (shown, focus, query submit with length bucket, mode switch, clear/floating submit/return, session both-modes). **`RealNativeInputManager`** fires discovery funnel + session usage + shown/focus/query on show/submit; **`NativeInputModeWidget`** hooks clear, IME go, hardware enter, floating send, and user-driven tab switches (guarded when the toggle is hidden).
> 
> **`DuckAiFeatureState.nativeInputFieldEnabled`** is exposed and used to re-gate **`InputScreenRetentionMonitor`** and **`InputScreenSessionUsageMetric`** (replacing **`showInputScreen`**, which stays false for native users). **`InputScreenDiscoveryFunnel.onNativeInputActive()`** seeds SettingsSeen/FeatureEnabled so funnel pixels can still advance for default-on native users.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bb39849d2ea0cfd8b5aa50fb72fab0b12843651. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->