### PR TITLE
Remove Omnibar Tests step from the non release blockers suite 

### DIFF
--- a/.github/workflows/e2e-nightly-non-blockers-suite.yml
+++ b/.github/workflows/e2e-nightly-non-blockers-suite.yml
@@ -70,24 +70,26 @@ jobs:
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
           test_suite_name: Release Binary Upload
 
-      - name: Omnibar Tests
-        id: maestro-omnibar
-        # Run regardless of earlier suite failures, but only if the release binary uploaded.
-        if: ${{ !cancelled() && steps.maestro-upload-release-binary.outcome == 'success' }}
-        uses: ./.github/actions/maestro-cloud-asana-reporter
-        timeout-minutes: 120
-        with:
-          maestro_api_key: ${{ secrets.ROBIN_API_KEY }}
-          maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
-          maestro_test_name: omnibar_${{ github.sha }}
-          maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
-          maestro_app_binary_id: ${{ steps.maestro-upload-release-binary.outputs.maestro_app_binary_id }}
-          maestro_include_tags: omnibarTest
-          maestro_api_level: 34
-          asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
-          asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
-          test_suite_name: Omnibar (Nightly)
+      # Disabled: no flow is currently tagged `omnibarTest` (split_omnibar_search.yaml has it commented out),
+      # so this step would fail on every run with "tags did not match any Flows".
+      # - name: Omnibar Tests
+      #   id: maestro-omnibar
+      #   # Run regardless of earlier suite failures, but only if the release binary uploaded.
+      #   if: ${{ !cancelled() && steps.maestro-upload-release-binary.outcome == 'success' }}
+      #   uses: ./.github/actions/maestro-cloud-asana-reporter
+      #   timeout-minutes: 120
+      #   with:
+      #     maestro_api_key: ${{ secrets.ROBIN_API_KEY }}
+      #     maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
+      #     maestro_test_name: omnibar_${{ github.sha }}
+      #     maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
+      #     maestro_app_binary_id: ${{ steps.maestro-upload-release-binary.outputs.maestro_app_binary_id }}
+      #     maestro_include_tags: omnibarTest
+      #     maestro_api_level: 34
+      #     asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+      #     asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
+      #     asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
+      #     test_suite_name: Omnibar (Nightly)
 
       - name: Run Duck Player Maestro Tests
         id: maestro-cloud-asana

--- a/.github/workflows/e2e-nightly-non-blockers-suite.yml
+++ b/.github/workflows/e2e-nightly-non-blockers-suite.yml
@@ -70,27 +70,6 @@ jobs:
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
           test_suite_name: Release Binary Upload
 
-      # Disabled: no flow is currently tagged `omnibarTest` (split_omnibar_search.yaml has it commented out),
-      # so this step would fail on every run with "tags did not match any Flows".
-      # - name: Omnibar Tests
-      #   id: maestro-omnibar
-      #   # Run regardless of earlier suite failures, but only if the release binary uploaded.
-      #   if: ${{ !cancelled() && steps.maestro-upload-release-binary.outcome == 'success' }}
-      #   uses: ./.github/actions/maestro-cloud-asana-reporter
-      #   timeout-minutes: 120
-      #   with:
-      #     maestro_api_key: ${{ secrets.ROBIN_API_KEY }}
-      #     maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
-      #     maestro_test_name: omnibar_${{ github.sha }}
-      #     maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
-      #     maestro_app_binary_id: ${{ steps.maestro-upload-release-binary.outputs.maestro_app_binary_id }}
-      #     maestro_include_tags: omnibarTest
-      #     maestro_api_level: 34
-      #     asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-      #     asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
-      #     asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
-      #     test_suite_name: Omnibar (Nightly)
-
       - name: Run Duck Player Maestro Tests
         id: maestro-cloud-asana
         # Run regardless of earlier suite failures, but only if the internal binary uploaded.

--- a/.maestro/omnibar/split_omnibar_search.yaml
+++ b/.maestro/omnibar/split_omnibar_search.yaml
@@ -1,8 +1,8 @@
 appId: com.duckduckgo.mobile.android
 androidWebViewHierarchy: devtools
 name: "Split omnibar test"
-#tags:
-#  - omnibarTest
+tags:
+  - omnibarTest
 ---
 - retry:
     maxRetries: 3

--- a/.maestro/omnibar/split_omnibar_search.yaml
+++ b/.maestro/omnibar/split_omnibar_search.yaml
@@ -1,8 +1,8 @@
 appId: com.duckduckgo.mobile.android
 androidWebViewHierarchy: devtools
 name: "Split omnibar test"
-tags:
-  - omnibarTest
+#tags:
+#  - omnibarTest
 ---
 - retry:
     maxRetries: 3


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1216190777842643?focus=true
Tech Design URL (if applicable): 

### Description

Removed the Omnibar Tests step from the non release blockers suite. The tests will be migrated to the native input field. 

### Steps to test this PR

_CI config_
- [ ] Confirm `split_omnibar_search.yaml` still parses as valid Maestro YAML with the `tags:` block commented out
- [ ] On the next run of "End to End Tests - Full Suite of non release blocker tests (Nightly)" (schedule or `workflow_dispatch`), confirm the workflow no longer fails on the omnibar step 

### UI changes
| Before  | After |
| ------ | ----- |
No UI changes | No UI changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that removes one Maestro suite from a non-blocking nightly job; no app runtime or release-blocker impact.
> 
> **Overview**
> Removes the **Omnibar Tests** Maestro job from the nightly **non release blockers** workflow (`e2e-nightly-non-blockers-suite.yml`). That step ran after a successful release binary upload, used the `omnibarTest` tag, and reported as **Omnibar (Nightly)**.
> 
> The workflow now goes directly from release binary upload to **Run Duck Player Maestro Tests** (and the rest of the suite is unchanged). Omnibar coverage is being dropped from this pipeline ahead of moving tests to the native input field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa11dbe11e3cdd1dabbdc40e315d68a86e756c36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


