### PR TITLE
Fire Mode: Translations

### DIFF
--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -1075,4 +1075,21 @@
     <!-- New Address Bar Picker -->
     <string name="newAddressBarPickerDuckDuckGo" translatable="false">DuckDuckGo</string>
     <string name="newAddressBarPickerConfirm">Потвърждаване</string>
+
+    <!-- Fire mode -->
+    <string name="openInFireTab">Отваряне в раздел Fire</string>
+    <string name="openInBackgroundTab">Отваряне във фонов режим</string>
+    <string name="browserModeToggleFireDescription">Превключване към раздели в режим Fire</string>
+    <string name="browserModeToggleRegularDescription">Превключване към обикновени раздели</string>
+    <string name="browserModeToggleTabCountInfinite">∞</string>
+    <string name="fireTabMenuItem">Раздел Fire</string>
+    <string name="fireTabNewTabPageTitle">Раздел Fire</string>
+    <string name="fireTabsEmptyStateTitle">Раздели Fire</string>
+    <string name="fireTabsFeatureNoHistory">Сърфиране без запазване на локалната история</string>
+    <string name="fireTabsFeatureDifferentAccount">Влизане в сайт с друг акаунт</string>
+    <string name="fireTabsFeatureTroubleshoot">Отстраняване на неизправности в уебсайтове</string>
+    <string name="fireTabsExplainer">Разделите Fire са изолирани от другите данни на браузъра. Когато затворите всички такива раздели, данните в тях се изгарят. Те имат същата защита от проследяване като другите раздели.</string>
+    <string name="fireTabsNewTabButton">Нов раздел Fire</string>
+    <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>НОВО!</b> Изпробвайте разделите Fire, в които сърфирате, без да запазвате локална история.]]></string>
+    <string name="singleTabFireDialogTitleFireMode">Изтриване на разделите Fire и данните в тях?</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1115,4 +1115,21 @@
     <!-- New Address Bar Picker -->
     <string name="newAddressBarPickerDuckDuckGo" translatable="false">DuckDuckGo</string>
     <string name="newAddressBarPickerConfirm">Potvrdit</string>
+
+    <!-- Fire mode -->
+    <string name="openInFireTab">Otevřít na kartě Fire</string>
+    <string name="openInBackgroundTab">Otevřít na pozadí</string>
+    <string name="browserModeToggleFireDescription">Přepnout na karty v režimu Fire</string>
+    <string name="browserModeToggleRegularDescription">Přepnout na běžné karty</string>
+    <string name="browserModeToggleTabCountInfinite">∞</string>
+    <string name="fireTabMenuItem">Karta Fire</string>
+    <string name="fireTabNewTabPageTitle">Karta Fire</string>
+    <string name="fireTabsEmptyStateTitle">Karty Fire</string>
+    <string name="fireTabsFeatureNoHistory">Prohlížení bez ukládání místní historie</string>
+    <string name="fireTabsFeatureDifferentAccount">Přihlášení na web pod jiným účtem</string>
+    <string name="fireTabsFeatureTroubleshoot">Řešení problémů s webovými stránkami</string>
+    <string name="fireTabsExplainer">Karty Fire jsou izolované od ostatních dat prohlížeče. Jakmile je všechny zavřeš, jejich data se vymažou. Poskytují stejnou ochranu před sledováním jako ostatní karty.</string>
+    <string name="fireTabsNewTabButton">Nová karta Fire</string>
+    <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NOVINKA!</b> Vyzkoušej karty Fire pro prohlížení bez ukládání místní historie.]]></string>
+    <string name="singleTabFireDialogTitleFireMode">Smazat karty Fire a jejich data?</string>
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1075,4 +1075,21 @@
     <!-- New Address Bar Picker -->
     <string name="newAddressBarPickerDuckDuckGo" translatable="false">DuckDuckGo</string>
     <string name="newAddressBarPickerConfirm">Bekræft</string>
+
+    <!-- Fire mode -->
+    <string name="openInFireTab">Åbn i en Fire-fane</string>
+    <string name="openInBackgroundTab">Åbn i baggrunden</string>
+    <string name="browserModeToggleFireDescription">Skift til Fire-faner</string>
+    <string name="browserModeToggleRegularDescription">Skift til almindelige faner</string>
+    <string name="browserModeToggleTabCountInfinite">∞</string>
+    <string name="fireTabMenuItem">Fire-fane</string>
+    <string name="fireTabNewTabPageTitle">Fire-fane</string>
+    <string name="fireTabsEmptyStateTitle">Fire-faner</string>
+    <string name="fireTabsFeatureNoHistory">Gennemse uden at gemme lokal historik</string>
+    <string name="fireTabsFeatureDifferentAccount">Log ind på et websted med en anden konto</string>
+    <string name="fireTabsFeatureTroubleshoot">Fejlfinding på websteder</string>
+    <string name="fireTabsExplainer">Fire-faner er isoleret fra andre browserdata. Dine data slettes, når du lukker dem alle. De giver dig samme sporingsbeskyttelse som andre faner.</string>
+    <string name="fireTabsNewTabButton">Ny Fire-fane</string>
+    <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NYT!</b> Prøv Fire-faner for at surfe uden at gemme lokal historik.]]></string>
+    <string name="singleTabFireDialogTitleFireMode">Slet Fire-faner og deres data?</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1075,4 +1075,21 @@
     <!-- New Address Bar Picker -->
     <string name="newAddressBarPickerDuckDuckGo" translatable="false">DuckDuckGo</string>
     <string name="newAddressBarPickerConfirm">Bestätigen</string>
