### PR TITLE
Android/Remove Chat History: Add x for history search item

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -83,6 +83,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 data class ChatTabSuggestions(
@@ -563,11 +564,22 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         result
     }
 
-    fun onDeleteChatUrlSuggestion(suggestion: AutoCompleteSuggestion) {
+    fun onDeleteChatUrlSuggestion(
+        suggestion: AutoCompleteSuggestion,
+        onDeleted: () -> Unit = {},
+    ) {
         appCoroutineScope.launch(dispatchers.io()) {
             when (suggestion) {
-                is AutoCompleteHistorySuggestion -> history.removeHistoryEntryByUrl(suggestion.url)
-                is AutoCompleteHistorySearchSuggestion -> history.removeHistoryEntryByQuery(suggestion.phrase)
+                is AutoCompleteHistorySuggestion -> {
+                    history.removeHistoryEntryByUrl(suggestion.url)
+                    withContext(dispatchers.main()) { onDeleted() }
+                }
+
+                is AutoCompleteHistorySearchSuggestion -> {
+                    history.removeHistoryEntryByQuery(suggestion.phrase)
+                    withContext(dispatchers.main()) { onDeleted() }
+                }
+
                 else -> {}
             }
         }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.browser.api.autocomplete.AutoComplete
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteResult
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion
+import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteHistoryRelatedSuggestion.AutoCompleteHistorySearchSuggestion
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteHistoryRelatedSuggestion.AutoCompleteHistorySuggestion
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteSearchSuggestion
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteUrlSuggestion.AutoCompleteBookmarkSuggestion
@@ -58,6 +59,7 @@ import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import com.duckduckgo.duckchat.store.impl.DuckAiChat
 import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
+import com.duckduckgo.history.api.NavigationHistory
 import com.duckduckgo.subscriptions.api.Product
 import com.duckduckgo.subscriptions.api.Subscriptions
 import kotlinx.coroutines.CoroutineScope
@@ -107,6 +109,7 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     private val nativeInputStateProvider: NativeInputStateProvider,
     private val modelManager: DuckAiModelManager,
     private val duckAiChatStore: DuckAiChatStore,
+    private val history: NavigationHistory,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
 ) : ViewModel() {
 
@@ -558,6 +561,16 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         )
         lastChatUrlSuggestions = result.urlSuggestions.suggestions
         result
+    }
+
+    fun onDeleteChatUrlSuggestion(suggestion: AutoCompleteSuggestion) {
+        appCoroutineScope.launch(dispatchers.io()) {
+            when (suggestion) {
+                is AutoCompleteHistorySuggestion -> history.removeHistoryEntryByUrl(suggestion.url)
+                is AutoCompleteHistorySearchSuggestion -> history.removeHistoryEntryByQuery(suggestion.phrase)
+                else -> {}
+            }
+        }
     }
 
     fun fireChatUrlSuggestionPixel(suggestion: AutoCompleteSuggestion) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinder.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinder.kt
