### PR TITLE
add E2E tests for Custom AI Onboarding

### DIFF
--- a/.github/workflows/e2e-nightly-non-blockers-suite.yml
+++ b/.github/workflows/e2e-nightly-non-blockers-suite.yml
@@ -109,7 +109,7 @@ jobs:
           test_suite_name: Android Design System (Nightly)
 
       - name: Internal Onboarding Flows
-        id: maestro-preonboarding
+        id: maestro-onboarding-internal
         # Run regardless of earlier suite failures, but only if the internal binary uploaded.
         if: ${{ !cancelled() && steps.maestro-upload-internal-binary.outcome == 'success' }}
         uses: ./.github/actions/maestro-cloud-asana-reporter
@@ -117,15 +117,15 @@ jobs:
         with:
           maestro_api_key: ${{ secrets.ROBIN_API_KEY }}
           maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
-          maestro_test_name: preonboarding_${{ github.sha }}
+          maestro_test_name: onboarding-internal_${{ github.sha }}
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_binary_id: ${{ steps.maestro-upload-internal-binary.outputs.maestro_app_binary_id }}
-          maestro_include_tags: preonboardingTest
-          maestro_api_level: 34
+          maestro_include_tags: onboardingInternalTest
+          maestro_api_level: 36
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
-          test_suite_name: Preonboarding (Nightly)
+          test_suite_name: Onboarding Internal (Nightly)
 
       - name: Create Asana task when workflow failed
         if: ${{ failure() }}

--- a/.maestro/onboarding/onboarding_custom_ai_full_path.yaml
+++ b/.maestro/onboarding/onboarding_custom_ai_full_path.yaml
@@ -1,0 +1,47 @@
+appId: com.duckduckgo.mobile.android
+name: "Onboarding: Custom AI flow triggered by a referrer parameter (full path)"
+tags:
+  - onboardingInternalTest
+---
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
+          arguments:
+            isMaestro: "true"
+            referrer: "onboarding=ai"
+      - assertVisible:
+          text: "Ready to chat privately with ChatGPT, Claude, and other AIs.*"
+      - tapOn: "Let's get started!"
+      - assertVisible:
+          text: "AI protections.activated!"
+      - tapOn: "Give Duck.ai a try!"
+      - assertVisible:
+          text: "Now, try a private AI.chat!"
+      - tapOn: "Surprise me!"
+      - assertVisible:
+          text: "That's Duck.ai!"
+      - assertVisible:
+          text: "Private AI chats you can delete anytime.*"
+      - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
+      - runFlow: ../shared/browser_screen/confirm_fire_dialog.yaml
+      - assertVisible:
+          text: "Want to make DuckDuckGo your default.browser."
+      - tapOn: "Choose Your Browser"
+      - runFlow:
+          when:
+            visible: "set as default"
+          commands:
+            - tapOn: "duckduckgo"
+            - tapOn: "set as default"
+      - assertVisible:
+          text: "Where should I put your address.bar."
+      - tapOn: "Next"
+      - assertVisible:
+          text: "Ask anything privately.*"
+      - assertVisible:
+          text: "You've got this!"
+      - assertVisible:
+          text: "Start a private AI chat with Duck.ai or toggle to Search for protected.browsing.*"
+      - tapOn: "High five!"

--- a/.maestro/onboarding/onboarding_custom_ai_skip_path.yaml
+++ b/.maestro/onboarding/onboarding_custom_ai_skip_path.yaml
@@ -1,0 +1,26 @@
+appId: com.duckduckgo.mobile.android
+name: "Onboarding: Custom AI flow triggered by a referrer parameter (skip path)"
+tags:
+  - onboardingInternalTest
+---
+- retry:
+    maxRetries: 3
+    commands:
+      # First launch as a fresh install
+      - launchApp:
+          clearState: true
+      # Wait for the welcome dialog so we create the reinstaller marker before relaunch
+      - assertVisible:
+          text: "Let's get started!"
+      # Relaunch with app data cleared
+      - launchApp:
+          clearState: true
+          arguments:
+            isMaestro: "true"
+            referrer: "onboarding=ai"
+      - assertVisible:
+          text: "Ready to chat privately with ChatGPT, Claude, and other AIs.*"
+      - tapOn: "I've been here before"
+      - tapOn: "Start AI Chat"
+      - assertVisible:
+          text: "Ask anything privately.*"

--- a/.maestro/onboarding/preonboarding_returning_user_show_tutorial.yaml
+++ b/.maestro/onboarding/preonboarding_returning_user_show_tutorial.yaml
@@ -1,7 +1,7 @@
 appId: com.duckduckgo.mobile.android
 name: "Preonboarding: Ensuring user can resume onboarding with show tutorial"
 tags:
-  - preonboardingTest
+  - onboardingInternalTest
 ---
 # Pre-requisite: None
 

--- a/.maestro/onboarding/preonboarding_returning_user_start_browsing.yaml
+++ b/.maestro/onboarding/preonboarding_returning_user_start_browsing.yaml
@@ -1,7 +1,7 @@
 appId: com.duckduckgo.mobile.android
 name: "Preonboarding: Ensuring user can skip onboarding and start browsing"
 tags:
-  - preonboardingTest
+  - onboardingInternalTest
 ---
 # Pre-requisite: None
 

--- a/.maestro/shared/browser_screen/click_on_fire_button.yaml
+++ b/.maestro/shared/browser_screen/click_on_fire_button.yaml
@@ -2,12 +2,28 @@ appId: com.duckduckgo.mobile.android
 ---
 - runFlow:
     when:
