### PR TITLE
Hide native input when opening Duck.ai Settings

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1429,7 +1429,6 @@ class BrowserTabFragment :
             tabs = viewModel.tabs,
             currentTabUrl = viewModel.siteLiveData.asFlow().map { it?.url },
             query = query,
-            initiallyHidden = isDuckAiSettingsPage(),
             initialInputMode = if (customAiOnboardingStore.consumeOpenInputOnDuckAiTab()) {
                 InputMode.DUCK_AI
             } else {
@@ -1528,11 +1527,6 @@ class BrowserTabFragment :
                 },
             ),
         )
-    }
-
-    private fun isDuckAiSettingsPage(): Boolean {
-        val uri = webView?.url?.toUri() ?: return false
-        return duckChat.isDuckChatUrl(uri) && uri.getQueryParameter("settings") == "open"
     }
 
     private fun launchInputScreen(

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1429,6 +1429,7 @@ class BrowserTabFragment :
             tabs = viewModel.tabs,
             currentTabUrl = viewModel.siteLiveData.asFlow().map { it?.url },
             query = query,
+            initiallyHidden = isDuckAiSettingsPage(),
             initialInputMode = if (customAiOnboardingStore.consumeOpenInputOnDuckAiTab()) {
                 InputMode.DUCK_AI
             } else {
@@ -1527,6 +1528,11 @@ class BrowserTabFragment :
                 },
             ),
         )
+    }
+
+    private fun isDuckAiSettingsPage(): Boolean {
+        val uri = webView?.url?.toUri() ?: return false
+        return duckChat.isDuckChatUrl(uri) && uri.getQueryParameter("settings") == "open"
     }
 
     private fun launchInputScreen(

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -120,6 +120,7 @@ interface NativeInputManager {
         query: String = "",
         callbacks: NativeInputCallbacks,
         initialInputMode: InputMode? = null,
+        initiallyHidden: Boolean = false,
     )
 
     fun hideNativeInput(animate: Boolean = true, isNavigation: Boolean = false): Boolean
@@ -401,6 +402,7 @@ class RealNativeInputManager @Inject constructor(
         query: String,
         callbacks: NativeInputCallbacks,
         initialInputMode: InputMode?,
+        initiallyHidden: Boolean,
     ) {
         if (!isNativeInputFieldEnabled) return
 
@@ -452,6 +454,9 @@ class RealNativeInputManager @Inject constructor(
             }
         }
         attachWidget(widgetView, isBottom, tabId)
+        if (initiallyHidden) {
+            widgetView.gone()
+        }
         val isNewTab = query.isEmpty() && omnibarController.getText().isEmpty()
         applyInitialTabSelection(widgetView, isNewTab, initialInputMode)
         if (omnibarController.isDuckAiMode()) {

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -59,9 +59,11 @@ import com.google.android.material.card.MaterialCardView
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import org.json.JSONArray
 import javax.inject.Inject
 
@@ -120,7 +122,6 @@ interface NativeInputManager {
         query: String = "",
         callbacks: NativeInputCallbacks,
         initialInputMode: InputMode? = null,
-        initiallyHidden: Boolean = false,
     )
 
     fun hideNativeInput(animate: Boolean = true, isNavigation: Boolean = false): Boolean
@@ -402,7 +403,6 @@ class RealNativeInputManager @Inject constructor(
         query: String,
         callbacks: NativeInputCallbacks,
         initialInputMode: InputMode?,
-        initiallyHidden: Boolean,
     ) {
         if (!isNativeInputFieldEnabled) return
 
@@ -454,8 +454,8 @@ class RealNativeInputManager @Inject constructor(
             }
         }
         attachWidget(widgetView, isBottom, tabId)
-        if (initiallyHidden) {
-            widgetView.gone()
+        lifecycleOwner.lifecycleScope.launch {
+            if (isDuckAiSettingsUrl(currentTabUrl.firstOrNull())) widgetView.gone()
         }
         val isNewTab = query.isEmpty() && omnibarController.getText().isEmpty()
         applyInitialTabSelection(widgetView, isNewTab, initialInputMode)
@@ -938,6 +938,11 @@ class RealNativeInputManager @Inject constructor(
         if (rawUrl.isNullOrBlank()) return null
         val uri = runCatching { rawUrl.toUri() }.getOrNull() ?: return null
         return uri.toChatIdOrNull(duckChat)
+    }
+
+    private fun isDuckAiSettingsUrl(url: String?): Boolean {
+        val uri = url?.toUri() ?: return false
+        return duckChat.isDuckChatUrl(uri) && uri.getQueryParameter("settings") == "open"
     }
 
     companion object {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -488,9 +488,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
                             showKeyboard()
                         }
                     }
-                    ChatState.READY -> {
-                        widgetRoot?.visibility = VISIBLE
-                    }
                     else -> {}
                 }
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1216262007606201?focus=true
Tech Design URL (if applicable): 

### Description

- Fixes an issue where the native input is visible when opening Duck.ai Settings

### Steps to test this PR

- [ ] Open Duck.ai Settings
- [ ] Verify that the native input is not visible
- [ ] Dismiss settings
- [ ] Verify that the native input is visible

### UI changes
| Before  | After |
| ------ | ----- |
<img width="1280" height="2856" alt="Screenshot_20260703_095849" src="https://github.com/user-attachments/assets/c495dd0b-f4bb-4b88-81fc-9d6a14082539" />|<img width="1280" height="2856" alt="Screenshot_20260703_143800" src="https://github.com/user-attachments/assets/6d695032-6846-4af8-8c8b-1a0c4f83cc69" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted UI visibility for one Duck.ai URL pattern plus removal of a redundant chat-state visibility path; no auth, data, or submission logic changes.
> 
> **Overview**
> Hides the **native input overlay** when the active tab is Duck.ai with **`settings=open`**, so the web settings UI is not covered by the unified input widget.
> 
> **`NativeInputManager`** adds **`isDuckAiSettingsUrl`** (Duck chat URL + `settings=open`) and, right after attaching the widget in **`showNativeInput`**, reads **`currentTabUrl`** once and calls **`gone()`** on the widget when that URL matches.
> 
> **`NativeInputModeWidget`** drops the **`ChatState.READY`** branch that forced the widget root visible; visibility is now driven only by **`HIDE`** / **`SHOW`** ( **`READY`** no longer overrides hiding).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c43ea74f5783b03ca70081f1b0eeb840959074c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->