### PR TITLE
Skip Asana failure task on manual workflow dispatch

### DIFF
--- a/.github/actions/maestro-cloud-asana-reporter/action.yml
+++ b/.github/actions/maestro-cloud-asana-reporter/action.yml
@@ -108,7 +108,7 @@ runs:
       run: echo "flow_summary_status=${{ steps.analyze-maestro.outputs.flow_summary_status }}"
 
     - name: Create Asana task when Maestro tests failed
-      if: always() && inputs.create_asana_error_task == 'true' && steps.analyze-maestro.outputs.flow_summary_status == 'failure'
+      if: always() && inputs.create_asana_error_task == 'true' && steps.analyze-maestro.outputs.flow_summary_status == 'failure' && github.event_name != 'workflow_dispatch'
       id: create-maestro-failure-task
       uses: duckduckgo/native-github-asana-sync@v2.0
       with:

--- a/.github/workflows/e2e-nightly-autofill.yml
+++ b/.github/workflows/e2e-nightly-autofill.yml
@@ -69,7 +69,7 @@ jobs:
           test_suite_name: Autofill Web Flows
 
       - name: Create Asana task when workflow failed
-        if: ${{ failure() && steps.maestro-critical-path.outputs.flow_summary_status != 'failure' && steps.maestro-web-flows.outputs.flow_summary_status != 'failure' }}
+        if: ${{ failure() && steps.maestro-critical-path.outputs.flow_summary_status != 'failure' && steps.maestro-web-flows.outputs.flow_summary_status != 'failure' && github.event_name != 'workflow_dispatch' }}
         id: create-failure-task
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:

--- a/.github/workflows/e2e-nightly-full-suite.yml
+++ b/.github/workflows/e2e-nightly-full-suite.yml
@@ -331,7 +331,7 @@ jobs:
           asana_releases_blocker_section_id: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_BLOCKER_SECTION_ID }}
 
       - name: Create Asana task when workflow failed
-        if: ${{ failure() && inputs.create_asana_tasks == true }}
+        if: ${{ failure() && inputs.create_asana_tasks == true && github.event_name != 'workflow_dispatch' }}
         id: create-failure-task
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:

--- a/.github/workflows/e2e-nightly-non-blockers-suite.yml
+++ b/.github/workflows/e2e-nightly-non-blockers-suite.yml
@@ -128,7 +128,7 @@ jobs:
           test_suite_name: Onboarding Internal (Nightly)
 
       - name: Create Asana task when workflow failed
-        if: ${{ failure() }}
+        if: ${{ failure() && github.event_name != 'workflow_dispatch' }}
         id: create-failure-task
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:

--- a/.github/workflows/nightly-metro.yml
+++ b/.github/workflows/nightly-metro.yml
@@ -101,7 +101,7 @@ jobs:
         run: ./gradlew assemble${{ matrix.variant }} -Pforce-default-variant -Pskip-onboarding -Pddg.di=Metro -x lint
 
       - name: Create Asana task on failure
-        if: ${{ failure() }}
+        if: ${{ failure() && github.event_name != 'workflow_dispatch' }}
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -219,7 +219,7 @@ jobs:
     name: Create Asana task when workflow failed
     runs-on: ubuntu-24.04 #https://github.com/actions/runner-images/issues/6709
     needs: [code_formatting, unit_tests, lint, android_tests]
-    if: ${{ failure() }}
+    if: ${{ failure() && github.event_name != 'workflow_dispatch' }}
     steps:
       - name: Create Asana task when workflow failed
         id: create-failure-task

--- a/.github/workflows/update-content-scope.yml
+++ b/.github/workflows/update-content-scope.yml
@@ -136,7 +136,7 @@ jobs:
           action: 'add-task-asana-project'
 
       - name: Create Asana task when workflow failed
-        if: ${{ failure() }}
+        if: ${{ failure() && github.event_name != 'workflow_dispatch' }}
         id: create-failure-task
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:

--- a/.github/workflows/update-pir-broker-bundle.yml
+++ b/.github/workflows/update-pir-broker-bundle.yml
@@ -110,7 +110,7 @@ jobs:
             -f "labels[]=automated pr"
 
       - name: Create Asana task when workflow failed
-        if: ${{ failure() }}
+        if: ${{ failure() && github.event_name != 'workflow_dispatch' }}
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}

--- a/.github/workflows/update-ref-tests.yml
+++ b/.github/workflows/update-ref-tests.yml
@@ -128,7 +128,7 @@ jobs:
           action: 'add-task-asana-project'
 
       - name: Create Asana task when workflow failed
