### PR TITLE
Fix Duck Player test and move init code to onCreate

### DIFF
--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/duckplayer/RealDuckPlayer.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/duckplayer/RealDuckPlayer.kt
@@ -24,6 +24,7 @@ import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import androidx.core.net.toUri
 import androidx.fragment.app.FragmentManager
+import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.adblocking.api.duckplayer.DuckPlayer
 import com.duckduckgo.adblocking.api.duckplayer.DuckPlayer.*
 import com.duckduckgo.adblocking.api.duckplayer.DuckPlayer.DuckPlayerOrigin.AUTO
@@ -57,6 +58,7 @@ import com.duckduckgo.adblocking.impl.duckplayer.ui.DuckPlayerPrimeDialogFragmen
 import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.di.IsMainProcess
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
@@ -112,6 +114,7 @@ interface DuckPlayerInternal : DuckPlayer {
 @ContributesBinding(AppScope::class, boundType = DuckPlayer::class)
 @ContributesBinding(AppScope::class, boundType = DuckPlayerInternal::class)
 @ContributesMultibinding(AppScope::class, boundType = PrivacyConfigCallbackPlugin::class)
+@ContributesMultibinding(AppScope::class, boundType = MainProcessLifecycleObserver::class)
 class RealDuckPlayer @Inject constructor(
     private val duckPlayerFeatureRepository: DuckPlayerFeatureRepository,
     private val duckPlayerFeature: DuckPlayerFeature,
@@ -123,7 +126,7 @@ class RealDuckPlayer @Inject constructor(
     private val appBuildConfig: AppBuildConfig,
     @IsMainProcess private val isMainProcess: Boolean,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
-) : DuckPlayerInternal, PrivacyConfigCallbackPlugin {
+) : DuckPlayerInternal, PrivacyConfigCallbackPlugin, MainProcessLifecycleObserver {
 
     private var shouldForceYTNavigation = false
     private var shouldHideOverlay = false
@@ -134,15 +137,19 @@ class RealDuckPlayer @Inject constructor(
     init {
         if (isMainProcess) {
             loadToMemory()
-            appCoroutineScope.launch {
-                combine(
-                    duckPlayerFeatureRepository.observeUserPreferences(),
-                    adBlockingExtensionFeature.self().enabled(),
-                    adBlockingExtensionFeature.enabledByDefault().enabled(),
-                    ::Triple,
-                ).collect { (stored, selfEnabled, enabledByDefault) ->
-                    applyAdBlockingRolloutDefaultIfEligible(stored, selfEnabled, enabledByDefault)
-                }
+        }
+    }
+
+    override fun onCreate(owner: LifecycleOwner) {
+        if (!isMainProcess) return
+        appCoroutineScope.launch {
+            combine(
+                duckPlayerFeatureRepository.observeUserPreferences(),
+                adBlockingExtensionFeature.self().enabled(),
+                adBlockingExtensionFeature.enabledByDefault().enabled(),
+                ::Triple,
+            ).collect { (stored, selfEnabled, enabledByDefault) ->
+                applyAdBlockingRolloutDefaultIfEligible(stored, selfEnabled, enabledByDefault)
             }
         }
     }

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/duckplayer/RealDuckPlayerTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/duckplayer/RealDuckPlayerTest.kt
@@ -24,6 +24,7 @@ import android.webkit.MimeTypeMap
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import androidx.core.net.toUri
+import androidx.lifecycle.LifecycleOwner
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.adblocking.api.duckplayer.DuckPlayer.DuckPlayerOrigin.AUTO
 import com.duckduckgo.adblocking.api.duckplayer.DuckPlayer.DuckPlayerState.DISABLED
@@ -50,6 +51,8 @@ import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.utils.UrlScheme.Companion.duck
 import com.duckduckgo.common.utils.UrlScheme.Companion.https
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.FakeToggleStore
+import com.duckduckgo.feature.toggles.api.FeatureToggles
 import com.duckduckgo.feature.toggles.api.Toggle.State
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -89,7 +92,13 @@ class RealDuckPlayerTest {
     private val mockDuckPlayerLocalFilesPath: DuckPlayerLocalFilesPath = mock()
     private val mimeType: MimeTypeMap = mock()
     private val dispatcherProvider = coroutineRule.testDispatcherProvider
-    private val adBlockingExtensionFeature = FakeFeatureToggleFactory.create(AdBlockingExtensionFeature::class.java)
+    private val adBlockingExtensionFeature = FeatureToggles.Builder()
+        .store(FakeToggleStore())
+        .appVersionProvider { Int.MAX_VALUE }
+        .featureName("adBlockingExtension")
+        .ioDispatcher(coroutineRule.testDispatcher)
+        .build()
+        .create(AdBlockingExtensionFeature::class.java)
     private val mockAppBuildConfig: AppBuildConfig = mock()
     private val storedUserPreferencesFlow = MutableStateFlow(StoredUserPreferences(false, null))
 
@@ -217,12 +226,14 @@ class RealDuckPlayerTest {
 
     //endregion
 
-    // region ad-blocking rollout default (driven by combine() in init)
+    // region ad-blocking rollout default (driven by combine() started in onCreate)
     @Test
     fun whenNotNewInstall_combineDoesNotPersistRolloutDefault() = runTest {
         whenever(mockAppBuildConfig.isNewInstall()).thenReturn(false)
         adBlockingExtensionFeature.self().setRawStoredState(State(true))
         adBlockingExtensionFeature.enabledByDefault().setRawStoredState(State(true))
+
+        testee.onCreate(mock(LifecycleOwner::class.java))
 
         verify(mockDuckPlayerFeatureRepository, never()).setUserPreferences(any())
     }
@@ -233,6 +244,8 @@ class RealDuckPlayerTest {
         adBlockingExtensionFeature.self().setRawStoredState(State(true))
         adBlockingExtensionFeature.enabledByDefault().setRawStoredState(State(false))
 
+        testee.onCreate(mock(LifecycleOwner::class.java))
+
         verify(mockDuckPlayerFeatureRepository, never()).setUserPreferences(any())
     }
 
@@ -242,16 +255,22 @@ class RealDuckPlayerTest {
         adBlockingExtensionFeature.self().setRawStoredState(State(false))
         adBlockingExtensionFeature.enabledByDefault().setRawStoredState(State(true))
 
+        testee.onCreate(mock(LifecycleOwner::class.java))
+
         verify(mockDuckPlayerFeatureRepository, never()).setUserPreferences(any())
     }
 
+    // Runs on the rule's dispatcher so advanceUntilIdle() drives the onCreate combine collector (which lives on
+    // coroutineRule.testScope); the fresh runTest scope keeps its own Job so the collector isn't policed for completion.
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun whenNewInstallAndRolloutOnAndNoStoredMode_combinePersistsDisabled() = runTest {
+    fun whenNewInstallAndRolloutOnAndNoStoredMode_combinePersistsDisabled() = runTest(coroutineRule.testDispatcher) {
         whenever(mockAppBuildConfig.isNewInstall()).thenReturn(true)
         storedUserPreferencesFlow.value = StoredUserPreferences(true, null)
         adBlockingExtensionFeature.self().setRawStoredState(State(true))
         adBlockingExtensionFeature.enabledByDefault().setRawStoredState(State(true))
+
+        testee.onCreate(mock(LifecycleOwner::class.java))
         advanceUntilIdle()
 
         // atLeastOnce because the mocked repo doesn't propagate the write back through
@@ -265,6 +284,8 @@ class RealDuckPlayerTest {
         storedUserPreferencesFlow.value = StoredUserPreferences(false, AlwaysAsk)
         adBlockingExtensionFeature.self().setRawStoredState(State(true))
         adBlockingExtensionFeature.enabledByDefault().setRawStoredState(State(true))
+
+        testee.onCreate(mock(LifecycleOwner::class.java))
 
         verify(mockDuckPlayerFeatureRepository, never()).setUserPreferences(any())
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1216267647049623?focus=true 
Tech Design URL (if applicable): 

### Description

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Timing of when new-install private-player defaults are persisted shifts from object construction to process lifecycle start; behavior is unchanged once `onCreate` runs but rollout could apply slightly later on cold start.
> 
> **Overview**
> **RealDuckPlayer** no longer starts the ad-blocking rollout `combine()` collector in `init`; it registers as a **`MainProcessLifecycleObserver`** and launches that flow from **`onCreate`**, while **`loadToMemory()`** still runs in `init` on the main process only.
> 
> Rollout tests now **`onCreate()`** the instance explicitly, build **`AdBlockingExtensionFeature`** with **`FeatureToggles.Builder`** (instead of **`FakeFeatureToggleFactory`**), and use the test rule’s dispatcher so the async collector can be driven with **`advanceUntilIdle()`** in the persist-default case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cec7f308f7001f634e7e6b3854dd14965307963b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->