+
+    <!-- Fire mode -->
+    <string name="openInFireTab">In einem Fire-Tab öffnen</string>
+    <string name="openInBackgroundTab">Im Hintergrund öffnen</string>
+    <string name="browserModeToggleFireDescription">Zu Fire-Modus-Tabs wechseln</string>
+    <string name="browserModeToggleRegularDescription">Zu regulären Tabs wechseln</string>
+    <string name="browserModeToggleTabCountInfinite">∞</string>
+    <string name="fireTabMenuItem">Fire-Tab</string>
+    <string name="fireTabNewTabPageTitle">Fire-Tab</string>
+    <string name="fireTabsEmptyStateTitle">Fire-Tabs</string>
+    <string name="fireTabsFeatureNoHistory">Durchsuchen ohne Speichern des lokalen Verlaufs</string>
+    <string name="fireTabsFeatureDifferentAccount">Melde dich mit einem anderen Konto bei einer Website an</string>
+    <string name="fireTabsFeatureTroubleshoot">Website-Fehlerbehebung</string>
+    <string name="fireTabsExplainer">Fire Tabs sind von anderen Browserdaten isoliert. Ihre Daten werden gelöscht, wenn du alle Fenster schließt. Sie haben den gleichen Tracking-Schutz wie andere Tabs.</string>
+    <string name="fireTabsNewTabButton">Neues Fire-Tab</string>
+    <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NEU!</b> Fire-Tabs ausprobieren, um zu surfen, ohne den lokalen Verlauf zu speichern.]]></string>
+    <string name="singleTabFireDialogTitleFireMode">Fire-Tabs und deren Daten löschen?</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -1075,4 +1075,21 @@
     <!-- New Address Bar Picker -->
     <string name="newAddressBarPickerDuckDuckGo" translatable="false">DuckDuckGo</string>
     <string name="newAddressBarPickerConfirm">Επιβεβαίωση</string>
+
+    <!-- Fire mode -->
+    <string name="openInFireTab">Άνοιγμα σε Καρτέλα Fire</string>
+    <string name="openInBackgroundTab">Άνοιγμα στο παρασκήνιο</string>
+    <string name="browserModeToggleFireDescription">Μετάβαση σε καρτέλες λειτουργίας Fire</string>
+    <string name="browserModeToggleRegularDescription">Αλλαγή σε κανονικές καρτέλες</string>
+    <string name="browserModeToggleTabCountInfinite">∞</string>
+    <string name="fireTabMenuItem">Καρτέλα Fire</string>
+    <string name="fireTabNewTabPageTitle">Καρτέλα Fire</string>
+    <string name="fireTabsEmptyStateTitle">Καρτέλες Fire</string>
+    <string name="fireTabsFeatureNoHistory">Περιηγηθείτε χωρίς να αποθηκεύετε το τοπικό ιστορικό</string>
+    <string name="fireTabsFeatureDifferentAccount">Συνδεθείτε σε ιστότοπο με διαφορετικό λογαριασμό</string>
+    <string name="fireTabsFeatureTroubleshoot">Αντιμετώπιση προβλημάτων ιστοτόπων</string>
+    <string name="fireTabsExplainer">Οι καρτέλες Fire είναι απομονωμένες από άλλα δεδομένα του προγράμματος περιήγησης. Τα δεδομένα τους καίγονται όταν τις κλείσετε όλες. Παρέχουν την ίδια προστασία παρακολούθησης με άλλες καρτέλες.</string>
+    <string name="fireTabsNewTabButton">Νέα καρτέλα Fire</string>
+    <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>ΝΕΟ!</b> Δοκιμάστε τις καρτέλες Fire για περιήγηση χωρίς να αποθηκεύετε το τοπικό ιστορικό.]]></string>
+    <string name="singleTabFireDialogTitleFireMode">Να διαγραφούν οι καρτέλες Fire και τα δεδομένα τους;</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1075,4 +1075,21 @@
     <!-- New Address Bar Picker -->
     <string name="newAddressBarPickerDuckDuckGo" translatable="false">DuckDuckGo</string>
     <string name="newAddressBarPickerConfirm">Confirmar</string>
+
+    <!-- Fire mode -->
+    <string name="openInFireTab">Abrir en Fire Tab</string>
+    <string name="openInBackgroundTab">Abrir en segundo plano</string>
+    <string name="browserModeToggleFireDescription">Cambia a las pestañas del modo Fire</string>
+    <string name="browserModeToggleRegularDescription">Cambiar a pestañas normales</string>
+    <string name="browserModeToggleTabCountInfinite">∞</string>
+    <string name="fireTabMenuItem">Fire tab</string>
+    <string name="fireTabNewTabPageTitle">Fire tab</string>
+    <string name="fireTabsEmptyStateTitle">Fire tabs</string>
+    <string name="fireTabsFeatureNoHistory">Navegar sin guardar el historial local</string>
+    <string name="fireTabsFeatureDifferentAccount">Iniciar sesión en un sitio con una cuenta diferente</string>
+    <string name="fireTabsFeatureTroubleshoot">Solucionar problemas de sitios web</string>
+    <string name="fireTabsExplainer">Las Fire tabs están aisladas de otros datos del navegador. Sus datos se queman cuando las cierras todas. Tienen la misma protección contra el rastreo que otras pestañas.</string>
+    <string name="fireTabsNewTabButton">Nueva Fire tab</string>
+    <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>¡NUEVO!</b> Prueba Fire Tabs para navegar sin guardar el historial local.]]></string>
+    <string name="singleTabFireDialogTitleFireMode">¿Eliminar Fire tabs y sus datos?</string>
 </resources>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -1075,4 +1075,21 @@
     <!-- New Address Bar Picker -->
     <string name="newAddressBarPickerDuckDuckGo" translatable="false">DuckDuckGo</string>
     <string name="newAddressBarPickerConfirm">Kinnita</string>
