### PR TITLE
Enable Develocity Setup Cache

### DIFF
--- a/.github/actions/develocity-artifact-cache/action.yml
+++ b/.github/actions/develocity-artifact-cache/action.yml
@@ -34,6 +34,14 @@ inputs:
     description: 'Develocity server URL'
     required: false
     default: 'https://duckduckgo.develocity.cloud'
+  disable-setup-cache:
+    description: 'Set to "true" to disable the Develocity Setup Cache.'
+    required: false
+    default: 'false'
+  disable-artifact-cache:
+    description: 'Set to "true" to disable the Develocity Artifact Cache.'
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
@@ -69,8 +77,16 @@ runs:
         # Honour a custom Gradle User Home; default to the conventional location so this
         # works on both GitHub-hosted and self-hosted runners (not just /home/runner).
         GRADLE_HOME_DIR="${GRADLE_USER_HOME:-$HOME/.gradle}"
-        # Only the artifact (dependency) cache is enabled; the Develocity setup cache stays disabled for now.
-        echo "ARTIFACT_CACHE_CMD_OPTS=--dv-server=${{ inputs.dv-server }} --image-name=${{ inputs.image-name }} --gradle-home=$GRADLE_HOME_DIR --disable-setup-cache" >> "$GITHUB_ENV"
+        # Both caches are enabled by default; either can be disabled via its input.
+        SETUP_CACHE_OPT=""
+        if [ "${{ inputs.disable-setup-cache }}" = "true" ]; then
+          SETUP_CACHE_OPT="--disable-setup-cache"
+        fi
+        ARTIFACT_CACHE_OPT=""
+        if [ "${{ inputs.disable-artifact-cache }}" = "true" ]; then
+          ARTIFACT_CACHE_OPT="--disable-artifact-cache"
+        fi
+        echo "ARTIFACT_CACHE_CMD_OPTS=--dv-server=${{ inputs.dv-server }} --image-name=${{ inputs.image-name }} --gradle-home=$GRADLE_HOME_DIR $SETUP_CACHE_OPT $ARTIFACT_CACHE_OPT" >> "$GITHUB_ENV"
 
     - name: Restore from Artifact Cache
       if: inputs.command == 'restore'

--- a/.github/workflows/build-debug-apk.yaml
+++ b/.github/workflows/build-debug-apk.yaml
@@ -62,7 +62,7 @@ jobs:
           cache-disabled: true # Develocity Artifact Cache supersedes setup-gradle's Gradle Home caching
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
-      - name: Restore Develocity Artifact Cache
+      - name: Restore Develocity Setup + Artifact Cache
         uses: ./.github/actions/develocity-artifact-cache
         with:
           command: restore
@@ -77,7 +77,7 @@ jobs:
           DUCKSANS_PACKAGE_AUTH_TOKEN: ${{ secrets.DAXMOBILE_GITHUB_PACKAGES_AUTOMATION }}
         run: ./gradlew assembleInternalDebug -Pforce-default-variant -Pddg.di=${{ matrix.di }}
 
-      - name: Store Develocity Artifact Cache
+      - name: Store Develocity Setup + Artifact Cache
         if: always()
         uses: ./.github/actions/develocity-artifact-cache
         with:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1215905086587362?focus=true
Tech Design URL (if applicable): N/A

### Description
Enables Develocity Setup Cache for the `build-debug-apk.yml` job that is run on every PR.

### Steps to test this PR
QA-optional

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only CI caching behavior; restore/store failures already warn and do not fail builds.
> 
> **Overview**
> **Enables the Develocity Setup Cache** alongside the existing artifact (dependency) cache in the shared `develocity-artifact-cache` composite action. Previously the CLI was always invoked with `--disable-setup-cache`; it now runs with **both caches on by default**.
> 
> Adds optional inputs `disable-setup-cache` and `disable-artifact-cache` (default `false`) so workflows can still turn either cache off via the corresponding CLI flags.
> 
> The **build debug APK** workflow only updates restore/store step names to “Develocity Setup + Artifact Cache”; it does not pass the new disable flags, so debug APK CI picks up setup cache automatically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0fb06711d93b61f38a01c02dd1aa31570527895. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->