### PR TITLE
Run Maestro E2E tests on API 34 instead of 35

### DIFF
--- a/.github/workflows/e2e-nightly-sync-critical-path.yml
+++ b/.github/workflows/e2e-nightly-sync-critical-path.yml
@@ -52,7 +52,7 @@ jobs:
           maestro_app_file: ${{ steps.assemble.outputs.internal_apk_path }}
           maestro_include_tags: syncCriticalPathTest
           test_suite_name: Sync Critical Path
-          maestro_api_level: 35
+          maestro_api_level: 34
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}

--- a/.github/workflows/e2e-privacy-dashboard.yml
+++ b/.github/workflows/e2e-privacy-dashboard.yml
@@ -63,7 +63,7 @@ jobs:
           maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           maestro_app_file: ${{ steps.assemble.outputs.play_apk_path }}
           maestro_include_tags: privacyTest
-          maestro_api_level: 35
+          maestro_api_level: 34
           asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1216257675123105?focus=true
Tech Design URL (if applicable):

### Description

Maestro E2E tests running on API 35 have been timing out and failing intermittently (e.g. 4/5 tests failed in a recent run). Tests running on API 34 pass reliably. This switches the `maestro_api_level` for the Sync Critical Path and Privacy Dashboard nightly E2E workflows from 35 to 34.

### Steps to test this PR
CI passes

### UI changes
| Before  | After |
| ------ | ----- |
|No UI changes|No UI changes|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only GitHub Actions workflow inputs change; no production-ready responses, security, or production behavior.
> 
> **Overview**
> **Nightly Sync Critical Path** and **Privacy Dashboard** Maestro jobs now pass `maestro_api_level: 34` to `maestro-cloud-asana-reporter` instead of **35**, so those suites run on an API 34 emulator/device in Maestro Cloud.
> 
> This is a CI-only change to address timeouts and flaky failures on API 35; app code and test tags are unchanged. Other workflows in the repo already pin different levels (e.g. Privacy Dashboard ad-click stays on **30**; Duck Player on **34**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3e68cea75869b3a084d7afa0a124beeb0a89441. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->