### PR TITLE
Ignore first() and last() lint checks on StateFlow

### DIFF
--- a/lint-rules/src/main/java/com/duckduckgo/lint/DenyListedApiDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/DenyListedApiDetector.kt
@@ -57,7 +57,7 @@ internal class DenyListedApiDetector : Detector(), SourceCodeScanner, XmlScanner
         DenyListedEntry(
             className = "kotlinx.coroutines.flow.FlowKt__ReduceKt",
             functionName = "last",
-            errorMessage = "last() will throw if there's not at least one item, lastOrNull() it's a safer option.",
+            errorMessage = "last() will throw if flow is empty, lastOrNull() it's a safer option.",
             // StateFlow always hold a value, so last() can never throw on them.
             excludedReceiverTypes = listOf("kotlinx.coroutines.flow.StateFlow"),
             allowInTests = true,

--- a/lint-rules/src/main/java/com/duckduckgo/lint/DenyListedApiDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/DenyListedApiDetector.kt
@@ -241,10 +241,11 @@ internal class DenyListedApiDetector : Detector(), SourceCodeScanner, XmlScanner
             node: UCallExpression,
         ): Boolean {
             val excluded = excludedReceiverTypes ?: return false
-            val receiverType = node.receiverType as? PsiClassType ?: return false
-            val receiverClass = context.evaluator.findClass(receiverType.rawType().canonicalText) ?: return false
+            val receiverType = node.receiverType ?: return false
+            val rawType = if (receiverType is PsiClassType) receiverType.rawType() else receiverType
+            val receiverClass = context.evaluator.findClass(rawType.canonicalText) ?: return false
             return excluded.any { fqcn ->
-                receiverClass.qualifiedName == fqcn || context.evaluator.inheritsFrom(receiverClass, fqcn, false)
+                receiverClass.qualifiedName == fqcn || context.evaluator.inheritsFrom(receiverClass, fqcn)
             }
         }
 

--- a/lint-rules/src/main/java/com/duckduckgo/lint/DenyListedApiDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/DenyListedApiDetector.kt
@@ -19,6 +19,7 @@ import com.android.tools.lint.detector.api.Severity.ERROR
 import com.android.tools.lint.detector.api.SourceCodeScanner
 import com.android.tools.lint.detector.api.XmlContext
 import com.android.tools.lint.detector.api.XmlScanner
+import com.intellij.psi.PsiClassType
 import com.intellij.psi.PsiField
 import com.intellij.psi.PsiMethod
 import com.duckduckgo.lint.DenyListedEntry.Companion.MATCH_ALL
@@ -49,12 +50,16 @@ internal class DenyListedApiDetector : Detector(), SourceCodeScanner, XmlScanner
             className = "kotlinx.coroutines.flow.FlowKt__ReduceKt",
             functionName = "first",
             errorMessage = "first() will throw if flow is empty, firstOrNull() it's a safer option.",