@@ -179,24 +179,25 @@ class NativeInputChatSuggestionsBinder @Inject constructor(
         onSearchForQuerySubmitted: (String) -> Unit,
         onChatHistoryShortcutClicked: () -> Unit,
         onChatSuggestionDeleteClicked: (ChatSuggestion) -> Unit = {},
+        onChatUrlSuggestionDeleteClicked: (AutoCompleteSuggestion) -> Unit = {},
     ): Binding {
+        val removeChatHistoryEnabled = duckChatFeature.removeChatHistory().isEnabled()
         val chatSuggestionsAdapter = ChatSuggestionsAdapter(
             // Only show the per-row delete (fire) icon when deletion will actually run. The delete
             // path (clearSelectedDuckAiChats) no-ops unless showClearDuckAIChatHistory is on, so
             // gating the icon on the same signal avoids a delete that looks done but did nothing.
-            showDeleteButton = duckChatFeature.removeChatHistory().isEnabled() &&
-                duckAiFeatureState.showClearDuckAIChatHistory.value,
+            showDeleteButton = removeChatHistoryEnabled && duckAiFeatureState.showClearDuckAIChatHistory.value,
             onChatClicked = { onChatSuggestionSelected(it) },
             onDeleteClicked = { onChatSuggestionDeleteClicked(it) },
         )
         val urlAdapter = BrowserAutoCompleteSuggestionsAdapter(
             immediateSearchClickListener = { onChatUrlSuggestionClicked(it) },
             editableSearchClickListener = { },
-            autoCompleteDeleteClickListener = { },
+            autoCompleteDeleteClickListener = { onChatUrlSuggestionDeleteClicked(it) },
             omnibarType = if (inputScreenConfigResolver.useTopBar()) OmnibarType.SINGLE_TOP else OmnibarType.SINGLE_BOTTOM,
             hideEditQueryArrow = true,
             hideSectionDividers = true,
-            isDeleteButtonVisible = false,
+            isDeleteButtonVisible = removeChatHistoryEnabled,
         )
         val urlDivider = SectionDividerAdapter()
         val searchDivider = SectionDividerAdapter()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinder.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinder.kt
@@ -193,7 +193,7 @@ class NativeInputChatSuggestionsBinder @Inject constructor(
         val urlAdapter = BrowserAutoCompleteSuggestionsAdapter(
             immediateSearchClickListener = { onChatUrlSuggestionClicked(it) },
             editableSearchClickListener = { },
-            autoCompleteDeleteClickListener = { onChatUrlSuggestionDeleteClicked(it) },
+            autoCompleteDeleteClickListener = { if (removeChatHistoryEnabled) onChatUrlSuggestionDeleteClicked(it) },
             omnibarType = if (inputScreenConfigResolver.useTopBar()) OmnibarType.SINGLE_TOP else OmnibarType.SINGLE_BOTTOM,
             hideEditQueryArrow = true,
             hideSectionDividers = true,

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -1270,6 +1270,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
                     viewModel.fireChatUrlSuggestionPixel(suggestion)
                     onChatUrlSuggestionClicked(suggestion)
                 },
+                onChatUrlSuggestionDeleteClicked = { suggestion ->
+                    viewModel.onDeleteChatUrlSuggestion(suggestion)
+                    refreshChatSuggestions()
+                },
                 onSearchForQuerySubmitted = { query ->
                     viewModel.fireDuckAiSearchForQuerySubmittedPixel()
                     onSearchForQuerySubmitted(query)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -1271,8 +1271,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
                     onChatUrlSuggestionClicked(suggestion)
                 },
                 onChatUrlSuggestionDeleteClicked = { suggestion ->
-                    viewModel.onDeleteChatUrlSuggestion(suggestion)
-                    refreshChatSuggestions()
+                    viewModel.onDeleteChatUrlSuggestion(suggestion) { refreshChatSuggestions() }
                 },
                 onSearchForQuerySubmitted = { query ->
                     viewModel.fireDuckAiSearchForQuerySubmittedPixel()

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -62,6 +62,7 @@ import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.store.impl.DuckAiChat
 import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
+import com.duckduckgo.history.api.NavigationHistory
 import com.duckduckgo.subscriptions.api.Product
 import com.duckduckgo.subscriptions.api.Subscriptions
 import kotlinx.coroutines.CompletableDeferred
@@ -116,6 +117,7 @@ class NativeInputModeWidgetViewModelTest {
     private val duckChatPixels: DuckChatPixels = mock()
     private val modelManager: DuckAiModelManager = mock()
     private val duckAiChatStore: DuckAiChatStore = mock()
+    private val history: NavigationHistory = mock()
 
     private val selectedTabFlow = MutableStateFlow<TabEntity?>(null)
     private val tabRepository: TabRepository = mock<TabRepository>().also {
@@ -186,6 +188,7 @@ class NativeInputModeWidgetViewModelTest {
             nativeInputStateProvider = nativeInputStateProvider,
             modelManager = modelManager,
             duckAiChatStore = duckAiChatStore,
+            history = history,
             appCoroutineScope = TestScope(coroutineRule.testDispatcher),
         )
     }
@@ -1592,6 +1595,41 @@ class NativeInputModeWidgetViewModelTest {
     fun whenStopGenerationTappedThenStopPixel() {
         testee.fireStopGenerationTapped()
         verify(duckChatPixels).fireStopGenerationTapped()
+    }
+
+    // endregion
+
+    // region search-history delete
+
+    @Test
+    fun whenDeleteHistorySuggestionThenRemovesByUrl() = runTest {
+        testee.onDeleteChatUrlSuggestion(
+            AutoCompleteHistorySuggestion(phrase = "q", title = "T", url = "https://example.com", isAllowedInTopHits = true),
+        )
+        advanceUntilIdle()
+
+        verify(history).removeHistoryEntryByUrl("https://example.com")
+    }
+
+    @Test
+    fun whenDeleteHistorySearchSuggestionThenRemovesByQuery() = runTest {
+        testee.onDeleteChatUrlSuggestion(
+            AutoCompleteHistorySearchSuggestion(phrase = "cats", isAllowedInTopHits = true),
+        )
+        advanceUntilIdle()
+
+        verify(history).removeHistoryEntryByQuery("cats")
+    }
+
+    @Test
+    fun whenDeleteNonHistorySuggestionThenNoHistoryRemoval() = runTest {
+        testee.onDeleteChatUrlSuggestion(
+            AutoCompleteBookmarkSuggestion(phrase = "b", title = "B", url = "https://b"),
+        )
+        advanceUntilIdle()
+
+        verify(history, never()).removeHistoryEntryByUrl(any())
+        verify(history, never()).removeHistoryEntryByQuery(any())
     }
 
     // endregion

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -88,6 +88,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.clearInvocations
 import org.mockito.kotlin.doSuspendableAnswer
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.stub
@@ -1630,6 +1631,23 @@ class NativeInputModeWidgetViewModelTest {
 
         verify(history, never()).removeHistoryEntryByUrl(any())
         verify(history, never()).removeHistoryEntryByQuery(any())
+    }
+
+    @Test
+    fun whenDeleteHistorySuggestionThenOnDeletedInvokedAfterRemoval() = runTest {
+        val onDeleted: () -> Unit = mock()
+
+        testee.onDeleteChatUrlSuggestion(
+            AutoCompleteHistorySuggestion(phrase = "q", title = "T", url = "https://example.com", isAllowedInTopHits = true),
+            onDeleted,
+        )
+        advanceUntilIdle()
+
+        // Refresh callback must fire only after the removal commits, else the re-fetch races the delete.
+        inOrder(history, onDeleted) {
+            verify(history).removeHistoryEntryByUrl("https://example.com")
+            verify(onDeleted).invoke()
+        }
     }
 
     // endregion


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214157224317277/task/1216105086737318?focus=true
Tech Design URL (if applicable): 

### Description
Adds per-row deleteicon to the omnibar's Duck.ai Search-history suggestions now show an "X" delete button, matching the Search tab. Tapping it removes the single history entry and refreshes the list.

This is gated on the new removeChatHistory feature flag (under aiChat).

### Steps to test this PR
Setup
  - [x] Use an internal build (both removeChatHistory and showClearDuckAIChatHistory are remote flags; override them via the internal feature-flag / privacy-config tools)
  - [x] Have at least one recent Duck.ai chat in history (so chat-history suggestions appear)
  - [x] Have existing browsing/search history (so search-history suggestions appear when typing)
  - [x] Open the omnibar and switch to the Duck.ai tab

  1. removeChatHistory disabled 
  - [x] Chat-history suggestion rows show NO fire/delete icon
  - [x] Search-history suggestion rows show NO "X" delete icon
  - [x] Tapping a chat-history row still opens that chat
  - [x] Tapping a search-history row still navigates / runs the search

  2. removeChatHistory enabled
  - [x] Search-history rows IS showing the "X" delete icon
  - [x] Chat-history rows IS showing the fire delete icon
  - [x] Tapping the "X" on a site history row removes that entry immediately (no dialog) and the row disappears
  - [x] Deleted history entry stays gone after re-typing the same query

  Regression checks
  - [x] Search tab search-history "X" delete still works and is unaffected
  - [x] Main browser omnibar autocomplete history delete still works
  - [x] Tapping a chat-history row (not the delete icon) still opens the chat
  - [x] Tapping a URL/search suggestion (not the "X") still navigates / searches
  - [x] "Search for [query]" row still submits a search


### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI and history-store deletes behind a feature flag, with tests; touches shared autocomplete adapter but only on the Duck.ai input surface.
> 
> **Overview**
> **Enables per-row “X” delete on browsing/search history rows in the Duck.ai omnibar autocomplete list**, aligned with the Search tab. Visibility and taps are gated on the **`removeChatHistory`** remote flag; chat-history fire icons still also require **`showClearDuckAIChatHistory`**.
> 
> **Deletion flow:** `NativeInputModeWidgetViewModel` injects **`NavigationHistory`** and handles **`onDeleteChatUrlSuggestion`**—site history via **`removeHistoryEntryByUrl`**, search history via **`removeHistoryEntryByQuery`**—on IO, then runs a main-thread callback so the widget can **`refreshChatSuggestions()`** without racing the delete. The suggestions binder wires **`BrowserAutoCompleteSuggestionsAdapter`** delete UI/listeners; the widget connects delete to the ViewModel.
> 
> **Tests** cover URL vs query removal, no-op for non-history suggestion types, and ordering of removal before refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84ff726db9067c52bd61955366b36c3efa33d217. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->