### PR TITLE
Keyboard not hidden after submitting prompt

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -910,6 +910,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
             }
             super.submitMessage(message)
         }
+        hideKeyboard()
     }
 
     private fun fireSubmissionPixels(hasText: Boolean) {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1216203205139058?focus=true
Tech Design URL (if applicable): 

### Description

- Fixes a bug where the keyboard is not dismissed when submitting a prompt

### Steps to test this PR

- [ ] Submit a prompt in Duck.ai
- [ ] Verify that the keyboard is dismissed

### UI changes
Before

https://github.com/user-attachments/assets/515ed918-05de-42a8-9f01-cb023cda3f1a

After

https://github.com/user-attachments/assets/7ed18482-0b74-4d28-a89c-a3ebb0b96428

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line UI behavior change in the native input submit path; no auth, data, or submission logic changes.
> 
> **Overview**
> Fixes the soft keyboard staying visible after the user sends a prompt from the **native Duck.ai input** (`NativeInputModeWidget`).
> 
> **`submitMessage`** now calls **`hideKeyboard()`** at the end of every submit path (IME go, send button, chat with text, attachment-only chat), using the widget’s existing `InputMethodManager.hideSoftInputFromWindow` helper. The base **`InputModeWidget`** path only **`clearFocus()`** when there is text to submit and did not dismiss the IME on its own.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d36d1f04fcb83dfd367d19ba5f34638f6c095ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->