+
+    <!-- Fire mode -->
+    <string name="openInFireTab">Ava Fire vahekaardil</string>
+    <string name="openInBackgroundTab">Ava taustal</string>
+    <string name="browserModeToggleFireDescription">Lülitu Fire-režiimi vahekaartidele</string>
+    <string name="browserModeToggleRegularDescription">Lülitu tavalistele vahekaartidele</string>
+    <string name="browserModeToggleTabCountInfinite">∞</string>
+    <string name="fireTabMenuItem">Fire vahekaart</string>
+    <string name="fireTabNewTabPageTitle">Fire vahekaart</string>
+    <string name="fireTabsEmptyStateTitle">Fire vahekaardid</string>
+    <string name="fireTabsFeatureNoHistory">Sirvi kohalikku ajalugu salvestamata</string>
+    <string name="fireTabsFeatureDifferentAccount">Logi saidile sisse teise kontoga</string>
+    <string name="fireTabsFeatureTroubleshoot">Tõrkeotsing veebilehtedel</string>
+    <string name="fireTabsExplainer">Fire vahekaardid on teistest brauseriandmetest isoleeritud. Nende andmed põletatakse, kui sa need kõik sulged. Need pakuvad sulle sama jälgimiskaitset kui teisedki vahekaardid.</string>
+    <string name="fireTabsNewTabButton">Uus Fire vahekaart</string>
+    <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>UUS!</b> Proovi Fire vahekaarte, et sirvida ilma kohalikku ajalugu salvestamata.]]></string>
+    <string name="singleTabFireDialogTitleFireMode">Kas kustutada Fire vahekaardid ja nende andmed?</string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -1075,4 +1075,21 @@
     <!-- New Address Bar Picker -->
     <string name="newAddressBarPickerDuckDuckGo" translatable="false">DuckDuckGo</string>
     <string name="newAddressBarPickerConfirm">Vahvista</string>
+
+    <!-- Fire mode -->
+    <string name="openInFireTab">Avaa Fire-välilehdessä</string>
+    <string name="openInBackgroundTab">Avaa taustalla</string>
+    <string name="browserModeToggleFireDescription">Vaihda Fire-tilan välilehtiin</string>
+    <string name="browserModeToggleRegularDescription">Vaihda tavallisiin välilehtiin</string>
+    <string name="browserModeToggleTabCountInfinite">∞</string>
+    <string name="fireTabMenuItem">Fire-välilehti</string>
+    <string name="fireTabNewTabPageTitle">Fire-välilehti</string>
+    <string name="fireTabsEmptyStateTitle">Fire-välilehdet</string>
+    <string name="fireTabsFeatureNoHistory">Selaa tallentamatta paikallista historiaa</string>
+    <string name="fireTabsFeatureDifferentAccount">Kirjaudu sivustolle eri tilillä</string>
+    <string name="fireTabsFeatureTroubleshoot">Vianmääritys verkkosivustoille</string>
+    <string name="fireTabsExplainer">Fire-välilehdet on eristetty muista selaintiedoista. Niiden tiedot poltetaan, kun suljet ne kaikki. Ne antavat sinulle saman seurantasuojan kuin muutkin välilehdet.</string>
+    <string name="fireTabsNewTabButton">Uusi Fire-välilehti</string>
+    <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>UUTTA!</b> Kokeile Fire-välilehtiä selataksesi ilman paikallisen historian tallentamista.]]></string>
+    <string name="singleTabFireDialogTitleFireMode">Poistetaanko Fire-välilehdet ja niiden tiedot?</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1075,4 +1075,21 @@
     <!-- New Address Bar Picker -->
     <string name="newAddressBarPickerDuckDuckGo" translatable="false">DuckDuckGo</string>
     <string name="newAddressBarPickerConfirm">Confirmer</string>
+
+    <!-- Fire mode -->
+    <string name="openInFireTab">Ouvrir dans l\'onglet Fire</string>
+    <string name="openInBackgroundTab">Ouvrir en arrière-plan</string>
+    <string name="browserModeToggleFireDescription">Passer aux onglets en mode Fire</string>
+    <string name="browserModeToggleRegularDescription">Passer aux onglets classiques</string>
+    <string name="browserModeToggleTabCountInfinite">∞</string>
+    <string name="fireTabMenuItem">Onglet Fire</string>
+    <string name="fireTabNewTabPageTitle">Onglet Fire</string>
+    <string name="fireTabsEmptyStateTitle">Onglets Fire</string>
+    <string name="fireTabsFeatureNoHistory">Parcourir sans enregistrer l\'historique local</string>
+    <string name="fireTabsFeatureDifferentAccount">Se connecter à un site avec un autre compte</string>
+    <string name="fireTabsFeatureTroubleshoot">Résoudre les problèmes des sites Web</string>
+    <string name="fireTabsExplainer">Les onglets Fire sont isolés des autres données du navigateur. Leurs données sont supprimées lorsque vous les fermez tous. Ils sont dotés de la même protection contre le pistage que les autres onglets.</string>
+    <string name="fireTabsNewTabButton">Nouvel onglet Fire</string>
+    <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NOUVEAU !</b> Essayez les onglets Fire pour naviguer sans enregistrer l\'historique local.]]></string>
+    <string name="singleTabFireDialogTitleFireMode">Supprimer les onglets Fire et leurs données ?</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1115,4 +1115,21 @@
     <!-- New Address Bar Picker -->
     <string name="newAddressBarPickerDuckDuckGo" translatable="false">DuckDuckGo</string>
     <string name="newAddressBarPickerConfirm">Potvrdi</string>
+
+    <!-- Fire mode -->
+    <string name="openInFireTab">Otvori na Fire kartici</string>
+    <string name="openInBackgroundTab">Otvori u pozadini</string>
+    <string name="browserModeToggleFireDescription">Prebaci se na kartice u načinu rada Fire</string>
+    <string name="browserModeToggleRegularDescription">Prebaci se na obične kartice</string>
+    <string name="browserModeToggleTabCountInfinite">∞</string>
+    <string name="fireTabMenuItem">Fire kartica</string>
+    <string name="fireTabNewTabPageTitle">Fire kartica</string>
+    <string name="fireTabsEmptyStateTitle">Fire kartice</string>
+    <string name="fireTabsFeatureNoHistory">Pregledavanje bez spremanja lokalne povijesti</string>
+    <string name="fireTabsFeatureDifferentAccount">Prijavi se na web-mjesto drugim računom</string>
+    <string name="fireTabsFeatureTroubleshoot">Rješavanje problema s web-mjestima</string>
+    <string name="fireTabsExplainer">Fire kartice izolirane su od ostalih podataka preglednika. Njihovi se podaci brišu kada ih sve zatvoriš. Daju ti istu zaštitu od praćenja kao i ostale kartice.</string>
+    <string name="fireTabsNewTabButton">Nova Fire kartica</string>
+    <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NOVO!</b> Isprobaj Fire kartice za pregledavanje bez spremanja lokalne povijesti.]]></string>
+    <string name="singleTabFireDialogTitleFireMode">Želiš li izbrisati Fire kartice i njihove podatke?</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -1075,4 +1075,21 @@
     <!-- New Address Bar Picker -->
     <string name="newAddressBarPickerDuckDuckGo" translatable="false">DuckDuckGo</string>
     <string name="newAddressBarPickerConfirm">Megerősítés</string>
