### PR TITLE
Make General Settings reachable by RMF navigation action

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/generalsettings/GeneralSettingsActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/GeneralSettingsActivity.kt
@@ -54,7 +54,7 @@ import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
 @InjectWith(ActivityScope::class)
-@ContributeToActivityStarter(GeneralSettingsScreenNoParams::class)
+@ContributeToActivityStarter(GeneralSettingsScreenNoParams::class, screenName = "settingsGeneral")
 class GeneralSettingsActivity : DuckDuckGoActivity() {
 
     @Inject


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1215861246875404?focus=true
Tech Design URL (if applicable): 

### Description

Makes the General Settings screen reachable by an RMF message's `navigation` action. `GeneralSettingsActivity` was contributed to the activity starter without a `screenName`, so it wasn't deeplinkable.

The name `settingsGeneral` [matches iOS](https://github.com/duckduckgo/apple-browsers/pull/4819) so both platforms' message configs can use the same action value. 

### Steps to test this PR

_Navigate to General Settings from a message_
- [ ] Configure a remote message with a primary action `{"type":"navigation","value":"settingsGeneral"}` on the New Tab Page surface.
- [ ] Show the message on the NTP and tap its button; verify General Settings opens.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single annotation parameter for activity-starter code generation; no runtime logic or security-sensitive paths change.
> 
> **Overview**
> Registers **General Settings** for RMF deeplink/navigation by adding `screenName = "settingsGeneral"` to `@ContributeToActivityStarter` on `GeneralSettingsActivity`.
> 
> That follows the existing pattern (e.g. `accessibility`, `apptp.main`) where `screenName` opts the activity into remote navigation without changing in-app UI or settings behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8c3f4f0c7c65486bc5d0b895f6fc7d0a3f366f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->