### PR TITLE
Do not display Chat Sync promo in Fire Mode

### DIFF
--- a/sync/sync-impl/build.gradle
+++ b/sync/sync-impl/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     implementation project(':js-messaging-api')
     implementation project(':duckchat-api')
     implementation project(':persistent-storage-api')
+    implementation project(':browser-mode-api')
 
     implementation project(path: ':anvil-annotations')
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/chat/ChatSyncPromotion.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/chat/ChatSyncPromotion.kt
@@ -52,16 +52,10 @@ class RealChatSyncPromotion @Inject constructor(
     private val pixel: Pixel,
     private val dispatchers: DispatcherProvider,
 ) : ChatSyncPromotion {
-    override suspend fun canShowPromotion(): Boolean {
-        if (browserModeStateHolder.currentMode.value == BrowserMode.FIRE) {
-            return false
-        }
-
-        return coroutineScope {
-            val isAvailable = async { !isPromoExhausted() }
-            val isEligible = async { isEligibleForPromo() }
-            isAvailable.await() && isEligible.await()
-        }
+    override suspend fun canShowPromotion(): Boolean = coroutineScope {
+        val isAvailable = async { !isPromoExhausted() }
+        val isEligible = async { isEligibleForPromo() }
+        return@coroutineScope isAvailable.await() && isEligible.await()
     }
 
     override suspend fun incrementImpressionCount() {
@@ -103,13 +97,19 @@ class RealChatSyncPromotion @Inject constructor(
         return isImpressionCapReached
     }
 
-    private suspend fun isEligibleForPromo() = coroutineScope {
-        val preconditions = listOf(
-            async { canTurnOnSync() },
-            async { hasChatHistoryEnabled() },
-            async { hasChatSuggestions() },
-        ).awaitAll()
-        return@coroutineScope preconditions.all { it }
+    private suspend fun isEligibleForPromo(): Boolean {
+        if (browserModeStateHolder.currentMode.value == BrowserMode.FIRE) {
+            return false
+        }
+
+        return coroutineScope {
+            val preconditions = listOf(
+                async { canTurnOnSync() },
+                async { hasChatHistoryEnabled() },
+                async { hasChatSuggestions() },
+            ).awaitAll()
+            preconditions.all { it }
+        }
     }
 
     private suspend fun canTurnOnSync(): Boolean = withContext(dispatchers.io()) {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/chat/ChatSyncPromotion.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/chat/ChatSyncPromotion.kt
@@ -18,6 +18,8 @@ package com.duckduckgo.sync.impl.promotion.chat
 
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeStateHolder
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.DuckChat
@@ -46,13 +48,20 @@ class RealChatSyncPromotion @Inject constructor(
     private val promotionDataStore: SyncPromotionDataStore,
     private val syncState: DeviceSyncState,
     private val duckChat: DuckChat,
+    private val browserModeStateHolder: BrowserModeStateHolder,
     private val pixel: Pixel,
     private val dispatchers: DispatcherProvider,
 ) : ChatSyncPromotion {
-    override suspend fun canShowPromotion(): Boolean = coroutineScope {
-        val isAvailable = async { !isPromoExhausted() }
-        val isEligible = async { isEligibleForPromo() }
-        return@coroutineScope isAvailable.await() && isEligible.await()
+    override suspend fun canShowPromotion(): Boolean {
+        if (browserModeStateHolder.currentMode.value == BrowserMode.FIRE) {
+            return false
+        }
+
+        return coroutineScope {
+            val isAvailable = async { !isPromoExhausted() }
+            val isEligible = async { isEligibleForPromo() }
+            isAvailable.await() && isEligible.await()
+        }
     }
 
     override suspend fun incrementImpressionCount() {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/promotion/chat/RealChatSyncPromotionTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/promotion/chat/RealChatSyncPromotionTest.kt
@@ -142,7 +142,7 @@ class RealChatSyncPromotionTest {
     }
 
     @Test
-    fun `when duck chat has no history is disabled cannot show promotion`() = runTest {
+    fun `when duck chat has no suggestions cannot show promotion`() = runTest {
         configurePromotionToShow()
 
         hasChatSuggestions.value = false

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/promotion/chat/RealChatSyncPromotionTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/promotion/chat/RealChatSyncPromotionTest.kt
@@ -20,6 +20,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelName
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Unique
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.sync.impl.promotion.FakeSyncPromotionDataStore
 import com.duckduckgo.sync.impl.promotion.SyncPromotionDataStore.PromotionType
@@ -51,6 +52,9 @@ class RealChatSyncPromotionTest {
     private var isChatHistoryEnabled = false
     private val hasChatSuggestions = MutableStateFlow(false)
 
+    // BrowserModeStateHolder properties
+    private val browserMode = MutableStateFlow(BrowserMode.REGULAR)
+
     private val testee = RealChatSyncPromotion(
         promotionDataStore = dataStore,
         syncState = mock {
@@ -61,6 +65,9 @@ class RealChatSyncPromotionTest {
         duckChat = mock {
             onBlocking { hasUserEnabledChatHistory() } doAnswer { isChatHistoryEnabled }
             on { observeHasChatSuggestions() } doReturn hasChatSuggestions
+        },
+        browserModeStateHolder = mock {
+            on { currentMode } doReturn browserMode
         },
         pixel = pixel,
         dispatchers = coroutineTestRule.testDispatcherProvider,
@@ -139,6 +146,14 @@ class RealChatSyncPromotionTest {
         configurePromotionToShow()
 
         hasChatSuggestions.value = false
+        assertFalse(testee.canShowPromotion())
+    }
+
+    @Test
+    fun `when browser is in Fire Mode cannot show promotion`() = runTest {
+        configurePromotionToShow()
+
+        browserMode.value = BrowserMode.FIRE
         assertFalse(testee.canShowPromotion())
     }
 
@@ -242,6 +257,7 @@ class RealChatSyncPromotionTest {
         isUserSignedIn = false
         isChatHistoryEnabled = true
         hasChatSuggestions.value = true
+        browserMode.value = BrowserMode.REGULAR
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216141116650503?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/72649045549333/task/1215842375041298?focus=true

### Description

This adds a condition to skip showing Chat Sync promo in case a tab is in Fire Mode.

### Steps to test this PR

_No promo in Fire Mode_
- [ ] Enable `fireTabs` in the FF inventory.
- [ ] Start a Duck.ai chat in normal mode.
- [ ] Open the native input and switch to the chat tab in normal mode.
- [ ] You should see the Chat Sync promo.
- [ ] Create a Fire tab.
- [ ] In Fire tab open the native input and switch to the chat tab.
- [ ] You should not see the Chat Sync promo.

### UI changes
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small eligibility guard in sync promotion logic with no auth or data changes; behavior is covered by a new unit test.
> 
> **Overview**
> **Chat Sync promotion** no longer appears when the active browser mode is **Fire Mode**.
> 
> `RealChatSyncPromotion` now depends on `BrowserModeStateHolder` and treats `BrowserMode.FIRE` as ineligible before the existing sync/chat preconditions run. **sync-impl** adds a **browser-mode-api** Gradle dependency to support that check.
> 
> Unit tests mock browser mode, reset regular mode in the happy path, add coverage for Fire Mode, and rename one test to match “no suggestions” wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73ceddda7595e1d6ff48d61948c454280d4d4d24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->