+
+    <!-- Fire mode -->
+    <string name="openInFireTab">Megnyitás Fire-lapon</string>
+    <string name="openInBackgroundTab">Megnyitás a háttérben</string>
+    <string name="browserModeToggleFireDescription">Váltás Fire-lapokra</string>
+    <string name="browserModeToggleRegularDescription">Váltás normál lapokra</string>
+    <string name="browserModeToggleTabCountInfinite">∞</string>
+    <string name="fireTabMenuItem">Fire-lap</string>
+    <string name="fireTabNewTabPageTitle">Fire-lap</string>
+    <string name="fireTabsEmptyStateTitle">Fire-lapoka</string>
+    <string name="fireTabsFeatureNoHistory">Böngéssz helyi előzmények mentése nélkül</string>
+    <string name="fireTabsFeatureDifferentAccount">Jelentkezz be egy webhelyre másik fiókkal</string>
+    <string name="fireTabsFeatureTroubleshoot">Oldd meg a webhelyekkel kapcsolatos problémákat</string>
+    <string name="fireTabsExplainer">A Fire-lapok elkülönülnek a többi böngészőadattól. Az összes bezárásakor a hozzájuk tartozó adatok törlésre kerülnek. Ugyanazt a követés elleni védelmet nyújtják, mint a többi lap.</string>
+    <string name="fireTabsNewTabButton">Új Fire-lap</string>
+    <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>ÚJ! </b> Próbáld ki a Fire-lapokat, és böngéssz helyi előzmények mentése nélkül.]]></string>
+    <string name="singleTabFireDialogTitleFireMode">Törlöd a Fire-lapokat és az adataikat?</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1075,4 +1075,21 @@
     <!-- New Address Bar Picker -->
     <string name="newAddressBarPickerDuckDuckGo" translatable="false">DuckDuckGo</string>
     <string name="newAddressBarPickerConfirm">Conferma</string>
+
+    <!-- Fire mode -->
+    <string name="openInFireTab">Apri in una scheda Fire</string>
+    <string name="openInBackgroundTab">Apri in background</string>
+    <string name="browserModeToggleFireDescription">Passa alle schede in modalità Fire</string>
+    <string name="browserModeToggleRegularDescription">Passa alle schede normali</string>
+    <string name="browserModeToggleTabCountInfinite">∞</string>
+    <string name="fireTabMenuItem">Scheda Fire</string>
+    <string name="fireTabNewTabPageTitle">Scheda Fire</string>
+    <string name="fireTabsEmptyStateTitle">Schede Fire</string>
+    <string name="fireTabsFeatureNoHistory">Sfoglia senza salvare la cronologia locale</string>
+    <string name="fireTabsFeatureDifferentAccount">Accedi a un sito con un altro account</string>
+    <string name="fireTabsFeatureTroubleshoot">Risolvi i problemi dei siti web</string>
+    <string name="fireTabsExplainer">Le schede Fire sono isolate dagli altri dati del browser. I dati vengono eliminati quando le chiudi tutte. Ti offrono la stessa protezione dal tracciamento delle altre schede.</string>
+    <string name="fireTabsNewTabButton">Nuova scheda Fire</string>
+    <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NOVITÀ!</b> Prova le schede Fire per navigare senza salvare la cronologia locale.]]></string>
+    <string name="singleTabFireDialogTitleFireMode">Eliminare le schede Fire e i relativi dati?</string>
 </resources>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -1115,4 +1115,21 @@
     <!-- New Address Bar Picker -->
     <string name="newAddressBarPickerDuckDuckGo" translatable="false">DuckDuckGo</string>
     <string name="newAddressBarPickerConfirm">Patvirtinti</string>
+
+    <!-- Fire mode -->
+    <string name="openInFireTab">Atidaryti „Fire“ skirtuke</string>
+    <string name="openInBackgroundTab">Atidaryti fone</string>
+    <string name="browserModeToggleFireDescription">Perjungti į „Fire“ režimo skirtukus</string>
+    <string name="browserModeToggleRegularDescription">Perjungti į įprastus skirtukus</string>
+    <string name="browserModeToggleTabCountInfinite">∞</string>
+    <string name="fireTabMenuItem">„Fire“ skirtukas</string>
+    <string name="fireTabNewTabPageTitle">„Fire“ skirtukas</string>
+    <string name="fireTabsEmptyStateTitle">„Fire“ skirtukai</string>
+    <string name="fireTabsFeatureNoHistory">Naršyti ir nesaugoti vietinės istorijos</string>
+    <string name="fireTabsFeatureDifferentAccount">Prisijungti prie svetainės su kita paskyra</string>
+    <string name="fireTabsFeatureTroubleshoot">Šalinti interneto svetainių triktis</string>
+    <string name="fireTabsExplainer">„Fire“ skirtukai yra izoliuoti nuo kitų naršyklės duomenų. Jų duomenys „sudeginami“, kai tik juos visus uždarote. Jie suteikia tokią pačią apsaugą nuo sekimo kaip ir kiti skirtukai.</string>
+    <string name="fireTabsNewTabButton">Naujas „Fire“ skirtukas</string>
+    <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NAUJIENA!</b> Išbandykite „Fire“ skirtukus naršymui neišsaugant vietinės naršymo istorijos.]]></string>
+    <string name="singleTabFireDialogTitleFireMode">Ar trinti „Fire“ skirtukus ir jų duomenis?</string>
 </resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -1095,4 +1095,21 @@
     <!-- New Address Bar Picker -->
     <string name="newAddressBarPickerDuckDuckGo" translatable="false">DuckDuckGo</string>
     <string name="newAddressBarPickerConfirm">Apstiprināt</string>
