### PR TITLE
Update settings page

### DIFF
--- a/ad-blocking/ad-blocking-impl/src/main/AndroidManifest.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/AndroidManifest.xml
@@ -27,5 +27,10 @@
             android:exported="false"
             android:label="@string/ad_blocking_settings_title"
             android:parentActivityName="com.duckduckgo.app.settings.SettingsActivity" />
+        <activity
+            android:name=".ui.AdBlockingSettingsV2Activity"
+            android:exported="false"
+            android:label="@string/ad_blocking_settings_title_v2"
+            android:parentActivityName="com.duckduckgo.app.settings.SettingsActivity" />
     </application>
 </manifest>

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsActivity.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsActivity.kt
@@ -23,6 +23,8 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.adblocking.api.duckplayer.DuckPlayerSettingsNoParams
+import com.duckduckgo.adblocking.api.duckplayer.PrivatePlayerMode.Disabled
+import com.duckduckgo.adblocking.api.duckplayer.PrivatePlayerMode.Enabled
 import com.duckduckgo.adblocking.impl.R
 import com.duckduckgo.adblocking.impl.databinding.ActivityAdBlockingSettingsBinding
 import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
@@ -98,6 +100,13 @@ class AdBlockingSettingsActivity : DuckDuckGoActivity() {
             .onEach { state ->
                 binding.blockAdsToggle.quietlySetIsChecked(state.isEnabled, blockAdsToggleListener)
                 renderDescription(state.showConsentDescription)
+                binding.duckPlayerEntry.setSecondaryText(
+                    when (state.duckPlayerMode) {
+                        Enabled -> getString(R.string.duck_player_mode_always)
+                        Disabled -> getString(R.string.duck_player_mode_never)
+                        else -> getString(R.string.duck_player_mode_always_ask)
+                    },
+                )
             }
             .launchIn(lifecycleScope)
 

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsEntryView.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsEntryView.kt
@@ -101,7 +101,7 @@ class AdBlockingSettingsEntryView @JvmOverloads constructor(
 
     private fun processCommand(command: Command) {
         when (command) {
-            is OpenSettings -> globalActivityStarter.start(context, AdBlockingSettingsNoParams, null)
+            is OpenSettings -> globalActivityStarter.start(context, command.params, null)
         }
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsEntryViewModel.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsEntryViewModel.kt
@@ -22,11 +22,13 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
 import com.duckduckgo.adblocking.impl.ui.AdBlockingSettingsEntryViewModel.Command.OpenSettings
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
@@ -45,12 +47,13 @@ import javax.inject.Inject
 class AdBlockingSettingsEntryViewModel @Inject constructor(
     private val statusChecker: AdBlockingStatusChecker,
     private val dispatcherProvider: DispatcherProvider,
+    private val feature: AdBlockingExtensionFeature,
 ) : ViewModel(), DefaultLifecycleObserver {
 
     data class ViewState(val isVisible: Boolean = false)
 
     sealed class Command {
-        data object OpenSettings : Command()
+        data class OpenSettings(val params: ActivityParams) : Command()
     }
 
     private val command = Channel<Command>(1, BufferOverflow.DROP_OLDEST)
@@ -77,7 +80,12 @@ class AdBlockingSettingsEntryViewModel @Inject constructor(
 
     fun onSettingClicked() {
         viewModelScope.launch {
-            command.send(OpenSettings)
+            val params = if (feature.adBlockingUXImprovements().isEnabled()) {
+                AdBlockingSettingsV2NoParams
+            } else {
+                AdBlockingSettingsNoParams
+            }
+            command.send(OpenSettings(params))
         }
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsScreens.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsScreens.kt
@@ -22,3 +22,9 @@ import com.duckduckgo.navigation.api.GlobalActivityStarter
  * Use this model to launch the YouTube Ad Blocking settings screen.
  */
 object AdBlockingSettingsNoParams : GlobalActivityStarter.ActivityParams
+
+/**
+ * Use this model to launch the YouTube Ad Blocking settings screen with the ad-blocking UX
+ * improvements appearance.
+ */
+object AdBlockingSettingsV2NoParams : GlobalActivityStarter.ActivityParams

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsV2Activity.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsV2Activity.kt
@@ -18,7 +18,10 @@ package com.duckduckgo.adblocking.impl.ui
 
 import android.os.Bundle
 import androidx.appcompat.widget.Toolbar
-import com.duckduckgo.adblocking.impl.databinding.ActivityAdBlockingSettingsBinding
+import com.duckduckgo.adblocking.api.duckplayer.PrivatePlayerMode.Disabled
+import com.duckduckgo.adblocking.api.duckplayer.PrivatePlayerMode.Enabled
+import com.duckduckgo.adblocking.impl.R
+import com.duckduckgo.adblocking.impl.databinding.ActivityAdBlockingSettingsV2Binding
 import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.view.listitem.DaxListItem
@@ -28,10 +31,10 @@ import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
 
 @InjectWith(ActivityScope::class)
-@ContributeToActivityStarter(AdBlockingSettingsNoParams::class)
-class AdBlockingSettingsActivity : BaseAdBlockingSettingsActivity() {
+@ContributeToActivityStarter(AdBlockingSettingsV2NoParams::class)
+class AdBlockingSettingsV2Activity : BaseAdBlockingSettingsActivity() {
 
-    private val binding: ActivityAdBlockingSettingsBinding by viewBinding()
+    private val binding: ActivityAdBlockingSettingsV2Binding by viewBinding()
 
     override val toolbar: Toolbar get() = binding.includeToolbar.toolbar
     override val blockAdsToggle: OneLineListItem get() = binding.blockAdsToggle
@@ -39,9 +42,24 @@ class AdBlockingSettingsActivity : BaseAdBlockingSettingsActivity() {
     override val duckPlayerEntry: DaxListItem get() = binding.duckPlayerEntry
     override val duckPlayerDescription: DaxTextView get() = binding.duckPlayerDescription
 
+    override val learnMoreScreenTitle: Int = R.string.ad_blocking_settings_title_v2
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
+        setTitle(R.string.ad_blocking_settings_title_v2)
         configure()
+    }
+
+    override fun render(state: AdBlockingSettingsViewModel.ViewState) {
+        super.render(state)
+        binding.adBlockingStatusIndicator.setStatus(state.isEnabled)
+        binding.duckPlayerEntry.setSecondaryText(
+            when (state.duckPlayerMode) {
+                Enabled -> getString(R.string.duck_player_mode_always)
+                Disabled -> getString(R.string.duck_player_mode_never)
+                else -> getString(R.string.duck_player_mode_always_ask)
+            },
+        )
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsViewModel.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsViewModel.kt
@@ -18,6 +18,9 @@ package com.duckduckgo.adblocking.impl.ui
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.duckduckgo.adblocking.api.duckplayer.DuckPlayer
+import com.duckduckgo.adblocking.api.duckplayer.PrivatePlayerMode
+import com.duckduckgo.adblocking.api.duckplayer.PrivatePlayerMode.AlwaysAsk
 import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_DISABLED_COUNT
 import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_DISABLED_DAILY
 import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_ENABLED_COUNT
@@ -37,7 +40,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted.Companion.WhileSubscribed
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -48,6 +51,7 @@ class AdBlockingSettingsViewModel @Inject constructor(
     statusChecker: AdBlockingStatusChecker,
     private val repository: AdBlockingSettingsRepository,
     private val pixel: Pixel,
+    duckPlayer: DuckPlayer,
 ) : ViewModel() {
 
     init {
@@ -58,6 +62,7 @@ class AdBlockingSettingsViewModel @Inject constructor(
     data class ViewState(
         val isEnabled: Boolean = false,
         val showConsentDescription: Boolean? = null,
+        val duckPlayerMode: PrivatePlayerMode = AlwaysAsk,
     )
 
     sealed class Command {
@@ -65,13 +70,16 @@ class AdBlockingSettingsViewModel @Inject constructor(
         data object OpenDuckPlayerSettings : Command()
     }
 
-    val viewState: StateFlow<ViewState> = statusChecker.observeState()
-        .map { state ->
-            ViewState(
-                isEnabled = state is AdBlockingState.Enabled,
-                showConsentDescription = state !is AdBlockingState.Enabled.Default,
-            )
-        }
+    val viewState: StateFlow<ViewState> = combine(
+        statusChecker.observeState(),
+        duckPlayer.observeUserPreferences(),
+    ) { state, duckPlayerPreferences ->
+        ViewState(
+            isEnabled = state is AdBlockingState.Enabled,
+            showConsentDescription = state !is AdBlockingState.Enabled.Default,
+            duckPlayerMode = duckPlayerPreferences.privatePlayerMode,
+        )
+    }
         .stateIn(
             viewModelScope,
             started = WhileSubscribed(),

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/BaseAdBlockingSettingsActivity.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/BaseAdBlockingSettingsActivity.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.ui
+
+import android.view.View
+import android.widget.CompoundButton
+import androidx.appcompat.widget.Toolbar
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import com.duckduckgo.adblocking.api.duckplayer.DuckPlayerSettingsNoParams
+import com.duckduckgo.adblocking.impl.R
+import com.duckduckgo.browser.api.ui.BrowserScreens
+import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.spans.DuckDuckGoClickableSpan
+import com.duckduckgo.common.ui.view.addClickableSpan
+import com.duckduckgo.common.ui.view.gone
+import com.duckduckgo.common.ui.view.listitem.DaxListItem
+import com.duckduckgo.common.ui.view.listitem.OneLineListItem
+import com.duckduckgo.common.ui.view.show
+import com.duckduckgo.common.ui.view.text.DaxTextView
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import dev.zacsweers.metro.HasMemberInjections
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+
+/**
+ * Shared logic for the Ad Blocking settings screen.
+ */
+@HasMemberInjections
+abstract class BaseAdBlockingSettingsActivity : DuckDuckGoActivity() {
+
+    protected val viewModel: AdBlockingSettingsViewModel by bindViewModel()
+
+    @Inject
+    lateinit var globalActivityStarter: GlobalActivityStarter
+
+    protected abstract val toolbar: Toolbar
+    protected abstract val blockAdsToggle: OneLineListItem
+    protected abstract val adBlockingDescription: DaxTextView
+    protected abstract val duckPlayerEntry: DaxListItem
+    protected abstract val duckPlayerDescription: DaxTextView
+
+    protected open val learnMoreScreenTitle: Int = R.string.ad_blocking_settings_title
+
+    private val blockAdsToggleListener = CompoundButton.OnCheckedChangeListener { _, isChecked ->
+        viewModel.onBlockAdsToggled(isChecked)
+    }
+
+    protected fun configure() {
+        setupToolbar(toolbar)
+
+        blockAdsToggle.setOnCheckedChangeListener(blockAdsToggleListener)
+        duckPlayerEntry.setClickListener { viewModel.onDuckPlayerClicked() }
+        duckPlayerDescription.setOnClickListener { viewModel.onDuckPlayerClicked() }
+
+        observeViewModel()
+    }
+
+    protected open fun render(state: AdBlockingSettingsViewModel.ViewState) {
+        blockAdsToggle.quietlySetIsChecked(state.isEnabled, blockAdsToggleListener)
+        renderDescription(state.showConsentDescription)
+    }
+
+    private fun renderDescription(showConsentDescription: Boolean?) {
+        if (showConsentDescription == null) {
+            adBlockingDescription.gone()
+            return
+        }
+        val descriptionRes = if (showConsentDescription) {
+            R.string.ad_blocking_settings_description_with_consent
+        } else {
+            R.string.ad_blocking_settings_description
+        }
+        adBlockingDescription.addClickableSpan(
+            textSequence = getText(descriptionRes),
+            spans = listOf(
+                "learn_more_link" to object : DuckDuckGoClickableSpan() {
+                    override fun onClick(widget: View) {
+                        viewModel.onLearnMoreClicked()
+                    }
+                },
+            ),
+        )
+        adBlockingDescription.show()
+    }
+
+    private fun observeViewModel() {
+        viewModel.viewState
+            .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+            .onEach { render(it) }
+            .launchIn(lifecycleScope)
+
+        viewModel.commands
+            .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+            .onEach { command ->
+                when (command) {
+                    is AdBlockingSettingsViewModel.Command.OpenLearnMore -> globalActivityStarter.start(
+                        this,
+                        BrowserScreens.WebViewActivityWithParams(
+                            url = command.url,
+                            screenTitle = getString(learnMoreScreenTitle),
+                        ),
+                    )
+                    AdBlockingSettingsViewModel.Command.OpenDuckPlayerSettings -> globalActivityStarter.start(
+                        this,
+                        DuckPlayerSettingsNoParams,
+                    )
+                }
+            }
+            .launchIn(lifecycleScope)
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/BaseAdBlockingSettingsActivity.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/BaseAdBlockingSettingsActivity.kt
@@ -65,7 +65,6 @@ abstract class BaseAdBlockingSettingsActivity : DuckDuckGoActivity() {
     protected fun configure() {
         setupToolbar(toolbar)
 
-        blockAdsToggle.setOnCheckedChangeListener(blockAdsToggleListener)
         duckPlayerEntry.setClickListener { viewModel.onDuckPlayerClicked() }
         duckPlayerDescription.setOnClickListener { viewModel.onDuckPlayerClicked() }
 
@@ -102,7 +101,7 @@ abstract class BaseAdBlockingSettingsActivity : DuckDuckGoActivity() {
 
     private fun observeViewModel() {
         viewModel.viewState
-            .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+            .flowWithLifecycle(lifecycle, Lifecycle.State.RESUMED)
             .onEach { render(it) }
             .launchIn(lifecycleScope)
 

--- a/ad-blocking/ad-blocking-impl/src/main/res/drawable/ad_blocking_128.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/drawable/ad_blocking_128.xml
@@ -1,0 +1,85 @@
+<!--
+  ~ Copyright (C) 2026 The Android Open Source Project
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="128dp"
+    android:height="96dp"
+    android:viewportWidth="128"
+    android:viewportHeight="96">
+  <path
+      android:pathData="M112.37,39.8L110.83,40.2C110.54,40.26 110.26,40.54 110.2,40.83L109.8,42.37C109.69,42.77 109.34,43 109,43C108.6,43 108.26,42.71 108.2,42.37L107.8,40.83C107.74,40.54 107.46,40.26 107.17,40.2L105.63,39.8C105.23,39.69 105,39.34 105,39C105,38.6 105.29,38.26 105.63,38.2L107.17,37.8C107.46,37.74 107.74,37.46 107.8,37.17L108.2,35.63C108.31,35.23 108.66,35 109,35C109.4,35 109.74,35.29 109.8,35.63L110.2,37.17C110.26,37.46 110.54,37.74 110.83,37.8L112.37,38.2C112.77,38.31 113,38.66 113,39C113,39.4 112.71,39.74 112.37,39.8Z"
+      android:strokeAlpha="0.2"
+      android:fillColor="#888888"
+      android:fillAlpha="0.2"/>
+  <path
+      android:pathData="M26.06,34.2L23.74,34.8C23.31,34.89 22.89,35.31 22.8,35.74L22.2,38.06C22.03,38.66 21.51,39 21,39C20.4,39 19.89,38.57 19.8,38.06L19.2,35.74C19.11,35.31 18.69,34.89 18.26,34.8L15.94,34.2C15.34,34.03 15,33.51 15,33C15,32.4 15.43,31.89 15.94,31.8L18.26,31.2C18.69,31.11 19.11,30.69 19.2,30.26L19.8,27.94C19.97,27.34 20.49,27 21,27C21.6,27 22.11,27.43 22.2,27.94L22.8,30.26C22.89,30.69 23.31,31.11 23.74,31.2L26.06,31.8C26.66,31.97 27,32.49 27,33C27,33.6 26.57,34.11 26.06,34.2Z"
+      android:strokeAlpha="0.2"
+      android:fillColor="#888888"
+      android:fillAlpha="0.2"/>
+  <path
+      android:pathData="M7.37,54.8L5.83,55.2C5.54,55.26 5.26,55.54 5.2,55.83L4.8,57.37C4.69,57.77 4.34,58 4,58C3.6,58 3.26,57.71 3.2,57.37L2.8,55.83C2.74,55.54 2.46,55.26 2.17,55.2L0.63,54.8C0.23,54.69 0,54.34 0,54C0,53.6 0.29,53.26 0.63,53.2L2.17,52.8C2.46,52.74 2.74,52.46 2.8,52.17L3.2,50.63C3.31,50.23 3.66,50 4,50C4.4,50 4.74,50.29 4.8,50.63L5.2,52.17C5.26,52.46 5.54,52.74 5.83,52.8L7.37,53.2C7.77,53.31 8,53.66 8,54C8,54.4 7.71,54.74 7.37,54.8Z"
+      android:strokeAlpha="0.2"
+      android:fillColor="#888888"
+      android:fillAlpha="0.2"/>
+  <path
+      android:pathData="M126.5,52C125.68,52 125,51.32 125,50.5C125,49.67 125.68,49 126.5,49C127.32,49 128,49.67 128,50.5C128,51.32 127.32,52 126.5,52Z"
+      android:strokeAlpha="0.2"
+      android:fillColor="#888888"
+      android:fillAlpha="0.2"/>
+  <path
+      android:pathData="M23,70C21.9,70 21,69.1 21,68C21,66.9 21.9,66 23,66C24.1,66 25,66.9 25,68C25,69.1 24.1,70 23,70Z"
+      android:strokeAlpha="0.2"
+      android:fillColor="#888888"
+      android:fillAlpha="0.2"/>
+  <path
+      android:pathData="M32,24C32,21.79 33.79,20 36,20H88C90.21,20 92,21.79 92,24V28H32V24Z"
+      android:fillColor="#2B55CA"/>
+  <path
+      android:pathData="M32,24C32,21.79 33.79,20 36,20H84C86.21,20 88,21.79 88,24V28H32V24Z"
+      android:fillColor="#7295F6"/>
+  <path
+      android:pathData="M87,51C75.95,51 67,59.95 67,71C67,73.76 64.76,76 62,76H38C34.69,76 32,73.31 32,70V28H92V46C92,48.76 89.76,51 87,51Z"
+      android:fillColor="#AAAAAA"/>
+  <path
+      android:pathData="M87,51C75.95,51 67,59.95 67,71C67,73.76 64.76,76 62,76H38C34.69,76 32,73.31 32,70V28H88V51H87Z"
+      android:fillColor="#E5E5E5"/>
+  <path
+      android:pathData="M40,34L58,34A2,2 0,0 1,60 36L60,50A2,2 0,0 1,58 52L40,52A2,2 0,0 1,38 50L38,36A2,2 0,0 1,40 34z"
+      android:fillColor="#ADC2FC"/>
+  <path
+      android:pathData="M67.02,70C67.46,61.12 73.68,53.77 82,51.63V36C82,34.9 81.1,34 80,34H66C64.9,34 64,34.9 64,36V68C64,69.1 64.9,70 66,70H67.02Z"
+      android:fillColor="#CCCCCC"/>
+  <path
+      android:pathData="M39,56L59,56A1,1 0,0 1,60 57L60,60A1,1 0,0 1,59 61L39,61A1,1 0,0 1,38 60L38,57A1,1 0,0 1,39 56z"
+      android:fillColor="#ADC2FC"/>
+  <path
+      android:pathData="M39,65L59,65A1,1 0,0 1,60 66L60,69A1,1 0,0 1,59 70L39,70A1,1 0,0 1,38 69L38,66A1,1 0,0 1,39 65z"
+      android:fillColor="#ADC2FC"/>
+  <path
+      android:pathData="M87,71m-16,0a16,16 0,1 1,32 0a16,16 0,1 1,-32 0"
+      android:fillColor="#EE1025"/>
+  <path
+      android:pathData="M79,68L95,68A2,2 0,0 1,97 70L97,72A2,2 0,0 1,95 74L79,74A2,2 0,0 1,77 72L77,70A2,2 0,0 1,79 68z"
+      android:fillColor="#ffffff"/>
+  <path
+      android:pathData="M108.5,59C108.8,59 109.1,59.12 109.32,59.35C109.78,59.82 109.78,60.58 109.32,61.05L106.99,63.45C106.54,63.92 105.8,63.92 105.34,63.45C104.89,62.98 104.89,62.22 105.34,61.75L107.67,59.35C107.9,59.12 108.2,59 108.5,59H108.5Z"
+      android:fillColor="#CCCCCC"/>
+  <path
+      android:pathData="M107.33,69.8H110.83C111.47,69.8 112,70.34 112,71C112,71.66 111.47,72.2 110.83,72.2H107.33C106.69,72.2 106.17,71.66 106.17,71C106.17,70.34 106.69,69.8 107.33,69.8Z"
+      android:fillColor="#CCCCCC"/>
+  <path
+      android:pathData="M105.35,78.55C105.58,78.32 105.88,78.2 106.18,78.2H106.18C106.48,78.2 106.78,78.32 107,78.55L109.34,80.95C109.79,81.42 109.79,82.18 109.34,82.65C108.88,83.12 108.14,83.12 107.68,82.65L105.35,80.25C104.9,79.78 104.9,79.02 105.35,78.55Z"
+      android:fillColor="#CCCCCC"/>
+</vector>

--- a/ad-blocking/ad-blocking-impl/src/main/res/layout/activity_ad_blocking_settings.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/layout/activity_ad_blocking_settings.xml
@@ -78,7 +78,7 @@
                 app:textType="secondary"
                 app:typography="body2" />
 
-            <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+            <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
                 android:id="@+id/duckPlayerEntry"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/ad-blocking/ad-blocking-impl/src/main/res/layout/activity_ad_blocking_settings_v2.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/layout/activity_ad_blocking_settings_v2.xml
@@ -43,7 +43,7 @@
                 android:layout_gravity="center"
                 android:layout_marginTop="@dimen/keyline_5"
                 android:importantForAccessibility="no"
-                android:src="@drawable/ad_blocking_header_128" />
+                android:src="@drawable/ad_blocking_128" />
 
             <com.duckduckgo.common.ui.view.text.DaxTextView
                 android:id="@+id/adBlockingHeaderTitle"

--- a/ad-blocking/ad-blocking-impl/src/main/res/layout/activity_ad_blocking_settings_v2.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/layout/activity_ad_blocking_settings_v2.xml
@@ -52,8 +52,26 @@
                 android:layout_marginHorizontal="@dimen/keyline_4"
                 android:layout_marginTop="@dimen/keyline_2"
                 android:gravity="center"
-                android:text="@string/ad_blocking_settings_title"
+                android:text="@string/ad_blocking_settings_title_v2"
                 app:typography="h2" />
+
+            <com.duckduckgo.common.ui.view.StatusIndicatorView
+                android:id="@+id/adBlockingStatusIndicator"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_marginTop="@dimen/keyline_1" />
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/adBlockingHeaderDescription"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/keyline_4"
+                android:layout_marginTop="@dimen/keyline_2"
+                android:gravity="center"
+                android:text="@string/ad_blocking_settings_header_description"
+                app:textType="secondary"
+                app:typography="body2" />
 
             <com.duckduckgo.common.ui.view.divider.HorizontalDivider
                 android:layout_width="match_parent"
@@ -78,7 +96,7 @@
                 app:textType="secondary"
                 app:typography="body2" />
 
-            <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+            <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
                 android:id="@+id/duckPlayerEntry"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/ad-blocking/ad-blocking-impl/src/main/res/values/donottranslate.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values/donottranslate.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<resources>
+    <string name="ad_blocking_settings_title_v2">Ad Blocking</string>
+    <string name="ad_blocking_settings_header_description">Blocks invasive trackers before they load, effectively eliminating ads that rely on tracking</string>
+</resources>

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsEntryViewModelTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsEntryViewModelTest.kt
@@ -16,14 +16,19 @@
 
 package com.duckduckgo.adblocking.impl.ui
 
+import android.annotation.SuppressLint
 import androidx.lifecycle.LifecycleOwner
 import app.cash.turbine.test
 import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
 import com.duckduckgo.adblocking.impl.ui.AdBlockingSettingsEntryViewModel.Command.OpenSettings
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -31,6 +36,7 @@ import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
+@SuppressLint("DenyListedApi") // setRawStoredState
 class AdBlockingSettingsEntryViewModelTest {
 
     @get:Rule
@@ -38,11 +44,16 @@ class AdBlockingSettingsEntryViewModelTest {
 
     private val statusChecker: AdBlockingStatusChecker = mock()
     private val lifecycleOwner: LifecycleOwner = mock()
+    private val feature = FakeFeatureToggleFactory.create(AdBlockingExtensionFeature::class.java)
 
-    private fun createViewModel() = AdBlockingSettingsEntryViewModel(
-        statusChecker,
-        coroutineRule.testDispatcherProvider,
-    )
+    private fun createViewModel(uxImprovements: Boolean = false): AdBlockingSettingsEntryViewModel {
+        feature.adBlockingUXImprovements().setRawStoredState(Toggle.State(remoteEnableState = uxImprovements))
+        return AdBlockingSettingsEntryViewModel(
+            statusChecker,
+            coroutineRule.testDispatcherProvider,
+            feature,
+        )
+    }
 
     @Test
     fun whenShownInSettingsThenVisible() = runTest {
@@ -92,6 +103,28 @@ class AdBlockingSettingsEntryViewModelTest {
             viewModel.onSettingClicked()
 
             assertTrue(awaitItem() is OpenSettings)
+        }
+    }
+
+    @Test
+    fun whenSettingClickedAndUxImprovementsDisabledThenOpensLegacyScreen() = runTest {
+        val viewModel = createViewModel(uxImprovements = false)
+
+        viewModel.commands().test {
+            viewModel.onSettingClicked()
+
+            assertEquals(AdBlockingSettingsNoParams, (awaitItem() as OpenSettings).params)
+        }
+    }
+
+    @Test
+    fun whenSettingClickedAndUxImprovementsEnabledThenOpensV2Screen() = runTest {
+        val viewModel = createViewModel(uxImprovements = true)
+
+        viewModel.commands().test {
+            viewModel.onSettingClicked()
+
+            assertEquals(AdBlockingSettingsV2NoParams, (awaitItem() as OpenSettings).params)
         }
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsViewModelTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsViewModelTest.kt
@@ -17,6 +17,12 @@
 package com.duckduckgo.adblocking.impl.ui
 
 import app.cash.turbine.test
+import com.duckduckgo.adblocking.api.duckplayer.DuckPlayer
+import com.duckduckgo.adblocking.api.duckplayer.DuckPlayer.UserPreferences
+import com.duckduckgo.adblocking.api.duckplayer.PrivatePlayerMode
+import com.duckduckgo.adblocking.api.duckplayer.PrivatePlayerMode.AlwaysAsk
+import com.duckduckgo.adblocking.api.duckplayer.PrivatePlayerMode.Disabled
+import com.duckduckgo.adblocking.api.duckplayer.PrivatePlayerMode.Enabled
 import com.duckduckgo.adblocking.impl.AdBlockingPixelNames
 import com.duckduckgo.adblocking.impl.AdBlockingSettingsRepository
 import com.duckduckgo.adblocking.impl.domain.AdBlockingState
@@ -42,8 +48,15 @@ class AdBlockingSettingsViewModelTest {
     private val statusChecker: AdBlockingStatusChecker = mock()
     private val repository: AdBlockingSettingsRepository = mock()
     private val pixel: Pixel = mock()
+    private val duckPlayer: DuckPlayer = mock()
 
-    private fun createViewModel() = AdBlockingSettingsViewModel(statusChecker, repository, pixel)
+    private fun createViewModel(duckPlayerMode: PrivatePlayerMode = AlwaysAsk): AdBlockingSettingsViewModel {
+        whenever(duckPlayer.observeUserPreferences()).thenReturn(flowOf(userPreferences(duckPlayerMode)))
+        return AdBlockingSettingsViewModel(statusChecker, repository, pixel, duckPlayer)
+    }
+
+    private fun userPreferences(privatePlayerMode: PrivatePlayerMode) =
+        UserPreferences(overlayInteracted = false, privatePlayerMode = privatePlayerMode)
 
     @Test
     fun whenEnabledByDefaultThenDoesNotShowConsentDescription() = runTest {
@@ -75,6 +88,24 @@ class AdBlockingSettingsViewModelTest {
             val state = expectMostRecentItem()
             assertFalse(state.isEnabled)
             assertEquals(true, state.showConsentDescription)
+        }
+    }
+
+    @Test
+    fun whenDuckPlayerModeIsEnabledThenViewStateReflectsIt() = runTest {
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Enabled.Default))
+
+        createViewModel(duckPlayerMode = Enabled).viewState.test {
+            assertEquals(Enabled, expectMostRecentItem().duckPlayerMode)
+        }
+    }
+
+    @Test
+    fun whenDuckPlayerModeIsDisabledThenViewStateReflectsIt() = runTest {
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Enabled.Default))
+
+        createViewModel(duckPlayerMode = Disabled).viewState.test {
+            assertEquals(Disabled, expectMostRecentItem().duckPlayerMode)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/481882893211075/task/1216168426960926?focus=true
Tech Design URL (if applicable): 

### Description

### Steps to test this PR

_Feature 1_
- [x] Fresh install
- [x] Open YouTube Ad Blocking settings
- [x] Check old design is displayed, no status indicator or Duck Player state shown

_Feature 1 2_
- [x] Open Feature Flags Inventory and toggle `adBlockingUxImprovements` on
- [x] Open YouTube Ad Blocking settings
- [x] Check Duck Player state is displayed
- [x] Click on "Duck Player"
- [x] Change selected mode
- [x] Navigate back and check state is updated
- [x] Toggle Ad Blocking and check status indicator at the top is updated

### UI changes
| Before  | After |
| ------ | ----- |
|<img width="1080" height="2340" alt="ad_blocking_settings_after" src="https://github.com/user-attachments/assets/72ef1075-7770-4f36-88d2-89638db16cd4" />|<img width="1080" height="2340" alt="Screenshot_20260702_173322" src="https://github.com/user-attachments/assets/1f1838bc-b294-4847-a599-bf2cc4fce60c" />|



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly settings UI and navigation behind a remote feature flag; ad-blocking enable/disable behavior is unchanged aside from shared lifecycle observation.
> 
> **Overview**
> Introduces a **feature-flagged** refreshed Ad Blocking settings experience (`adBlockingUXImprovements`) while keeping the legacy screen when the flag is off.
> 
> Settings entry navigation now passes `AdBlockingSettingsNoParams` or `AdBlockingSettingsV2NoParams` based on that toggle. Shared screen behavior is extracted into `BaseAdBlockingSettingsActivity`; the legacy activity stays on the old layout, and **V2** adds a header (icon, title, description), a **status indicator** tied to the block-ads toggle, and **Duck Player mode** as secondary text on the row (fed by combining ad-blocking state with `DuckPlayer.observeUserPreferences()` in the view model).
> 
> View-state collection in the base activity moves to `Lifecycle.State.RESUMED` (from `STARTED`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f40c3e23e7062b48b73d11b83c4386ccfcb46537. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->