### PR TITLE
Make NTP as default idle page after inactivity

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabPageViewModel.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.app.browser.remotemessage.CommandActionMapper
 import com.duckduckgo.app.cta.db.DismissedCtaDao
 import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.app.cta.ui.CtaViewModel
+import com.duckduckgo.app.generalsettings.showonapplaunch.rmf.AfterIdleMessageTriggerProvider
 import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -45,12 +46,14 @@ import com.duckduckgo.sync.api.engine.SyncEngine.SyncTrigger.FEATURE_READ
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -61,10 +64,12 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 @SuppressLint("NoLifecycleObserver") // we don't observe app lifecycle
+@OptIn(ExperimentalCoroutinesApi::class)
 class NewTabPageViewModel @AssistedInject constructor(
     @Assisted private val showDaxLogo: Boolean,
     private val dispatchers: DispatcherProvider,
     private val remoteMessagingModel: RemoteMessageModel,
+    private val afterIdleMessageTriggerProvider: AfterIdleMessageTriggerProvider,
     private val playStoreUtils: PlayStoreUtils,
     private val savedSitesRepository: SavedSitesRepository,
     private val syncEngine: SyncEngine,
@@ -143,7 +148,10 @@ class NewTabPageViewModel @AssistedInject constructor(
         viewModelScope.launch(dispatchers.io()) {
             savedSitesRepository.getFavorites()
                 .combine(
-                    remoteMessagingModel.observeActiveMessages()
+                    afterIdleMessageTriggerProvider.activeTrigger()
+                        .flatMapLatest { trigger ->
+                            remoteMessagingModel.observeActiveMessages(trigger)
+                        }
                         .map { message ->
                             if (message?.surfaces?.contains(Surface.NEW_TAB_PAGE) == true) message else null
                         },

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/GeneralSettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/GeneralSettingsActivity.kt
@@ -54,7 +54,7 @@ import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
 @InjectWith(ActivityScope::class)
-@ContributeToActivityStarter(GeneralSettingsScreenNoParams::class)
+@ContributeToActivityStarter(GeneralSettingsScreenNoParams::class, screenName = "settingsGeneral")
 class GeneralSettingsActivity : DuckDuckGoActivity() {
 
     @Inject

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/rmf/AfterIdleMessageTriggerProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/rmf/AfterIdleMessageTriggerProvider.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch.rmf
+
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
+import com.duckduckgo.remote.messaging.api.MessageTrigger
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+/**
+ * Resolves the after-idle NTP context into [MessageTrigger.AFTER_IDLE]
+ */
+class AfterIdleMessageTriggerProvider @Inject constructor(
+    private val ntpAfterIdleManager: NtpAfterIdleManager,
+    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
+) {
+
+    fun activeTrigger(): Flow<MessageTrigger?> {
+        val rolloutEnabled = androidBrowserConfigFeature.showNTPAfterIdleReturn().isEnabled() &&
+            androidBrowserConfigFeature.ntpAsDefaultAfterIdleReturn().isEnabled()
+        if (!rolloutEnabled) return flowOf(null)
+
+        return ntpAfterIdleManager.isAfterIdleReturn.map { afterIdle ->
+            if (afterIdle) MessageTrigger.AFTER_IDLE else null
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/rmf/RMFNtpAfterIdleStateMatchingAttribute.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/rmf/RMFNtpAfterIdleStateMatchingAttribute.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch.rmf
+
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
+import com.duckduckgo.app.generalsettings.showonapplaunch.rmf.NtpAfterIdleState.ELIGIBLE_CARD_HIDDEN
+import com.duckduckgo.app.generalsettings.showonapplaunch.rmf.NtpAfterIdleState.ELIGIBLE_CARD_SHOWN
+import com.duckduckgo.app.generalsettings.showonapplaunch.rmf.NtpAfterIdleState.NOT_ELIGIBLE
+import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
+import com.duckduckgo.remote.messaging.api.AttributeMatcherPlugin
+import com.duckduckgo.remote.messaging.api.JsonMatchingAttribute
+import com.duckduckgo.remote.messaging.api.JsonToMatchingAttributeMapper
+import com.duckduckgo.remote.messaging.api.MatchingAttribute
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.flow.firstOrNull
+import javax.inject.Inject
+
+/**
+ * Matches the user's NTP-after-idle state, combining the after-idle "open on launch" option with the
+ * return-to-tab card visibility into a single value.
+ */
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = JsonToMatchingAttributeMapper::class,
+)
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = AttributeMatcherPlugin::class,
+)
+@SingleInstanceIn(AppScope::class)
+class RMFNtpAfterIdleStateMatchingAttribute @Inject constructor(
+    private val showOnAppLaunchOptionDataStore: ShowOnAppLaunchOptionDataStore,
+    private val ntpAfterIdleManager: NtpAfterIdleManager,
+    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
+) : JsonToMatchingAttributeMapper, AttributeMatcherPlugin {
+
+    override suspend fun evaluate(matchingAttribute: MatchingAttribute): Boolean? {
+        if (matchingAttribute is NtpAfterIdleStateMatchingAttribute) {
+            return currentState() in matchingAttribute.states
+        }
+        return null
+    }
+
+    override fun map(
+        key: String,
+        jsonMatchingAttribute: JsonMatchingAttribute,
+    ): MatchingAttribute? {
+        if (key != NtpAfterIdleStateMatchingAttribute.KEY) return null
+        // Rollout gate: when either flag is off, leave the attribute unmapped so RMF treats it as Unknown(fallback).
+        val rolloutEnabled = androidBrowserConfigFeature.showNTPAfterIdleReturn().isEnabled() &&
+            androidBrowserConfigFeature.ntpAsDefaultAfterIdleReturn().isEnabled()
+        if (!rolloutEnabled) return null
+        val value = jsonMatchingAttribute.value
+        if (value is List<*>) {
+            val states = value.filterIsInstance<String>()
+                .mapNotNull { raw -> NtpAfterIdleState.entries.firstOrNull { it.jsonValue == raw } }
+            if (states.isNotEmpty()) {
+                return NtpAfterIdleStateMatchingAttribute(states)
+            }
+        }
+        return null
+    }
+
+    private suspend fun currentState(): NtpAfterIdleState {
+        if (showOnAppLaunchOptionDataStore.optionFlow.firstOrNull() != NewTabPage) return NOT_ELIGIBLE
+        return if (ntpAfterIdleManager.returnToLastTabEnabled.firstOrNull() == true) ELIGIBLE_CARD_SHOWN else ELIGIBLE_CARD_HIDDEN
+    }
+}
+
+internal enum class NtpAfterIdleState(val jsonValue: String) {
+    NOT_ELIGIBLE("notEligible"),
+    ELIGIBLE_CARD_SHOWN("eligibleCardShown"),
+    ELIGIBLE_CARD_HIDDEN("eligibleCardHidden"),
+}
+
+internal data class NtpAfterIdleStateMatchingAttribute(
+    val states: List<NtpAfterIdleState>,
+) : MatchingAttribute {
+    companion object {
+        const val KEY = "ntpAfterIdleState"
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/store/ShowOnAppLaunchOptionDataStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/store/ShowOnAppLaunchOptionDataStore.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchO
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.SpecificPage
 import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore.Companion.DEFAULT_SPECIFIC_PAGE_URL
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
@@ -55,6 +56,7 @@ interface ShowOnAppLaunchOptionDataStore {
 @SingleInstanceIn(AppScope::class)
 class ShowOnAppLaunchOptionPrefsDataStore @Inject constructor(
     @ShowOnAppLaunch private val store: DataStore<Preferences>,
+    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
 ) : ShowOnAppLaunchOptionDataStore {
 
     override var showOnAppLaunchTabId: String? = null
@@ -75,8 +77,17 @@ class ShowOnAppLaunchOptionPrefsDataStore @Inject constructor(
                     SpecificPage(url, resolvedUrl)
                 }
             }
-        } ?: LastOpenedTab
+        } ?: defaultShowOnAppLaunchOption()
     }
+
+    private fun defaultShowOnAppLaunchOption(): ShowOnAppLaunchOption =
+        if (androidBrowserConfigFeature.showNTPAfterIdleReturn().isEnabled() &&
+            androidBrowserConfigFeature.ntpAsDefaultAfterIdleReturn().isEnabled()
+        ) {
+            NewTabPage
+        } else {
+            LastOpenedTab
+        }
 
     override val specificPageUrlFlow: Flow<String> = store.data.map { preferences ->
         preferences[stringPreferencesKey(KEY_SHOW_ON_APP_LAUNCH_SPECIFIC_PAGE_URL)] ?: DEFAULT_SPECIFIC_PAGE_URL

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -161,6 +161,14 @@ interface AndroidBrowserConfigFeature {
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun showNTPAfterIdleReturn(): Toggle
 
+    /**
+     * @return `true` when the remote config has the global "ntpAsDefaultAfterIdleReturn" androidBrowserConfig
+     * sub-feature flag enabled
+     * If the remote feature is not present defaults to `false`
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun ntpAsDefaultAfterIdleReturn(): Toggle
+
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun storeFaviconSuspend(): Toggle
 

--- a/app/src/test/java/com/duckduckgo/app/browser/newtab/NewTabPageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/newtab/NewTabPageViewModelTest.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.app.browser.remotemessage.CommandActionMapper
 import com.duckduckgo.app.cta.db.DismissedCtaDao
 import com.duckduckgo.app.cta.model.CtaId.DAX_END
 import com.duckduckgo.app.cta.ui.CtaViewModel
+import com.duckduckgo.app.generalsettings.showonapplaunch.rmf.AfterIdleMessageTriggerProvider
 import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -35,6 +36,7 @@ import com.duckduckgo.mobile.android.R
 import com.duckduckgo.mobile.android.app.tracking.AppTrackingProtection
 import com.duckduckgo.remote.messaging.api.Action
 import com.duckduckgo.remote.messaging.api.Content
+import com.duckduckgo.remote.messaging.api.MessageTrigger
 import com.duckduckgo.remote.messaging.api.RemoteMessage
 import com.duckduckgo.remote.messaging.api.RemoteMessageModel
 import com.duckduckgo.remote.messaging.api.Surface
@@ -70,6 +72,7 @@ class NewTabPageViewModelTest {
     private var mockCommandActionMapper: CommandActionMapper = mock()
     private var mockPlaystoreUtils: PlayStoreUtils = mock()
     private var mockRemoteMessageModel: RemoteMessageModel = mock()
+    private var mockAfterIdleMessageTriggerProvider: AfterIdleMessageTriggerProvider = mock()
     private var mockDismissedCtaDao: DismissedCtaDao = mock()
     private val mockSettingsDataStore: SettingsDataStore = mock()
     private val mockLowPriorityMessagingModel: LowPriorityMessagingModel = mock()
@@ -86,6 +89,7 @@ class NewTabPageViewModelTest {
         whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockDisabledToggle)
         whenever(mockSavedSitesRepository.getFavorites()).thenReturn(flowOf(emptyList()))
         whenever(mockRemoteMessageModel.observeActiveMessages()).thenReturn(flowOf(null))
+        whenever(mockAfterIdleMessageTriggerProvider.activeTrigger()).thenReturn(flowOf(null))
         whenever(mockAppTrackingProtection.isEnabled()).thenReturn(false)
 
         testee = createTestee()
@@ -99,6 +103,7 @@ class NewTabPageViewModelTest {
             showDaxLogo = showLogo,
             dispatchers = coroutinesTestRule.testDispatcherProvider,
             remoteMessagingModel = mockRemoteMessageModel,
+            afterIdleMessageTriggerProvider = mockAfterIdleMessageTriggerProvider,
             playStoreUtils = mockPlaystoreUtils,
             savedSitesRepository = mockSavedSitesRepository,
             syncEngine = mockSyncEngine,
@@ -112,6 +117,21 @@ class NewTabPageViewModelTest {
             ctaViewModel = mockCtaViewModel,
             browserMode = browserMode,
         )
+    }
+
+    @Test
+    fun whenActiveTriggerIsAfterIdleThenObservesMessagesWithThatTrigger() = runTest {
+        val remoteMessage = RemoteMessage("id1", Content.Small("", ""), emptyList(), emptyList(), listOf(Surface.NEW_TAB_PAGE))
+        whenever(mockAfterIdleMessageTriggerProvider.activeTrigger()).thenReturn(flowOf(MessageTrigger.AFTER_IDLE))
+        // Only the AFTER_IDLE overload returns the message; the no-trigger default (stubbed in setUp) returns
+        // null, so the message surfacing proves the VM threaded AFTER_IDLE into observeActiveMessages.
+        whenever(mockRemoteMessageModel.observeActiveMessages(MessageTrigger.AFTER_IDLE)).thenReturn(flowOf(remoteMessage))
+
+        testee.onStart(mockLifecycleOwner)
+
+        testee.viewState.test {
+            assertEquals(remoteMessage, expectMostRecentItem().message)
+        }
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/rmf/AfterIdleMessageTriggerProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/rmf/AfterIdleMessageTriggerProviderTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch.rmf
+
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
+import com.duckduckgo.remote.messaging.api.MessageTrigger
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class AfterIdleMessageTriggerProviderTest {
+
+    private val ntpAfterIdleManager: NtpAfterIdleManager = mock()
+    private val feature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
+
+    private val testee = AfterIdleMessageTriggerProvider(ntpAfterIdleManager, feature)
+
+    @Test
+    fun whenBothFlagsEnabledAndAfterIdleReturnThenAfterIdleTrigger() = runTest {
+        enableBothFlags()
+        whenever(ntpAfterIdleManager.isAfterIdleReturn).thenReturn(MutableStateFlow(true))
+
+        assertEquals(MessageTrigger.AFTER_IDLE, testee.activeTrigger().firstOrNull())
+    }
+
+    @Test
+    fun whenBothFlagsEnabledAndNotAfterIdleReturnThenNull() = runTest {
+        enableBothFlags()
+        whenever(ntpAfterIdleManager.isAfterIdleReturn).thenReturn(MutableStateFlow(false))
+
+        assertNull(testee.activeTrigger().firstOrNull())
+    }
+
+    @Test
+    fun whenShowNtpAfterIdleReturnFlagDisabledThenNull() = runTest {
+        feature.ntpAsDefaultAfterIdleReturn().setRawStoredState(Toggle.State(enable = true))
+        // showNTPAfterIdleReturn stays off → gated out before idle state is observed
+
+        assertNull(testee.activeTrigger().firstOrNull())
+    }
+
+    @Test
+    fun whenNtpAsDefaultFlagDisabledThenNull() = runTest {
+        feature.showNTPAfterIdleReturn().setRawStoredState(Toggle.State(enable = true))
+        // ntpAsDefaultAfterIdleReturn stays off → gated out before idle state is observed
+
+        assertNull(testee.activeTrigger().firstOrNull())
+    }
+
+    private fun enableBothFlags() {
+        feature.showNTPAfterIdleReturn().setRawStoredState(Toggle.State(enable = true))
+        feature.ntpAsDefaultAfterIdleReturn().setRawStoredState(Toggle.State(enable = true))
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/rmf/RMFNtpAfterIdleStateMatchingAttributeTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/rmf/RMFNtpAfterIdleStateMatchingAttributeTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch.rmf
+
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.LastOpenedTab
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
+import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
+import com.duckduckgo.remote.messaging.api.JsonMatchingAttribute
+import com.duckduckgo.remote.messaging.api.MatchingAttribute
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class RMFNtpAfterIdleStateMatchingAttributeTest {
+
+    private val showOnAppLaunchOptionDataStore: ShowOnAppLaunchOptionDataStore = mock()
+    private val ntpAfterIdleManager: NtpAfterIdleManager = mock()
+    private val feature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
+
+    private val testee = RMFNtpAfterIdleStateMatchingAttribute(showOnAppLaunchOptionDataStore, ntpAfterIdleManager, feature)
+
+    // --- map (this is where the rollout is gated: flags off => attribute is left unmapped) ---
+
+    @Test
+    fun whenKeyIsNotNtpAfterIdleStateThenMapReturnsNull() {
+        assertNull(testee.map("someOtherKey", JsonMatchingAttribute(value = listOf("eligibleCardShown"))))
+    }
+
+    @Test
+    fun whenRolloutDisabledThenMapReturnsNull() {
+        // both flags default off → attribute not mapped (RMF treats it as Unknown(fallback))
+        assertNull(testee.map("ntpAfterIdleState", JsonMatchingAttribute(value = listOf("eligibleCardShown"))))
+    }
+
+    @Test
+    fun whenRolloutEnabledAndValueHasKnownStatesThenMapReturnsAttribute() {
+        enableRollout()
+
+        val result = testee.map("ntpAfterIdleState", JsonMatchingAttribute(value = listOf("eligibleCardShown")))
+
+        assertEquals(NtpAfterIdleStateMatchingAttribute(listOf(NtpAfterIdleState.ELIGIBLE_CARD_SHOWN)), result)
+    }
+
+    @Test
+    fun whenRolloutEnabledAndValueHasNoKnownStatesThenMapReturnsNull() {
+        enableRollout()
+
+        assertNull(testee.map("ntpAfterIdleState", JsonMatchingAttribute(value = listOf("futureState"))))
+    }
+
+    // --- evaluate (only reached once mapped, i.e. rollout on; it computes state from the settings) ---
+
+    @Test
+    fun whenOptionNotNtpThenNotEligible() = runTest {
+        whenever(showOnAppLaunchOptionDataStore.optionFlow).thenReturn(flowOf(LastOpenedTab))
+
+        assertEquals(true, testee.evaluate(attr(NtpAfterIdleState.NOT_ELIGIBLE)))
+        assertEquals(false, testee.evaluate(attr(NtpAfterIdleState.ELIGIBLE_CARD_SHOWN)))
+    }
+
+    @Test
+    fun whenNtpAndCardShownThenEligibleCardShown() = runTest {
+        whenever(showOnAppLaunchOptionDataStore.optionFlow).thenReturn(flowOf(NewTabPage))
+        whenever(ntpAfterIdleManager.returnToLastTabEnabled).thenReturn(flowOf(true))
+
+        assertEquals(true, testee.evaluate(attr(NtpAfterIdleState.ELIGIBLE_CARD_SHOWN)))
+        assertEquals(false, testee.evaluate(attr(NtpAfterIdleState.ELIGIBLE_CARD_HIDDEN)))
+    }
+
+    @Test
+    fun whenNtpAndCardHiddenThenEligibleCardHidden() = runTest {
+        whenever(showOnAppLaunchOptionDataStore.optionFlow).thenReturn(flowOf(NewTabPage))
+        whenever(ntpAfterIdleManager.returnToLastTabEnabled).thenReturn(flowOf(false))
+
+        assertEquals(true, testee.evaluate(attr(NtpAfterIdleState.ELIGIBLE_CARD_HIDDEN)))
+        assertEquals(false, testee.evaluate(attr(NtpAfterIdleState.ELIGIBLE_CARD_SHOWN)))
+    }
+
+    @Test
+    fun whenAttributeIsNotNtpAfterIdleStateThenEvaluateReturnsNull() = runTest {
+        assertNull(testee.evaluate(object : MatchingAttribute {}))
+    }
+
+    private fun attr(vararg states: NtpAfterIdleState) = NtpAfterIdleStateMatchingAttribute(states.toList())
+
+    private fun enableRollout() {
+        feature.showNTPAfterIdleReturn().setRawStoredState(Toggle.State(enable = true))
+        feature.ntpAsDefaultAfterIdleReturn().setRawStoredState(Toggle.State(enable = true))
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/store/ShowOnAppLaunchPrefsDataStoreTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/store/ShowOnAppLaunchPrefsDataStoreTest.kt
@@ -27,7 +27,10 @@ import app.cash.turbine.test
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.LastOpenedTab
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.SpecificPage
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -54,8 +57,10 @@ class ShowOnAppLaunchPrefsDataStoreTest {
             produceFile = { dataStoreFile },
         )
 
+    private val androidBrowserConfigFeature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
+
     private val testee: ShowOnAppLaunchOptionPrefsDataStore =
-        ShowOnAppLaunchOptionPrefsDataStore(testDataStore)
+        ShowOnAppLaunchOptionPrefsDataStore(testDataStore, androidBrowserConfigFeature)
 
     @After
     fun after() {
@@ -64,6 +69,37 @@ class ShowOnAppLaunchPrefsDataStoreTest {
 
     @Test
     fun whenOptionIsNullThenShouldReturnLastOpenedTab() = runTest {
+        assertEquals(LastOpenedTab, testee.optionFlow.first())
+    }
+
+    @Test
+    fun whenOptionNullAndBothNtpDefaultFlagsEnabledThenReturnsNewTabPage() = runTest {
+        androidBrowserConfigFeature.showNTPAfterIdleReturn().setRawStoredState(Toggle.State(enable = true))
+        androidBrowserConfigFeature.ntpAsDefaultAfterIdleReturn().setRawStoredState(Toggle.State(enable = true))
+
+        assertEquals(NewTabPage, testee.optionFlow.first())
+    }
+
+    @Test
+    fun whenOptionNullAndOnlyShowNtpAfterIdleEnabledThenReturnsLastOpenedTab() = runTest {
+        androidBrowserConfigFeature.showNTPAfterIdleReturn().setRawStoredState(Toggle.State(enable = true))
+
+        assertEquals(LastOpenedTab, testee.optionFlow.first())
+    }
+
+    @Test
+    fun whenOptionNullAndOnlyNtpAsDefaultEnabledThenReturnsLastOpenedTab() = runTest {
+        androidBrowserConfigFeature.ntpAsDefaultAfterIdleReturn().setRawStoredState(Toggle.State(enable = true))
+
+        assertEquals(LastOpenedTab, testee.optionFlow.first())
+    }
+
+    @Test
+    fun whenOptionExplicitlySetThenNtpDefaultFlagsAreIgnored() = runTest {
+        androidBrowserConfigFeature.showNTPAfterIdleReturn().setRawStoredState(Toggle.State(enable = true))
+        androidBrowserConfigFeature.ntpAsDefaultAfterIdleReturn().setRawStoredState(Toggle.State(enable = true))
+        testee.setShowOnAppLaunchOption(LastOpenedTab)
+
         assertEquals(LastOpenedTab, testee.optionFlow.first())
     }
 

--- a/remote-messaging/remote-messaging-api/src/main/java/com/duckduckgo/remote/messaging/api/RemoteMessage.kt
+++ b/remote-messaging/remote-messaging-api/src/main/java/com/duckduckgo/remote/messaging/api/RemoteMessage.kt
@@ -39,11 +39,30 @@ data class RemoteMessage(
     val matchingRules: List<Int>,
     val exclusionRules: List<Int>,
     val surfaces: List<Surface>,
+    val displayConditions: DisplayConditions? = null,
 )
 
 enum class Surface(val jsonValue: String) {
     MODAL("modal"),
     NEW_TAB_PAGE("new_tab_page"),
+}
+
+/**
+ * Conditions controlling when and for how long a message is displayed.
+ * Evaluated internally by RMF; null fields mean "no restriction".
+ */
+data class DisplayConditions(
+    val trigger: MessageTrigger?,
+    val dismissAfterDaysShown: Int?,
+)
+
+/**
+ * The context a message targets, supplied by the consumer at read time.
+ * A triggered message is returned only in that context.
+ * A message with no trigger is unrestricted.
+ */
+enum class MessageTrigger(val jsonValue: String) {
+    AFTER_IDLE("after_idle"),
 }
 
 sealed class Content(val messageType: MessageType) {

--- a/remote-messaging/remote-messaging-api/src/main/java/com/duckduckgo/remote/messaging/api/RemoteMessageModel.kt
+++ b/remote-messaging/remote-messaging-api/src/main/java/com/duckduckgo/remote/messaging/api/RemoteMessageModel.kt
@@ -20,9 +20,9 @@ import kotlinx.coroutines.flow.Flow
 
 interface RemoteMessageModel {
 
-    fun getActiveMessage(): RemoteMessage?
+    fun getActiveMessage(activeTrigger: MessageTrigger? = null): RemoteMessage?
 
-    fun observeActiveMessages(): Flow<RemoteMessage?>
+    fun observeActiveMessages(activeTrigger: MessageTrigger? = null): Flow<RemoteMessage?>
 
     suspend fun onMessageShown(remoteMessage: RemoteMessage)
 

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepository.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepository.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.remote.messaging.impl
 
+import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.remote.messaging.api.RemoteMessage
 import com.duckduckgo.remote.messaging.api.Surface
 import com.duckduckgo.remote.messaging.impl.mappers.MessageMapper
@@ -28,6 +29,7 @@ import com.duckduckgo.remote.messaging.store.RemoteMessagingConfigRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import java.util.concurrent.TimeUnit
 
 interface RemoteMessagingRepository {
     fun getMessageById(id: String): RemoteMessage?
@@ -51,6 +53,7 @@ class AppRemoteMessagingRepository(
     private val remoteMessagesDao: RemoteMessagesDao,
     private val messageMapper: MessageMapper,
     private val remoteMessageImageStore: RemoteMessageImageStore,
+    private val currentTimeProvider: CurrentTimeProvider,
 ) : RemoteMessagingRepository {
 
     override fun getMessageById(id: String): RemoteMessage? {
@@ -71,38 +74,58 @@ class AppRemoteMessagingRepository(
     override fun didShow(id: String) = remoteMessagesDao.messagesById(id)?.shown ?: false
 
     override fun markAsShown(remoteMessage: RemoteMessage) {
-        val message = remoteMessagesDao.messagesById(remoteMessage.id) ?: return
-        remoteMessagesDao.insert(message.copy(shown = true))
+        val messageEntity = remoteMessagesDao.messagesById(remoteMessage.id) ?: return
+        // Stamp the first-shown timestamp on the first impression only.
+        remoteMessagesDao.insert(
+            messageEntity.copy(
+                shown = true,
+                firstShownDate = messageEntity.firstShownDate ?: currentTimeProvider.currentTimeMillis(),
+            ),
+        )
     }
 
     override fun message(): RemoteMessage? {
-        val message = remoteMessagesDao.message()
-        if (message == null || message.message.isEmpty()) return null
+        val messageEntity = remoteMessagesDao.message()
+        if (messageEntity == null || messageEntity.message.isEmpty()) return null
 
-        val remoteMessage = messageMapper.fromMessage(message.message) ?: return null
-        RemoteMessage(
-            id = message.id,
-            content = remoteMessage.content,
-            emptyList(),
-            emptyList(),
-            remoteMessage.surfaces,
-        )
+        val remoteMessage = messageMapper.fromMessage(messageEntity.message) ?: return null
+        if (remoteMessage.isExpired(messageEntity.firstShownDate)) {
+            dismissExpiredMessage(messageEntity.id)
+            return null
+        }
         return remoteMessage
     }
 
     override fun messageFlow(): Flow<RemoteMessage?> {
-        return remoteMessagesDao.messagesFlow().distinctUntilChanged().map {
-            if (it == null || it.message.isEmpty()) return@map null
+        return remoteMessagesDao.messagesFlow().distinctUntilChanged().map { messageEntity ->
+            if (messageEntity == null || messageEntity.message.isEmpty()) return@map null
 
-            val message = messageMapper.fromMessage(it.message) ?: return@map null
+            val remoteMessage = messageMapper.fromMessage(messageEntity.message) ?: return@map null
+            if (remoteMessage.isExpired(messageEntity.firstShownDate)) {
+                dismissExpiredMessage(messageEntity.id)
+                return@map null
+            }
             RemoteMessage(
-                id = it.id,
-                content = message.content,
+                id = messageEntity.id,
+                content = remoteMessage.content,
                 emptyList(),
                 emptyList(),
-                message.surfaces,
+                remoteMessage.surfaces,
+                remoteMessage.displayConditions,
             )
         }
+    }
+
+    private fun RemoteMessage.isExpired(firstShownDate: Long?): Boolean {
+        val threshold = displayConditions?.dismissAfterDaysShown?.takeIf { it > 0 } ?: return false
+        val firstShown = firstShownDate ?: return false
+        val elapsedDays = TimeUnit.MILLISECONDS.toDays(currentTimeProvider.currentTimeMillis() - firstShown)
+        return elapsedDays >= threshold
+    }
+
+    private fun dismissExpiredMessage(id: String) {
+        remoteMessagesDao.updateState(id, Status.DISMISSED)
+        remoteMessagingConfigRepository.invalidate()
     }
 
     override suspend fun dismissMessage(id: String) {

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/RealRemoteMessageModel.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/RealRemoteMessageModel.kt
@@ -20,11 +20,14 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.remote.messaging.api.Action
 import com.duckduckgo.remote.messaging.api.Content
+import com.duckduckgo.remote.messaging.api.MessageTrigger
 import com.duckduckgo.remote.messaging.api.RemoteMessage
 import com.duckduckgo.remote.messaging.api.RemoteMessageModel
 import com.duckduckgo.remote.messaging.api.Surface
 import com.duckduckgo.remote.messaging.impl.pixels.RemoteMessagingPixels
 import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
@@ -35,8 +38,11 @@ class RealRemoteMessageModel @Inject constructor(
     private val dispatchers: DispatcherProvider,
 ) : RemoteMessageModel {
 
-    override fun getActiveMessage(): RemoteMessage? = remoteMessagingRepository.message()
-    override fun observeActiveMessages() = remoteMessagingRepository.messageFlow()
+    override fun getActiveMessage(activeTrigger: MessageTrigger?): RemoteMessage? =
+        remoteMessagingRepository.message()?.takeIf { it.matchesTrigger(activeTrigger) }
+
+    override fun observeActiveMessages(activeTrigger: MessageTrigger?): Flow<RemoteMessage?> =
+        remoteMessagingRepository.messageFlow().map { message -> message?.takeIf { it.matchesTrigger(activeTrigger) } }
 
     override suspend fun onMessageShown(remoteMessage: RemoteMessage) {
         withContext(dispatchers.io()) {
@@ -119,5 +125,10 @@ class RealRemoteMessageModel @Inject constructor(
             }
             else -> null
         }
+    }
+
+    private fun RemoteMessage.matchesTrigger(activeTrigger: MessageTrigger?): Boolean {
+        val requiredTrigger = displayConditions?.trigger ?: return true
+        return requiredTrigger == activeTrigger
     }
 }

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/di/RemoteMessagingModule.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/di/RemoteMessagingModule.kt
@@ -21,6 +21,7 @@ import androidx.room.Room
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.browser.api.AppProperties
 import com.duckduckgo.browser.api.UserBrowserProperties
+import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.DaggerSet
 import com.duckduckgo.di.scopes.AppScope
@@ -102,12 +103,14 @@ object DataSourceModule {
         remoteMessagesDao: RemoteMessagesDao,
         messageMapper: MessageMapper,
         remoteMessageImageStore: RemoteMessageImageStore,
+        currentTimeProvider: CurrentTimeProvider,
     ): RemoteMessagingRepository {
         return AppRemoteMessagingRepository(
             remoteMessagingConfigRepository,
             remoteMessagesDao,
             messageMapper,
             remoteMessageImageStore,
+            currentTimeProvider,
         )
     }
 

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/JsonRemoteMessageMapper.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/JsonRemoteMessageMapper.kt
@@ -27,8 +27,10 @@ import com.duckduckgo.remote.messaging.api.Content.Medium
 import com.duckduckgo.remote.messaging.api.Content.Placeholder
 import com.duckduckgo.remote.messaging.api.Content.PromoSingleAction
 import com.duckduckgo.remote.messaging.api.Content.Small
+import com.duckduckgo.remote.messaging.api.DisplayConditions
 import com.duckduckgo.remote.messaging.api.JsonMessageAction
 import com.duckduckgo.remote.messaging.api.MessageActionMapperPlugin
+import com.duckduckgo.remote.messaging.api.MessageTrigger
 import com.duckduckgo.remote.messaging.api.RemoteMessage
 import com.duckduckgo.remote.messaging.api.Surface
 import com.duckduckgo.remote.messaging.impl.models.*
@@ -40,6 +42,7 @@ import com.duckduckgo.remote.messaging.impl.models.JsonMessageType.PROMO_SINGLE_
 import com.duckduckgo.remote.messaging.impl.models.JsonMessageType.SMALL
 import com.duckduckgo.remote.messaging.impl.models.asJsonFormat
 import logcat.LogPriority.ERROR
+import logcat.LogPriority.INFO
 import logcat.logcat
 import java.util.Locale
 
@@ -162,6 +165,14 @@ private fun JsonRemoteMessage.map(
     locale: Locale,
     actionMappers: Set<MessageActionMapperPlugin>,
 ): RemoteMessage? {
+    // Resolve display conditions up front. An unrecognized trigger means this message targets a
+    // context this client version doesn't understand so we skip it.
+    val displayConditions = this.displayConditions?.let { conditions ->
+        conditions.toDisplayConditionsOrNull() ?: run {
+            logcat(INFO) { "RMF: skipping message id=${this.id}, unknown trigger '${conditions.trigger}'" }
+            return null
+        }
+    }
     return runCatching {
         val remoteMessage = RemoteMessage(
             id = this.id.failIfEmpty(),
@@ -169,6 +180,7 @@ private fun JsonRemoteMessage.map(
             matchingRules = this.matchingRules.orEmpty(),
             exclusionRules = this.exclusionRules.orEmpty(),
             surfaces = this.surfaces.toSurfaceList(),
+            displayConditions = displayConditions,
         )
         remoteMessage.localizeMessage(this.translations, locale)
     }.onFailure {
@@ -180,6 +192,20 @@ private fun List<String>?.toSurfaceList(): List<Surface> {
     return this?.mapNotNull { value ->
         Surface.entries.firstOrNull { it.jsonValue == value }
     } ?: listOf(Surface.NEW_TAB_PAGE)
+}
+
+// Returns null when a trigger string is present but unrecognized, so the caller can drop the
+// message (forward-compat). A null trigger is valid and means "no trigger" (unrestricted).
+private fun JsonDisplayConditions.toDisplayConditionsOrNull(): DisplayConditions? {
+    val resolvedTrigger = if (trigger == null) {
+        null
+    } else {
+        MessageTrigger.entries.firstOrNull { it.jsonValue == trigger } ?: return null
+    }
+    return DisplayConditions(
+        trigger = resolvedTrigger,
+        dismissAfterDaysShown = dismissAfterDaysShown,
+    )
 }
 
 private fun RemoteMessage.localizeMessage(

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/models/JsonRemoteMessagingConfig.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/models/JsonRemoteMessagingConfig.kt
@@ -32,6 +32,12 @@ data class JsonRemoteMessage(
     val matchingRules: List<Int>?,
     val translations: Map<String, JsonContentTranslations>,
     val surfaces: List<String>?,
+    val displayConditions: JsonDisplayConditions? = null,
+)
+
+data class JsonDisplayConditions(
+    val trigger: String? = null,
+    val dismissAfterDaysShown: Int? = null,
 )
 
 data class JsonContent(

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/fixtures/JsonRemoteMessageOM.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/fixtures/JsonRemoteMessageOM.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.remote.messaging.fixtures
 import com.duckduckgo.remote.messaging.api.JsonMessageAction
 import com.duckduckgo.remote.messaging.impl.models.JsonContent
 import com.duckduckgo.remote.messaging.impl.models.JsonContentTranslations
+import com.duckduckgo.remote.messaging.impl.models.JsonDisplayConditions
 import com.duckduckgo.remote.messaging.impl.models.JsonListItem
 import com.duckduckgo.remote.messaging.impl.models.JsonMatchingRule
 import com.duckduckgo.remote.messaging.impl.models.JsonRemoteMessage
@@ -159,6 +160,7 @@ object JsonRemoteMessageOM {
         matchingRules: List<Int> = emptyList(),
         translations: Map<String, JsonContentTranslations> = emptyMap(),
         surfaces: List<String>? = null,
+        displayConditions: JsonDisplayConditions? = null,
     ) = JsonRemoteMessage(
         id = id,
         content = content,
@@ -166,6 +168,7 @@ object JsonRemoteMessageOM {
         matchingRules = matchingRules,
         translations = translations,
         surfaces = surfaces,
+        displayConditions = displayConditions,
     )
 
     fun aJsonRemoteMessagingConfig(

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepositoryTest.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/AppRemoteMessagingRepositoryTest.kt
@@ -21,6 +21,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.remote.messaging.api.Action
 import com.duckduckgo.remote.messaging.api.Action.Share
 import com.duckduckgo.remote.messaging.api.Content.BigSingleAction
@@ -30,6 +31,8 @@ import com.duckduckgo.remote.messaging.api.Content.Placeholder.ANNOUNCE
 import com.duckduckgo.remote.messaging.api.Content.Placeholder.MAC_AND_WINDOWS
 import com.duckduckgo.remote.messaging.api.Content.PromoSingleAction
 import com.duckduckgo.remote.messaging.api.Content.Small
+import com.duckduckgo.remote.messaging.api.DisplayConditions
+import com.duckduckgo.remote.messaging.api.MessageTrigger
 import com.duckduckgo.remote.messaging.api.RemoteMessage
 import com.duckduckgo.remote.messaging.api.Surface
 import com.duckduckgo.remote.messaging.fixtures.getMessageMapper
@@ -48,6 +51,7 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import java.util.concurrent.TimeUnit
 
 // TODO: when pattern established, refactor objects to use (create module https://app.asana.com/0/0/1201807285420697/f)
 @RunWith(AndroidJUnit4::class)
@@ -66,12 +70,14 @@ class AppRemoteMessagingRepositoryTest {
 
     private val remoteMessagingConfigRepository: RemoteMessagingConfigRepository = mock()
     private val remoteMessageImageStore: RemoteMessageImageStore = mock()
+    private val currentTimeProvider: CurrentTimeProvider = mock()
 
     private val testee = AppRemoteMessagingRepository(
         remoteMessagingConfigRepository,
         dao,
         getMessageMapper(),
         remoteMessageImageStore,
+        currentTimeProvider,
     )
 
     @After
@@ -471,6 +477,75 @@ class AppRemoteMessagingRepositoryTest {
         assertNull(result)
     }
 
+    @Test
+    fun whenMarkAsShownThenFirstShownDateStampedOnce() {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(1000L)
+        testee.activeMessage(aRemoteMessage("id"))
+
+        testee.markAsShown(aRemoteMessage("id"))
+        assertEquals(1000L, dao.messagesById("id")?.firstShownDate)
+
+        // a second impression must not move the timestamp
+        testee.markAsShown(aRemoteMessage("id"))
+        assertEquals(1000L, dao.messagesById("id")?.firstShownDate)
+    }
+
+    @Test
+    fun whenExpiryThresholdReachedThenMessageDismissedAndConfigInvalidated() = runTest {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(0L, TimeUnit.DAYS.toMillis(5))
+        testee.activeMessage(aRemoteMessageWithDisplayConditions("id", DisplayConditions(trigger = null, dismissAfterDaysShown = 5)))
+        testee.markAsShown(aRemoteMessage("id"))
+
+        assertNull(testee.message())
+        assertEquals(Status.DISMISSED, dao.messagesById("id")?.status)
+        // mirrors dismissMessage(): invalidate so the next eligible message is scheduled
+        verify(remoteMessagingConfigRepository).invalidate()
+    }
+
+    @Test
+    fun whenExpiryThresholdIsZeroThenMessageNeverExpires() = runTest {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(0L, TimeUnit.DAYS.toMillis(99))
+        testee.activeMessage(aRemoteMessageWithDisplayConditions("id", DisplayConditions(trigger = null, dismissAfterDaysShown = 0)))
+        testee.markAsShown(aRemoteMessage("id"))
+
+        assertEquals("id", testee.message()?.id)
+    }
+
+    @Test
+    fun whenWithinExpiryThresholdThenMessageReturned() = runTest {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(0L, TimeUnit.DAYS.toMillis(3))
+        testee.activeMessage(aRemoteMessageWithDisplayConditions("id", DisplayConditions(trigger = null, dismissAfterDaysShown = 5)))
+        testee.markAsShown(aRemoteMessage("id"))
+
+        assertEquals("id", testee.message()?.id)
+        assertEquals(Status.SCHEDULED, dao.messagesById("id")?.status)
+    }
+
+    @Test
+    fun whenNeverShownThenNotExpiredEvenPastThreshold() = runTest {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(TimeUnit.DAYS.toMillis(99))
+        testee.activeMessage(aRemoteMessageWithDisplayConditions("id", DisplayConditions(trigger = null, dismissAfterDaysShown = 5)))
+
+        assertEquals("id", testee.message()?.id)
+    }
+
+    @Test
+    fun whenNoExpiryConfiguredThenMessageNeverExpires() = runTest {
+        whenever(currentTimeProvider.currentTimeMillis()).thenReturn(0L, TimeUnit.DAYS.toMillis(3650))
+        testee.activeMessage(aRemoteMessage("id"))
+        testee.markAsShown(aRemoteMessage("id"))
+
+        assertEquals("id", testee.message()?.id)
+    }
+
+    @Test
+    fun whenMessageHasDisplayConditionsThenStoredAndReadBackIntact() = runTest {
+        val conditions = DisplayConditions(trigger = MessageTrigger.AFTER_IDLE, dismissAfterDaysShown = 5)
+        testee.activeMessage(aRemoteMessageWithDisplayConditions("id", conditions))
+
+        assertEquals(conditions, testee.message()?.displayConditions)
+    }
+
     companion object {
         fun aRemoteMessage(id: String) = RemoteMessage(
             id = id,
@@ -487,5 +562,10 @@ class AppRemoteMessagingRepositoryTest {
             exclusionRules = emptyList(),
             surfaces = listOf(Surface.NEW_TAB_PAGE),
         )
+
+        fun aRemoteMessageWithDisplayConditions(
+            id: String,
+            displayConditions: DisplayConditions,
+        ) = aRemoteMessage(id).copy(displayConditions = displayConditions)
     }
 }

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/JsonRemoteMessageDisplayConditionsTest.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/JsonRemoteMessageDisplayConditionsTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.remote.messaging.impl
+
+import com.duckduckgo.remote.messaging.api.MessageTrigger
+import com.duckduckgo.remote.messaging.fixtures.JsonRemoteMessageOM.aJsonMessage
+import com.duckduckgo.remote.messaging.fixtures.JsonRemoteMessageOM.smallJsonContent
+import com.duckduckgo.remote.messaging.fixtures.messageActionPlugins
+import com.duckduckgo.remote.messaging.impl.mappers.mapToRemoteMessage
+import com.duckduckgo.remote.messaging.impl.models.JsonDisplayConditions
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Locale
+
+class JsonRemoteMessageDisplayConditionsTest {
+
+    @Test
+    fun whenDisplayConditionsHasKnownTriggerThenParsed() {
+        val mapped = listOf(
+            aJsonMessage(
+                id = "id",
+                content = smallJsonContent(),
+                displayConditions = JsonDisplayConditions(trigger = "after_idle", dismissAfterDaysShown = 5),
+            ),
+        ).mapToRemoteMessage(Locale.US, messageActionPlugins)
+
+        val conditions = mapped.single().displayConditions
+        assertEquals(MessageTrigger.AFTER_IDLE, conditions?.trigger)
+        assertEquals(5, conditions?.dismissAfterDaysShown)
+    }
+
+    @Test
+    fun whenDisplayConditionsHasOnlyExpiryThenTriggerIsNull() {
+        val mapped = listOf(
+            aJsonMessage(
+                id = "id",
+                content = smallJsonContent(),
+                displayConditions = JsonDisplayConditions(dismissAfterDaysShown = 5),
+            ),
+        ).mapToRemoteMessage(Locale.US, messageActionPlugins)
+
+        val conditions = mapped.single().displayConditions
+        assertNull(conditions?.trigger)
+        assertEquals(5, conditions?.dismissAfterDaysShown)
+    }
+
+    @Test
+    fun whenTriggerUnrecognizedThenMessageDropped() {
+        val mapped = listOf(
+            aJsonMessage(
+                id = "id",
+                content = smallJsonContent(),
+                displayConditions = JsonDisplayConditions(trigger = "some_future_trigger"),
+            ),
+        ).mapToRemoteMessage(Locale.US, messageActionPlugins)
+
+        assertTrue(mapped.isEmpty())
+    }
+
+    @Test
+    fun whenNoDisplayConditionsThenNull() {
+        val mapped = listOf(
+            aJsonMessage(id = "id", content = smallJsonContent()),
+        ).mapToRemoteMessage(Locale.US, messageActionPlugins)
+
+        assertNull(mapped.single().displayConditions)
+    }
+}

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/RemoteMessagingModelTests.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/RemoteMessagingModelTests.kt
@@ -20,15 +20,20 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.remote.messaging.api.Action
 import com.duckduckgo.remote.messaging.api.Content
 import com.duckduckgo.remote.messaging.api.Content.Placeholder.VISUAL_DESIGN_UPDATE
+import com.duckduckgo.remote.messaging.api.DisplayConditions
+import com.duckduckgo.remote.messaging.api.MessageTrigger
 import com.duckduckgo.remote.messaging.api.RemoteMessage
 import com.duckduckgo.remote.messaging.api.Surface
 import com.duckduckgo.remote.messaging.impl.pixels.RemoteMessagingPixels
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -45,6 +50,15 @@ class RemoteMessagingModelTests {
     private lateinit var testee: RealRemoteMessageModel
 
     val remoteMessage = RemoteMessage("id1", Content.Small("", ""), emptyList(), emptyList(), emptyList())
+
+    private val triggeredMessage = RemoteMessage(
+        "id1",
+        Content.Small("", ""),
+        emptyList(),
+        emptyList(),
+        emptyList(),
+        DisplayConditions(trigger = MessageTrigger.AFTER_IDLE, dismissAfterDaysShown = null),
+    )
 
     @Before
     fun setup() {
@@ -117,6 +131,63 @@ class RemoteMessagingModelTests {
         verify(remoteMessagingPixels).fireRemoteMessageActionClickedPixel(remoteMessage)
         verify(remoteMessagingRepository, never()).dismissMessage(remoteMessage.id)
         assertEquals(action, result)
+    }
+
+    @Test
+    fun whenGetActiveMessageWithMatchingTriggerThenMessageReturned() = runTest {
+        whenever(remoteMessagingRepository.message()).thenReturn(triggeredMessage)
+
+        assertEquals(triggeredMessage, testee.getActiveMessage(MessageTrigger.AFTER_IDLE))
+    }
+
+    @Test
+    fun whenGetActiveMessageWithNonMatchingTriggerThenHiddenButNotDismissed() = runTest {
+        whenever(remoteMessagingRepository.message()).thenReturn(triggeredMessage)
+
+        assertNull(testee.getActiveMessage(null))
+        // trigger filtering only hides the message for this context; it must never dismiss it (unlike expiry)
+        verify(remoteMessagingRepository, never()).dismissMessage(any())
+    }
+
+    @Test
+    fun whenGetActiveMessageHasNoTriggerThenReturnedForAnyContext() = runTest {
+        whenever(remoteMessagingRepository.message()).thenReturn(remoteMessage)
+
+        assertEquals(remoteMessage, testee.getActiveMessage(MessageTrigger.AFTER_IDLE))
+        assertEquals(remoteMessage, testee.getActiveMessage(null))
+    }
+
+    @Test
+    fun whenGetActiveMessageHasConditionsButNoTriggerThenReturnedForAnyContext() = runTest {
+        val messageWithoutTrigger = remoteMessage.copy(
+            displayConditions = DisplayConditions(trigger = null, dismissAfterDaysShown = 5),
+        )
+        whenever(remoteMessagingRepository.message()).thenReturn(messageWithoutTrigger)
+
+        assertEquals(messageWithoutTrigger, testee.getActiveMessage(MessageTrigger.AFTER_IDLE))
+        assertEquals(messageWithoutTrigger, testee.getActiveMessage(null))
+    }
+
+    @Test
+    fun whenObserveActiveMessagesWithMatchingTriggerThenMessageEmitted() = runTest {
+        whenever(remoteMessagingRepository.messageFlow()).thenReturn(flowOf(triggeredMessage))
+
+        assertEquals(triggeredMessage, testee.observeActiveMessages(MessageTrigger.AFTER_IDLE).first())
+    }
+
+    @Test
+    fun whenObserveActiveMessagesWithNonMatchingTriggerThenNullEmitted() = runTest {
+        whenever(remoteMessagingRepository.messageFlow()).thenReturn(flowOf(triggeredMessage))
+
+        assertNull(testee.observeActiveMessages(null).first())
+    }
+
+    @Test
+    fun whenObserveActiveMessagesHasNoTriggerThenEmittedForAnyContext() = runTest {
+        whenever(remoteMessagingRepository.messageFlow()).thenReturn(flowOf(remoteMessage))
+
+        assertEquals(remoteMessage, testee.observeActiveMessages(MessageTrigger.AFTER_IDLE).first())
+        assertEquals(remoteMessage, testee.observeActiveMessages(null).first())
     }
 
     @Test

--- a/remote-messaging/remote-messaging-store/build.gradle
+++ b/remote-messaging/remote-messaging-store/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     testImplementation Testing.junit4
     testImplementation Testing.robolectric
     testImplementation AndroidX.test.ext.junit
+    testImplementation AndroidX.room.testing
 
     coreLibraryDesugaring Android.tools.desugarJdkLibs
 }

--- a/remote-messaging/remote-messaging-store/schemas/com.duckduckgo.remote.messaging.store.RemoteMessagingDatabase/3.json
+++ b/remote-messaging/remote-messaging-store/schemas/com.duckduckgo.remote.messaging.store.RemoteMessagingDatabase/3.json
@@ -1,0 +1,114 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "7ca8b1cf7ad06ef5c6184b39ab818e62",
+    "entities": [
+      {
+        "tableName": "remote_messaging",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `version` INTEGER NOT NULL, `invalidate` INTEGER NOT NULL, `evaluationTimestamp` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "version",
+            "columnName": "version",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "invalidate",
+            "columnName": "invalidate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "evaluationTimestamp",
+            "columnName": "evaluationTimestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "remote_message",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `message` TEXT NOT NULL, `status` TEXT NOT NULL, `shown` INTEGER NOT NULL, `firstShownDate` INTEGER, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shown",
+            "columnName": "shown",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstShownDate",
+            "columnName": "firstShownDate",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "remote_messaging_cohort",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`messageId` TEXT NOT NULL, `percentile` REAL NOT NULL, PRIMARY KEY(`messageId`))",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "percentile",
+            "columnName": "percentile",
+            "affinity": "REAL",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "messageId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7ca8b1cf7ad06ef5c6184b39ab818e62')"
+    ]
+  }
+}

--- a/remote-messaging/remote-messaging-store/src/main/java/com/duckduckgo/remote/messaging/store/RemoteMessageEntity.kt
+++ b/remote-messaging/remote-messaging-store/src/main/java/com/duckduckgo/remote/messaging/store/RemoteMessageEntity.kt
@@ -25,6 +25,7 @@ data class RemoteMessageEntity(
     val message: String,
     val status: Status,
     val shown: Boolean = false,
+    val firstShownDate: Long? = null,
 ) {
     enum class Status {
         SCHEDULED,

--- a/remote-messaging/remote-messaging-store/src/main/java/com/duckduckgo/remote/messaging/store/RemoteMessagingDatabase.kt
+++ b/remote-messaging/remote-messaging-store/src/main/java/com/duckduckgo/remote/messaging/store/RemoteMessagingDatabase.kt
@@ -23,7 +23,7 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Database(
     exportSchema = true,
-    version = 2,
+    version = 3,
     entities = [
         RemoteMessagingConfig::class,
         RemoteMessageEntity::class,
@@ -48,7 +48,12 @@ abstract class RemoteMessagingDatabase : RoomDatabase() {
                 }
             }
         }
+        private val MIGRATION_2_3 = object : Migration(2, 3) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `remote_message` ADD COLUMN `firstShownDate` INTEGER")
+            }
+        }
         val ALL_MIGRATIONS: Array<Migration>
-            get() = arrayOf(MIGRATION_1_2)
+            get() = arrayOf(MIGRATION_1_2, MIGRATION_2_3)
     }
 }

--- a/remote-messaging/remote-messaging-store/src/test/java/com/duckduckgo/remote/messaging/store/RemoteMessagingDatabaseMigrationTest.kt
+++ b/remote-messaging/remote-messaging-store/src/test/java/com/duckduckgo/remote/messaging/store/RemoteMessagingDatabaseMigrationTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.remote.messaging.store
+
+import androidx.room.Room
+import androidx.room.testing.MigrationTestHelper
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RemoteMessagingDatabaseMigrationTest {
+
+    @get:Rule
+    val testHelper = MigrationTestHelper(
+        InstrumentationRegistry.getInstrumentation(),
+        RemoteMessagingDatabase::class.java,
+        emptyList(),
+    )
+
+    @Test
+    fun whenMigratingFromV2ToV3ThenFirstShownDateAddedAsNullAndExistingRowPreserved() {
+        testHelper.createDatabase(TEST_DB_NAME, 2).apply {
+            execSQL("INSERT INTO remote_message (id, message, status, shown) VALUES ('id1', '{}', 'SCHEDULED', 0)")
+            close()
+        }
+
+        testHelper.runMigrationsAndValidate(TEST_DB_NAME, 3, true, *RemoteMessagingDatabase.ALL_MIGRATIONS).apply {
+            val cursor = query(
+                "SELECT message, status, shown, firstShownDate FROM remote_message WHERE id = 'id1'",
+            )
+            cursor.moveToFirst()
+            assertEquals("{}", cursor.getString(cursor.getColumnIndexOrThrow("message")))
+            assertEquals("SCHEDULED", cursor.getString(cursor.getColumnIndexOrThrow("status")))
+            assertEquals(0, cursor.getInt(cursor.getColumnIndexOrThrow("shown")))
+            // the new column is added with a null default for rows that existed before the migration
+            assertTrue(cursor.isNull(cursor.getColumnIndexOrThrow("firstShownDate")))
+            cursor.close()
+            close()
+        }
+    }
+
+    @Test
+    fun whenMigratingToLatestThenValidatesAgainstCurrentSchema() {
+        testHelper.createDatabase(TEST_DB_NAME, 2).apply { close() }
+
+        Room.databaseBuilder(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            RemoteMessagingDatabase::class.java,
+            TEST_DB_NAME,
+        ).addMigrations(*RemoteMessagingDatabase.ALL_MIGRATIONS).build().apply {
+            openHelper.writableDatabase
+            close()
+        }
+    }
+
+    companion object {
+        private const val TEST_DB_NAME = "remote_messaging_migration_test"
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1215861246875405?focus=true 
Tech Design URL (if applicable): N/A

### Description

PR 2/5

Adds a feature flag `ntpAsDefaultAfterIdleReturn` (in `AndroidBrowserConfigFeature`, default **off**) that controls the default "show on app launch" option.

When enabled together with the existing `showNTPAfterIdleReturn` flag, users who have never explicitly chosen an option default to **New Tab Page**.

### Steps to test this PR
A bit difficult to test because you need an old build that defaulted to “Last Opened Tab” And never touched the inactivity. New users are forced into NTP due to `ensureNewUserDefault`.  You can test it by commenting out the call to `ensureNewUserDefault()` to avoid overriding the option for a fresh install and test without it. 

- [x] With **both** `showNTPAfterIdleReturn` and `ntpAsDefaultAfterIdleReturn` enabled, a user who hasn't picked a "show on app launch" option defaults to **New Tab Page**.
- [x] With **either** flag off, an un-set user still defaults to **Last Opened Tab** (today's behaviour).
- [x] A user who has **explicitly** picked an option keeps it, regardless of the flags.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default launch behavior and which RMF messages appear on NTP (flag-gated), plus a DB migration and automatic message dismissal logic that could affect messaging if misconfigured remotely.
> 
> **Overview**
> Extends the **after-idle return to NTP** rollout with a new remote flag **`ntpAsDefaultAfterIdleReturn`**. When it is on together with **`showNTPAfterIdleReturn`**, users who never chose a “show on app launch” option now default to **New Tab Page** instead of **Last Opened Tab**; an explicit choice is unchanged.
> 
> **Remote messaging** gains **display conditions**: optional **`after_idle`** trigger (consumer passes context at read time) and **`dismissAfterDaysShown`**, with first-impression timestamping, auto-dismiss when the day threshold is met, and JSON parsing that drops messages with unknown triggers. The NTP screen resolves **`MessageTrigger.AFTER_IDLE`** via **`AfterIdleMessageTriggerProvider`** and threads it into **`observeActiveMessages`**. A new RMF attribute **`ntpAfterIdleState`** targets **`notEligible` / `eligibleCardShown` / `eligibleCardHidden`**, gated behind the same two flags.
> 
> Also adds Room **v3** migration for **`firstShownDate`** on stored messages and sets **`screenName = "settingsGeneral"`** on general settings activity registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6856f13827bb745f00dd1566e512b38f800bbecc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->