-        if: ${{ failure() }}
+        if: ${{ failure() && github.event_name != 'workflow_dispatch' }}
         id: create-failure-task
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212087397361015/task/1216196262697693
Tech Design URL (if applicable):

### Description

Nightly/scheduled workflows auto-create Asana task(s) when they fail. When one is triggered **manually** (`workflow_dispatch`), a failure almost always means a human is already investigating — so the auto-created task is noise.

This appends one guard to the relevant failure-reporting `if:` conditions:

```yaml
github.event_name != 'workflow_dispatch'
```

Filtering is by **dispatch type, not branch**: the branch is already implied by the `schedule` trigger, and dispatch-type is the precise signal for "a human is driving this run." The guard silences a fresh manual dispatch only — `schedule`, orchestrator-driven `workflow_call` children, and re-runs (original triggering event is preserved, only `run_attempt` increments) all keep reporting.

**Included — guard added (report skipped on manual dispatch):**

| File                                                      | Trigger(s)                                                                                                            |
|-----------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
| `.github/actions/maestro-cloud-asana-reporter/action.yml` | (composite, covers 6 E2E flows: autofill, non-blockers, full-suite, sync-critical-path, duckplayer, privacy-dashboard |
| `.github/workflows/nightly.yml`                           | `workflow_call`, `workflow_dispatch`                                                                                  |
| `.github/workflows/nightly-metro.yml`                     | `schedule`, `workflow_call`, `workflow_dispatch`                                                                      |
| `.github/workflows/e2e-nightly-autofill.yml`              | `schedule`, `workflow_dispatch`                                                                                       |
| `.github/workflows/e2e-nightly-non-blockers-suite.yml`    | `schedule`, `workflow_dispatch`                                                                                       |
| `.github/workflows/e2e-nightly-full-suite.yml`            | `workflow_call`, `workflow_dispatch`                                                                                  |
| `.github/workflows/update-content-scope.yml`              | `workflow_call`, `workflow_dispatch`                                                                                  |
| `.github/workflows/update-ref-tests.yml`                  | `workflow_call`, `workflow_dispatch`                                                                                  |
| `.github/workflows/update-pir-broker-bundle.yml`          | `schedule`, `workflow_dispatch`                                                                                       |

Already guarded before this work, unchanged (listed for completeness): `privacy.yml`, `e2e-duckplayer.yml`, `e2e-nightly-sync-critical-path.yml`. Guarded surface total: **12** (1 composite + 8 new + 3 pre-existing).

**Excluded — exempt (always report, even on manual dispatch).** Manual dispatch is the normal operation here; a failure is actionable, not noise.

| File | Why exempt |
|---|---|
| `.github/workflows/nightly-orchestrator.yml` | LGC tagging is routine manual|
| `.github/workflows/release_create_task.yml` | Release pipeline |
| `.github/workflows/release_create_tag.yml` | Release pipeline |
| `.github/workflows/release_upload_play_store.yml` | Release pipeline |
| `.github/workflows/release_upload_internal.yml` | Release pipeline |
| `.github/workflows/release_update_release_notes.yml` | `workflow_dispatch`-only — guard would silence it entirely |
| `.github/workflows/hotfix_prepare.yml` | Manual hotfix process |
| `.github/workflows/hotfix_finish.yml` | Manual hotfix process |
| `.github/workflows/build-fdroid-apk.yml` | Gated to `push` on `develop`; dispatch already excluded |
| `.github/workflows/e2e-maestro.yml` | Passes `create_asana_error_task: false` — never reports |


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only conditional changes with no app or secret logic; the main risk is missing Asana alerts if a manual dispatch fails without follow-up, which is intentional.
> 
> **Overview**
> Adds **`github.event_name != 'workflow_dispatch'`** to the `if:` conditions that create Asana tasks on CI failures, so manually triggered runs no longer open duplicate/noise tasks when someone is already debugging.
> 
> The guard is applied in the **Maestro Cloud Asana reporter** composite (Maestro test failures) and in **workflow-level** “Create Asana task when workflow failed” steps across nightly, E2E, Metro assemble, and dependency-update workflows. **Scheduled runs**, **`workflow_call`** invocations, and **re-runs** (original event preserved) still create tasks as before; only fresh **manual dispatch** is suppressed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 527238b1c8cc997d90c425c90bdd64fd931b0509. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->