### PR TITLE
Align pictograms in Duck.ai section from Settings->AI Features

### DIFF
--- a/duckchat/duckchat-impl/src/main/res/layout/include_duck_ai_input_screen_settings.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/include_duck_ai_input_screen_settings.xml
@@ -52,7 +52,8 @@
             app:layout_constraintEnd_toStartOf="@+id/duckAiInputScreenWithAiContainer"
             app:layout_constraintHorizontal_chainStyle="packed"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0">
 
             <ImageView
                 android:id="@+id/duckAiInputScreenToggleWithoutAiImage"
@@ -95,7 +96,8 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@+id/duckAiInputScreenWithoutAiContainer"
-            app:layout_constraintTop_toTopOf="parent">
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintVertical_bias="0">
 
             <ImageView
                 android:id="@+id/duckAiInputScreenToggleWithAiImage"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1216201649526164?focus=true
Tech Design URL (if applicable):

### Description

Add vertical bias to layout constraints in AI input screen settings.

### Steps to test this PR

- Install from this branch
- Go to Settings -> AI Features
- Check the 2 images are aligned. See attached screenshots.

### UI changes

| Before | After |
| --- | --- |
|<img width="351" height="715" alt="Screenshot 2026-07-01 at 12 09 45" src="https://github.com/user-attachments/assets/855b1622-4875-43af-91a7-a06cabe968f1" />|<img width="1080" height="2424" alt="Screenshot_20260701_165756" src="https://github.com/user-attachments/assets/468a3799-143f-4912-b717-ad8d9b24d141" />|

| Variations | Variations |Variations|
| --- | --- | --- |
|<img width="1080" height="2424" alt="Screenshot_20260701_165835" src="https://github.com/user-attachments/assets/cce5c8eb-b278-49b4-b25b-bc485920525c" />|<img width="1080" height="2424" alt="Screenshot_20260701_165828" src="https://github.com/user-attachments/assets/c5f01bce-7a8b-4c4b-8126-9c3a51f9041d" />|<img width="1080" height="2424" alt="Screenshot_20260701_165800" src="https://github.com/user-attachments/assets/bc49d180-c40f-4742-8644-fbc5bf3a3776" />|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only constraint tweak in a settings screen; no logic, data, or security impact.
> 
> **Overview**
> Fixes misaligned **Without AI** / **With AI** preview pictograms on **Settings → AI Features** by setting `app:layout_constraintVertical_bias="0"` on both `duckAiInputScreenWithoutAiContainer` and `duckAiInputScreenWithAiContainer` in `include_duck_ai_input_screen_settings.xml`.
> 
> Those columns are top- and bottom-constrained in a `ConstraintLayout`; when the two sides differ in height (e.g. the With AI label row), the default bias was vertically centering them so the images no longer lined up. Bias `0` anchors both columns to the top so the pictograms align.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5f237a6207a4f77e82292cdd18d70a3f1ed9d5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->