### PR TITLE
Disable chat sync promo feature flag

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/chat/ChatSyncPromoChatTabItemPlugin.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/chat/ChatSyncPromoChatTabItemPlugin.kt
@@ -41,7 +41,7 @@ import javax.inject.Inject
 @ContributesActivePlugin(
     scope = AppScope::class,
     boundType = NativeInputChatTabItemPlugin::class,
-    defaultActiveValue = DefaultFeatureValue.INTERNAL,
+    defaultActiveValue = DefaultFeatureValue.FALSE,
     priority = NativeInputChatTabItemPlugin.PRIORITY_PROMO,
     featureName = "pluginChatSyncPromoChatTabItemPlugin",
     parentFeatureName = "pluginPointNativeInputChatTabItemPlugin",


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1216237628805838?focus=true
Tech Design URL (if applicable): 

### Description

Disables the feature flag so it doesn't impact negatively developement as the feature is not being shipped at the moment.

### Steps to test this PR

Code review should be enough.

### UI changes
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single default flag change with no logic or data-path changes; promo can still be turned on via the existing feature toggle.
> 
> **Overview**
> Turns off the **chat sync promo** native input tab plugin at the feature-toggle layer so it no longer runs by default while the feature is not shipping.
> 
> The only code change is in `ChatSyncPromoChatTabItemPlugin`: **`defaultActiveValue`** moves from **`DefaultFeatureValue.INTERNAL`** to **`DefaultFeatureValue.FALSE`**, so the plugin stays inactive unless the `pluginChatSyncPromoChatTabItemPlugin` flag is explicitly enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cfc2cf83a5b45b0ba6c49c895681e431e5ff9bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->