### PR TITLE
Add chat sync promo translations

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/chat/ChatSyncPromotion.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/chat/ChatSyncPromotion.kt
@@ -60,19 +60,19 @@ class RealChatSyncPromotion @Inject constructor(
 
     override suspend fun incrementImpressionCount() {
         promotionDataStore.recordPromoImpression(ChatTabPage)
-        pixel.fire(SyncPixelName.SYNC_FEATURE_PROMOTION_DISPLAYED, pixelParmas())
+        pixel.fire(SyncPixelName.SYNC_FEATURE_PROMOTION_DISPLAYED, pixelParams())
     }
 
     override suspend fun recordPromotionAccepted() {
         promotionDataStore.recordPromoDismissed(ChatTabPage)
-        pixel.fire(SyncPixelName.SYNC_FEATURE_PROMOTION_CONFIRMED, pixelParmas())
+        pixel.fire(SyncPixelName.SYNC_FEATURE_PROMOTION_CONFIRMED, pixelParams())
     }
 
     override suspend fun recordPromotionDismissed() {
         promotionDataStore.recordPromoDismissed(ChatTabPage)
         pixel.fire(
             pixel = SyncPixelName.SYNC_FEATURE_PROMOTION_DISMISSED,
-            parameters = pixelParmas {
+            parameters = pixelParams {
                 put(SyncPixelParameters.SYNC_FEATURE_PROMOTION_DISMISS_REASON, PIXEL_DISMISS_REASON_USER_TAPPED)
             },
         )
@@ -88,7 +88,7 @@ class RealChatSyncPromotion @Inject constructor(
         if (isImpressionCapReached) {
             pixel.fire(
                 pixel = SyncPixelName.SYNC_FEATURE_PROMOTION_DISMISSED,
-                parameters = pixelParmas {
+                parameters = pixelParams {
                     put(SyncPixelParameters.SYNC_FEATURE_PROMOTION_DISMISS_REASON, PIXEL_DISMISS_REASON_IMPRESSION_CAP)
                 },
                 type = Unique(MAX_IMPRESSION_CAP_PIXEL_TAG),
@@ -122,7 +122,7 @@ class RealChatSyncPromotion @Inject constructor(
 
     private suspend fun hasChatSuggestions(): Boolean = duckChat.observeHasChatSuggestions().firstOrNull() == true
 
-    private fun pixelParmas(
+    private fun pixelParams(
         customParams: (MutableMap<String, String>.() -> Unit)? = null,
     ): Map<String, String> = buildMap {
         put(SyncPixelParameters.SYNC_FEATURE_PROMOTION_SOURCE, PIXEL_SOURCE)

--- a/sync/sync-impl/src/main/res/values-bg/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-bg/strings-sync.xml
@@ -241,4 +241,12 @@
     <string name="sync_recover_data_download_pdf">Изтегляне като PDF</string>
     <string name="sync_restore_on_reinstall_title">Възстановяване при преинсталиране на приложението</string>
     <string name="sync_restore_on_reinstall_description">Ако преинсталирате приложението DuckDuckGo, ще Ви попитаме дали искате да възстановите данните на това устройство.</string>
+
+    <!-- Chat sync promo -->
+    <string name="sync_chat_promo_banner_title">Можете да отваряте своите чатове на всички устройства, като използвате Sync &amp; Backup.</string>
+    <string name="sync_chat_promo_banner_cta_title">Синхронизиране с друго устройство</string>
+    <string name="sync_chat_bottom_sheet_title">Нека синхронизираме чатовете на всичките устройства!</string>
+    <string name="sync_chat_bottom_sheet_description">Намерете QR кода в приложението DuckDuckGo на другото устройство, като отворите Настройки › Sync &amp; Backup › Синхронизиране с друго устройство.</string>
+    <string name="sync_chat_bottom_sheet_positive">Сканиране на QR код</string>
+    <string name="sync_chat_bottom_sheet_negative">Не сега</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values-cs/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-cs/strings-sync.xml
@@ -241,4 +241,12 @@
     <string name="sync_recover_data_download_pdf">Stáhnout jako PDF</string>
     <string name="sync_restore_on_reinstall_title">Obnovit při přeinstalaci aplikace</string>
     <string name="sync_restore_on_reinstall_description">Pokud přeinstaluješ aplikaci DuckDuckGo, zeptáme se tě, jestli chceš obnovit data na tomto zařízení.</string>
+
+    <!-- Chat sync promo -->
+    <string name="sync_chat_promo_banner_title">Získej přístup ke svým chatům napříč všemi zařízeními pomocí funkce Sync &amp; Backup.</string>
+    <string name="sync_chat_promo_banner_cta_title">Synchronizovat s jiným zařízením</string>
+    <string name="sync_chat_bottom_sheet_title">Pojďme synchronizovat tvé chaty napříč tvými zařízeními!</string>
+    <string name="sync_chat_bottom_sheet_description">QR kód najdeš v aplikaci DuckDuckGo na druhém zařízení v nabídce Nastavení › Sync &amp; Backup › Synchronizace s jiným zařízením.</string>
+    <string name="sync_chat_bottom_sheet_positive">Naskenuj QR kód</string>
+    <string name="sync_chat_bottom_sheet_negative">Teď ne</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values-da/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-da/strings-sync.xml
@@ -241,4 +241,12 @@
     <string name="sync_recover_data_download_pdf">Download som PDF-fil</string>
     <string name="sync_restore_on_reinstall_title">Gendan ved geninstallation af appen</string>
     <string name="sync_restore_on_reinstall_description">Hvis du geninstallerer DuckDuckGo-appen, spørger vi, om du vil gendanne dine data på denne enhed.</string>
+
+    <!-- Chat sync promo -->
+    <string name="sync_chat_promo_banner_title">Få adgang til dine chats på tværs af dine enheder ved hjælp af Sync &amp; Backup.</string>
+    <string name="sync_chat_promo_banner_cta_title">Synkroniser med en anden enhed</string>
+    <string name="sync_chat_bottom_sheet_title">Lad os synkronisere dine chats på tværs af dine enheder!</string>
+    <string name="sync_chat_bottom_sheet_description">Find QR-koden i DuckDuckGo-appen på din anden enhed ved at gå til Indstillinger › Sync &amp; Backup › Synkroniser med en anden enhed.</string>
+    <string name="sync_chat_bottom_sheet_positive">Scan QR-kode</string>
+    <string name="sync_chat_bottom_sheet_negative">Ikke nu</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values-de/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-de/strings-sync.xml
@@ -241,4 +241,12 @@
     <string name="sync_recover_data_download_pdf">Als PDF herunterladen</string>
     <string name="sync_restore_on_reinstall_title">Bei App-Neuinstallation wiederherstellen</string>
     <string name="sync_restore_on_reinstall_description">Wenn du die DuckDuckGo-App neu installierst, werden wir dich fragen, ob du deine Daten auf diesem Gerät wiederherstellen möchtest.</string>
+
+    <!-- Chat sync promo -->
+    <string name="sync_chat_promo_banner_title">Mit Sync &amp; Backup kannst du geräteübergreifend auf deine Chats zugreifen.</string>
+    <string name="sync_chat_promo_banner_cta_title">Mit anderem Gerät synchronisieren</string>
+    <string name="sync_chat_bottom_sheet_title">Lass uns deine Chats auf deinen Geräten synchronisieren!</string>
+    <string name="sync_chat_bottom_sheet_description">Finde den QR-Code in der DuckDuckGo-App auf deinem anderen Gerät unter **Einstellungen** › **Sync &amp; Backup** › **Mit anderem Gerät synchronisieren**.</string>
+    <string name="sync_chat_bottom_sheet_positive">QR-Code scannen</string>
+    <string name="sync_chat_bottom_sheet_negative">Jetzt nicht</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values-de/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-de/strings-sync.xml
@@ -246,7 +246,7 @@
     <string name="sync_chat_promo_banner_title">Mit Sync &amp; Backup kannst du geräteübergreifend auf deine Chats zugreifen.</string>
     <string name="sync_chat_promo_banner_cta_title">Mit anderem Gerät synchronisieren</string>
     <string name="sync_chat_bottom_sheet_title">Lass uns deine Chats auf deinen Geräten synchronisieren!</string>
-    <string name="sync_chat_bottom_sheet_description">Finde den QR-Code in der DuckDuckGo-App auf deinem anderen Gerät unter **Einstellungen** › **Sync &amp; Backup** › **Mit anderem Gerät synchronisieren**.</string>
+    <string name="sync_chat_bottom_sheet_description">Finde den &lt;b&gt;QR-Code&lt;/b&gt; in der DuckDuckGo-App auf deinem anderen Gerät unter &lt;strong&gt;Einstellungen&lt;/strong&gt; › &lt;strong&gt;Sync &amp; Backup&lt;/strong&gt; › &lt;strong&gt;Mit anderem Gerät synchronisieren&lt;/strong&gt;.</string>
     <string name="sync_chat_bottom_sheet_positive">QR-Code scannen</string>
     <string name="sync_chat_bottom_sheet_negative">Jetzt nicht</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values-de/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-de/strings-sync.xml
@@ -246,7 +246,7 @@
     <string name="sync_chat_promo_banner_title">Mit Sync &amp; Backup kannst du geräteübergreifend auf deine Chats zugreifen.</string>
     <string name="sync_chat_promo_banner_cta_title">Mit anderem Gerät synchronisieren</string>
     <string name="sync_chat_bottom_sheet_title">Lass uns deine Chats auf deinen Geräten synchronisieren!</string>
-    <string name="sync_chat_bottom_sheet_description">Finde den QR-Code in der DuckDuckGo-App auf deinem anderen Gerät unter **Einstellungen** › **Sync &amp; Backup** › **Mit anderem Gerät synchronisieren**.</string>
+    <string name="sync_chat_bottom_sheet_description">Finde den QR-Code in der DuckDuckGo-App auf deinem anderen Gerät unter Einstellungen › Sync &amp; Backup › Mit anderem Gerät synchronisieren.</string>
     <string name="sync_chat_bottom_sheet_positive">QR-Code scannen</string>
     <string name="sync_chat_bottom_sheet_negative">Jetzt nicht</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values-de/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-de/strings-sync.xml
@@ -246,7 +246,7 @@
     <string name="sync_chat_promo_banner_title">Mit Sync &amp; Backup kannst du geräteübergreifend auf deine Chats zugreifen.</string>
     <string name="sync_chat_promo_banner_cta_title">Mit anderem Gerät synchronisieren</string>
     <string name="sync_chat_bottom_sheet_title">Lass uns deine Chats auf deinen Geräten synchronisieren!</string>
-    <string name="sync_chat_bottom_sheet_description">Finde den &lt;b&gt;QR-Code&lt;/b&gt; in der DuckDuckGo-App auf deinem anderen Gerät unter &lt;strong&gt;Einstellungen&lt;/strong&gt; › &lt;strong&gt;Sync &amp; Backup&lt;/strong&gt; › &lt;strong&gt;Mit anderem Gerät synchronisieren&lt;/strong&gt;.</string>
+    <string name="sync_chat_bottom_sheet_description">Finde den QR-Code in der DuckDuckGo-App auf deinem anderen Gerät unter **Einstellungen** › **Sync &amp; Backup** › **Mit anderem Gerät synchronisieren**.</string>
     <string name="sync_chat_bottom_sheet_positive">QR-Code scannen</string>
     <string name="sync_chat_bottom_sheet_negative">Jetzt nicht</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values-el/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-el/strings-sync.xml
@@ -241,4 +241,12 @@
     <string name="sync_recover_data_download_pdf">Λήψη σε μορφή PDF</string>
     <string name="sync_restore_on_reinstall_title">Επαναφορά στην Εκ νέου εγκατάσταση εφαρμογής</string>
     <string name="sync_restore_on_reinstall_description">Εάν εγκαταστήσετε ξανά την εφαρμογή DuckDuckGo, θα σας ρωτήσουμε εάν θέλετε να επαναφέρετε τα δεδομένα σας σε αυτήν τη συσκευή.</string>
+
+    <!-- Chat sync promo -->
+    <string name="sync_chat_promo_banner_title">Απόκτησε πρόσβαση στις συνομιλίες σου σε όλες τις συσκευές σου χρησιμοποιώντας το Sync &amp; Backup.</string>
+    <string name="sync_chat_promo_banner_cta_title">Συγχρονισμός με άλλη συσκευή</string>
+    <string name="sync_chat_bottom_sheet_title">Ας συγχρονίσουμε τις συνομιλίες σου σε όλες\nτις συσκευές σου!</string>
+    <string name="sync_chat_bottom_sheet_description">Βρες τον κωδικό QR στην εφαρμογή DuckDuckGo στην άλλη συσκευή σου μεταβαίνοντας στις Ρυθμίσεις › Sync &amp; Backup › Συγχρονισμός με άλλη συσκευή.</string>
+    <string name="sync_chat_bottom_sheet_positive">Σάρωση κωδικού QR</string>
+    <string name="sync_chat_bottom_sheet_negative">Όχι τώρα</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values-es/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-es/strings-sync.xml
@@ -241,4 +241,12 @@
     <string name="sync_recover_data_download_pdf">Descargar como PDF</string>
     <string name="sync_restore_on_reinstall_title">Restaurar al reinstalar la aplicación</string>
     <string name="sync_restore_on_reinstall_description">Si vuelves a instalar la aplicación DuckDuckGo, te preguntaremos si quieres restaurar los datos en este dispositivo.</string>
+
+    <!-- Chat sync promo -->
+    <string name="sync_chat_promo_banner_title">Accede a tus chats en todos tus dispositivos usando Sync &amp; Backup.</string>
+    <string name="sync_chat_promo_banner_cta_title">Sincronizar con otro dispositivo</string>
+    <string name="sync_chat_bottom_sheet_title">¡Sincroniza tus chats en todos tus dispositivos!</string>
+    <string name="sync_chat_bottom_sheet_description">Encuentra el código QR en la aplicación DuckDuckGo de tu otro dispositivo yendo a Ajustes › Sync &amp; Backup › Sincronizar con otro dispositivo.</string>
+    <string name="sync_chat_bottom_sheet_positive">Escanear código QR</string>
+    <string name="sync_chat_bottom_sheet_negative">Ahora no</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values-et/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-et/strings-sync.xml
@@ -241,4 +241,12 @@
     <string name="sync_recover_data_download_pdf">Laadi alla PDF-ina</string>
     <string name="sync_restore_on_reinstall_title">Taasta andmed rakenduse uuesti installimisel</string>
     <string name="sync_restore_on_reinstall_description">Kui installid DuckDuckGo rakenduse uuesti, küsime, kas soovid oma andmed selles seadmes taastada.</string>
+
+    <!-- Chat sync promo -->
+    <string name="sync_chat_promo_banner_title">Kasuta funktsiooni „Sync &amp; Backup“, et pääseda oma vestlustele ligi kõikidelt seadmetelt.</string>
+    <string name="sync_chat_promo_banner_cta_title">Sünkrooni teise seadmega</string>
+    <string name="sync_chat_bottom_sheet_title">Sünkroniseerime vestlused\nsinu seadmete vahel!</string>
+    <string name="sync_chat_bottom_sheet_description">Leia QR-kood oma teises seadmes DuckDuckGo rakendusest, minnes menüüsse Seaded › Sync &amp; Backup › Sünkrooni teise seadmega.</string>
+    <string name="sync_chat_bottom_sheet_positive">Skanni QR-kood</string>
+    <string name="sync_chat_bottom_sheet_negative">Mitte praegu</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values-fi/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-fi/strings-sync.xml
@@ -241,4 +241,12 @@
     <string name="sync_recover_data_download_pdf">Lataa PDF-muodossa</string>
     <string name="sync_restore_on_reinstall_title">Palauta sovelluksen uudelleenasennuksen yhteydessä</string>
     <string name="sync_restore_on_reinstall_description">Jos asennat DuckDuckGo-sovelluksen uudelleen, kysymme, haluatko palauttaa laitteen tiedot.</string>
+
+    <!-- Chat sync promo -->
+    <string name="sync_chat_promo_banner_title">Pääset käsiksi keskusteluihisi kaikilla laitteillasi Sync &amp; Backup -toiminnon avulla.</string>
+    <string name="sync_chat_promo_banner_cta_title">Synkronoi toisen laitteen kanssa</string>
+    <string name="sync_chat_bottom_sheet_title">Synkronoidaan keskustelusi\nlaitteidesi välillä!</string>
+    <string name="sync_chat_bottom_sheet_description">Etsi QR-koodi DuckDuckGo-sovelluksesta toisella laitteellasi siirtymällä kohtaan Asetukset › Sync &amp; Backup › Synkronoi toisen laitteen kanssa.</string>
+    <string name="sync_chat_bottom_sheet_positive">Skannaa QR-koodi</string>
+    <string name="sync_chat_bottom_sheet_negative">Ei nyt</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values-fr/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-fr/strings-sync.xml
@@ -241,4 +241,12 @@
     <string name="sync_recover_data_download_pdf">Télécharger au format PDF</string>
     <string name="sync_restore_on_reinstall_title">Rétablir lors de la réinstallation de l\'application</string>
     <string name="sync_restore_on_reinstall_description">Si vous réinstallez l\'application DuckDuckGo, nous vous demanderons si vous souhaitez rétablir vos données sur cet appareil.</string>
+
+    <!-- Chat sync promo -->
+    <string name="sync_chat_promo_banner_title">Accédez à vos discussions sur tous vos appareils en utilisant Sync &amp; Backup.</string>
+    <string name="sync_chat_promo_banner_cta_title">Synchroniser avec un autre appareil</string>
+    <string name="sync_chat_bottom_sheet_title">Synchronisons vos discussions sur tous vos appareils !</string>
+    <string name="sync_chat_bottom_sheet_description">Trouvez le code QR sur l\'application DuckDuckGo installée sur votre autre appareil en allant dans Paramètres › Sync &amp; Backup › « Synchroniser avec un autre appareil ».</string>
+    <string name="sync_chat_bottom_sheet_positive">Scanner le code QR</string>
+    <string name="sync_chat_bottom_sheet_negative">Pas maintenant</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values-hr/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-hr/strings-sync.xml
@@ -241,4 +241,12 @@
     <string name="sync_recover_data_download_pdf">Preuzmi kao PDF</string>
     <string name="sync_restore_on_reinstall_title">Vraćanje prilikom ponovne instalacije aplikacije</string>
     <string name="sync_restore_on_reinstall_description">Ako ponovno instaliraš aplikaciju DuckDuckGo, pitat ćemo te želiš li vratiti podatke na ovom uređaju.</string>
+
+    <!-- Chat sync promo -->
+    <string name="sync_chat_promo_banner_title">Pristupi svojim čavrljanjima na svim uređajima pomoću opcije Sync &amp; Backup.</string>
+    <string name="sync_chat_promo_banner_cta_title">Sinkronizacija s drugim uređajem</string>
+    <string name="sync_chat_bottom_sheet_title">Sinkroniziraj svoje razgovore na\nsvim svojim uređajima!</string>
+    <string name="sync_chat_bottom_sheet_description">Pronađi QR kôd u aplikaciji DuckDuckGo na drugom uređaju tako da odeš na Postavke › Sync &amp; Backup › Sinkroniziraj s drugim uređajem.</string>
+    <string name="sync_chat_bottom_sheet_positive">Skeniraj QR kôd</string>
+    <string name="sync_chat_bottom_sheet_negative">Ne sada</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values-hu/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-hu/strings-sync.xml
@@ -241,4 +241,12 @@
     <string name="sync_recover_data_download_pdf">Letöltés PDF-ként</string>
     <string name="sync_restore_on_reinstall_title">Visszaállítás az alkalmazás újratelepítésekor</string>
     <string name="sync_restore_on_reinstall_description">Ha újratelepíted a DuckDuckGo-alkalmazást, megkérdezzük, hogy szeretnéd-e visszaállítani az adataidat ezen az eszközön.</string>
+
+    <!-- Chat sync promo -->
+    <string name="sync_chat_promo_banner_title">Hozzáférés a csevegésekhez minden eszközödön a Sync &amp; Backup használatával.</string>
+    <string name="sync_chat_promo_banner_cta_title">Szinkronizálás másik eszközzel</string>
+    <string name="sync_chat_bottom_sheet_title">Szinkronizáld a csevegéseket az eszközeid között!</string>
+    <string name="sync_chat_bottom_sheet_description">A másik eszközödön keresd meg a QR-kódot a DuckDuckGo alkalmazás Beállítások › Sync &amp; Backup › Szinkronizálás másik eszközzel menüpontjában.</string>
+    <string name="sync_chat_bottom_sheet_positive">QR-kód beolvasása</string>
+    <string name="sync_chat_bottom_sheet_negative">Most nem</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values-it/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-it/strings-sync.xml
@@ -241,4 +241,12 @@
     <string name="sync_recover_data_download_pdf">Scarica come PDF</string>
     <string name="sync_restore_on_reinstall_title">Ripristino alla reinstallazione dell\'app</string>
     <string name="sync_restore_on_reinstall_description">Se reinstalli l\'app DuckDuckGo, ti chiederemo se desideri ripristinare i tuoi dati su questo dispositivo.</string>
+
+    <!-- Chat sync promo -->
+    <string name="sync_chat_promo_banner_title">Accedi alle tue chat su tutti i tuoi dispositivi utilizzando Sync &amp; Backup.</string>
+    <string name="sync_chat_promo_banner_cta_title">Sincronizza con un altro dispositivo</string>
+    <string name="sync_chat_bottom_sheet_title">Sincronizziamo le tue chat su tutti i tuoi dispositivi!</string>
+    <string name="sync_chat_bottom_sheet_description">Trova il codice QR nell\'app DuckDuckGo sull\'altro dispositivo andando su Impostazioni › Sync &amp; Backup › Sincronizza con un altro dispositivo.</string>
+    <string name="sync_chat_bottom_sheet_positive">Scansiona il codice QR</string>
+    <string name="sync_chat_bottom_sheet_negative">Non adesso</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values-lt/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-lt/strings-sync.xml
@@ -241,4 +241,12 @@
     <string name="sync_recover_data_download_pdf">Atsisiųsti kaip PDF</string>
     <string name="sync_restore_on_reinstall_title">Atkurti iš naujo įdiegus programą</string>
     <string name="sync_restore_on_reinstall_description">Jei iš naujo įdiegsi programą „DuckDuckGo“, paklausime, ar nori atkurti duomenis šiame įrenginyje.</string>
+
+    <!-- Chat sync promo -->
+    <string name="sync_chat_promo_banner_title">Pasiekite savo pokalbius visuose įrenginiuose – naudokite „Sync &amp; Backup“.</string>
+    <string name="sync_chat_promo_banner_cta_title">Sinchronizuoti su kitu įrenginiu</string>
+    <string name="sync_chat_bottom_sheet_title">Sinchronizuokime pokalbius visuose įrenginiuose!</string>
+    <string name="sync_chat_bottom_sheet_description">Kitame įrenginyje esančioje programėlėje „DuckDuckGo“ rasite QR kodą nuėję į Nustatymai › Sync &amp; Backup › Sinchronizuoti su kitu įrenginiu.</string>
+    <string name="sync_chat_bottom_sheet_positive">Nuskaityti QR kodą</string>
+    <string name="sync_chat_bottom_sheet_negative">Ne dabar</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values-lv/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-lv/strings-sync.xml
@@ -241,4 +241,12 @@
     <string name="sync_recover_data_download_pdf">Lejupielādēt PDF formātā</string>
     <string name="sync_restore_on_reinstall_title">Atjauno, atkārtoti instalējot lietotni</string>
     <string name="sync_restore_on_reinstall_description">Ja atkārtoti instalēsi lietotni DuckDuckGo, mēs jautāsim, vai vēlies atjaunot datus šajā ierīcē.</string>
+
+    <!-- Chat sync promo -->
+    <string name="sync_chat_promo_banner_title">Piekļūsti savām tērzēšanas sarunām visās savās ierīcēs, izmantojot Sync &amp; Backup.</string>
+    <string name="sync_chat_promo_banner_cta_title">Sinhronizēt ar citu ierīci</string>
+    <string name="sync_chat_bottom_sheet_title">Sinhronizēsim tērzēšanas sarunas visās tavās ierīcēs!</string>
+    <string name="sync_chat_bottom_sheet_description">Atrodi QR kodu DuckDuckGo lietotnē savā otrā ierīcē, dodoties uz Iestatījumi › Sync &amp; Backup › Sinhronizēt ar citu ierīci.</string>
+    <string name="sync_chat_bottom_sheet_positive">Kvadrātkoda skenēšana</string>
+    <string name="sync_chat_bottom_sheet_negative">Ne tagad</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values-nb/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-nb/strings-sync.xml
@@ -241,4 +241,12 @@
     <string name="sync_recover_data_download_pdf">Last ned som PDF</string>
     <string name="sync_restore_on_reinstall_title">Gjenopprett ved ny appinstallasjon</string>
     <string name="sync_restore_on_reinstall_description">Hvis du installerer DuckDuckGo-appen på nytt, spør vi deg om du vil gjenopprette dataene dine på denne enheten.</string>
+
+    <!-- Chat sync promo -->
+    <string name="sync_chat_promo_banner_title">Få tilgang til chattene på alle enhetene dine med Sync &amp; Backup.</string>
+    <string name="sync_chat_promo_banner_cta_title">Synkroniser med en annen enhet</string>
+    <string name="sync_chat_bottom_sheet_title">La oss synkronisere chattene på\nalle enhetene dine!</string>
+    <string name="sync_chat_bottom_sheet_description">Finn QR-koden på DuckDuckGo-appen på den andre enheten din ved å gå til Innstillinger › Sync &amp; Backup › Synkroniser med en annen enhet.</string>
+    <string name="sync_chat_bottom_sheet_positive">Skann QR-kode</string>
+    <string name="sync_chat_bottom_sheet_negative">Ikke nå</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values-nl/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-nl/strings-sync.xml
@@ -241,4 +241,12 @@
     <string name="sync_recover_data_download_pdf">Downloaden als PDF</string>
     <string name="sync_restore_on_reinstall_title">Herstellen bij app-herinstallatie</string>
     <string name="sync_restore_on_reinstall_description">Als je de DuckDuckGo-app opnieuw installeert, vragen we of je je gegevens op dit apparaat wilt herstellen.</string>
+
+    <!-- Chat sync promo -->
+    <string name="sync_chat_promo_banner_title">Krijg toegang tot je chats op al je apparaten met Sync &amp; Backup.</string>
+    <string name="sync_chat_promo_banner_cta_title">Synchroniseren met een ander apparaat</string>
+    <string name="sync_chat_bottom_sheet_title">Laten we je chats synchroniseren op al je apparaten!</string>
+    <string name="sync_chat_bottom_sheet_description">Zoek de QR-code in de DuckDuckGo-app op je andere apparaat door op dat apparaat naar \'Instellingen\' › \'Sync &amp; Backup\' › \'Synchroniseren\' te gaan.</string>
+    <string name="sync_chat_bottom_sheet_positive">QR-code scannen</string>
+    <string name="sync_chat_bottom_sheet_negative">Niet nu</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values-pl/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-pl/strings-sync.xml
@@ -241,4 +241,12 @@
     <string name="sync_recover_data_download_pdf">Pobierz jako PDF</string>
     <string name="sync_restore_on_reinstall_title">Przywróć po ponownej instalacji aplikacji</string>
     <string name="sync_restore_on_reinstall_description">Jeśli ponownie zainstalujesz aplikację DuckDuckGo, zapytamy, czy chcesz przywrócić dane na tym urządzeniu.</string>
+
+    <!-- Chat sync promo -->
+    <string name="sync_chat_promo_banner_title">Uzyskaj dostęp do czatów na wielu urządzeniach za pomocą funkcji Sync &amp; Backup.</string>
+    <string name="sync_chat_promo_banner_cta_title">Synchronizuj z innym urządzeniem</string>
+    <string name="sync_chat_bottom_sheet_title">Zsynchronizujmy Twoje czaty na wszystkich urządzeniach!</string>
+    <string name="sync_chat_bottom_sheet_description">Znajdź kod QR w aplikacji DuckDuckGo na innym urządzeniu, przechodząc do Ustawienia › Sync &amp; Backup › Synchronizuj z innym urządzeniem.</string>
+    <string name="sync_chat_bottom_sheet_positive">Zeskanuj kod QR</string>
+    <string name="sync_chat_bottom_sheet_negative">Nie teraz</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values-pt/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-pt/strings-sync.xml
@@ -241,4 +241,12 @@
     <string name="sync_recover_data_download_pdf">Descarregar como PDF</string>
     <string name="sync_restore_on_reinstall_title">Restaurar na reinstalação da aplicação</string>
     <string name="sync_restore_on_reinstall_description">Se reinstalares a aplicação DuckDuckGo, perguntaremos se queres restaurar os teus dados neste dispositivo.</string>
+
+    <!-- Chat sync promo -->
+    <string name="sync_chat_promo_banner_title">Acede às tuas conversas em todos os teus dispositivos através da funcionalidade Sync &amp; Backup.</string>
+    <string name="sync_chat_promo_banner_cta_title">Sincronizar com outro dispositivo</string>
+    <string name="sync_chat_bottom_sheet_title">Vamos sincronizar as tuas conversas em todos os teus dispositivos!</string>
+    <string name="sync_chat_bottom_sheet_description">Encontra o código QR na aplicação DuckDuckGo no teu outro dispositivo, indo a Definições › Sync &amp; Backup › Sincronizar com outro dispositivo.</string>
+    <string name="sync_chat_bottom_sheet_positive">Ler código QR</string>
+    <string name="sync_chat_bottom_sheet_negative">Agora não</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values-ro/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-ro/strings-sync.xml
@@ -241,4 +241,12 @@
     <string name="sync_recover_data_download_pdf">Descarcă ca PDF</string>
     <string name="sync_restore_on_reinstall_title">Restaurează la reinstalarea aplicației</string>
     <string name="sync_restore_on_reinstall_description">Dacă reinstalezi aplicația DuckDuckGo, te vom întreba dacă dorești să restaurezi datele pe acest dispozitiv.</string>
+
+    <!-- Chat sync promo -->
+    <string name="sync_chat_promo_banner_title">Accesează-ți chaturile pe toate dispozitivele folosind Sync &amp; Backup.</string>
+    <string name="sync_chat_promo_banner_cta_title">Sincronizează cu un alt dispozitiv</string>
+    <string name="sync_chat_bottom_sheet_title">Haide să-ți sincronizăm chaturile pe toate dispozitivele!</string>
+    <string name="sync_chat_bottom_sheet_description">Găsește codul QR în aplicația DuckDuckGo de pe celălalt dispozitiv, accesând Setări › Sync &amp; Backup › Sincronizează cu un alt dispozitiv.</string>
+    <string name="sync_chat_bottom_sheet_positive">Scanează codul QR</string>
+    <string name="sync_chat_bottom_sheet_negative">Nu acum</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values-ru/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-ru/strings-sync.xml
@@ -241,4 +241,12 @@
     <string name="sync_recover_data_download_pdf">Скачать в формате PDF</string>
     <string name="sync_restore_on_reinstall_title">Восстановить при переустановке приложения</string>
     <string name="sync_restore_on_reinstall_description">В случае переустановки приложение DuckDuckGo предложит вам восстановить свои данные на этом устройстве.</string>
+
+    <!-- Chat sync promo -->
+    <string name="sync_chat_promo_banner_title">Получите доступ к своим чатам на всех устройствах благодаря опции Sync &amp; Backup.</string>
+    <string name="sync_chat_promo_banner_cta_title">Синхронизировать с другим устройством</string>
+    <string name="sync_chat_bottom_sheet_title">Давайте синхронизируем ваши чаты на всех ваших устройствах!</string>
+    <string name="sync_chat_bottom_sheet_description">Найдите QR-код в приложении DuckDuckGo на другом устройстве: для этого перейдите в «Настройки» → «Sync &amp; Backup» → «Синхронизация с другим устройством».</string>
+    <string name="sync_chat_bottom_sheet_positive">Сканировать QR-код</string>
+    <string name="sync_chat_bottom_sheet_negative">Не сейчас</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values-sk/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-sk/strings-sync.xml
@@ -241,4 +241,12 @@
     <string name="sync_recover_data_download_pdf">Stiahnuť ako PDF</string>
     <string name="sync_restore_on_reinstall_title">Obnoviť pri preinštalovaní aplikácie</string>
     <string name="sync_restore_on_reinstall_description">Ak preinštaluješ aplikáciu DuckDuckGo, opýtame sa ťa, či chceš obnoviť svoje údaje na tomto zariadení.</string>
+
+    <!-- Chat sync promo -->
+    <string name="sync_chat_promo_banner_title">Pristupuj k svojim chatom zo všetkých zariadení pomocou funkcie Sync &amp; Backup.</string>
+    <string name="sync_chat_promo_banner_cta_title">Synchronizácia s iným zariadením</string>
+    <string name="sync_chat_bottom_sheet_title">Poďme synchronizovať tvoje čety na všetkých tvojich zariadeniach!</string>
+    <string name="sync_chat_bottom_sheet_description">Nájdi QR kód v aplikácii DuckDuckGo na svojom druhom zariadení tak, že prejdeš do časti Nastavenia › Sync &amp; Backup › „Synchronizovať s iným zariadením“.</string>
+    <string name="sync_chat_bottom_sheet_positive">Skenovanie kódu QR</string>
+    <string name="sync_chat_bottom_sheet_negative">Teraz nie</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values-sl/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-sl/strings-sync.xml
@@ -241,4 +241,12 @@
     <string name="sync_recover_data_download_pdf">Prenesi kot PDF</string>
     <string name="sync_restore_on_reinstall_title">Obnovi ob ponovni namestitvi aplikacije</string>
     <string name="sync_restore_on_reinstall_description">Če ponovno namestite aplikacijo DuckDuckGo, vas bomo vprašali, ali želite obnoviti podatke v tej napravi.</string>
+
+    <!-- Chat sync promo -->
+    <string name="sync_chat_promo_banner_title">Do klepetov lahko dostopate v vseh napravah z uporabo funkcije Sync &amp; Backup.</string>
+    <string name="sync_chat_promo_banner_cta_title">Sinhronizacija z drugo napravo</string>
+    <string name="sync_chat_bottom_sheet_title">Sinhronizirajte svoje klepete\nmed napravami!</string>
+    <string name="sync_chat_bottom_sheet_description">Poiščite kodo QR v aplikaciji DuckDuckGo v drugi napravi tako, da odprete Nastavitve › Sync &amp; Backup › Sinhronizacija z drugo napravo.</string>
+    <string name="sync_chat_bottom_sheet_positive">Skeniranje kode QR</string>
+    <string name="sync_chat_bottom_sheet_negative">Ne zdaj</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values-sv/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-sv/strings-sync.xml
@@ -241,4 +241,12 @@
     <string name="sync_recover_data_download_pdf">Ladda ner som PDF</string>
     <string name="sync_restore_on_reinstall_title">Återställ vid ominstallation av appen</string>
     <string name="sync_restore_on_reinstall_description">Om du installerar om DuckDuckGo-appen frågar vi dig om du vill återställa dina data på den här enheten.</string>
+
+    <!-- Chat sync promo -->
+    <string name="sync_chat_promo_banner_title">Få tillgång till dina chattar på alla dina enheter med Sync &amp; Backup.</string>
+    <string name="sync_chat_promo_banner_cta_title">Synkronisera med en annan enhet</string>
+    <string name="sync_chat_bottom_sheet_title">Låt oss synkronisera dina chattar mellan dina enheter!</string>
+    <string name="sync_chat_bottom_sheet_description">Hitta QR-koden i DuckDuckGo-appen på din andra enhet genom att gå till Inställningar › Sync &amp; Backup › Synkronisera med en annan enhet.</string>
+    <string name="sync_chat_bottom_sheet_positive">Skanna QR-kod</string>
+    <string name="sync_chat_bottom_sheet_negative">Inte nu</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values-tr/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-tr/strings-sync.xml
@@ -241,4 +241,12 @@
     <string name="sync_recover_data_download_pdf">PDF olarak indir</string>
     <string name="sync_restore_on_reinstall_title">Uygulama Yeniden Yüklendiğinde Geri Yükle</string>
     <string name="sync_restore_on_reinstall_description">DuckDuckGo uygulamasını yeniden yüklerseniz, verilerinizi bu cihazda geri yüklemek isteyip istemediğinizi sorarız.</string>
+
+    <!-- Chat sync promo -->
+    <string name="sync_chat_promo_banner_title">Sync &amp; Backup özelliğini kullanarak sohbetlerinize tüm cihazlarınızdan erişin.</string>
+    <string name="sync_chat_promo_banner_cta_title">Başka Bir Cihazla Senkronize Et</string>
+    <string name="sync_chat_bottom_sheet_title">Sohbetlerinizi cihazlarınız arasında senkronize edelim!</string>
+    <string name="sync_chat_bottom_sheet_description">Diğer cihazınızdaki DuckDuckGo uygulamasında Ayarlar › Sync &amp; Backup › Başka Bir Cihazla Senkronize Et seçeneğine giderek QR kodunu bulun.</string>
+    <string name="sync_chat_bottom_sheet_positive">QR kodunu tara</string>
+    <string name="sync_chat_bottom_sheet_negative">Şimdi Değil</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values/donottranslate.xml
+++ b/sync/sync-impl/src/main/res/values/donottranslate.xml
@@ -40,12 +40,4 @@
     <string name="sync_v2_error_got_it">Got It</string>
     <string name="sync_v2_already_paired_title">Already synced.</string>
     <string name="sync_v2_already_paired_message">These devices are already connected to Sync &amp; Backup.</string>
-
-    <!-- Chat sync promo -->
-    <string name="sync_chat_promo_banner_title">Access your chats across your devices using Sync &amp; Backup.</string>
-    <string name="sync_chat_promo_banner_cta_title">Sync With Another Device</string>
-    <string name="sync_chat_bottom_sheet_title">Let’s sync your chats across\nyour devices!</string>
-    <string name="sync_chat_bottom_sheet_description">Find the QR Code on the DuckDuckGo app on your other device by going to Settings › Sync &amp; Backup › Sync With Another Device.</string>
-    <string name="sync_chat_bottom_sheet_positive">Scan QR code</string>
-    <string name="sync_chat_bottom_sheet_negative">Not Now</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values/strings-sync.xml
@@ -241,4 +241,12 @@
     <string name="sync_recover_data_download_pdf">Download as PDF</string>
     <string name="sync_restore_on_reinstall_title">Restore on App Reinstall</string>
     <string name="sync_restore_on_reinstall_description">If you reinstall the DuckDuckGo app, we\'ll ask if you want to restore your data on this device.</string>
+
+    <!-- Chat sync promo -->
+    <string name="sync_chat_promo_banner_title">Access your chats across your devices using Sync &amp; Backup.</string>
+    <string name="sync_chat_promo_banner_cta_title">Sync With Another Device</string>
+    <string name="sync_chat_bottom_sheet_title">Let’s sync your chats across\nyour devices!</string>
+    <string name="sync_chat_bottom_sheet_description">Find the QR Code on the DuckDuckGo app on your other device by going to Settings › Sync &amp; Backup › Sync With Another Device.</string>
+    <string name="sync_chat_bottom_sheet_positive">Scan QR code</string>
+    <string name="sync_chat_bottom_sheet_negative">Not Now</string>
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216069207880337?focus=true
Tech Design URL (if applicable): 

### Description

Translations for the Chat Sync promo. Also a small code typo fix.

### Steps to test this PR

N/A

### UI changes

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only localization with no behavior or sync logic changes; worst case is copy or formatting issues in specific locales.
> 
> **Overview**
> Adds **localized copy** for the Chat Sync promo UI by moving six `sync_chat_*` strings out of English-only `donottranslate.xml` into the main `strings-sync.xml` and mirroring them across many `values-*/strings-sync.xml` locale files.
> 
> The strings cover the **in-chat promo banner** (title + “Sync with another device” CTA) and the **bottom sheet** (headline, QR setup instructions, “Scan QR code” / “Not now”). No Kotlin or layout changes in this diff—only resource text so `ChatSyncPromoAdapter` and `dialog_chat_sync_promo.xml` can show translated UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ccf5219be3ab0a65afbc75cf76cee320c90109b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->