+
+    <!-- Fire mode -->
+    <string name="openInFireTab">Atvērt Fire cilnē</string>
+    <string name="openInBackgroundTab">Atvērt fonā</string>
+    <string name="browserModeToggleFireDescription">Pārslēdzies uz Fire režīma cilnēm</string>
+    <string name="browserModeToggleRegularDescription">Pārslēgties uz parastajām cilnēm</string>
+    <string name="browserModeToggleTabCountInfinite">∞</string>
+    <string name="fireTabMenuItem">Fire cilne</string>
+    <string name="fireTabNewTabPageTitle">Fire cilne</string>
+    <string name="fireTabsEmptyStateTitle">Fire cilnes</string>
+    <string name="fireTabsFeatureNoHistory">Pārlūkot, nesaglabājot vietējo vēsturi</string>
+    <string name="fireTabsFeatureDifferentAccount">Pierakstīties vietnē ar citu kontu</string>
+    <string name="fireTabsFeatureTroubleshoot">Tīmekļa vietņu problēmu novēršana</string>
+    <string name="fireTabsExplainer">Fire cilnes ir izolētas no citiem pārlūkprogrammas datiem. Tās visas aizverot, to dati tiek iznīcināti. Tām ir tāda pati izsekošanas aizsardzība kā citām cilnēm.</string>
+    <string name="fireTabsNewTabButton">Jauna Fire cilne</string>
+    <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>JAUNUMS!</b> Izmēģini Fire Tabs, lai pārlūkotu, nesaglabājot vietējo vēsturi.]]></string>
+    <string name="singleTabFireDialogTitleFireMode">Vai dzēst Fire cilnes un to datus?</string>
 </resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -1075,4 +1075,21 @@
     <!-- New Address Bar Picker -->
     <string name="newAddressBarPickerDuckDuckGo" translatable="false">DuckDuckGo</string>
     <string name="newAddressBarPickerConfirm">Bekreft</string>
+
+    <!-- Fire mode -->
+    <string name="openInFireTab">Åpne i Fire-fanen</string>
+    <string name="openInBackgroundTab">Åpne i bakgrunnen</string>
+    <string name="browserModeToggleFireDescription">Bytt til Fire-modus-faner</string>
+    <string name="browserModeToggleRegularDescription">Bytt til vanlige faner</string>
+    <string name="browserModeToggleTabCountInfinite">∞</string>
+    <string name="fireTabMenuItem">Fire-fane</string>
+    <string name="fireTabNewTabPageTitle">Fire-fane</string>
+    <string name="fireTabsEmptyStateTitle">Fire-faner</string>
+    <string name="fireTabsFeatureNoHistory">Surf uten å lagre lokal historikk</string>
+    <string name="fireTabsFeatureDifferentAccount">Logg inn på et nettsted med en annen konto</string>
+    <string name="fireTabsFeatureTroubleshoot">Feilsøk nettsteder</string>
+    <string name="fireTabsExplainer">Fire-faner er isolert fra andre nettleserdata. Dataene deres blir slettet når du lukker alle sammen. De gir deg samme sporingsbeskyttelse som andre faner.</string>
+    <string name="fireTabsNewTabButton">Ny Fire-fane</string>
+    <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NYHET!</b> Prøv Fire-faner for å surfe uten å lagre lokal historikk.]]></string>
+    <string name="singleTabFireDialogTitleFireMode">Vil du slette Fire-faner og dataene i dem?</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1075,4 +1075,21 @@
     <!-- New Address Bar Picker -->
     <string name="newAddressBarPickerDuckDuckGo" translatable="false">DuckDuckGo</string>
     <string name="newAddressBarPickerConfirm">Bevestigen</string>
+
+    <!-- Fire mode -->
+    <string name="openInFireTab">Openen in Fire-tabblad</string>
+    <string name="openInBackgroundTab">Openen op de achtergrond</string>
+    <string name="browserModeToggleFireDescription">Overschakelen naar Fire-tabbladen</string>
+    <string name="browserModeToggleRegularDescription">Overschakelen naar normale tabbladen</string>
+    <string name="browserModeToggleTabCountInfinite">∞</string>
+    <string name="fireTabMenuItem">Fire-tabblad</string>
+    <string name="fireTabNewTabPageTitle">Fire-tabblad</string>
+    <string name="fireTabsEmptyStateTitle">Fire-tabbladen</string>
+    <string name="fireTabsFeatureNoHistory">Bladeren zonder lokale geschiedenis op te slaan</string>
+    <string name="fireTabsFeatureDifferentAccount">Meld je aan bij een website met een ander account</string>
+    <string name="fireTabsFeatureTroubleshoot">Problemen met websites oplossen</string>
+    <string name="fireTabsExplainer">Fire-tabbladen zijn geïsoleerd van andere browsergegevens. Hun gegevens worden verwijderd als je ze allemaal afsluit. Ze geven je dezelfde trackingbeveiliging als andere tabbladen.</string>
+    <string name="fireTabsNewTabButton">Nieuw Fire-tabblad</string>
+    <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NIEUW!</b> Probeer Fire Tabs om te browsen zonder de lokale geschiedenis op te slaan.]]></string>
+    <string name="singleTabFireDialogTitleFireMode">Fire-tabbladen en hun gegevens verwijderen?</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1115,4 +1115,21 @@
     <!-- New Address Bar Picker -->
     <string name="newAddressBarPickerDuckDuckGo" translatable="false">DuckDuckGo</string>
     <string name="newAddressBarPickerConfirm">Potwierdź</string>
