### PR TITLE
Fire Mode: Mode-specific CookieManager

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/browser/cookies/AppThirdPartyCookieManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/cookies/AppThirdPartyCookieManagerTest.kt
@@ -26,7 +26,6 @@ import com.duckduckgo.app.browser.cookies.db.AuthCookiesAllowedDomainsDao
 import com.duckduckgo.app.browser.cookies.db.AuthCookiesAllowedDomainsRepository
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.browsermode.api.BrowserMode
-import com.duckduckgo.browsermode.impl.RealBrowserModeStateHolder
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.cookies.api.ThirdPartyCookieNames
 import com.duckduckgo.cookies.impl.DefaultCookieManagerProvider
@@ -46,7 +45,7 @@ class AppThirdPartyCookieManagerTest {
     @get:Rule
     var coroutinesTestRule = CoroutineTestRule()
 
-    private val cookieManagerProvider = DefaultCookieManagerProvider(mock(), RealBrowserModeStateHolder())
+    private val cookieManagerProvider = DefaultCookieManagerProvider(mock())
     private val cookieManager = cookieManagerProvider.forMode(BrowserMode.REGULAR)!!
     private lateinit var db: AppDatabase
     private lateinit var authCookiesAllowedDomainsDao: AuthCookiesAllowedDomainsDao
@@ -87,7 +86,7 @@ class AppThirdPartyCookieManagerTest {
     @UiThreadTest
     @Test
     fun whenProcessUriForThirdPartyCookiesIfDomainIsNotGoogleAuthAndIsNotInTheListThenThirdPartyCookiesDisabled() = runTest {
-        testee.processUriForThirdPartyCookies(webView, EXAMPLE_URI)
+        testee.processUriForThirdPartyCookies(webView, EXAMPLE_URI, BrowserMode.REGULAR)
 
         assertFalse(cookieManager.acceptThirdPartyCookies(webView))
     }
@@ -98,7 +97,7 @@ class AppThirdPartyCookieManagerTest {
         givenDomainIsInTheThirdPartyCookieList(EXAMPLE_URI.host!!)
         givenUserIdCookieIsSet()
 
-        testee.processUriForThirdPartyCookies(webView, EXAMPLE_URI)
+        testee.processUriForThirdPartyCookies(webView, EXAMPLE_URI, BrowserMode.REGULAR)
 
         assertTrue(cookieManager.acceptThirdPartyCookies(webView))
     }
@@ -108,7 +107,7 @@ class AppThirdPartyCookieManagerTest {
     fun whenProcessUriForThirdPartyCookiesIfDomainIsNotGoogleAuthAndIsInTheListAndDoesNotHaveCookieThenThirdPartyCookiesDisabled() = runTest {
         givenDomainIsInTheThirdPartyCookieList(EXAMPLE_URI.host!!)
 
-        testee.processUriForThirdPartyCookies(webView, EXAMPLE_URI)
+        testee.processUriForThirdPartyCookies(webView, EXAMPLE_URI, BrowserMode.REGULAR)
 
         assertFalse(cookieManager.acceptThirdPartyCookies(webView))
     }
@@ -119,7 +118,7 @@ class AppThirdPartyCookieManagerTest {
         givenUserIdCookieIsSet()
         givenDomainIsInTheThirdPartyCookieList(EXAMPLE_URI.host!!)
 
-        testee.processUriForThirdPartyCookies(webView, EXAMPLE_URI)
+        testee.processUriForThirdPartyCookies(webView, EXAMPLE_URI, BrowserMode.REGULAR)
 
         assertNull(authCookiesAllowedDomainsRepository.getDomain(EXAMPLE_URI.host!!))
     }
@@ -129,7 +128,7 @@ class AppThirdPartyCookieManagerTest {
     fun whenProcessUriForThirdPartyCookiesIfDomainIsInTheListAndCookieIsNotSetThenDomainRemovedFromList() = runTest {
         givenDomainIsInTheThirdPartyCookieList(EXAMPLE_URI.host!!)
 
-        testee.processUriForThirdPartyCookies(webView, EXAMPLE_URI)
+        testee.processUriForThirdPartyCookies(webView, EXAMPLE_URI, BrowserMode.REGULAR)
 
         assertNull(authCookiesAllowedDomainsRepository.getDomain(EXAMPLE_URI.host!!))
     }
@@ -139,7 +138,7 @@ class AppThirdPartyCookieManagerTest {
     fun whenProcessUriForThirdPartyCookiesIfDomainIsInTheListAndIsFromExceptionListThenDomainNotRemovedFromList() = runTest {
         givenDomainIsInTheThirdPartyCookieList(EXCLUDED_DOMAIN_URI.host!!)
 
-        testee.processUriForThirdPartyCookies(webView, EXCLUDED_DOMAIN_URI)
+        testee.processUriForThirdPartyCookies(webView, EXCLUDED_DOMAIN_URI, BrowserMode.REGULAR)
 
         assertNotNull(authCookiesAllowedDomainsRepository.getDomain(EXCLUDED_DOMAIN_URI.host!!))
     }
@@ -147,7 +146,7 @@ class AppThirdPartyCookieManagerTest {
     @UiThreadTest
     @Test
     fun whenProcessUriForThirdPartyCookiesIfUrlIsGoogleAuthAndIsTokenTypeThenDomainAddedToTheList() = runTest {
-        testee.processUriForThirdPartyCookies(webView, THIRD_PARTY_AUTH_URI)
+        testee.processUriForThirdPartyCookies(webView, THIRD_PARTY_AUTH_URI, BrowserMode.REGULAR)
 
         assertNotNull(authCookiesAllowedDomainsRepository.getDomain(EXAMPLE_URI.host!!))
     }
@@ -155,7 +154,7 @@ class AppThirdPartyCookieManagerTest {
     @UiThreadTest
     @Test
     fun whenProcessUriForThirdPartyCookiesIfUrlIsGoogleAuthAndIsNotTokenTypeThenDomainNotAddedToTheList() = runTest {
-        testee.processUriForThirdPartyCookies(webView, NON_THIRD_PARTY_AUTH_URI)
+        testee.processUriForThirdPartyCookies(webView, NON_THIRD_PARTY_AUTH_URI, BrowserMode.REGULAR)
 
         assertNull(authCookiesAllowedDomainsRepository.getDomain(EXAMPLE_URI.host!!))
     }
@@ -163,7 +162,7 @@ class AppThirdPartyCookieManagerTest {
     @UiThreadTest
     @Test
     fun whenProcessUriForThirdPartyCookiesIfUrlIsGoogleAuthWithAppDomainAndNoSsDomainThenDomainAddedToTheList() = runTest {
-        testee.processUriForThirdPartyCookies(webView, THIRD_PARTY_AUTH_APP_DOMAIN_URI)
+        testee.processUriForThirdPartyCookies(webView, THIRD_PARTY_AUTH_APP_DOMAIN_URI, BrowserMode.REGULAR)
 
         assertNotNull(authCookiesAllowedDomainsRepository.getDomain(EXAMPLE_URI.host!!))
     }
@@ -171,7 +170,7 @@ class AppThirdPartyCookieManagerTest {
     @UiThreadTest
     @Test
     fun whenProcessUriForThirdPartyCookiesIfUrlIsGoogleAuthWithBothSsDomainAndAppDomainThenSsDomainUsed() = runTest {
-        testee.processUriForThirdPartyCookies(webView, THIRD_PARTY_AUTH_BOTH_DOMAINS_URI)
+        testee.processUriForThirdPartyCookies(webView, THIRD_PARTY_AUTH_BOTH_DOMAINS_URI, BrowserMode.REGULAR)
 
         assertNotNull(authCookiesAllowedDomainsRepository.getDomain("ss.com"))
         assertNull(authCookiesAllowedDomainsRepository.getDomain("app.com"))

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/cookies/AppThirdPartyCookieManagerTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/cookies/AppThirdPartyCookieManagerTest.kt
@@ -25,6 +25,8 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.browser.cookies.db.AuthCookiesAllowedDomainsDao
 import com.duckduckgo.app.browser.cookies.db.AuthCookiesAllowedDomainsRepository
 import com.duckduckgo.app.global.db.AppDatabase
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.impl.RealBrowserModeStateHolder
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.cookies.api.ThirdPartyCookieNames
 import com.duckduckgo.cookies.impl.DefaultCookieManagerProvider
@@ -44,8 +46,8 @@ class AppThirdPartyCookieManagerTest {
     @get:Rule
     var coroutinesTestRule = CoroutineTestRule()
 
-    private val cookieManagerProvider = DefaultCookieManagerProvider()
-    private val cookieManager = cookieManagerProvider.get()!!
+    private val cookieManagerProvider = DefaultCookieManagerProvider(mock(), RealBrowserModeStateHolder())
+    private val cookieManager = cookieManagerProvider.forMode(BrowserMode.REGULAR)!!
     private lateinit var db: AppDatabase
     private lateinit var authCookiesAllowedDomainsDao: AuthCookiesAllowedDomainsDao
     private lateinit var authCookiesAllowedDomainsRepository: AuthCookiesAllowedDomainsRepository

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/urlextraction/UrlExtractingWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/urlextraction/UrlExtractingWebViewClientTest.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.app.browser.*
 import com.duckduckgo.app.browser.certificates.rootstore.TrustedCertificateStore
 import com.duckduckgo.app.browser.cookies.ThirdPartyCookieManager
 import com.duckduckgo.app.browser.httpauth.WebViewHttpAuthStore
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import kotlinx.coroutines.test.TestScope
@@ -63,8 +64,9 @@ class UrlExtractingWebViewClientTest {
             TestScope(),
             coroutinesTestRule.testDispatcherProvider,
             urlExtractor,
+            BrowserMode.REGULAR,
         )
-        whenever(cookieManagerProvider.forCurrentBrowserMode()).thenReturn(cookieManager)
+        whenever(cookieManagerProvider.forMode(BrowserMode.REGULAR)).thenReturn(cookieManager)
     }
 
     @UiThreadTest
@@ -78,7 +80,7 @@ class UrlExtractingWebViewClientTest {
     @Test
     fun whenOnPageStartedCalledThenProcessUriForThirdPartyCookiesCalled() = runTest {
         testee.onPageStarted(mockWebView, EXAMPLE_URL, null)
-        verify(thirdPartyCookieManager).processUriForThirdPartyCookies(mockWebView, EXAMPLE_URL.toUri())
+        verify(thirdPartyCookieManager).processUriForThirdPartyCookies(mockWebView, EXAMPLE_URL.toUri(), BrowserMode.REGULAR)
     }
 
     @UiThreadTest

--- a/app/src/androidTest/java/com/duckduckgo/app/browser/urlextraction/UrlExtractingWebViewClientTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/browser/urlextraction/UrlExtractingWebViewClientTest.kt
@@ -64,7 +64,7 @@ class UrlExtractingWebViewClientTest {
             coroutinesTestRule.testDispatcherProvider,
             urlExtractor,
         )
-        whenever(cookieManagerProvider.get()).thenReturn(cookieManager)
+        whenever(cookieManagerProvider.forCurrentBrowserMode()).thenReturn(cookieManager)
     }
 
     @UiThreadTest

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/FireproofingReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/FireproofingReferenceTest.kt
@@ -59,7 +59,7 @@ class FireproofingReferenceTest(private val testCase: TestCase) {
 
     private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
     private val db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
-    private val cookieManagerProvider = DefaultCookieManagerProvider(mock(), mock())
+    private val cookieManagerProvider = DefaultCookieManagerProvider(mock())
     private val cookieManager = cookieManagerProvider.forMode(BrowserMode.REGULAR)!!
     private val fireproofWebsiteDao = db.fireproofWebsiteDao()
     private val webViewDatabaseLocator = WebViewDatabaseLocator(context)

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/FireproofingReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/FireproofingReferenceTest.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.app.fire.WebViewDatabaseLocator
 import com.duckduckgo.app.fire.fireproofwebsite.data.FireproofWebsiteEntity
 import com.duckduckgo.app.fire.fireproofwebsite.data.FireproofWebsiteRepositoryImpl
 import com.duckduckgo.app.global.db.AppDatabase
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.test.FileUtilities
 import com.duckduckgo.common.utils.DefaultDispatcherProvider
 import com.duckduckgo.common.utils.domain
@@ -58,8 +59,8 @@ class FireproofingReferenceTest(private val testCase: TestCase) {
 
     private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
     private val db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java).build()
-    private val cookieManagerProvider = DefaultCookieManagerProvider()
-    private val cookieManager = cookieManagerProvider.get()!!
+    private val cookieManagerProvider = DefaultCookieManagerProvider(mock(), mock())
+    private val cookieManager = cookieManagerProvider.forMode(BrowserMode.REGULAR)!!
     private val fireproofWebsiteDao = db.fireproofWebsiteDao()
     private val webViewDatabaseLocator = WebViewDatabaseLocator(context)
     private val fireproofWebsiteRepositoryImpl = FireproofWebsiteRepositoryImpl(fireproofWebsiteDao, DefaultDispatcherProvider(), mock())

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/FirstPartyCookiesReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/FirstPartyCookiesReferenceTest.kt
@@ -25,6 +25,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.fire.FireproofRepository
 import com.duckduckgo.app.fire.WebViewDatabaseLocator
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.test.FileUtilities
 import com.duckduckgo.common.utils.DefaultDispatcherProvider
 import com.duckduckgo.cookies.impl.DefaultCookieManagerProvider
@@ -68,8 +69,8 @@ import kotlin.coroutines.suspendCoroutine
 class FirstPartyCookiesReferenceTest(private val testCase: TestCase) {
 
     private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
-    private val cookieManagerProvider = DefaultCookieManagerProvider()
-    private val cookieManager = cookieManagerProvider.get()!!
+    private val cookieManagerProvider = DefaultCookieManagerProvider(mock(), mock())
+    private val cookieManager = cookieManagerProvider.forMode(BrowserMode.REGULAR)!!
     private val cookiesRepository = mock<CookiesRepository>()
     private val unprotectedTemporary = mock<UnprotectedTemporary>()
     private val userAllowListRepository = mock<UserAllowListRepository>()

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/FirstPartyCookiesReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/FirstPartyCookiesReferenceTest.kt
@@ -69,7 +69,7 @@ import kotlin.coroutines.suspendCoroutine
 class FirstPartyCookiesReferenceTest(private val testCase: TestCase) {
 
     private val context: Context = InstrumentationRegistry.getInstrumentation().targetContext
-    private val cookieManagerProvider = DefaultCookieManagerProvider(mock(), mock())
+    private val cookieManagerProvider = DefaultCookieManagerProvider(mock())
     private val cookieManager = cookieManagerProvider.forMode(BrowserMode.REGULAR)!!
     private val cookiesRepository = mock<CookiesRepository>()
     private val unprotectedTemporary = mock<UnprotectedTemporary>()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3296,7 +3296,8 @@ class BrowserTabFragment :
             client.urlExtractionListener = viewModel
 
             logcat { "AMP link detection: Creating WebView for URL extraction" }
-            urlExtractingWebView = UrlExtractingWebView(requireContext(), client, urlExtractorUserAgent.get(), urlExtractor.get())
+            urlExtractingWebView =
+                UrlExtractingWebView(requireContext(), client, urlExtractorUserAgent.get(), urlExtractor.get(), webViewModeInitializer, browserMode)
 
             urlExtractingWebView?.urlExtractionListener = viewModel
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3357,7 +3357,7 @@ class BrowserTabFragment :
         webView?.let {
             val url = it.url ?: return
             launch {
-                thirdPartyCookieManager.processUriForThirdPartyCookies(it, url.toUri())
+                thirdPartyCookieManager.processUriForThirdPartyCookies(it, url.toUri(), browserMode)
             }
         }
     }
@@ -5249,6 +5249,7 @@ class BrowserTabFragment :
                 contentDisposition = contentDisposition,
                 mimeType = mimeType,
                 subfolder = Environment.DIRECTORY_DOWNLOADS,
+                browserMode = browserMode,
             )
 
         if (hasWriteStoragePermission()) {
@@ -5266,6 +5267,7 @@ class BrowserTabFragment :
             PendingFileDownload(
                 url = url,
                 subfolder = Environment.DIRECTORY_DOWNLOADS,
+                browserMode = browserMode,
             )
 
         if (hasWriteStoragePermission()) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -4077,7 +4077,7 @@ class BrowserTabViewModel @Inject constructor(
         pdfDownloadJob += viewModelScope.launch {
             // downloadToCache wraps its own work in withContext(io); viewModelScope.launch
             // defaults to Main, so we stay on Main for the LiveData updates below.
-            val result = inlinePdfHandler.downloadToCache(url, forceRefresh = forceRefresh)
+            val result = inlinePdfHandler.downloadToCache(url, forceRefresh = forceRefresh, browserMode = browserMode)
             loadingViewState.value = currentLoadingViewState().copy(isLoading = false, progress = 100)
             when (result) {
                 is PdfDownloadResult.Success -> {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -76,6 +76,7 @@ import com.duckduckgo.autoconsent.api.Autoconsent
 import com.duckduckgo.autofill.api.BrowserAutofill
 import com.duckduckgo.autofill.api.InternalTestUserChecker
 import com.duckduckgo.browser.api.JsInjectorPlugin
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.utils.AppUrl.ParamKey.QUERY
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -138,6 +139,7 @@ class BrowserWebViewClient @Inject constructor(
     private val contentScopeExperiments: ContentScopeExperiments,
     private val appSchemeInterceptionFeature: AppSchemeInterceptionFeature,
     private val forceWebViewRecompositeFeature: ForceWebViewRecompositeFeature,
+    private val browserMode: BrowserMode,
 ) : WebViewClient() {
     var webViewClientListener: WebViewClientListener? = null
     var clientProvider: ClientBrandHintProvider? = null
@@ -538,8 +540,10 @@ class BrowserWebViewClient @Inject constructor(
             handleMediaPlayback(webView, it)
             autoconsent.injectAutoconsent(webView, url)
             adClickManager.detectAdDomain(url)
-            appCoroutineScope.launch(dispatcherProvider.io()) {
-                thirdPartyCookieManager.processUriForThirdPartyCookies(webView, url.toUri())
+
+            val scope = webView.findViewTreeLifecycleOwner()?.lifecycleScope ?: return@let
+            scope.launch(dispatcherProvider.io()) {
+                thirdPartyCookieManager.processUriForThirdPartyCookies(webView, url.toUri(), browserMode)
             }
         }
         val navigationList = webView.safeCopyBackForwardList() ?: return
@@ -702,8 +706,9 @@ class BrowserWebViewClient @Inject constructor(
      */
     private fun flushCookies(webView: WebView) {
         val scope = webView.findViewTreeLifecycleOwner()?.lifecycleScope ?: return
+        val cookieManager = cookieManagerProvider.forMode(browserMode)
         scope.launch(dispatcherProvider.io()) {
-            cookieManagerProvider.forCurrentBrowserMode()?.flush()
+            cookieManager?.flush()
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -703,7 +703,7 @@ class BrowserWebViewClient @Inject constructor(
     private fun flushCookies(webView: WebView) {
         val scope = webView.findViewTreeLifecycleOwner()?.lifecycleScope ?: return
         scope.launch(dispatcherProvider.io()) {
-            cookieManagerProvider.get()?.flush()
+            cookieManagerProvider.forCurrentBrowserMode()?.flush()
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/cookies/ThirdPartyCookieManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/cookies/ThirdPartyCookieManager.kt
@@ -71,10 +71,10 @@ class AppThirdPartyCookieManager(
             // Allow third-party cookies for domains that need cross-domain functionality
             if (hostsThatAlwaysRequireThirdPartyCookies.contains(host) || (domain != null && hasExcludedCookieName())) {
                 logcat { "Cookies enabled for $uri" }
-                cookieManagerProvider.get()?.setAcceptThirdPartyCookies(webView, true)
+                cookieManagerProvider.forCurrentBrowserMode()?.setAcceptThirdPartyCookies(webView, true)
             } else {
                 logcat { "Cookies disabled for $uri" }
-                cookieManagerProvider.get()?.setAcceptThirdPartyCookies(webView, false)
+                cookieManagerProvider.forCurrentBrowserMode()?.setAcceptThirdPartyCookies(webView, false)
             }
             domain?.let { deleteHost(it) }
         }
@@ -98,7 +98,7 @@ class AppThirdPartyCookieManager(
     }
 
     private fun hasExcludedCookieName(): Boolean {
-        return cookieManagerProvider.get()?.getCookie(GOOGLE_ACCOUNTS_URL)?.split(";")?.firstOrNull {
+        return cookieManagerProvider.forCurrentBrowserMode()?.getCookie(GOOGLE_ACCOUNTS_URL)?.split(";")?.firstOrNull {
             thirdPartyCookieNames.hasExcludedCookieName(it)
         } != null
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/cookies/ThirdPartyCookieManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/cookies/ThirdPartyCookieManager.kt
@@ -21,6 +21,7 @@ import android.webkit.WebView
 import androidx.core.net.toUri
 import com.duckduckgo.app.browser.cookies.db.AuthCookieAllowedDomainEntity
 import com.duckduckgo.app.browser.cookies.db.AuthCookiesAllowedDomainsRepository
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.utils.DefaultDispatcherProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.cookies.api.CookieManagerProvider
@@ -33,6 +34,7 @@ interface ThirdPartyCookieManager {
     suspend fun processUriForThirdPartyCookies(
         webView: WebView,
         uri: Uri,
+        browserMode: BrowserMode,
     )
 
     suspend fun clearAllData()
@@ -49,11 +51,12 @@ class AppThirdPartyCookieManager(
     override suspend fun processUriForThirdPartyCookies(
         webView: WebView,
         uri: Uri,
+        browserMode: BrowserMode,
     ) {
         if (uri.host == GOOGLE_ACCOUNTS_HOST) {
             addHostToList(uri)
         } else {
-            processThirdPartyCookiesSetting(webView, uri)
+            processThirdPartyCookiesSetting(webView, uri, browserMode)
         }
     }
 
@@ -64,17 +67,18 @@ class AppThirdPartyCookieManager(
     private suspend fun processThirdPartyCookiesSetting(
         webView: WebView,
         uri: Uri,
+        browserMode: BrowserMode,
     ) {
         val host = uri.host ?: return
         val domain = authCookiesAllowedDomainsRepository.getDomain(host)
         withContext(dispatchers.main()) {
             // Allow third-party cookies for domains that need cross-domain functionality
-            if (hostsThatAlwaysRequireThirdPartyCookies.contains(host) || (domain != null && hasExcludedCookieName())) {
+            if (hostsThatAlwaysRequireThirdPartyCookies.contains(host) || (domain != null && hasExcludedCookieName(browserMode))) {
                 logcat { "Cookies enabled for $uri" }
-                cookieManagerProvider.forCurrentBrowserMode()?.setAcceptThirdPartyCookies(webView, true)
+                cookieManagerProvider.forMode(browserMode)?.setAcceptThirdPartyCookies(webView, true)
             } else {
                 logcat { "Cookies disabled for $uri" }
-                cookieManagerProvider.forCurrentBrowserMode()?.setAcceptThirdPartyCookies(webView, false)
+                cookieManagerProvider.forMode(browserMode)?.setAcceptThirdPartyCookies(webView, false)
             }
             domain?.let { deleteHost(it) }
         }
@@ -97,8 +101,8 @@ class AppThirdPartyCookieManager(
         }
     }
 
-    private fun hasExcludedCookieName(): Boolean {
-        return cookieManagerProvider.forCurrentBrowserMode()?.getCookie(GOOGLE_ACCOUNTS_URL)?.split(";")?.firstOrNull {
+    private fun hasExcludedCookieName(browserMode: BrowserMode): Boolean {
+        return cookieManagerProvider.forMode(browserMode)?.getCookie(GOOGLE_ACCOUNTS_URL)?.split(";")?.firstOrNull {
             thirdPartyCookieNames.hasExcludedCookieName(it)
         } != null
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/di/BrowserModule.kt
@@ -33,7 +33,6 @@ import com.duckduckgo.app.browser.addtohome.AddToHomeSystemCapabilityDetector
 import com.duckduckgo.app.browser.api.DuckAiChatDeletionListener
 import com.duckduckgo.app.browser.applinks.AppSchemeInterceptionFeature
 import com.duckduckgo.app.browser.applinks.ExternalAppIntentFlagsFeature
-import com.duckduckgo.app.browser.certificates.rootstore.TrustedCertificateStore
 import com.duckduckgo.app.browser.cookies.AppThirdPartyCookieManager
 import com.duckduckgo.app.browser.cookies.ThirdPartyCookieManager
 import com.duckduckgo.app.browser.cookies.db.AuthCookiesAllowedDomainsRepository
@@ -43,7 +42,6 @@ import com.duckduckgo.app.browser.downloader.*
 import com.duckduckgo.app.browser.duckchat.AIChatQueryDetectionFeature
 import com.duckduckgo.app.browser.favicon.FaviconPersister
 import com.duckduckgo.app.browser.favicon.FileBasedFaviconPersister
-import com.duckduckgo.app.browser.httpauth.WebViewHttpAuthStore
 import com.duckduckgo.app.browser.httperrors.HttpCodeSiteErrorHandler
 import com.duckduckgo.app.browser.httperrors.HttpCodeSiteErrorHandlerImpl
 import com.duckduckgo.app.browser.httperrors.StringSiteErrorHandler
@@ -58,7 +56,6 @@ import com.duckduckgo.app.browser.tabpreview.WebViewPreviewGenerator
 import com.duckduckgo.app.browser.tabpreview.WebViewPreviewPersister
 import com.duckduckgo.app.browser.urlextraction.DOMUrlExtractor
 import com.duckduckgo.app.browser.urlextraction.JsUrlExtractor
-import com.duckduckgo.app.browser.urlextraction.UrlExtractingWebViewClient
 import com.duckduckgo.app.browser.webview.MaliciousSiteBlockerWebViewIntegration
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.di.IsMainProcess
@@ -136,29 +133,6 @@ class BrowserModule {
             duckChat,
             androidBrowserConfigFeature,
             serpSettingsFeature,
-        )
-    }
-
-    @Provides
-    fun urlExtractingWebViewClient(
-        webViewHttpAuthStore: WebViewHttpAuthStore,
-        trustedCertificateStore: TrustedCertificateStore,
-        requestInterceptor: RequestInterceptor,
-        cookieManagerProvider: CookieManagerProvider,
-        thirdPartyCookieManager: ThirdPartyCookieManager,
-        @AppCoroutineScope appCoroutineScope: CoroutineScope,
-        dispatcherProvider: DispatcherProvider,
-        urlExtractor: DOMUrlExtractor,
-    ): UrlExtractingWebViewClient {
-        return UrlExtractingWebViewClient(
-            webViewHttpAuthStore,
-            trustedCertificateStore,
-            requestInterceptor,
-            cookieManagerProvider,
-            thirdPartyCookieManager,
-            appCoroutineScope,
-            dispatcherProvider,
-            urlExtractor,
         )
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/pdf/InlinePdfHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pdf/InlinePdfHandler.kt
@@ -160,7 +160,7 @@ class RealInlinePdfHandler @Inject constructor(
 
             val requestBuilder = Request.Builder().url(url)
 
-            val cookie = cookieManagerProvider.get()?.getCookie(url)
+            val cookie = cookieManagerProvider.forCurrentBrowserMode()?.getCookie(url)
             if (cookie != null) {
                 requestBuilder.addHeader("Cookie", cookie)
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/pdf/InlinePdfHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pdf/InlinePdfHandler.kt
@@ -167,7 +167,11 @@ class RealInlinePdfHandler @Inject constructor(
 
             val requestBuilder = Request.Builder().url(url)
 
-            val cookie = cookieManagerProvider.forMode(browserMode)?.getCookie(url)
+            // The Fire manager (ProfileStore-backed, @UiThread) resolves to null off-main until warmed,
+            // so fall back to the main thread only in that cold case; getCookie itself is thread-safe.
+            val cookieManager = cookieManagerProvider.forMode(browserMode)
+                ?: withContext(dispatcherProvider.main()) { cookieManagerProvider.forMode(browserMode) }
+            val cookie = cookieManager?.getCookie(url)
             if (cookie != null) {
                 requestBuilder.addHeader("Cookie", cookie)
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/pdf/InlinePdfHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/pdf/InlinePdfHandler.kt
@@ -25,6 +25,7 @@ import android.os.Parcel
 import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.di.scopes.AppScope
@@ -84,8 +85,10 @@ interface InlinePdfHandler {
      * @param forceRefresh when true, ignore any existing cache entry and re-fetch from the network.
      *   Used by the user-triggered refresh action so an updated server-side document replaces the
      *   stale cached copy.
+     * @param browserMode the browser mode whose cookie jar authenticates the download — the caller passes
+     *   its own (frozen) mode so the request carries the cookies of the tab the PDF was opened in.
      */
-    suspend fun downloadToCache(url: String, forceRefresh: Boolean = false): PdfDownloadResult
+    suspend fun downloadToCache(url: String, forceRefresh: Boolean = false, browserMode: BrowserMode): PdfDownloadResult
 
     /**
      * Extracts a sanitized filename from the PDF [url]'s last path segment.
@@ -142,7 +145,11 @@ class RealInlinePdfHandler @Inject constructor(
     private val cacheDir: File
         get() = File(context.cacheDir, PDF_CACHE_DIR).also { it.mkdirs() }
 
-    override suspend fun downloadToCache(url: String, forceRefresh: Boolean): PdfDownloadResult = withContext(dispatcherProvider.io()) {
+    override suspend fun downloadToCache(
+        url: String,
+        forceRefresh: Boolean,
+        browserMode: BrowserMode,
+    ): PdfDownloadResult = withContext(dispatcherProvider.io()) {
         val fileName = extractFileName(url)
         // Prefix the cache filename with the URL hash so two URLs sharing a last path segment
         // (e.g. report.pdf at site A and site B) don't collide and serve stale content.
@@ -160,7 +167,7 @@ class RealInlinePdfHandler @Inject constructor(
 
             val requestBuilder = Request.Builder().url(url)
 
-            val cookie = cookieManagerProvider.forCurrentBrowserMode()?.getCookie(url)
+            val cookie = cookieManagerProvider.forMode(browserMode)?.getCookie(url)
             if (cookie != null) {
                 requestBuilder.addHeader("Cookie", cookie)
             }

--- a/app/src/main/java/com/duckduckgo/app/browser/urlextraction/UrlExtractingWebView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/urlextraction/UrlExtractingWebView.kt
@@ -21,7 +21,11 @@ import android.content.Context
 import android.webkit.WebSettings
 import android.webkit.WebView
 import com.duckduckgo.app.browser.BuildConfig
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.WebViewModeInitializer
 import com.duckduckgo.user.agent.api.UserAgentProvider
+import logcat.LogPriority.WARN
+import logcat.logcat
 
 @SuppressLint("SetJavaScriptEnabled", "ViewConstructor")
 class UrlExtractingWebView(
@@ -29,12 +33,17 @@ class UrlExtractingWebView(
     webViewClient: UrlExtractingWebViewClient,
     userAgentProvider: UserAgentProvider,
     urlExtractor: DOMUrlExtractor,
+    webViewModeInitializer: WebViewModeInitializer,
+    browserMode: BrowserMode,
 ) : WebView(context) {
 
     var urlExtractionListener: UrlExtractionListener? = null
     lateinit var initialUrl: String
 
     init {
+        webViewModeInitializer.bind(this, browserMode).onFailure {
+            logcat(WARN) { "URL extractor WebView profile bind failed for $browserMode: ${it.message}" }
+        }
         settings.apply {
             userAgentString = userAgentProvider.userAgent()
             javaScriptEnabled = true

--- a/app/src/main/java/com/duckduckgo/app/browser/urlextraction/UrlExtractingWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/urlextraction/UrlExtractingWebViewClient.kt
@@ -28,21 +28,25 @@ import com.duckduckgo.app.browser.certificates.rootstore.CertificateValidationSt
 import com.duckduckgo.app.browser.certificates.rootstore.TrustedCertificateStore
 import com.duckduckgo.app.browser.cookies.ThirdPartyCookieManager
 import com.duckduckgo.app.browser.httpauth.WebViewHttpAuthStore
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import kotlinx.coroutines.*
 import logcat.LogPriority.VERBOSE
 import logcat.logcat
+import javax.inject.Inject
 
-class UrlExtractingWebViewClient(
+class UrlExtractingWebViewClient @Inject constructor(
     private val webViewHttpAuthStore: WebViewHttpAuthStore,
     private val trustedCertificateStore: TrustedCertificateStore,
     private val requestInterceptor: RequestInterceptor,
     private val cookieManagerProvider: CookieManagerProvider,
     private val thirdPartyCookieManager: ThirdPartyCookieManager,
-    private val appCoroutineScope: CoroutineScope,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
     private val urlExtractor: DOMUrlExtractor,
+    private val browserMode: BrowserMode,
 ) : WebViewClient() {
 
     var urlExtractionListener: UrlExtractionListener? = null
@@ -52,7 +56,7 @@ class UrlExtractingWebViewClient(
         logcat(VERBOSE) { "onPageStarted webViewUrl: ${webView.url} URL: $url" }
         url?.let {
             appCoroutineScope.launch(dispatcherProvider.io()) {
-                thirdPartyCookieManager.processUriForThirdPartyCookies(webView, url.toUri())
+                thirdPartyCookieManager.processUriForThirdPartyCookies(webView, url.toUri(), browserMode)
             }
         }
         logcat { "AMP link detection: Injecting JS for URL extraction" }
@@ -66,7 +70,8 @@ class UrlExtractingWebViewClient(
     }
 
     private fun flushCookies() {
-        appCoroutineScope.launch(dispatcherProvider.io()) { cookieManagerProvider.forCurrentBrowserMode()?.flush() }
+        val cookieManager = cookieManagerProvider.forMode(browserMode)
+        appCoroutineScope.launch(dispatcherProvider.io()) { cookieManager?.flush() }
     }
 
     @WorkerThread

--- a/app/src/main/java/com/duckduckgo/app/browser/urlextraction/UrlExtractingWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/urlextraction/UrlExtractingWebViewClient.kt
@@ -66,7 +66,7 @@ class UrlExtractingWebViewClient(
     }
 
     private fun flushCookies() {
-        appCoroutineScope.launch(dispatcherProvider.io()) { cookieManagerProvider.get()?.flush() }
+        appCoroutineScope.launch(dispatcherProvider.io()) { cookieManagerProvider.forCurrentBrowserMode()?.flush() }
     }
 
     @WorkerThread

--- a/app/src/main/java/com/duckduckgo/app/di/TabRepositoryActivityModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/di/TabRepositoryActivityModule.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.di
 
 import androidx.appcompat.app.AppCompatActivity
 import com.duckduckgo.app.browser.customtabs.CustomTabActivity
+import com.duckduckgo.app.browser.webview.WebViewActivity
 import com.duckduckgo.app.tabs.model.TabRepository
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.browsermode.api.BrowserModeStateHolder
@@ -48,9 +49,10 @@ class TabRepositoryActivityModule {
      * mid-construction — the activity recreates on real mode changes, so the next instance
      * captures the new value cleanly.
      *
-     * [CustomTabActivity] always resolves to [BrowserMode.REGULAR] regardless of the state holder:
-     * Custom Tabs are launched by third-party apps and must not inherit the user's Fire-mode
-     * session, nor leak Custom Tab browsing into Fire-mode storage.
+     * [CustomTabActivity] and [WebViewActivity] always resolve to [BrowserMode.REGULAR] regardless of
+     * the state holder: Custom Tabs are launched by third-party apps, and [WebViewActivity] is a
+     * standalone in-app web viewer (help/settings/external links), not a browser tab. Neither should
+     * inherit the user's Fire-mode session, and both keep their WebView on the default profile.
      */
     @Provides
     @SingleInstanceIn(ActivityScope::class)
@@ -58,7 +60,7 @@ class TabRepositoryActivityModule {
         activity: AppCompatActivity,
         browserModeStateHolder: BrowserModeStateHolder,
     ): BrowserMode = when (activity) {
-        is CustomTabActivity -> BrowserMode.REGULAR
+        is CustomTabActivity, is WebViewActivity -> BrowserMode.REGULAR
         else -> browserModeStateHolder.currentMode.value
     }
 

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherActivity.kt
@@ -329,6 +329,9 @@ class TabSwitcherActivity :
     override fun onResume() {
         super.onResume()
 
+        // Bail when onCreate aborted before wiring up views to recreate into the launch-requested mode.
+        if (!::tabsRecycler.isInitialized) return
+
         // Safety net: a recreate()/animation race must never leave the tabs recycler permanently hidden.
         // If we're "fading in" but no fade-in is running and tabs exist, force it back to visible.
         val hasTabs = tabsAdapter.itemCount > 0

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -5592,6 +5592,7 @@ class BrowserTabViewModelTest {
             contentDisposition = contentDisposition,
             mimeType = mimeType,
             subfolder = "folder",
+            browserMode = BrowserMode.REGULAR,
         )
 
     @Test
@@ -11135,7 +11136,9 @@ class BrowserTabViewModelTest {
     fun whenPdfEnabledAndApi31ThenDownloadToCacheAndEmitShowPdfCommand() = runTest {
         whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val testUri = Uri.parse("file:///cache/test.pdf")
-        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf")).thenReturn(PdfDownloadResult.Success(testUri))
+        whenever(
+            mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf", browserMode = BrowserMode.REGULAR),
+        ).thenReturn(PdfDownloadResult.Success(testUri))
         val webView: WebView = mock()
 
         testee.requestFileDownload(webView, "https://example.com/doc.pdf", null, "application/pdf", true, false)
@@ -11149,7 +11152,9 @@ class BrowserTabViewModelTest {
     @Test
     fun whenPdfDownloadToCacheFailsThenFallbackToStandardDownload() = runTest {
         whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
-        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf")).thenReturn(PdfDownloadResult.Failure(PdfErrorType.UNKNOWN))
+        whenever(
+            mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf", browserMode = BrowserMode.REGULAR),
+        ).thenReturn(PdfDownloadResult.Failure(PdfErrorType.UNKNOWN))
         val webView: WebView = mock()
 
         testee.requestFileDownload(webView, "https://example.com/doc.pdf", null, "application/pdf", true, false)
@@ -11161,7 +11166,9 @@ class BrowserTabViewModelTest {
     fun whenPdfInlineThenExpandOmnibarCommandIsEmitted() = runTest {
         whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val testUri = Uri.parse("file:///cache/test.pdf")
-        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf")).thenReturn(PdfDownloadResult.Success(testUri))
+        whenever(
+            mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf", browserMode = BrowserMode.REGULAR),
+        ).thenReturn(PdfDownloadResult.Success(testUri))
         val webView: WebView = mock()
 
         testee.requestFileDownload(webView, "https://example.com/doc.pdf", null, "application/pdf", true, false)
@@ -11173,7 +11180,9 @@ class BrowserTabViewModelTest {
     fun whenPdfDownloadStartsThenLoadingStateShowsProgress() = runTest {
         whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val testUri = Uri.parse("file:///cache/test.pdf")
-        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf")).thenReturn(PdfDownloadResult.Success(testUri))
+        whenever(
+            mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf", browserMode = BrowserMode.REGULAR),
+        ).thenReturn(PdfDownloadResult.Success(testUri))
         val webView: WebView = mock()
 
         testee.requestFileDownload(webView, "https://example.com/doc.pdf", null, "application/pdf", true, false)
@@ -11185,7 +11194,9 @@ class BrowserTabViewModelTest {
     @Test
     fun whenPdfDownloadFailsThenLoadingStateIsReset() = runTest {
         whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
-        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf")).thenReturn(PdfDownloadResult.Failure(PdfErrorType.UNKNOWN))
+        whenever(
+            mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf", browserMode = BrowserMode.REGULAR),
+        ).thenReturn(PdfDownloadResult.Failure(PdfErrorType.UNKNOWN))
         val webView: WebView = mock()
 
         testee.requestFileDownload(webView, "https://example.com/doc.pdf", null, "application/pdf", true, false)
@@ -11213,7 +11224,9 @@ class BrowserTabViewModelTest {
     fun whenPdfWithContentDispositionInlineThenShowPdf() = runTest {
         whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val testUri = Uri.parse("file:///cache/test.pdf")
-        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf")).thenReturn(PdfDownloadResult.Success(testUri))
+        whenever(
+            mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf", browserMode = BrowserMode.REGULAR),
+        ).thenReturn(PdfDownloadResult.Success(testUri))
         val webView: WebView = mock()
 
         testee.requestFileDownload(webView, "https://example.com/doc.pdf", "inline", "application/pdf", true, false)
@@ -11236,7 +11249,7 @@ class BrowserTabViewModelTest {
     fun whenPdfDownloadInProgressAndUserNavigatesAwayThenShowPdfNotEmitted() = runTest {
         whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         // Return COROUTINE_SUSPENDED to simulate a long-running download that never completes
-        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf")).thenAnswer {
+        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf", browserMode = BrowserMode.REGULAR)).thenAnswer {
             COROUTINE_SUSPENDED
         }
         val webView: WebView = mock()
@@ -11261,10 +11274,10 @@ class BrowserTabViewModelTest {
 
         // First download hangs forever; second resolves immediately. ConflatedJob should
         // ensure only the second one's command is emitted.
-        whenever(mockInlinePdfHandler.downloadToCache(urlA)).thenAnswer {
+        whenever(mockInlinePdfHandler.downloadToCache(urlA, browserMode = BrowserMode.REGULAR)).thenAnswer {
             COROUTINE_SUSPENDED
         }
-        whenever(mockInlinePdfHandler.downloadToCache(urlB)).thenReturn(PdfDownloadResult.Success(uriB))
+        whenever(mockInlinePdfHandler.downloadToCache(urlB, browserMode = BrowserMode.REGULAR)).thenReturn(PdfDownloadResult.Success(uriB))
         val webView: WebView = mock()
 
         testee.requestFileDownload(webView, urlA, null, "application/pdf", true, false)
@@ -11282,7 +11295,7 @@ class BrowserTabViewModelTest {
         whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val url = "https://example.com/doc.pdf"
         val cachedUri = Uri.parse("file:///cache/doc.pdf")
-        whenever(mockInlinePdfHandler.downloadToCache(url)).thenReturn(PdfDownloadResult.Success(cachedUri))
+        whenever(mockInlinePdfHandler.downloadToCache(url, browserMode = BrowserMode.REGULAR)).thenReturn(PdfDownloadResult.Success(cachedUri))
         whenever(mockInlinePdfHandler.extractFileName(url)).thenReturn("doc.pdf")
         val webView: WebView = mock()
 
@@ -11296,7 +11309,9 @@ class BrowserTabViewModelTest {
     fun whenPdfShownAfterFreshViewModelThenPerPageMenuFlagsArePopulated() = runTest {
         whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val url = "https://example.com/doc.pdf"
-        whenever(mockInlinePdfHandler.downloadToCache(url)).thenReturn(PdfDownloadResult.Success(Uri.parse("file:///cache/doc.pdf")))
+        whenever(
+            mockInlinePdfHandler.downloadToCache(url, browserMode = BrowserMode.REGULAR),
+        ).thenReturn(PdfDownloadResult.Success(Uri.parse("file:///cache/doc.pdf")))
         whenever(mockInlinePdfHandler.extractFileName(url)).thenReturn("doc.pdf")
         testee.browserViewState.value = browserViewState().copy(
             canSaveSite = false,
@@ -11325,7 +11340,9 @@ class BrowserTabViewModelTest {
     fun whenPdfShownThenPrivacyShieldEnabled() = runTest {
         whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val url = "https://example.com/doc.pdf"
-        whenever(mockInlinePdfHandler.downloadToCache(url)).thenReturn(PdfDownloadResult.Success(Uri.parse("file:///cache/doc.pdf")))
+        whenever(
+            mockInlinePdfHandler.downloadToCache(url, browserMode = BrowserMode.REGULAR),
+        ).thenReturn(PdfDownloadResult.Success(Uri.parse("file:///cache/doc.pdf")))
         whenever(mockInlinePdfHandler.extractFileName(url)).thenReturn("doc.pdf")
         testee.browserViewState.value = browserViewState().copy(
             showPrivacyShield = HighlightableButton.Visible(enabled = false),
@@ -11341,7 +11358,7 @@ class BrowserTabViewModelTest {
         whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val url = "https://example.com/doc.pdf"
         val certificate: SslCertificate = mock()
-        whenever(mockInlinePdfHandler.downloadToCache(url))
+        whenever(mockInlinePdfHandler.downloadToCache(url, browserMode = BrowserMode.REGULAR))
             .thenReturn(PdfDownloadResult.Success(Uri.parse("file:///cache/doc.pdf"), certificate))
         whenever(mockInlinePdfHandler.extractFileName(url)).thenReturn("doc.pdf")
 
@@ -11354,7 +11371,7 @@ class BrowserTabViewModelTest {
     fun whenPdfDownloadHasNoCertificateThenSiteCertificateRemainsNull() = runTest {
         whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val url = "https://example.com/doc.pdf"
-        whenever(mockInlinePdfHandler.downloadToCache(url))
+        whenever(mockInlinePdfHandler.downloadToCache(url, browserMode = BrowserMode.REGULAR))
             .thenReturn(PdfDownloadResult.Success(Uri.parse("file:///cache/doc.pdf"), certificate = null))
         whenever(mockInlinePdfHandler.extractFileName(url)).thenReturn("doc.pdf")
 
@@ -11379,7 +11396,7 @@ class BrowserTabViewModelTest {
     fun whenPdfReopenedAfterUserAllowListedThenShieldShowsUnprotected() = runTest {
         whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val pdfUrl = "https://www.example.com/doc.pdf"
-        whenever(mockInlinePdfHandler.downloadToCache(pdfUrl))
+        whenever(mockInlinePdfHandler.downloadToCache(pdfUrl, browserMode = BrowserMode.REGULAR))
             .thenReturn(PdfDownloadResult.Success(Uri.parse("file:///cache/doc.pdf")))
         whenever(mockInlinePdfHandler.extractFileName(pdfUrl)).thenReturn("doc.pdf")
         // Domain is already in the user allow list (user disabled protection in a previous session).
@@ -11419,12 +11436,14 @@ class BrowserTabViewModelTest {
             currentPdfCachedUri = Uri.parse("file:///cache/doc.pdf"),
             currentPdfFileName = "doc.pdf",
         )
-        whenever(mockInlinePdfHandler.downloadToCache(pdfUrl, forceRefresh = true)).thenReturn(PdfDownloadResult.Success(refreshedUri))
+        whenever(
+            mockInlinePdfHandler.downloadToCache(pdfUrl, forceRefresh = true, browserMode = BrowserMode.REGULAR),
+        ).thenReturn(PdfDownloadResult.Success(refreshedUri))
 
         testee.onRefreshRequested(triggeredByUser = true)
         advanceUntilIdle()
 
-        verify(mockInlinePdfHandler).downloadToCache(pdfUrl, forceRefresh = true)
+        verify(mockInlinePdfHandler).downloadToCache(pdfUrl, forceRefresh = true, browserMode = BrowserMode.REGULAR)
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
         val lastShowPdf = commandCaptor.allValues.filterIsInstance<Command.ShowPdfInTab>().last()
         assertEquals(pdfUrl, lastShowPdf.url)
@@ -11441,7 +11460,7 @@ class BrowserTabViewModelTest {
         advanceUntilIdle()
 
         assertCommandIssued<NavigationCommand.Refresh>()
-        verify(mockInlinePdfHandler, never()).downloadToCache(any(), eq(true))
+        verify(mockInlinePdfHandler, never()).downloadToCache(any(), eq(true), any())
     }
 
     @Test
@@ -11453,7 +11472,9 @@ class BrowserTabViewModelTest {
             currentPdfCachedUri = originalUri,
             currentPdfFileName = "doc.pdf",
         )
-        whenever(mockInlinePdfHandler.downloadToCache(pdfUrl, forceRefresh = true)).thenReturn(PdfDownloadResult.Failure(PdfErrorType.IO_ERROR))
+        whenever(
+            mockInlinePdfHandler.downloadToCache(pdfUrl, forceRefresh = true, browserMode = BrowserMode.REGULAR),
+        ).thenReturn(PdfDownloadResult.Failure(PdfErrorType.IO_ERROR))
 
         testee.onRefreshRequested(triggeredByUser = true)
         advanceUntilIdle()
@@ -11698,7 +11719,7 @@ class BrowserTabViewModelTest {
     fun whenPdfRenderedInlineThenAllThreeOpenedPixelsFire() = runTest {
         whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val testUri = Uri.parse("file:///cache/doc.pdf")
-        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf"))
+        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf", browserMode = BrowserMode.REGULAR))
             .thenReturn(PdfDownloadResult.Success(testUri))
 
         testee.requestFileDownload(mock(), "https://example.com/doc.pdf", null, "application/pdf", true, false)
@@ -11711,7 +11732,7 @@ class BrowserTabViewModelTest {
     @Test
     fun whenPdfDownloadFailsWithIoErrorThenRenderFailurePixelFiresWithErrorType() = runTest {
         whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
-        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf"))
+        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf", browserMode = BrowserMode.REGULAR))
             .thenReturn(PdfDownloadResult.Failure(PdfErrorType.IO_ERROR))
 
         testee.requestFileDownload(mock(), "https://example.com/doc.pdf", null, "application/pdf", true, false)
@@ -11722,7 +11743,7 @@ class BrowserTabViewModelTest {
     @Test
     fun whenPdfDownloadFailsWithUnknownThenRenderFailurePixelFiresWithUnknownErrorType() = runTest {
         whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
-        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf"))
+        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/doc.pdf", browserMode = BrowserMode.REGULAR))
             .thenReturn(PdfDownloadResult.Failure(PdfErrorType.UNKNOWN))
 
         testee.requestFileDownload(mock(), "https://example.com/doc.pdf", null, "application/pdf", true, false)
@@ -11761,7 +11782,9 @@ class BrowserTabViewModelTest {
         whenever(mockPdfDownloadTooltipDataStore.canShow()).thenReturn(true)
         whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val testUri = Uri.parse("file:///cache/test.pdf")
-        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/test.pdf")).thenReturn(PdfDownloadResult.Success(testUri))
+        whenever(
+            mockInlinePdfHandler.downloadToCache("https://example.com/test.pdf", browserMode = BrowserMode.REGULAR),
+        ).thenReturn(PdfDownloadResult.Success(testUri))
         whenever(mockInlinePdfHandler.extractFileName("https://example.com/test.pdf")).thenReturn("test.pdf")
 
         testee.requestFileDownload(mock(), "https://example.com/test.pdf", null, "application/pdf", true, false)
@@ -11775,7 +11798,9 @@ class BrowserTabViewModelTest {
         whenever(mockPdfDownloadTooltipDataStore.canShow()).thenReturn(false)
         whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val testUri = Uri.parse("file:///cache/test.pdf")
-        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/test.pdf")).thenReturn(PdfDownloadResult.Success(testUri))
+        whenever(
+            mockInlinePdfHandler.downloadToCache("https://example.com/test.pdf", browserMode = BrowserMode.REGULAR),
+        ).thenReturn(PdfDownloadResult.Success(testUri))
         whenever(mockInlinePdfHandler.extractFileName("https://example.com/test.pdf")).thenReturn("test.pdf")
 
         testee.requestFileDownload(mock(), "https://example.com/test.pdf", null, "application/pdf", true, false)
@@ -11787,7 +11812,9 @@ class BrowserTabViewModelTest {
     @Test
     fun whenInlinePdfDownloadFailsThenTooltipCommandIsNotEmittedAndStoreIsNotIncremented() = runTest {
         whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
-        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/test.pdf")).thenReturn(PdfDownloadResult.Failure(PdfErrorType.IO_ERROR))
+        whenever(
+            mockInlinePdfHandler.downloadToCache("https://example.com/test.pdf", browserMode = BrowserMode.REGULAR),
+        ).thenReturn(PdfDownloadResult.Failure(PdfErrorType.IO_ERROR))
 
         testee.requestFileDownload(mock(), "https://example.com/test.pdf", null, "application/pdf", true, false)
 
@@ -11801,7 +11828,9 @@ class BrowserTabViewModelTest {
         whenever(mockPdfDownloadTooltipDataStore.canShow()).thenReturn(true)
         whenever(mockInlinePdfHandler.classifyPdfRequest(any(), anyOrNull(), any())).thenReturn(PdfRenderDecision.Inline)
         val testUri = Uri.parse("file:///cache/test.pdf")
-        whenever(mockInlinePdfHandler.downloadToCache("https://example.com/test.pdf")).thenReturn(PdfDownloadResult.Success(testUri))
+        whenever(
+            mockInlinePdfHandler.downloadToCache("https://example.com/test.pdf", browserMode = BrowserMode.REGULAR),
+        ).thenReturn(PdfDownloadResult.Success(testUri))
         whenever(mockInlinePdfHandler.extractFileName("https://example.com/test.pdf")).thenReturn("test.pdf")
 
         testee.requestFileDownload(mock(), "https://example.com/test.pdf", null, "application/pdf", true, false)

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -236,7 +236,7 @@ class BrowserWebViewClientTest {
                 )
             testee.webViewClientListener = listener
             whenever(webResourceRequest.url).thenReturn(Uri.EMPTY)
-            whenever(cookieManagerProvider.get()).thenReturn(cookieManager)
+            whenever(cookieManagerProvider.forCurrentBrowserMode()).thenReturn(cookieManager)
             whenever(currentTimeProvider.elapsedRealtime()).thenReturn(0)
             whenever(webViewVersionProvider.getMajorVersion()).thenReturn("1")
             whenever(deviceInfo.appVersion).thenReturn("1")

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -77,6 +77,7 @@ import com.duckduckgo.autofill.api.BrowserAutofill
 import com.duckduckgo.autofill.api.InternalTestUserChecker
 import com.duckduckgo.browser.api.JsInjectorPlugin
 import com.duckduckgo.browser.api.WebViewVersionProvider
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.device.DeviceInfo
@@ -233,10 +234,11 @@ class BrowserWebViewClientTest {
                     mockContentScopeExperiments,
                     mockAppSchemeInterceptionFeature,
                     mockForceWebViewRecompositeFeature,
+                    BrowserMode.REGULAR,
                 )
             testee.webViewClientListener = listener
             whenever(webResourceRequest.url).thenReturn(Uri.EMPTY)
-            whenever(cookieManagerProvider.forCurrentBrowserMode()).thenReturn(cookieManager)
+            whenever(cookieManagerProvider.forMode(BrowserMode.REGULAR)).thenReturn(cookieManager)
             whenever(currentTimeProvider.elapsedRealtime()).thenReturn(0)
             whenever(webViewVersionProvider.getMajorVersion()).thenReturn("1")
             whenever(deviceInfo.appVersion).thenReturn("1")
@@ -318,7 +320,7 @@ class BrowserWebViewClientTest {
     fun whenOnPageStartedCalledThenProcessUriForThirdPartyCookiesCalled() =
         runTest {
             testee.onPageStarted(webView, EXAMPLE_URL, null)
-            verify(thirdPartyCookieManager).processUriForThirdPartyCookies(webView, EXAMPLE_URL.toUri())
+            verify(thirdPartyCookieManager).processUriForThirdPartyCookies(webView, EXAMPLE_URL.toUri(), BrowserMode.REGULAR)
         }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerPreApi31Test.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerPreApi31Test.kt
@@ -48,7 +48,7 @@ class InlinePdfHandlerPreApi31Test {
     private val androidBrowserConfigFeature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
 
     private val cookieManagerProvider = object : CookieManagerProvider {
-        override fun get(): CookieManager? = null
+        override fun forCurrentBrowserMode(): CookieManager? = null
     }
 
     @Before

--- a/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerPreApi31Test.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerPreApi31Test.kt
@@ -20,6 +20,7 @@ import android.webkit.CookieManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
@@ -48,7 +49,7 @@ class InlinePdfHandlerPreApi31Test {
     private val androidBrowserConfigFeature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
 
     private val cookieManagerProvider = object : CookieManagerProvider {
-        override fun forCurrentBrowserMode(): CookieManager? = null
+        override fun forMode(mode: BrowserMode): CookieManager? = null
     }
 
     @Before

--- a/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerTest.kt
@@ -61,7 +61,7 @@ class InlinePdfHandlerTest {
     private val androidBrowserConfigFeature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
 
     private val cookieManagerProvider = object : CookieManagerProvider {
-        override fun get(): CookieManager? = null
+        override fun forCurrentBrowserMode(): CookieManager? = null
     }
 
     @Before
@@ -385,7 +385,7 @@ class InlinePdfHandlerTest {
         val mockCookieManager: CookieManager = mock()
         whenever(mockCookieManager.getCookie(any())).thenReturn("session=abc123")
         val cookieAwareProvider = object : CookieManagerProvider {
-            override fun get(): CookieManager = mockCookieManager
+            override fun forCurrentBrowserMode(): CookieManager = mockCookieManager
         }
         val handlerWithCookies = RealInlinePdfHandler(
             context = InstrumentationRegistry.getInstrumentation().targetContext,

--- a/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerTest.kt
@@ -20,6 +20,7 @@ import android.webkit.CookieManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
@@ -61,7 +62,7 @@ class InlinePdfHandlerTest {
     private val androidBrowserConfigFeature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
 
     private val cookieManagerProvider = object : CookieManagerProvider {
-        override fun forCurrentBrowserMode(): CookieManager? = null
+        override fun forMode(mode: BrowserMode): CookieManager? = null
     }
 
     @Before
@@ -95,7 +96,7 @@ class InlinePdfHandlerTest {
                 .setBody(Buffer().write(pdfBytes)),
         )
 
-        val result = inlinePdfHandler.downloadToCache(server.url("/test.pdf").toString())
+        val result = inlinePdfHandler.downloadToCache(server.url("/test.pdf").toString(), browserMode = BrowserMode.REGULAR)
 
         assertTrue(result is PdfDownloadResult.Success)
         val file = File((result as PdfDownloadResult.Success).uri.path!!)
@@ -112,7 +113,7 @@ class InlinePdfHandlerTest {
                 .setBody(Buffer().write(pdfBytes)),
         )
 
-        val result = inlinePdfHandler.downloadToCache(server.url("/test.pdf").toString())
+        val result = inlinePdfHandler.downloadToCache(server.url("/test.pdf").toString(), browserMode = BrowserMode.REGULAR)
 
         assertTrue(result is PdfDownloadResult.Success)
         assertNull((result as PdfDownloadResult.Success).certificate)
@@ -122,7 +123,7 @@ class InlinePdfHandlerTest {
     fun whenServerReturnsErrorThenReturnsFailureUnknown() = runTest {
         server.enqueue(MockResponse().setResponseCode(404))
 
-        val result = inlinePdfHandler.downloadToCache(server.url("/missing.pdf").toString())
+        val result = inlinePdfHandler.downloadToCache(server.url("/missing.pdf").toString(), browserMode = BrowserMode.REGULAR)
 
         assertEquals(PdfDownloadResult.Failure(PdfErrorType.UNKNOWN), result)
     }
@@ -136,7 +137,7 @@ class InlinePdfHandlerTest {
                 .setBody(Buffer().write(pdfBytes)),
         )
 
-        val result = inlinePdfHandler.downloadToCache(server.url("/document").toString())
+        val result = inlinePdfHandler.downloadToCache(server.url("/document").toString(), browserMode = BrowserMode.REGULAR)
 
         assertTrue(result is PdfDownloadResult.Success)
         assertTrue((result as PdfDownloadResult.Success).uri.path!!.endsWith(".pdf"))
@@ -151,7 +152,7 @@ class InlinePdfHandlerTest {
                 .setBody(Buffer().write(htmlBytes)),
         )
 
-        val result = inlinePdfHandler.downloadToCache(server.url("/fake.pdf").toString())
+        val result = inlinePdfHandler.downloadToCache(server.url("/fake.pdf").toString(), browserMode = BrowserMode.REGULAR)
 
         assertEquals(PdfDownloadResult.Failure(PdfErrorType.UNKNOWN), result)
     }
@@ -267,11 +268,11 @@ class InlinePdfHandlerTest {
         )
         val url = server.url("/cached.pdf").toString()
 
-        val firstResult = inlinePdfHandler.downloadToCache(url)
+        val firstResult = inlinePdfHandler.downloadToCache(url, browserMode = BrowserMode.REGULAR)
         assertTrue(firstResult is PdfDownloadResult.Success)
         assertEquals(1, server.requestCount)
 
-        val secondResult = inlinePdfHandler.downloadToCache(url)
+        val secondResult = inlinePdfHandler.downloadToCache(url, browserMode = BrowserMode.REGULAR)
         assertTrue(secondResult is PdfDownloadResult.Success)
         assertEquals((firstResult as PdfDownloadResult.Success).uri, (secondResult as PdfDownloadResult.Success).uri)
         assertEquals(1, server.requestCount)
@@ -285,11 +286,11 @@ class InlinePdfHandlerTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(secondBytes)))
         val url = server.url("/refreshable.pdf").toString()
 
-        val firstResult = inlinePdfHandler.downloadToCache(url)
+        val firstResult = inlinePdfHandler.downloadToCache(url, browserMode = BrowserMode.REGULAR)
         assertTrue(firstResult is PdfDownloadResult.Success)
         assertEquals(1, server.requestCount)
 
-        val refreshResult = inlinePdfHandler.downloadToCache(url, forceRefresh = true)
+        val refreshResult = inlinePdfHandler.downloadToCache(url, forceRefresh = true, browserMode = BrowserMode.REGULAR)
         assertTrue(refreshResult is PdfDownloadResult.Success)
         assertEquals(2, server.requestCount)
 
@@ -313,13 +314,13 @@ class InlinePdfHandlerTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(replacementBytes)))
         val url = server.url("/refresh-fails.pdf").toString()
 
-        assertTrue(inlinePdfHandler.downloadToCache(url) is PdfDownloadResult.Success)
-        val refreshResult = inlinePdfHandler.downloadToCache(url, forceRefresh = true)
+        assertTrue(inlinePdfHandler.downloadToCache(url, browserMode = BrowserMode.REGULAR) is PdfDownloadResult.Success)
+        val refreshResult = inlinePdfHandler.downloadToCache(url, forceRefresh = true, browserMode = BrowserMode.REGULAR)
         assertEquals(PdfDownloadResult.Failure(PdfErrorType.IO_ERROR), refreshResult)
 
         // A subsequent non-force-refresh load must not pick up a corrupt partial: it should
         // re-fetch from the server (3rd request) and return the replacement bytes.
-        val recovered = inlinePdfHandler.downloadToCache(url)
+        val recovered = inlinePdfHandler.downloadToCache(url, browserMode = BrowserMode.REGULAR)
         assertTrue(recovered is PdfDownloadResult.Success)
         assertEquals(3, server.requestCount)
         val recoveredFile = File((recovered as PdfDownloadResult.Success).uri.path!!)
@@ -335,8 +336,8 @@ class InlinePdfHandlerTest {
         val urlA = server.url("/site-a/report.pdf").toString()
         val urlB = server.url("/site-b/report.pdf").toString()
 
-        val resultA = inlinePdfHandler.downloadToCache(urlA)
-        val resultB = inlinePdfHandler.downloadToCache(urlB)
+        val resultA = inlinePdfHandler.downloadToCache(urlA, browserMode = BrowserMode.REGULAR)
+        val resultB = inlinePdfHandler.downloadToCache(urlB, browserMode = BrowserMode.REGULAR)
 
         assertTrue(resultA is PdfDownloadResult.Success)
         assertTrue(resultB is PdfDownloadResult.Success)
@@ -360,7 +361,7 @@ class InlinePdfHandlerTest {
         val url = server.url("/cancelled.pdf").toString()
 
         val deferred = async {
-            inlinePdfHandler.downloadToCache(url)
+            inlinePdfHandler.downloadToCache(url, browserMode = BrowserMode.REGULAR)
         }
 
         delay(100)
@@ -385,7 +386,7 @@ class InlinePdfHandlerTest {
         val mockCookieManager: CookieManager = mock()
         whenever(mockCookieManager.getCookie(any())).thenReturn("session=abc123")
         val cookieAwareProvider = object : CookieManagerProvider {
-            override fun forCurrentBrowserMode(): CookieManager = mockCookieManager
+            override fun forMode(mode: BrowserMode): CookieManager = mockCookieManager
         }
         val handlerWithCookies = RealInlinePdfHandler(
             context = InstrumentationRegistry.getInstrumentation().targetContext,
@@ -403,7 +404,7 @@ class InlinePdfHandlerTest {
         )
         val url = server.url("/auth.pdf").toString()
 
-        val result = handlerWithCookies.downloadToCache(url)
+        val result = handlerWithCookies.downloadToCache(url, browserMode = BrowserMode.REGULAR)
 
         assertTrue(result is PdfDownloadResult.Success)
         val recordedRequest = server.takeRequest()
@@ -420,7 +421,7 @@ class InlinePdfHandlerTest {
     fun whenServerReturnsEmptyBodyThenReturnsFailureUnknown() = runTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody(""))
 
-        val result = inlinePdfHandler.downloadToCache(server.url("/empty.pdf").toString())
+        val result = inlinePdfHandler.downloadToCache(server.url("/empty.pdf").toString(), browserMode = BrowserMode.REGULAR)
 
         assertEquals(PdfDownloadResult.Failure(PdfErrorType.UNKNOWN), result)
     }
@@ -434,7 +435,7 @@ class InlinePdfHandlerTest {
         )
         val url = server.url("/short.pdf").toString()
 
-        val result = inlinePdfHandler.downloadToCache(url)
+        val result = inlinePdfHandler.downloadToCache(url, browserMode = BrowserMode.REGULAR)
 
         assertEquals(PdfDownloadResult.Failure(PdfErrorType.UNKNOWN), result)
         val cacheDir = File(
@@ -460,7 +461,7 @@ class InlinePdfHandlerTest {
             androidBrowserConfigFeature = androidBrowserConfigFeature,
         )
 
-        val result = handlerWithFailingDns.downloadToCache("https://example.com/test.pdf")
+        val result = handlerWithFailingDns.downloadToCache("https://example.com/test.pdf", browserMode = BrowserMode.REGULAR)
 
         assertEquals(PdfDownloadResult.Failure(PdfErrorType.IO_ERROR), result)
     }
@@ -476,7 +477,7 @@ class InlinePdfHandlerTest {
         )
         val url = server.url("/reset.pdf").toString()
 
-        val result = inlinePdfHandler.downloadToCache(url)
+        val result = inlinePdfHandler.downloadToCache(url, browserMode = BrowserMode.REGULAR)
 
         assertEquals(PdfDownloadResult.Failure(PdfErrorType.IO_ERROR), result)
     }
@@ -547,7 +548,7 @@ class InlinePdfHandlerTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(pdfBytes)))
         val url = server.url("/touch.pdf").toString()
 
-        val firstResult = inlinePdfHandler.downloadToCache(url)
+        val firstResult = inlinePdfHandler.downloadToCache(url, browserMode = BrowserMode.REGULAR)
         assertTrue(firstResult is PdfDownloadResult.Success)
         val cachedFile = File((firstResult as PdfDownloadResult.Success).uri.path!!)
 
@@ -556,7 +557,7 @@ class InlinePdfHandlerTest {
         cachedFile.setLastModified(backdated)
 
         val before = cachedFile.lastModified()
-        inlinePdfHandler.downloadToCache(url)
+        inlinePdfHandler.downloadToCache(url, browserMode = BrowserMode.REGULAR)
         val after = cachedFile.lastModified()
 
         assertTrue("Cache hit should bump lastModified to keep LRU semantics accurate", after > before)
@@ -617,7 +618,7 @@ class InlinePdfHandlerTest {
         // Sidecar contains arbitrary bytes that aren't a valid marshaled Bundle.
         File(cacheDir, "${targetFile.name}.cert").writeBytes("not a valid bundle".toByteArray())
 
-        val result = inlinePdfHandler.downloadToCache(url)
+        val result = inlinePdfHandler.downloadToCache(url, browserMode = BrowserMode.REGULAR)
 
         assertTrue(result is PdfDownloadResult.Success)
         assertNull((result as PdfDownloadResult.Success).certificate)
@@ -629,11 +630,11 @@ class InlinePdfHandlerTest {
         server.enqueue(MockResponse().setResponseCode(200).setBody(Buffer().write(pdfBytes)))
         val url = server.url("/no-sidecar.pdf").toString()
 
-        val first = inlinePdfHandler.downloadToCache(url)
+        val first = inlinePdfHandler.downloadToCache(url, browserMode = BrowserMode.REGULAR)
         assertTrue(first is PdfDownloadResult.Success)
         assertNull((first as PdfDownloadResult.Success).certificate)
 
-        val second = inlinePdfHandler.downloadToCache(url)
+        val second = inlinePdfHandler.downloadToCache(url, browserMode = BrowserMode.REGULAR)
         assertTrue(second is PdfDownloadResult.Success)
         assertNull((second as PdfDownloadResult.Success).certificate)
     }

--- a/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerTest.kt
@@ -22,9 +22,12 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
@@ -49,6 +52,7 @@ import org.mockito.kotlin.whenever
 import org.robolectric.annotation.Config
 import java.io.File
 import java.net.UnknownHostException
+import java.util.concurrent.Executors
 
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [34])
@@ -409,6 +413,53 @@ class InlinePdfHandlerTest {
         assertTrue(result is PdfDownloadResult.Success)
         val recordedRequest = server.takeRequest()
         assertEquals("session=abc123", recordedRequest.getHeader("Cookie"))
+    }
+
+    @Test
+    fun whenFireCookieResolvableOnlyOnMainThreadThenStillForwardedAsHeader() = runTest {
+        val mockCookieManager: CookieManager = mock()
+        whenever(mockCookieManager.getCookie(any())).thenReturn("session=abc123")
+
+        val mainExecutor = Executors.newSingleThreadExecutor { r -> Thread(r, "pdf-test-main") }
+        val ioExecutor = Executors.newSingleThreadExecutor { r -> Thread(r, "pdf-test-io") }
+        // Mirrors DefaultCookieManagerProvider: the Fire CookieManager can only be resolved on the
+        // main thread and returns null off it.
+        val mainThreadOnlyProvider = object : CookieManagerProvider {
+            override fun forMode(mode: BrowserMode): CookieManager? =
+                if (Thread.currentThread().name.contains("pdf-test-main")) mockCookieManager else null
+        }
+        val dispatchers = object : DispatcherProvider {
+            override fun io(): CoroutineDispatcher = ioExecutor.asCoroutineDispatcher()
+            override fun main(): CoroutineDispatcher = mainExecutor.asCoroutineDispatcher()
+            override fun computation(): CoroutineDispatcher = ioExecutor.asCoroutineDispatcher()
+            override fun unconfined(): CoroutineDispatcher = ioExecutor.asCoroutineDispatcher()
+        }
+        val handlerWithCookies = RealInlinePdfHandler(
+            context = InstrumentationRegistry.getInstrumentation().targetContext,
+            okHttpClient = OkHttpClient(),
+            cookieManagerProvider = mainThreadOnlyProvider,
+            dispatcherProvider = dispatchers,
+            androidBrowserConfigFeature = androidBrowserConfigFeature,
+        )
+
+        val pdfBytes = "%PDF-1.4 test content".toByteArray()
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody(Buffer().write(pdfBytes)),
+        )
+        val url = server.url("/auth.pdf").toString()
+
+        try {
+            val result = handlerWithCookies.downloadToCache(url, browserMode = BrowserMode.FIRE)
+
+            assertTrue(result is PdfDownloadResult.Success)
+            val recordedRequest = server.takeRequest()
+            assertEquals("session=abc123", recordedRequest.getHeader("Cookie"))
+        } finally {
+            mainExecutor.shutdown()
+            ioExecutor.shutdown()
+        }
     }
 
     @Test

--- a/autofill/autofill-impl/build.gradle
+++ b/autofill/autofill-impl/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation project(path: ':design-system')
     implementation project(path: ':autofill-api')
     implementation project(path: ':browser-api')
+    implementation project(path: ':browser-mode-api')
     implementation project(path: ':statistics-api')
     testImplementation project(path: ':autofill-test')
     implementation project(path: ':sync-api')

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/takeout/zip/TakeoutZipDownloader.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/importing/takeout/zip/TakeoutZipDownloader.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.autofill.impl.importing.takeout.zip
 
 import android.content.Context
 import android.net.Uri
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.di.scopes.AppScope
@@ -79,7 +80,7 @@ class RealTakeoutZipDownloader @Inject constructor(
                 .addHeader(HEADER_USER_AGENT, userAgent)
 
         // Extract cookies from WebView's CookieManager for this URL
-        val cookieManager = cookieManagerProvider.get()
+        val cookieManager = cookieManagerProvider.forMode(BrowserMode.REGULAR)
         val cookies = cookieManager?.getCookie(url)
         if (cookies != null) {
             requestBuilder.addHeader(HEADER_COOKIE, cookies)

--- a/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/takeout/zip/RealTakeoutZipDownloaderTest.kt
+++ b/autofill/autofill-impl/src/test/java/com/duckduckgo/autofill/impl/importing/takeout/zip/RealTakeoutZipDownloaderTest.kt
@@ -3,6 +3,7 @@ package com.duckduckgo.autofill.impl.importing.takeout.zip
 import android.content.Context
 import android.webkit.CookieManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import dagger.Lazy
@@ -56,7 +57,7 @@ class RealTakeoutZipDownloaderTest {
 
     @Before
     fun setup() {
-        whenever(mockCookieManagerProvider.get()).thenReturn(mockCookieManager)
+        whenever(mockCookieManagerProvider.forMode(BrowserMode.REGULAR)).thenReturn(mockCookieManager)
         whenever(mockOkHttpClient.newCall(any())).thenReturn(mockCall)
         whenever(mockCall.execute()).thenReturn(mockResponse)
 

--- a/cookies/cookies-api/build.gradle
+++ b/cookies/cookies-api/build.gradle
@@ -22,6 +22,7 @@ plugins {
 apply from: "$rootProject.projectDir/gradle/android-library.gradle"
 
 dependencies {
+    implementation project(':browser-mode-api')
     implementation KotlinX.coroutines.core
     implementation AndroidX.core.ktx
 }

--- a/cookies/cookies-api/src/main/java/com/duckduckgo/cookies/api/CookieManagerProvider.kt
+++ b/cookies/cookies-api/src/main/java/com/duckduckgo/cookies/api/CookieManagerProvider.kt
@@ -17,11 +17,31 @@
 package com.duckduckgo.cookies.api
 
 import android.webkit.CookieManager
+import com.duckduckgo.browsermode.api.BrowserMode
 
 /** Public interface for CookieManagerProvider */
 interface CookieManagerProvider {
     /**
-     * This method returns the [CookieManager] instance. This is a singleton instance.
+     * Returns the [CookieManager] for the browser mode that is currently active.
      */
-    fun get(): CookieManager?
+    fun forCurrentBrowserMode(): CookieManager?
+
+    /**
+     * Returns the [CookieManager] for the given [mode], regardless of which mode is currently active.
+     */
+    fun forMode(mode: BrowserMode): CookieManager? = forCurrentBrowserMode()
+}
+
+/**
+ * Sets [cookieString] for [url] in every browser mode's cookie jar (the default profile plus any
+ * non-default ones), flushing each.
+ */
+fun CookieManagerProvider.setCookieForAllModes(url: String, cookieString: String) {
+    BrowserMode.entries
+        .mapNotNull { forMode(it) }
+        .distinct()
+        .forEach { cookieManager ->
+            cookieManager.setCookie(url, cookieString)
+            cookieManager.flush()
+        }
 }

--- a/cookies/cookies-api/src/main/java/com/duckduckgo/cookies/api/CookieManagerProvider.kt
+++ b/cookies/cookies-api/src/main/java/com/duckduckgo/cookies/api/CookieManagerProvider.kt
@@ -22,14 +22,10 @@ import com.duckduckgo.browsermode.api.BrowserMode
 /** Public interface for CookieManagerProvider */
 interface CookieManagerProvider {
     /**
-     * Returns the [CookieManager] for the browser mode that is currently active.
+     * Returns the [CookieManager] for the given [mode]. Callers always specify the mode explicitly — the
+     * tab/activity's frozen mode for WebView-bound work, or the mode carried with a deferred request.
      */
-    fun forCurrentBrowserMode(): CookieManager?
-
-    /**
-     * Returns the [CookieManager] for the given [mode], regardless of which mode is currently active.
-     */
-    fun forMode(mode: BrowserMode): CookieManager? = forCurrentBrowserMode()
+    fun forMode(mode: BrowserMode): CookieManager?
 }
 
 /**

--- a/cookies/cookies-impl/build.gradle
+++ b/cookies/cookies-impl/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation project(':cookies-api')
     implementation project(':cookies-store')
     implementation project(':browser-api')
+    implementation project(':browser-mode-api')
     implementation project(':statistics-api')
     implementation project(':content-scope-scripts-api')
     implementation project(':duckchat-api')
@@ -52,6 +53,7 @@ dependencies {
 
     implementation Google.dagger
     implementation AndroidX.core.ktx
+    implementation AndroidX.webkit
     implementation AndroidX.work.runtimeKtx
     implementation AndroidX.room.runtime
 

--- a/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/DefaultCookieManagerProvider.kt
+++ b/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/DefaultCookieManagerProvider.kt
@@ -21,7 +21,6 @@ import android.os.Looper
 import android.webkit.CookieManager
 import androidx.webkit.ProfileStore
 import com.duckduckgo.browsermode.api.BrowserMode
-import com.duckduckgo.browsermode.api.BrowserModeStateHolder
 import com.duckduckgo.browsermode.api.FireModeAvailability
 import com.duckduckgo.browsermode.api.profileName
 import com.duckduckgo.cookies.api.CookieManagerProvider
@@ -38,7 +37,6 @@ import javax.inject.Inject
 @SuppressLint("RequiresFeature")
 class DefaultCookieManagerProvider @Inject constructor(
     private val fireModeAvailability: Lazy<FireModeAvailability>,
-    private val browserModeStateHolder: BrowserModeStateHolder,
 ) : CookieManagerProvider {
 
     @Volatile
@@ -46,8 +44,6 @@ class DefaultCookieManagerProvider @Inject constructor(
 
     @Volatile
     private var fireInstance: CookieManager? = null
-
-    override fun forCurrentBrowserMode(): CookieManager? = forMode(browserModeStateHolder.currentMode.value)
 
     override fun forMode(mode: BrowserMode): CookieManager? = when (mode) {
         BrowserMode.REGULAR -> defaultManager()

--- a/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/DefaultCookieManagerProvider.kt
+++ b/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/DefaultCookieManagerProvider.kt
@@ -16,25 +16,57 @@
 
 package com.duckduckgo.cookies.impl
 
+import android.annotation.SuppressLint
+import android.os.Looper
 import android.webkit.CookieManager
+import androidx.webkit.ProfileStore
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.BrowserModeStateHolder
+import com.duckduckgo.browsermode.api.FireModeAvailability
+import com.duckduckgo.browsermode.api.profileName
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
+import dagger.Lazy
 import dagger.SingleInstanceIn
+import logcat.LogPriority
+import logcat.logcat
 import javax.inject.Inject
 
 @ContributesBinding(AppScope::class)
 @SingleInstanceIn(AppScope::class)
-class DefaultCookieManagerProvider @Inject constructor() : CookieManagerProvider {
+@SuppressLint("RequiresFeature")
+class DefaultCookieManagerProvider @Inject constructor(
+    private val fireModeAvailability: Lazy<FireModeAvailability>,
+    private val browserModeStateHolder: BrowserModeStateHolder,
+) : CookieManagerProvider {
 
     @Volatile
-    private var instance: CookieManager? = null
+    private var defaultInstance: CookieManager? = null
 
-    override fun get(): CookieManager? {
-        return runCatching {
-            instance ?: synchronized(this) {
-                instance ?: CookieManager.getInstance().also { instance = it }
-            }
-        }.getOrNull()
+    @Volatile
+    private var fireInstance: CookieManager? = null
+
+    override fun forCurrentBrowserMode(): CookieManager? = forMode(browserModeStateHolder.currentMode.value)
+
+    override fun forMode(mode: BrowserMode): CookieManager? = when (mode) {
+        BrowserMode.REGULAR -> defaultManager()
+        BrowserMode.FIRE -> if (fireModeAvailability.get().isAvailable()) fireManager() else defaultManager()
     }
+
+    private fun fireManager(): CookieManager? {
+        fireInstance?.let { return it }
+        // ProfileStore is @UiThread: off the main thread we can't resolve the Fire profile
+        if (Looper.myLooper() != Looper.getMainLooper()) {
+            logcat(LogPriority.WARN) { "Fire CookieManager requested off the main thread before warm-up; returning null" }
+            return null
+        }
+
+        return runCatching {
+            ProfileStore.getInstance().getOrCreateProfile(BrowserMode.FIRE.profileName).cookieManager
+        }.getOrNull()?.also { fireInstance = it }
+    }
+
+    private fun defaultManager(): CookieManager? =
+        runCatching { defaultInstance ?: CookieManager.getInstance().also { defaultInstance = it } }.getOrNull()
 }

--- a/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/SQLCookieRemover.kt
+++ b/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/SQLCookieRemover.kt
@@ -43,6 +43,7 @@ import kotlin.coroutines.suspendCoroutine
 class CookieManagerRemover @Inject constructor(private val cookieManagerProvider: CookieManagerProvider) : CookieRemover {
     override suspend fun removeCookies(): Boolean {
         suspendCoroutine { continuation ->
+            // Regular mode used here because this is Regular mode-only data-clearing
             cookieManagerProvider.forMode(BrowserMode.REGULAR)?.removeAllCookies {
                 logcat(VERBOSE) { "All cookies removed; restoring DDG cookies" }
                 continuation.resume(Unit)

--- a/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/SQLCookieRemover.kt
+++ b/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/SQLCookieRemover.kt
@@ -22,6 +22,7 @@ import android.database.sqlite.SQLiteDatabase
 import com.duckduckgo.app.fire.DatabaseLocator
 import com.duckduckgo.app.fire.FireproofRepository
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.cookies.api.CookieRemover
@@ -42,7 +43,7 @@ import kotlin.coroutines.suspendCoroutine
 class CookieManagerRemover @Inject constructor(private val cookieManagerProvider: CookieManagerProvider) : CookieRemover {
     override suspend fun removeCookies(): Boolean {
         suspendCoroutine { continuation ->
-            cookieManagerProvider.get()?.removeAllCookies {
+            cookieManagerProvider.forMode(BrowserMode.REGULAR)?.removeAllCookies {
                 logcat(VERBOSE) { "All cookies removed; restoring DDG cookies" }
                 continuation.resume(Unit)
             }

--- a/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/WebViewCookieManager.kt
+++ b/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/WebViewCookieManager.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.cookies.impl
 
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.utils.AppUrl
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.cookies.api.CookieManagerProvider
@@ -51,7 +52,7 @@ class WebViewCookieManager @Inject constructor(
         // These cookies are not stored in a personally identifiable way. For example, the large size setting is stored as 's=l.'
         // More info in https://duckduckgo.com/privacy
         val ddgCookies = getDuckDuckGoCookies()
-        if (cookieManager.get()?.hasCookies() == true) {
+        if (cookieManager.forMode(BrowserMode.REGULAR)?.hasCookies() == true) {
             removeCookies.removeCookies()
             storeDuckDuckGoCookies(ddgCookies)
         }
@@ -72,7 +73,7 @@ class WebViewCookieManager @Inject constructor(
 
     private suspend fun storeCookie(cookie: String, host: String) {
         suspendCoroutine { continuation ->
-            cookieManager.get()?.setCookie(host, cookie) { success ->
+            cookieManager.forMode(BrowserMode.REGULAR)?.setCookie(host, cookie) { success ->
                 logcat(VERBOSE) { "Cookie $cookie stored successfully: $success" }
                 continuation.resume(Unit)
             }
@@ -82,13 +83,13 @@ class WebViewCookieManager @Inject constructor(
     private fun getDuckDuckGoCookies(): Map<String, List<String>> {
         val map = mutableMapOf<String, List<String>>()
         ddgCookieDomains.forEach { host ->
-            map[host] = cookieManager.get()?.getCookie(host)?.split(";").orEmpty()
+            map[host] = cookieManager.forMode(BrowserMode.REGULAR)?.getCookie(host)?.split(";").orEmpty()
         }
         return map
     }
 
     override fun flush() {
-        cookieManager.get()?.flush()
+        cookieManager.forMode(BrowserMode.REGULAR)?.flush()
     }
 
     private val ddgCookieDomains: List<String> = listOf(AppUrl.Url.COOKIES, AppUrl.Url.SURVEY_COOKIES, "https://${duckAiHostProvider.getHost()}")

--- a/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/WebViewCookieManager.kt
+++ b/cookies/cookies-impl/src/main/java/com/duckduckgo/cookies/impl/WebViewCookieManager.kt
@@ -39,6 +39,8 @@ class WebViewCookieManager @Inject constructor(
     private val dispatcher: DispatcherProvider,
     duckAiHostProvider: DuckAiHostProvider,
 ) : DuckDuckGoCookieManager {
+    // Regular mode used here because this is Regular mode-only data-clearing
+    private val browserMode = BrowserMode.REGULAR
 
     override suspend fun removeExternalCookies() {
         withContext(dispatcher.io()) {
@@ -52,7 +54,7 @@ class WebViewCookieManager @Inject constructor(
         // These cookies are not stored in a personally identifiable way. For example, the large size setting is stored as 's=l.'
         // More info in https://duckduckgo.com/privacy
         val ddgCookies = getDuckDuckGoCookies()
-        if (cookieManager.forMode(BrowserMode.REGULAR)?.hasCookies() == true) {
+        if (cookieManager.forMode(browserMode)?.hasCookies() == true) {
             removeCookies.removeCookies()
             storeDuckDuckGoCookies(ddgCookies)
         }
@@ -73,7 +75,7 @@ class WebViewCookieManager @Inject constructor(
 
     private suspend fun storeCookie(cookie: String, host: String) {
         suspendCoroutine { continuation ->
-            cookieManager.forMode(BrowserMode.REGULAR)?.setCookie(host, cookie) { success ->
+            cookieManager.forMode(browserMode)?.setCookie(host, cookie) { success ->
                 logcat(VERBOSE) { "Cookie $cookie stored successfully: $success" }
                 continuation.resume(Unit)
             }
@@ -83,13 +85,13 @@ class WebViewCookieManager @Inject constructor(
     private fun getDuckDuckGoCookies(): Map<String, List<String>> {
         val map = mutableMapOf<String, List<String>>()
         ddgCookieDomains.forEach { host ->
-            map[host] = cookieManager.forMode(BrowserMode.REGULAR)?.getCookie(host)?.split(";").orEmpty()
+            map[host] = cookieManager.forMode(browserMode)?.getCookie(host)?.split(";").orEmpty()
         }
         return map
     }
 
     override fun flush() {
-        cookieManager.forMode(BrowserMode.REGULAR)?.flush()
+        cookieManager.forMode(browserMode)?.flush()
     }
 
     private val ddgCookieDomains: List<String> = listOf(AppUrl.Url.COOKIES, AppUrl.Url.SURVEY_COOKIES, "https://${duckAiHostProvider.getHost()}")

--- a/cookies/cookies-impl/src/test/java/com/duckduckgo/cookies/impl/SetCookieForAllModesTest.kt
+++ b/cookies/cookies-impl/src/test/java/com/duckduckgo/cookies/impl/SetCookieForAllModesTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.cookies.impl
+
+import android.webkit.CookieManager
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.cookies.api.CookieManagerProvider
+import com.duckduckgo.cookies.api.setCookieForAllModes
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class SetCookieForAllModesTest {
+
+    private val regularManager: CookieManager = mock()
+    private val fireManager: CookieManager = mock()
+    private val provider: CookieManagerProvider = mock()
+
+    @Test
+    fun whenEachModeHasADistinctManagerThenEachIsWrittenAndFlushedOnce() {
+        whenever(provider.forMode(BrowserMode.REGULAR)).thenReturn(regularManager)
+        whenever(provider.forMode(BrowserMode.FIRE)).thenReturn(fireManager)
+
+        provider.setCookieForAllModes(URL, COOKIE)
+
+        verify(regularManager).setCookie(URL, COOKIE)
+        verify(regularManager).flush()
+        verify(fireManager).setCookie(URL, COOKIE)
+        verify(fireManager).flush()
+    }
+
+    @Test
+    fun whenAllModesResolveToTheSameManagerThenItIsWrittenAndFlushedOnce() {
+        // Fire unavailable / cold off-main: forMode(FIRE) == forMode(REGULAR), so distinct() must collapse to one write.
+        whenever(provider.forMode(any())).thenReturn(regularManager)
+
+        provider.setCookieForAllModes(URL, COOKIE)
+
+        verify(regularManager, times(1)).setCookie(URL, COOKIE)
+        verify(regularManager, times(1)).flush()
+    }
+
+    @Test
+    fun whenAModeResolvesToNullThenItIsSkippedAndTheRestAreStillWritten() {
+        whenever(provider.forMode(BrowserMode.REGULAR)).thenReturn(regularManager)
+        whenever(provider.forMode(BrowserMode.FIRE)).thenReturn(null)
+
+        provider.setCookieForAllModes(URL, COOKIE)
+
+        verify(regularManager).setCookie(URL, COOKIE)
+        verify(regularManager).flush()
+        verify(fireManager, never()).setCookie(any(), any())
+    }
+
+    companion object {
+        private const val URL = "https://example.com"
+        private const val COOKIE = "name=value"
+    }
+}

--- a/cookies/cookies-impl/src/test/java/com/duckduckgo/cookies/impl/WebViewCookieManagerTest.kt
+++ b/cookies/cookies-impl/src/test/java/com/duckduckgo/cookies/impl/WebViewCookieManagerTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.cookies.impl
 
 import android.webkit.CookieManager
 import android.webkit.ValueCallback
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.cookies.api.RemoveCookiesStrategy
@@ -54,7 +55,7 @@ class WebViewCookieManagerTest {
 
     @Before
     fun setup() {
-        whenever(cookieManagerProvider.get()).thenReturn(cookieManager)
+        whenever(cookieManagerProvider.forMode(BrowserMode.REGULAR)).thenReturn(cookieManager)
         whenever(cookieManager.setCookie(any(), any(), any())).then {
             (it.getArgument(2) as ValueCallback<Boolean>).onReceiveValue(true)
         }

--- a/downloads/downloads-api/build.gradle
+++ b/downloads/downloads-api/build.gradle
@@ -23,6 +23,7 @@ apply from: "$rootProject.projectDir/gradle/android-library.gradle"
 
 dependencies {
     implementation project(':navigation-api')
+    implementation project(':browser-mode-api')
     implementation KotlinX.coroutines.core
     implementation Google.android.material
 }

--- a/downloads/downloads-api/src/main/java/com/duckduckgo/downloads/api/FileDownloader.kt
+++ b/downloads/downloads-api/src/main/java/com/duckduckgo/downloads/api/FileDownloader.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.downloads.api
 
 import android.os.Environment
 import androidx.annotation.AnyThread
+import com.duckduckgo.browsermode.api.BrowserMode
 import java.io.File
 import java.io.Serializable
 
@@ -37,5 +38,6 @@ interface FileDownloader {
         val directory: File = Environment.getExternalStoragePublicDirectory(subfolder),
         val isUrlCompressed: Boolean = false,
         val fileName: String? = null,
+        val browserMode: BrowserMode,
     ) : Serializable
 }

--- a/downloads/downloads-impl/build.gradle
+++ b/downloads/downloads-impl/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     implementation project(path: ':downloads-store')
     implementation project(path: ':data-store-api')
     implementation project(path: ':cookies-api')
+    implementation project(path: ':browser-mode-api')
 
     implementation AndroidX.dataStore.preferences
     implementation AndroidX.core.ktx

--- a/downloads/downloads-impl/build.gradle
+++ b/downloads/downloads-impl/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     implementation project(path: ':app-build-config-api')
     implementation project(path: ':downloads-store')
     implementation project(path: ':data-store-api')
+    implementation project(path: ':cookies-api')
 
     implementation AndroidX.dataStore.preferences
     implementation AndroidX.core.ktx

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/CookieManagerWrapper.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/CookieManagerWrapper.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.downloads.impl
 
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
@@ -24,17 +25,16 @@ import javax.inject.Inject
 // This class is basically a convenience wrapper for easier testing
 interface CookieManagerWrapper {
     /**
-     * @return the cookie stored for the given [url] in the active browser mode's cookie store, or
-     * null if none.
+     * @return the cookie stored for the given [url] in [browserMode]'s cookie store, or null if none.
      */
-    fun getCookie(url: String): String?
+    fun getCookie(url: String, browserMode: BrowserMode): String?
 }
 
 @ContributesBinding(AppScope::class)
 class CookieManagerWrapperImpl @Inject constructor(
     private val cookieManagerProvider: CookieManagerProvider,
 ) : CookieManagerWrapper {
-    override fun getCookie(url: String): String? {
-        return cookieManagerProvider.forCurrentBrowserMode()?.getCookie(url)
+    override fun getCookie(url: String, browserMode: BrowserMode): String? {
+        return cookieManagerProvider.forMode(browserMode)?.getCookie(url)
     }
 }

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/CookieManagerWrapper.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/CookieManagerWrapper.kt
@@ -16,7 +16,7 @@
 
 package com.duckduckgo.downloads.impl
 
-import android.webkit.CookieManager
+import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import javax.inject.Inject
@@ -24,14 +24,17 @@ import javax.inject.Inject
 // This class is basically a convenience wrapper for easier testing
 interface CookieManagerWrapper {
     /**
-     * @return the cookie stored for the given [url] if any, null otherwise
+     * @return the cookie stored for the given [url] in the active browser mode's cookie store, or
+     * null if none.
      */
     fun getCookie(url: String): String?
 }
 
 @ContributesBinding(AppScope::class)
-class CookieManagerWrapperImpl @Inject constructor() : CookieManagerWrapper {
+class CookieManagerWrapperImpl @Inject constructor(
+    private val cookieManagerProvider: CookieManagerProvider,
+) : CookieManagerWrapper {
     override fun getCookie(url: String): String? {
-        return CookieManager.getInstance().getCookie(url)
+        return cookieManagerProvider.forCurrentBrowserMode()?.getCookie(url)
     }
 }

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/CookieManagerWrapper.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/CookieManagerWrapper.kt
@@ -17,9 +17,11 @@
 package com.duckduckgo.downloads.impl
 
 import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
 // This class is basically a convenience wrapper for easier testing
@@ -33,8 +35,13 @@ interface CookieManagerWrapper {
 @ContributesBinding(AppScope::class)
 class CookieManagerWrapperImpl @Inject constructor(
     private val cookieManagerProvider: CookieManagerProvider,
+    private val dispatcherProvider: DispatcherProvider,
 ) : CookieManagerWrapper {
     override fun getCookie(url: String, browserMode: BrowserMode): String? {
-        return cookieManagerProvider.forMode(browserMode)?.getCookie(url)
+        // Downloads run on a worker thread; the Fire manager (ProfileStore-backed, @UiThread) resolves
+        // to null off-main until warmed, so fall back to the main thread only in that cold case.
+        val cookieManager = cookieManagerProvider.forMode(browserMode)
+            ?: runBlocking(dispatcherProvider.main()) { cookieManagerProvider.forMode(browserMode) }
+        return cookieManager?.getCookie(url)
     }
 }

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/FileDownloadNotificationActionReceiver.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/FileDownloadNotificationActionReceiver.kt
@@ -26,6 +26,7 @@ import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.extensions.registerNotExportedReceiver
 import com.duckduckgo.di.scopes.AppScope
@@ -99,6 +100,8 @@ class FileDownloadNotificationActionReceiver @Inject constructor(
                 val pendingDownload = PendingFileDownload(
                     url = url,
                     subfolder = Environment.DIRECTORY_DOWNLOADS,
+                    // an app-level action with no live browsing session uses the Regular mode jar
+                    browserMode = BrowserMode.REGULAR,
                 )
                 logcat { "Retrying download for $url" }
                 downloadsRepository.delete(downloadId)

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/FileDownloadWorker.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/FileDownloadWorker.kt
@@ -24,6 +24,7 @@ import androidx.work.Data
 import androidx.work.Data.MAX_DATA_BYTES
 import androidx.work.WorkerParameters
 import com.duckduckgo.anvil.annotations.ContributesWorker
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.downloads.api.DownloadFailReason
@@ -67,6 +68,7 @@ private const val CONTENT_DISPOSITION = "CONTENT_DISPOSITION"
 private const val MIME_TYPE = "MIME_TYPE"
 private const val SUBFOLDER = "SUBFOLDER"
 private const val DIRECTORY = "DIRECTORY"
+private const val BROWSER_MODE = "BROWSER_MODE"
 
 @VisibleForTesting
 internal const val IS_URL_COMPRESSED = "IS_URL_COMPRESSED"
@@ -82,6 +84,7 @@ fun FileDownloader.PendingFileDownload.toInputData(): Data {
         .putString(SUBFOLDER, subfolder)
         .putString(DIRECTORY, directory.absolutePath)
         .putBoolean(IS_URL_COMPRESSED, urlTooLarge)
+        .putString(BROWSER_MODE, browserMode.name)
         .build()
 }
 
@@ -95,6 +98,7 @@ fun Data.toPendingFileDownload(): FileDownloader.PendingFileDownload {
         subfolder = getString(SUBFOLDER)!!,
         directory = File(getString(DIRECTORY)!!),
         isUrlCompressed = false,
+        browserMode = getString(BROWSER_MODE)?.let { BrowserMode.valueOf(it) } ?: BrowserMode.REGULAR,
     )
 }
 

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/UrlFileDownloader.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/UrlFileDownloader.kt
@@ -52,7 +52,7 @@ class UrlFileDownloader @Inject constructor(
         val directory = pendingFileDownload.directory
         val call = downloadFileService.downloadFile(
             urlString = url,
-            cookie = cookieManagerWrapper.getCookie(url).handleNull(),
+            cookie = cookieManagerWrapper.getCookie(url, pendingFileDownload.browserMode).handleNull(),
         )
         val downloadId = Random.nextLong()
         urlFileDownloadCallManager.add(downloadId, call)

--- a/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/CookieManagerWrapperImplTest.kt
+++ b/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/CookieManagerWrapperImplTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.downloads.impl
+
+import android.webkit.CookieManager
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.cookies.api.CookieManagerProvider
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.asCoroutineDispatcher
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.util.concurrent.Executors
+
+class CookieManagerWrapperImplTest {
+
+    private val mainExecutor = Executors.newSingleThreadExecutor { r -> Thread(r, "cmw-test-main") }
+    private val ioExecutor = Executors.newSingleThreadExecutor { r -> Thread(r, "cmw-test-io") }
+
+    private val mockCookieManager: CookieManager = mock<CookieManager>().apply {
+        whenever(getCookie(URL)).thenReturn("session=abc123")
+    }
+
+    // Mirrors DefaultCookieManagerProvider: the Fire CookieManager can only be resolved on the main
+    // thread and returns null off it.
+    private val mainThreadOnlyProvider = object : CookieManagerProvider {
+        override fun forMode(mode: BrowserMode): CookieManager? =
+            if (Thread.currentThread().name.contains("cmw-test-main")) mockCookieManager else null
+    }
+
+    private val dispatchers = object : DispatcherProvider {
+        override fun io(): CoroutineDispatcher = ioExecutor.asCoroutineDispatcher()
+        override fun main(): CoroutineDispatcher = mainExecutor.asCoroutineDispatcher()
+        override fun computation(): CoroutineDispatcher = ioExecutor.asCoroutineDispatcher()
+        override fun unconfined(): CoroutineDispatcher = ioExecutor.asCoroutineDispatcher()
+    }
+
+    private val wrapper = CookieManagerWrapperImpl(mainThreadOnlyProvider, dispatchers)
+
+    @After
+    fun tearDown() {
+        mainExecutor.shutdown()
+        ioExecutor.shutdown()
+    }
+
+    @Test
+    fun whenCookieResolvableOnlyOnMainThreadThenGetCookieCalledFromWorkerThreadStillReturnsCookie() {
+        // Downloads run on a worker thread; resolving the Fire CookieManager there would otherwise miss it.
+        val result = ioExecutor.submit<String?> { wrapper.getCookie(URL, BrowserMode.FIRE) }.get()
+
+        assertEquals("session=abc123", result)
+    }
+
+    companion object {
+        private const val URL = "https://example.com/file.txt"
+    }
+}

--- a/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/DataUriDownloaderTest.kt
+++ b/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/DataUriDownloaderTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.downloads.impl
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.downloads.api.DownloadFailReason
 import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
 import com.duckduckgo.downloads.impl.DataUriParser.GeneratedFilename
@@ -149,6 +150,7 @@ class DataUriDownloaderTest {
             url = url,
             subfolder = "Downloads",
             directory = temporaryFolder.newFolder("downloads_${folderCounter++}"),
+            browserMode = BrowserMode.REGULAR,
         )
     }
 }

--- a/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/PendingDownloadStoreTest.kt
+++ b/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/PendingDownloadStoreTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.downloads.impl
 
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
@@ -31,6 +32,7 @@ class PendingDownloadStoreTest {
         url = url,
         subfolder = "Downloads",
         directory = File("/tmp"),
+        browserMode = BrowserMode.REGULAR,
     )
 
     private fun putAndTrack(download: PendingFileDownload): String {

--- a/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/PendingFileDownloadCompressTest.kt
+++ b/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/PendingFileDownloadCompressTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.downloads.impl
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.downloads.api.FileDownloader
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -95,6 +96,7 @@ class PendingFileDownloadCompressTest {
             mimeType = "image/png",
             subfolder = "folder",
             directory = File("directory"),
+            browserMode = BrowserMode.REGULAR,
         )
     }
 }

--- a/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/UriUtilsFilenameExtractorTest.kt
+++ b/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/UriUtilsFilenameExtractorTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.downloads.impl
 import android.webkit.MimeTypeMap
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.downloads.api.FileDownloader.PendingFileDownload
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -292,6 +293,7 @@ class UriUtilsFilenameExtractorTest {
             contentDisposition = contentDisposition,
             mimeType = mimeType,
             subfolder = "aFolder",
+            browserMode = BrowserMode.REGULAR,
         )
     }
 }

--- a/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/UrlFileDownloaderTest.kt
+++ b/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/UrlFileDownloaderTest.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.downloads.impl
 
 import android.annotation.SuppressLint
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.downloads.api.DownloadFailReason
 import com.duckduckgo.downloads.api.FileDownloader
@@ -244,11 +245,12 @@ class UrlFileDownloaderTest {
             mimeType = mimeType,
             subfolder = "folder",
             directory = File("directory"),
+            browserMode = BrowserMode.REGULAR,
         )
     }
 
     private class FakeCookieManagerWrapper(private val cookie: String? = null) : CookieManagerWrapper {
-        override fun getCookie(url: String): String? {
+        override fun getCookie(url: String, browserMode: BrowserMode): String? {
             return cookie
         }
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.app.di.IsMainProcess
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.utils.AppUrl
 import com.duckduckgo.common.utils.AppUrl.ParamKey.QUERY
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -799,7 +800,7 @@ class RealDuckChat @Inject constructor(
     override suspend fun wasOpenedBefore(): Boolean = duckChatFeatureRepository.wasOpenedBefore()
 
     override suspend fun isStandaloneMigrationCompleted(): Boolean {
-        val cookieManager = cookiesManager.get()
+        val cookieManager = cookiesManager.forMode(BrowserMode.REGULAR)
         val ddgCookies = cookieManager?.getCookie(AppUrl.Url.COOKIES)?.split(";").orEmpty()
         val isMigrationCompleted = ddgCookies.contains("migration_status_dev_01=migrated_dev_01")
         return isMigrationCompleted

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -1017,6 +1017,7 @@ class DuckChatContextualFragment :
             mimeType = mimeType,
             subfolder = Environment.DIRECTORY_DOWNLOADS,
             fileName = "duck.ai_${System.currentTimeMillis()}",
+            browserMode = browserMode,
         )
 
         if (hasWriteStoragePermission()) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -72,6 +72,7 @@ import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.FragmentViewModelFactory
 import com.duckduckgo.common.utils.extensions.hideKeyboard
+import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.downloads.api.DOWNLOAD_SNACKBAR_DELAY
 import com.duckduckgo.downloads.api.DOWNLOAD_SNACKBAR_LENGTH
@@ -110,6 +111,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import logcat.LogPriority.WARN
 import logcat.logcat
 import org.json.JSONObject
 import java.io.File
@@ -199,7 +201,10 @@ class DuckChatContextualFragment :
     @Inject
     lateinit var browserMode: BrowserMode
 
-    private val cookieManager: CookieManager by lazy { CookieManager.getInstance() }
+    @Inject
+    lateinit var cookieManagerProvider: CookieManagerProvider
+
+    private val cookieManager: CookieManager? by lazy { cookieManagerProvider.forMode(browserMode) }
 
     private var pendingFileDownload: FileDownloader.PendingFileDownload? = null
     private val downloadMessagesJob = ConflatedJob()
@@ -263,12 +268,16 @@ class DuckChatContextualFragment :
     ) {
         super.onViewCreated(view, savedInstanceState)
 
-        // Explicitly enable cookies for this WebView
-        cookieManager.setAcceptCookie(true)
-        cookieManager.setAcceptThirdPartyCookies(simpleWebview, true)
-
         simpleWebview.let {
-            webViewModeInitializer.bind(it, browserMode)
+            webViewModeInitializer.bind(it, browserMode).onFailure { throwable ->
+                logcat(WARN) { "Duck.ai WebView profile bind failed for $browserMode: ${throwable.message}" }
+            }
+
+            // Explicitly enable cookies for this tab's profile
+            cookieManager?.apply {
+                setAcceptCookie(true)
+                setAcceptThirdPartyCookies(it, true)
+            }
 
             it.webViewClient = webViewClient
             webViewClient
@@ -1075,7 +1084,7 @@ class DuckChatContextualFragment :
         downloadMessagesJob.cancel()
         simpleWebview.onPause()
         appCoroutineScope.launch(dispatcherProvider.io()) {
-            cookieManager.flush()
+            cookieManager?.flush()
         }
         super.onPause()
     }
@@ -1090,7 +1099,7 @@ class DuckChatContextualFragment :
         binding.root.viewTreeObserver.removeOnGlobalLayoutListener(keyboardVisibilityListener)
         super.onDestroyView()
         appCoroutineScope.launch(dispatcherProvider.io()) {
-            cookieManager.flush()
+            cookieManager?.flush()
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryReader.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryReader.kt
@@ -23,7 +23,10 @@ import android.webkit.WebSettings
 import android.webkit.WebView
 import com.duckduckgo.app.di.ActivityContext
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.WebViewModeInitializer
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper
 import com.duckduckgo.duckchat.impl.ui.DuckChatWebViewClient
@@ -37,6 +40,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
+import logcat.LogPriority.WARN
 import logcat.logcat
 import org.json.JSONObject
 import javax.inject.Inject
@@ -57,8 +61,11 @@ class RealChatHistoryReader @Inject constructor(
     @Named("ContentScopeScripts") private val contentScopeScripts: JsMessaging,
     private val duckChatWebViewClient: DuckChatWebViewClient,
     private val duckChatJSHelper: DuckChatJSHelper,
+    private val cookieManagerProvider: CookieManagerProvider,
+    private val webViewModeInitializer: WebViewModeInitializer,
+    private val browserMode: BrowserMode,
 ) : ChatHistoryReader {
-    private val cookieManager: CookieManager by lazy { CookieManager.getInstance() }
+    private val cookieManager: CookieManager? by lazy { cookieManagerProvider.forMode(browserMode) }
 
     private var webView: WebView? = null
     private var pageLoadDeferred: CompletableDeferred<Unit>? = null
@@ -95,7 +102,11 @@ class RealChatHistoryReader @Inject constructor(
     private fun getOrCreateWebView(): WebView {
         webView?.let { return it }
 
-        val wv = WebView(context).apply {
+        val wv = WebView(context)
+        webViewModeInitializer.bind(wv, browserMode).onFailure {
+            logcat(WARN) { "ChatHistoryReader: WebView profile bind failed for $browserMode: ${it.message}" }
+        }
+        wv.apply {
             settings.apply {
                 userAgentString = CUSTOM_UA
                 javaScriptEnabled = true
@@ -105,9 +116,6 @@ class RealChatHistoryReader @Inject constructor(
                 mixedContentMode = WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
                 cacheMode = WebSettings.LOAD_DEFAULT
             }
-
-            cookieManager.setAcceptCookie(true)
-            cookieManager.setAcceptThirdPartyCookies(this, true)
 
             duckChatWebViewClient.onPageFinishedListener = { url ->
                 logcat { "ChatHistoryReader: onPageFinished $url" }
@@ -131,6 +139,10 @@ class RealChatHistoryReader @Inject constructor(
                 },
             )
         }
+        cookieManager?.apply {
+            setAcceptCookie(true)
+            setAcceptThirdPartyCookies(wv, true)
+        }
 
         webView = wv
         return wv
@@ -138,7 +150,7 @@ class RealChatHistoryReader @Inject constructor(
 
     private fun handleDuckChatMessage(featureName: String, method: String, id: String?, data: JSONObject?) {
         appCoroutineScope.launch(dispatchers.io()) {
-            duckChatJSHelper.processJsCallbackMessage(featureName, method, id, data)?.let { response ->
+            duckChatJSHelper.processJsCallbackMessage(featureName, method, id, data, browserMode = browserMode)?.let { response ->
                 withContext(dispatchers.main()) {
                     contentScopeScripts.onResponse(response)
                 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatWebViewFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatWebViewFragment.kt
@@ -59,6 +59,7 @@ import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.FragmentViewModelFactory
+import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.downloads.api.DOWNLOAD_SNACKBAR_DELAY
 import com.duckduckgo.downloads.api.DOWNLOAD_SNACKBAR_LENGTH
@@ -104,6 +105,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import logcat.LogPriority.WARN
 import logcat.logcat
 import org.json.JSONObject
 import java.io.File
@@ -185,7 +187,10 @@ open class DuckChatWebViewFragment : DuckDuckGoFragment(R.layout.activity_duck_c
     @Inject
     lateinit var browserMode: BrowserMode
 
-    private val cookieManager: CookieManager by lazy { CookieManager.getInstance() }
+    @Inject
+    lateinit var cookieManagerProvider: CookieManagerProvider
+
+    private val cookieManager: CookieManager? by lazy { cookieManagerProvider.forMode(browserMode) }
 
     private var pendingFileDownload: PendingFileDownload? = null
 
@@ -208,12 +213,16 @@ open class DuckChatWebViewFragment : DuckDuckGoFragment(R.layout.activity_duck_c
 
         val url = arguments?.getString(KEY_DUCK_AI_URL) ?: "https://duckduckgo.com/?q=DuckDuckGo+AI+Chat&ia=chat&duckai=5"
 
-        // Explicitly enable cookies for this WebView
-        cookieManager.setAcceptCookie(true)
-        cookieManager.setAcceptThirdPartyCookies(simpleWebview, true)
-
         simpleWebview.let {
-            webViewModeInitializer.bind(it, browserMode)
+            webViewModeInitializer.bind(it, browserMode).onFailure { throwable ->
+                logcat(WARN) { "Duck.ai WebView profile bind failed for $browserMode: ${throwable.message}" }
+            }
+
+            // Explicitly enable cookies for this tab's profile
+            cookieManager?.apply {
+                setAcceptCookie(true)
+                setAcceptThirdPartyCookies(it, true)
+            }
 
             it.webViewClient = webViewClient
             it.webChromeClient = object : WebChromeClient() {
@@ -740,7 +749,7 @@ open class DuckChatWebViewFragment : DuckDuckGoFragment(R.layout.activity_duck_c
         downloadMessagesJob.cancel()
         simpleWebview.onPause()
         appCoroutineScope.launch(dispatcherProvider.io()) {
-            cookieManager.flush()
+            cookieManager?.flush()
         }
         super.onPause()
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatWebViewFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/DuckChatWebViewFragment.kt
@@ -683,6 +683,7 @@ open class DuckChatWebViewFragment : DuckDuckGoFragment(R.layout.activity_duck_c
             mimeType = mimeType,
             subfolder = Environment.DIRECTORY_DOWNLOADS,
             fileName = "duck.ai_${System.currentTimeMillis()}",
+            browserMode = browserMode,
         )
 
         if (hasWriteStoragePermission()) {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -29,6 +29,7 @@ import app.cash.turbine.test
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.BrowserNav
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.AppUrl
 import com.duckduckgo.cookies.api.CookieManagerProvider
@@ -1554,7 +1555,7 @@ class RealDuckChatTest {
     @Test
     fun `when migration cookie present and kill switch enabled then isDuckChatContextualModeEnabled returns true`() = runTest {
         val cookieManager = mock<CookieManager>()
-        whenever(cookiesManager.get()).thenReturn(cookieManager)
+        whenever(cookiesManager.forMode(BrowserMode.REGULAR)).thenReturn(cookieManager)
         whenever(cookieManager.getCookie(AppUrl.Url.COOKIES)).thenReturn("migration_status_dev_01=migrated_dev_01")
         duckChatFeature.contextualMode().setRawStoredState(State(enable = false))
         duckChatFeature.contextualModeKillSwitch().setRawStoredState(State(enable = true))
@@ -1567,7 +1568,7 @@ class RealDuckChatTest {
     @Test
     fun `when migration cookie present then isStandaloneMigrationCompleted returns true`() = runTest {
         val cookieManager = mock<CookieManager>()
-        whenever(cookiesManager.get()).thenReturn(cookieManager)
+        whenever(cookiesManager.forMode(BrowserMode.REGULAR)).thenReturn(cookieManager)
         whenever(cookieManager.getCookie(AppUrl.Url.COOKIES)).thenReturn("a=b;migration_status_dev_01=migrated_dev_01;c=d")
 
         assertTrue(testee.isStandaloneMigrationCompleted())
@@ -1576,7 +1577,7 @@ class RealDuckChatTest {
     @Test
     fun `when migration cookie missing then isStandaloneMigrationCompleted returns false`() = runTest {
         val cookieManager = mock<CookieManager>()
-        whenever(cookiesManager.get()).thenReturn(cookieManager)
+        whenever(cookiesManager.forMode(BrowserMode.REGULAR)).thenReturn(cookieManager)
         whenever(cookieManager.getCookie(AppUrl.Url.COOKIES)).thenReturn("a=b; c=d")
 
         assertFalse(testee.isStandaloneMigrationCompleted())
@@ -1584,7 +1585,7 @@ class RealDuckChatTest {
 
     @Test
     fun `when cookie manager is null then isStandaloneMigrationCompleted returns false`() = runTest {
-        whenever(cookiesManager.get()).thenReturn(null)
+        whenever(cookiesManager.forMode(BrowserMode.REGULAR)).thenReturn(null)
 
         assertFalse(testee.isStandaloneMigrationCompleted())
     }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryReaderTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/history/ChatHistoryReaderTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.history
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.browsermode.api.BrowserMode
+import com.duckduckgo.browsermode.api.WebViewModeInitializer
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.cookies.api.CookieManagerProvider
+import com.duckduckgo.duckchat.impl.helper.DuckChatJSHelper
+import com.duckduckgo.duckchat.impl.ui.DuckChatWebViewClient
+import com.duckduckgo.js.messaging.api.JsMessageCallback
+import com.duckduckgo.js.messaging.api.JsMessaging
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.json.JSONObject
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyBlocking
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(AndroidJUnit4::class)
+class ChatHistoryReaderTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val contentScopeScripts: JsMessaging = mock()
+    private val duckChatWebViewClient: DuckChatWebViewClient = mock()
+    private val duckChatJSHelper: DuckChatJSHelper = mock()
+    private val cookieManagerProvider: CookieManagerProvider = mock()
+    private val webViewModeInitializer: WebViewModeInitializer = mock()
+
+    private fun createTestee(browserMode: BrowserMode) = RealChatHistoryReader(
+        context,
+        coroutineRule.testDispatcherProvider,
+        coroutineRule.testScope,
+        contentScopeScripts,
+        duckChatWebViewClient,
+        duckChatJSHelper,
+        cookieManagerProvider,
+        webViewModeInitializer,
+        browserMode,
+    )
+
+    @Before
+    fun setup() {
+        whenever(webViewModeInitializer.bind(any(), any())).thenReturn(Result.success(Unit))
+    }
+
+    @Test
+    fun whenInFireModeThenForwardsFireBrowserModeToTheJsHelper() {
+        verifyReaderForwardsItsBrowserMode(BrowserMode.FIRE)
+    }
+
+    @Test
+    fun whenInRegularModeThenForwardsRegularBrowserModeToTheJsHelper() {
+        verifyReaderForwardsItsBrowserMode(BrowserMode.REGULAR)
+    }
+
+    // refresh() builds the headless WebView and registers the content-scope-scripts bridge callback. Drive
+    // everything from plain test code via the rule's scheduler (so advanceUntilIdle can drain the reader's
+    // launched forwarding coroutine), then assert the reader forwards its own browser mode to the JS helper.
+    private fun verifyReaderForwardsItsBrowserMode(mode: BrowserMode) {
+        val testee = createTestee(mode)
+
+        coroutineRule.testScope.launch { testee.refresh() }
+        coroutineRule.testScope.advanceUntilIdle()
+
+        val callbackCaptor = argumentCaptor<JsMessageCallback>()
+        verify(contentScopeScripts).register(any(), callbackCaptor.capture())
+        callbackCaptor.firstValue!!.process(FEATURE, METHOD, ID, JSONObject())
+        coroutineRule.testScope.advanceUntilIdle()
+
+        verifyBlocking(duckChatJSHelper) {
+            processJsCallbackMessage(eq(FEATURE), eq(METHOD), eq(ID), anyOrNull(), any(), any(), any(), eq(mode))
+        }
+    }
+
+    companion object {
+        private const val FEATURE = "aiChat"
+        private const val METHOD = "someMethod"
+        private const val ID = "someId"
+    }
+}

--- a/network-protection/network-protection-impl/build.gradle
+++ b/network-protection/network-protection-impl/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     implementation project(':anvil-annotations')
     implementation project(':app-build-config-api')
     implementation project(':browser-api')
+    implementation project(':browser-mode-api')
+    implementation project(':cookies-api')
     implementation project(':common-utils')
     implementation project(':design-system')
     implementation project(':di')

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/reddit/RedditBlockWorkaround.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/reddit/RedditBlockWorkaround.kt
@@ -16,13 +16,13 @@
 
 package com.duckduckgo.networkprotection.impl.reddit
 
+import android.webkit.CookieManager
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.cookies.api.CookieManagerProvider
-import com.duckduckgo.cookies.api.setCookieForAllModes
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.networkprotection.api.NetworkProtectionState
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -59,56 +59,75 @@ class RedditBlockWorkaround @Inject constructor(
     }
 
     private suspend fun addRedditEmptyCookie() {
-        runCatching {
-            val redditCookies = cookieManager.getCookie(HTTPS_WWW_REDDIT_COM) ?: ""
-            val redditSessionCookies = redditCookies.split(";").filter { it.contains("reddit_session") }
-            if (networkProtectionState.isEnabled() && redditSessionCookies.isEmpty()) {
+        // Decide per jar: each mode's session is read and mutated in isolation, so a logged-out
+        // profile can't clobber a real reddit_session living in another profile (e.g. Fire).
+        val vpnEnabled = networkProtectionState.isEnabled()
+        forEachResolvedProfile { jar ->
+            val redditSessionCookies = jar.redditSessionCookies()
+            if (vpnEnabled && redditSessionCookies.isEmpty()) {
                 // if the VPN is enabled and there's no reddit_session cookie we just add a fake one
                 // when the user logs into reddit, the fake reddit_session cookie is replaced automatically by the correct one
                 // when the user logs out, the reddit_session cookie is cleared
-                setCookieOnAllProfiles(HTTPS_WWW_REDDIT_COM, REDDIT_SESSION_)
+                jar.setCookie(HTTPS_WWW_REDDIT_COM, REDDIT_SESSION_)
             } else {
-                removeRedditEmptyCookie()
+                jar.expireDummyIfPresent()
+            }
+        }
+    }
+
+    private suspend fun removeRedditEmptyCookie() {
+        forEachResolvedProfile { jar ->
+            jar.expireDummyIfPresent()
+        }
+    }
+
+    private suspend fun forEachResolvedProfile(action: (CookieJar) -> Unit) {
+        runCatching {
+            withContext(dispatcherProvider.io()) {
+                cookieManager.resolvedProfiles().forEach(action)
             }
         }.onFailure {
             logcat { "Reddit workaround error: ${it.asLog()}" }
         }
     }
 
-    private suspend fun removeRedditEmptyCookie() {
-        runCatching {
-            if (cookieManager.containsRedditDummyCookie()) {
-                setCookieOnAllProfiles(HTTPS_WWW_REDDIT_COM, REDDIT_SESSION_EXPIRED_)
-            }
+    private fun CookieJar.expireDummyIfPresent() {
+        if (containsRedditDummyCookie()) {
+            setCookie(HTTPS_WWW_REDDIT_COM, REDDIT_SESSION_EXPIRED_)
         }
     }
 
-    // Apply the workaround to every already-resolved browser-mode cookie jar
-    private suspend fun setCookieOnAllProfiles(url: String, cookieString: String) {
-        withContext(dispatcherProvider.io()) {
-            cookieManager.setCookieOnAllProfiles(url, cookieString)
-        }
+    private fun CookieJar.redditSessionCookies(): List<String> {
+        val redditCookies = getCookie(HTTPS_WWW_REDDIT_COM) ?: ""
+        return redditCookies.split(";").filter { it.contains("reddit_session") }
     }
 
-    private fun CookieManagerWrapper.containsRedditDummyCookie(): Boolean {
-        val redditCookies = this.getCookie(HTTPS_WWW_REDDIT_COM) ?: ""
-        val redditSessionCookies = redditCookies.split(";").filter { it.contains("reddit_session") }
-        return redditSessionCookies.firstOrNull()?.split("=")?.lastOrNull()?.isEmpty() == true
+    private fun CookieJar.containsRedditDummyCookie(): Boolean {
+        return redditSessionCookies().firstOrNull()?.split("=")?.lastOrNull()?.isEmpty() == true
     }
 }
 
 // This class is basically a convenience wrapper for easier testing
 interface CookieManagerWrapper {
     /**
-     * @return the cookie stored for the given [url] if any, null otherwise
+     * Returns a handle for each already-resolved browser-mode cookie jar (the default profile plus
+     * any non-default profiles). Jars that can't be resolved on the current thread are omitted, and
+     * browser modes that share a jar collapse to a single entry.
+     */
+    fun resolvedProfiles(): List<CookieJar>
+}
+
+// A single browser-mode cookie jar.
+interface CookieJar {
+    /**
+     * @return the cookie stored for the given [url] in this jar if any, null otherwise
      */
     fun getCookie(url: String): String?
 
     /**
-     * Sets the given [cookieString] for the given [url] on every browser mode's cookie jar (the
-     * default profile plus any non-default profiles).
+     * Sets the given [cookieString] for the given [url] in this jar, flushing it.
      */
-    fun setCookieOnAllProfiles(url: String, cookieString: String)
+    fun setCookie(url: String, cookieString: String)
 }
 
 @Retention(AnnotationRetention.BINARY)
@@ -128,11 +147,19 @@ private class CookieManagerWrapperImpl constructor(
     private val cookieManagerProvider: CookieManagerProvider,
 ) : CookieManagerWrapper {
 
-    override fun getCookie(url: String): String? {
-        return cookieManagerProvider.forMode(BrowserMode.REGULAR)?.getCookie(url)
+    override fun resolvedProfiles(): List<CookieJar> {
+        return BrowserMode.entries
+            .mapNotNull { cookieManagerProvider.forMode(it) }
+            .distinct()
+            .map { RealCookieJar(it) }
     }
+}
 
-    override fun setCookieOnAllProfiles(url: String, cookieString: String) {
-        cookieManagerProvider.setCookieForAllModes(url, cookieString)
+private class RealCookieJar(private val cookieManager: CookieManager) : CookieJar {
+    override fun getCookie(url: String): String? = cookieManager.getCookie(url)
+
+    override fun setCookie(url: String, cookieString: String) {
+        cookieManager.setCookie(url, cookieString)
+        cookieManager.flush()
     }
 }

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/reddit/RedditBlockWorkaround.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/reddit/RedditBlockWorkaround.kt
@@ -16,11 +16,13 @@
 
 package com.duckduckgo.networkprotection.impl.reddit
 
-import android.webkit.CookieManager
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.cookies.api.CookieManagerProvider
+import com.duckduckgo.cookies.api.setCookieForAllModes
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.networkprotection.api.NetworkProtectionState
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -28,6 +30,7 @@ import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import logcat.asLog
 import logcat.logcat
 import javax.inject.Inject
@@ -63,7 +66,7 @@ class RedditBlockWorkaround @Inject constructor(
                 // if the VPN is enabled and there's no reddit_session cookie we just add a fake one
                 // when the user logs into reddit, the fake reddit_session cookie is replaced automatically by the correct one
                 // when the user logs out, the reddit_session cookie is cleared
-                cookieManager.setCookie(HTTPS_WWW_REDDIT_COM, REDDIT_SESSION_)
+                setCookieOnAllProfiles(HTTPS_WWW_REDDIT_COM, REDDIT_SESSION_)
             } else {
                 removeRedditEmptyCookie()
             }
@@ -72,11 +75,18 @@ class RedditBlockWorkaround @Inject constructor(
         }
     }
 
-    private fun removeRedditEmptyCookie() {
+    private suspend fun removeRedditEmptyCookie() {
         runCatching {
             if (cookieManager.containsRedditDummyCookie()) {
-                cookieManager.setCookie(HTTPS_WWW_REDDIT_COM, REDDIT_SESSION_EXPIRED_)
+                setCookieOnAllProfiles(HTTPS_WWW_REDDIT_COM, REDDIT_SESSION_EXPIRED_)
             }
+        }
+    }
+
+    // Apply the workaround to every already-resolved browser-mode cookie jar
+    private suspend fun setCookieOnAllProfiles(url: String, cookieString: String) {
+        withContext(dispatcherProvider.io()) {
+            cookieManager.setCookieOnAllProfiles(url, cookieString)
         }
     }
 
@@ -94,7 +104,11 @@ interface CookieManagerWrapper {
      */
     fun getCookie(url: String): String?
 
-    fun setCookie(url: String, cookieString: String)
+    /**
+     * Sets the given [cookieString] for the given [url] on every browser mode's cookie jar (the
+     * default profile plus any non-default profiles).
+     */
+    fun setCookieOnAllProfiles(url: String, cookieString: String)
 }
 
 @Retention(AnnotationRetention.BINARY)
@@ -106,19 +120,19 @@ private annotation class InternalApi
 object CookieManagerWrapperModule {
     @Provides
     @InternalApi
-    fun providesCookieManagerWrapper(): CookieManagerWrapper {
-        return CookieManagerWrapperImpl()
+    fun providesCookieManagerWrapper(cookieManagerProvider: CookieManagerProvider): CookieManagerWrapper {
+        return CookieManagerWrapperImpl(cookieManagerProvider)
     }
 }
-private class CookieManagerWrapperImpl constructor() : CookieManagerWrapper {
+private class CookieManagerWrapperImpl constructor(
+    private val cookieManagerProvider: CookieManagerProvider,
+) : CookieManagerWrapper {
 
-    private val cookieManager: CookieManager by lazy { CookieManager.getInstance() }
     override fun getCookie(url: String): String? {
-        return cookieManager.getCookie(url)
+        return cookieManagerProvider.forMode(BrowserMode.REGULAR)?.getCookie(url)
     }
 
-    override fun setCookie(domain: String, cookie: String) {
-        cookieManager.setCookie(domain, cookie)
-        cookieManager.flush()
+    override fun setCookieOnAllProfiles(url: String, cookieString: String) {
+        cookieManagerProvider.setCookieForAllModes(url, cookieString)
     }
 }

--- a/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/reddit/RedditBlockWorkaroundTest.kt
+++ b/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/reddit/RedditBlockWorkaroundTest.kt
@@ -35,7 +35,10 @@ class RedditBlockWorkaroundTest {
     private val networkProtectionState: NetworkProtectionState = mock()
     private lateinit var lifecycleOwner: LifecycleOwner
 
-    private val cookieManager = FakeCookieManagerWrapper()
+    // Two independent cookie jars, mirroring a Regular profile and a Fire profile.
+    private val regularJar = FakeCookieJar()
+    private val fireJar = FakeCookieJar()
+    private val cookieManager = FakeCookieManagerWrapper(listOf(regularJar, fireJar))
 
     private lateinit var redditBlockWorkaround: RedditBlockWorkaround
 
@@ -54,7 +57,7 @@ class RedditBlockWorkaroundTest {
         redditBlockWorkaround.onResume(lifecycleOwner)
 
         redditBlockWorkaround.onResume(lifecycleOwner)
-        assertEquals("reddit_session=; Expires=Wed, 21 Oct 2015 07:28:00 GMT", cookieManager.getCookie(".reddit.com"))
+        assertEquals("reddit_session=; Expires=Wed, 21 Oct 2015 07:28:00 GMT", regularJar.getCookie(".reddit.com"))
     }
 
     @Test
@@ -62,7 +65,7 @@ class RedditBlockWorkaroundTest {
         whenever(networkProtectionState.isEnabled()).thenReturn(true)
 
         redditBlockWorkaround.onResume(lifecycleOwner)
-        assertEquals("reddit_session=;", cookieManager.getCookie(".reddit.com"))
+        assertEquals("reddit_session=;", regularJar.getCookie(".reddit.com"))
     }
 
     @Test
@@ -70,62 +73,95 @@ class RedditBlockWorkaroundTest {
         whenever(networkProtectionState.isEnabled()).thenReturn(false)
 
         redditBlockWorkaround.onResume(lifecycleOwner)
-        assertNull(cookieManager.getCookie(".reddit.com"))
+        assertNull(regularJar.getCookie(".reddit.com"))
     }
 
     @Test
     fun `on resume with netp enabled noops if reddit_session present`() = runTest {
         whenever(networkProtectionState.isEnabled()).thenReturn(true)
-        cookieManager.setCookieOnAllProfiles(".reddit.com", "reddit_session=value;")
+        regularJar.setCookie(".reddit.com", "reddit_session=value;")
 
         redditBlockWorkaround.onResume(lifecycleOwner)
-        assertEquals("reddit_session=value;", cookieManager.getCookie(".reddit.com"))
+        assertEquals("reddit_session=value;", regularJar.getCookie(".reddit.com"))
     }
 
     @Test
     fun `on resume with netp disabled noops if reddit_session present`() = runTest {
         whenever(networkProtectionState.isEnabled()).thenReturn(false)
-        cookieManager.setCookieOnAllProfiles(".reddit.com", "reddit_session=value;")
+        regularJar.setCookie(".reddit.com", "reddit_session=value;")
 
         redditBlockWorkaround.onResume(lifecycleOwner)
-        assertEquals("reddit_session=value;", cookieManager.getCookie(".reddit.com"))
+        assertEquals("reddit_session=value;", regularJar.getCookie(".reddit.com"))
+    }
+
+    @Test
+    fun `on resume with netp enabled adds the dummy to every resolved profile`() = runTest {
+        whenever(networkProtectionState.isEnabled()).thenReturn(true)
+
+        redditBlockWorkaround.onResume(lifecycleOwner)
+
+        assertEquals("reddit_session=;", regularJar.getCookie(".reddit.com"))
+        assertEquals("reddit_session=;", fireJar.getCookie(".reddit.com"))
+    }
+
+    @Test
+    fun `on resume with netp enabled does not clobber a real session in another profile`() = runTest {
+        whenever(networkProtectionState.isEnabled()).thenReturn(true)
+        // The Fire profile holds a real reddit login while the Regular profile is logged out.
+        fireJar.setCookie(".reddit.com", "reddit_session=realtoken;")
+
+        redditBlockWorkaround.onResume(lifecycleOwner)
+
+        // Regular gets the dummy, but Fire's real session must be left untouched.
+        assertEquals("reddit_session=;", regularJar.getCookie(".reddit.com"))
+        assertEquals("reddit_session=realtoken;", fireJar.getCookie(".reddit.com"))
+    }
+
+    @Test
+    fun `on pause with netp enabled does not clobber a real session in another profile`() = runTest {
+        whenever(networkProtectionState.isEnabled()).thenReturn(true)
+        fireJar.setCookie(".reddit.com", "reddit_session=realtoken;")
+
+        redditBlockWorkaround.onPause(lifecycleOwner)
+
+        assertEquals("reddit_session=realtoken;", fireJar.getCookie(".reddit.com"))
     }
 
     @Test
     fun `on pause expires the reddit_session dummy if present`() = runTest {
         whenever(networkProtectionState.isEnabled()).thenReturn(false)
-        cookieManager.setCookieOnAllProfiles(".reddit.com", "reddit_session=;")
+        regularJar.setCookie(".reddit.com", "reddit_session=;")
         redditBlockWorkaround.onPause(lifecycleOwner)
-        assertEquals("reddit_session=; Expires=Wed, 21 Oct 2015 07:28:00 GMT", cookieManager.getCookie(".reddit.com"))
+        assertEquals("reddit_session=; Expires=Wed, 21 Oct 2015 07:28:00 GMT", regularJar.getCookie(".reddit.com"))
     }
 
     @Test
     fun `on pause noops if reddit_session dummy if not present`() = runTest {
         whenever(networkProtectionState.isEnabled()).thenReturn(false)
         redditBlockWorkaround.onPause(lifecycleOwner)
-        assertNull(cookieManager.getCookie(".reddit.com"))
+        assertNull(regularJar.getCookie(".reddit.com"))
     }
 }
 
-class FakeCookieManagerWrapper() : CookieManagerWrapper {
+class FakeCookieManagerWrapper(private val profiles: List<FakeCookieJar>) : CookieManagerWrapper {
+    override fun resolvedProfiles(): List<CookieJar> = profiles
+}
 
-    val cookieStore: MutableMap<String, MutableList<Cookie>> = mutableMapOf()
-    // private val cookieStore: MutableMap<String, MutableList<String>> = mutableMapOf()
+class FakeCookieJar : CookieJar {
 
-    // Function to get cookies for a specific URL
+    private val cookieStore: MutableMap<String, MutableList<Cookie>> = mutableMapOf()
+
     override fun getCookie(url: String): String? {
         val host = getCookieHost(url)
         val cookies = cookieStore[host] ?: return null
         return cookies.joinToString(";") { it.toString() }
     }
 
-    // Function to set cookies for a specific URL or domain
-    override fun setCookieOnAllProfiles(url: String, cookieString: String) {
+    override fun setCookie(url: String, cookieString: String) {
         val uri = URI(url)
         val domain = runCatching { if (uri.host.startsWith(".")) uri.host.substring(1) else uri.host }.getOrElse { url }
         val cookie = Cookie.fromString(cookieString)
 
-        // Add cookie to the specific domain
         val cookies = cookieStore.computeIfAbsent(domain) { mutableListOf() }.filter { it.name != cookie.name }.toMutableList().apply {
             add(cookie)
         }

--- a/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/reddit/RedditBlockWorkaroundTest.kt
+++ b/network-protection/network-protection-impl/src/test/java/com/duckduckgo/networkprotection/impl/reddit/RedditBlockWorkaroundTest.kt
@@ -76,7 +76,7 @@ class RedditBlockWorkaroundTest {
     @Test
     fun `on resume with netp enabled noops if reddit_session present`() = runTest {
         whenever(networkProtectionState.isEnabled()).thenReturn(true)
-        cookieManager.setCookie(".reddit.com", "reddit_session=value;")
+        cookieManager.setCookieOnAllProfiles(".reddit.com", "reddit_session=value;")
 
         redditBlockWorkaround.onResume(lifecycleOwner)
         assertEquals("reddit_session=value;", cookieManager.getCookie(".reddit.com"))
@@ -85,7 +85,7 @@ class RedditBlockWorkaroundTest {
     @Test
     fun `on resume with netp disabled noops if reddit_session present`() = runTest {
         whenever(networkProtectionState.isEnabled()).thenReturn(false)
-        cookieManager.setCookie(".reddit.com", "reddit_session=value;")
+        cookieManager.setCookieOnAllProfiles(".reddit.com", "reddit_session=value;")
 
         redditBlockWorkaround.onResume(lifecycleOwner)
         assertEquals("reddit_session=value;", cookieManager.getCookie(".reddit.com"))
@@ -94,7 +94,7 @@ class RedditBlockWorkaroundTest {
     @Test
     fun `on pause expires the reddit_session dummy if present`() = runTest {
         whenever(networkProtectionState.isEnabled()).thenReturn(false)
-        cookieManager.setCookie(".reddit.com", "reddit_session=;")
+        cookieManager.setCookieOnAllProfiles(".reddit.com", "reddit_session=;")
         redditBlockWorkaround.onPause(lifecycleOwner)
         assertEquals("reddit_session=; Expires=Wed, 21 Oct 2015 07:28:00 GMT", cookieManager.getCookie(".reddit.com"))
     }
@@ -120,7 +120,7 @@ class FakeCookieManagerWrapper() : CookieManagerWrapper {
     }
 
     // Function to set cookies for a specific URL or domain
-    override fun setCookie(url: String, cookieString: String) {
+    override fun setCookieOnAllProfiles(url: String, cookieString: String) {
         val uri = URI(url)
         val domain = runCatching { if (uri.host.startsWith(".")) uri.host.substring(1) else uri.host }.getOrElse { url }
         val cookie = Cookie.fromString(cookieString)

--- a/subscriptions/subscriptions-impl/build.gradle
+++ b/subscriptions/subscriptions-impl/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 
     implementation project(path: ':di')
     implementation project(path: ':cookies-api')
+    implementation project(path: ':browser-mode-api')
     implementation project(path: ':common-utils')
     implementation project(path: ':design-system')
     implementation project(path: ':app-build-config-api')

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/serp_promo/SerpPromo.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/serp_promo/SerpPromo.kt
@@ -16,12 +16,13 @@
 
 package com.duckduckgo.subscriptions.impl.serp_promo
 
-import android.webkit.CookieManager
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.cookies.api.CookieManagerProvider
+import com.duckduckgo.cookies.api.setCookieForAllModes
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.subscriptions.api.Subscriptions
 import com.duckduckgo.subscriptions.impl.SubscriptionsFeature
@@ -59,15 +60,16 @@ class RealSerpPromo @Inject constructor(
     private val subscriptions: Lazy<Subscriptions>, // break dep cycle
 ) : SerpPromo, MainProcessLifecycleObserver {
 
-    override suspend fun injectCookie(cookieValue: String?) = withContext(dispatcherProvider.io()) {
-        if (subscriptionsFeature.get().serpPromoCookie().isEnabled()) {
+    override suspend fun injectCookie(cookieValue: String?) {
+        if (!subscriptionsFeature.get().serpPromoCookie().isEnabled()) return
+
+        withContext(dispatcherProvider.io()) {
             synchronized(cookieManager) {
                 kotlin.runCatching {
                     val cookieString = "$SERP_PPRO_PROMO_COOKIE_NAME=${cookieValue.orEmpty()};HttpOnly;Path=/;"
-                    cookieManager.setCookie(HTTPS_WWW_SUBSCRIPTION_DDG_COM, cookieString)
+                    cookieManager.setCookieOnAllProfiles(HTTPS_WWW_SUBSCRIPTION_DDG_COM, cookieString)
                 }
             }
-            return@withContext
         }
     }
 
@@ -90,7 +92,11 @@ interface CookieManagerWrapper {
      */
     fun getCookie(url: String): String?
 
-    fun setCookie(url: String, cookieString: String)
+    /**
+     * Sets the given [cookieString] for the given [url] on every browser mode's cookie jar (the
+     * default profile plus any non-default profiles).
+     */
+    fun setCookieOnAllProfiles(url: String, cookieString: String)
 }
 
 @Retention(AnnotationRetention.BINARY)
@@ -110,15 +116,12 @@ private class CookieManagerWrapperImpl constructor(
     private val cookieManagerProvider: CookieManagerProvider,
 ) : CookieManagerWrapper {
 
-    private val cookieManager: CookieManager? by lazy { cookieManagerProvider.get() }
-
     override fun getCookie(url: String): String? {
-        return cookieManager?.getCookie(url)
+        return cookieManagerProvider.forMode(BrowserMode.REGULAR)?.getCookie(url)
     }
 
-    override fun setCookie(domain: String, cookie: String) {
-        logcat { "Setting cookie $cookie for domain $domain" }
-        cookieManager?.setCookie(domain, cookie)
-        cookieManager?.flush()
+    override fun setCookieOnAllProfiles(url: String, cookieString: String) {
+        logcat { "Setting cookie $cookieString for domain $url" }
+        cookieManagerProvider.setCookieForAllModes(url, cookieString)
     }
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/serp_promo/SerpPromo.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/serp_promo/SerpPromo.kt
@@ -19,7 +19,6 @@ package com.duckduckgo.subscriptions.impl.serp_promo
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
-import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.cookies.api.setCookieForAllModes
@@ -88,11 +87,6 @@ class RealSerpPromo @Inject constructor(
 // This class is basically a convenience wrapper for easier testing
 interface CookieManagerWrapper {
     /**
-     * @return the cookie stored for the given [url] if any, null otherwise
-     */
-    fun getCookie(url: String): String?
-
-    /**
      * Sets the given [cookieString] for the given [url] on every browser mode's cookie jar (the
      * default profile plus any non-default profiles).
      */
@@ -115,10 +109,6 @@ object CookieManagerWrapperModule {
 private class CookieManagerWrapperImpl constructor(
     private val cookieManagerProvider: CookieManagerProvider,
 ) : CookieManagerWrapper {
-
-    override fun getCookie(url: String): String? {
-        return cookieManagerProvider.forMode(BrowserMode.REGULAR)?.getCookie(url)
-    }
 
     override fun setCookieOnAllProfiles(url: String, cookieString: String) {
         logcat { "Setting cookie $cookieString for domain $url" }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
@@ -48,6 +48,7 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.app.browser.SpecialUrlDetector
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.browser.api.ui.BrowserScreens.SettingsScreenNoParams
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.hide
@@ -424,6 +425,8 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
             contentDisposition = contentDisposition,
             mimeType = mimeType,
             subfolder = Environment.DIRECTORY_DOWNLOADS,
+            // The subscription web flow runs in the default profile, so its downloads use the Regular cookie jar.
+            browserMode = BrowserMode.REGULAR,
         )
 
         if (hasWriteStoragePermission()) {

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/serp_promo/SerpPromoTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/serp_promo/SerpPromoTest.kt
@@ -41,7 +41,7 @@ class SerpPromoTest {
 
         serpPromo.injectCookie("value")
 
-        verify(cookieManager).setCookie(".subscriptions.duckduckgo.com", "privacy_pro_access_token=value;HttpOnly;Path=/;")
+        verify(cookieManager).setCookieOnAllProfiles(".subscriptions.duckduckgo.com", "privacy_pro_access_token=value;HttpOnly;Path=/;")
     }
 
     @Test
@@ -50,7 +50,7 @@ class SerpPromoTest {
 
         serpPromo.injectCookie("value")
 
-        verify(cookieManager, never()).setCookie(any(), any())
+        verify(cookieManager, never()).setCookieOnAllProfiles(any(), any())
     }
 
     @Test
@@ -59,7 +59,7 @@ class SerpPromoTest {
 
         serpPromo.onStart(lifecycleOwner)
 
-        verify(cookieManager).setCookie(".subscriptions.duckduckgo.com", "privacy_pro_access_token=;HttpOnly;Path=/;")
+        verify(cookieManager).setCookieOnAllProfiles(".subscriptions.duckduckgo.com", "privacy_pro_access_token=;HttpOnly;Path=/;")
     }
 
     @Test
@@ -68,7 +68,7 @@ class SerpPromoTest {
 
         serpPromo.onStart(lifecycleOwner)
 
-        verify(cookieManager, never()).setCookie(any(), any())
+        verify(cookieManager, never()).setCookieOnAllProfiles(any(), any())
     }
 
     @Test
@@ -77,7 +77,7 @@ class SerpPromoTest {
         whenever(cookieManager.getCookie(any())).thenReturn("privacy_pro_access_token=value;")
 
         serpPromo.onStart(lifecycleOwner)
-        verify(cookieManager).setCookie(".subscriptions.duckduckgo.com", "privacy_pro_access_token=;HttpOnly;Path=/;")
+        verify(cookieManager).setCookieOnAllProfiles(".subscriptions.duckduckgo.com", "privacy_pro_access_token=;HttpOnly;Path=/;")
     }
 
     @Test
@@ -87,7 +87,7 @@ class SerpPromoTest {
         whenever(subscriptions.getAccessToken()).thenReturn("value")
 
         serpPromo.onStart(lifecycleOwner)
-        verify(cookieManager).setCookie(".subscriptions.duckduckgo.com", "privacy_pro_access_token=value;HttpOnly;Path=/;")
+        verify(cookieManager).setCookieOnAllProfiles(".subscriptions.duckduckgo.com", "privacy_pro_access_token=value;HttpOnly;Path=/;")
     }
 
     @Test
@@ -96,7 +96,7 @@ class SerpPromoTest {
         whenever(cookieManager.getCookie(any())).thenReturn("privacy_pro_access_token=value;")
 
         serpPromo.onStart(lifecycleOwner)
-        verify(cookieManager, never()).setCookie(any(), any())
+        verify(cookieManager, never()).setCookieOnAllProfiles(any(), any())
     }
 
     @Test
@@ -105,7 +105,7 @@ class SerpPromoTest {
         whenever(cookieManager.getCookie(any())).thenReturn("another_cookie=value;")
 
         serpPromo.onStart(lifecycleOwner)
-        verify(cookieManager).setCookie(".subscriptions.duckduckgo.com", "privacy_pro_access_token=;HttpOnly;Path=/;")
+        verify(cookieManager).setCookieOnAllProfiles(".subscriptions.duckduckgo.com", "privacy_pro_access_token=;HttpOnly;Path=/;")
     }
 
     @Test
@@ -115,7 +115,7 @@ class SerpPromoTest {
         whenever(subscriptions.getAccessToken()).thenReturn("value")
 
         serpPromo.onStart(lifecycleOwner)
-        verify(cookieManager).setCookie(".subscriptions.duckduckgo.com", "privacy_pro_access_token=value;HttpOnly;Path=/;")
+        verify(cookieManager).setCookieOnAllProfiles(".subscriptions.duckduckgo.com", "privacy_pro_access_token=value;HttpOnly;Path=/;")
     }
 
     @Test
@@ -124,7 +124,7 @@ class SerpPromoTest {
         whenever(cookieManager.getCookie(any())).thenReturn("another_cookie=value;")
 
         serpPromo.onStart(lifecycleOwner)
-        verify(cookieManager, never()).setCookie(any(), any())
+        verify(cookieManager, never()).setCookieOnAllProfiles(any(), any())
     }
 
     @Test
@@ -134,6 +134,6 @@ class SerpPromoTest {
         whenever(subscriptions.getAccessToken()).thenReturn("value")
 
         serpPromo.onStart(lifecycleOwner)
-        verify(cookieManager, never()).setCookie(any(), any())
+        verify(cookieManager, never()).setCookieOnAllProfiles(any(), any())
     }
 }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/serp_promo/SerpPromoTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/serp_promo/SerpPromoTest.kt
@@ -72,68 +72,12 @@ class SerpPromoTest {
     }
 
     @Test
-    fun whenOnStartAndPromoCookieSetThenSetEmptyCookie() = runTest {
+    fun whenOnStartAndAccessTokenThenSetAccessTokenCookie() = runTest {
         subscriptionsFeature.serpPromoCookie().setRawStoredState(Toggle.State(enable = true))
-        whenever(cookieManager.getCookie(any())).thenReturn("privacy_pro_access_token=value;")
-
-        serpPromo.onStart(lifecycleOwner)
-        verify(cookieManager).setCookieOnAllProfiles(".subscriptions.duckduckgo.com", "privacy_pro_access_token=;HttpOnly;Path=/;")
-    }
-
-    @Test
-    fun whenOnStartAndPromoCookieSetAndAccessTokenThenSetEmptyCookie() = runTest {
-        subscriptionsFeature.serpPromoCookie().setRawStoredState(Toggle.State(enable = true))
-        whenever(cookieManager.getCookie(any())).thenReturn("privacy_pro_access_token=value;")
         whenever(subscriptions.getAccessToken()).thenReturn("value")
 
         serpPromo.onStart(lifecycleOwner)
+
         verify(cookieManager).setCookieOnAllProfiles(".subscriptions.duckduckgo.com", "privacy_pro_access_token=value;HttpOnly;Path=/;")
-    }
-
-    @Test
-    fun whenKillSwitchedOnStartAndPromoCookieSetThenNoop() = runTest {
-        subscriptionsFeature.serpPromoCookie().setRawStoredState(Toggle.State(enable = false))
-        whenever(cookieManager.getCookie(any())).thenReturn("privacy_pro_access_token=value;")
-
-        serpPromo.onStart(lifecycleOwner)
-        verify(cookieManager, never()).setCookieOnAllProfiles(any(), any())
-    }
-
-    @Test
-    fun whenOnStartAndOtherCookiesSetThenSetEmptyCookie() = runTest {
-        subscriptionsFeature.serpPromoCookie().setRawStoredState(Toggle.State(enable = true))
-        whenever(cookieManager.getCookie(any())).thenReturn("another_cookie=value;")
-
-        serpPromo.onStart(lifecycleOwner)
-        verify(cookieManager).setCookieOnAllProfiles(".subscriptions.duckduckgo.com", "privacy_pro_access_token=;HttpOnly;Path=/;")
-    }
-
-    @Test
-    fun whenOnStartAndOtherCookiesSetAndAccessTokenThenSetAccessTokenCookie() = runTest {
-        subscriptionsFeature.serpPromoCookie().setRawStoredState(Toggle.State(enable = true))
-        whenever(cookieManager.getCookie(any())).thenReturn("another_cookie=value;")
-        whenever(subscriptions.getAccessToken()).thenReturn("value")
-
-        serpPromo.onStart(lifecycleOwner)
-        verify(cookieManager).setCookieOnAllProfiles(".subscriptions.duckduckgo.com", "privacy_pro_access_token=value;HttpOnly;Path=/;")
-    }
-
-    @Test
-    fun whenKillSwitchedOnStartAndOtherCookiesSetThenNoop() = runTest {
-        subscriptionsFeature.serpPromoCookie().setRawStoredState(Toggle.State(enable = false))
-        whenever(cookieManager.getCookie(any())).thenReturn("another_cookie=value;")
-
-        serpPromo.onStart(lifecycleOwner)
-        verify(cookieManager, never()).setCookieOnAllProfiles(any(), any())
-    }
-
-    @Test
-    fun whenKillSwitchedOnStartAndOtherCookiesSetAndAccessTokenThenNoop() = runTest {
-        subscriptionsFeature.serpPromoCookie().setRawStoredState(Toggle.State(enable = false))
-        whenever(cookieManager.getCookie(any())).thenReturn("another_cookie=value;")
-        whenever(subscriptions.getAccessToken()).thenReturn("value")
-
-        serpPromo.onStart(lifecycleOwner)
-        verify(cookieManager, never()).setCookieOnAllProfiles(any(), any())
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1216110164786817?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1207418217763355/task/1214558513236397?focus=true

### Description

Cookie access is now **mode-aware**. Each browser mode has its own cookie jar (Regular → the default WebView profile, Fire → the Fire profile), and `CookieManagerProvider` hands out the `CookieManager` for a given mode:

- `forMode(mode)` — the jar for a specific mode
- `setCookieForAllModes(url, cookie)` — seeds every mode's jar

This started as a crash fix: calling `setAcceptThirdPartyCookies` on the default `CookieManager` against a Fire-profile WebView SIGSEGVs natively. The wider change is routing every cookie call site to the jar that is correct for what it does.

**There is no live "current mode" read at any cookie call site.** The mode is either injected and frozen at construction (WebView clients) or carried with a deferred request (downloads). That is what makes the routing race-free — a mid-operation mode switch can't redirect a call to the wrong jar.

### Which jar each call site uses

**1. The WebView's own mode — `forMode(mode)`**, where `mode` is the tab/WebView's profile, obtained without a live global read:

| Component | How it gets the mode | What it does |
|---|---|---|
| `ThirdPartyCookieManager` | passed by `BrowserTabFragment` | enable/check 3rd-party cookies on the active WebView — **a profile mismatch here was the SIGSEGV** (always on the main thread) |
| `BrowserWebViewClient.flushCookies` | injected (the tab's mode; `REGULAR` in `WebViewActivity`, an in-app viewer that shares this client and stays on the default profile) | flush the tab's cookies after page events |
| `UrlExtractingWebViewClient.flushCookies` | injected | flush the AMP URL-extraction WebView's cookies |
| `InlinePdfHandler` | passed by `BrowserTabViewModel` | forward the page's cookies to the inline-PDF request |
| Duck.ai WebView surfaces (`DuckChatWebViewFragment`, `DuckChatContextualFragment`, `ChatHistoryReader`) | injected (fragment graph) | forward the chat WebView's cookies |
| `downloads/CookieManagerWrapper.getCookie` | carried on `PendingFileDownload` through WorkManager | forward cookies to the download request |

**2. The persistent (Regular) jar — `forMode(REGULAR)`** — durable, mode-independent state, or the Regular data-clearing path that must never touch the ephemeral Fire jar:

| Component | What it does |
|---|---|
| `WebViewCookieManager` + `SQLCookieRemover` / `CookieManagerRemover` | Regular Fire-button cookie clear (the Fire jar has its own burn) |
| `RealDuckChat.isStandaloneMigrationCompleted` | reads the one-time `migration_status` cookie — a durable global flag |
| `TakeoutZipDownloader` | forwards Google session cookies to authorize a Takeout export (Settings/import runs in Regular) |
| `SerpPromo` / `RedditBlockWorkaround` (reads) | checks the existing DDG/Reddit session, which lives in the persistent jar |

**3. All jars — `setCookieForAllModes()`** — seed a cookie every mode must see:

| Component | What it does |
|---|---|
| `SerpPromo.injectCookie` | seeds the Privacy Pro access token (a Regular and an active Fire SERP tab both need it) |
| `RedditBlockWorkaround` | seeds/expires the Reddit dummy session for VPN users |

Both run off the main thread (as before). The default jar is always seeded; the Fire jar is seeded only when its manager is already resolved — a non-default jar is never silently replaced by the wrong one.

### Implementation notes

- The Fire profile's `CookieManager` is resolved via `ProfileStore` (`@UiThread`) and **cached**. Off-main callers read the cached instance; off-main with a cold cache returns `null` (skip) rather than the wrong default jar — never a crash
- The third-party-cookie setup launched from `BrowserWebViewClient.onPageStarted` runs on the **WebView's `lifecycleScope`**. It is cancelled when the WebView is torn down so `setAcceptThirdPartyCookies` can't run on a stale WebView

### Steps to test this PR

Use an **internal** build with Fire mode enabled (`fireTabs` remote feature on).

_Crash fix (the original report)_
- [x] Enter Fire mode
- [x] Open a tab, tap the URL bar and browse a few sites
- [x] Verify no native crash (previously a SIGSEGV in `libwebviewchromium`)

_Cookie isolation_
- [x] In Fire mode
- [x] Sign in to / set cookies on a site 
- [x] Switch to Regular
- [x] Verify you are **not** signed in there 
- [x] Burn all tabs 
- [x] Re-enter Fire mode 
- [x] Verify the earlier Fire cookies are gone

_In-app web viewer_
- [x] Switch to Fire mode
- [x] Open an in-app page (e.g. a link that opens `WebViewActivity` from the About screen)
- [x] Verify loads, no crash

_Downloads (cookies forwarded to the download request) (Optional)_
- [x] In Fire mode, sign in so a site sets a session cookie in the Fire profile
- [x] Trigger an account-gated download
- [x] Verify it completes (would fail / bounce to login if the empty/Regular jar were used)

_Inline PDF (page cookies forwarded to the PDF fetch) (Optional)_
- [ ] In Fire mode, sign into a site
- [ ] On a site you signed into, open a PDF served behind that session
- [ ] Verify it renders inline, no login prompt

_AMP link de-cloaking (extraction runs on the active mode's profile) (Optional)_
- [ ] In Fire mode, open a Google AMP / `…/amp/…` link (e.g. `https://www-bbc-com.cdn.ampproject.org/c/s/www.bbc.com/news/articles/`)
- [ ] Verify it resolves to the canonical (non-AMP) URL, no crash
- [ ] Switch to Regular 
- [ ] Verify no session from the AMP page leaked there


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication cookies, third-party cookie policy, downloads, and WebView profile binding—core browsing and session isolation—with many call sites across the app.
> 
> **Overview**
> Replaces the singleton **`CookieManagerProvider.get()`** with **`forMode(BrowserMode)`** so Regular and Fire each use their own WebView cookie jar (Fire via **`ProfileStore`**), plus **`setCookieForAllModes`** for cookies that must land in every profile.
> 
> **WebView and tab flows** now pass a frozen **`browserMode`** into third-party cookie handling, cookie flush, AMP URL extraction (profile bind + injectable client), inline PDF fetch, and Duck.ai surfaces. **`BrowserWebViewClient`** runs third-party cookie work on the WebView **`lifecycleScope`** instead of app scope. **`WebViewActivity`** is pinned to **`REGULAR`** like Custom Tabs; **`TabSwitcherActivity`** guards **`onResume`** when views were not initialized after an aborted recreate.
> 
> **Downloads** carry **`browserMode`** on **`PendingFileDownload`** through WorkManager; download and PDF paths resolve Fire cookies on a worker with a main-thread fallback when the Fire manager is not warmed yet.
> 
> **Clearing and global work** keep **`REGULAR`** for Fire-button / SQL cookie removal and durable reads (e.g. migration cookie, Takeout). **Serp promo** and **Reddit VPN workaround** write or read per resolved profile so one jar does not overwrite another session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 543608fcda0ee62d0bca56ce1a7be493cb2cf668. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->