### PR TITLE
Fix external keyboard bug

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -358,9 +358,14 @@ class RealNativeInputManager @Inject constructor(
                 omnibarController.hideBackground()
                 duckAiToolbarHidden = false
             }
-            updateWidgetFocus(widget)
+            if (!isExternalKeyboardConnected()) {
+                updateWidgetFocus(widget)
+            }
         }
     }
+
+    private fun isExternalKeyboardConnected(): Boolean =
+        rootView.resources.configuration.keyboard != Configuration.KEYBOARD_NOKEYS
 
     private fun isLandscape(): Boolean =
         rootView.resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1216108632851027?focus=true
Tech Design URL (if applicable): 

### Description

- Fixes an issue where the keyboard would defocus after typing into the native input

### Steps to test this PR

- [ ] Using a BT keyboard on Samsung, type into the input
- [ ] Verify that the input is not defocussed


https://github.com/user-attachments/assets/7fa69693-cc80-429c-a7bd-6c0d5966b553

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to keyboard-hide focus logic in Duck.ai native input; no auth or data handling.
> 
> **Overview**
> Fixes incorrect native input focus handling when a **physical keyboard** is connected in Duck.ai mode.
> 
> When the soft keyboard hides, `onKeyboardHidden` used to always call `updateWidgetFocus`, which could clear or reshuffle input focus even though the user is still typing on an external keyboard. The change adds `isExternalKeyboardConnected()` (via `Configuration.keyboard != KEYBOARD_NOKEYS`) and **skips** `updateWidgetFocus` when a hardware keyboard is present. Omnibar restore after landscape toolbar hide is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c76ee304cf679dea6a21378b358a4197ef004663. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->