+
+    <!-- Fire mode -->
+    <string name="openInFireTab">Otwórz w karcie Fire</string>
+    <string name="openInBackgroundTab">Otwórz w tle</string>
+    <string name="browserModeToggleFireDescription">Przełącz się na karty w trybie Fire</string>
+    <string name="browserModeToggleRegularDescription">Przełącz na zwykłe karty</string>
+    <string name="browserModeToggleTabCountInfinite">∞</string>
+    <string name="fireTabMenuItem">Karta Fire</string>
+    <string name="fireTabNewTabPageTitle">Karta Fire</string>
+    <string name="fireTabsEmptyStateTitle">Karty Fire</string>
+    <string name="fireTabsFeatureNoHistory">Przeglądaj bez zapisywania historii lokalnej</string>
+    <string name="fireTabsFeatureDifferentAccount">Zaloguj się do witryny przy użyciu innego konta</string>
+    <string name="fireTabsFeatureTroubleshoot">Rozwiązuj problemy z witrynami</string>
+    <string name="fireTabsExplainer">Karty Fire są izolowane od innych danych przeglądarki. Ich dane zostaną zniszczone, gdy zamkniesz je wszystkie. Zapewniają one taką samą ochronę przed śledzeniem jak inne karty.</string>
+    <string name="fireTabsNewTabButton">Nowa karta Fire</string>
+    <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NOWOŚĆ!</b> Wypróbuj karty Fire, aby przeglądać bez lokalnego zapisywania historii.]]></string>
+    <string name="singleTabFireDialogTitleFireMode">Usunąć karty Fire i ich dane?</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1075,4 +1075,21 @@
     <!-- New Address Bar Picker -->
     <string name="newAddressBarPickerDuckDuckGo" translatable="false">DuckDuckGo</string>
     <string name="newAddressBarPickerConfirm">Confirmar</string>
+
+    <!-- Fire mode -->
+    <string name="openInFireTab">Abrir num separador Fire</string>
+    <string name="openInBackgroundTab">Abrir em segundo plano</string>
+    <string name="browserModeToggleFireDescription">Mudar para separadores do modo Fire</string>
+    <string name="browserModeToggleRegularDescription">Mudar para separadores normais</string>
+    <string name="browserModeToggleTabCountInfinite">∞</string>
+    <string name="fireTabMenuItem">Separador Fire</string>
+    <string name="fireTabNewTabPageTitle">Separador Fire</string>
+    <string name="fireTabsEmptyStateTitle">Separadores Fire</string>
+    <string name="fireTabsFeatureNoHistory">Navegar sem guardar o histórico local</string>
+    <string name="fireTabsFeatureDifferentAccount">Iniciar sessão num site com uma conta diferente</string>
+    <string name="fireTabsFeatureTroubleshoot">Resolver problemas de sites</string>
+    <string name="fireTabsExplainer">Os separadores Fire estão isolados de outros dados do navegador. Os dados deles são queimados quando fechas o separador. Têm a mesma proteção contra rastreio que os outros separadores.</string>
+    <string name="fireTabsNewTabButton">Novo separador Fire</string>
+    <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NOVO!</b> Experimenta os separadores Fire para navegar sem guardar o histórico local.]]></string>
+    <string name="singleTabFireDialogTitleFireMode">Eliminar separadores Fire e respetivos dados?</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1095,4 +1095,21 @@
     <!-- New Address Bar Picker -->
     <string name="newAddressBarPickerDuckDuckGo" translatable="false">DuckDuckGo</string>
     <string name="newAddressBarPickerConfirm">Confirmă</string>
+
+    <!-- Fire mode -->
+    <string name="openInFireTab">Deschide în fila Fire</string>
+    <string name="openInBackgroundTab">Deschide în fundal</string>
+    <string name="browserModeToggleFireDescription">Comută la filele modului Fire</string>
+    <string name="browserModeToggleRegularDescription">Comută la filele obișnuite</string>
+    <string name="browserModeToggleTabCountInfinite">∞</string>
+    <string name="fireTabMenuItem">Filă Fire</string>
+    <string name="fireTabNewTabPageTitle">Filă Fire</string>
+    <string name="fireTabsEmptyStateTitle">File Fire</string>
+    <string name="fireTabsFeatureNoHistory">Navighează fără a salva istoricul local</string>
+    <string name="fireTabsFeatureDifferentAccount">Conectează-te la un site cu un alt cont</string>
+    <string name="fireTabsFeatureTroubleshoot">Depanează site-uri</string>
+    <string name="fireTabsExplainer">Filele Fire sunt izolate de alte date din browser. Datele acestora sunt distruse când le închizi pe toate. Acestea îți oferă aceeași protecție împotriva urmăririi ca și alte file.</string>
+    <string name="fireTabsNewTabButton">Noua filă Fire</string>
+    <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NOU!</b> Încearcă filele Fire pentru a naviga fără a salva istoricul local.]]></string>
+    <string name="singleTabFireDialogTitleFireMode">Ștergi filele Fire și datele aferente?</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1115,4 +1115,21 @@
     <!-- New Address Bar Picker -->
     <string name="newAddressBarPickerDuckDuckGo" translatable="false">DuckDuckGo</string>
     <string name="newAddressBarPickerConfirm">Подтвердить</string>
+
+    <!-- Fire mode -->
+    <string name="openInFireTab">Открыть в Fire-вкладке</string>
+    <string name="openInBackgroundTab">Открыть в фоновом режиме</string>
+    <string name="browserModeToggleFireDescription">Переключиться на Fire-вкладки</string>
+    <string name="browserModeToggleRegularDescription">Перейти на обычные вкладки</string>
+    <string name="browserModeToggleTabCountInfinite">∞</string>
+    <string name="fireTabMenuItem">Fire-вкладка</string>
+    <string name="fireTabNewTabPageTitle">Fire-вкладка</string>
+    <string name="fireTabsEmptyStateTitle">Fire-вкладки</string>
+    <string name="fireTabsFeatureNoHistory">Просмотр сайтов без сохранения локальной истории</string>
+    <string name="fireTabsFeatureDifferentAccount">Вход на сайт через другую учетную запись</string>
+    <string name="fireTabsFeatureTroubleshoot">Устранение неполадок с сайтами</string>
+    <string name="fireTabsExplainer">Данные Fire-вкладок изолированы от прочих данных браузера. При закрытии их данные будут уничтожены. Защита от отслеживания в таких вкладках не отличается от стандартной.</string>
+    <string name="fireTabsNewTabButton">Новая Fire-вкладка</string>
+    <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>Новинка!</b> Используйте Fire-вкладки, чтобы просматривать веб-страницы без сохранения локальной истории.]]></string>
+    <string name="singleTabFireDialogTitleFireMode">Удалить Fire-вкладки и их данные?</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1115,4 +1115,21 @@
     <!-- New Address Bar Picker -->
     <string name="newAddressBarPickerDuckDuckGo" translatable="false">DuckDuckGo</string>
     <string name="newAddressBarPickerConfirm">Potvrdiť</string>
