### PR TITLE
Support Gemma4/Tinfoil in Duck.ai model picker

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/AIChatModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/AIChatModel.kt
@@ -157,12 +157,13 @@ enum class ModelProvider {
 
     companion object {
         fun from(id: String, providerString: String?): ModelProvider {
+            val provider = providerString?.lowercase()
             return when {
-                id.startsWith("meta-llama/") || id.startsWith("meta-llama_") || providerString == "azure" -> META
-                id.startsWith("mistralai/") || id.startsWith("mistralai_") || providerString == "mistral" -> MISTRAL
-                id.contains("gpt-oss") -> OSS
-                providerString == "anthropic" -> ANTHROPIC
-                providerString == "openai" -> OPENAI
+                id.startsWith("meta-llama/") || id.startsWith("meta-llama_") || provider == "azure" -> META
+                id.startsWith("mistralai/") || id.startsWith("mistralai_") || provider == "mistral" -> MISTRAL
+                id.contains("gpt-oss") || id.startsWith("tinfoil/") || provider == "tinfoil" -> OSS
+                provider == "anthropic" -> ANTHROPIC
+                provider == "openai" -> OPENAI
                 else -> UNKNOWN
             }
         }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerView.kt
@@ -344,19 +344,15 @@ class ModelPickerView @JvmOverloads constructor(
         addView(item)
     }
 
-    private fun PopupMenuItemView.setLeadingIcon(@DrawableRes iconRes: Int?) {
+    private fun PopupMenuItemView.setLeadingIcon(@DrawableRes iconRes: Int) {
         val label = findViewById<DaxTextView>(com.duckduckgo.mobile.android.R.id.label) ?: return
         label.maxLines = 1
         label.isSingleLine = true
         label.ellipsize = TextUtils.TruncateAt.END
         label.setPaddingRelative(label.paddingStart, label.paddingTop, 0, label.paddingBottom)
-        val drawable = iconRes?.let { AppCompatResources.getDrawable(context, it) }
+        val drawable = AppCompatResources.getDrawable(context, iconRes)
         label.setCompoundDrawablesRelativeWithIntrinsicBounds(drawable, null, null, null)
-        label.compoundDrawablePadding = if (drawable != null) {
-            resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.keyline_2)
-        } else {
-            0
-        }
+        label.compoundDrawablePadding = resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.keyline_2)
     }
 
     private fun PopupMenuItemView.configureTrailingIcon() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
@@ -213,13 +213,13 @@ class ModelPickerViewModel @Inject constructor(
     }
 
     @DrawableRes
-    fun getIconResForModel(model: AIChatModel): Int? = when (model.provider) {
+    fun getIconResForModel(model: AIChatModel): Int = when (model.provider) {
         ModelProvider.OPENAI -> R.drawable.ic_ai_model_openai_16
         ModelProvider.ANTHROPIC -> R.drawable.ic_ai_model_claude_16
         ModelProvider.MISTRAL -> R.drawable.ic_ai_model_mistral_16
         ModelProvider.META -> R.drawable.ic_ai_model_llama_16
-        ModelProvider.OSS -> R.drawable.ic_ai_model_oss_16
-        ModelProvider.UNKNOWN -> null
+        // OSS doubles as the fallback for unrecognised providers so a model never renders without an icon.
+        ModelProvider.OSS, ModelProvider.UNKNOWN -> R.drawable.ic_ai_model_oss_16
     }
 
     private fun List<AIChatModel>.toSectionOrNull(@StringRes headerRes: Int?): ModelSection? =

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/ModelProviderTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/ModelProviderTest.kt
@@ -67,6 +67,31 @@ class ModelProviderTest {
     }
 
     @Test
+    fun whenProviderIsTinfoilThenOss() {
+        assertEquals(ModelProvider.OSS, ModelProvider.from("tinfoil/gemma4-31b", providerString = "tinfoil"))
+    }
+
+    @Test
+    fun whenIdHasTinfoilSlashPrefixAndProviderMissingThenOss() {
+        assertEquals(ModelProvider.OSS, ModelProvider.from("tinfoil/gemma4-31b", providerString = null))
+    }
+
+    @Test
+    fun whenProviderIsTinfoilCapitalisedThenOss() {
+        assertEquals(ModelProvider.OSS, ModelProvider.from("gemma-3n-e4b-it", providerString = "Tinfoil"))
+    }
+
+    @Test
+    fun whenProviderIsCapitalisedOpenAiThenOpenAi() {
+        assertEquals(ModelProvider.OPENAI, ModelProvider.from("gpt-5-mini", providerString = "OpenAI"))
+    }
+
+    @Test
+    fun whenProviderIsCapitalisedAnthropicThenAnthropic() {
+        assertEquals(ModelProvider.ANTHROPIC, ModelProvider.from("claude-3-5-sonnet", providerString = "Anthropic"))
+    }
+
+    @Test
     fun whenProviderIsUnknownStringThenUnknown() {
         assertEquals(ModelProvider.UNKNOWN, ModelProvider.from("some-id", providerString = "perplexity"))
     }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
@@ -503,10 +503,10 @@ class ModelPickerViewModelTest {
     }
 
     @Test
-    fun whenModelProviderIsUnknownThenNoIcon() {
+    fun whenModelProviderIsUnknownThenOssIconFallback() {
         val model = freeModel(id = "some-other-model", shortName = "Other", provider = ModelProvider.UNKNOWN)
 
-        assertNull(testee.getIconResForModel(model))
+        assertEquals(R.drawable.ic_ai_model_oss_16, testee.getIconResForModel(model))
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1174433894299346/task/1216112317576899
Tech Design URL (if applicable):

### Description

The `/models` endpoint now returns Gemma4 (`id: "tinfoil/gemma4-31b"`, `provider: "Tinfoil"`), an open-source model served by Tinfoil. The app had no mapping for it, so it resolved to `UNKNOWN` and rendered **without an icon** in the native input model picker.

This PR:
- Classifies Tinfoil-provided models as `OSS`, so Gemma4 reuses the existing `ic_ai_model_oss_16` icon — matching what FE does.
- Matches on both the `tinfoil/` id prefix and the `provider` string (mirroring how `meta-llama` / `mistralai` are detected), so classification survives a missing or renamed provider field.
- Normalises the provider string to lowercase, so backend capitalisation (e.g. `"Tinfoil"`, `"OpenAI"`) can no longer silently drop a model into `UNKNOWN`.
- Falls back to the OSS icon for `UNKNOWN` providers, so a model never renders without an icon again (per discussion on the iOS task — Windows already has a fallback).

### Steps to test this PR

_Gemma4 shows an icon in the model picker_
- [x] Build an internal flavour with the `internal` cookie so Gemma4 is returned by `/models`
- [x] Open Duck.ai → native input → model picker
- [ ] Confirm Gemma4 appears with the OSS icon (same as GPT-OSS-120b), not blank

_Unknown-provider fallback_
- [ ] Confirm any model with an unrecognised provider shows the OSS icon rather than no icon

### UI changes
| Before  | After |
| ------ | ----- |
|(Gemma4 with no icon)|(Gemma4 with OSS icon)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only provider classification and icon display in the Duck.ai model picker; no auth, networking, or chat routing changes.
> 
> **Overview**
> **Tinfoil / Gemma4** models from `/models` are now mapped to **`OSS`** in `ModelProvider.from` via `tinfoil/` id prefix and `provider: "tinfoil"`, aligned with FE. Provider strings are **lowercased** before matching so capitalized values (e.g. `"Tinfoil"`, `"OpenAI"`) no longer misclassify as `UNKNOWN`.
> 
> The native **model picker** always shows a leading icon: `getIconResForModel` returns a non-null drawable and **`UNKNOWN`** uses the same **`ic_ai_model_oss_16`** fallback as OSS. `ModelPickerView.setLeadingIcon` is simplified to require a drawable resource instead of optional icons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a2424769dbcaf464efc74a3ff96aa89baffbdd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->