### PR TITLE
Add captcha eventHub aggregation pixel definitions

### DIFF
--- a/PixelDefinitions/pixels/definitions/event_hub.json5
+++ b/PixelDefinitions/pixels/definitions/event_hub.json5
@@ -34,5 +34,185 @@
                 "description": "Unix timestamp (UTC) denoting the start of the measurement period"
             }
         ]
+    },
+    "webTelemetry_captcha_recaptcha_day": {
+        "description": "Daily bucketed count of reCAPTCHA detections across all pages. Fired by the eventHub feature at the end of each 1-day period.",
+        "owners": ["GuiltyDolphin"],
+        "triggers": ["other"],
+        "parameters": [
+            {
+                "key": "count",
+                "type": "string",
+                "description": "Bucketed reCAPTCHA detection count for the period",
+                "pattern": "^\\d+(-\\d+|\\+)?$"
+            },
+            {
+                "key": "attributionPeriod",
+                "type": "integer",
+                "description": "Unix timestamp (UTC) denoting the start of the measurement period"
+            }
+        ]
+    },
+    "webTelemetry_captcha_recaptcha_week": {
+        "description": "Weekly bucketed count of reCAPTCHA detections across all pages. Fired by the eventHub feature at the end of each 7-day period.",
+        "owners": ["GuiltyDolphin"],
+        "triggers": ["other"],
+        "parameters": [
+            {
+                "key": "count",
+                "type": "string",
+                "description": "Bucketed reCAPTCHA detection count for the period",
+                "pattern": "^\\d+(-\\d+|\\+)?$"
+            },
+            {
+                "key": "attributionPeriod",
+                "type": "integer",
+                "description": "Unix timestamp (UTC) denoting the start of the measurement period"
+            }
+        ]
+    },
+    "webTelemetry_captcha_hcaptcha_day": {
+        "description": "Daily bucketed count of hCaptcha detections across all pages. Fired by the eventHub feature at the end of each 1-day period.",
+        "owners": ["GuiltyDolphin"],
+        "triggers": ["other"],
+        "parameters": [
+            {
+                "key": "count",
+                "type": "string",
+                "description": "Bucketed hCaptcha detection count for the period",
+                "pattern": "^\\d+(-\\d+|\\+)?$"
+            },
+            {
+                "key": "attributionPeriod",
+                "type": "integer",
+                "description": "Unix timestamp (UTC) denoting the start of the measurement period"
+            }
+        ]
+    },
+    "webTelemetry_captcha_hcaptcha_week": {
+        "description": "Weekly bucketed count of hCaptcha detections across all pages. Fired by the eventHub feature at the end of each 7-day period.",
+        "owners": ["GuiltyDolphin"],
+        "triggers": ["other"],
+        "parameters": [
+            {
+                "key": "count",
+                "type": "string",
+                "description": "Bucketed hCaptcha detection count for the period",
+                "pattern": "^\\d+(-\\d+|\\+)?$"
+            },
+            {
+                "key": "attributionPeriod",
+                "type": "integer",
+                "description": "Unix timestamp (UTC) denoting the start of the measurement period"
+            }
+        ]
+    },
+    "webTelemetry_captcha_turnstile_day": {
+        "description": "Daily bucketed count of Cloudflare Turnstile CAPTCHA detections across all pages. Fired by the eventHub feature at the end of each 1-day period.",
+        "owners": ["GuiltyDolphin"],
+        "triggers": ["other"],
+        "parameters": [
+            {
+                "key": "count",
+                "type": "string",
+                "description": "Bucketed Cloudflare Turnstile detection count for the period",
+                "pattern": "^\\d+(-\\d+|\\+)?$"
+            },
+            {
+                "key": "attributionPeriod",
+                "type": "integer",
+                "description": "Unix timestamp (UTC) denoting the start of the measurement period"
+            }
+        ]
+    },
+    "webTelemetry_captcha_turnstile_week": {
+        "description": "Weekly bucketed count of Cloudflare Turnstile CAPTCHA detections across all pages. Fired by the eventHub feature at the end of each 7-day period.",
+        "owners": ["GuiltyDolphin"],
+        "triggers": ["other"],
+        "parameters": [
+            {
+                "key": "count",
+                "type": "string",
+                "description": "Bucketed Cloudflare Turnstile detection count for the period",
+                "pattern": "^\\d+(-\\d+|\\+)?$"
+            },
+            {
+                "key": "attributionPeriod",
+                "type": "integer",
+                "description": "Unix timestamp (UTC) denoting the start of the measurement period"
+            }
+        ]
+    },
+    "webTelemetry_captcha_cloudflare_day": {
+        "description": "Daily bucketed count of Cloudflare challenge-page detections across all pages. Fired by the eventHub feature at the end of each 1-day period.",
+        "owners": ["GuiltyDolphin"],
+        "triggers": ["other"],
+        "parameters": [
+            {
+                "key": "count",
+                "type": "string",
+                "description": "Bucketed Cloudflare challenge-page detection count for the period",
+                "pattern": "^\\d+(-\\d+|\\+)?$"
+            },
+            {
+                "key": "attributionPeriod",
+                "type": "integer",
+                "description": "Unix timestamp (UTC) denoting the start of the measurement period"
+            }
+        ]
+    },
+    "webTelemetry_captcha_cloudflare_week": {
+        "description": "Weekly bucketed count of Cloudflare challenge-page detections across all pages. Fired by the eventHub feature at the end of each 7-day period.",
+        "owners": ["GuiltyDolphin"],
+        "triggers": ["other"],
+        "parameters": [
+            {
+                "key": "count",
+                "type": "string",
+                "description": "Bucketed Cloudflare challenge-page detection count for the period",
+                "pattern": "^\\d+(-\\d+|\\+)?$"
+            },
+            {
+                "key": "attributionPeriod",
+                "type": "integer",
+                "description": "Unix timestamp (UTC) denoting the start of the measurement period"
+            }
+        ]
+    },
+    "webTelemetry_captcha_other_day": {
+        "description": "Daily bucketed count of other/generic CAPTCHA detections across all pages. Fired by the eventHub feature at the end of each 1-day period.",
+        "owners": ["GuiltyDolphin"],
+        "triggers": ["other"],
+        "parameters": [
+            {
+                "key": "count",
+                "type": "string",
+                "description": "Bucketed other/generic CAPTCHA detection count for the period",
+                "pattern": "^\\d+(-\\d+|\\+)?$"
+            },
+            {
+                "key": "attributionPeriod",
+                "type": "integer",
+                "description": "Unix timestamp (UTC) denoting the start of the measurement period"
+            }
+        ]
+    },
+    "webTelemetry_captcha_other_week": {
+        "description": "Weekly bucketed count of other/generic CAPTCHA detections across all pages. Fired by the eventHub feature at the end of each 7-day period.",
+        "owners": ["GuiltyDolphin"],
+        "triggers": ["other"],
+        "parameters": [
+            {
+                "key": "count",
+                "type": "string",
+                "description": "Bucketed other/generic CAPTCHA detection count for the period",
+                "pattern": "^\\d+(-\\d+|\\+)?$"
+            },
+            {
+                "key": "attributionPeriod",
+                "type": "integer",
+                "description": "Unix timestamp (UTC) denoting the start of the measurement period"
+            }
+        ]
     }
 }


### PR DESCRIPTION


Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216219466895942
Tech Design URL (if applicable): 

### Description
Goes with https://github.com/duckduckgo/privacy-configuration/pull/5475
Document the day/week bucketed captcha detection pixels (recaptcha, hcaptcha, turnstile, cloudflare, other) fired by the eventHub feature.

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only pixel documentation with no runtime or client logic changes in this PR.
> 
> **Overview**
> Adds **10 new eventHub pixel definitions** in `event_hub.json5` for bucketed CAPTCHA detection telemetry, mirroring the existing adwall day/week events.
> 
> Each CAPTCHA category gets **daily and weekly** pixels: **reCAPTCHA**, **hCaptcha**, **Cloudflare Turnstile**, **Cloudflare challenge pages**, and **other/generic**. All use the same **`count`** (bucketed string) and **`attributionPeriod`** (period start Unix timestamp) parameters, with **`other`** triggers and **GuiltyDolphin** as owner—intended to document pixels emitted by the paired privacy-configuration eventHub work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89811c0ada7e3c23462132d405e32609ff8fcc61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->