+            // StateFlow always hold a value, so first() can never throw on them.
+            excludedReceiverTypes = listOf("kotlinx.coroutines.flow.StateFlow"),
             allowInTests = true,
         ),
         DenyListedEntry(
             className = "kotlinx.coroutines.flow.FlowKt__ReduceKt",
             functionName = "last",
             errorMessage = "last() will throw if there's not at least one item, lastOrNull() it's a safer option.",
+            // StateFlow always hold a value, so last() can never throw on them.
+            excludedReceiverTypes = listOf("kotlinx.coroutines.flow.StateFlow"),
             allowInTests = true,
         ),
         DenyListedEntry(
@@ -182,6 +187,7 @@ internal class DenyListedApiDetector : Detector(), SourceCodeScanner, XmlScanner
 
                 deniedFunctions.forEach { denyListEntry ->
                     if (denyListEntry.allowInTests && context.isTestSource) return@forEach
+                    if (denyListEntry.receiverTypeExcluded(context, node)) return@forEach
                     if (denyListEntry.parametersMatchWith(function) && denyListEntry.argumentsMatchWith(node)) {
                         context.report(
                             issue = ISSUE,
@@ -228,6 +234,18 @@ internal class DenyListedApiDetector : Detector(), SourceCodeScanner, XmlScanner
                 location = context.getLocation(element, type = NAME),
                 message = denyListEntry.errorMessage,
             )
+        }
+
+        private fun DenyListedEntry.receiverTypeExcluded(
+            context: JavaContext,
+            node: UCallExpression,
+        ): Boolean {
+            val excluded = excludedReceiverTypes ?: return false
+            val receiverType = node.receiverType as? PsiClassType ?: return false
+            val receiverClass = context.evaluator.findClass(receiverType.rawType().canonicalText) ?: return false
+            return excluded.any { fqcn ->
+                receiverClass.qualifiedName == fqcn || context.evaluator.inheritsFrom(receiverClass, fqcn, false)
+            }
         }
 
         private fun DenyListedEntry.parametersMatchWith(function: PsiMethod): Boolean {
@@ -295,6 +313,8 @@ data class DenyListedEntry(
     val parameters: List<String>? = null,
     /** Argument expressions to match at the call site, or null to match all invocations. */
     val arguments: List<String>? = null,
+    /** Fully-qualified receiver types (and their subtypes) to exclude from matching, or null to match all receivers. */
+    val excludedReceiverTypes: List<String>? = null,
     val errorMessage: String,
     /** When true, this entry is not reported in test sources (`src/test/...`, `src/androidTest/...`). */
     val allowInTests: Boolean = false,

--- a/lint-rules/src/test/java/com/duckduckgo/lint/NoFlowTerminalOperatorWithoutValueDetectorTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/NoFlowTerminalOperatorWithoutValueDetectorTest.kt
@@ -22,7 +22,6 @@ import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
 import com.android.tools.lint.checks.infrastructure.TestMode
 import org.junit.Test
 
-@Suppress("UnstableApiUsage")
 class NoFlowTerminalOperatorWithoutValueDetectorTest {
     @Test
     fun `first() on Flow is flagged`() {

--- a/lint-rules/src/test/java/com/duckduckgo/lint/NoFlowTerminalOperatorWithoutValueDetectorTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/NoFlowTerminalOperatorWithoutValueDetectorTest.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint
+
+import com.android.tools.lint.checks.infrastructure.TestFile
+import com.android.tools.lint.checks.infrastructure.TestFiles.kt
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import com.android.tools.lint.checks.infrastructure.TestMode
+import org.junit.Test
+
+@Suppress("UnstableApiUsage")
+class NoFlowTerminalOperatorWithoutValueDetectorTest {
+    @Test
+    fun `first() on Flow is flagged`() {
+        lint()
+            .files(
+                *flowStubs(),
+                kt(
+                    """
+                    import kotlinx.coroutines.flow.Flow
+                    import kotlinx.coroutines.flow.first
+
+                    suspend fun read(flow: Flow<Boolean>): Boolean {
+                        return flow.first()
+                    }
+                    """,
+                ).indented(),
+            )
+            .issues(DenyListedApiDetector.ISSUE)
+            .testModes(TestMode.DEFAULT)
+            .run()
+            .expectContains("first() will throw if flow is empty")
+    }
+
+    @Test
+    fun `last() on Flow is flagged`() {
+        lint()
+            .files(
+                *flowStubs(),
+                kt(
+                    """
+                    import kotlinx.coroutines.flow.Flow
+                    import kotlinx.coroutines.flow.last
+
+                    suspend fun read(flow: Flow<Boolean>): Boolean {
+                        return flow.last()
+                    }
+                    """,
+                ).indented(),
+            )
+            .issues(DenyListedApiDetector.ISSUE)
+            .testModes(TestMode.DEFAULT)
+            .run()
+            .expectContains("last() will throw if there's not at least one item")
+    }
+
+    @Test
+    fun `first() on StateFlow is allowed`() {
+        lint()
+            .files(
+                *flowStubs(),
+                kt(
+                    """
+                    import kotlinx.coroutines.flow.StateFlow
+                    import kotlinx.coroutines.flow.first
+
+                    suspend fun read(state: StateFlow<Boolean>): Boolean {
+                        return state.first()
+                    }
+                    """,
+                ).indented(),
+            )
+            .issues(DenyListedApiDetector.ISSUE)
+            .testModes(TestMode.DEFAULT)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `first() on MutableStateFlow is allowed`() {
+        lint()
+            .files(
+                *flowStubs(),
+                kt(
+                    """
+                    import kotlinx.coroutines.flow.MutableStateFlow
+                    import kotlinx.coroutines.flow.first
+
+                    suspend fun read(state: MutableStateFlow<Boolean>): Boolean {
+                        return state.first()
+                    }
+                    """,
+                ).indented(),
+            )
+            .issues(DenyListedApiDetector.ISSUE)
+            .testModes(TestMode.DEFAULT)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `last() on StateFlow is allowed`() {
+        lint()
+            .files(
+                *flowStubs(),
+                kt(
+                    """
+                    import kotlinx.coroutines.flow.StateFlow
+                    import kotlinx.coroutines.flow.last
+
+                    suspend fun read(state: StateFlow<Boolean>): Boolean {
+                        return state.last()
+                    }
+                    """,
+                ).indented(),
+            )
+            .issues(DenyListedApiDetector.ISSUE)
+            .testModes(TestMode.DEFAULT)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `last() on MutableStateFlow is allowed`() {
+        lint()
+            .files(
+                *flowStubs(),
+                kt(
+                    """
+                    import kotlinx.coroutines.flow.MutableStateFlow
+                    import kotlinx.coroutines.flow.last
+
+                    suspend fun read(state: MutableStateFlow<Boolean>): Boolean {
+                        return state.last()
+                    }
+                    """,
+                ).indented(),
+            )
+            .issues(DenyListedApiDetector.ISSUE)
+            .testModes(TestMode.DEFAULT)
+            .run()
+            .expectClean()
+    }
+
+    private fun flowStubs(): Array<TestFile> = arrayOf(
+        kt("""
+            package kotlinx.coroutines.flow
+    
+            interface Flow<out T>
+            interface StateFlow<out T> : Flow<T>
+            interface MutableStateFlow<T> : StateFlow<T>
+        """).indented(),
+        // At runtime `Flow.first()` / `Flow.last()` live in the compiler-generated multifile facade
+        // class `kotlinx.coroutines.flow.FlowKt__ReduceKt`. This is what DenyListedApiDetector
+        // matches against, so we force the facade name with `@file:JvmName("FlowKt__ReduceKt")`.
+        kt("""
+            @file:JvmName("FlowKt__ReduceKt")
+            package kotlinx.coroutines.flow
+    
+            suspend fun <T> Flow<T>.first(): T = TODO()
+            suspend fun <T> Flow<T>.last(): T = TODO()
+        """).indented(),
+    )
+}

--- a/lint-rules/src/test/java/com/duckduckgo/lint/NoFlowTerminalOperatorWithoutValueDetectorTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/NoFlowTerminalOperatorWithoutValueDetectorTest.kt
@@ -65,7 +65,7 @@ class NoFlowTerminalOperatorWithoutValueDetectorTest {
             .issues(DenyListedApiDetector.ISSUE)
             .testModes(TestMode.DEFAULT)
             .run()
-            .expectContains("last() will throw if there's not at least one item")
+            .expectContains("last() will throw if flow is empty")
     }
 
     @Test

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/chat/ChatSyncPromoChatTabItemPlugin.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/chat/ChatSyncPromoChatTabItemPlugin.kt
@@ -34,7 +34,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -75,7 +75,7 @@ class ChatSyncPromoChatTabItemPlugin @Inject constructor(
         showJob: Job,
     ) {
         launch {
-            duckChatInput.inputQuery.first(String::isNotEmpty)
+            duckChatInput.inputQuery.firstOrNull(String::isNotEmpty) ?: return@launch
             showJob.cancelAndJoin()
             adapter.dismiss(shouldAnimate = false)
         }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/chat/ChatSyncPromoChatTabItemPlugin.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/chat/ChatSyncPromoChatTabItemPlugin.kt
@@ -34,7 +34,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -75,7 +75,7 @@ class ChatSyncPromoChatTabItemPlugin @Inject constructor(
         showJob: Job,
     ) {
         launch {
-            duckChatInput.inputQuery.firstOrNull(String::isNotEmpty) ?: return@launch
+            duckChatInput.inputQuery.first(String::isNotEmpty)
             showJob.cancelAndJoin()
             adapter.dismiss(shouldAnimate = false)
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1216015637040041?focus=true
Tech Design URL (if applicable): 

### Description

Improves the `Flow.first()` and `Flow.last()` lint checks by excluding `StateFlow` from them. While this might seem like a weird choice, since `StateFlow` has direct `value` access, `first()` and `last()` have overloads that accept a predicate.

The exclusion is implemented as an optional list of receiver FQCNs in `DenyListedEntry`. If a call is dispatched to a type in the receiver list, the lint check is skipped.

I also aligned the error messages between the `first()` and `last()` detections.

### Steps to test this PR

_StateFlow check_
- [ ] Already covered by a change in `ChatSyncPromoChatTabItemPlugin` that uses `StateFlow`.
- [ ] CI lint check should pass.

_Flow check_
- [ ] Add `flowOf(1).first()` somewhere in the code.
- [ ] Run `./gradlew lint`.
- [ ] Lint should fail.

### UI changes
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint-only behavior in the custom rules module; no runtime app logic changes.
> 
> **Overview**
> Extends **DenyListedApiDetector** so deny-list entries can skip calls based on the receiver type, then uses that to stop flagging **`first()`** and **`last()`** on **`StateFlow`** and subtypes like **`MutableStateFlow`** (they always hold a value, so those operators cannot throw for an empty flow).
> 
> The **`last()`** lint message is aligned with **`first()`** (“flow is empty”). New unit tests assert plain **`Flow`** still fails while **`StateFlow`** / **`MutableStateFlow`** stay clean.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfba66463ce0c5dbf6b25f85262d31300b2b2469. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->