+
+    <!-- Fire mode -->
+    <string name="openInFireTab">Otvoriť na karte Fire</string>
+    <string name="openInBackgroundTab">Otvoriť na pozadí</string>
+    <string name="browserModeToggleFireDescription">Prejdi na karty v režime Fire</string>
+    <string name="browserModeToggleRegularDescription">Prepnúť na bežné karty</string>
+    <string name="browserModeToggleTabCountInfinite">∞</string>
+    <string name="fireTabMenuItem">Karta Fire</string>
+    <string name="fireTabNewTabPageTitle">Karta Fire</string>
+    <string name="fireTabsEmptyStateTitle">Karty Fire</string>
+    <string name="fireTabsFeatureNoHistory">Prehliadaj bez lokálneho ukladania histórie</string>
+    <string name="fireTabsFeatureDifferentAccount">Prihlás sa na stránku s iným účtom</string>
+    <string name="fireTabsFeatureTroubleshoot">Riešenie problémov s webovými stránkami</string>
+    <string name="fireTabsExplainer">Karty Fire sú izolované od ostatných údajov prehliadača. Keď ich všetky zatvoríš, ich údaje sa vymažú. Poskytujú ti rovnakú ochranu proti sledovaniu ako ostatné karty.</string>
+    <string name="fireTabsNewTabButton">Nová karta Fire</string>
+    <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NOVINKA!</b> Vyskúšaj karty Fire na prehliadanie bez ukladania do lokálnej histórie.]]></string>
+    <string name="singleTabFireDialogTitleFireMode">Chceš vymazať karty Fire a ich údaje?</string>
 </resources>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -1115,4 +1115,21 @@
     <!-- New Address Bar Picker -->
     <string name="newAddressBarPickerDuckDuckGo" translatable="false">DuckDuckGo</string>
     <string name="newAddressBarPickerConfirm">Potrdi</string>
+
+    <!-- Fire mode -->
+    <string name="openInFireTab">Odpri v zavihku Fire</string>
+    <string name="openInBackgroundTab">Odpri v ozadju</string>
+    <string name="browserModeToggleFireDescription">Preklopi na zavihke v načinu Fire</string>
+    <string name="browserModeToggleRegularDescription">Preklopi na običajne zavihke</string>
+    <string name="browserModeToggleTabCountInfinite">∞</string>
+    <string name="fireTabMenuItem">Zavihek Fire</string>
+    <string name="fireTabNewTabPageTitle">Zavihek Fire</string>
+    <string name="fireTabsEmptyStateTitle">Zavihki Fire</string>
+    <string name="fireTabsFeatureNoHistory">Brskaj brez shranjevanja lokalne zgodovine</string>
+    <string name="fireTabsFeatureDifferentAccount">Prijava v spletno mesto z drugim računom</string>
+    <string name="fireTabsFeatureTroubleshoot">Odpravljanje težav s spletnimi mesti</string>
+    <string name="fireTabsExplainer">Zavihki Fire so ločeni od drugih podatkov brskanja. Njihovi podatki se izbrišejo, ko jih vse zaprete. Imajo enako zaščito pred sledenjem kot drugi zavihki.</string>
+    <string name="fireTabsNewTabButton">Nov zavihek Fire</string>
+    <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NOVO!</b> Preizkusite zavihke Fire za brskanje brez shranjevanja lokalne zgodovine.]]></string>
+    <string name="singleTabFireDialogTitleFireMode">Želite izbrisati zavihke Fire in njihove podatke?</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -1075,4 +1075,21 @@
     <!-- New Address Bar Picker -->
     <string name="newAddressBarPickerDuckDuckGo" translatable="false">DuckDuckGo</string>
     <string name="newAddressBarPickerConfirm">Bekräfta</string>
+
+    <!-- Fire mode -->
+    <string name="openInFireTab">Öppna på en Fire-flik</string>
+    <string name="openInBackgroundTab">Öppna i bakgrunden</string>
+    <string name="browserModeToggleFireDescription">Växla till Fire-flikar</string>
+    <string name="browserModeToggleRegularDescription">Byt till vanliga flikar</string>
+    <string name="browserModeToggleTabCountInfinite">∞</string>
+    <string name="fireTabMenuItem">Fire-flik</string>
+    <string name="fireTabNewTabPageTitle">Fire-flik</string>
+    <string name="fireTabsEmptyStateTitle">Fire-flikar</string>
+    <string name="fireTabsFeatureNoHistory">Surfa utan att spara lokal historik</string>
+    <string name="fireTabsFeatureDifferentAccount">Logga in på en webbplats med ett annat konto</string>
+    <string name="fireTabsFeatureTroubleshoot">Felsöka webbplatser</string>
+    <string name="fireTabsExplainer">Fire-flikar är isolerade från andra webbläsardata. Deras data rensas när du stänger dem alla. De ger dig samma spårningsskydd som andra flikar.</string>
+    <string name="fireTabsNewTabButton">Ny Fire-flik</string>
+    <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NYTT!</b> Prova Fire-flikar för att surfa utan att spara lokal historik.]]></string>
+    <string name="singleTabFireDialogTitleFireMode">Ta bort Fire Tabs och deras data?</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1075,4 +1075,21 @@
     <!-- New Address Bar Picker -->
     <string name="newAddressBarPickerDuckDuckGo" translatable="false">DuckDuckGo</string>
     <string name="newAddressBarPickerConfirm">Onayla</string>
