### PR TITLE
Wire after-idle trigger into New Tab Page remote messages

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabPageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabPageViewModel.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.app.browser.remotemessage.CommandActionMapper
 import com.duckduckgo.app.cta.db.DismissedCtaDao
 import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.app.cta.ui.CtaViewModel
+import com.duckduckgo.app.generalsettings.showonapplaunch.rmf.AfterIdleMessageTriggerProvider
 import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -45,12 +46,14 @@ import com.duckduckgo.sync.api.engine.SyncEngine.SyncTrigger.FEATURE_READ
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -61,10 +64,12 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 @SuppressLint("NoLifecycleObserver") // we don't observe app lifecycle
+@OptIn(ExperimentalCoroutinesApi::class)
 class NewTabPageViewModel @AssistedInject constructor(
     @Assisted private val showDaxLogo: Boolean,
     private val dispatchers: DispatcherProvider,
     private val remoteMessagingModel: RemoteMessageModel,
+    private val afterIdleMessageTriggerProvider: AfterIdleMessageTriggerProvider,
     private val playStoreUtils: PlayStoreUtils,
     private val savedSitesRepository: SavedSitesRepository,
     private val syncEngine: SyncEngine,
@@ -143,7 +148,10 @@ class NewTabPageViewModel @AssistedInject constructor(
         viewModelScope.launch(dispatchers.io()) {
             savedSitesRepository.getFavorites()
                 .combine(
-                    remoteMessagingModel.observeActiveMessages()
+                    afterIdleMessageTriggerProvider.activeTrigger()
+                        .flatMapLatest { trigger ->
+                            remoteMessagingModel.observeActiveMessages(trigger)
+                        }
                         .map { message ->
                             if (message?.surfaces?.contains(Surface.NEW_TAB_PAGE) == true) message else null
                         },

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/GeneralSettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/GeneralSettingsActivity.kt
@@ -54,7 +54,7 @@ import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
 @InjectWith(ActivityScope::class)
-@ContributeToActivityStarter(GeneralSettingsScreenNoParams::class)
+@ContributeToActivityStarter(GeneralSettingsScreenNoParams::class, screenName = "settingsGeneral")
 class GeneralSettingsActivity : DuckDuckGoActivity() {
 
     @Inject

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/rmf/AfterIdleMessageTriggerProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/rmf/AfterIdleMessageTriggerProvider.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch.rmf
+
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
+import com.duckduckgo.remote.messaging.api.MessageTrigger
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+
+/**
+ * Resolves the after-idle NTP context into [MessageTrigger.AFTER_IDLE]
+ */
+class AfterIdleMessageTriggerProvider @Inject constructor(
+    private val ntpAfterIdleManager: NtpAfterIdleManager,
+    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
+) {
+
+    fun activeTrigger(): Flow<MessageTrigger?> {
+        val rolloutEnabled = androidBrowserConfigFeature.showNTPAfterIdleReturn().isEnabled() &&
+            androidBrowserConfigFeature.ntpAsDefaultAfterIdleReturn().isEnabled()
+        if (!rolloutEnabled) return flowOf(null)
+
+        return ntpAfterIdleManager.isAfterIdleReturn.map { afterIdle ->
+            if (afterIdle) MessageTrigger.AFTER_IDLE else null
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/rmf/RMFNtpAfterIdleStateMatchingAttribute.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/rmf/RMFNtpAfterIdleStateMatchingAttribute.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch.rmf
+
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
+import com.duckduckgo.app.generalsettings.showonapplaunch.rmf.NtpAfterIdleState.ELIGIBLE_CARD_HIDDEN
+import com.duckduckgo.app.generalsettings.showonapplaunch.rmf.NtpAfterIdleState.ELIGIBLE_CARD_SHOWN
+import com.duckduckgo.app.generalsettings.showonapplaunch.rmf.NtpAfterIdleState.NOT_ELIGIBLE
+import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
+import com.duckduckgo.remote.messaging.api.AttributeMatcherPlugin
+import com.duckduckgo.remote.messaging.api.JsonMatchingAttribute
+import com.duckduckgo.remote.messaging.api.JsonToMatchingAttributeMapper
+import com.duckduckgo.remote.messaging.api.MatchingAttribute
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.flow.firstOrNull
+import javax.inject.Inject
+
+/**
+ * Matches the user's NTP-after-idle state, combining the after-idle "open on launch" option with the
+ * return-to-tab card visibility into a single value.
+ */
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = JsonToMatchingAttributeMapper::class,
+)
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = AttributeMatcherPlugin::class,
+)
+@SingleInstanceIn(AppScope::class)
+class RMFNtpAfterIdleStateMatchingAttribute @Inject constructor(
+    private val showOnAppLaunchOptionDataStore: ShowOnAppLaunchOptionDataStore,
+    private val ntpAfterIdleManager: NtpAfterIdleManager,
+    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
+) : JsonToMatchingAttributeMapper, AttributeMatcherPlugin {
+
+    override suspend fun evaluate(matchingAttribute: MatchingAttribute): Boolean? {
+        if (matchingAttribute is NtpAfterIdleStateMatchingAttribute) {
+            return currentState() in matchingAttribute.states
+        }
+        return null
+    }
+
+    override fun map(
+        key: String,
+        jsonMatchingAttribute: JsonMatchingAttribute,
+    ): MatchingAttribute? {
+        if (key != NtpAfterIdleStateMatchingAttribute.KEY) return null
+        // Rollout gate: when either flag is off, leave the attribute unmapped so RMF treats it as Unknown(fallback).
+        val rolloutEnabled = androidBrowserConfigFeature.showNTPAfterIdleReturn().isEnabled() &&
+            androidBrowserConfigFeature.ntpAsDefaultAfterIdleReturn().isEnabled()
+        if (!rolloutEnabled) return null
+        val value = jsonMatchingAttribute.value
+        if (value is List<*>) {
+            val states = value.filterIsInstance<String>()
+                .mapNotNull { raw -> NtpAfterIdleState.entries.firstOrNull { it.jsonValue == raw } }
+            if (states.isNotEmpty()) {
+                return NtpAfterIdleStateMatchingAttribute(states)
+            }
+        }
+        return null
+    }
+
+    private suspend fun currentState(): NtpAfterIdleState {
+        if (showOnAppLaunchOptionDataStore.optionFlow.firstOrNull() != NewTabPage) return NOT_ELIGIBLE
+        return if (ntpAfterIdleManager.returnToLastTabEnabled.firstOrNull() == true) ELIGIBLE_CARD_SHOWN else ELIGIBLE_CARD_HIDDEN
+    }
+}
+
+internal enum class NtpAfterIdleState(val jsonValue: String) {
+    NOT_ELIGIBLE("notEligible"),
+    ELIGIBLE_CARD_SHOWN("eligibleCardShown"),
+    ELIGIBLE_CARD_HIDDEN("eligibleCardHidden"),
+}
+
+internal data class NtpAfterIdleStateMatchingAttribute(
+    val states: List<NtpAfterIdleState>,
+) : MatchingAttribute {
+    companion object {
+        const val KEY = "ntpAfterIdleState"
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/newtab/NewTabPageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/newtab/NewTabPageViewModelTest.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.app.browser.remotemessage.CommandActionMapper
 import com.duckduckgo.app.cta.db.DismissedCtaDao
 import com.duckduckgo.app.cta.model.CtaId.DAX_END
 import com.duckduckgo.app.cta.ui.CtaViewModel
+import com.duckduckgo.app.generalsettings.showonapplaunch.rmf.AfterIdleMessageTriggerProvider
 import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
@@ -35,6 +36,7 @@ import com.duckduckgo.mobile.android.R
 import com.duckduckgo.mobile.android.app.tracking.AppTrackingProtection
 import com.duckduckgo.remote.messaging.api.Action
 import com.duckduckgo.remote.messaging.api.Content
+import com.duckduckgo.remote.messaging.api.MessageTrigger
 import com.duckduckgo.remote.messaging.api.RemoteMessage
 import com.duckduckgo.remote.messaging.api.RemoteMessageModel
 import com.duckduckgo.remote.messaging.api.Surface
@@ -70,6 +72,7 @@ class NewTabPageViewModelTest {
     private var mockCommandActionMapper: CommandActionMapper = mock()
     private var mockPlaystoreUtils: PlayStoreUtils = mock()
     private var mockRemoteMessageModel: RemoteMessageModel = mock()
+    private var mockAfterIdleMessageTriggerProvider: AfterIdleMessageTriggerProvider = mock()
     private var mockDismissedCtaDao: DismissedCtaDao = mock()
     private val mockSettingsDataStore: SettingsDataStore = mock()
     private val mockLowPriorityMessagingModel: LowPriorityMessagingModel = mock()
@@ -86,6 +89,7 @@ class NewTabPageViewModelTest {
         whenever(mockOnboardingBrandDesignUpdateToggles.brandDesignUpdate()).thenReturn(mockDisabledToggle)
         whenever(mockSavedSitesRepository.getFavorites()).thenReturn(flowOf(emptyList()))
         whenever(mockRemoteMessageModel.observeActiveMessages()).thenReturn(flowOf(null))
+        whenever(mockAfterIdleMessageTriggerProvider.activeTrigger()).thenReturn(flowOf(null))
         whenever(mockAppTrackingProtection.isEnabled()).thenReturn(false)
 
         testee = createTestee()
@@ -99,6 +103,7 @@ class NewTabPageViewModelTest {
             showDaxLogo = showLogo,
             dispatchers = coroutinesTestRule.testDispatcherProvider,
             remoteMessagingModel = mockRemoteMessageModel,
+            afterIdleMessageTriggerProvider = mockAfterIdleMessageTriggerProvider,
             playStoreUtils = mockPlaystoreUtils,
             savedSitesRepository = mockSavedSitesRepository,
             syncEngine = mockSyncEngine,
@@ -112,6 +117,21 @@ class NewTabPageViewModelTest {
             ctaViewModel = mockCtaViewModel,
             browserMode = browserMode,
         )
+    }
+
+    @Test
+    fun whenActiveTriggerIsAfterIdleThenObservesMessagesWithThatTrigger() = runTest {
+        val remoteMessage = RemoteMessage("id1", Content.Small("", ""), emptyList(), emptyList(), listOf(Surface.NEW_TAB_PAGE))
+        whenever(mockAfterIdleMessageTriggerProvider.activeTrigger()).thenReturn(flowOf(MessageTrigger.AFTER_IDLE))
+        // Only the AFTER_IDLE overload returns the message; the no-trigger default (stubbed in setUp) returns
+        // null, so the message surfacing proves the VM threaded AFTER_IDLE into observeActiveMessages.
+        whenever(mockRemoteMessageModel.observeActiveMessages(MessageTrigger.AFTER_IDLE)).thenReturn(flowOf(remoteMessage))
+
+        testee.onStart(mockLifecycleOwner)
+
+        testee.viewState.test {
+            assertEquals(remoteMessage, expectMostRecentItem().message)
+        }
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/rmf/AfterIdleMessageTriggerProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/rmf/AfterIdleMessageTriggerProviderTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch.rmf
+
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
+import com.duckduckgo.remote.messaging.api.MessageTrigger
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class AfterIdleMessageTriggerProviderTest {
+
+    private val ntpAfterIdleManager: NtpAfterIdleManager = mock()
+    private val feature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
+
+    private val testee = AfterIdleMessageTriggerProvider(ntpAfterIdleManager, feature)
+
+    @Test
+    fun whenBothFlagsEnabledAndAfterIdleReturnThenAfterIdleTrigger() = runTest {
+        enableBothFlags()
+        whenever(ntpAfterIdleManager.isAfterIdleReturn).thenReturn(MutableStateFlow(true))
+
+        assertEquals(MessageTrigger.AFTER_IDLE, testee.activeTrigger().firstOrNull())
+    }
+
+    @Test
+    fun whenBothFlagsEnabledAndNotAfterIdleReturnThenNull() = runTest {
+        enableBothFlags()
+        whenever(ntpAfterIdleManager.isAfterIdleReturn).thenReturn(MutableStateFlow(false))
+
+        assertNull(testee.activeTrigger().firstOrNull())
+    }
+
+    @Test
+    fun whenShowNtpAfterIdleReturnFlagDisabledThenNull() = runTest {
+        feature.ntpAsDefaultAfterIdleReturn().setRawStoredState(Toggle.State(enable = true))
+        // showNTPAfterIdleReturn stays off → gated out before idle state is observed
+
+        assertNull(testee.activeTrigger().firstOrNull())
+    }
+
+    @Test
+    fun whenNtpAsDefaultFlagDisabledThenNull() = runTest {
+        feature.showNTPAfterIdleReturn().setRawStoredState(Toggle.State(enable = true))
+        // ntpAsDefaultAfterIdleReturn stays off → gated out before idle state is observed
+
+        assertNull(testee.activeTrigger().firstOrNull())
+    }
+
+    private fun enableBothFlags() {
+        feature.showNTPAfterIdleReturn().setRawStoredState(Toggle.State(enable = true))
+        feature.ntpAsDefaultAfterIdleReturn().setRawStoredState(Toggle.State(enable = true))
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/rmf/RMFNtpAfterIdleStateMatchingAttributeTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/rmf/RMFNtpAfterIdleStateMatchingAttributeTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch.rmf
+
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.LastOpenedTab
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
+import com.duckduckgo.app.generalsettings.showonapplaunch.store.ShowOnAppLaunchOptionDataStore
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
+import com.duckduckgo.remote.messaging.api.JsonMatchingAttribute
+import com.duckduckgo.remote.messaging.api.MatchingAttribute
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class RMFNtpAfterIdleStateMatchingAttributeTest {
+
+    private val showOnAppLaunchOptionDataStore: ShowOnAppLaunchOptionDataStore = mock()
+    private val ntpAfterIdleManager: NtpAfterIdleManager = mock()
+    private val feature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
+
+    private val testee = RMFNtpAfterIdleStateMatchingAttribute(showOnAppLaunchOptionDataStore, ntpAfterIdleManager, feature)
+
+    // --- map (this is where the rollout is gated: flags off => attribute is left unmapped) ---
+
+    @Test
+    fun whenKeyIsNotNtpAfterIdleStateThenMapReturnsNull() {
+        assertNull(testee.map("someOtherKey", JsonMatchingAttribute(value = listOf("eligibleCardShown"))))
+    }
+
+    @Test
+    fun whenRolloutDisabledThenMapReturnsNull() {
+        // both flags default off → attribute not mapped (RMF treats it as Unknown(fallback))
+        assertNull(testee.map("ntpAfterIdleState", JsonMatchingAttribute(value = listOf("eligibleCardShown"))))
+    }
+
+    @Test
+    fun whenRolloutEnabledAndValueHasKnownStatesThenMapReturnsAttribute() {
+        enableRollout()
+
+        val result = testee.map("ntpAfterIdleState", JsonMatchingAttribute(value = listOf("eligibleCardShown")))
+
+        assertEquals(NtpAfterIdleStateMatchingAttribute(listOf(NtpAfterIdleState.ELIGIBLE_CARD_SHOWN)), result)
+    }
+
+    @Test
+    fun whenRolloutEnabledAndValueHasNoKnownStatesThenMapReturnsNull() {
+        enableRollout()
+
+        assertNull(testee.map("ntpAfterIdleState", JsonMatchingAttribute(value = listOf("futureState"))))
+    }
+
+    // --- evaluate (only reached once mapped, i.e. rollout on; it computes state from the settings) ---
+
+    @Test
+    fun whenOptionNotNtpThenNotEligible() = runTest {
+        whenever(showOnAppLaunchOptionDataStore.optionFlow).thenReturn(flowOf(LastOpenedTab))
+
+        assertEquals(true, testee.evaluate(attr(NtpAfterIdleState.NOT_ELIGIBLE)))
+        assertEquals(false, testee.evaluate(attr(NtpAfterIdleState.ELIGIBLE_CARD_SHOWN)))
+    }
+
+    @Test
+    fun whenNtpAndCardShownThenEligibleCardShown() = runTest {
+        whenever(showOnAppLaunchOptionDataStore.optionFlow).thenReturn(flowOf(NewTabPage))
+        whenever(ntpAfterIdleManager.returnToLastTabEnabled).thenReturn(flowOf(true))
+
+        assertEquals(true, testee.evaluate(attr(NtpAfterIdleState.ELIGIBLE_CARD_SHOWN)))
+        assertEquals(false, testee.evaluate(attr(NtpAfterIdleState.ELIGIBLE_CARD_HIDDEN)))
+    }
+
+    @Test
+    fun whenNtpAndCardHiddenThenEligibleCardHidden() = runTest {
+        whenever(showOnAppLaunchOptionDataStore.optionFlow).thenReturn(flowOf(NewTabPage))
+        whenever(ntpAfterIdleManager.returnToLastTabEnabled).thenReturn(flowOf(false))
+
+        assertEquals(true, testee.evaluate(attr(NtpAfterIdleState.ELIGIBLE_CARD_HIDDEN)))
+        assertEquals(false, testee.evaluate(attr(NtpAfterIdleState.ELIGIBLE_CARD_SHOWN)))
+    }
+
+    @Test
+    fun whenAttributeIsNotNtpAfterIdleStateThenEvaluateReturnsNull() = runTest {
+        assertNull(testee.evaluate(object : MatchingAttribute {}))
+    }
+
+    private fun attr(vararg states: NtpAfterIdleState) = NtpAfterIdleStateMatchingAttribute(states.toList())
+
+    private fun enableRollout() {
+        feature.showNTPAfterIdleReturn().setRawStoredState(Toggle.State(enable = true))
+        feature.ntpAsDefaultAfterIdleReturn().setRawStoredState(Toggle.State(enable = true))
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216206454813408?focus=true 
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/481882893211075/task/1215861246875401

### Description

PR 4/5

Wires the RMF `AFTER_IDLE` display trigger into the New Tab Page so a remote
message configured with that trigger is shown only when the NTP is opened as an
after-idle return, and only while the rollout flags are enabled.

Only the legacy NTP (`NewTabPageViewModel`) is wired here that's the NTP the
after-idle return actually opens. Wiring the other NTP consumers (RemoteMessageViewModel and RemoteMessageNewTabSectionPlugin) will be tracked separately.

### Steps to test this PR (Testable once the RMF message is configured)

_After-idle message shows_
- [ ] Enable `showNTPAfterIdleReturn` and `ntpAsDefaultAfterIdleReturn` (both default off).
- [ ] Configure a remote message with an `AFTER_IDLE` display trigger and the New Tab Page surface.
- [ ] Leave the app idle past the inactivity threshold, then return so the NTP opens as an after-idle return; verify the message appears.
- [ ] Open the NTP normally (not after idle); verify the message does NOT appear.

_Feature off = unchanged_
- [ ] With both flags off, verify RMF messages without a trigger still show on the NTP as before, and the `AFTER_IDLE` message never shows.

### UI changes
No UI changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which remote messages appear on the legacy NTP, but rollout is behind two default-off feature flags and is limited to that ViewModel only.
> 
> **Overview**
> Legacy **New Tab Page** remote messaging now passes a dynamic **display trigger** into `observeActiveMessages` instead of always using the default (no trigger) path.
> 
> A new **`AfterIdleMessageTriggerProvider`** emits `MessageTrigger.AFTER_IDLE` only when both rollout toggles (`showNTPAfterIdleReturn` and `ntpAsDefaultAfterIdleReturn`) are on **and** `NtpAfterIdleManager` reports an after-idle return; otherwise it emits `null` so untriggered NTP messages behave as before. **`NewTabPageViewModel`** uses `flatMapLatest` on that flow to re-subscribe when idle context changes.
> 
> **`GeneralSettingsActivity`** adds `screenName = "settingsGeneral"` on the activity starter annotation (analytics/navigation). Unit tests cover the provider’s flag gating and the ViewModel passing `AFTER_IDLE` into the messaging model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 679d7fbec7cb578f88e42c0d4180ac0ba5397db2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->