### PR TITLE
Fix clear text button selector in split omnibar E2E test

### DIFF
--- a/.maestro/omnibar/split_omnibar_search.yaml
+++ b/.maestro/omnibar/split_omnibar_search.yaml
@@ -52,7 +52,7 @@ tags:
 - tapOn:
     id: "omnibarTextInput"
 - tapOn:
-    id: "clearTextButton"
+    id: "inputFieldClearText"
 - inputText: "eff.org"
 - pressKey: Enter
 - assertVisible:
@@ -67,7 +67,7 @@ tags:
 - tapOn:
     id: "omnibarTextInput"
 - tapOn:
-    id: "clearTextButton"
+    id: "inputFieldClearText"
 - tapOn:
     id: "quickAccessFavicon"
     childOf:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1216149200058231?focus=true
Tech Design URL (if applicable): 

### Description

The split omnibar Maestro test (`split_omnibar_search.yaml`) was asserting on the `clearTextButton` id when clearing the omnibar text. The split omnibar now opens the native input field (duckchat's `InputModeWidget`) instead of the legacy `OmnibarLayout`, whose clear button uses the `inputFieldClearText` id. Updated the two selectors accordingly so the E2E test matches the current view hierarchy.

### Steps to test this PR

_Split omnibar clear text selector_
- [ ] Apply this patch: 
```
Index: app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt	(revision dc9f1ceb553435929d7c521e334f4cc83585ef8e)
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt	(date 1782882242290)
@@ -534,7 +534,7 @@
         }
         widget.onClearTextTapped = {
             if (!widget.isChatTabSelected()) {
-                callbacks.onClearAutocomplete()
+                // callbacks.onClearAutocomplete()
             }
         }
     }
```

- [ ] Run `maestro test .maestro/omnibar/split_omnibar_search.yaml` on a device/emulator and confirm the flow passes, including the two steps that tap the clear button after focusing `omnibarTextInput`.

### UI changes
| Before  | After |
| ------ | ----- |
No UI changes | No UI changes |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only selector updates with no app or production behavior changes.
> 
> **Overview**
> The split omnibar Maestro flow (`split_omnibar_search.yaml`) was tapping **`clearTextButton`** when clearing text after focusing **`omnibarTextInput`**. Split omnibar now uses duckchat’s **`InputModeWidget`** clear control, which exposes **`inputFieldClearText`** instead of the legacy omnibar id.
> 
> Both clear-button steps in the test (before submitting `eff.org` and before opening a favorite) now target **`inputFieldClearText`** so the E2E hierarchy matches production UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc9f1ceb553435929d7c521e334f4cc83585ef8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->