### PR TITLE
Android/Duck.Ai: Hide address bar duck.ai entry for Search only (focused state)

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatViewModel.kt
@@ -37,17 +37,21 @@ class StartChatViewModel @Inject constructor(
 
     /**
      * Show the start-chat icon only when Duck.ai is available (feature enabled +
-     * user setting on) but the input-screen toggle is off — i.e. the user has Duck.ai
-     * but is in `SEARCH_ONLY` mode. The feature + user-setting gate is needed because
-     * `inputMode == SEARCH_ONLY` also covers the case where Duck.ai is entirely
-     * disabled, which would let the icon navigate to a Duck.ai URL the user has opted out of.
+     * user setting on), the address bar shortcut is enabled, but the input-screen
+     * toggle is off — i.e. the user has Duck.ai but is in `SEARCH_ONLY` mode. The
+     * feature + user-setting gate is needed because `inputMode == SEARCH_ONLY` also
+     * covers the case where Duck.ai is entirely disabled, which would let the icon
+     * navigate to a Duck.ai URL the user has opted out of. The address bar shortcut
+     * gate ensures the icon stays hidden when the user has turned off the Duck.ai
+     * address bar shortcut, even while in `SEARCH_ONLY` mode.
      */
     val isVisible: Flow<Boolean> = combine(
         duckAiFeatureState.showSettings,
         duckChatInternal.observeEnableDuckChatUserSetting(),
+        duckChatInternal.observeShowInAddressBarUserSetting(),
         nativeInputStateProvider.state,
-    ) { isFeatureEnabled, isUserEnabled, state ->
-        isFeatureEnabled && isUserEnabled &&
+    ) { isFeatureEnabled, isUserEnabled, isAddressBarShortcutEnabled, state ->
+        isFeatureEnabled && isUserEnabled && isAddressBarShortcutEnabled &&
             state.inputMode == InputMode.SEARCH_ONLY &&
             state.toggleSelection == ToggleSelection.SEARCH
     }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/StartChatViewModelTest.kt
@@ -44,6 +44,7 @@ class StartChatViewModelTest {
 
     private val featureShowSettingsFlow = MutableStateFlow(true)
     private val enableDuckChatFlow = MutableStateFlow(true)
+    private val showInAddressBarFlow = MutableStateFlow(true)
     private val providerStateFlow = MutableSharedFlow<NativeInputState>(replay = 1)
 
     private val duckAiFeatureState: DuckAiFeatureState = mock<DuckAiFeatureState>().also {
@@ -51,6 +52,7 @@ class StartChatViewModelTest {
     }
     private val duckChatInternal: DuckChatInternal = mock<DuckChatInternal>().also {
         whenever(it.observeEnableDuckChatUserSetting()).thenReturn(enableDuckChatFlow)
+        whenever(it.observeShowInAddressBarUserSetting()).thenReturn(showInAddressBarFlow)
     }
     private val nativeInputStateProvider: NativeInputStateProvider = mock<NativeInputStateProvider>().also {
         whenever(it.state).thenReturn(providerStateFlow)
@@ -86,6 +88,19 @@ class StartChatViewModelTest {
     fun whenUserSettingDisabledThenNotVisible() = runTest {
         featureShowSettingsFlow.value = true
         enableDuckChatFlow.value = false
+        providerStateFlow.emit(stateOf(InputMode.SEARCH_ONLY, ToggleSelection.SEARCH))
+
+        testee.isVisible.test {
+            assertFalse(awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenAddressBarShortcutDisabledThenNotVisible() = runTest {
+        featureShowSettingsFlow.value = true
+        enableDuckChatFlow.value = true
+        showInAddressBarFlow.value = false
         providerStateFlow.emit(stateOf(InputMode.SEARCH_ONLY, ToggleSelection.SEARCH))
 
         testee.isVisible.test {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216235994106257?focus=true 
Tech Design URL (if applicable): 

### Description
StartChatViewModel.isVisible now also gates on observeShowInAddressBarUserSetting(), so the icon stays hidden whenever the address bar shortcut is disabled — alongside the existing feature-flag, Duck.ai user-setting, and input-mode/toggle checks.

### Steps to test this PR
  1. Duck.ai enabled, Address Bar shortcut = ON, input = Search only                                                                         
  - [ ] Settings → Duck.ai shortcut → Address Bar toggle is ON
  - [ ] Duck.ai start-chat icon IS visible in the address bar input field (focused or unfocused)
  - [ ] Tapping the icon submits the typed query to Duck.ai and starts a chat

  2. Duck.ai enabled, Address Bar shortcut = OFF, input = Search only, toggle = Search
  - [ ] Settings → Duck.ai shortcut → Address Bar toggle is OFF
  - [ ] Duck.ai start-chat icon is NOT visible in the address bar input field (focused or unfocused)
  - [ ] No empty gap/container remains where the icon was

  5. Duck.ai disabled by user
  - [ ] Disable Duck.ai 
  - [ ] Icon is NOT visible anywhere

  6. Input mode = Search and Duck.ai, Address Bar shortcut = ON
  - [ ] Enable Search and Duck.ai input mode (SEARCH_AND_DUCK_AI)
  - [ ] Start-chat icon is visible in unfocused input.
  - [ ] Start-chat icon is NOT visible in focused input since we have the tab already.
  
  7.  Input mode = Search and Duck.ai,, Address Bar shortcut = OFF
  - [ ] Enable Search and Duck.ai input mode (SEARCH_AND_DUCK_AI)
  - [ ] Settings → Duck.ai shortcut → Address Bar toggle is OFF
  - [ ] Start-chat icon is NOT visible in unfocused input.


### UI changes
Before: https://github.com/user-attachments/assets/91e0a95f-27fa-4fac-9207-d618cbd7d0b5
After: https://github.com/user-attachments/assets/ca37afc1-26ab-4eaf-aac4-9543465a6888

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small visibility logic change in Duck.ai UI with matching unit test; no auth, data, or network impact.
> 
> **Overview**
> **Start-chat icon visibility** on the native input screen (search-only / search toggle) now also requires the user’s **“show Duck.ai in address bar”** setting to be on, via `observeShowInAddressBarUserSetting()` in `StartChatViewModel.isVisible`.
> 
> Previously the icon could still appear in `SEARCH_ONLY` mode even after the user disabled the address bar shortcut; that entry point is now suppressed in that case. KDoc is updated to document the new gate, and **`whenAddressBarShortcutDisabledThenNotVisible`** covers it in unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebd596b5066b30ca4fea202f416bf36c3b754446. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->