### PR TITLE
Add a spinner to the data clearing black screen

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/global/view/SingleTabFireDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/SingleTabFireDialog.kt
@@ -398,6 +398,8 @@ class SingleTabFireDialog : BottomSheetDialogFragment(), FireDialog {
             canFinish = true
             if (event is ClearAllEvent.ClearingFinished) {
                 binding.fireAnimationView.addAnimatorUpdateListener(accelerateAnimatorUpdateListener)
+            } else {
+                binding.clearingProgressIndicator.show()
             }
         } else {
             if (viewModel.shouldRestartAfterClearing) {

--- a/app/src/main/res/layout/sheet_fire_single_tab.xml
+++ b/app/src/main/res/layout/sheet_fire_single_tab.xml
@@ -127,4 +127,14 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.core.widget.NestedScrollView>
+
+    <com.google.android.material.progressindicator.CircularProgressIndicator
+        android:id="@+id/clearingProgressIndicator"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:indeterminate="true"
+        android:visibility="gone"
+        app:indicatorColor="@android:color/white" />
+
 </FrameLayout>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1216232615375424?focus=true

### Description

This PR adds a spinner to the data clearing dialog, which will appear after the fire animation. This will indicate to the users that the app hasn't frozen and is still performing data clearing.

### Steps to test this PR

- [x] Tap on the fire button
- [x] Perform a single tab burn
- [x] Notice a spinner appears after the fire animation

### UI changes

[Screen_recording_20260702_104444.webm](https://github.com/user-attachments/assets/4ef2c978-58fd-45b6-8488-141e0fbf3ee9)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change to the fire dialog; no changes to clearing, restart, or data-handling logic.
> 
> **Overview**
> Adds a **centered indeterminate progress indicator** on the single-tab fire dialog’s full-screen black phase so users see activity while data clearing runs after the fire animation.
> 
> A `CircularProgressIndicator` is added to `sheet_fire_single_tab.xml` (hidden by default, white indicator). In `SingleTabFireDialog.onClearAllEvent`, when the flow first becomes finishable on **`AnimationFinished`** (animation done, clearing still in progress), the spinner is shown; **`ClearingFinished`** still only attaches the animation speed-up listener, unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11ca89b26ede058176827514a1167cd1ce0015da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->