### PR TITLE
Fix Duck.ai contextual UninitializedPropertyAccessException

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.js.messaging.api.SubscriptionEventData
 import com.google.android.material.card.MaterialCardView
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.json.JSONArray
@@ -75,6 +76,7 @@ class RealContextualNativeInputManager @Inject constructor(
     private var jsMessaging: JsMessaging? = null
     private var widget: NativeInputModeWidget? = null
     private var lastMode: Mode? = null
+    private val modelPickerEnabled = MutableStateFlow(true)
 
     private enum class Mode { WEBVIEW, INPUT }
 
@@ -115,7 +117,7 @@ class RealContextualNativeInputManager @Inject constructor(
             card?.show()
             // WEBVIEW mode means a chat is in progress.
             // Hide the picker so the user can't change models mid-chat.
-            widget?.setModelPickerEnabled(false)
+            modelPickerEnabled.value = false
         } else {
             card?.gone()
         }
@@ -125,7 +127,7 @@ class RealContextualNativeInputManager @Inject constructor(
         lastMode = Mode.INPUT
         card?.gone()
         // INPUT mode is a new chat: restore the picker
-        if (isNativeInputEnabled) widget?.setModelPickerEnabled(true)
+        if (isNativeInputEnabled) modelPickerEnabled.value = true
     }
 
     private fun applyCardShape(card: MaterialCardView) {
@@ -150,6 +152,7 @@ class RealContextualNativeInputManager @Inject constructor(
     ) {
         widget.configureContextual(tabId)
         widget.bindChatIdSource(chatIdFlow)
+        widget.bindModelPickerEnabledSource(modelPickerEnabled)
         widget.hideMainButtons()
         widget.onStopTapped = ::sendStopEvent
         widget.bindAttachmentCallbacks(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -130,7 +130,6 @@ interface NativeInputWidget {
     fun getSelectedTool(): String?
     fun clearSelectedTool()
     fun onPromptSubmitted()
-    fun setModelPickerEnabled(enabled: Boolean)
 
     /** Block all interaction with the widget's controls and dim them, or restore. */
     fun setInteractionLocked(locked: Boolean)
@@ -1075,10 +1074,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     override fun onPromptSubmitted() {
         viewModel.onPromptSubmitted()
-    }
-
-    override fun setModelPickerEnabled(enabled: Boolean) {
-        viewModel.setModelPickerEnabled(enabled)
     }
 
     override fun bindModelPickerEnabledSource(source: Flow<Boolean>) {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealContextualNativeInputManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealContextualNativeInputManagerTest.kt
@@ -21,6 +21,7 @@ import android.view.View
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
+import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
@@ -30,9 +31,13 @@ import com.duckduckgo.js.messaging.api.JsMessaging
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.shape.ShapeAppearanceModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -96,6 +101,37 @@ class RealContextualNativeInputManagerTest {
 
         // inputMode is owned by the main widget VM; the reset must leave it alone.
         assertEquals(NativeInputState.InputMode.SEARCH_ONLY, updated.inputMode)
+    }
+
+    @Test
+    fun `when webview mode then input mode modelPickerEnabled emits false then true`() = runTest {
+        val enabled = MutableStateFlow(true)
+        whenever(duckChat.observeNativeChatInputEnabled()).thenReturn(enabled)
+        val widget = mock<NativeInputModeWidget>()
+        val pickerFlowCaptor = argumentCaptor<Flow<Boolean>>()
+        testee.init(
+            tabId = "tab",
+            card = mockCard(),
+            widget = widget,
+            jsMessaging = mock<JsMessaging>(),
+            lifecycleOwner = lifecycleOwner(),
+            chatIdFlow = emptyFlow(),
+            onSearchSubmitted = {},
+        )
+        verify(widget).bindModelPickerEnabledSource(pickerFlowCaptor.capture())
+        val pickerFlow = pickerFlowCaptor.firstValue
+
+        pickerFlow.test {
+            assertTrue(awaitItem())
+
+            testee.onWebViewMode()
+            assertFalse(awaitItem())
+
+            testee.onInputMode()
+            assertTrue(awaitItem())
+
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1216201888574930?focus=true
Tech Design URL (if applicable): 

### Description

- Fixes `UninitializedPropertyAccessException` by removing `setModelPickerEnabled()` and using a flow instead.

### Steps to test this PR

- [ ] Open contextual Duck.ai
- [ ] Verify that the model picker is hidden


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized contextual input wiring and UI gating; behavior is covered by a new flow-based unit test with no auth or data-layer changes.
> 
> **Overview**
> Fixes contextual Duck.ai **`UninitializedPropertyAccessException`** by stopping direct **`setModelPickerEnabled()`** calls on **`NativeInputModeWidget`**.
> 
> **`RealContextualNativeInputManager`** now owns a **`MutableStateFlow<Boolean>`** for model-picker enablement, wires it with **`bindModelPickerEnabledSource`** during **`init`**, and toggles it on **`onWebViewMode()`** (false while a chat is in progress) and **`onInputMode()`** (true for a new chat). The widget API drops **`setModelPickerEnabled`**; enablement is only updated through the bound flow into the view model.
> 
> A unit test asserts the bound flow emits **true → false → true** across webview and input mode transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df708a24b5a67d04e3de05731e2a0a196c6de0fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->