### PR TITLE
Add ntpAfterIdleState remote message matching attribute

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/rmf/RMFNtpAfterIdleStateMatchingAttribute.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/rmf/RMFNtpAfterIdleStateMatchingAttribute.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch.rmf
+
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
+import com.duckduckgo.app.generalsettings.showonapplaunch.rmf.NtpAfterIdleState.ELIGIBLE_CARD_HIDDEN
+import com.duckduckgo.app.generalsettings.showonapplaunch.rmf.NtpAfterIdleState.ELIGIBLE_CARD_SHOWN
+import com.duckduckgo.app.generalsettings.showonapplaunch.rmf.NtpAfterIdleState.NOT_ELIGIBLE
+import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
+import com.duckduckgo.remote.messaging.api.AttributeMatcherPlugin
+import com.duckduckgo.remote.messaging.api.JsonMatchingAttribute
+import com.duckduckgo.remote.messaging.api.JsonToMatchingAttributeMapper
+import com.duckduckgo.remote.messaging.api.MatchingAttribute
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.flow.firstOrNull
+import javax.inject.Inject
+
+/**
+ * Matches the user's NTP-after-idle state, combining the after-idle "open on launch" option with the
+ * return-to-tab card visibility into a single value.
+ */
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = JsonToMatchingAttributeMapper::class,
+)
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = AttributeMatcherPlugin::class,
+)
+@SingleInstanceIn(AppScope::class)
+class RMFNtpAfterIdleStateMatchingAttribute @Inject constructor(
+    private val showOnAppLaunchOptionDataStore: ShowOnAppLaunchOptionDataStore,
+    private val ntpAfterIdleManager: NtpAfterIdleManager,
+    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
+) : JsonToMatchingAttributeMapper, AttributeMatcherPlugin {
+
+    override suspend fun evaluate(matchingAttribute: MatchingAttribute): Boolean? {
+        if (matchingAttribute is NtpAfterIdleStateMatchingAttribute) {
+            return currentState() in matchingAttribute.states
+        }
+        return null
+    }
+
+    override fun map(
+        key: String,
+        jsonMatchingAttribute: JsonMatchingAttribute,
+    ): MatchingAttribute? {
+        if (key != NtpAfterIdleStateMatchingAttribute.KEY) return null
+        // Rollout gate: when either flag is off, leave the attribute unmapped so RMF treats it as Unknown(fallback).
+        val rolloutEnabled = androidBrowserConfigFeature.showNTPAfterIdleReturn().isEnabled() &&
+            androidBrowserConfigFeature.ntpAsDefaultAfterIdleReturn().isEnabled()
+        if (!rolloutEnabled) return null
+        val value = jsonMatchingAttribute.value
+        if (value is List<*>) {
+            val states = value.filterIsInstance<String>()
+                .mapNotNull { raw -> NtpAfterIdleState.entries.firstOrNull { it.jsonValue == raw } }
+            if (states.isNotEmpty()) {
+                return NtpAfterIdleStateMatchingAttribute(states)
+            }
+        }
+        return null
+    }
+
+    private suspend fun currentState(): NtpAfterIdleState {
+        if (showOnAppLaunchOptionDataStore.optionFlow.firstOrNull() != NewTabPage) return NOT_ELIGIBLE
+        return if (ntpAfterIdleManager.returnToLastTabEnabled.firstOrNull() == true) ELIGIBLE_CARD_SHOWN else ELIGIBLE_CARD_HIDDEN
+    }
+}
+
+internal enum class NtpAfterIdleState(val jsonValue: String) {
+    NOT_ELIGIBLE("notEligible"),
+    ELIGIBLE_CARD_SHOWN("eligibleCardShown"),
+    ELIGIBLE_CARD_HIDDEN("eligibleCardHidden"),
+}
+
+internal data class NtpAfterIdleStateMatchingAttribute(
+    val states: List<NtpAfterIdleState>,
+) : MatchingAttribute {
+    companion object {
+        const val KEY = "ntpAfterIdleState"
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/rmf/RMFNtpAfterIdleStateMatchingAttributeTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/rmf/RMFNtpAfterIdleStateMatchingAttributeTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch.rmf
+
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.LastOpenedTab
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
+import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
+import com.duckduckgo.remote.messaging.api.JsonMatchingAttribute
+import com.duckduckgo.remote.messaging.api.MatchingAttribute
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class RMFNtpAfterIdleStateMatchingAttributeTest {
+
+    private val showOnAppLaunchOptionDataStore: ShowOnAppLaunchOptionDataStore = mock()
+    private val ntpAfterIdleManager: NtpAfterIdleManager = mock()
+    private val feature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
+
+    private val testee = RMFNtpAfterIdleStateMatchingAttribute(showOnAppLaunchOptionDataStore, ntpAfterIdleManager, feature)
+
+    // --- map (this is where the rollout is gated: flags off => attribute is left unmapped) ---
+
+    @Test
+    fun whenKeyIsNotNtpAfterIdleStateThenMapReturnsNull() {
+        assertNull(testee.map("someOtherKey", JsonMatchingAttribute(value = listOf("eligibleCardShown"))))
+    }
+
+    @Test
+    fun whenRolloutDisabledThenMapReturnsNull() {
+        // both flags default off → attribute not mapped (RMF treats it as Unknown(fallback))
+        assertNull(testee.map("ntpAfterIdleState", JsonMatchingAttribute(value = listOf("eligibleCardShown"))))
+    }
+
+    @Test
+    fun whenRolloutEnabledAndValueHasKnownStatesThenMapReturnsAttribute() {
+        enableRollout()
+
+        val result = testee.map("ntpAfterIdleState", JsonMatchingAttribute(value = listOf("eligibleCardShown")))
+
+        assertEquals(NtpAfterIdleStateMatchingAttribute(listOf(NtpAfterIdleState.ELIGIBLE_CARD_SHOWN)), result)
+    }
+
+    @Test
+    fun whenRolloutEnabledAndValueHasNoKnownStatesThenMapReturnsNull() {
+        enableRollout()
+
+        assertNull(testee.map("ntpAfterIdleState", JsonMatchingAttribute(value = listOf("futureState"))))
+    }
+
+    // --- evaluate (only reached once mapped, i.e. rollout on; it computes state from the settings) ---
+
+    @Test
+    fun whenOptionNotNtpThenNotEligible() = runTest {
+        whenever(showOnAppLaunchOptionDataStore.optionFlow).thenReturn(flowOf(LastOpenedTab))
+
+        assertEquals(true, testee.evaluate(attr(NtpAfterIdleState.NOT_ELIGIBLE)))
+        assertEquals(false, testee.evaluate(attr(NtpAfterIdleState.ELIGIBLE_CARD_SHOWN)))
+    }
+
+    @Test
+    fun whenNtpAndCardShownThenEligibleCardShown() = runTest {
+        whenever(showOnAppLaunchOptionDataStore.optionFlow).thenReturn(flowOf(NewTabPage))
+        whenever(ntpAfterIdleManager.returnToLastTabEnabled).thenReturn(flowOf(true))
+
+        assertEquals(true, testee.evaluate(attr(NtpAfterIdleState.ELIGIBLE_CARD_SHOWN)))
+        assertEquals(false, testee.evaluate(attr(NtpAfterIdleState.ELIGIBLE_CARD_HIDDEN)))
+    }
+
+    @Test
+    fun whenNtpAndCardHiddenThenEligibleCardHidden() = runTest {
+        whenever(showOnAppLaunchOptionDataStore.optionFlow).thenReturn(flowOf(NewTabPage))
+        whenever(ntpAfterIdleManager.returnToLastTabEnabled).thenReturn(flowOf(false))
+
+        assertEquals(true, testee.evaluate(attr(NtpAfterIdleState.ELIGIBLE_CARD_HIDDEN)))
+        assertEquals(false, testee.evaluate(attr(NtpAfterIdleState.ELIGIBLE_CARD_SHOWN)))
+    }
+
+    @Test
+    fun whenAttributeIsNotNtpAfterIdleStateThenEvaluateReturnsNull() = runTest {
+        assertNull(testee.evaluate(object : MatchingAttribute {}))
+    }
+
+    private fun attr(vararg states: NtpAfterIdleState) = NtpAfterIdleStateMatchingAttribute(states.toList())
+
+    private fun enableRollout() {
+        feature.showNTPAfterIdleReturn().setRawStoredState(Toggle.State(enable = true))
+        feature.ntpAsDefaultAfterIdleReturn().setRawStoredState(Toggle.State(enable = true))
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1216206454813403?focus=true 
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1207619243206445/task/1216034379142815?focus=true

### Description

PR 3/5

Adds a new RMF matching attribute, `ntpAfterIdleState`, so remote messages can target the user's NTP-after-idle state. It combines two settings into a single value:

- `notEligible`: the after-inactivity "open on launch" option is **not** New Tab Page
- `eligibleCardShown`: option is New Tab Page **and** the return-to-tab card is shown
- `eligibleCardHidden`: option is New Tab Page **and** the return-to-tab card is hidden

This is the targeting for the two mutually-exclusive after-idle message copies (card / no-card).

**Rollout-gated:** the attribute is only mapped when both `showNTPAfterIdleReturn` and `ntpAsDefaultAfterIdleReturn` are enabled. When either is off, `map` returns `null`, so RMF treats the attribute as `Unknown(fallback)`

### Steps to test this PR

- [ ] Unit tests pass: `./gradlew :app:testPlayDebugUnitTest --tests "*RMFNtpAfterIdleStateMatchingAttribute*"`.
- [ ] No behaviour change. nothing consumes the attribute yet and it's gated off by default, so existing RMF messages still schedule/show as before.
- [ ] (Optional, with flags on) A message matching `ntpAfterIdleState:[eligibleCardShown]` is selected only for users on New Tab Page with the return-to-tab card shown; `[eligibleCardHidden]` only when the card is hidden; neither when the option isn't New Tab Page.

### UI changes
No UI changes



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive RMF plugin only; attribute is unmapped until both feature flags are enabled, so production message matching is unchanged by default.
> 
> **Overview**
> Adds a new remote messaging (RMF) matching attribute **`ntpAfterIdleState`** so campaigns can target users by combined NTP-after-idle settings: launch option plus return-to-tab card visibility (`notEligible`, `eligibleCardShown`, `eligibleCardHidden`).
> 
> The attribute is registered via the usual **`JsonToMatchingAttributeMapper`** / **`AttributeMatcherPlugin`** multibindings. **`map`** only recognizes the key when both **`showNTPAfterIdleReturn`** and **`ntpAsDefaultingDefaultAfterIdleReturn`** are on; otherwise it returns null so RMF uses **Unknown(fallback)**. **`evaluate`** derives the current state from **`ShowOnAppLaunchOptionDataStore`** and **`NtpAfterIdleManager`**.
> 
> Unit tests cover rollout gating, JSON mapping, and all three evaluation paths. Nothing consumes the attribute yet and rollout is off by default, so existing message behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 076eb9aa97609b849e86cfeaa938ee0139f392ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->