### PR TITLE
Add support for contingency messaging

### DIFF
--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionJsInjectorPlugin.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionJsInjectorPlugin.kt
@@ -40,6 +40,7 @@ class AdBlockingExtensionJsInjectorPlugin @Inject constructor(
     private val statusChecker: AdBlockingStatusChecker,
     repository: AdBlockingExtensionRepository,
     private val domainMatcher: AdBlockingExtensionDomainMatcher,
+    private val contingencyMessageHandler: ContingencyMessageHandler,
     @AppCoroutineScope appScope: CoroutineScope,
 ) : JsInjectorPlugin {
 
@@ -55,6 +56,7 @@ class AdBlockingExtensionJsInjectorPlugin @Inject constructor(
         isDesktopMode: Boolean?,
         activeExperiments: List<Toggle>,
     ) {
+        contingencyMessageHandler.cancelPendingShow()
         if (!statusChecker.canInject()) {
             logcat { "Status checker rejected injection, skipping" }
             return
@@ -72,7 +74,9 @@ class AdBlockingExtensionJsInjectorPlugin @Inject constructor(
         webView.evaluateJavascript("javascript:$script", null)
     }
 
-    override fun onPageFinished(webView: WebView, url: String?, site: Site?) = Unit
+    override fun onPageFinished(webView: WebView, url: String?, site: Site?) {
+        contingencyMessageHandler.onPageLoaded(webView, url)
+    }
 
     private fun buildScript(scriptlets: List<Scriptlet>): String? =
         scriptlets

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ContingencyMessageBottomSheetFragment.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ContingencyMessageBottomSheetFragment.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.duckduckgo.adblocking.impl.databinding.BottomSheetContingencyMessageBinding
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+
+class ContingencyMessageBottomSheetFragment : BottomSheetDialogFragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        val binding = BottomSheetContingencyMessageBinding.inflate(inflater, container, false)
+        binding.contingencyMessageCloseButton.setOnClickListener { dismiss() }
+        binding.contingencyMessagePrimaryButton.setOnClickListener { dismiss() }
+        return binding.root
+    }
+
+    companion object {
+        const val TAG = "ContingencyMessageBottomSheet"
+
+        fun newInstance() = ContingencyMessageBottomSheetFragment()
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ContingencyMessageHandler.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ContingencyMessageHandler.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl
+
+import android.webkit.WebView
+import androidx.annotation.UiThread
+import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
+import com.duckduckgo.adblocking.impl.remoteconfig.ContingencyMessageStore
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+interface ContingencyMessageHandler {
+    /** Called on page load. Shows the contingency message if all conditions are met. */
+    @UiThread
+    fun onPageLoaded(webView: WebView, url: String?)
+
+    /** Cancels any presentation deferred by a previous [onPageLoaded]. Call when a new page starts loading. */
+    @UiThread
+    fun cancelPendingShow()
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(scope = AppScope::class, boundType = ContingencyMessageHandler::class)
+@ContributesMultibinding(scope = AppScope::class, boundType = MainProcessLifecycleObserver::class)
+class RealContingencyMessageHandler @Inject constructor(
+    private val feature: AdBlockingExtensionFeature,
+    private val store: ContingencyMessageStore,
+    private val view: ContingencyMessageView,
+    private val domainMatcher: AdBlockingExtensionDomainMatcher,
+    @AppCoroutineScope private val appScope: CoroutineScope,
+    private val dispatchers: DispatcherProvider,
+) : ContingencyMessageHandler, MainProcessLifecycleObserver {
+
+    @Volatile
+    private var shownInSession = false
+
+    private var pendingJob: Job? = null
+
+    override fun onCreate(owner: LifecycleOwner) {
+        appScope.launch(dispatchers.io()) {
+            feature.enableContingencyMode().enabled()
+                .distinctUntilChanged()
+                .collect { onContingencyModeChanged(it) }
+        }
+    }
+
+    @UiThread
+    override fun onPageLoaded(webView: WebView, url: String?) {
+        if (!webView.isShown) return
+        if (!shouldShow(url)) return
+        if (pendingJob?.isActive == true) return
+        pendingJob = view.launchWhenFocused(webView) {
+            if (!shouldShow(webView.url)) return@launchWhenFocused
+            if (view.show(webView)) {
+                shownInSession = true
+                appScope.launch(dispatchers.io()) { store.setShown() }
+            }
+        }
+    }
+
+    @UiThread
+    override fun cancelPendingShow() {
+        pendingJob?.cancel()
+        pendingJob = null
+    }
+
+    internal suspend fun onContingencyModeChanged(contingencyEnabled: Boolean) {
+        val shown = store.shown.value
+        if (!contingencyEnabled) {
+            shownInSession = false
+            if (shown) store.reset()
+        }
+    }
+
+    internal fun shouldShow(url: String?): Boolean {
+        val uxImprovements = feature.adBlockingUXImprovements().isEnabled()
+        val contingency = feature.enableContingencyMode().isEnabled()
+        val shown = shownInSession || store.shown.value
+        val isExtensionDomain = domainMatcher.matches(url)
+        val result = uxImprovements && contingency && isExtensionDomain && !shown
+        return result
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ContingencyMessageView.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ContingencyMessageView.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl
+
+import android.content.Context
+import android.content.ContextWrapper
+import android.view.ViewTreeObserver
+import android.webkit.WebView
+import androidx.annotation.UiThread
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentManager
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import javax.inject.Inject
+import kotlin.coroutines.resume
+
+interface ContingencyMessageView {
+    /**
+     * Launches [block] on the WebView's lifecycle scope once its window regains focus.
+     *
+     * @return the [Job] driving the deferred work (so the caller can track or cancel it), or null if no
+     * lifecycle owner is available.
+     */
+    @UiThread
+    fun launchWhenFocused(webView: WebView, block: suspend () -> Unit): Job?
+
+    /**
+     * Presents the contingency message bottom sheet.
+     *
+     * @return true only if the sheet was actually presented; false when the fragment manager is unavailable,
+     * its state is saved, or the sheet is already showing.
+     */
+    @UiThread
+    fun show(webView: WebView): Boolean
+}
+
+@ContributesBinding(AppScope::class)
+class RealContingencyMessageView @Inject constructor() : ContingencyMessageView {
+
+    override fun launchWhenFocused(webView: WebView, block: suspend () -> Unit): Job? {
+        val lifecycleOwner = webView.findViewTreeLifecycleOwner() ?: return null
+        return lifecycleOwner.lifecycleScope.launch {
+            webView.awaitWindowFocus()
+            block()
+        }
+    }
+
+    override fun show(webView: WebView): Boolean {
+        val fragmentManager = webView.resolveFragmentManager() ?: return false
+        if (fragmentManager.isStateSaved) return false
+        if (fragmentManager.findFragmentByTag(ContingencyMessageBottomSheetFragment.TAG) != null) return false
+        ContingencyMessageBottomSheetFragment.newInstance()
+            .show(fragmentManager, ContingencyMessageBottomSheetFragment.TAG)
+        return true
+    }
+}
+
+/**
+ * Resolves a [FragmentManager] able to host the bottom sheet, supporting both a fragment-hosted WebView
+ * (e.g. BrowserTabFragment) or an Activity-hosted WebView. Returns null when neither is available.
+ */
+private fun WebView.resolveFragmentManager(): FragmentManager? {
+    runCatching { FragmentManager.findFragment<Fragment>(this) }
+        .getOrNull()
+        ?.let { return it.childFragmentManager }
+    return context.findFragmentActivity()?.supportFragmentManager
+}
+
+private tailrec fun Context.findFragmentActivity(): FragmentActivity? = when (this) {
+    is FragmentActivity -> this
+    is ContextWrapper -> baseContext.findFragmentActivity()
+    else -> null
+}
+
+private suspend fun WebView.awaitWindowFocus() {
+    if (hasWindowFocus()) return
+    suspendCancellableCoroutine { continuation ->
+        val observer = viewTreeObserver
+        val listener = object : ViewTreeObserver.OnWindowFocusChangeListener {
+            override fun onWindowFocusChanged(hasFocus: Boolean) {
+                if (hasFocus) {
+                    observer.removeOnWindowFocusChangeListener(this)
+                    continuation.resume(Unit)
+                }
+            }
+        }
+        observer.addOnWindowFocusChangeListener(listener)
+        continuation.invokeOnCancellation { observer.removeOnWindowFocusChangeListener(listener) }
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/ContingencyMessageDataStoreModule.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/ContingencyMessageDataStoreModule.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.remoteconfig
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesTo
+import dagger.Module
+import dagger.Provides
+import javax.inject.Qualifier
+
+@ContributesTo(AppScope::class)
+@Module
+object ContingencyMessageDataStoreModule {
+
+    private val Context.contingencyMessageDataStore: DataStore<Preferences> by preferencesDataStore(
+        name = "ad_blocking_contingency_message",
+    )
+
+    @Provides
+    @ContingencyMessage
+    fun provideContingencyMessageDataStore(context: Context): DataStore<Preferences> = context.contingencyMessageDataStore
+}
+
+@Qualifier
+internal annotation class ContingencyMessage

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/ContingencyMessageStore.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/ContingencyMessageStore.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.remoteconfig
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+
+interface ContingencyMessageStore {
+    /**
+     * Whether the contingency message has already been shown to the user. Cached so it can be
+     * read synchronously ([StateFlow.value]) from the UI thread.
+     */
+    val shown: StateFlow<Boolean>
+
+    suspend fun setShown()
+
+    suspend fun reset()
+}
+
+@ContributesBinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
+class SharedPreferencesContingencyMessageStore @Inject constructor(
+    @ContingencyMessage private val store: DataStore<Preferences>,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+) : ContingencyMessageStore {
+
+    private object Keys {
+        val CONTINGENCY_MESSAGE_SHOWN = booleanPreferencesKey(name = "CONTINGENCY_MESSAGE_SHOWN")
+    }
+
+    override val shown: StateFlow<Boolean> = store.data
+        .map { prefs -> prefs[Keys.CONTINGENCY_MESSAGE_SHOWN] ?: false }
+        .distinctUntilChanged()
+        .stateIn(appCoroutineScope, SharingStarted.Eagerly, false)
+
+    override suspend fun setShown() {
+        store.edit { prefs -> prefs[Keys.CONTINGENCY_MESSAGE_SHOWN] = true }
+    }
+
+    override suspend fun reset() {
+        store.edit { prefs -> prefs.remove(Keys.CONTINGENCY_MESSAGE_SHOWN) }
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsV2Activity.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsV2Activity.kt
@@ -24,8 +24,10 @@ import com.duckduckgo.adblocking.impl.R
 import com.duckduckgo.adblocking.impl.databinding.ActivityAdBlockingSettingsV2Binding
 import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.listitem.DaxListItem
 import com.duckduckgo.common.ui.view.listitem.OneLineListItem
+import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
@@ -53,7 +55,7 @@ class AdBlockingSettingsV2Activity : BaseAdBlockingSettingsActivity() {
 
     override fun render(state: AdBlockingSettingsViewModel.ViewState) {
         super.render(state)
-        binding.adBlockingStatusIndicator.setStatus(state.isEnabled)
+        binding.adBlockingStatusIndicator.setStatus(state.isStatusIndicatorOn)
         binding.duckPlayerEntry.setSecondaryText(
             when (state.duckPlayerMode) {
                 Enabled -> getString(R.string.duck_player_mode_always)
@@ -61,5 +63,13 @@ class AdBlockingSettingsV2Activity : BaseAdBlockingSettingsActivity() {
                 else -> getString(R.string.duck_player_mode_always_ask)
             },
         )
+        if (state.isContingencyMode) {
+            binding.blockAdsToggle.gone()
+            binding.adBlockingDescription.gone()
+            binding.contingencyModeItem.show()
+        } else {
+            binding.contingencyModeItem.gone()
+            binding.blockAdsToggle.show()
+        }
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsViewModel.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsViewModel.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_SETTINGS_
 import com.duckduckgo.adblocking.impl.AdBlockingSettingsRepository
 import com.duckduckgo.adblocking.impl.domain.AdBlockingState
 import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
 import com.duckduckgo.adblocking.impl.ui.AdBlockingSettingsViewModel.Command.OpenDuckPlayerSettings
 import com.duckduckgo.adblocking.impl.ui.AdBlockingSettingsViewModel.Command.OpenLearnMore
 import com.duckduckgo.anvil.annotations.ContributesViewModel
@@ -49,6 +50,7 @@ import javax.inject.Inject
 @ContributesViewModel(ActivityScope::class)
 class AdBlockingSettingsViewModel @Inject constructor(
     statusChecker: AdBlockingStatusChecker,
+    feature: AdBlockingExtensionFeature,
     private val repository: AdBlockingSettingsRepository,
     private val pixel: Pixel,
     duckPlayer: DuckPlayer,
@@ -63,6 +65,8 @@ class AdBlockingSettingsViewModel @Inject constructor(
         val isEnabled: Boolean = false,
         val showConsentDescription: Boolean? = null,
         val duckPlayerMode: PrivatePlayerMode = AlwaysAsk,
+        val isContingencyMode: Boolean = false,
+        val isStatusIndicatorOn: Boolean = false,
     )
 
     sealed class Command {
@@ -73,10 +77,16 @@ class AdBlockingSettingsViewModel @Inject constructor(
     val viewState: StateFlow<ViewState> = combine(
         statusChecker.observeState(),
         duckPlayer.observeUserPreferences(),
-    ) { state, duckPlayerPreferences ->
+        feature.adBlockingUXImprovements().enabled(),
+        feature.enableContingencyMode().enabled(),
+    ) { state, duckPlayerPreferences, uxImprovements, contingencyModeOn ->
+        val isEnabled = state is AdBlockingState.Enabled
+        val isContingencyMode = uxImprovements && contingencyModeOn
         ViewState(
-            isEnabled = state is AdBlockingState.Enabled,
+            isEnabled = isEnabled,
             showConsentDescription = state !is AdBlockingState.Enabled.Default,
+            isContingencyMode = isContingencyMode,
+            isStatusIndicatorOn = isEnabled && !isContingencyMode,
             duckPlayerMode = duckPlayerPreferences.privatePlayerMode,
         )
     }

--- a/ad-blocking/ad-blocking-impl/src/main/res/layout/activity_ad_blocking_settings_v2.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/layout/activity_ad_blocking_settings_v2.xml
@@ -97,6 +97,17 @@
                 app:typography="body2" />
 
             <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                android:id="@+id/contingencyModeItem"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/keyline_1"
+                android:visibility="gone"
+                app:primaryText="@string/ad_blocking_settings_toggle_title"
+                app:secondaryText="@string/contingencyMessageContent"
+                app:trailingIcon="@drawable/ic_exclamation_yellow_24"
+                tools:visibility="visible" />
+
+            <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
                 android:id="@+id/duckPlayerEntry"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/ad-blocking/ad-blocking-impl/src/main/res/layout/bottom_sheet_contingency_message.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/layout/bottom_sheet_contingency_message.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingTop="@dimen/keyline_6"
+    android:paddingBottom="@dimen/keyline_5">
+
+    <ImageButton
+        android:id="@+id/contingencyMessageCloseButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/keyline_4"
+        android:background="?actionBarItemBackground"
+        android:contentDescription="@string/contingencyMessageCloseContentDescription"
+        android:src="@drawable/ic_close_24"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/contingencyMessageIcon"
+        android:layout_width="wrap_content"
+        android:layout_height="96dp"
+        android:adjustViewBounds="true"
+        android:importantForAccessibility="no"
+        android:src="@drawable/youtube_warning_96"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.duckduckgo.common.ui.view.text.DaxTextView
+        android:id="@+id/contingencyMessageTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="40dp"
+        android:layout_marginTop="@dimen/keyline_4"
+        android:gravity="center"
+        android:text="@string/contingencyMessageTitle"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/contingencyMessageIcon"
+        app:typography="h2" />
+
+    <com.duckduckgo.common.ui.view.text.DaxTextView
+        android:id="@+id/contingencyMessageContent"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="56dp"
+        android:layout_marginTop="@dimen/keyline_4"
+        android:gravity="center"
+        android:text="@string/contingencyMessageContent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/contingencyMessageTitle"
+        app:textType="secondary"
+        app:typography="body2" />
+
+    <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+        android:id="@+id/contingencyMessagePrimaryButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="40dp"
+        android:layout_marginTop="@dimen/keyline_5"
+        android:text="@string/contingencyMessagePrimaryButton"
+        app:daxButtonSize="large"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/contingencyMessageContent"
+        tools:text="Got It" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-bg/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-bg/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo премахва рекламите на видеоклипове в YouTube, за да можете да гледате видеоклипове без прекъсване. <annotation type="learn_more_link">Научете повече</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Отваря видеоклипове в режим на киносалон без разсейване, който предотвратява влиянието на гледаното съдържание върху емисията в YouTube.</string>
+    <string name="ad_blocking_settings_title_v2">Блокиране на реклами</string>
+    <string name="ad_blocking_settings_header_description">Блокира инвазивните тракери, преди да се заредят, като ефективно елиминира рекламите, които разчитат на проследяването</string>
+    <string name="contingencyMessageTitle">Блокирането на реклами в YouTube е недостъпно</string>
+    <string name="contingencyMessageContent">Блокирането на реклами е засегнато от скорошни промени в YouTube. Работим за отстраняване на тези проблеми и оценяваме Вашето разбиране</string>
+    <string name="contingencyMessagePrimaryButton">Разбрах</string>
+    <string name="contingencyMessageCloseContentDescription">Затваряне</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-cs/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-cs/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo blokuje při sledování videí na YouTube reklamy, takže se můžeš dívat bez přerušení. <annotation type="learn_more_link">Další informace</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Otevírá videa v režimu kina, který brání tomu, aby sledovaná videa ovlivňovala tvůj feed na YouTube.</string>
+    <string name="ad_blocking_settings_title_v2">Blokování reklam</string>
+    <string name="ad_blocking_settings_header_description">Zablokuje invazivní trackery ještě před jejich načtením, čímž účinně eliminuje reklamy, které spoléhají na sledování.</string>
+    <string name="contingencyMessageTitle">Blokování reklam na YouTube není k dispozici</string>
+    <string name="contingencyMessageContent">Blokování reklam bylo ovlivněno nedávnými změnami na YouTube. Problémy se snažíme opravit. Děkujeme za pochopení.</string>
+    <string name="contingencyMessagePrimaryButton">Rozumím</string>
+    <string name="contingencyMessageCloseContentDescription">Zavřít</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-da/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-da/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo blokerer videoannoncer på YouTube, så du kan se videoer uden afbrydelser. <annotation type="learn_more_link">Læs mere</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Åbner videoer i en distraktionsfri biograftilstand, der forhindrer, at det, du ser, påvirker dit YouTube-feed.</string>
+    <string name="ad_blocking_settings_title_v2">Annonceblokering</string>
+    <string name="ad_blocking_settings_header_description">Vi blokerer invasive trackere, før de indlæses, hvilket effektivt eliminerer annoncer, der er afhængige af sporing</string>
+    <string name="contingencyMessageTitle">Blokering af YouTube-annoncer ikke tilgængelig</string>
+    <string name="contingencyMessageContent">Annonceblokering er påvirket af de seneste ændringer i YouTube. Vi arbejder på at løse disse problemer og sætter pris på din forståelse</string>
+    <string name="contingencyMessagePrimaryButton">Forstået</string>
+    <string name="contingencyMessageCloseContentDescription">Luk</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-de/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-de/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo blockiert Video-Werbung auf YouTube, sodass du Videos ohne Unterbrechungen ansehen kannst. <annotation type="learn_more_link">Mehr erfahren</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Öffnet Videos in einem ablenkungsfreien Theatermodus, der verhindert, dass das, was du ansiehst, deinen YouTube-Feed beeinflusst.</string>
+    <string name="ad_blocking_settings_title_v2">Werbeblockierung</string>
+    <string name="ad_blocking_settings_header_description">Blockiert invasive Tracker, bevor sie geladen werden, und eliminiert so effektiv Werbung, die auf Tracking basiert.</string>
+    <string name="contingencyMessageTitle">YouTube-Werbeblocker nicht verfügbar</string>
+    <string name="contingencyMessageContent">Die Werbeblockierung wurde durch die jüngsten Änderungen bei YouTube beeinträchtigt. Vielen Dank für dein Verständnis, während wir daran arbeiten, diese Probleme zu beheben.</string>
+    <string name="contingencyMessagePrimaryButton">Verstanden</string>
+    <string name="contingencyMessageCloseContentDescription">Schließen</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-el/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-el/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">Το DuckDuckGo αποκλείει τις διαφημίσεις βίντεο στο YouTube, ώστε να μπορείς να βλέπεις βίντεο χωρίς διακοπές. <annotation type="learn_more_link">Μάθε περισσότερα</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Ανοίγει βίντεο σε λειτουργία κινηματογράφου χωρίς περισπάσεις, η οποία εμποδίζει το περιεχόμενο που παρακολουθείς να επηρεάσει τη ροή σου στο YouTube.</string>
+    <string name="ad_blocking_settings_title_v2">Αποκλεισμός διαφημίσεων</string>
+    <string name="ad_blocking_settings_header_description">Αποκλείει επεμβατικά προγράμματα παρακολούθησης προτού φορτώσουν, εξαλείφοντας αποτελεσματικά διαφημίσεις που βασίζονται σε παρακολούθηση</string>
+    <string name="contingencyMessageTitle">Ο αποκλεισμός διαφημίσεων στο YouTube δεν είναι διαθέσιμος</string>
+    <string name="contingencyMessageContent">Ο αποκλεισμός διαφημίσεων έχει επηρεαστεί από τις πρόσφατες αλλαγές στο YouTube. Προσπαθούμε να διορθώσουμε αυτά τα προβλήματα και εκτιμούμε την κατανόησή σου</string>
+    <string name="contingencyMessagePrimaryButton">Κατάλαβα</string>
+    <string name="contingencyMessageCloseContentDescription">Κλείσιμο</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-es/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-es/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo bloquea los anuncios de vídeo en YouTube, para que puedas ver vídeos sin interrupciones. <annotation type="learn_more_link">Más información</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Abre vídeos en modo teatro sin distracciones que impide que lo que ves influya en tu feed de YouTube.</string>
+    <string name="ad_blocking_settings_title_v2">Bloqueo de anuncios</string>
+    <string name="ad_blocking_settings_header_description">Bloquea los rastreadores invasivos antes de que se carguen, eliminando de manera efectiva los anuncios que se basan en el rastreo</string>
+    <string name="contingencyMessageTitle">El bloqueo de anuncios en YouTube no está disponible</string>
+    <string name="contingencyMessageContent">El bloqueo de anuncios se ha visto afectado por los cambios recientes en YouTube. Estamos trabajando para solucionar estos problemas y agradecemos tu comprensión</string>
+    <string name="contingencyMessagePrimaryButton">Entendido</string>
+    <string name="contingencyMessageCloseContentDescription">Cerrar</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-et/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-et/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo blokeerib YouTube\'is videoreklaamid, nii et saad videoid katkestusteta vaadata. <annotation type="learn_more_link">Lisateave</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Avab videod segajatevabas kinorežiimis, mis hoiab ära selle, et vaadatav sisu mõjutaks sinu YouTube’i voogu.</string>
+    <string name="ad_blocking_settings_title_v2">Reklaamide blokeerimine</string>
+    <string name="ad_blocking_settings_header_description">Blokeerib invasiivsed jälgijad enne nende laadimist, kõrvaldades tõhusalt reklaamid, mis tuginevad jälgimisele</string>
+    <string name="contingencyMessageTitle">YouTube\'i reklaamiblokeerija pole saadaval</string>
+    <string name="contingencyMessageContent">YouTube\'i hiljutised muudatused on mõjutanud reklaamide blokeerimist. Töötame nende probleemide lahendamise nimel ja täname sind mõistva suhtumise eest</string>
+    <string name="contingencyMessagePrimaryButton">Sain aru</string>
+    <string name="contingencyMessageCloseContentDescription">Sulge</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-fi/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-fi/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo estää videomainokset YouTubessa, joten voit katsoa videoita keskeytyksettä. <annotation type="learn_more_link">Lue lisää</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Avaa videot häiriöttömässä teatteritilassa, jolloin katsomasi sisältö ei vaikuta YouTube-syötteeseesi.</string>
+    <string name="ad_blocking_settings_title_v2">Mainosten esto</string>
+    <string name="ad_blocking_settings_header_description">Estää tunkeilevat seurantaohjelmat ennen niiden latautumista, mikä eliminoi tehokkaasti seurantaa käyttävät mainokset</string>
+    <string name="contingencyMessageTitle">YouTube-mainosten esto ei ole käytettävissä</string>
+    <string name="contingencyMessageContent">YouTuben viimeaikaiset muutokset ovat vaikuttaneet mainosten estämiseen. Pyrimme korjaamaan nämä ongelmat. Kiitos ymmärryksestä.</string>
+    <string name="contingencyMessagePrimaryButton">Selvä</string>
+    <string name="contingencyMessageCloseContentDescription">Sulje</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-fr/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-fr/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo bloque les publicités vidéo sur YouTube, afin que vous puissiez regarder des vidéos sans interruption. <annotation type="learn_more_link">En savoir plus</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Ouvre les vidéos en mode « Salle de projection sans distractions », ce qui empêche ce que vous regardez d\'influencer votre fil d\'actualité YouTube.</string>
+    <string name="ad_blocking_settings_title_v2">Blocage des publicités</string>
+    <string name="ad_blocking_settings_header_description">Bloque les traqueurs invasifs avant leur chargement, ce qui permet d\'éliminer efficacement les publicités reposant sur le pistage</string>
+    <string name="contingencyMessageTitle">Blocage des publicités sur YouTube indisponible</string>
+    <string name="contingencyMessageContent">Les récents changements apportés à YouTube ont affecté le blocage des publicités. Nous nous efforçons de résoudre ces problèmes et vous remercions de votre compréhension.</string>
+    <string name="contingencyMessagePrimaryButton">J\'ai compris</string>
+    <string name="contingencyMessageCloseContentDescription">Fermer</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-hr/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-hr/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo blokira video oglase na YouTubeu, tako da videozapise možeš gledati bez prekida. <annotation type="learn_more_link">Saznaj više</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Otvara videozapise u kino načinu rada bez ometanja koji sprječava da ono što gledaš utječe na tvoj YouTube feed.</string>
+    <string name="ad_blocking_settings_title_v2">Blokiranje oglasa</string>
+    <string name="ad_blocking_settings_header_description">Blokira invazivne alate za praćenje prije nego što se učitaju, učinkovito eliminirajući oglase koji se oslanjaju na praćenje</string>
+    <string name="contingencyMessageTitle">Blokiranje oglasa na YouTubeu nije dostupno</string>
+    <string name="contingencyMessageContent">Blokiranje oglasa pogođeno je nedavnim promjenama na YouTubeu. Radimo na rješavanju tih problema i cijenimo tvoje razumijevanje</string>
+    <string name="contingencyMessagePrimaryButton">Shvaćam</string>
+    <string name="contingencyMessageCloseContentDescription">Zatvori</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-hu/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-hu/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">A DuckDuckGo blokkolja a videohirdetéseket a YouTube-on, így megszakítás nélkül nézhetsz videókat. <annotation type="learn_more_link">További információk</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Zavaró elemektől mentes, mozis nézetben nyitja meg a videókat, így a nézett tartalom nem befolyásolja a YouTube-hírfolyamodat.</string>
+    <string name="ad_blocking_settings_title_v2">Hirdetésblokkolás</string>
+    <string name="ad_blocking_settings_header_description">Még betöltés előtt blokkolja az invazív nyomkövetőket, így hatékonyan kiküszöböljük a nyomkövetésre épülő hirdetéseket</string>
+    <string name="contingencyMessageTitle">YouTube-hirdetésblokkolás nem érhető el</string>
+    <string name="contingencyMessageContent">A hirdetésblokkolást érintették a YouTube legutóbbi módosításai. Dolgozunk a problémák megoldásán, és köszönjük a megértésedet.</string>
+    <string name="contingencyMessagePrimaryButton">Értem</string>
+    <string name="contingencyMessageCloseContentDescription">Bezárás</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-it/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-it/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo blocca gli annunci video su YouTube, così puoi guardare video senza interruzioni. <annotation type="learn_more_link">Ulteriori informazioni</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Apre i video in una modalità cinema senza distrazioni che impedisce a ciò che guardi di influenzare il tuo feed di YouTube.</string>
+    <string name="ad_blocking_settings_title_v2">Blocco degli annunci</string>
+    <string name="ad_blocking_settings_header_description">Blocca i sistemi di tracciamento prima che vengano caricati, eliminando di fatto gli annunci che si basano sul tracciamento</string>
+    <string name="contingencyMessageTitle">Blocco degli annunci su YouTube non disponibile</string>
+    <string name="contingencyMessageContent">Il blocco degli annunci è stato influenzato dalle recenti modifiche a YouTube. Stiamo lavorando per risolvere questi problemi. Grazie per la comprensione</string>
+    <string name="contingencyMessagePrimaryButton">Ho capito</string>
+    <string name="contingencyMessageCloseContentDescription">Chiudi</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-lt/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-lt/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">„DuckDuckGo“ blokuoja vaizdo įrašų reklamas platformoje „YouTube“, todėl galite žiūrėti vaizdo įrašus be trukdžių. <annotation type="learn_more_link">Sužinokite daugiau</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Atidaro vaizdo įrašus neblaškančiu kino teatro režimu, kad tai, ką žiūri, nedarytų įtakos tavo „YouTube“ srautui.</string>
+    <string name="ad_blocking_settings_title_v2">Reklamų blokavimas</string>
+    <string name="ad_blocking_settings_header_description">Blokuoja įkyrias sekimo priemones dar prieš jas įkeliant, todėl veiksmingai pašalina sekimu pagrįstas reklamas</string>
+    <string name="contingencyMessageTitle">„YouTube“ reklamų blokavimas nepasiekiamas</string>
+    <string name="contingencyMessageContent">Naujausi „YouTube“ pakeitimai paveikė reklamų blokavimą. Sprendžiame šias problemas ir dėkojame už supratingumą</string>
+    <string name="contingencyMessagePrimaryButton">Supratau</string>
+    <string name="contingencyMessageCloseContentDescription">Uždaryti</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-lv/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-lv/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo bloķē videoreklāmas pakalpojumā YouTube, lai tu varētu skatīties videoklipus bez pārtraukumiem. <annotation type="learn_more_link">Uzzināt vairāk</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Atver videoklipus teātra režīmā bez uzmanības novēršanas, kas neļauj skatītajam ietekmēt tavu YouTube plūsmu.</string>
+    <string name="ad_blocking_settings_title_v2">Reklāmu bloķēšana</string>
+    <string name="ad_blocking_settings_header_description">Bloķē uzmācīgus izsekotājus, pirms tie tiek ielādēti, tādējādi efektīvi novēršot izsekošanā balstītās reklāmas.</string>
+    <string name="contingencyMessageTitle">YouTube reklāmu bloķēšana nav pieejama</string>
+    <string name="contingencyMessageContent">Reklāmu bloķēšanu ir ietekmējušas nesenās izmaiņas pakalpojumā YouTube. Mēs jau strādājam pie šo problēmu novēršanas un novērtējam tavu sapratni.</string>
+    <string name="contingencyMessagePrimaryButton">Sapratu</string>
+    <string name="contingencyMessageCloseContentDescription">Aizvērt</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-nb/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-nb/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo blokkerer videoannonser på YouTube, slik at du kan se videoer uten avbrudd. <annotation type="learn_more_link">Finn ut mer</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Åpner videoer i en distraksjonsfri kinomodus som hindrer at det du ser på påvirker YouTube-feeden din.</string>
+    <string name="ad_blocking_settings_title_v2">Annonseblokkering</string>
+    <string name="ad_blocking_settings_header_description">Blokkerer invaderende sporere før de blir lastet inn, og dette eliminerer også annonser som er basert på sporing</string>
+    <string name="contingencyMessageTitle">Annonseblokkering på YouTube er ikke tilgjengelig</string>
+    <string name="contingencyMessageContent">Annonseblokkering har blitt påvirket av nylige endringer på YouTube. Vi jobber med å løse disse problemene og takker for tålmodigheten</string>
+    <string name="contingencyMessagePrimaryButton">Den er grei</string>
+    <string name="contingencyMessageCloseContentDescription">Lukk</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-nl/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-nl/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo blokkeert videoadvertenties op YouTube, zodat je video\'s zonder onderbreking kunt bekijken. <annotation type="learn_more_link">Meer informatie</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Opent video\'s in een afleidingsvrije theatermodus die voorkomt dat wat je bekijkt je YouTube-feed beïnvloedt.</string>
+    <string name="ad_blocking_settings_title_v2">Advertentieblokkering</string>
+    <string name="ad_blocking_settings_header_description">Blokkeert invasieve trackers voordat ze worden geladen, waardoor advertenties die afhankelijk zijn van tracking effectief worden geëlimineerd</string>
+    <string name="contingencyMessageTitle">YouTube-advertentieblokkering niet beschikbaar</string>
+    <string name="contingencyMessageContent">Door recente wijzigingen in YouTube werkt advertentieblokkering niet meer naar behoren. We werken aan een oplossing voor deze problemen. Bedankt voor je begrip.</string>
+    <string name="contingencyMessagePrimaryButton">Ik snap het</string>
+    <string name="contingencyMessageCloseContentDescription">Sluiten</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-pl/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-pl/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo blokuje reklamy wideo na YouTube, dzięki czemu możesz oglądać filmy bez przerw. <annotation type="learn_more_link">Dowiedz się więcej</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Otwiera filmy w trybie kinowym bez rozpraszania uwagi, który zapobiega wpływowi oglądania na Twój kanał YouTube.</string>
+    <string name="ad_blocking_settings_title_v2">Blokowanie reklam</string>
+    <string name="ad_blocking_settings_header_description">Blokuje inwazyjne mechanizmy śledzące przed ich załadowaniem, skutecznie eliminując reklamy, które opierają się na śledzeniu</string>
+    <string name="contingencyMessageTitle">Blokowanie reklam na YouTube jest niedostępne</string>
+    <string name="contingencyMessageContent">Niedawne zmiany na YouTube wpłynęły na blokowanie reklam. Pracujemy nad rozwiązaniem tych problemów i dziękujemy za zrozumienie.</string>
+    <string name="contingencyMessagePrimaryButton">Rozumiem</string>
+    <string name="contingencyMessageCloseContentDescription">Zamknij</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-pt/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-pt/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">O DuckDuckGo bloqueia anúncios de vídeo no YouTube para que possas ver vídeos sem interrupções. <annotation type="learn_more_link">Sabe mais</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Abre vídeos num modo de cinema sem distrações que impede que os vídeos que vês influenciem o teu feed do YouTube.</string>
+    <string name="ad_blocking_settings_title_v2">Bloqueio de anúncios</string>
+    <string name="ad_blocking_settings_header_description">Bloqueia os rastreadores invasivos antes de serem carregados, eliminando eficazmente os anúncios que usam rastreio</string>
+    <string name="contingencyMessageTitle">Bloqueio de anúncios do YouTube indisponível</string>
+    <string name="contingencyMessageContent">O bloqueio de anúncios foi afetado por alterações recentes ao YouTube. Estamos a trabalhar para resolver estes problemas e agradecemos a tua compreensão.</string>
+    <string name="contingencyMessagePrimaryButton">Entendido</string>
+    <string name="contingencyMessageCloseContentDescription">Fechar</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-ro/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-ro/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo blochează reclamele video pe YouTube, astfel încât să poți viziona videoclipuri fără întrerupere. <annotation type="learn_more_link">Află mai multe</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Deschide videoclipurile într-un mod cinematografic fără distrageri, care te împiedică să influențezi fluxul de YouTube prin ceea ce vizionezi.</string>
+    <string name="ad_blocking_settings_title_v2">Blocarea reclamelor</string>
+    <string name="ad_blocking_settings_header_description">Blochează tehnologiile de urmărire invazive înainte de a se încărca, eliminând eficient reclamele care se bazează pe urmărire</string>
+    <string name="contingencyMessageTitle">Blocarea reclamelor pe YouTube este indisponibilă</string>
+    <string name="contingencyMessageContent">Blocarea reclamelor a fost afectată de modificările recente aduse YouTube. Lucrăm pentru a remedia aceste probleme și apreciem înțelegerea ta</string>
+    <string name="contingencyMessagePrimaryButton">Am înțeles</string>
+    <string name="contingencyMessageCloseContentDescription">Închide</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-ru/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-ru/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo блокирует видеорекламу на YouTube, чтобы вы могли смотреть видео без перерывов. <annotation type="learn_more_link">Подробнее</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Проигрыватель Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Открывает видео в режиме кинотеатра без отвлекающих элементов, чтобы просмотренные видео не влияли на вашу ленту YouTube.</string>
+    <string name="ad_blocking_settings_title_v2">Блокировка рекламы</string>
+    <string name="ad_blocking_settings_header_description">Блокирует навязчивые трекеры до их загрузки, устраняя рекламу с отслеживанием</string>
+    <string name="contingencyMessageTitle">Блокировка рекламы на YouTube недоступна</string>
+    <string name="contingencyMessageContent">Недавние изменения на YouTube повлияли на работу блокировки рекламы. Мы занимаемся решением этой проблемы и благодарим вас за понимание.</string>
+    <string name="contingencyMessagePrimaryButton">Понятно</string>
+    <string name="contingencyMessageCloseContentDescription">Закрыть</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-sk/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-sk/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo blokuje videoreklamy na YouTube, takže môžeš sledovať videá bez prerušenia. <annotation type="learn_more_link">Zisti viac</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Otvára videá v režime kina bez rušivých vplyvov, ktorý zabraňuje tomu, aby sledované položky ovplyvňovali tvoj kanál YouTube.</string>
+    <string name="ad_blocking_settings_title_v2">Blokovanie reklám</string>
+    <string name="ad_blocking_settings_header_description">Blokuje invazívne sledovače skôr, než sa načítajú, čím efektívne eliminuje reklamy, ktoré sa spoliehajú na sledovanie.</string>
+    <string name="contingencyMessageTitle">Blokovanie reklám na YouTube nie je k dispozícii</string>
+    <string name="contingencyMessageContent">Blokovanie reklám bolo ovplyvnené nedávnymi zmenami na YouTube. Na odstránení týchto problémov pracujeme. Ďakujeme za pochopenie.</string>
+    <string name="contingencyMessagePrimaryButton">Rozumiem</string>
+    <string name="contingencyMessageCloseContentDescription">Zatvoriť</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-sl/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-sl/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo blokira video oglase na YouTubu, tako da si lahko videoposnetke ogledate brez prekinitev. <annotation type="learn_more_link">Več o tem</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Videoposnetke odpre v načinu zasebnega kina, ki preprečuje, da bi vsebina, ki jo gledate, vplivala na vaša priporočila v YouTubu.</string>
+    <string name="ad_blocking_settings_title_v2">Blokiranje oglasov</string>
+    <string name="ad_blocking_settings_header_description">Blokira invazivne sledilnike, še preden se naložijo, s čimer učinkovito odstrani oglase, ki temeljijo na sledenju</string>
+    <string name="contingencyMessageTitle">Blokiranje oglasov na YouTubu ni na voljo</string>
+    <string name="contingencyMessageContent">Nedavne spremembe na YouTubu so vplivale na delovanje funkcije blokiranja oglasov. Prizadevamo si za odpravljanje teh težav in cenimo vaše razumevanje.</string>
+    <string name="contingencyMessagePrimaryButton">Razumem</string>
+    <string name="contingencyMessageCloseContentDescription">Zapri</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-sv/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-sv/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo blockerar videoannonser på YouTube, så du kan titta på videor utan avbrott. <annotation type="learn_more_link">Läs mer</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Öppnar videor i ett störningsfritt visningsläge som förhindrar att det du tittar på påverkar ditt YouTube-flöde.</string>
+    <string name="ad_blocking_settings_title_v2">Annonsblockering</string>
+    <string name="ad_blocking_settings_header_description">Blockerar invasiva spårare innan de läses in, vilket i stort sett eliminerar annonser som bygger på spårning</string>
+    <string name="contingencyMessageTitle">Annonsblockering på YouTube är inte tillgänglig</string>
+    <string name="contingencyMessageContent">De senaste ändringarna på YouTube har påverkat annonsblockeringen. Vi jobbar på att lösa problemen och tackar för din förståelse.</string>
+    <string name="contingencyMessagePrimaryButton">Jag förstår</string>
+    <string name="contingencyMessageCloseContentDescription">Stäng</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-tr/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-tr/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo, YouTube\'daki video reklamlarını engelleyerek videoları kesintisiz izlemenizi sağlar. <annotation type="learn_more_link">Daha fazla bilgi</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Videoları, izlediğiniz içeriğin YouTube akışınızı etkilemesini engelleyen, dikkat dağıtıcı unsurlardan arındırılmış bir sinema moduyla açar.</string>
+    <string name="ad_blocking_settings_title_v2">Reklam Engelleme</string>
+    <string name="ad_blocking_settings_header_description">İstilacı izleyicileri yüklenmeden önce engelleyerek, izlemeye dayalı reklamları etkili bir şekilde ortadan kaldırır</string>
+    <string name="contingencyMessageTitle">YouTube\'da Reklam Engelleme Kullanılamıyor</string>
+    <string name="contingencyMessageContent">YouTube\'da yapılan son değişiklikler reklam engelleme özelliğini etkiledi. Bu sorunları çözmeye çalışıyoruz. Anlayışınız için teşekkür ederiz</string>
+    <string name="contingencyMessagePrimaryButton">Anladım</string>
+    <string name="contingencyMessageCloseContentDescription">Kapat</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values/donottranslate.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values/donottranslate.xml
@@ -15,6 +15,5 @@
   -->
 
 <resources>
-    <string name="ad_blocking_settings_title_v2">Ad Blocking</string>
-    <string name="ad_blocking_settings_header_description">Blocks invasive trackers before they load, effectively eliminating ads that rely on tracking</string>
+
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values/strings-ad-blocking.xml
@@ -22,4 +22,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo blocks video ads on YouTube, so you can watch videos without interruption. <annotation type="learn_more_link">Learn more</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Opens videos in a distraction-free theater mode that prevents what you watch from influencing your YouTube feed.</string>
+    <string name="ad_blocking_settings_title_v2">Ad Blocking</string>
+    <string name="ad_blocking_settings_header_description">Blocks invasive trackers before they load, effectively eliminating ads that rely on tracking</string>
+    <string name="contingencyMessageTitle">YouTube Ad Blocking Unavailable</string>
+    <string name="contingencyMessageContent">Ad Blocking has been affected by recent changes to YouTube. We\'re working to fix these issues and appreciate your understanding</string>
+    <string name="contingencyMessagePrimaryButton">Got It</string>
+    <string name="contingencyMessageCloseContentDescription">Close</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionJsInjectorPluginTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionJsInjectorPluginTest.kt
@@ -52,6 +52,7 @@ class AdBlockingExtensionJsInjectorPluginTest {
         on { scriptletsFlow() } doReturn scriptletsFlow
     }
     private val webView: WebView = mock()
+    private val contingencyMessageHandler: ContingencyMessageHandler = mock()
     private val testScope = CoroutineScope(UnconfinedTestDispatcher())
 
     private val isolatedName = "scriptlets/isolated/ublock-filters.js"
@@ -74,6 +75,7 @@ class AdBlockingExtensionJsInjectorPluginTest {
             statusChecker = statusChecker,
             repository = repository,
             domainMatcher = mockDomainMatcher,
+            contingencyMessageHandler = contingencyMessageHandler,
             appScope = testScope,
         )
     }
@@ -243,5 +245,14 @@ class AdBlockingExtensionJsInjectorPluginTest {
         plugin.onPageFinished(webView, url = "https://youtube.com/page", site = null)
 
         verify(webView, never()).evaluateJavascript(any(), isNull())
+    }
+
+    @Test
+    fun whenOnPageFinishedCalledThenContingencyMessageHandlerIsNotified() {
+        val url = "https://youtube.com/page"
+
+        plugin.onPageFinished(webView, url = url, site = null)
+
+        verify(contingencyMessageHandler).onPageLoaded(webView, url)
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/RealContingencyMessageHandlerTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/RealContingencyMessageHandlerTest.kt
@@ -1,0 +1,338 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl
+
+import android.annotation.SuppressLint
+import android.net.Uri
+import android.webkit.WebView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
+import com.duckduckgo.adblocking.impl.remoteconfig.ContingencyMessageStore
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@SuppressLint("DenyListedApi") // setRawStoredState
+@RunWith(AndroidJUnit4::class)
+class RealContingencyMessageHandlerTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val feature = FakeFeatureToggleFactory.create(AdBlockingExtensionFeature::class.java)
+
+    private val shownFlow = MutableStateFlow(false)
+    private val store = object : ContingencyMessageStore {
+        override val shown: StateFlow<Boolean> = shownFlow
+        override suspend fun setShown() {
+            shownFlow.value = true
+        }
+
+        override suspend fun reset() {
+            shownFlow.value = false
+        }
+    }
+
+    private val view = FakeContingencyMessageView()
+
+    private val mockDomainMatcher: AdBlockingExtensionDomainMatcher = mock() {
+        on { matches(any<Uri>()) } doReturn true
+        on { matches(any<String>()) } doReturn true
+    }
+
+    private val handler = RealContingencyMessageHandler(
+        feature = feature,
+        store = store,
+        view = view,
+        domainMatcher = mockDomainMatcher,
+        appScope = coroutineRule.testScope,
+        dispatchers = coroutineRule.testDispatcherProvider,
+    )
+
+    private fun setToggles(uxImprovements: Boolean, contingency: Boolean) {
+        feature.adBlockingUXImprovements().setRawStoredState(Toggle.State(remoteEnableState = uxImprovements))
+        feature.enableContingencyMode().setRawStoredState(Toggle.State(remoteEnableState = contingency))
+    }
+
+    @Test
+    fun whenAllGatesOpenAndYouTubeAndNotShownThenShouldShow() {
+        setToggles(uxImprovements = true, contingency = true)
+
+        assertTrue(handler.shouldShow("https://youtube.com/watch?v=abc"))
+    }
+
+    @Test
+    fun whenYouTubeSubdomainThenShouldShow() {
+        setToggles(uxImprovements = true, contingency = true)
+
+        assertTrue(handler.shouldShow("https://m.youtube.com/watch?v=abc"))
+    }
+
+    @Test
+    fun whenYouTubeNoCookieThenShouldShow() {
+        setToggles(uxImprovements = true, contingency = true)
+
+        assertTrue(handler.shouldShow("https://youtube-nocookie.com/watch?v=abc"))
+    }
+
+    @Test
+    fun whenUxImprovementsDisabledThenShouldNotShow() {
+        setToggles(uxImprovements = false, contingency = true)
+
+        assertFalse(handler.shouldShow("https://youtube.com/watch?v=abc"))
+    }
+
+    @Test
+    fun whenContingencyModeDisabledThenShouldNotShow() {
+        setToggles(uxImprovements = true, contingency = false)
+
+        assertFalse(handler.shouldShow("https://youtube.com/watch?v=abc"))
+    }
+
+    @Test
+    fun whenUrlIsNotYouTubeThenShouldNotShow() {
+        setToggles(uxImprovements = true, contingency = true)
+        whenever(mockDomainMatcher.matches(any<String>())).thenReturn(false)
+
+        assertFalse(handler.shouldShow("https://example.com/watch?v=abc"))
+    }
+
+    @Test
+    fun whenUrlIsNullThenShouldNotShow() {
+        setToggles(uxImprovements = true, contingency = true)
+
+        assertFalse(handler.shouldShow(null))
+    }
+
+    @Test
+    fun whenAlreadyShownThenShouldNotShow() {
+        setToggles(uxImprovements = true, contingency = true)
+        shownFlow.value = true
+
+        assertFalse(handler.shouldShow("https://youtube.com/watch?v=abc"))
+    }
+
+    @Test
+    fun whenContingencyModeDisabledThenShownIsReset() = runTest {
+        shownFlow.value = true
+
+        handler.onContingencyModeChanged(contingencyEnabled = false)
+
+        assertFalse(shownFlow.value)
+    }
+
+    @Test
+    fun whenContingencyModeEnabledThenShownIsNotReset() = runTest {
+        shownFlow.value = true
+
+        handler.onContingencyModeChanged(contingencyEnabled = true)
+
+        assertTrue(shownFlow.value)
+    }
+
+    @Test
+    fun whenPageLoadedRepeatedlyBeforeStoreWriteReflectsThenShowsOnlyOnce() = runTest {
+        setToggles(uxImprovements = true, contingency = true)
+        // Model DataStore write latency: setShown() never flips the observable value during the
+        // test, so only the in-memory guard can prevent a repeat show.
+        val handler = handlerWith(laggingStore())
+        val webView = foregroundWebView()
+
+        handler.onPageLoaded(webView, YOUTUBE_URL)
+        handler.onPageLoaded(webView, YOUTUBE_URL)
+        handler.onPageLoaded(webView, YOUTUBE_URL)
+
+        assertEquals(1, view.shownCount)
+    }
+
+    @Test
+    fun whenContingencyDisabledThenReenabledThenShowsAgain() = runTest {
+        setToggles(uxImprovements = true, contingency = true)
+        val handler = handlerWith(laggingStore())
+        val webView = foregroundWebView()
+
+        handler.onPageLoaded(webView, YOUTUBE_URL)
+        handler.onContingencyModeChanged(contingencyEnabled = false)
+        handler.onPageLoaded(webView, YOUTUBE_URL)
+
+        assertEquals(2, view.shownCount)
+    }
+
+    @Test
+    fun whenWebViewNotShownThenDoesNotShow() = runTest {
+        setToggles(uxImprovements = true, contingency = true)
+        val handler = handlerWith(laggingStore())
+
+        handler.onPageLoaded(backgroundWebView(), YOUTUBE_URL)
+
+        assertEquals(0, view.shownCount)
+    }
+
+    @Test
+    fun whenBackgroundLoadThenOneOffNotConsumedAndForegroundStillShows() = runTest {
+        setToggles(uxImprovements = true, contingency = true)
+        val store = laggingStore()
+        val handler = handlerWith(store)
+
+        handler.onPageLoaded(backgroundWebView(), YOUTUBE_URL)
+        handler.onPageLoaded(foregroundWebView(), YOUTUBE_URL)
+
+        assertEquals(1, view.shownCount)
+    }
+
+    @Test
+    fun whenViewDoesNotPresentThenOneOffNotConsumedAndNextLoadRetries() = runTest {
+        setToggles(uxImprovements = true, contingency = true)
+        val handler = handlerWith(laggingStore())
+        val webView = foregroundWebView()
+        view.presents = false
+
+        handler.onPageLoaded(webView, YOUTUBE_URL)
+        view.presents = true
+        handler.onPageLoaded(webView, YOUTUBE_URL)
+
+        assertEquals(2, view.invokedCount)
+        assertEquals(1, view.shownCount)
+    }
+
+    @Test
+    fun whenPendingShowCancelledBeforeFocusThenNotShownAndOneOffNotConsumed() = runTest {
+        setToggles(uxImprovements = true, contingency = true)
+        val handler = handlerWith(laggingStore())
+        view.deferralScope = this
+        val webView = foregroundWebView()
+
+        handler.onPageLoaded(webView, YOUTUBE_URL)
+        handler.cancelPendingShow()
+        view.gate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(0, view.shownCount)
+    }
+
+    @Test
+    fun whenGatesCloseWhileDeferredThenNotShownAndOneOffNotConsumed() = runTest {
+        setToggles(uxImprovements = true, contingency = true)
+        val handler = handlerWith(laggingStore())
+        view.deferralScope = this
+        val webView = foregroundWebView()
+
+        handler.onPageLoaded(webView, YOUTUBE_URL)
+        setToggles(uxImprovements = true, contingency = false)
+        view.gate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(0, view.shownCount)
+    }
+
+    @Test
+    fun whenPageLoadedRepeatedlyWhileDeferredThenLaunchesAndShowsOnce() = runTest {
+        setToggles(uxImprovements = true, contingency = true)
+        val handler = handlerWith(laggingStore())
+        view.deferralScope = this
+        val webView = foregroundWebView()
+
+        handler.onPageLoaded(webView, YOUTUBE_URL)
+        handler.onPageLoaded(webView, YOUTUBE_URL)
+        handler.onPageLoaded(webView, YOUTUBE_URL)
+        view.gate.complete(Unit)
+        advanceUntilIdle()
+
+        assertEquals(1, view.invokedCount)
+        assertEquals(1, view.shownCount)
+    }
+
+    private fun foregroundWebView() = mock<WebView> {
+        on { isShown } doReturn true
+        on { url } doReturn YOUTUBE_URL
+    }
+
+    private fun backgroundWebView() = mock<WebView> { on { isShown } doReturn false }
+
+    private fun laggingStore() = object : ContingencyMessageStore {
+        private val value = MutableStateFlow(false)
+        override val shown: StateFlow<Boolean> = value
+        override suspend fun setShown() { /* write is async; observable value lags */ }
+        override suspend fun reset() { value.value = false }
+    }
+
+    private fun handlerWith(store: ContingencyMessageStore) = RealContingencyMessageHandler(
+        feature = feature,
+        store = store,
+        view = view,
+        domainMatcher = mockDomainMatcher,
+        appScope = coroutineRule.testScope,
+        dispatchers = coroutineRule.testDispatcherProvider,
+    )
+
+    private class FakeContingencyMessageView : ContingencyMessageView {
+        var shownCount = 0
+        var invokedCount = 0
+
+        var presents = true
+
+        // When set, presentation is deferred on this scope until [gate] completes, modelling awaitWindowFocus
+        // suspending until the WebView's window regains focus. Left null for synchronous presentation.
+        var deferralScope: CoroutineScope? = null
+        val gate = CompletableDeferred<Unit>()
+
+        override fun launchWhenFocused(webView: WebView, block: suspend () -> Unit): Job? {
+            invokedCount++
+            val scope = deferralScope ?: run {
+                // Synchronous focus: the block has no real suspension points, so an unconfined
+                // dispatcher runs it to completion before returning.
+                CoroutineScope(UnconfinedTestDispatcher()).launch { block() }
+                return null
+            }
+            return scope.launch {
+                gate.await()
+                block()
+            }
+        }
+
+        override fun show(webView: WebView): Boolean {
+            if (!presents) return false
+            shownCount++
+            return true
+        }
+    }
+
+    private companion object {
+        private const val YOUTUBE_URL = "https://youtube.com/watch?v=abc"
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/remoteconfig/SharedPreferencesContingencyMessageStoreTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/remoteconfig/SharedPreferencesContingencyMessageStoreTest.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.remoteconfig
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStoreFile
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SharedPreferencesContingencyMessageStoreTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    private val testDataStore: DataStore<Preferences> =
+        PreferenceDataStoreFactory.create(
+            scope = coroutineRule.testScope,
+            produceFile = { context.preferencesDataStoreFile("ad_blocking_contingency_message_test") },
+        )
+
+    private val testee = SharedPreferencesContingencyMessageStore(testDataStore, coroutineRule.testScope)
+
+    @Test
+    fun whenNothingStoredThenShownIsFalse() = runTest {
+        assertFalse(testee.shown.first())
+    }
+
+    @Test
+    fun whenSetShownThenShownIsTrue() = runTest {
+        testee.setShown()
+
+        assertTrue(testee.shown.first())
+    }
+
+    @Test
+    fun whenResetAfterSetShownThenShownIsFalse() = runTest {
+        testee.setShown()
+        assertTrue(testee.shown.first())
+
+        testee.reset()
+
+        assertFalse(testee.shown.first())
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsViewModelTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsViewModelTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.adblocking.impl.ui
 
+import android.annotation.SuppressLint
 import app.cash.turbine.test
 import com.duckduckgo.adblocking.api.duckplayer.DuckPlayer
 import com.duckduckgo.adblocking.api.duckplayer.DuckPlayer.UserPreferences
@@ -27,8 +28,12 @@ import com.duckduckgo.adblocking.impl.AdBlockingPixelNames
 import com.duckduckgo.adblocking.impl.AdBlockingSettingsRepository
 import com.duckduckgo.adblocking.impl.domain.AdBlockingState
 import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeToggleStore
+import com.duckduckgo.feature.toggles.api.FeatureToggles
+import com.duckduckgo.feature.toggles.api.Toggle
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -40,19 +45,32 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
+@SuppressLint("DenyListedApi") // setRawStoredState
 class AdBlockingSettingsViewModelTest {
 
     @get:Rule
     val coroutineRule = CoroutineTestRule()
 
     private val statusChecker: AdBlockingStatusChecker = mock()
+    private val feature = FeatureToggles.Builder()
+        .store(FakeToggleStore())
+        .appVersionProvider { Int.MAX_VALUE }
+        .featureName("adBlockingExtension")
+        .ioDispatcher(coroutineRule.testDispatcher)
+        .build()
+        .create(AdBlockingExtensionFeature::class.java)
     private val repository: AdBlockingSettingsRepository = mock()
     private val pixel: Pixel = mock()
     private val duckPlayer: DuckPlayer = mock()
 
     private fun createViewModel(duckPlayerMode: PrivatePlayerMode = AlwaysAsk): AdBlockingSettingsViewModel {
         whenever(duckPlayer.observeUserPreferences()).thenReturn(flowOf(userPreferences(duckPlayerMode)))
-        return AdBlockingSettingsViewModel(statusChecker, repository, pixel, duckPlayer)
+        return AdBlockingSettingsViewModel(statusChecker, feature, repository, pixel, duckPlayer)
+    }
+
+    private fun setToggles(uxImprovements: Boolean, contingency: Boolean) {
+        feature.adBlockingUXImprovements().setRawStoredState(Toggle.State(remoteEnableState = uxImprovements))
+        feature.enableContingencyMode().setRawStoredState(Toggle.State(remoteEnableState = contingency))
     }
 
     private fun userPreferences(privatePlayerMode: PrivatePlayerMode) =
@@ -106,6 +124,68 @@ class AdBlockingSettingsViewModelTest {
 
         createViewModel(duckPlayerMode = Disabled).viewState.test {
             assertEquals(Disabled, expectMostRecentItem().duckPlayerMode)
+        }
+    }
+
+    @Test
+    fun whenContingencyModeAndUxImprovementsOnThenIsContingencyMode() = runTest {
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Enabled.Default))
+        setToggles(uxImprovements = true, contingency = true)
+
+        createViewModel().viewState.test {
+            assertTrue(expectMostRecentItem().isContingencyMode)
+        }
+    }
+
+    @Test
+    fun whenContingencyModeOnButUxImprovementsOffThenNotContingencyMode() = runTest {
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Enabled.Default))
+        setToggles(uxImprovements = false, contingency = true)
+
+        createViewModel().viewState.test {
+            assertFalse(expectMostRecentItem().isContingencyMode)
+        }
+    }
+
+    @Test
+    fun whenContingencyModeOffThenNotContingencyMode() = runTest {
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Enabled.Default))
+        setToggles(uxImprovements = true, contingency = false)
+
+        createViewModel().viewState.test {
+            assertFalse(expectMostRecentItem().isContingencyMode)
+        }
+    }
+
+    @Test
+    fun whenEnabledAndNotContingencyModeThenStatusIndicatorOn() = runTest {
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Enabled.Default))
+        setToggles(uxImprovements = true, contingency = false)
+
+        createViewModel().viewState.test {
+            assertTrue(expectMostRecentItem().isStatusIndicatorOn)
+        }
+    }
+
+    @Test
+    fun whenContingencyModeOnThenStatusIndicatorOff() = runTest {
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Enabled.Default))
+        setToggles(uxImprovements = true, contingency = true)
+
+        createViewModel().viewState.test {
+            val state = expectMostRecentItem()
+            assertTrue(state.isEnabled)
+            assertFalse(state.isStatusIndicatorOn)
+        }
+    }
+
+    @Test
+    fun whenDisabledThenStatusIndicatorOff() = runTest {
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled))
+        setToggles(uxImprovements = true, contingency = false)
+
+        createViewModel().viewState.test {
+            assertFalse(expectMostRecentItem().isStatusIndicatorOn)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1214489465023873?focus=true
Tech Design URL (if applicable): 

### Description
Add support for contingency messaging:
* Bottom sheet when visiting YouTube
* Message in settings with hidden toggle

### Steps to test this PR

_Feature 1_
- [x] Fresh install the app
- [x] Go to YouTube ad blocking settings and enable the feature
- [x] Go to Feature Flag Inventory and enable adBlockingExtensionFeature -> enableContingencyMode
- [x] Go to YouTube ad blocking settings and check nothing changed
- [x] Open a YouTube video (you might see ads), check no contingency messaging is shown
- [x] Go to Feature Flag Inventory and enable adBlockingExtensionFeature -> adBlockingUXImprovements
- [x] Go to YouTube ad blocking settings and check the toggle disappeared and there's a contingency message
- [x] Go back and reload the video
- [x] Check a contingency message is shown, Dismiss it
- [x] Navigate to another video
- [x] Check contingency message not shown again
- [x] Go to Feature Flag Inventory and disable and immediately enable adBlockingExtensionFeature -> enableContingencyMode
- [x] Go back and reload the video
- [x] Check contingency messaging is shown again


### UI changes
| Before  | After |
| ------ | ----- |
|<img width="1080" height="2340" alt="Screenshot_20260702_173322" src="https://github.com/user-attachments/assets/9d65a20b-96c2-4091-a7c3-df99b6cd73ac" />|<img width="1080" height="2340" alt="Screenshot_20260702_180254" src="https://github.com/user-attachments/assets/330d9bef-926a-43ab-a911-d3869172674b" />|
| |<img width="1080" height="2340" alt="contingency-after" src="https://github.com/user-attachments/assets/249d0a1e-e65f-41f8-b13f-a49d6431c1aa" />|






<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-visible browser and settings behavior tied to remote feature flags, including when script injection is skipped in contingency mode elsewhere in the module; well-tested but worth validating navigation timing and one-shot messaging edge cases.
> 
> **Overview**
> Adds **contingency messaging** when remote flags `adBlockingUXImprovements` and `enableContingencyMode` are on, so users are told YouTube ad blocking is temporarily unavailable instead of seeing a broken toggle or silent failure.
> 
> On **YouTube extension domains**, a one-time bottom sheet is shown after page load (deferred until the WebView has window focus); pending shows are cancelled on the next `onPageStarted`. Whether the message already appeared is persisted in DataStore and resets when contingency mode is turned off.
> 
> **Ad Blocking settings (v2)** switches to a read-only contingency row (warning icon + copy) and hides the block-ads toggle and description; the header status indicator stays off in contingency mode even if blocking would otherwise be enabled.
> 
> Contingency copy and v2 settings strings are added across locales (moved out of `donottranslate.xml`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da76a95f2e626dbd1ac3752242789e4f6a85cf19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->