### PR TITLE
Fix E2E test selector on post-fire button usage 

### DIFF
--- a/.maestro/privacy_tests/14_-_Single-site,_single-tab,_no-session-after-fire.yaml
+++ b/.maestro/privacy_tests/14_-_Single-site,_single-tab,_no-session-after-fire.yaml
@@ -59,7 +59,7 @@ tags:
             - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
             - runFlow: ../shared/browser_screen/confirm_fire_dialog.yaml
             - tapOn:
-                id: "omnibarTextInputClickCatcher"
+                id: "inputField"
             - pasteText
             - pressKey: Enter
             - assertVisible:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1216168681143452?focus=true
Tech Design URL (if applicable): 

### Description

The privacy E2E test `14_-_Single-site,_single-tab,_no-session-after-fire` was flaky/failing on the second tap of `omnibarTextInputClickCatcher`.

After the native-input migration (#9016), the click-catcher overlay only exists on a **loaded page** (where the disabled `omnibarTextInput` sits behind it). The fire button clears all data and returns the app to the **new-tab page**, where the native input widget auto-opens as `inputField` and there is no `omnibarTextInputClickCatcher` to tap — so the tap could not find its target.

This changes the post-fire URL re-entry step to tap `inputField`.

### Steps to test this PR

_Privacy E2E — no session after fire_
- [ ] Run `maestro test .maestro/privacy_tests/14_-_Single-site,_single-tab,_no-session-after-fire.yaml` against a native-input privacy config
- [ ] Confirm the flow completes: after the fire button, the URL is re-entered via `inputField` and `Publisher site` loads with conversion requests blocked
- [ ] Test passes in maestro console

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Maestro test selector change only; no production code or user-facing behavior.
> 
> **Overview**
> Fixes flaky/failing privacy Maestro flow **`14_-_Single-site,_single-tab,_no-session-after-fire`** by updating the post–fire-button URL re-entry step to tap **`inputField`** instead of **`omnibarTextInputClickCatcher`**.
> 
> After clearing data with fire, the app lands on the **new-tab page**, where the native omnibar uses **`inputField`** and the click-catcher overlay is not present (unlike on a loaded page). The change matches the native-input selector pattern already used in **`6_-_Multi-tab.yaml`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13d55d0cc39c5669b699580a99f79abf3298dd5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->