### PR TITLE
Document pixel privacy review + triage in pixel rules

### DIFF
--- a/.cursor/rules/pixel-definitions.mdc
+++ b/.cursor/rules/pixel-definitions.mdc
@@ -294,4 +294,3 @@ Always run `validate-defs-without-formatting` after making changes. CI will run 
 5. If the pixel is temporary, add `"expires": "YYYY-MM-DD"`
 6. Run `npm run validate-defs-without-formatting` from the `PixelDefinitions` directory
 7. Run `npm run lint.fix` if formatting issues are reported
-8. Open the PR and **apply the `privacy review required` label** — this auto-creates the Privacy Triage task in Asana. Agents opening the PR must set this label (`gh pr create --label "privacy review required"`). See the **Privacy Review & Triage** section in the `pixels` rule.

--- a/.cursor/rules/pixel-definitions.mdc
+++ b/.cursor/rules/pixel-definitions.mdc
@@ -294,3 +294,4 @@ Always run `validate-defs-without-formatting` after making changes. CI will run 
 5. If the pixel is temporary, add `"expires": "YYYY-MM-DD"`
 6. Run `npm run validate-defs-without-formatting` from the `PixelDefinitions` directory
 7. Run `npm run lint.fix` if formatting issues are reported
+8. Open the PR and **apply the `privacy review required` label** — this auto-creates the Privacy Triage task in Asana. Agents opening the PR must set this label (`gh pr create --label "privacy review required"`). See the **Privacy Review & Triage** section in the `pixels` rule.

--- a/.cursor/rules/pixels.mdc
+++ b/.cursor/rules/pixels.mdc
@@ -93,6 +93,18 @@ npm run validate-defs-without-formatting
 npm run lint
 ```
 
+## Privacy Review & Triage
+
+Any PR that **adds a new pixel or modifies the pixel registry** (`PixelDefinitions/**`) must go through privacy triage. The mechanism is a single label:
+
+- **Apply the `privacy review required` label to the PR.** This automatically creates a Privacy Triage task in Asana and adds the PR author as a collaborator; the Privacy Triage DRI follows up there. Applying the label *is* how the triage is created — there is no separate manual step.
+- **When an agent creates or helps create a pixel PR, it MUST add this label when opening the PR** (e.g. `gh pr create --label "privacy review required"`). If the agent cannot set labels, it must say so explicitly so the author applies it. This is in addition to updating the pixel definitions — both are required, do not skip either.
+- Self-service still applies: you may proceed with implementation without blocking on triage where appropriate, but the label must still be applied so triage happens.
+
+**Modifying an existing pixel that isn't in the registry yet:** first document the old pixel in the registry. If the change is small, note in the PR/code which parts are new; if it's large, split into two commits/PRs (one documenting the already-approved existing pixel, one for the change). If a prior triage is known, record it in the pixel's `privacyReview` property.
+
+Full process: [Pixels Triage using the Pixel Registry](https://app.asana.com/1/137249556945/task/1208615048491217).
+
 ## When to Use a Wide Event Instead
 
 Use a **wide event** rather than a pixel when:

--- a/.cursor/rules/pixels.mdc
+++ b/.cursor/rules/pixels.mdc
@@ -95,7 +95,7 @@ npm run lint
 
 ## Privacy Review & Triage
 
-Any PR that **adds a new pixel or modifies the pixel registry** (`PixelDefinitions/**`) must go through privacy triage. The mechanism is a single label:
+Any PR that **adds a new pixel or modifies the pixel registry** (the definition files under `PixelDefinitions/pixels/definitions/`) must go through privacy triage. The mechanism is a single label:
 
 - **Apply the `privacy review required` label to the PR.** This automatically creates a Privacy Triage task in Asana and adds the PR author as a collaborator; the Privacy Triage DRI follows up there. Applying the label *is* how the triage is created — there is no separate manual step.
 - **When an agent creates or helps create a pixel PR, it MUST add this label when opening the PR** (e.g. `gh pr create --label "privacy review required"`). If the agent cannot set labels, it must say so explicitly so the author applies it. This is in addition to updating the pixel definitions — both are required, do not skip either.

--- a/.cursor/rules/pixels.mdc
+++ b/.cursor/rules/pixels.mdc
@@ -95,7 +95,7 @@ npm run lint
 
 ## Privacy Review & Triage
 
-Any PR that **adds a new pixel or modifies the pixel registry** (the definition files under `PixelDefinitions/pixels/definitions/`) must go through privacy triage. The mechanism is a single label:
+Any PR that **adds a new pixel or modifies the pixel registry** (anything under `PixelDefinitions/pixels` — pixel definitions, wide-event definitions, and the shared params/suffixes dictionaries) must go through privacy triage. The mechanism is a single label:
 
 - **Apply the `privacy review required` label to the PR.** This automatically creates a Privacy Triage task in Asana and adds the PR author as a collaborator; the Privacy Triage DRI follows up there. Applying the label *is* how the triage is created — there is no separate manual step.
 - **When an agent creates or helps create a pixel PR, it MUST add this label when opening the PR** (e.g. `gh pr create --label "privacy review required"`). If the agent cannot set labels, it must say so explicitly so the author applies it. This is in addition to updating the pixel definitions — both are required, do not skip either.


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216144193395874

### Description

Documents the pixel privacy review + triage requirement in the project's pixel rules so it's preserved for the whole team (humans and AI agents working in the repo), not just remembered ad hoc.

- `pixels.mdc`: new **Privacy Review & Triage** section — any PR that adds a pixel or modifies the pixel registry (`PixelDefinitions/**`) must apply the `privacy review required` label, which auto-creates the Privacy Triage task in Asana (per the [Pixels Triage process](https://app.asana.com/1/137249556945/task/1208615048491217)). Agents creating/helping with a pixel PR must set the label (`gh pr create --label "privacy review required"`) and update the pixel definitions. Also documents the undocumented-existing-pixel case (`privacyReview` property, split commits/PRs).
- `pixel-definitions.mdc`: added a step to the "Quick Reference: Adding a New Pixel" checklist for applying the label.

This is the guidance ("soft") layer. A follow-up can add the CI enforcement layer (auto-labeler keyed on `PixelDefinitions/**` + CODEOWNERS + branch protection) so it's gated regardless of tooling.

### Steps to test this PR

_Docs only — no runtime change_
- [x] Review `.cursor/rules/pixels.mdc` "Privacy Review & Triage" section for accuracy against the Pixels Triage process.
- [x] Review the new checklist step in `.cursor/rules/pixel-definitions.mdc`.

### UI changes

None.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to Cursor rules; no runtime, CI, or pixel schema behavior is modified in this diff.
> 
> **Overview**
> Adds a **Privacy Review & Triage** section to `pixels.mdc` so pixel-registry work has a written, agent-visible process instead of ad hoc reminders.
> 
> Registry-touching PRs (under `PixelDefinitions/pixels`, including definitions, wide events, and shared dictionaries) must get the **`privacy review required`** label, which triggers Asana Privacy Triage. The rules spell out that applying the label is the triage step, that AI agents must set it when opening pixel PRs (or tell the author to), and that implementation can continue without blocking on triage as long as the label is applied.
> 
> Also documents the **undocumented existing pixel** path: register the current pixel first, split large changes across PRs/commits", and use the pixel `privacyReview` property when prior triage is known, with a link to the full Asana process.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e7c90bb928890879091b4eb9fc44bf53c243497. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->