+
+    <!-- Fire mode -->
+    <string name="openInFireTab">Fire Sekmesinde Aç</string>
+    <string name="openInBackgroundTab">Arka Planda Aç</string>
+    <string name="browserModeToggleFireDescription">Fire modu sekmelerine geçin</string>
+    <string name="browserModeToggleRegularDescription">Normal sekmelere geç</string>
+    <string name="browserModeToggleTabCountInfinite">∞</string>
+    <string name="fireTabMenuItem">Fire Sekmesi</string>
+    <string name="fireTabNewTabPageTitle">Fire Sekmesi</string>
+    <string name="fireTabsEmptyStateTitle">Fire Sekmeleri</string>
+    <string name="fireTabsFeatureNoHistory">Yerel geçmişi kaydetmeden göz atın</string>
+    <string name="fireTabsFeatureDifferentAccount">Bir sitede farklı bir hesapla oturum açın</string>
+    <string name="fireTabsFeatureTroubleshoot">Web sitelerindeki sorunları giderin</string>
+    <string name="fireTabsExplainer">Fire Sekmeleri diğer tarayıcı verilerinden izole edilmiştir. Tüm pencereleri kapattığınızda veriler imha edilir. Diğer sekmelerle aynı izleme korumasını sunarlar.</string>
+    <string name="fireTabsNewTabButton">Yeni Fire Sekmesi</string>
+    <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>YENİ!</b> Yerel geçmişi kaydetmeden göz atmak için Fire Sekmelerini deneyin.]]></string>
+    <string name="singleTabFireDialogTitleFireMode">Fire Sekmeleri ve verileri silinsin mi?</string>
 </resources>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -94,23 +94,6 @@
         <item quantity="other" instruction="%1$d is the number of chats the user is about to delete.">Delete %1$d chats?</item>
     </plurals>
 
-    <!-- Fire mode -->
-    <string name="openInFireTab">Open in Fire Tab</string>
-    <string name="openInBackgroundTab">Open in Background</string>
-    <string name="browserModeToggleFireDescription">Switch to Fire mode tabs</string>
-    <string name="browserModeToggleRegularDescription">Switch to regular tabs</string>
-    <string name="browserModeToggleTabCountInfinite">∞</string>
-    <string name="fireTabMenuItem">Fire Tab</string>
-    <string name="fireTabNewTabPageTitle">Fire Tab</string>
-    <string name="fireTabsEmptyStateTitle">Fire Tabs</string>
-    <string name="fireTabsFeatureNoHistory">Browse without saving local history</string>
-    <string name="fireTabsFeatureDifferentAccount">Sign in to a site with a different account</string>
-    <string name="fireTabsFeatureTroubleshoot">Troubleshoot websites</string>
-    <string name="fireTabsExplainer">Fire Tabs are isolated from other browser data. Their data is burned when you close them all. They give you the same tracking protection as other tabs.</string>
-    <string name="fireTabsNewTabButton">New Fire Tab</string>
-    <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NEW!</b> Try Fire Tabs to browse without saving local history.]]></string>
-    <string name="singleTabFireDialogTitleFireMode">Delete Fire Tabs and their data?</string>
-
     <!-- After Inactivity: return-to-last-tab hatch setting -->
     <string name="returnToLastTabSettingTitle">Return To Last Tab</string>
     <string name="returnToLastTabSettingSubtitle">Show a link to your last tab on the New Tab Page when you reopen the app</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1074,4 +1074,21 @@
     <!-- New Address Bar Picker -->
     <string name="newAddressBarPickerDuckDuckGo" translatable="false">DuckDuckGo</string>
     <string name="newAddressBarPickerConfirm">Confirm</string>
+
+    <!-- Fire mode -->
+    <string name="openInFireTab">Open in Fire Tab</string>
+    <string name="openInBackgroundTab">Open in Background</string>
+    <string name="browserModeToggleFireDescription">Switch to Fire mode tabs</string>
+    <string name="browserModeToggleRegularDescription">Switch to regular tabs</string>
+    <string name="browserModeToggleTabCountInfinite">∞</string>
+    <string name="fireTabMenuItem">Fire Tab</string>
+    <string name="fireTabNewTabPageTitle">Fire Tab</string>
+    <string name="fireTabsEmptyStateTitle">Fire Tabs</string>
+    <string name="fireTabsFeatureNoHistory">Browse without saving local history</string>
+    <string name="fireTabsFeatureDifferentAccount">Sign in to a site with a different account</string>
+    <string name="fireTabsFeatureTroubleshoot">Troubleshoot websites</string>
+    <string name="fireTabsExplainer">Fire Tabs are isolated from other browser data. Their data is burned when you close them all. They give you the same tracking protection as other tabs.</string>
+    <string name="fireTabsNewTabButton">New Fire Tab</string>
+    <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NEW!</b> Try Fire Tabs to browse without saving local history.]]></string>
+    <string name="singleTabFireDialogTitleFireMode">Delete Fire Tabs and their data?</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
@@ -49,7 +49,7 @@
     <string name="duck_ai_shortcut_settings_description">Izvēlies, kurus Duck.ai īsceļus parādīt</string>
 
     <!-- Default Toggle Position -->
-    <string name="duckAiDefaultTogglePositionTitle" instruction="&apos;Toggle&apos; refers to the UI tab switcher component (Search/Duck.ai), not the verb &apos;to toggle&apos;.">Jauna cilnes slēdža pozīcija</string>
+    <string name="duckAiDefaultTogglePositionTitle" instruction="&apos;Toggle&apos; refers to the UI tab switcher component (Search/Duck.ai), not the verb &apos;to toggle&apos;.">Pārslēga novietojums jaunā cilnē</string>
     <string name="duckAiDefaultTogglePositionSearch">Meklēt</string>
     <string name="duckAiDefaultTogglePositionDuckAi">Duck.ai</string>
     <string name="duckAiDefaultTogglePositionLastUsed">Pēdējo reizi lietots</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1216213420213818?focus=true

### Description

This PR submits new strings for a translation.

### Steps to test this PR

QA-optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-resource-only changes with no app logic; risk is limited to translation or missing-locale fallback issues.
> 
> **Overview**
> Moves **Fire mode / Fire Tabs** UI copy out of `donottranslate.xml` into the main translatable `strings.xml` resources so Smartling/localization can ship it.
> 
> The same **15 string keys** (e.g. open in Fire tab, mode toggle labels, empty state, promo, delete confirmation) are added to the default `values/strings.xml` and mirrored across **~25 locale** `values-*/strings.xml` files with translated text. English defaults are unchanged in wording; only resource placement changes.
> 
> Also includes an unrelated **Latvian** copy tweak in `duckchat` for `duckAiDefaultTogglePositionTitle` (“toggle position on new tab”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a1a226ce327aef20990536dfebf0c16e2fc448f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->