### PR TITLE
Add Duck.ai Settings to AI Features

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -296,4 +296,11 @@ interface DuckChatFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun aiFeaturesNativeControls(): Toggle
+
+    /**
+     * @return `true` when the "Duck.ai Settings" link is visible in AI Features.
+     * If the remote feature is not present defaults to `internal`
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun duckAiSettings(): Toggle
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsActivity.kt
@@ -218,7 +218,7 @@ class DuckChatSettingsActivity : DuckDuckGoActivity() {
         )
         inputScreenSettingsBinding.duckAiInputScreenDescription.updatePadding(left = offset)
         inputScreenSettingsBinding.duckAiShortcuts.updatePadding(left = offset)
-        inputScreenSettingsBinding.duckAiWebSettingsNative.updatePadding(left = offset)
+        inputScreenSettingsBinding.duckAiWebSettings.updatePadding(left = offset)
         inputScreenSettingsBinding.duckAIAutomaticContext.updatePadding(left = offset)
 
         binding.duckChatSettingsText.addClickableSpan(
@@ -281,11 +281,11 @@ class DuckChatSettingsActivity : DuckDuckGoActivity() {
             viewModel.onDuckAiShortcutsClicked()
         }
 
-        binding.duckAiWebSettings.isVisible = viewState.isDuckAiWebSettingsVisible && !viewState.isNativeControlsEnabled
-        binding.duckAiWebSettings.updatePadding(left = offset)
-        binding.duckAiWebSettings.setOnClickListener { viewModel.onDuckAiWebSettingsClicked() }
-        inputScreenSettingsBinding.duckAiWebSettingsNative.isVisible = viewState.isDuckAiWebSettingsVisible && viewState.isNativeControlsEnabled
-        inputScreenSettingsBinding.duckAiWebSettingsNative.setOnClickListener { viewModel.onDuckAiWebSettingsClicked() }
+        binding.duckAiWebSettingsItem.isVisible = viewState.isDuckAiWebSettingsVisible && !viewState.isNativeControlsEnabled
+        binding.duckAiWebSettingsItem.updatePadding(left = offset)
+        binding.duckAiWebSettingsItem.setOnClickListener { viewModel.onDuckAiWebSettingsClicked() }
+        inputScreenSettingsBinding.duckAiWebSettings.isVisible = viewState.isDuckAiWebSettingsVisible && viewState.isNativeControlsEnabled
+        inputScreenSettingsBinding.duckAiWebSettings.setOnClickListener { viewModel.onDuckAiWebSettingsClicked() }
 
         renderSearchSettingsSection(viewState)
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsActivity.kt
@@ -218,6 +218,7 @@ class DuckChatSettingsActivity : DuckDuckGoActivity() {
         )
         inputScreenSettingsBinding.duckAiInputScreenDescription.updatePadding(left = offset)
         inputScreenSettingsBinding.duckAiShortcuts.updatePadding(left = offset)
+        inputScreenSettingsBinding.duckAiWebSettingsNative.updatePadding(left = offset)
         inputScreenSettingsBinding.duckAIAutomaticContext.updatePadding(left = offset)
 
         binding.duckChatSettingsText.addClickableSpan(
@@ -279,6 +280,12 @@ class DuckChatSettingsActivity : DuckDuckGoActivity() {
         inputScreenSettingsBinding.duckAiShortcuts.setOnClickListener {
             viewModel.onDuckAiShortcutsClicked()
         }
+
+        binding.duckAiWebSettings.isVisible = viewState.isDuckAiWebSettingsVisible && !viewState.isNativeControlsEnabled
+        binding.duckAiWebSettings.updatePadding(left = offset)
+        binding.duckAiWebSettings.setOnClickListener { viewModel.onDuckAiWebSettingsClicked() }
+        inputScreenSettingsBinding.duckAiWebSettingsNative.isVisible = viewState.isDuckAiWebSettingsVisible && viewState.isNativeControlsEnabled
+        inputScreenSettingsBinding.duckAiWebSettingsNative.setOnClickListener { viewModel.onDuckAiWebSettingsClicked() }
 
         renderSearchSettingsSection(viewState)
 
@@ -407,6 +414,10 @@ class DuckChatSettingsActivity : DuckDuckGoActivity() {
 
             is DuckChatSettingsViewModel.Command.ShowHideAiGeneratedImagesDialog -> {
                 showHideAiGeneratedImagesDialog(command.current)
+            }
+
+            is DuckChatSettingsViewModel.Command.OpenDuckAiWebSettings -> {
+                startActivity(browserNav.openInNewTab(this@DuckChatSettingsActivity, command.url))
             }
         }
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModel.kt
@@ -86,6 +86,7 @@ class DuckChatSettingsViewModel @AssistedInject constructor(
         val searchAssistVisibility: SearchAssistVisibility = DEFAULT_SEARCH_ASSIST_VISIBILITY,
         val hideAiGeneratedImages: HideAiGeneratedImages = HideAiGeneratedImages.OFF,
         val isUseWithoutAiActionEnabled: Boolean = true,
+        val isDuckAiWebSettingsVisible: Boolean = false,
     )
 
     private data class FeatureState(
@@ -159,6 +160,7 @@ class DuckChatSettingsViewModel @AssistedInject constructor(
                 searchAssistVisibility = resolvedSearchAssistVisibility,
                 hideAiGeneratedImages = hideAiGeneratedImages,
                 isUseWithoutAiActionEnabled = !isAlreadyWithoutAi,
+                isDuckAiWebSettingsVisible = isDuckChatUserEnabled && duckChatFeature.duckAiSettings().isEnabled(),
             )
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), ViewState())
 
@@ -187,6 +189,8 @@ class DuckChatSettingsViewModel @AssistedInject constructor(
         data class ShowHideAiGeneratedImagesDialog(
             val current: HideAiGeneratedImages,
         ) : Command()
+
+        data class OpenDuckAiWebSettings(val url: String) : Command()
     }
 
     fun onDuckChatUserEnabledToggled(checked: Boolean) {
@@ -327,6 +331,12 @@ class DuckChatSettingsViewModel @AssistedInject constructor(
     fun onDuckAiShortcutsClicked() {
         viewModelScope.launch {
             commandChannel.send(OpenShortcutSettings)
+        }
+    }
+
+    fun onDuckAiWebSettingsClicked() {
+        viewModelScope.launch {
+            commandChannel.send(Command.OpenDuckAiWebSettings(duckChat.getDuckChatSettingsUrl()))
         }
     }
 

--- a/duckchat/duckchat-impl/src/main/res/layout/activity_duck_chat_settings.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/activity_duck_chat_settings.xml
@@ -84,12 +84,12 @@
                 app:showSwitch="true" />
 
             <com.duckduckgo.common.ui.view.listitem.OneLineListItem
-                android:id="@+id/duckAiWebSettings"
+                android:id="@+id/duckAiWebSettingsItem"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:visibility="gone"
                 app:trailingIcon="@drawable/ic_open_in_24_small"
-                app:primaryText="@string/duck_ai_web_settings_title" />
+                app:primaryText="@string/duckAiSettingsTitle" />
 
             <include
                 android:id="@+id/inputScreenSettings"

--- a/duckchat/duckchat-impl/src/main/res/layout/activity_duck_chat_settings.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/activity_duck_chat_settings.xml
@@ -83,6 +83,14 @@
                 app:secondaryText="@string/duck_chat_enable_duck_ai_setting_description"
                 app:showSwitch="true" />
 
+            <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+                android:id="@+id/duckAiWebSettings"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                app:trailingIcon="@drawable/ic_open_in_24_small"
+                app:primaryText="@string/duck_ai_web_settings_title" />
+
             <include
                 android:id="@+id/inputScreenSettings"
                 layout="@layout/include_duck_ai_input_screen_settings" />

--- a/duckchat/duckchat-impl/src/main/res/layout/include_duck_ai_input_screen_settings.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/include_duck_ai_input_screen_settings.xml
@@ -167,12 +167,12 @@
         app:secondaryText="@string/duck_ai_shortcut_settings_description" />
 
     <com.duckduckgo.common.ui.view.listitem.OneLineListItem
-        android:id="@+id/duckAiWebSettingsNative"
+        android:id="@+id/duckAiWebSettings"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:visibility="gone"
         app:trailingIcon="@drawable/ic_open_in_24_small"
-        app:primaryText="@string/duck_ai_web_settings_title" />
+        app:primaryText="@string/duckAiSettingsTitle" />
 
     <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
         android:id="@+id/duckAIAutomaticContext"

--- a/duckchat/duckchat-impl/src/main/res/layout/include_duck_ai_input_screen_settings.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/include_duck_ai_input_screen_settings.xml
@@ -166,6 +166,14 @@
         app:primaryText="@string/duck_ai_shortcut_settings_title"
         app:secondaryText="@string/duck_ai_shortcut_settings_description" />
 
+    <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+        android:id="@+id/duckAiWebSettingsNative"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:trailingIcon="@drawable/ic_open_in_24_small"
+        app:primaryText="@string/duck_ai_web_settings_title" />
+
     <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
         android:id="@+id/duckAIAutomaticContext"
         android:layout_width="match_parent"

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -75,4 +75,8 @@
     <!-- Search Assist Visibility -->
     <string name="duckAiSearchAssistVisibilityTitle">Search Assist</string>
     <string name="duckAiSearchAssistSettingsTitle">Search Assist</string>
+
+    <!-- Settings -->
+    <string name="duckAiSettingsTitle">Duck.ai Settings</string>
+
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -46,6 +46,7 @@
     <string name="duck_chat_assist_settings_description">Choose how often you want AI-Assisted answers to appear in your searches</string>
     <string name="duck_ai_shortcut_settings_title">Duck.ai Shortcuts</string>
     <string name="duck_ai_shortcut_settings_description">Choose which Duck.ai shortcuts to display</string>
+    <string name="duck_ai_web_settings_title">Duck.ai Settings</string>
 
     <!-- Default Toggle Position -->
     <string name="duckAiDefaultTogglePositionTitle" instruction="'Toggle' refers to the UI tab switcher component (Search/Duck.ai), not the verb 'to toggle'.">New Tab Toggle Position</string>

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -46,7 +46,6 @@
     <string name="duck_chat_assist_settings_description">Choose how often you want AI-Assisted answers to appear in your searches</string>
     <string name="duck_ai_shortcut_settings_title">Duck.ai Shortcuts</string>
     <string name="duck_ai_shortcut_settings_description">Choose which Duck.ai shortcuts to display</string>
-    <string name="duck_ai_web_settings_title">Duck.ai Settings</string>
 
     <!-- Default Toggle Position -->
     <string name="duckAiDefaultTogglePositionTitle" instruction="'Toggle' refers to the UI tab switcher component (Search/Duck.ai), not the verb 'to toggle'.">New Tab Toggle Position</string>

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModelTest.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import com.duckduckgo.duckchat.impl.store.HideAiGeneratedImages
 import com.duckduckgo.duckchat.impl.store.SearchAssistVisibility
 import com.duckduckgo.duckchat.impl.ui.settings.DuckChatSettingsViewModel.Command.LaunchFeedback
+import com.duckduckgo.duckchat.impl.ui.settings.DuckChatSettingsViewModel.Command.OpenDuckAiWebSettings
 import com.duckduckgo.duckchat.impl.ui.settings.DuckChatSettingsViewModel.Command.OpenLink
 import com.duckduckgo.duckchat.impl.ui.settings.DuckChatSettingsViewModel.Command.OpenLinkInNewTab
 import com.duckduckgo.duckchat.impl.ui.settings.DuckChatSettingsViewModel.Command.OpenShortcutSettings
@@ -1039,6 +1040,91 @@ class DuckChatSettingsViewModelTest {
 
             testee.viewState.test {
                 assertTrue(awaitItem().isUseWithoutAiActionEnabled)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `when duckAiSettings toggle enabled and duck chat enabled then isDuckAiWebSettingsVisible is true`() =
+        runTest {
+            @Suppress("DenyListedApi")
+            duckChatFeature.duckAiSettings().setRawStoredState(State(enable = true))
+            whenever(duckChat.observeEnableDuckChatUserSetting()).thenReturn(flowOf(true))
+            testee = DuckChatSettingsViewModel(
+                duckChatActivityParams = DuckChatSettingsNoParams,
+                duckChat = duckChat,
+                pixel = mockPixel,
+                inputScreenDiscoveryFunnel = mockInputScreenDiscoveryFunnel,
+                settingsPageFeature = settingsPageFeature,
+                duckChatPixels = mockDuckChatPixels,
+                dispatcherProvider = coroutineRule.testDispatcherProvider,
+                duckChatFeature = duckChatFeature,
+                serpSettingsDataProvider = serpSettingsDataProvider,
+            )
+
+            testee.viewState.test {
+                assertTrue(awaitItem().isDuckAiWebSettingsVisible)
+            }
+        }
+
+    @Test
+    fun `when duckAiSettings toggle disabled then isDuckAiWebSettingsVisible is false`() =
+        runTest {
+            @Suppress("DenyListedApi")
+            duckChatFeature.duckAiSettings().setRawStoredState(State(enable = false))
+            whenever(duckChat.observeEnableDuckChatUserSetting()).thenReturn(flowOf(true))
+            testee = DuckChatSettingsViewModel(
+                duckChatActivityParams = DuckChatSettingsNoParams,
+                duckChat = duckChat,
+                pixel = mockPixel,
+                inputScreenDiscoveryFunnel = mockInputScreenDiscoveryFunnel,
+                settingsPageFeature = settingsPageFeature,
+                duckChatPixels = mockDuckChatPixels,
+                dispatcherProvider = coroutineRule.testDispatcherProvider,
+                duckChatFeature = duckChatFeature,
+                serpSettingsDataProvider = serpSettingsDataProvider,
+            )
+
+            testee.viewState.test {
+                assertFalse(awaitItem().isDuckAiWebSettingsVisible)
+            }
+        }
+
+    @Test
+    fun `when duckAiSettings toggle enabled and duck chat disabled then isDuckAiWebSettingsVisible is false`() =
+        runTest {
+            @Suppress("DenyListedApi")
+            duckChatFeature.duckAiSettings().setRawStoredState(State(enable = true))
+            whenever(duckChat.observeEnableDuckChatUserSetting()).thenReturn(flowOf(false))
+            testee = DuckChatSettingsViewModel(
+                duckChatActivityParams = DuckChatSettingsNoParams,
+                duckChat = duckChat,
+                pixel = mockPixel,
+                inputScreenDiscoveryFunnel = mockInputScreenDiscoveryFunnel,
+                settingsPageFeature = settingsPageFeature,
+                duckChatPixels = mockDuckChatPixels,
+                dispatcherProvider = coroutineRule.testDispatcherProvider,
+                duckChatFeature = duckChatFeature,
+                serpSettingsDataProvider = serpSettingsDataProvider,
+            )
+
+            testee.viewState.test {
+                assertFalse(awaitItem().isDuckAiWebSettingsVisible)
+            }
+        }
+
+    @Test
+    fun `when onDuckAiWebSettingsClicked then OpenDuckAiWebSettings command sent`() =
+        runTest {
+            val expectedUrl = "https://duck.ai?settings=open"
+            whenever(duckChat.getDuckChatSettingsUrl()).thenReturn(expectedUrl)
+
+            testee.onDuckAiWebSettingsClicked()
+
+            testee.commands.test {
+                val command = awaitItem()
+                assertTrue(command is OpenDuckAiWebSettings)
+                assertEquals(expectedUrl, (command as OpenDuckAiWebSettings).url)
                 cancelAndIgnoreRemainingEvents()
             }
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1216108753891672?focus=true
Tech Design URL (if applicable): 

### Description

- Adds a “Duck.ai Settings” item to AI Features which opens the Duck.ai web settings.

### Steps to test this PR

_With duckAiSettings enabled_
- [ ] Go to AI Features
- [ ] Tap “Duck.ai Settings"
- [ ] Verify that settings are opened in a new Duck.ai tab

_With duckAiSettings disabled_
- [ ] Go to AI Features
- [ ] Verify that the “Duck.ai Settings” item is not present

### UI changes
| Before  | After |
| ------ | ----- |
<img width="1280" height="2856" alt="Screenshot_20260702_202048" src="https://github.com/user-attachments/assets/7ad873b7-da09-4bd4-ace7-a6342f90c195" />|<img width="1280" height="2856" alt="Screenshot_20260702_202014" src="https://github.com/user-attachments/assets/b6f1e65c-0312-47a3-8387-00234f955666" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Settings UI and navigation only; visibility is remote-flagged and reuses existing Duck.ai settings URL APIs with unit test coverage.
> 
> **Overview**
> Adds a **Duck.ai Settings** entry on the AI Features settings screen, gated by a new remote toggle `duckAiSettings()` and only when Duck.ai is enabled for the user.
> 
> Tapping the row opens Duck.ai web settings in a **new browser tab** via `getDuckChatSettingsUrl()` (`OpenDuckAiWebSettings` → `browserNav.openInNewTab`). The row appears in two layouts: under the main enable toggle when native AI controls are off, and inside the input-screen block when native controls are on.
> 
> Includes the `duckAiSettingsTitle` string and ViewModel tests for visibility (toggle + user setting) and the open-settings command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9cf8261329362c15d641d9647ce8336611b0ead. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->