### PR TITLE
PIR: Add charging constraint to PIR scheduled scan worker

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scan/PirScanScheduler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scan/PirScanScheduler.kt
@@ -115,6 +115,7 @@ class RealPirScanScheduler @Inject constructor(
             Constraints
                 .Builder()
                 .setRequiredNetworkType(NetworkType.CONNECTED)
+                .setRequiresCharging(true)
                 .build()
 
         val periodicWorkRequest =

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scan/RealPirScanSchedulerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scan/RealPirScanSchedulerTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.pir.impl.scan
 import android.content.Context
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
@@ -140,6 +141,33 @@ class RealPirScanSchedulerTest {
             any(),
             any<PeriodicWorkRequest>(),
         )
+    }
+
+    @Test
+    fun whenScheduleScansThenScheduledScanWorkRequiresCharging() {
+        testee.scheduleScans()
+
+        val scheduledScan = capturePeriodicWorkRequests().getValue(PirScheduledScanRemoteWorker.TAG_SCHEDULED_SCAN)
+
+        assertTrue(scheduledScan.workSpec.constraints.requiresCharging())
+    }
+
+    @Test
+    fun whenScheduleScansThenScheduledScanWorkStillRequiresConnectedNetwork() {
+        testee.scheduleScans()
+
+        val scheduledScan = capturePeriodicWorkRequests().getValue(PirScheduledScanRemoteWorker.TAG_SCHEDULED_SCAN)
+
+        assertEquals(NetworkType.CONNECTED, scheduledScan.workSpec.constraints.requiredNetworkType)
+    }
+
+    @Test
+    fun whenScheduleScansThenEmailConfirmationWorkDoesNotRequireCharging() {
+        testee.scheduleScans()
+
+        val emailConfirmation = capturePeriodicWorkRequests().getValue(PirEmailConfirmationRemoteWorker.TAG_EMAIL_CONFIRMATION)
+
+        assertFalse(emailConfirmation.workSpec.constraints.requiresCharging())
     }
 
     @Test
@@ -378,5 +406,16 @@ class RealPirScanSchedulerTest {
             .thenReturn(flowOf(emptyList()))
 
         assertFalse(testee.isScheduledScanRunning())
+    }
+
+    private fun capturePeriodicWorkRequests(): Map<String, PeriodicWorkRequest> {
+        val tagCaptor = argumentCaptor<String>()
+        val requestCaptor = argumentCaptor<PeriodicWorkRequest>()
+        verify(mockWorkManager, times(4)).enqueueUniquePeriodicWork(
+            tagCaptor.capture(),
+            any(),
+            requestCaptor.capture(),
+        )
+        return tagCaptor.allValues.zip(requestCaptor.allValues).toMap()
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216237628845912?focus=true
Tech Design URL (if applicable): N/A

### Description
Adds back the charging constraint to PIR scheduled scan worker

### Steps to test this PR
QA-optional

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when periodic PIR scans can run in the background, which may delay scans for users who rarely charge but is limited to WorkManager scheduling constraints.
> 
> **Overview**
> Restores a **charging requirement** on the periodic **PIR scheduled scan** WorkManager job in `PirScanScheduler`, alongside the existing connected to run only when the device has a connected network and is plugged in.
> 
> **Tests** assert the scheduled-scan work spec requires charging and still uses `NetworkType.CONNECTED`, and that the email-confirmation periodic worker is **not** given a charging constraint. A shared test helper captures enqueued periodic work by tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6af100cd6d873798cdbed717e3f0d557f46cd8fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->