### PR TITLE
Align Duck.ai picker upsell origins with the android naming convention

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/PickerUpsell.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/PickerUpsell.kt
@@ -20,10 +20,10 @@ import com.duckduckgo.duckchat.impl.models.UserTier
 import logcat.logcat
 
 enum class PickerSurface(val origin: String) {
-    MODEL_PICKER_ADDRESS_BAR("funnel_nativeinput_androidapp__modelpicker"),
-    MODEL_PICKER_DUCK_AI_TAB("funnel_duckai_androidapp__modelpicker"),
-    REASONING_PICKER_ADDRESS_BAR("funnel_nativeinput_androidapp__reasoningpicker"),
-    REASONING_PICKER_DUCK_AI_TAB("funnel_duckai_androidapp__reasoningpicker"),
+    MODEL_PICKER_ADDRESS_BAR("funnel_nativeinput_android__modelpicker"),
+    MODEL_PICKER_DUCK_AI_TAB("funnel_duckai_android__modelpicker"),
+    REASONING_PICKER_ADDRESS_BAR("funnel_nativeinput_android__reasoningpicker"),
+    REASONING_PICKER_DUCK_AI_TAB("funnel_duckai_android__reasoningpicker"),
 }
 
 sealed class UpsellCommand {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1216194607799304?focus=true 
Tech Design URL (if applicable): 

### Description

The Duck.ai model/reasoning picker upsell flows used `androidapp` as the origin funnel values, while every other funnel origin in the app uses android (e.g. funnel_onboarding_android, funnel_appsettings_android). This aligns the 4 picker origins with that convention.

Updated PickerSurface :
- funnel_nativeinput_android__modelpicker
- funnel_duckai_android__modelpicker
- funnel_nativeinput_android__reasoningpicker
- funnel_duckai_android__reasoningpicker


### Steps to test this PR

- Smoke test on the upsell flow if needed (pick a model that you don’t have access to (PRO), the upsell flow should start. 

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only attribution changes for upsell origins; no logic or UI behavior changes, though downstream analytics may need to expect the new origin values.
> 
> **Overview**
> Updates **subscription upsell funnel `origin` strings** on `PickerSurface` so analytics and purchase flows use `android` instead of `androidapp`.
> 
> All four origins change the same way: `funnel_nativeinput_androidapp__*` → `funnel_nativeinput_android__*` and `funnel_duckai_androidapp__*` → `funnel_duckai_android__*` for model and reasoning pickers on the address bar and Duck AI tab. Those values still pass through `UpsellCommand` into `SubscriptionPurchase` / `SubscriptionUpgrade` unchanged aside from the string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edef41f1e3881fe27cfa14b77523fd615ce5c45b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->