### PR TITLE
Add RMF display conditions (trigger + auto-dismiss)

### DIFF
--- a/remote-messaging/remote-messaging-api/src/main/java/com/duckduckgo/remote/messaging/api/RemoteMessage.kt
+++ b/remote-messaging/remote-messaging-api/src/main/java/com/duckduckgo/remote/messaging/api/RemoteMessage.kt
@@ -39,11 +39,30 @@ data class RemoteMessage(
     val matchingRules: List<Int>,
     val exclusionRules: List<Int>,
     val surfaces: List<Surface>,
+    val displayConditions: DisplayConditions? = null,
 )
 
 enum class Surface(val jsonValue: String) {
     MODAL("modal"),
     NEW_TAB_PAGE("new_tab_page"),
+}
+
+/**
+ * Conditions controlling when and for how long a message is displayed.
+ * Evaluated internally by RMF; null fields mean "no restriction".
+ */
+data class DisplayConditions(
+    val trigger: MessageTrigger?,
+    val dismissAfterDaysShown: Int?,
+)
+
+/**
+ * The context a message targets, supplied by the consumer at read time.
+ * A triggered message is returned only in that context.
+ * A message with no trigger is unrestricted.
+ */
+enum class MessageTrigger(val jsonValue: String) {
+    AFTER_IDLE("after_idle"),
 }
 
 sealed class Content(val messageType: MessageType) {

--- a/remote-messaging/remote-messaging-api/src/main/java/com/duckduckgo/remote/messaging/api/RemoteMessageModel.kt
+++ b/remote-messaging/remote-messaging-api/src/main/java/com/duckduckgo/remote/messaging/api/RemoteMessageModel.kt
@@ -20,9 +20,9 @@ import kotlinx.coroutines.flow.Flow
 
 interface RemoteMessageModel {
 
-    fun getActiveMessage(): RemoteMessage?
+    fun getActiveMessage(activeTrigger: MessageTrigger? = null): RemoteMessage?
 
-    fun observeActiveMessages(): Flow<RemoteMessage?>
+    fun observeActiveMessages(activeTrigger: MessageTrigger? = null): Flow<RemoteMessage?>
 
     suspend fun onMessageShown(remoteMessage: RemoteMessage)
 

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepository.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepository.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.remote.messaging.impl
 
+import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.remote.messaging.api.RemoteMessage
 import com.duckduckgo.remote.messaging.api.Surface
 import com.duckduckgo.remote.messaging.impl.mappers.MessageMapper
@@ -28,6 +29,7 @@ import com.duckduckgo.remote.messaging.store.RemoteMessagingConfigRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import java.util.concurrent.TimeUnit
 
 interface RemoteMessagingRepository {
     fun getMessageById(id: String): RemoteMessage?
@@ -51,6 +53,7 @@ class AppRemoteMessagingRepository(
     private val remoteMessagesDao: RemoteMessagesDao,
     private val messageMapper: MessageMapper,
     private val remoteMessageImageStore: RemoteMessageImageStore,
+    private val currentTimeProvider: CurrentTimeProvider,
 ) : RemoteMessagingRepository {
 
     override fun getMessageById(id: String): RemoteMessage? {
@@ -71,38 +74,58 @@ class AppRemoteMessagingRepository(
     override fun didShow(id: String) = remoteMessagesDao.messagesById(id)?.shown ?: false
 
     override fun markAsShown(remoteMessage: RemoteMessage) {
-        val message = remoteMessagesDao.messagesById(remoteMessage.id) ?: return
-        remoteMessagesDao.insert(message.copy(shown = true))
+        val messageEntity = remoteMessagesDao.messagesById(remoteMessage.id) ?: return
+        // Stamp the first-shown timestamp on the first impression only.
+        remoteMessagesDao.insert(
+            messageEntity.copy(
+                shown = true,
+                firstShownDate = messageEntity.firstShownDate ?: currentTimeProvider.currentTimeMillis(),
+            ),
+        )
     }
 
     override fun message(): RemoteMessage? {
-        val message = remoteMessagesDao.message()
-        if (message == null || message.message.isEmpty()) return null
+        val messageEntity = remoteMessagesDao.message()
+        if (messageEntity == null || messageEntity.message.isEmpty()) return null
 
-        val remoteMessage = messageMapper.fromMessage(message.message) ?: return null
-        RemoteMessage(
-            id = message.id,
-            content = remoteMessage.content,
-            emptyList(),
-            emptyList(),
-            remoteMessage.surfaces,
-        )
+        val remoteMessage = messageMapper.fromMessage(messageEntity.message) ?: return null
+        if (remoteMessage.isExpired(messageEntity.firstShownDate)) {
+            dismissExpiredMessage(messageEntity.id)
+            return null
+        }
         return remoteMessage
     }
 
     override fun messageFlow(): Flow<RemoteMessage?> {
-        return remoteMessagesDao.messagesFlow().distinctUntilChanged().map {
-            if (it == null || it.message.isEmpty()) return@map null
+        return remoteMessagesDao.messagesFlow().distinctUntilChanged().map { messageEntity ->
+            if (messageEntity == null || messageEntity.message.isEmpty()) return@map null
 
-            val message = messageMapper.fromMessage(it.message) ?: return@map null
+            val remoteMessage = messageMapper.fromMessage(messageEntity.message) ?: return@map null
+            if (remoteMessage.isExpired(messageEntity.firstShownDate)) {
+                dismissExpiredMessage(messageEntity.id)
+                return@map null
+            }
             RemoteMessage(
-                id = it.id,
-                content = message.content,
+                id = messageEntity.id,
+                content = remoteMessage.content,
                 emptyList(),
                 emptyList(),
-                message.surfaces,
+                remoteMessage.surfaces,
+                remoteMessage.displayConditions,
             )
         }
+    }
+
+    private fun RemoteMessage.isExpired(firstShownDate: Long?): Boolean {
+        val threshold = displayConditions?.dismissAfterDaysShown?.takeIf { it > 0 } ?: return false
+        val firstShown = firstShownDate ?: return false
+        val elapsedDays = TimeUnit.MILLISECONDS.toDays(currentTimeProvider.currentTimeMillis() - firstShown)
+        return elapsedDays >= threshold
+    }
+
+    private fun dismissExpiredMessage(id: String) {
+        remoteMessagesDao.updateState(id, Status.DISMISSED)
+        remoteMessagingConfigRepository.invalidate()
     }
 
     override suspend fun dismissMessage(id: String) {

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/RealRemoteMessageModel.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/RealRemoteMessageModel.kt
@@ -20,11 +20,14 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.remote.messaging.api.Action
 import com.duckduckgo.remote.messaging.api.Content
+import com.duckduckgo.remote.messaging.api.MessageTrigger
 import com.duckduckgo.remote.messaging.api.RemoteMessage
 import com.duckduckgo.remote.messaging.api.RemoteMessageModel
 import com.duckduckgo.remote.messaging.api.Surface
 import com.duckduckgo.remote.messaging.impl.pixels.RemoteMessagingPixels
 import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
@@ -35,8 +38,11 @@ class RealRemoteMessageModel @Inject constructor(
     private val dispatchers: DispatcherProvider,
 ) : RemoteMessageModel {
 
-    override fun getActiveMessage(): RemoteMessage? = remoteMessagingRepository.message()
-    override fun observeActiveMessages() = remoteMessagingRepository.messageFlow()
+    override fun getActiveMessage(activeTrigger: MessageTrigger?): RemoteMessage? =
+        remoteMessagingRepository.message()?.takeIf { it.matchesTrigger(activeTrigger) }
+
+    override fun observeActiveMessages(activeTrigger: MessageTrigger?): Flow<RemoteMessage?> =
+        remoteMessagingRepository.messageFlow().map { message -> message?.takeIf { it.matchesTrigger(activeTrigger) } }
 
     override suspend fun onMessageShown(remoteMessage: RemoteMessage) {
         withContext(dispatchers.io()) {
@@ -119,5 +125,10 @@ class RealRemoteMessageModel @Inject constructor(
             }
             else -> null
         }
+    }
+
+    private fun RemoteMessage.matchesTrigger(activeTrigger: MessageTrigger?): Boolean {
+        val requiredTrigger = displayConditions?.trigger ?: return true
+        return requiredTrigger == activeTrigger
     }
 }

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/di/RemoteMessagingModule.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/di/RemoteMessagingModule.kt
@@ -21,6 +21,7 @@ import androidx.room.Room
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.browser.api.AppProperties
 import com.duckduckgo.browser.api.UserBrowserProperties
+import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.DaggerSet
 import com.duckduckgo.di.scopes.AppScope
@@ -102,12 +103,14 @@ object DataSourceModule {
         remoteMessagesDao: RemoteMessagesDao,
         messageMapper: MessageMapper,
         remoteMessageImageStore: RemoteMessageImageStore,
+        currentTimeProvider: CurrentTimeProvider,
     ): RemoteMessagingRepository {
         return AppRemoteMessagingRepository(
             remoteMessagingConfigRepository,
             remoteMessagesDao,
             messageMapper,
             remoteMessageImageStore,
+            currentTimeProvider,
         )
     }
 

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/JsonRemoteMessageMapper.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/JsonRemoteMessageMapper.kt
@@ -27,8 +27,10 @@ import com.duckduckgo.remote.messaging.api.Content.Medium
 import com.duckduckgo.remote.messaging.api.Content.Placeholder
 import com.duckduckgo.remote.messaging.api.Content.PromoSingleAction
 import com.duckduckgo.remote.messaging.api.Content.Small
+import com.duckduckgo.remote.messaging.api.DisplayConditions
 import com.duckduckgo.remote.messaging.api.JsonMessageAction
 import com.duckduckgo.remote.messaging.api.MessageActionMapperPlugin
+import com.duckduckgo.remote.messaging.api.MessageTrigger
 import com.duckduckgo.remote.messaging.api.RemoteMessage
 import com.duckduckgo.remote.messaging.api.Surface
 import com.duckduckgo.remote.messaging.impl.models.*
@@ -40,6 +42,7 @@ import com.duckduckgo.remote.messaging.impl.models.JsonMessageType.PROMO_SINGLE_
 import com.duckduckgo.remote.messaging.impl.models.JsonMessageType.SMALL
 import com.duckduckgo.remote.messaging.impl.models.asJsonFormat
 import logcat.LogPriority.ERROR
+import logcat.LogPriority.INFO
 import logcat.logcat
 import java.util.Locale
 
@@ -162,6 +165,14 @@ private fun JsonRemoteMessage.map(
     locale: Locale,
     actionMappers: Set<MessageActionMapperPlugin>,
 ): RemoteMessage? {
+    // Resolve display conditions up front. An unrecognized trigger means this message targets a
+    // context this client version doesn't understand so we skip it.
+    val displayConditions = this.displayConditions?.let { conditions ->
+        conditions.toDisplayConditionsOrNull() ?: run {
+            logcat(INFO) { "RMF: skipping message id=${this.id}, unknown trigger '${conditions.trigger}'" }
+            return null
+        }
+    }
     return runCatching {
         val remoteMessage = RemoteMessage(
             id = this.id.failIfEmpty(),
@@ -169,6 +180,7 @@ private fun JsonRemoteMessage.map(
             matchingRules = this.matchingRules.orEmpty(),
             exclusionRules = this.exclusionRules.orEmpty(),
             surfaces = this.surfaces.toSurfaceList(),
+            displayConditions = displayConditions,
         )
         remoteMessage.localizeMessage(this.translations, locale)
     }.onFailure {
@@ -180,6 +192,20 @@ private fun List<String>?.toSurfaceList(): List<Surface> {
     return this?.mapNotNull { value ->
         Surface.entries.firstOrNull { it.jsonValue == value }
     } ?: listOf(Surface.NEW_TAB_PAGE)
+}
+
+// Returns null when a trigger string is present but unrecognized, so the caller can drop the
+// message (forward-compat). A null trigger is valid and means "no trigger" (unrestricted).
+private fun JsonDisplayConditions.toDisplayConditionsOrNull(): DisplayConditions? {
+    val resolvedTrigger = if (trigger == null) {
+        null
+    } else {
+        MessageTrigger.entries.firstOrNull { it.jsonValue == trigger } ?: return null
+    }
+    return DisplayConditions(
+        trigger = resolvedTrigger,
+        dismissAfterDaysShown = dismissAfterDaysShown,
+    )
 }
 
 private fun RemoteMessage.localizeMessage(

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/models/JsonRemoteMessagingConfig.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/models/JsonRemoteMessagingConfig.kt
@@ -32,6 +32,12 @@ data class JsonRemoteMessage(
     val matchingRules: List<Int>?,
     val translations: Map<String, JsonContentTranslations>,
     val surfaces: List<String>?,
+    val displayConditions: JsonDisplayConditions? = null,
+)
+
+data class JsonDisplayConditions(
+    val trigger: String? = null,
+    val dismissAfterDaysShown: Int? = null,
 )
 
 data class JsonContent(

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/fixtures/JsonRemoteMessageOM.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/fixtures/JsonRemoteMessageOM.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.remote.messaging.fixtures
 import com.duckduckgo.remote.messaging.api.JsonMessageAction
 import com.duckduckgo.remote.messaging.impl.models.JsonContent
 import com.duckduckgo.remote.messaging.impl.models.JsonContentTranslations
+import com.duckduckgo.remote.messaging.impl.models.JsonDisplayConditions
 import com.duckduckgo.remote.messaging.impl.models.JsonListItem
 import com.duckduckgo.remote.messaging.impl.models.JsonMatchingRule
 import com.duckduckgo.remote.messaging.impl.models.JsonRemoteMessage
@@ -159,6 +160,7 @@ object JsonRemoteMessageOM {
         matchingRules: List<Int> = emptyList(),
         translations: Map<String, JsonContentTranslations> = emptyMap(),
         surfaces: List<String>? = null,
+        displayConditions: JsonDisplayConditions? = null,
     ) = JsonRemoteMessage(
         id = id,
         content = content,
@@ -166,6 +168,7 @@ object JsonRemoteMessageOM {
         matchingRules = matchingRules,
         translations = translations,
         surfaces = surfaces,
+        displayConditions = displayConditions,
     )
 
     fun aJsonRemoteMessagingConfig(

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepositoryTest.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepositoryTest.kt
@@ -21,6 +21,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.remote.messaging.api.Action
 import com.duckduckgo.remote.messaging.api.Action.Share
 import com.duckduckgo.remote.messaging.api.Content.BigSingleAction
@@ -30,6 +31,8 @@ import com.duckduckgo.remote.messaging.api.Content.Placeholder.ANNOUNCE
 import com.duckduckgo.remote.messaging.api.Content.Placeholder.MAC_AND_WINDOWS
 import com.duckduckgo.remote.messaging.api.Content.PromoSingleAction
 import com.duckduckgo.remote.messaging.api.Content.Small
+import com.duckduckgo.remote.messaging.api.DisplayConditions
+import com.duckduckgo.remote.messaging.api.MessageTrigger
 import com.duckduckgo.remote.messaging.api.RemoteMessage
 import com.duckduckgo.remote.messaging.api.Surface
 import com.duckduckgo.remote.messaging.fixtures.getMessageMapper
@@ -48,6 +51,7 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.util.concurrent.TimeUnit
 
 // TODO: when pattern established, refactor objects to use (create module https://app.asana.com/0/0/1201807285420697/f)
 @RunWith(AndroidJUnit4::class)
@@ -66,12 +70,14 @@ class AppRemoteMessagingRepositoryTest {
 
     private val remoteMessagingConfigRepository: RemoteMessagingConfigRepository = mock()
     private val remoteMessageImageStore: RemoteMessageImageStore = mock()
+    private val currentTimeProvider: CurrentTimeProvider = mock()
 
     private val testee = AppRemoteMessagingRepository(
         remoteMessagingConfigRepository,
         dao,
         getMessageMapper(),
         remoteMessageImageStore,
+        currentTimeProvider,
     )
 
     @After
@@ -471,6 +477,75 @@ class AppRemoteMessagingRepositoryTest {
         assertNull(result)
     }
 
+    @Test
+    fun whenMarkAsShownThenFirstShownDateStampedOnce() {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(1000L)
+        testee.activeMessage(aRemoteMessage("id"))
+
+        testee.markAsShown(aRemoteMessage("id"))
+        assertEquals(1000L, dao.messagesById("id")?.firstShownDate)
+
+        // a second impression must not move the timestamp
+        testee.markAsShown(aRemoteMessage("id"))
+        assertEquals(1000L, dao.messagesById("id")?.firstShownDate)
+    }
+
+    @Test
+    fun whenExpiryThresholdReachedThenMessageDismissedAndConfigInvalidated() = runTest {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(0L, TimeUnit.DAYS.toMillis(5))
+        testee.activeMessage(aRemoteMessageWithDisplayConditions("id", DisplayConditions(trigger = null, dismissAfterDaysShown = 5)))
+        testee.markAsShown(aRemoteMessage("id"))
+
+        assertNull(testee.message())
+        assertEquals(Status.DISMISSED, dao.messagesById("id")?.status)
+        // mirrors dismissMessage(): invalidate so the next eligible message is scheduled
+        verify(remoteMessagingConfigRepository).invalidate()
+    }
+
+    @Test
+    fun whenExpiryThresholdIsZeroThenMessageNeverExpires() = runTest {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(0L, TimeUnit.DAYS.toMillis(99))
+        testee.activeMessage(aRemoteMessageWithDisplayConditions("id", DisplayConditions(trigger = null, dismissAfterDaysShown = 0)))
+        testee.markAsShown(aRemoteMessage("id"))
+
+        assertEquals("id", testee.message()?.id)
+    }
+
+    @Test
+    fun whenWithinExpiryThresholdThenMessageReturned() = runTest {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(0L, TimeUnit.DAYS.toMillis(3))
+        testee.activeMessage(aRemoteMessageWithDisplayConditions("id", DisplayConditions(trigger = null, dismissAfterDaysShown = 5)))
+        testee.markAsShown(aRemoteMessage("id"))
+
+        assertEquals("id", testee.message()?.id)
+        assertEquals(Status.SCHEDULED, dao.messagesById("id")?.status)
+    }
+
+    @Test
+    fun whenNeverShownThenNotExpiredEvenPastThreshold() = runTest {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(TimeUnit.DAYS.toMillis(99))
+        testee.activeMessage(aRemoteMessageWithDisplayConditions("id", DisplayConditions(trigger = null, dismissAfterDaysShown = 5)))
+
+        assertEquals("id", testee.message()?.id)
+    }
+
+    @Test
+    fun whenNoExpiryConfiguredThenMessageNeverExpires() = runTest {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(0L, TimeUnit.DAYS.toMillis(3650))
+        testee.activeMessage(aRemoteMessage("id"))
+        testee.markAsShown(aRemoteMessage("id"))
+
+        assertEquals("id", testee.message()?.id)
+    }
+
+    @Test
+    fun whenMessageHasDisplayConditionsThenStoredAndReadBackIntact() = runTest {
+        val conditions = DisplayConditions(trigger = MessageTrigger.AFTER_IDLE, dismissAfterDaysShown = 5)
+        testee.activeMessage(aRemoteMessageWithDisplayConditions("id", conditions))
+
+        assertEquals(conditions, testee.message()?.displayConditions)
+    }
+
     companion object {
         fun aRemoteMessage(id: String) = RemoteMessage(
             id = id,
@@ -487,5 +562,10 @@ class AppRemoteMessagingRepositoryTest {
             exclusionRules = emptyList(),
             surfaces = listOf(Surface.NEW_TAB_PAGE),
         )
+
+        fun aRemoteMessageWithDisplayConditions(
+            id: String,
+            displayConditions: DisplayConditions,
+        ) = aRemoteMessage(id).copy(displayConditions = displayConditions)
     }
 }

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/JsonRemoteMessageDisplayConditionsTest.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/JsonRemoteMessageDisplayConditionsTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.remote.messaging.impl
+
+import com.duckduckgo.remote.messaging.api.MessageTrigger
+import com.duckduckgo.remote.messaging.fixtures.JsonRemoteMessageOM.aJsonMessage
+import com.duckduckgo.remote.messaging.fixtures.JsonRemoteMessageOM.smallJsonContent
+import com.duckduckgo.remote.messaging.fixtures.messageActionPlugins
+import com.duckduckgo.remote.messaging.impl.mappers.mapToRemoteMessage
+import com.duckduckgo.remote.messaging.impl.models.JsonDisplayConditions
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Locale
+
+class JsonRemoteMessageDisplayConditionsTest {
+
+    @Test
+    fun whenDisplayConditionsHasKnownTriggerThenParsed() {
+        val mapped = listOf(
+            aJsonMessage(
+                id = "id",
+                content = smallJsonContent(),
+                displayConditions = JsonDisplayConditions(trigger = "after_idle", dismissAfterDaysShown = 5),
+            ),
+        ).mapToRemoteMessage(Locale.US, messageActionPlugins)
+
+        val conditions = mapped.single().displayConditions
+        assertEquals(MessageTrigger.AFTER_IDLE, conditions?.trigger)
+        assertEquals(5, conditions?.dismissAfterDaysShown)
+    }
+
+    @Test
+    fun whenDisplayConditionsHasOnlyExpiryThenTriggerIsNull() {
+        val mapped = listOf(
+            aJsonMessage(
+                id = "id",
+                content = smallJsonContent(),
+                displayConditions = JsonDisplayConditions(dismissAfterDaysShown = 5),
+            ),
+        ).mapToRemoteMessage(Locale.US, messageActionPlugins)
+
+        val conditions = mapped.single().displayConditions
+        assertNull(conditions?.trigger)
+        assertEquals(5, conditions?.dismissAfterDaysShown)
+    }
+
+    @Test
+    fun whenTriggerUnrecognizedThenMessageDropped() {
+        val mapped = listOf(
+            aJsonMessage(
+                id = "id",
+                content = smallJsonContent(),
+                displayConditions = JsonDisplayConditions(trigger = "some_future_trigger"),
+            ),
+        ).mapToRemoteMessage(Locale.US, messageActionPlugins)
+
+        assertTrue(mapped.isEmpty())
+    }
+
+    @Test
+    fun whenNoDisplayConditionsThenNull() {
+        val mapped = listOf(
+            aJsonMessage(id = "id", content = smallJsonContent()),
+        ).mapToRemoteMessage(Locale.US, messageActionPlugins)
+
+        assertNull(mapped.single().displayConditions)
+    }
+}

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/RemoteMessagingModelTests.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/RemoteMessagingModelTests.kt
@@ -20,15 +20,20 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.remote.messaging.api.Action
 import com.duckduckgo.remote.messaging.api.Content
 import com.duckduckgo.remote.messaging.api.Content.Placeholder.VISUAL_DESIGN_UPDATE
+import com.duckduckgo.remote.messaging.api.DisplayConditions
+import com.duckduckgo.remote.messaging.api.MessageTrigger
 import com.duckduckgo.remote.messaging.api.RemoteMessage
 import com.duckduckgo.remote.messaging.api.Surface
 import com.duckduckgo.remote.messaging.impl.pixels.RemoteMessagingPixels
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -45,6 +50,15 @@ class RemoteMessagingModelTests {
     private lateinit var testee: RealRemoteMessageModel
 
     val remoteMessage = RemoteMessage("id1", Content.Small("", ""), emptyList(), emptyList(), emptyList())
+
+    private val triggeredMessage = RemoteMessage(
+        "id1",
+        Content.Small("", ""),
+        emptyList(),
+        emptyList(),
+        emptyList(),
+        DisplayConditions(trigger = MessageTrigger.AFTER_IDLE, dismissAfterDaysShown = null),
+    )
 
     @Before
     fun setup() {
@@ -117,6 +131,63 @@ class RemoteMessagingModelTests {
         verify(remoteMessagingPixels).fireRemoteMessageActionClickedPixel(remoteMessage)
         verify(remoteMessagingRepository, never()).dismissMessage(remoteMessage.id)
         assertEquals(action, result)
+    }
+
+    @Test
+    fun whenGetActiveMessageWithMatchingTriggerThenMessageReturned() = runTest {
+        whenever(remoteMessagingRepository.message()).thenReturn(triggeredMessage)
+
+        assertEquals(triggeredMessage, testee.getActiveMessage(MessageTrigger.AFTER_IDLE))
+    }
+
+    @Test
+    fun whenGetActiveMessageWithNonMatchingTriggerThenHiddenButNotDismissed() = runTest {
+        whenever(remoteMessagingRepository.message()).thenReturn(triggeredMessage)
+
+        assertNull(testee.getActiveMessage(null))
+        // trigger filtering only hides the message for this context; it must never dismiss it (unlike expiry)
+        verify(remoteMessagingRepository, never()).dismissMessage(any())
+    }
+
+    @Test
+    fun whenGetActiveMessageHasNoTriggerThenReturnedForAnyContext() = runTest {
+        whenever(remoteMessagingRepository.message()).thenReturn(remoteMessage)
+
+        assertEquals(remoteMessage, testee.getActiveMessage(MessageTrigger.AFTER_IDLE))
+        assertEquals(remoteMessage, testee.getActiveMessage(null))
+    }
+
+    @Test
+    fun whenGetActiveMessageHasConditionsButNoTriggerThenReturnedForAnyContext() = runTest {
+        val messageWithoutTrigger = remoteMessage.copy(
+            displayConditions = DisplayConditions(trigger = null, dismissAfterDaysShown = 5),
+        )
+        whenever(remoteMessagingRepository.message()).thenReturn(messageWithoutTrigger)
+
+        assertEquals(messageWithoutTrigger, testee.getActiveMessage(MessageTrigger.AFTER_IDLE))
+        assertEquals(messageWithoutTrigger, testee.getActiveMessage(null))
+    }
+
+    @Test
+    fun whenObserveActiveMessagesWithMatchingTriggerThenMessageEmitted() = runTest {
+        whenever(remoteMessagingRepository.messageFlow()).thenReturn(flowOf(triggeredMessage))
+
+        assertEquals(triggeredMessage, testee.observeActiveMessages(MessageTrigger.AFTER_IDLE).first())
+    }
+
+    @Test
+    fun whenObserveActiveMessagesWithNonMatchingTriggerThenNullEmitted() = runTest {
+        whenever(remoteMessagingRepository.messageFlow()).thenReturn(flowOf(triggeredMessage))
+
+        assertNull(testee.observeActiveMessages(null).first())
+    }
+
+    @Test
+    fun whenObserveActiveMessagesHasNoTriggerThenEmittedForAnyContext() = runTest {
+        whenever(remoteMessagingRepository.messageFlow()).thenReturn(flowOf(remoteMessage))
+
+        assertEquals(remoteMessage, testee.observeActiveMessages(MessageTrigger.AFTER_IDLE).first())
+        assertEquals(remoteMessage, testee.observeActiveMessages(null).first())
     }
 
     @Test

--- a/remote-messaging/remote-messaging-store/build.gradle
+++ b/remote-messaging/remote-messaging-store/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     testImplementation Testing.junit4
     testImplementation Testing.robolectric
     testImplementation AndroidX.test.ext.junit
+    testImplementation AndroidX.room.testing
 
     coreLibraryDesugaring Android.tools.desugarJdkLibs
 }

--- a/remote-messaging/remote-messaging-store/schemas/com.duckduckgo.remote.messaging.store.RemoteMessagingDatabase/3.json
+++ b/remote-messaging/remote-messaging-store/schemas/com.duckduckgo.remote.messaging.store.RemoteMessagingDatabase/3.json
@@ -1,0 +1,114 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "7ca8b1cf7ad06ef5c6184b39ab818e62",
+    "entities": [
+      {
+        "tableName": "remote_messaging",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `version` INTEGER NOT NULL, `invalidate` INTEGER NOT NULL, `evaluationTimestamp` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "invalidate",
+            "columnName": "invalidate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "evaluationTimestamp",
+            "columnName": "evaluationTimestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "remote_message",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `message` TEXT NOT NULL, `status` TEXT NOT NULL, `shown` INTEGER NOT NULL, `firstShownDate` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shown",
+            "columnName": "shown",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstShownDate",
+            "columnName": "firstShownDate",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "remote_messaging_cohort",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`messageId` TEXT NOT NULL, `percentile` REAL NOT NULL, PRIMARY KEY(`messageId`))",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "percentile",
+            "columnName": "percentile",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "messageId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7ca8b1cf7ad06ef5c6184b39ab818e62')"
+    ]
+  }
+}

--- a/remote-messaging/remote-messaging-store/src/main/java/com/duckduckgo/remote/messaging/store/RemoteMessageEntity.kt
+++ b/remote-messaging/remote-messaging-store/src/main/java/com/duckduckgo/remote/messaging/store/RemoteMessageEntity.kt
@@ -25,6 +25,7 @@ data class RemoteMessageEntity(
     val message: String,
     val status: Status,
     val shown: Boolean = false,
+    val firstShownDate: Long? = null,
 ) {
     enum class Status {
         SCHEDULED,

--- a/remote-messaging/remote-messaging-store/src/main/java/com/duckduckgo/remote/messaging/store/RemoteMessagingDatabase.kt
+++ b/remote-messaging/remote-messaging-store/src/main/java/com/duckduckgo/remote/messaging/store/RemoteMessagingDatabase.kt
@@ -23,7 +23,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     exportSchema = true,
-    version = 2,
+    version = 3,
     entities = [
         RemoteMessagingConfig::class,
         RemoteMessageEntity::class,
@@ -48,7 +48,12 @@ abstract class RemoteMessagingDatabase : RoomDatabase() {
                 }
             }
         }
+        private val MIGRATION_2_3 = object : Migration(2, 3) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `remote_message` ADD COLUMN `firstShownDate` INTEGER")
+            }
+        }
         val ALL_MIGRATIONS: Array<Migration>
-            get() = arrayOf(MIGRATION_1_2)
+            get() = arrayOf(MIGRATION_1_2, MIGRATION_2_3)
     }
 }

--- a/remote-messaging/remote-messaging-store/src/test/java/com/duckduckgo/remote/messaging/store/RemoteMessagingDatabaseMigrationTest.kt
+++ b/remote-messaging/remote-messaging-store/src/test/java/com/duckduckgo/remote/messaging/store/RemoteMessagingDatabaseMigrationTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.remote.messaging.store
+
+import androidx.room.Room
+import androidx.room.testing.MigrationTestHelper
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RemoteMessagingDatabaseMigrationTest {
+
+    @get:Rule
+    val testHelper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        RemoteMessagingDatabase::class.java,
+        emptyList(),
+    )
+
+    @Test
+    fun whenMigratingFromV2ToV3ThenFirstShownDateAddedAsNullAndExistingRowPreserved() {
+        testHelper.createDatabase(TEST_DB_NAME, 2).apply {
+            execSQL("INSERT INTO remote_message (id, message, status, shown) VALUES ('id1', '{}', 'SCHEDULED', 0)")
+            close()
+        }
+
+        testHelper.runMigrationsAndValidate(TEST_DB_NAME, 3, true, *RemoteMessagingDatabase.ALL_MIGRATIONS).apply {
+            val cursor = query(
+                "SELECT message, status, shown, firstShownDate FROM remote_message WHERE id = 'id1'",
+            )
+            cursor.moveToFirst()
+            assertEquals("{}", cursor.getString(cursor.getColumnIndexOrThrow("message")))
+            assertEquals("SCHEDULED", cursor.getString(cursor.getColumnIndexOrThrow("status")))
+            assertEquals(0, cursor.getInt(cursor.getColumnIndexOrThrow("shown")))
+            // the new column is added with a null default for rows that existed before the migration
+            assertTrue(cursor.isNull(cursor.getColumnIndexOrThrow("firstShownDate")))
+            cursor.close()
+            close()
+        }
+    }
+
+    @Test
+    fun whenMigratingToLatestThenValidatesAgainstCurrentSchema() {
+        testHelper.createDatabase(TEST_DB_NAME, 2).apply { close() }
+
+        Room.databaseBuilder(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            RemoteMessagingDatabase::class.java,
+            TEST_DB_NAME,
+        ).addMigrations(*RemoteMessagingDatabase.ALL_MIGRATIONS).build().apply {
+            openHelper.writableDatabase
+            close()
+        }
+    }
+
+    companion object {
+        private const val TEST_DB_NAME = "remote_messaging_migration_test"
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1215861246875402?focus=true 
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1212810093780571/task/1215861246875401

### Description

PR 1/5

Adds two generic, backward-compatible capabilities to the Remote Messaging Framework, usable by any message. This is the framework layer (PR 1 of 2); the NTP-after-idle consumer + the `ntpAfterIdleState` matching attribute will be done in a follow-up PR.

**`displayConditions.trigger`**: a message can target a display context. The consumer passes the context it's reading in via the read API (`getActiveMessage(activeTrigger)` / `observeActiveMessages(activeTrigger)`) and RMF decides whether to return the message. A message with no trigger is unrestricted (today's behaviour); a message whose trigger string is unrecognized (a future trigger this client version doesn't know) is dropped at parse time.

**`displayConditions.dismissAfterDaysShown`**: a message auto-dismisses N days after it is first shown. A nullable `firstShownDate` is stored once on the first impression; on read, an expired message is marked `DISMISSED` (and the config is invalidated, so the next eligible message is scheduled on the next config download) and not returned.

This is purely additive: no message declares `displayConditions` yet and no consumer is wired to a trigger, so existing messages and behaviour are unchanged.

API Proposal: https://app.asana.com/1/137249556945/project/1212810093780571/task/1216122076743697?focus=true

### Steps to test this PR

- [ ] All unit tests pass: `./gradlew :remote-messaging-impl:testDebugUnitTest :remote-messaging-store:testDebugUnitTest`.
- [ ] RMF still works as expected. this PR is purely additive (no message declares `displayConditions` yet), so existing remote messages still schedule, show, and dismiss normally on the NTP.
- [ ] After upgrading an existing install, the `remote_message` table has the new nullable `firstShownDate` column (null for pre-existing rows).


### UI changes
 No UI changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Includes a Room schema migration and new auto-dismiss logic on the active-message read path; changes are additive and existing callers still use default trigger null, but expiry side effects affect scheduling once configs use displayConditions.
> 
> **Overview**
> Adds optional **`displayConditions`** on remote messages so RMF can gate visibility by **display context** and **time since first impression**, without changing current NTP behavior until messages and consumers opt in.
> 
> **Trigger filtering:** Config can set `displayConditions.trigger` (e.g. `after_idle`). `getActiveMessage(activeTrigger)` and `observeActiveMessages(activeTrigger)` only surface a message when the caller’s trigger matches; messages with no trigger stay visible for any context. A trigger the app doesn’t know is dropped at JSON parse time (forward compatibility). Mismatch **hides** the message only—it does not dismiss it.
> 
> **Auto-dismiss after N days shown:** `dismissAfterDaysShown` is enforced on read: the repo records **`firstShownDate`** on the first `onMessageShown`, compares elapsed days via `CurrentTimeProvider`, and if past the threshold marks the message **DISMISSED**, invalidates config, and returns null. Unshown messages never expire; zero or missing expiry disables the rule.
> 
> **Persistence:** Room DB bumps to **v3** with nullable `firstShownDate` on `remote_message` and a **2→3 migration** (plus migration tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efe055885632e3cc7ebc11ca12b12446a4563f4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->