-        notVisible:
-            id: 'com.duckduckgo.mobile.android:id/fireIconImageView'
+      notVisible:
+        id: 'com.duckduckgo.mobile.android:id/fireIconImageView'
     commands:
-        - hideKeyboard
-        - assertVisible:
-            id: 'com.duckduckgo.mobile.android:id/fireIconImageView'
+      - runFlow:
+          when:
+            notVisible:
+              id: 'com.duckduckgo.mobile.android:id/inputFieldFireIconImageview'
+          commands:
+            - hideKeyboard
 
-- tapOn:
-    id: 'com.duckduckgo.mobile.android:id/fireIconImageView'
+- runFlow:
+    when:
+      visible:
+        id: 'com.duckduckgo.mobile.android:id/fireIconImageView'
+    commands:
+      - tapOn:
+          id: 'com.duckduckgo.mobile.android:id/fireIconImageView'
+
+- runFlow:
+    when:
+      visible:
+        id: 'com.duckduckgo.mobile.android:id/inputFieldFireIconImageview'
+    commands:
+      - tapOn:
+          id: 'com.duckduckgo.mobile.android:id/inputFieldFireIconImageview'

--- a/.maestro/shared/browser_screen/confirm_fire_dialog.yaml
+++ b/.maestro/shared/browser_screen/confirm_fire_dialog.yaml
@@ -12,3 +12,8 @@ appId: com.duckduckgo.mobile.android
         visible: "Delete All"
     commands:
         - tapOn: "Delete All"
+- runFlow:
+    when:
+        visible: "Delete Chat"
+    commands:
+        - tapOn: "Delete Chat"

--- a/referral/referral-impl/build.gradle
+++ b/referral/referral-impl/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     implementation project(':verified-installation-api')
     implementation project(':referral-api')
     implementation project(':data-store-api')
+    implementation project(':test-seeder-api')
 
     implementation Google.dagger
     implementation AndroidX.core.ktx

--- a/referral/referral-impl/src/internal/java/com/duckduckgo/referral/impl/QueryParamReferrerParserSeederPlugin.kt
+++ b/referral/referral-impl/src/internal/java/com/duckduckgo/referral/impl/QueryParamReferrerParserSeederPlugin.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.referral.impl
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.testseeder.api.TestSeederKey
+import com.duckduckgo.testseeder.api.TestSeederPlugin
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class QueryParamReferrerParserSeederPlugin @Inject constructor(
+    private val appInstallationReferrerParser: AppInstallationReferrerParser,
+) : TestSeederPlugin {
+    override val handledKeys: Set<String>
+        get() = setOf(TestSeederKey.REFERRER.key)
+
+    override suspend fun apply(
+        key: String,
+        value: String,
+    ) {
+        if (key == TestSeederKey.REFERRER.key) {
+            appInstallationReferrerParser.parse(referrer = value)
+        }
+    }
+}

--- a/test-seeder/test-seeder-api/src/main/java/com/duckduckgo/testseeder/api/TestSeederKey.kt
+++ b/test-seeder/test-seeder-api/src/main/java/com/duckduckgo/testseeder/api/TestSeederKey.kt
@@ -36,4 +36,13 @@ enum class TestSeederKey(val key: String, val description: String) {
         "Semicolon-separated list of URLs to seed as bookmarks. " +
             "URLs without a scheme are normalised to https://. Example: \"reddit.com;eff.org;cnn.com\"",
     ),
+    REFERRER(
+        key = "referrer",
+        description = """
+            |Simulates a Play Store install that came from a link with a referrer param.
+            |Pass the decoded referrer value, e.g. 'origin=funnel_appnosupport_website&onboarding=ai'.
+            |This is the referrer part of a Play Store link such as:
+            |https://play.google.com/store/apps/details?id=com.duckduckgo.mobile.android&referrer=origin%3Dfunnel_appnosupport_website%26onboarding%3Dai
+        """.trimMargin(),
+    ),
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1215995113004612
Tech Design URL (if applicable): 

### Description
Adds E2E tests for Custom AI Onboarding happy paths.

### Steps to test this PR
QA optional.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Maestro flows, CI tagging, and internal-only test seeding gated by `isMaestro`; production referral behavior is only invoked through existing parser code during automated tests.
> 
> **Overview**
> Adds **Maestro coverage** for the Custom AI onboarding funnel when install is seeded with `referrer=onboarding=ai`, including a **full happy path** (Duck.ai try flow, fire button, default browser, address bar, finish) and a **returning-user skip path** (“I've been here before” → Start AI Chat).
> 
> The nightly non-blocker workflow **renames** the onboarding Maestro job to **Onboarding Internal**, switches the tag from `preonboardingTest` to **`onboardingInternalTest`**, and runs on **API 36**. Existing preonboarding returning-user flows are **retagged** into that suite; two new YAML flows are added under `.maestro/onboarding/`.
> 
> Shared browser helpers are **extended** so fire-button taps work when the icon lives on the **input field**, and the fire confirmation flow also accepts **“Delete Chat”**.
> 
> For internal builds only, a new **`referrer` test-seeder key** and **`QueryParamReferrerParserSeederPlugin`** feed Maestro launch args into `AppInstallationReferrerParser`, so E2E can mimic Play Store referrer params without a real install referrer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46e9085d887b77ea686cd08549a38faeaf49f48f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->