### PR TITLE
Sync exchange v2 update pixels for more granularity

### DIFF
--- a/PixelDefinitions/pixels/definitions/sync_setup.json5
+++ b/PixelDefinitions/pixels/definitions/sync_setup.json5
@@ -155,6 +155,12 @@
                 "type": "string",
                 "description": "This device's credential kind. Always ddg for the native client",
                 "enum": ["ddg", "3party"]
+            },
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Why the scanned code failed parsing/recognition. Emitted from v2 call sites when the parser rejects the code.",
+                "enum": ["unrecognized_code", "needs_upgrade", "incompatible_code"]
             }
         ]
     },
@@ -182,6 +188,12 @@
                 "type": "string",
                 "description": "This device's credential kind. Always ddg for the native client",
                 "enum": ["ddg", "3party"]
+            },
+            {
+                "key": "reason",
+                "type": "string",
+                "description": "Why the pasted code failed parsing/recognition. Emitted from v2 call sites when the parser rejects the code.",
+                "enum": ["unrecognized_code", "needs_upgrade", "incompatible_code"]
             }
         ]
     },
@@ -238,17 +250,49 @@
         "parameters": [
             "appVersion",
             {
+                "key": "source",
+                "type": "string",
+                "description": "Which sync setup flow failed",
+                "enum": ["connect", "exchange"]
+            },
+            {
                 "key": "reason",
                 "type": "string",
-                "description": "Why the v2 setup failed, aligned with the error codes we handle",
+                "description": "Why the v2 setup failed, per the canonical reason vocabulary in the v2 sync pixels spec (Exchange V2 Unified Algorithm)",
                 "enum": [
-                    "needs_upgrade",
-                    "already_upgraded",
-                    "invalid_credentials",
-                    "pairing_unavailable",
-                    "protocol_error",
+                    "session_timeout",
                     "transport_failure",
+                    "needs_upgrade",
+                    "invalid_credentials",
+                    "account_creation_failed",
+                    "account_upgrade_failed",
+                    "already_upgraded",
+                    "already_paired",
+                    "recovery_code_preparation_failed",
+                    "missing_3party_credential",
+                    "undecryptable_3party_credential",
+                    "account_extend_failed",
+                    "missing_3party_key",
+                    "local_storage_failed",
+                    "peer_recovery_code_unavailable",
+                    "unexpected_second_hello",
+                    "unexpected_event",
+                    "pairing_session_not_ready",
+                    "relay_channel_unavailable",
+                    "protocol_error",
                     "unexpected_failure"
+                ]
+            },
+            {
+                "key": "timeout_stage",
+                "type": "string",
+                "description": "Which phase of the v2 setup was in progress when reason=session_timeout. Emitted only when reason is session_timeout; omitted otherwise",
+                "enum": [
+                    "waiting_for_peer_hello",
+                    "waiting_for_peer_status",
+                    "waiting_for_confirmation",
+                    "waiting_for_recovery_code",
+                    "logging_in"
                 ]
             },
             {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcher.kt
@@ -24,8 +24,14 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.NO_RECOVERY_CODE
 import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
 import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_SESSION_NOT_READY
 import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_UNAVAILABLE
+import com.duckduckgo.sync.impl.AccountErrorCodes.PEER_RECOVERY_CODE_UNAVAILABLE
+import com.duckduckgo.sync.impl.AccountErrorCodes.RECOVERY_CODE_PREPARATION_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.RELAY_CHANNEL_UNAVAILABLE
+import com.duckduckgo.sync.impl.AccountErrorCodes.SESSION_TIMEOUT
 import com.duckduckgo.sync.impl.AccountErrorCodes.UNEXPECTED_EVENT
+import com.duckduckgo.sync.impl.AccountErrorCodes.UNEXPECTED_SECOND_HELLO
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Message
@@ -33,6 +39,7 @@ import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2QrCode
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
 import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
+import com.duckduckgo.sync.impl.exchange.v2.SessionErrorKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
@@ -124,7 +131,7 @@ class RealSyncCodeDispatcher @Inject constructor(
     private fun mapV2PresentEventToOutcome(event: ExchangeV2Event, peerKind: PeerKind?): DispatchOutcome? = when (event) {
         is ExchangeV2Event.SessionStarted -> event.linkingCode?.let { DispatchOutcome.LinkingCodeReady(it) }
         is ExchangeV2Event.Transition -> mapV2Transition(event, peerKind)
-        is ExchangeV2Event.SessionError -> sessionErrorToOutcome(event.message)
+        is ExchangeV2Event.SessionError -> sessionErrorToOutcome(event)
         else -> null
     }
 
@@ -289,7 +296,7 @@ class RealSyncCodeDispatcher @Inject constructor(
 
     private fun mapV2LinkingEventToOutcome(event: ExchangeV2Event, peerKind: PeerKind?): DispatchOutcome? = when (event) {
         is ExchangeV2Event.Transition -> mapV2Transition(event, peerKind)
-        is ExchangeV2Event.SessionError -> sessionErrorToOutcome(event.message)
+        is ExchangeV2Event.SessionError -> sessionErrorToOutcome(event)
         else -> null
     }
 
@@ -317,21 +324,32 @@ class RealSyncCodeDispatcher @Inject constructor(
             is ExchangeV2Message.RecoveryCodeDenied ->
                 DispatchOutcome.Failed("peer_denied_recovery_code", PAIRING_REJECTED.code)
             is ExchangeV2Message.RecoveryCodeUnavailable ->
-                DispatchOutcome.Failed("peer_recovery_code_unavailable", PAIRING_UNAVAILABLE.code)
+                DispatchOutcome.Failed("peer_recovery_code_unavailable", PEER_RECOVERY_CODE_UNAVAILABLE.code)
             else -> DispatchOutcome.Failed("peer_aborted", PAIRING_REJECTED.code)
         }
         ExchangeV2State.Joiner.AbortedLocal -> joinerAbortedLocalToOutcome(transition.localTrigger, transition.trigger)
-        ExchangeV2State.Aborted -> DispatchOutcome.Failed("negotiation_aborted", NEGOTIATION_ABORTED.code)
+        ExchangeV2State.Aborted -> DispatchOutcome.Failed("negotiation_aborted", UNEXPECTED_EVENT.code)
         else -> null
     }
 
-    private fun sessionErrorToOutcome(message: String): DispatchOutcome {
-        val match = VERSION_TOO_NEW_REGEX.find(message)
-        return if (match != null) {
-            DispatchOutcome.UpgradeRequired(codeMajor = match.groupValues[1].toIntOrNull() ?: -1)
-        } else {
-            DispatchOutcome.Failed(message, PAIRING_FAILED.code)
+    private fun sessionErrorToOutcome(event: ExchangeV2Event.SessionError): DispatchOutcome {
+        val match = VERSION_TOO_NEW_REGEX.find(event.message)
+        if (match != null) {
+            return DispatchOutcome.UpgradeRequired(codeMajor = match.groupValues[1].toIntOrNull() ?: -1)
         }
+        // The structured kind lets sync_setup_ended_failed distinguish v2 protocol violations from a
+        // generic transport failure. Unknown falls back to PAIRING_FAILED → transport_failure.
+        val code = when (event.kind) {
+            SessionErrorKind.SessionTimeout -> SESSION_TIMEOUT.code
+            SessionErrorKind.UnexpectedSecondHello -> UNEXPECTED_SECOND_HELLO.code
+            SessionErrorKind.UnexpectedEvent -> UNEXPECTED_EVENT.code
+            SessionErrorKind.PairingSessionNotReady -> PAIRING_SESSION_NOT_READY.code
+            SessionErrorKind.RelayChannelUnavailable -> RELAY_CHANNEL_UNAVAILABLE.code
+            SessionErrorKind.RecoveryCodePreparationFailed -> RECOVERY_CODE_PREPARATION_FAILED.code
+            SessionErrorKind.MalformedRelayRequest -> NEGOTIATION_ABORTED.code
+            SessionErrorKind.Unknown -> PAIRING_FAILED.code
+        }
+        return DispatchOutcome.Failed(event.message, code, timeoutStage = event.timeoutStage)
     }
 
     private fun hostAbortedToOutcome(

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
@@ -824,7 +824,10 @@ class AppSyncAccountRepository @Inject constructor(
                 )
             }
             logcat(ERROR) { "Sync-ScopedToken: /access-credentials/ddg POST failed: ${postResult.reason}" }
-            return postResult.copy(reason = "JoinFrom3party: ${postResult.reason}")
+            return postResult.copy(
+                code = AccountErrorCodes.ACCOUNT_UPGRADE_FAILED.code,
+                reason = "JoinFrom3party: ${postResult.reason}",
+            )
         }
 
         // Step 7 — Native login as the new ddg credential. Required: without a login inside the
@@ -1494,6 +1497,20 @@ enum class AccountErrorCodes(val code: Int) {
     NO_RECOVERY_CODE(62),
     PAIRING_FAILED(63),
     UNEXPECTED_EVENT(64),
+    SESSION_TIMEOUT(65),
+    ACCOUNT_CREATION_FAILED(66),
+    ACCOUNT_UPGRADE_FAILED(67),
+    RECOVERY_CODE_PREPARATION_FAILED(68),
+    MISSING_3PARTY_CREDENTIAL(69),
+    UNDECRYPTABLE_3PARTY_CREDENTIAL(70),
+    ACCOUNT_EXTEND_FAILED(71),
+    MISSING_3PARTY_KEY(72),
+    LOCAL_STORAGE_FAILED(73),
+    PEER_RECOVERY_CODE_UNAVAILABLE(74),
+    ALREADY_PAIRED(75),
+    UNEXPECTED_SECOND_HELLO(76),
+    PAIRING_SESSION_NOT_READY(77),
+    RELAY_CHANNEL_UNAVAILABLE(78),
 }
 
 sealed interface SyncAuthCode {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncCodeDispatcher.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncCodeDispatcher.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.sync.impl
 import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
+import com.duckduckgo.sync.impl.pixels.SyncPixels.TimeoutStage
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -170,5 +171,11 @@ sealed interface DispatchOutcome {
         val path: SetupPath? = null,
         val myRole: SetupRole? = null,
         val peerKind: PeerKind? = null,
+        /**
+         * Populated only when [code] is [AccountErrorCodes.SESSION_TIMEOUT] — identifies which phase
+         * of the flow was in progress at the deadline so the "Setup failed" pixel can split
+         * `reason=session_timeout` by user-facing stage.
+         */
+        val timeoutStage: TimeoutStage? = null,
     ) : DispatchOutcome
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Channel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Channel.kt
@@ -33,6 +33,15 @@ import javax.inject.Inject
  *
  * Spec: Transport TD (Asana 1214486492252757) §BE Relay + §Polling for messages.
  */
+/** Own channel is gone on the relay (HTTP 404/410 on poll). Peer or BE TTL deleted it. */
+class ChannelGone(val status: Int) : RuntimeException("Poll got $status — channel gone")
+
+/** Malformed poll request (HTTP 400). Client-side protocol bug. */
+class PollBadRequest(val status: Int) : RuntimeException("Poll rejected with $status — malformed request")
+
+/** Poll auth/policy failure (HTTP 401/403). Credentials invalidated or server-side policy denied. */
+class PollAuthDenied(val status: Int) : RuntimeException("Poll denied with $status — auth or policy")
+
 interface ExchangeV2Channel {
 
     /**
@@ -52,10 +61,10 @@ interface ExchangeV2Channel {
     ): Result<Unit>
 
     /**
-     * Poll loop on [ownChannelId], emitting decrypted + parsed messages. See spec §Polling.
-     *  - Completes on a non-recoverable HTTP status; transient statuses keep polling.
-     *  - Throws [EnvelopeVersionTooNew] (too-new version) and [EnvelopeDecryptFailure]
-     *    (decrypt failure) as terminal; drops unknown message types (forward-compat).
+     * Poll loop on [ownChannelId], emitting decrypted + parsed messages.
+     *  - Transient statuses (5xx / 429 / network / timeouts) keep polling; the 5-min session timer catches persistent transient failures.
+     *  - Throws [ChannelGone] on 404/410 (channel deleted or TTL'd), [PollBadRequest] on 400, [PollAuthDenied] on 401/403
+     *  - Throws [EnvelopeVersionTooNew] on a too-new envelope and [EnvelopeDecryptFailure] on decrypt failure
      */
     fun poll(ownChannelId: String, ownPrivateKeyBase64: String): Flow<ExchangeV2Message>
 
@@ -103,12 +112,12 @@ class RealExchangeV2Channel @Inject constructor(
                     }
                 }
                 is Result.Error -> {
-                    if (outcome.code in NON_RECOVERABLE_HTTP_CODES) {
-                        // Re-polling won't recover; stop.
-                        logcat { "Sync-ExchangeV2: ending poll on $ownChannelId — non-recoverable status ${outcome.code} (${outcome.reason})" }
-                        return@flow
+                    when (outcome.code) {
+                        404, 410 -> throw ChannelGone(outcome.code)
+                        400 -> throw PollBadRequest(outcome.code)
+                        401, 403 -> throw PollAuthDenied(outcome.code)
+                        else -> logcat(ERROR) { "Sync-ExchangeV2: transient poll error ${outcome.code}: ${outcome.reason}, retrying" }
                     }
-                    logcat(ERROR) { "Sync-ExchangeV2: transient poll error ${outcome.code}: ${outcome.reason}, retrying" }
                 }
             }
             delay(POLL_INTERVAL_MS)
@@ -134,15 +143,5 @@ class RealExchangeV2Channel @Inject constructor(
 
     companion object {
         private const val POLL_INTERVAL_MS: Long = 1_000L
-
-        // Statuses that won't recover by re-polling; transient ones (5xx / 429 / 418 / timeouts)
-        // are deliberately absent so they keep polling.
-        private val NON_RECOVERABLE_HTTP_CODES = setOf(
-            400, // Bad Request — malformed poll
-            401, // Unauthorized
-            403, // Forbidden
-            404, // Not Found — channel gone (the normal end when the peer/server closed it)
-            410, // Gone — channel permanently removed
-        )
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Event.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Event.kt
@@ -16,6 +16,8 @@
 
 package com.duckduckgo.sync.impl.exchange.v2
 
+import com.duckduckgo.sync.impl.pixels.SyncPixels.TimeoutStage
+
 /**
  * Observable events emitted by the v2 exchange runner. Downstream consumers
  * subscribe to the runner's event flow and react.
@@ -54,11 +56,26 @@ sealed interface ExchangeV2Event {
         val linkingCode: String?,
     ) : ExchangeV2Event
 
-    /** A transport or protocol-level failure during bootstrap / poll / send. */
+    /**
+     * A transport or protocol-level failure during bootstrap / poll / send.
+     */
     data class SessionError(
         override val timestampMs: Long,
         val message: String,
+        val kind: SessionErrorKind = SessionErrorKind.Unknown,
+        val timeoutStage: TimeoutStage? = null,
     ) : ExchangeV2Event
 }
 
 enum class RejectReason { ImplicitAbort, SameAccount, UnknownMessageDropped }
+
+enum class SessionErrorKind {
+    SessionTimeout,
+    UnexpectedSecondHello,
+    UnexpectedEvent,
+    PairingSessionNotReady,
+    RelayChannelUnavailable,
+    RecoveryCodePreparationFailed,
+    MalformedRelayRequest,
+    Unknown,
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -195,7 +195,7 @@ class RealExchangeV2Runner @Inject constructor(
             }
             emitSessionStarted()
             if (!sendHello()) {
-                // sendOnWireAndRecord already emitted a SessionError classified by HTTP status
+                // sendHello already emitted a SessionError (incomplete state or HTTP status)
                 cancel()
                 return@launch
             }
@@ -653,10 +653,14 @@ class RealExchangeV2Runner @Inject constructor(
 
     /** Returns true if hello reached the relay; false signals a fatal abort to the caller. */
     private fun sendHello(): Boolean {
-        val own = ownChannelId ?: return false
-        val peer = peerChannelId ?: return false
-        val peerKey = peerPublicKey ?: return false
-        val ourKey = ownKeyPair ?: return false
+        val own = ownChannelId
+        val peer = peerChannelId
+        val peerKey = peerPublicKey
+        val ourKey = ownKeyPair
+        if (own == null || peer == null || peerKey == null || ourKey == null) {
+            emitSessionError("Cannot send hello — pairing session state is incomplete", SessionErrorKind.PairingSessionNotReady)
+            return false
+        }
         val json = JSONObject().apply {
             put("type", "hello")
             put("channel_id", own)

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.Host
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.Joiner
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State.SameAccountAbort
+import com.duckduckgo.sync.impl.pixels.SyncPixels.TimeoutStage
 import com.duckduckgo.sync.store.SyncStore
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
@@ -194,11 +195,8 @@ class RealExchangeV2Runner @Inject constructor(
             }
             emitSessionStarted()
             if (!sendHello()) {
-                // Couldn't reach the Presenter (their channel TTL'd out, or a stale/typo'd code) — abort.
-                failSession(
-                    "Pairing aborted — couldn't reach the Presenter. Their session may have expired (5-min TTL). " +
-                        "Ask them to Start as Presenter again.",
-                )
+                // sendOnWireAndRecord already emitted a SessionError classified by HTTP status
+                cancel()
                 return@launch
             }
             sendOwnAvailability()
@@ -255,13 +253,16 @@ class RealExchangeV2Runner @Inject constructor(
                     if (r.code == HTTP_CONFLICT) {
                         logcat { "Sync-ExchangeV2: channel_id $candidate already taken, retrying (${attempt + 1}/$MAX_CHANNEL_CREATE_RETRIES)" }
                     } else {
-                        emitSessionError("Failed to create channel")
+                        emitSessionError("Failed to create channel", SessionErrorKind.RelayChannelUnavailable)
                         return null
                     }
                 }
             }
         }
-        emitSessionError("Could not allocate unique channel_id after $MAX_CHANNEL_CREATE_RETRIES attempts")
+        emitSessionError(
+            "Could not allocate unique channel_id after $MAX_CHANNEL_CREATE_RETRIES attempts",
+            SessionErrorKind.RelayChannelUnavailable,
+        )
         return null
     }
 
@@ -271,16 +272,33 @@ class RealExchangeV2Runner @Inject constructor(
         withContext(NonCancellable) { mutex.withLock { cancelLocked() } }
     }
 
-    /** Emit one error, then tear down. No-ops if the session already ended, so a late timeout or
-     *  poll error can't surface a spurious error over a completed session. */
-    private suspend fun failSession(reason: String) {
+    /**
+     * Emit one error, then tear down. No-op if the session already ended, so a late timeout or poll error
+     * can't produce an error if a session already completed.
+     */
+    private suspend fun failSession(
+        reason: String,
+        kind: SessionErrorKind = SessionErrorKind.Unknown,
+        timeoutStage: TimeoutStage? = null,
+    ) {
         withContext(NonCancellable) {
             mutex.withLock {
-                if (session == null) return@withLock
-                emitSessionError(reason)
-                cancelLocked()
+                failSessionLocked(reason, kind, timeoutStage)
             }
         }
+    }
+
+    /** Caller MUST hold [mutex]. Same as [failSession] but assumes the lock is already held — call
+     *  this from paths already inside `mutex.withLock` (e.g. [processIncomingLocked]) to avoid the
+     *  non-reentrant `Mutex` deadlocking on itself. */
+    private fun failSessionLocked(
+        reason: String,
+        kind: SessionErrorKind = SessionErrorKind.Unknown,
+        timeoutStage: TimeoutStage? = null,
+    ) {
+        if (session == null) return
+        emitSessionError(reason, kind, timeoutStage)
+        cancelLocked()
     }
 
     /** Caller MUST hold [mutex]. The single teardown path, so field resets can't drift between
@@ -337,6 +355,12 @@ class RealExchangeV2Runner @Inject constructor(
                     "Couldn't decrypt a message from the peer (seq=${decryptFailure.seq}): " +
                         "${decryptFailure.cause?.message}. The keys probably don't match — try restarting pairing.",
                 )
+            } catch (gone: ChannelGone) {
+                failSession("Poll got ${gone.status} — channel gone", SessionErrorKind.RelayChannelUnavailable)
+            } catch (badRequest: PollBadRequest) {
+                failSession("Poll rejected with ${badRequest.status} — malformed request", SessionErrorKind.MalformedRelayRequest)
+            } catch (authDenied: PollAuthDenied) {
+                failSession("Poll denied with ${authDenied.status} — auth or policy", SessionErrorKind.Unknown)
             } catch (cancellation: CancellationException) {
                 throw cancellation // normal teardown (cancel() / scope cancellation) — let it propagate
             } catch (t: Throwable) {
@@ -357,8 +381,21 @@ class RealExchangeV2Runner @Inject constructor(
         timeoutJob = appScope.launch(dispatchers.io()) {
             delay(SESSION_TIMEOUT_MS)
             logcat { "Sync-ExchangeV2: session deadline (${SESSION_TIMEOUT_MS}ms) reached" }
-            failSession("Session timed out")
+            // Capture the phase we were stuck in before failSession() tears the state machine down
+            val stage = mutex.withLock { session?.currentState?.toTimeoutStage() }
+            failSession("Session timed out", kind = SessionErrorKind.SessionTimeout, timeoutStage = stage)
         }
+    }
+
+    /**
+     * Map the state active at the moment the 5-min deadline fires into a [TimeoutStage].
+     */
+    private fun ExchangeV2State.toTimeoutStage(): TimeoutStage? = when (this) {
+        ExchangeV2State.Bootstrapped -> TimeoutStage.WAITING_FOR_PEER_HELLO
+        ExchangeV2State.Negotiating -> TimeoutStage.WAITING_FOR_PEER_STATUS
+        Host.Confirming, Joiner.Confirming -> TimeoutStage.WAITING_FOR_CONFIRMATION
+        Host.Sending, Joiner.Waiting -> TimeoutStage.WAITING_FOR_RECOVERY_CODE
+        else -> null
     }
 
     // -----------------------------------------------------------------------
@@ -373,7 +410,11 @@ class RealExchangeV2Runner @Inject constructor(
 
     private suspend fun processIncomingLocked(message: ExchangeV2Message) {
         val sm = session ?: run {
-            logcat { "Sync-ExchangeV2: deliverIncomingMessage ${message.messageType} ignored — no active session" }
+            logcat { "Sync-ExchangeV2: deliverIncomingMessage ${message.messageType} rejected — no active session" }
+            emitSessionError(
+                "Received ${message.messageType} with no active pairing session",
+                SessionErrorKind.PairingSessionNotReady,
+            )
             return
         }
 
@@ -382,6 +423,13 @@ class RealExchangeV2Runner @Inject constructor(
         if (sm.currentState == ExchangeV2State.Joiner.Confirming && message.isJoinerWaitingPhase()) {
             logcat { "Sync-ExchangeV2: buffering ${message.messageType} (Joiner still in Confirming; will replay after user confirms)" }
             pendingJoinerWaitingMessages.add(message)
+            return
+        }
+
+        // Hello is only valid as the first inbound message. Surface it as UnexpectedSecondHello for a precise error.
+        if (message is ExchangeV2Message.Hello && sm.currentState != ExchangeV2State.Bootstrapped) {
+            logcat { "Sync-ExchangeV2: unexpected hello in state ${sm.currentState} — aborting" }
+            failSessionLocked("Unexpected hello received in state ${sm.currentState}", kind = SessionErrorKind.UnexpectedSecondHello)
             return
         }
 
@@ -685,7 +733,10 @@ class RealExchangeV2Runner @Inject constructor(
                 logcat(ERROR) { "Sync-ExchangeV2: recovery code unavailable for peerKind=$_peerKind: ${codeResult.reason}" }
                 val json = """{"type":"recovery_code_unavailable"}"""
                 sendOnWireAndRecord(json, peer, peerKey, ExchangeV2Message.RecoveryCodeUnavailable(json))
-                emitSessionError("Couldn't generate a recovery code: ${codeResult.reason}")
+                emitSessionError(
+                    "Couldn't generate a recovery code: ${codeResult.reason}",
+                    SessionErrorKind.RecoveryCodePreparationFailed,
+                )
                 false
             }
         }
@@ -743,10 +794,20 @@ class RealExchangeV2Runner @Inject constructor(
                 true
             }
             is Result.Error -> {
-                emitSessionError("Failed to send message to peer over channel")
+                emitSessionError("Failed to send message to peer over channel (${r.code})", r.code.toSendFailureKind())
                 false
             }
         }
+    }
+
+    /**
+     * Map HTTP status returned by [ExchangeV2Channel.sendMessage] into a [SessionErrorKind]
+     * Allows us to differentiate between a peer-channel-gone (404/410), client-side malformed body (400), and a generic transport failure
+     */
+    private fun Int.toSendFailureKind(): SessionErrorKind = when (this) {
+        404, 410 -> SessionErrorKind.RelayChannelUnavailable
+        400 -> SessionErrorKind.MalformedRelayRequest
+        else -> SessionErrorKind.Unknown
     }
 
     override fun recordSentMessage(message: ExchangeV2Message) {
@@ -783,8 +844,12 @@ class RealExchangeV2Runner @Inject constructor(
         emit(ExchangeV2Event.SessionStarted(clock.nowMs(), role, ch, _linkingCode))
     }
 
-    private fun emitSessionError(message: String) {
-        emit(ExchangeV2Event.SessionError(clock.nowMs(), message))
+    private fun emitSessionError(
+        message: String,
+        kind: SessionErrorKind = SessionErrorKind.Unknown,
+        timeoutStage: TimeoutStage? = null,
+    ) {
+        emit(ExchangeV2Event.SessionError(clock.nowMs(), message, kind, timeoutStage))
     }
 
     private fun ExchangeV2State.isTerminal(): Boolean = when (this) {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -45,6 +45,7 @@ import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_PATH
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_PEER_KIND
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_REASON
 import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE
+import com.duckduckgo.sync.impl.pixels.SyncPixelParameters.SYNC_SETUP_TIMEOUT_STAGE
 import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
 import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
 import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
@@ -52,6 +53,7 @@ import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupFailureReason
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
+import com.duckduckgo.sync.impl.pixels.SyncPixels.TimeoutStage
 import com.duckduckgo.sync.impl.stats.SyncStatsRepository
 import com.duckduckgo.sync.store.SharedPrefsProvider
 import com.squareup.anvil.annotations.ContributesBinding
@@ -125,20 +127,25 @@ interface SyncPixels {
     fun fireSyncSetupAbandoned(screenType: ScreenType, reason: CancellationReason? = null)
     fun fireSyncSetupManualCodeScreenShown(screenType: ScreenType)
     fun fireSyncSetupCodePastedParseSuccess(screenType: ScreenType, codeVersion: CodeVersion, codeType: SyncCodeType? = null)
-    fun fireSyncSetupCodePastedParseFailure(screenType: ScreenType)
+    fun fireSyncSetupCodePastedParseFailure(screenType: ScreenType, reason: SetupFailureReason? = null)
     fun fireSyncSetupCodeCopiedToClipboard(screenType: ScreenType)
-    fun fireBarcodeScannerParseError(screenType: ScreenType)
+    fun fireBarcodeScannerParseError(screenType: ScreenType, reason: SetupFailureReason? = null)
     fun fireBarcodeScannerParseSuccess(screenType: ScreenType, codeVersion: CodeVersion, codeType: SyncCodeType? = null)
 
     /**
      * "Setup failed" — a v2 setup that started (code recognized) then failed with an error (not a
-     * user cancellation). [path]/[myRole]/[peerKind] are best-effort and omitted when unknown.
+     * user cancellation). [screenType] identifies the originating screen.
+     * [path]/[myRole]/[peerKind] are best-effort and omitted when unknown.
+     * [timeoutStage] is only meaningful when [reason] is [SetupFailureReason.SESSION_TIMEOUT] and
+     * identifies which phase of the flow was reached at the deadline.
      */
     fun fireSyncSetupFailed(
+        screenType: ScreenType,
         reason: SetupFailureReason,
         path: SetupPath? = null,
         myRole: SetupRole? = null,
         peerKind: PeerKind? = null,
+        timeoutStage: TimeoutStage? = null,
     )
 
     enum class ScreenType(val value: String) {
@@ -181,15 +188,38 @@ interface SyncPixels {
         CANCELLED_BEFORE_FINISHED("cancelled_before_finished"),
     }
 
-    /** Why a v2 setup failed, per the "Setup failed" telemetry. Aligned with the error codes we handle. */
     enum class SetupFailureReason(val value: String) {
-        NEEDS_UPGRADE("needs_upgrade"),
-        ALREADY_UPGRADED("already_upgraded"),
-        INVALID_CREDENTIALS("invalid_credentials"),
-        PAIRING_UNAVAILABLE("pairing_unavailable"),
-        PROTOCOL_ERROR("protocol_error"),
+        SESSION_TIMEOUT("session_timeout"),
         TRANSPORT_FAILURE("transport_failure"),
+        UNRECOGNIZED_CODE("unrecognized_code"),
+        NEEDS_UPGRADE("needs_upgrade"),
+        INCOMPATIBLE_CODE("incompatible_code"),
+        INVALID_CREDENTIALS("invalid_credentials"),
+        ACCOUNT_CREATION_FAILED("account_creation_failed"),
+        ACCOUNT_UPGRADE_FAILED("account_upgrade_failed"),
+        ALREADY_UPGRADED("already_upgraded"),
+        ALREADY_PAIRED("already_paired"),
+        RECOVERY_CODE_PREPARATION_FAILED("recovery_code_preparation_failed"),
+        MISSING_3PARTY_CREDENTIAL("missing_3party_credential"),
+        UNDECRYPTABLE_3PARTY_CREDENTIAL("undecryptable_3party_credential"),
+        ACCOUNT_EXTEND_FAILED("account_extend_failed"),
+        MISSING_3PARTY_KEY("missing_3party_key"),
+        LOCAL_STORAGE_FAILED("local_storage_failed"),
+        PEER_RECOVERY_CODE_UNAVAILABLE("peer_recovery_code_unavailable"),
+        UNEXPECTED_SECOND_HELLO("unexpected_second_hello"),
+        UNEXPECTED_EVENT("unexpected_event"),
+        PAIRING_SESSION_NOT_READY("pairing_session_not_ready"),
+        RELAY_CHANNEL_UNAVAILABLE("relay_channel_unavailable"),
+        PROTOCOL_ERROR("protocol_error"),
         UNEXPECTED_FAILURE("unexpected_failure"),
+    }
+
+    enum class TimeoutStage(val value: String) {
+        WAITING_FOR_PEER_HELLO("waiting_for_peer_hello"),
+        WAITING_FOR_PEER_STATUS("waiting_for_peer_status"),
+        WAITING_FOR_CONFIRMATION("waiting_for_confirmation"),
+        WAITING_FOR_RECOVERY_CODE("waiting_for_recovery_code"),
+        LOGGING_IN("logging_in"),
     }
     fun fireSetupDeepLinkFlowStarted()
     fun fireSetupDeepLinkFlowSuccess()
@@ -534,16 +564,20 @@ class RealSyncPixels @Inject constructor(
     }
 
     override fun fireSyncSetupFailed(
+        screenType: ScreenType,
         reason: SetupFailureReason,
         path: SetupPath?,
         myRole: SetupRole?,
         peerKind: PeerKind?,
+        timeoutStage: TimeoutStage?,
     ) {
         val params = buildMap {
+            put(SYNC_SETUP_SCREEN_TYPE, screenType.value)
             put(SYNC_SETUP_REASON, reason.value)
             if (path != null) put(SYNC_SETUP_PATH, path.value)
             if (myRole != null) put(SYNC_SETUP_MY_ROLE, myRole.value)
             if (peerKind != null) put(SYNC_SETUP_PEER_KIND, peerKind.value)
+            if (timeoutStage != null) put(SYNC_SETUP_TIMEOUT_STAGE, timeoutStage.value)
             putAll(setupFlowMetadata())
         }
         pixel.fire(SyncPixelName.SYNC_SETUP_ENDED_FAILED, parameters = params)
@@ -559,8 +593,12 @@ class RealSyncPixels @Inject constructor(
         pixel.fire(SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_SUCCESS, parameters = params)
     }
 
-    override fun fireSyncSetupCodePastedParseFailure(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value) + setupFlowMetadata()
+    override fun fireSyncSetupCodePastedParseFailure(screenType: ScreenType, reason: SetupFailureReason?) {
+        val params = buildMap {
+            put(SYNC_SETUP_SCREEN_TYPE, screenType.value)
+            if (reason != null) put(SYNC_SETUP_REASON, reason.value)
+            putAll(setupFlowMetadata())
+        }
         pixel.fire(SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_FAILED, parameters = params)
     }
 
@@ -574,8 +612,12 @@ class RealSyncPixels @Inject constructor(
         pixel.fire(SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_SUCCESS, parameters = params)
     }
 
-    override fun fireBarcodeScannerParseError(screenType: ScreenType) {
-        val params = mapOf(SYNC_SETUP_SCREEN_TYPE to screenType.value) + setupFlowMetadata()
+    override fun fireBarcodeScannerParseError(screenType: ScreenType, reason: SetupFailureReason?) {
+        val params = buildMap {
+            put(SYNC_SETUP_SCREEN_TYPE, screenType.value)
+            if (reason != null) put(SYNC_SETUP_REASON, reason.value)
+            putAll(setupFlowMetadata())
+        }
         pixel.fire(SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_FAILED, parameters = params)
     }
 
@@ -787,6 +829,7 @@ object SyncPixelParameters {
     const val SYNC_SETUP_MY_ROLE = "my_role"
     const val SYNC_SETUP_PEER_KIND = "peer_kind"
     const val SYNC_SETUP_REASON = "reason"
+    const val SYNC_SETUP_TIMEOUT_STAGE = "timeout_stage"
     const val CONNECTED_DEVICES_WHEN_DELETING = "connected_devices"
 
     const val AUTO_RESTORE_SOURCE = "source"
@@ -817,18 +860,28 @@ object SyncPixelsRequiringDataCleaning : PixelParamRemovalPlugin {
     }
 }
 
-/**
- * Maps a v2 [com.duckduckgo.sync.impl.DispatchOutcome.Failed] error code to the "Setup failed"
- * telemetry [SetupFailureReason], aligned with the error codes we already handle. Cancellation codes
- * (`PAIRING_CANCELLED`, `PAIRING_REJECTED`) are excluded by the caller, so they fall to the catch-all.
- */
 internal fun Int.toSetupFailureReason(): SetupFailureReason = when (this) {
+    AccountErrorCodes.SESSION_TIMEOUT.code -> SetupFailureReason.SESSION_TIMEOUT
     AccountErrorCodes.THIRD_PARTY_ALREADY_UPGRADED.code -> SetupFailureReason.ALREADY_UPGRADED
+    AccountErrorCodes.ALREADY_PAIRED.code -> SetupFailureReason.ALREADY_PAIRED
     AccountErrorCodes.LOGIN_FAILED.code,
     AccountErrorCodes.INVALID_CODE.code,
     AccountErrorCodes.EXCHANGE_FAILED.code,
     -> SetupFailureReason.INVALID_CREDENTIALS
-    AccountErrorCodes.PAIRING_UNAVAILABLE.code -> SetupFailureReason.PAIRING_UNAVAILABLE
+    AccountErrorCodes.CREATE_ACCOUNT_FAILED.code -> SetupFailureReason.ACCOUNT_CREATION_FAILED
+    AccountErrorCodes.ACCOUNT_UPGRADE_FAILED.code -> SetupFailureReason.ACCOUNT_UPGRADE_FAILED
+    AccountErrorCodes.RECOVERY_CODE_PREPARATION_FAILED.code -> SetupFailureReason.RECOVERY_CODE_PREPARATION_FAILED
+    AccountErrorCodes.MISSING_3PARTY_CREDENTIAL.code -> SetupFailureReason.MISSING_3PARTY_CREDENTIAL
+    AccountErrorCodes.UNDECRYPTABLE_3PARTY_CREDENTIAL.code -> SetupFailureReason.UNDECRYPTABLE_3PARTY_CREDENTIAL
+    AccountErrorCodes.ACCOUNT_EXTEND_FAILED.code -> SetupFailureReason.ACCOUNT_EXTEND_FAILED
+    AccountErrorCodes.MISSING_3PARTY_KEY.code -> SetupFailureReason.MISSING_3PARTY_KEY
+    AccountErrorCodes.LOCAL_STORAGE_FAILED.code -> SetupFailureReason.LOCAL_STORAGE_FAILED
+    AccountErrorCodes.PEER_RECOVERY_CODE_UNAVAILABLE.code -> SetupFailureReason.PEER_RECOVERY_CODE_UNAVAILABLE
+    AccountErrorCodes.UNEXPECTED_SECOND_HELLO.code -> SetupFailureReason.UNEXPECTED_SECOND_HELLO
+    AccountErrorCodes.UNEXPECTED_EVENT.code -> SetupFailureReason.UNEXPECTED_EVENT
+    AccountErrorCodes.PAIRING_SESSION_NOT_READY.code -> SetupFailureReason.PAIRING_SESSION_NOT_READY
+    AccountErrorCodes.RELAY_CHANNEL_UNAVAILABLE.code -> SetupFailureReason.RELAY_CHANNEL_UNAVAILABLE
+    AccountErrorCodes.PAIRING_UNAVAILABLE.code,
     AccountErrorCodes.NEGOTIATION_ABORTED.code,
     AccountErrorCodes.NO_RECOVERY_CODE.code,
     -> SetupFailureReason.PROTOCOL_ERROR
@@ -842,27 +895,39 @@ internal fun Int.toSetupFailureReason(): SetupFailureReason = when (this) {
  * setup errors (the latter pending the cancellation-telemetry follow-up).
  */
 
-internal fun SyncPixels.fireSetupFailed(outcome: DispatchOutcome) {
+internal fun SyncPixels.fireSetupFailed(screenType: ScreenType, outcome: DispatchOutcome) {
     when (outcome) {
         is DispatchOutcome.UpgradeRequired ->
-            fireSyncSetupFailed(SetupFailureReason.NEEDS_UPGRADE, outcome.path, outcome.myRole, outcome.peerKind)
+            fireSyncSetupFailed(screenType, SetupFailureReason.NEEDS_UPGRADE, outcome.path, outcome.myRole, outcome.peerKind)
+        is DispatchOutcome.AlreadyConnected ->
+            // v2 same-account case: both devices exchanged intros and discovered a matching user_id.
+            // Per spec, we report a failed pixel with reason=already_paired even though the user-facing
+            // outcome is a benign "Connected" — the flow did not produce a new pairing.
+            fireSyncSetupFailed(screenType, SetupFailureReason.ALREADY_PAIRED, path = SetupPath.PAIRING)
         is DispatchOutcome.Failed -> {
             if (outcome.code == AccountErrorCodes.PAIRING_CANCELLED.code || outcome.code == AccountErrorCodes.PAIRING_REJECTED.code) {
                 return
             }
-            fireSyncSetupFailed(outcome.code.toSetupFailureReason(), outcome.path, outcome.myRole, outcome.peerKind)
+            fireSyncSetupFailed(
+                screenType,
+                outcome.code.toSetupFailureReason(),
+                outcome.path,
+                outcome.myRole,
+                outcome.peerKind,
+                timeoutStage = outcome.timeoutStage,
+            )
         }
         else -> {}
     }
 }
 
-/**
- * Fire the "Cancellation" pixel (sync_setup_ended_abandoned) when a v2 outcome is this device's own
- * confirmation denial ([AccountErrorCodes.PAIRING_CANCELLED]). Peer denials (`PAIRING_REJECTED`) are
- * intentionally ignored — the peer reports its own cancel. No-op for any other outcome.
- */
-internal fun SyncPixels.fireSetupCancelledIfDenied(outcome: DispatchOutcome, screenType: SyncPixels.ScreenType) {
-    if (outcome is DispatchOutcome.Failed && outcome.code == AccountErrorCodes.PAIRING_CANCELLED.code) {
+// Both devices fire the "abandoned" pixel on a v2 confirmation denial — from each device's POV the
+// setup ended via denial. PAIRING_CANCELLED is this device's own denial; PAIRING_REJECTED is the peer's
+// denial received on the wire.
+internal fun SyncPixels.fireSetupCancelledIfDenied(outcome: DispatchOutcome, screenType: ScreenType) {
+    if (outcome is DispatchOutcome.Failed &&
+        (outcome.code == AccountErrorCodes.PAIRING_CANCELLED.code || outcome.code == AccountErrorCodes.PAIRING_REJECTED.code)
+    ) {
         fireSyncSetupAbandoned(screenType, CancellationReason.CONFIRMATION_DENIED)
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/pixels/SyncPixels.kt
@@ -924,7 +924,7 @@ internal fun SyncPixels.fireSetupFailed(screenType: ScreenType, outcome: Dispatc
 // Both devices fire the "abandoned" pixel on a v2 confirmation denial — from each device's POV the
 // setup ended via denial. PAIRING_CANCELLED is this device's own denial; PAIRING_REJECTED is the peer's
 // denial received on the wire.
-internal fun SyncPixels.fireSetupCancelledIfDenied(outcome: DispatchOutcome, screenType: ScreenType) {
+internal fun SyncPixels.fireSetupCancelledIfDenied(screenType: ScreenType, outcome: DispatchOutcome) {
     if (outcome is DispatchOutcome.Failed &&
         (outcome.code == AccountErrorCodes.PAIRING_CANCELLED.code || outcome.code == AccountErrorCodes.PAIRING_REJECTED.code)
     ) {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
@@ -157,7 +157,7 @@ class EnterCodeViewModel @Inject constructor(
         previousPrimaryKey: String,
     ) {
         syncPixels.fireSetupFailed(codeType.asScreenType(), outcome)
-        syncPixels.fireSetupCancelledIfDenied(outcome, codeType.asScreenType())
+        syncPixels.fireSetupCancelledIfDenied(codeType.asScreenType(), outcome)
         when (outcome) {
             is DispatchOutcome.LoggedIn -> onLoginSuccess(previousPrimaryKey, outcome.path, outcome.myRole, outcome.peerKind)
             is DispatchOutcome.AlreadyConnected -> {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/EnterCodeViewModel.kt
@@ -49,6 +49,7 @@ import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
+import com.duckduckgo.sync.impl.pixels.fireSetupCancelledIfDenied
 import com.duckduckgo.sync.impl.pixels.fireSetupFailed
 import com.duckduckgo.sync.impl.ui.EnterCodeActivity.Companion.Code
 import com.duckduckgo.sync.impl.ui.EnterCodeViewModel.Command.AskToSwitchAccount
@@ -155,7 +156,8 @@ class EnterCodeViewModel @Inject constructor(
         outcome: DispatchOutcome,
         previousPrimaryKey: String,
     ) {
-        syncPixels.fireSetupFailed(outcome)
+        syncPixels.fireSetupFailed(codeType.asScreenType(), outcome)
+        syncPixels.fireSetupCancelledIfDenied(outcome, codeType.asScreenType())
         when (outcome) {
             is DispatchOutcome.LoggedIn -> onLoginSuccess(previousPrimaryKey, outcome.path, outcome.myRole, outcome.peerKind)
             is DispatchOutcome.AlreadyConnected -> {
@@ -316,7 +318,10 @@ class EnterCodeViewModel @Inject constructor(
 
     private fun SyncAuthCode.onCodePasted() {
         when (this) {
-            is SyncAuthCode.Unknown -> syncPixels.fireSyncSetupCodePastedParseFailure(codeType.asScreenType())
+            is SyncAuthCode.Unknown -> syncPixels.fireSyncSetupCodePastedParseFailure(
+                codeType.asScreenType(),
+                reason = SyncPixels.SetupFailureReason.UNRECOGNIZED_CODE,
+            )
             else -> syncPixels.fireSyncSetupCodePastedParseSuccess(codeType.asScreenType(), CodeVersion.V1)
         }
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
@@ -146,7 +146,7 @@ class SyncConnectViewModel @Inject constructor(
     /** Map one v2 [DispatchOutcome] onto this VM's command pipeline. Shared by the Presenter and Scanner paths. */
     private suspend fun handleV2Outcome(outcome: DispatchOutcome) {
         syncPixels.fireSetupFailed(SYNC_CONNECT, outcome)
-        syncPixels.fireSetupCancelledIfDenied(outcome, SYNC_CONNECT)
+        syncPixels.fireSetupCancelledIfDenied(SYNC_CONNECT, outcome)
         when (outcome) {
             is DispatchOutcome.LinkingCodeReady -> renderV2QrCode(outcome.linkingCode)
             is DispatchOutcome.HostConfirmationRequested -> command.send(Command.AskHostConfirmation(outcome.peerName, outcome.peerKind))

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModel.kt
@@ -53,6 +53,7 @@ import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
 import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
 import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_CONNECT
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupFailureReason
 import com.duckduckgo.sync.impl.pixels.fireSetupCancelledIfDenied
 import com.duckduckgo.sync.impl.pixels.fireSetupFailed
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Command.FinishWithError
@@ -144,7 +145,7 @@ class SyncConnectViewModel @Inject constructor(
 
     /** Map one v2 [DispatchOutcome] onto this VM's command pipeline. Shared by the Presenter and Scanner paths. */
     private suspend fun handleV2Outcome(outcome: DispatchOutcome) {
-        syncPixels.fireSetupFailed(outcome)
+        syncPixels.fireSetupFailed(SYNC_CONNECT, outcome)
         syncPixels.fireSetupCancelledIfDenied(outcome, SYNC_CONNECT)
         when (outcome) {
             is DispatchOutcome.LinkingCodeReady -> renderV2QrCode(outcome.linkingCode)
@@ -338,7 +339,7 @@ class SyncConnectViewModel @Inject constructor(
 
     private fun SyncAuthCode.onCodeScanned() {
         when (this) {
-            is Unknown -> syncPixels.fireBarcodeScannerParseError(SYNC_CONNECT)
+            is Unknown -> syncPixels.fireBarcodeScannerParseError(SYNC_CONNECT, reason = SetupFailureReason.UNRECOGNIZED_CODE)
             else -> syncPixels.fireBarcodeScannerParseSuccess(SYNC_CONNECT, CodeVersion.V1)
         }
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
@@ -133,7 +133,7 @@ class SyncLoginViewModel @Inject constructor(
     /** Map one v2 [DispatchOutcome] onto this VM's existing command pipeline. */
     private suspend fun handleV2Outcome(outcome: DispatchOutcome) {
         syncPixels.fireSetupFailed(SYNC_EXCHANGE, outcome)
-        syncPixels.fireSetupCancelledIfDenied(outcome, SYNC_EXCHANGE)
+        syncPixels.fireSetupCancelledIfDenied(SYNC_EXCHANGE, outcome)
         when (outcome) {
             is DispatchOutcome.LoggedIn -> {
                 syncPixels.fireLoginPixel()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncLoginViewModel.kt
@@ -42,6 +42,8 @@ import com.duckduckgo.sync.impl.onFailure
 import com.duckduckgo.sync.impl.onSuccess
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
+import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_EXCHANGE
+import com.duckduckgo.sync.impl.pixels.fireSetupCancelledIfDenied
 import com.duckduckgo.sync.impl.pixels.fireSetupFailed
 import com.duckduckgo.sync.impl.ui.SyncConnectViewModel.Companion.POLLING_INTERVAL_EXCHANGE_FLOW
 import com.duckduckgo.sync.impl.ui.SyncLoginViewModel.Command.LoginSucess
@@ -130,7 +132,8 @@ class SyncLoginViewModel @Inject constructor(
 
     /** Map one v2 [DispatchOutcome] onto this VM's existing command pipeline. */
     private suspend fun handleV2Outcome(outcome: DispatchOutcome) {
-        syncPixels.fireSetupFailed(outcome)
+        syncPixels.fireSetupFailed(SYNC_EXCHANGE, outcome)
+        syncPixels.fireSetupCancelledIfDenied(outcome, SYNC_EXCHANGE)
         when (outcome) {
             is DispatchOutcome.LoggedIn -> {
                 syncPixels.fireLoginPixel()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
@@ -53,6 +53,7 @@ import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
 import com.duckduckgo.sync.impl.pixels.SyncPixels.CodeVersion
 import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_EXCHANGE
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupFailureReason
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
 import com.duckduckgo.sync.impl.pixels.fireSetupCancelledIfDenied
@@ -293,7 +294,7 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
         outcome: DispatchOutcome,
         previousPrimaryKey: String,
     ) {
-        syncPixels.fireSetupFailed(outcome)
+        syncPixels.fireSetupFailed(SYNC_EXCHANGE, outcome)
         syncPixels.fireSetupCancelledIfDenied(outcome, SYNC_EXCHANGE)
         // Cancel the deep-link timeout only on terminal outcomes; keep it running across confirmation prompts.
         when (outcome) {
@@ -487,7 +488,7 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
         if (isDeepLink) return
 
         when (this) {
-            is Unknown -> syncPixels.fireBarcodeScannerParseError(SYNC_EXCHANGE)
+            is Unknown -> syncPixels.fireBarcodeScannerParseError(SYNC_EXCHANGE, reason = SetupFailureReason.UNRECOGNIZED_CODE)
             else -> syncPixels.fireBarcodeScannerParseSuccess(SYNC_EXCHANGE, CodeVersion.V1)
         }
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncWithAnotherActivityViewModel.kt
@@ -295,7 +295,7 @@ class SyncWithAnotherActivityViewModel @Inject constructor(
         previousPrimaryKey: String,
     ) {
         syncPixels.fireSetupFailed(SYNC_EXCHANGE, outcome)
-        syncPixels.fireSetupCancelledIfDenied(outcome, SYNC_EXCHANGE)
+        syncPixels.fireSetupCancelledIfDenied(SYNC_EXCHANGE, outcome)
         // Cancel the deep-link timeout only on terminal outcomes; keep it running across confirmation prompts.
         when (outcome) {
             is DispatchOutcome.LoggedIn -> {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/RealSyncCodeDispatcherTest.kt
@@ -29,6 +29,9 @@ import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
 import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_FAILED
 import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_REJECTED
 import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_UNAVAILABLE
+import com.duckduckgo.sync.impl.AccountErrorCodes.PEER_RECOVERY_CODE_UNAVAILABLE
+import com.duckduckgo.sync.impl.AccountErrorCodes.RECOVERY_CODE_PREPARATION_FAILED
+import com.duckduckgo.sync.impl.AccountErrorCodes.SESSION_TIMEOUT
 import com.duckduckgo.sync.impl.AccountErrorCodes.UNEXPECTED_EVENT
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2CodeParseResult
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Event
@@ -38,6 +41,7 @@ import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2Runner
 import com.duckduckgo.sync.impl.exchange.v2.ExchangeV2State
 import com.duckduckgo.sync.impl.exchange.v2.LocalTrigger
 import com.duckduckgo.sync.impl.exchange.v2.PairingRole
+import com.duckduckgo.sync.impl.exchange.v2.SessionErrorKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.PeerKind
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
 import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupRole
@@ -778,6 +782,41 @@ class RealSyncCodeDispatcherTest {
         }
     }
 
+    @Test fun `Presenter maps a RecoveryCodePreparationFailed-kind SessionError to Failed with RECOVERY_CODE_PREPARATION_FAILED code`() = runTest {
+        dispatcher.presentV2().test {
+            runnerEventsFlow.emit(
+                ExchangeV2Event.SessionError(
+                    timestampMs = System.currentTimeMillis(),
+                    message = "Couldn't generate a recovery code: boom",
+                    kind = SessionErrorKind.RecoveryCodePreparationFailed,
+                ),
+            )
+            assertEquals(
+                DispatchOutcome.Failed(
+                    "Couldn't generate a recovery code: boom",
+                    RECOVERY_CODE_PREPARATION_FAILED.code,
+                    path = SetupPath.PAIRING,
+                ),
+                awaitItem(),
+            )
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test fun `Presenter maps a SessionTimeout-kind SessionError to Failed with SESSION_TIMEOUT code`() = runTest {
+        dispatcher.presentV2().test {
+            runnerEventsFlow.emit(
+                ExchangeV2Event.SessionError(
+                    timestampMs = System.currentTimeMillis(),
+                    message = "Session timed out",
+                    kind = SessionErrorKind.SessionTimeout,
+                ),
+            )
+            assertEquals(DispatchOutcome.Failed("Session timed out", SESSION_TIMEOUT.code, path = SetupPath.PAIRING), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
     @Test fun `Presenter emits Failed when Joiner_Done arrives without a recovery code`() = runTest {
         dispatcher.presentV2().test {
             runnerEventsFlow.emit(transition(from = ExchangeV2State.Joiner.Waiting, to = ExchangeV2State.Joiner.Done))
@@ -1083,7 +1122,7 @@ class RealSyncCodeDispatcherTest {
         }
     }
 
-    @Test fun `Scanner - Joiner_AbortedByHost with RecoveryCodeUnavailable maps to Failed PAIRING_UNAVAILABLE`() = runTest {
+    @Test fun `Scanner - Joiner_AbortedByHost with RecoveryCodeUnavailable maps to Failed PEER_RECOVERY_CODE_UNAVAILABLE`() = runTest {
         startLinking().test {
             runnerEventsFlow.emit(
                 transition(
@@ -1092,7 +1131,7 @@ class RealSyncCodeDispatcherTest {
                     trigger = ExchangeV2Message.RecoveryCodeUnavailable(rawJson = "{}"),
                 ),
             )
-            assertEquals(PAIRING_UNAVAILABLE.code, (awaitItem() as DispatchOutcome.Failed).code)
+            assertEquals(PEER_RECOVERY_CODE_UNAVAILABLE.code, (awaitItem() as DispatchOutcome.Failed).code)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -1139,10 +1178,10 @@ class RealSyncCodeDispatcherTest {
         }
     }
 
-    @Test fun `Scanner - Aborted maps to Failed NEGOTIATION_ABORTED`() = runTest {
+    @Test fun `Scanner - Aborted maps to Failed UNEXPECTED_EVENT`() = runTest {
         startLinking().test {
             runnerEventsFlow.emit(transition(from = ExchangeV2State.Negotiating, to = ExchangeV2State.Aborted))
-            assertEquals(NEGOTIATION_ABORTED.code, (awaitItem() as DispatchOutcome.Failed).code)
+            assertEquals(UNEXPECTED_EVENT.code, (awaitItem() as DispatchOutcome.Failed).code)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2ChannelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2ChannelTest.kt
@@ -20,7 +20,8 @@ import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncApi
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert.assertTrue
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
@@ -40,27 +41,55 @@ class RealExchangeV2ChannelTest {
         messageParser = messageParser,
     )
 
-    @Test fun `poll stops without retrying when the relay returns a non-recoverable status`() = runTest {
+    @Test fun `poll throws PollAuthDenied on 403 without retrying`() = runTest {
         whenever(syncApi.pollExchangeMessages(any(), any())).thenReturn(
             Result.Error(code = 403, reason = "Forbidden"),
             Result.Error(code = 404, reason = "should not be reached"),
         )
 
-        val received = channel.poll("own-channel", "own-priv").toList()
+        var thrown: PollAuthDenied? = null
+        try { channel.poll("own-channel", "own-priv").toList() } catch (e: PollAuthDenied) { thrown = e }
 
-        assertTrue(received.isEmpty())
+        assertNotNull(thrown)
+        assertEquals(403, thrown!!.status)
         verify(syncApi, times(1)).pollExchangeMessages(any(), any())
     }
 
-    @Test fun `poll keeps polling after a transient status and ends on 404`() = runTest {
+    @Test fun `poll throws PollBadRequest on 400 without retrying`() = runTest {
+        whenever(syncApi.pollExchangeMessages(any(), any())).thenReturn(
+            Result.Error(code = 400, reason = "Bad Request"),
+        )
+
+        var thrown: PollBadRequest? = null
+        try { channel.poll("own-channel", "own-priv").toList() } catch (e: PollBadRequest) { thrown = e }
+
+        assertNotNull(thrown)
+        assertEquals(400, thrown!!.status)
+    }
+
+    @Test fun `poll keeps polling after a transient status and throws ChannelGone on 404`() = runTest {
         whenever(syncApi.pollExchangeMessages(any(), any())).thenReturn(
             Result.Error(code = 500, reason = "Server error"),
             Result.Error(code = 404, reason = "channel gone"),
         )
 
-        val received = channel.poll("own-channel", "own-priv").toList()
+        var thrown: ChannelGone? = null
+        try { channel.poll("own-channel", "own-priv").toList() } catch (e: ChannelGone) { thrown = e }
 
-        assertTrue(received.isEmpty())
+        assertNotNull(thrown)
+        assertEquals(404, thrown!!.status)
         verify(syncApi, times(2)).pollExchangeMessages(any(), any())
+    }
+
+    @Test fun `poll throws ChannelGone on 410`() = runTest {
+        whenever(syncApi.pollExchangeMessages(any(), any())).thenReturn(
+            Result.Error(code = 410, reason = "Gone"),
+        )
+
+        var thrown: ChannelGone? = null
+        try { channel.poll("own-channel", "own-priv").toList() } catch (e: ChannelGone) { thrown = e }
+
+        assertNotNull(thrown)
+        assertEquals(410, thrown!!.status)
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -33,7 +33,9 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertSame
 import org.junit.Assert.assertTrue
@@ -130,11 +132,12 @@ class RealExchangeV2RunnerTest {
         }
     }
 
-    @Test fun `deliverIncomingMessage without a session is a no-op`() = runTest {
+    @Test fun `deliverIncomingMessage without a session emits PairingSessionNotReady`() = runTest {
         val runner = newRunner()
-        runner.events.test {
+        runner.events.filterIsInstance<ExchangeV2Event.SessionError>().test {
             runner.deliverIncomingMessage(Hello("{}"))
-            expectNoEvents()
+            val event = awaitItem()
+            assertEquals(SessionErrorKind.PairingSessionNotReady, event.kind)
         }
     }
 
@@ -395,15 +398,15 @@ class RealExchangeV2RunnerTest {
         assertSame(ExchangeV2State.Host.Confirming, runner.currentState)
     }
 
-    @Test fun `Scanner hello during negotiating aborts and tears down the session`() = runTest {
+    @Test fun `Scanner hello during negotiating emits UnexpectedSecondHello SessionError and tears down`() = runTest {
         whenever(syncStore.userId).thenReturn("my-user")
         val runner = newRunner()
         runner.startScan("")
 
-        runner.events.filterIsInstance<ExchangeV2Event.Transition>().test {
+        runner.events.filterIsInstance<ExchangeV2Event.SessionError>().test {
             runner.deliverIncomingMessage(Hello("{}"))
             val event = awaitItem()
-            assertSame(ExchangeV2State.Aborted, event.to)
+            assertSame(SessionErrorKind.UnexpectedSecondHello, event.kind)
         }
         assertNull(runner.currentState)
     }
@@ -458,10 +461,14 @@ class RealExchangeV2RunnerTest {
 
         advanceTimeBy(6 * 60 * 1000L) // past the 5-min session deadline
 
-        val timedOut = runner.events.replayCache
-            .filterIsInstance<ExchangeV2Event.SessionError>()
-            .any { it.message.contains("timed out", ignoreCase = true) }
-        assertTrue("expected a 'timed out' SessionError", timedOut)
+        val sessionErrors = runner.events.replayCache.filterIsInstance<ExchangeV2Event.SessionError>()
+        val timedOut = sessionErrors.singleOrNull { it.message.contains("timed out", ignoreCase = true) }
+        assertNotNull("expected a 'timed out' SessionError", timedOut)
+        assertEquals(
+            "deadline timeouts must carry the SessionTimeout kind so the consumer can map them to SESSION_TIMEOUT.code",
+            SessionErrorKind.SessionTimeout,
+            timedOut!!.kind,
+        )
         assertNull(runner.currentState)
     }
 
@@ -492,10 +499,15 @@ class RealExchangeV2RunnerTest {
         val runner = newRunner()
         runner.startPresent()
 
-        val errored = runner.events.replayCache
+        val pollError = runner.events.replayCache
             .filterIsInstance<ExchangeV2Event.SessionError>()
-            .any { it.message.contains("boom") }
-        assertTrue("expected a SessionError from the failed poll loop", errored)
+            .singleOrNull { it.message.contains("boom") }
+        assertNotNull("expected a SessionError from the failed poll loop", pollError)
+        assertEquals(
+            "non-timeout SessionErrors must keep the default Unknown kind so they continue to map to PAIRING_FAILED.code",
+            SessionErrorKind.Unknown,
+            pollError!!.kind,
+        )
         assertNull(runner.currentState)
     }
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
@@ -494,8 +494,8 @@ class RealSyncPixelsTest {
         syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
 
         testee.fireSetupCancelledIfDenied(
-            DispatchOutcome.Failed(reason = "user_denied", code = AccountErrorCodes.PAIRING_CANCELLED.code),
             ScreenType.SYNC_CONNECT,
+            DispatchOutcome.Failed(reason = "user_denied", code = AccountErrorCodes.PAIRING_CANCELLED.code),
         )
 
         verify(pixel).fire(
@@ -514,8 +514,8 @@ class RealSyncPixelsTest {
         syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
 
         testee.fireSetupCancelledIfDenied(
-            DispatchOutcome.Failed(reason = "peer", code = AccountErrorCodes.PAIRING_REJECTED.code),
             ScreenType.SYNC_EXCHANGE,
+            DispatchOutcome.Failed(reason = "peer", code = AccountErrorCodes.PAIRING_REJECTED.code),
         )
 
         verify(pixel).fire(
@@ -532,8 +532,8 @@ class RealSyncPixelsTest {
     @Test
     fun whenFireSetupCancelledIfDeniedForNonCancellationOutcomeThenNotFired() {
         testee.fireSetupCancelledIfDenied(
-            DispatchOutcome.Failed(reason = "boom", code = AccountErrorCodes.PAIRING_FAILED.code),
             ScreenType.SYNC_CONNECT,
+            DispatchOutcome.Failed(reason = "boom", code = AccountErrorCodes.PAIRING_FAILED.code),
         )
 
         verifyNoInteractions(pixel)

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/pixels/SyncPixelsTest.kt
@@ -359,10 +359,11 @@ class RealSyncPixelsTest {
     }
 
     @Test
-    fun whenSetupFailedWithAllDimsThenPixelFiredWithReasonPathRoleAndPeer() {
+    fun whenSyncSetupFailedWithPathRolePeerKindThenAllIncludedInPixel() {
         syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
 
         testee.fireSyncSetupFailed(
+            ScreenType.SYNC_CONNECT,
             SetupFailureReason.TRANSPORT_FAILURE,
             SetupPath.PAIRING,
             SetupRole.JOINER,
@@ -372,6 +373,7 @@ class RealSyncPixelsTest {
         verify(pixel).fire(
             SyncPixelName.SYNC_SETUP_ENDED_FAILED,
             mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
                 SyncPixelParameters.SYNC_SETUP_REASON to "transport_failure",
                 SyncPixelParameters.SYNC_SETUP_PATH to "pairing",
                 SyncPixelParameters.SYNC_SETUP_MY_ROLE to "joiner",
@@ -383,14 +385,15 @@ class RealSyncPixelsTest {
     }
 
     @Test
-    fun whenSetupFailedWithReasonOnlyThenOptionalDimsOmitted() {
+    fun whenSyncSetupFailedWithoutPathRolePeerKindThenThoseParamsOmitted() {
         syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
 
-        testee.fireSyncSetupFailed(SetupFailureReason.UNEXPECTED_FAILURE)
+        testee.fireSyncSetupFailed(ScreenType.SYNC_EXCHANGE, SetupFailureReason.UNEXPECTED_FAILURE)
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SETUP_ENDED_FAILED,
             mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
                 SyncPixelParameters.SYNC_SETUP_REASON to "unexpected_failure",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
                 SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
@@ -402,11 +405,15 @@ class RealSyncPixelsTest {
     fun whenFireSetupFailedForUpgradeRequiredThenNeedsUpgrade() {
         syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
 
-        testee.fireSetupFailed(DispatchOutcome.UpgradeRequired(codeMajor = 3, path = SetupPath.PAIRING, myRole = SetupRole.HOST))
+        testee.fireSetupFailed(
+            ScreenType.SYNC_CONNECT,
+            DispatchOutcome.UpgradeRequired(codeMajor = 3, path = SetupPath.PAIRING, myRole = SetupRole.HOST),
+        )
 
         verify(pixel).fire(
             SyncPixelName.SYNC_SETUP_ENDED_FAILED,
             mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
                 SyncPixelParameters.SYNC_SETUP_REASON to "needs_upgrade",
                 SyncPixelParameters.SYNC_SETUP_PATH to "pairing",
                 SyncPixelParameters.SYNC_SETUP_MY_ROLE to "host",
@@ -421,6 +428,7 @@ class RealSyncPixelsTest {
         syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
 
         testee.fireSetupFailed(
+            ScreenType.SYNC_EXCHANGE,
             DispatchOutcome.Failed(
                 reason = "boom",
                 code = AccountErrorCodes.INVALID_CODE.code,
@@ -431,6 +439,7 @@ class RealSyncPixelsTest {
         verify(pixel).fire(
             SyncPixelName.SYNC_SETUP_ENDED_FAILED,
             mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
                 SyncPixelParameters.SYNC_SETUP_REASON to "invalid_credentials",
                 SyncPixelParameters.SYNC_SETUP_PATH to "recovery",
                 SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
@@ -441,8 +450,8 @@ class RealSyncPixelsTest {
 
     @Test
     fun whenFireSetupFailedForCancellationCodesThenPixelNotFired() {
-        testee.fireSetupFailed(DispatchOutcome.Failed(reason = "user", code = AccountErrorCodes.PAIRING_CANCELLED.code))
-        testee.fireSetupFailed(DispatchOutcome.Failed(reason = "peer", code = AccountErrorCodes.PAIRING_REJECTED.code))
+        testee.fireSetupFailed(ScreenType.SYNC_CONNECT, DispatchOutcome.Failed(reason = "user", code = AccountErrorCodes.PAIRING_CANCELLED.code))
+        testee.fireSetupFailed(ScreenType.SYNC_CONNECT, DispatchOutcome.Failed(reason = "peer", code = AccountErrorCodes.PAIRING_REJECTED.code))
 
         verifyNoInteractions(pixel)
     }
@@ -501,11 +510,27 @@ class RealSyncPixelsTest {
     }
 
     @Test
-    fun whenFireSetupCancelledIfDeniedForPeerRejectionOrOtherThenNotFired() {
+    fun whenFireSetupCancelledIfDeniedForPeerRejectionThenAbandonedFired() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
         testee.fireSetupCancelledIfDenied(
             DispatchOutcome.Failed(reason = "peer", code = AccountErrorCodes.PAIRING_REJECTED.code),
-            ScreenType.SYNC_CONNECT,
+            ScreenType.SYNC_EXCHANGE,
         )
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_ABANDONED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_REASON to "sync_confirmation_denied",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSetupCancelledIfDeniedForNonCancellationOutcomeThenNotFired() {
         testee.fireSetupCancelledIfDenied(
             DispatchOutcome.Failed(reason = "boom", code = AccountErrorCodes.PAIRING_FAILED.code),
             ScreenType.SYNC_CONNECT,
@@ -608,6 +633,184 @@ class RealSyncPixelsTest {
         testee.fireAiChatsRescopeTokenError(error)
 
         verifyNoInteractions(pixel)
+    }
+
+    @Test
+    fun whenBarcodeScannerParseErrorWithReasonThenPixelFiredWithReason() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireBarcodeScannerParseError(ScreenType.SYNC_CONNECT, reason = SetupFailureReason.UNRECOGNIZED_CODE)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_BARCODE_SCANNER_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_REASON to "unrecognized_code",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenManualCodeEnteredFailureWithReasonThenPixelFiredWithReason() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSyncSetupCodePastedParseFailure(ScreenType.SYNC_EXCHANGE, reason = SetupFailureReason.UNRECOGNIZED_CODE)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_MANUAL_CODE_ENTERED_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_REASON to "unrecognized_code",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSetupFailedForSessionTimeoutCodeThenSessionTimeoutReason() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSetupFailed(
+            ScreenType.SYNC_EXCHANGE,
+            DispatchOutcome.Failed(reason = "Session timed out", code = AccountErrorCodes.SESSION_TIMEOUT.code),
+        )
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_REASON to "session_timeout",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSetupFailedForCreateAccountFailedCodeThenAccountCreationFailedReason() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSetupFailed(
+            ScreenType.SYNC_CONNECT,
+            DispatchOutcome.Failed(reason = "create_account_failed", code = AccountErrorCodes.CREATE_ACCOUNT_FAILED.code),
+        )
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_REASON to "account_creation_failed",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSetupFailedForAccountUpgradeFailedCodeThenAccountUpgradeFailedReason() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSetupFailed(
+            ScreenType.SYNC_EXCHANGE,
+            DispatchOutcome.Failed(reason = "upgrade_failed", code = AccountErrorCodes.ACCOUNT_UPGRADE_FAILED.code),
+        )
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_REASON to "account_upgrade_failed",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSetupFailedForAlreadyPairedCodeThenAlreadyPairedReason() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSetupFailed(
+            ScreenType.SYNC_EXCHANGE,
+            DispatchOutcome.Failed(reason = "same_account", code = AccountErrorCodes.ALREADY_PAIRED.code),
+        )
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_REASON to "already_paired",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSetupFailedForAlreadyConnectedOutcomeThenAlreadyPairedReasonWithPairingPath() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        // v2 same-account case: both peers exchange intros and discover a matching user_id
+        testee.fireSetupFailed(ScreenType.SYNC_CONNECT, DispatchOutcome.AlreadyConnected)
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "connect",
+                SyncPixelParameters.SYNC_SETUP_REASON to "already_paired",
+                SyncPixelParameters.SYNC_SETUP_PATH to "pairing",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSetupFailedWithTimeoutStageThenPixelIncludesTimeoutStageParam() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSetupFailed(
+            ScreenType.SYNC_EXCHANGE,
+            DispatchOutcome.Failed(
+                reason = "Session timed out",
+                code = AccountErrorCodes.SESSION_TIMEOUT.code,
+                timeoutStage = SyncPixels.TimeoutStage.WAITING_FOR_CONFIRMATION,
+            ),
+        )
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_REASON to "session_timeout",
+                SyncPixelParameters.SYNC_SETUP_TIMEOUT_STAGE to "waiting_for_confirmation",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
+    }
+
+    @Test
+    fun whenFireSetupFailedForPairingUnavailableCodeThenProtocolErrorReason() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+
+        testee.fireSetupFailed(
+            ScreenType.SYNC_EXCHANGE,
+            DispatchOutcome.Failed(reason = "pairing_unavailable", code = AccountErrorCodes.PAIRING_UNAVAILABLE.code),
+        )
+
+        verify(pixel).fire(
+            SyncPixelName.SYNC_SETUP_ENDED_FAILED,
+            mapOf(
+                SyncPixelParameters.SYNC_SETUP_SCREEN_TYPE to "exchange",
+                SyncPixelParameters.SYNC_SETUP_REASON to "protocol_error",
+                SyncPixelParameters.SYNC_SETUP_FLOW_VERSION to "v2",
+                SyncPixelParameters.SYNC_SETUP_MY_KIND to "ddg",
+            ),
+        )
     }
 
     private fun givenSomeDailyStats(): DailyStats {

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncConnectViewModelTest.kt
@@ -783,10 +783,12 @@ class SyncConnectViewModelTest {
         }
 
         verify(syncPixels).fireSyncSetupFailed(
-            eq(SetupFailureReason.TRANSPORT_FAILURE),
-            eq(SetupPath.PAIRING),
-            isNull(),
-            isNull(),
+            screenType = eq(SYNC_CONNECT),
+            reason = eq(SetupFailureReason.TRANSPORT_FAILURE),
+            path = eq(SetupPath.PAIRING),
+            myRole = isNull(),
+            peerKind = isNull(),
+            timeoutStage = isNull(),
         )
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1216244452632489?focus=true
Tech Design URL (if applicable): 

### Description

Adds granular `reason` classification to the v2 sync setup failure pixels, matching the canonical vocabulary in the [[Exchange V2 Unified Algorithm spec](https://app.asana.com/1/137249556945/task/1214739740392701)](https://app.asana.com/1/137249556945/task/1214739740392701).

Previously `sync_setup_ended_failed` was emitted with only broad reasons (`transport_failure`, `unexpected_failure`), making it hard to tell a benign network blip from a protocol violation or a peer-side problem. 

This PR:

- Adds `SessionErrorKind` on `ExchangeV2Event.SessionError` so the runner classifies transport, protocol, and preparation errors distinctly at the source.
- Extends the `sync_setup_ended_failed` enum with the spec's canonical reasons
- Adds a `timeout_stage` parameter to `sync_setup_ended_failed`, sent only when `reason=session_timeout`
- Adds a `reason` parameter to the parse-error pixels

### Steps to test this PR

> [!NOTE]
> Requires the Python pairing reference client for the broken-mode scenarios.

**Logcat filter (Android Studio format):**
```
message~:"Pixel sent: sync_setup"
```

For each scenario below, start with no existing sync account.

#### 1. `unrecognized_code` — simplest, no companion client needed

Verifies the new `reason` parameter on the manual-code parse-error pixel.

- [x] On Android: Sync settings → Sync With Another Device → **Manually Enter Code**.
- [x] Paste any nonsense string (e.g. `not-a-sync-code`) and confirm.
- [x] Expected pixel: `Pixel sent: sync_setup_manual_code_entered_failed with params: {..., reason=unrecognized_code, flow_version=v2, ...}`

#### 2. `unexpected_second_hello` — protocol violation classification

Verifies the new precise reason for second/duplicate hello (previously would have surfaced as a generic transport failure).

**Direction:** Android = Presenter (shows code), Python = Scanner.

- [x] On Android: Sync settings → Sync With Another Device → **Copy Text Code**.
- [x] In a terminal:
    ```
    poetry run pairing-client \
      --server-url https://sync.duckduckgo.com/ \
      --broken-mode duplicate-hello \
      --kind 3party
    ```
- [x] When Python prompts `Paste the other device's code:`, paste Android's code.
- [x] Expected pixel: `Pixel sent: sync_setup_ended_failed with params: {..., reason=unexpected_second_hello, ...}`

#### 3. `unexpected_event` — out-of-order message classification

Verifies that a non-hello message arriving before hello (SM implicit abort from `Bootstrapped`) surfaces as `unexpected_event` rather than the previous generic bucket.

**Direction:** Android = Presenter, Python = Scanner.

- [x] Android: same as scenario 2 — Sync With Another Device → **Copy Text Code**.
- [x] In a terminal:
    ```
    poetry run pairing-client \
      --server-url https://sync.duckduckgo.com/ \
      --broken-mode response-without-hello \
      --kind 3party
    ```
- [x] Paste Android's code into Python when prompted.
- [x] Expected pixel: `Pixel sent: sync_setup_ended_failed with params: {..., reason=unexpected_event, ...}`

#### 4. (Optional, long-running) `session_timeout` + `timeout_stage=waiting_for_peer_hello`

Verifies the new `timeout_stage` sub-parameter. Skip if you don't want to wait 5 minutes — the mapping is exercised by unit tests in `SyncPixelsTest`.

- [x] Android: Sync settings → Sync With Another Device → **Copy Text Code**.
- [x] Leave the phone on the code screen for 5 minutes. Don't scan the code anywhere.
- [x] Expected pixel: `Pixel sent: sync_setup_ended_failed with params: {..., reason=session_timeout, timeout_stage=waiting_for_peer_hello, ...}`

### UI changes

None. Error dialogs and copy are unchanged; only the pixel payloads gain more granular parameters.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes v2 pairing error handling and poll-loop behavior (terminal throws vs silent stop), which could alter when sessions fail or retry; risk is mitigated by extensive unit tests and telemetry-only user impact.
> 
> **Overview**
> Aligns **v2 sync setup telemetry** with the Exchange V2 Unified Algorithm spec by classifying failures at the source and emitting richer pixel payloads.
> 
> **Exchange v2 runner and relay:** `SessionError` now carries `SessionErrorKind` and optional `TimeoutStage` (for 5‑minute deadlines). Poll/send HTTP outcomes throw typed exceptions (`ChannelGone`, `PollBadRequest`, `PollAuthDenied`) instead of silently stopping the poll loop, so failures surface as specific session errors (e.g. relay unavailable, malformed request, unexpected second hello, pairing session not ready).
> 
> **Dispatcher → pixels:** `RealSyncCodeDispatcher` maps each `SessionErrorKind` to dedicated `AccountErrorCodes` (including `SESSION_TIMEOUT`, `PEER_RECOVERY_CODE_UNAVAILABLE`, etc.) and passes `timeoutStage` on `DispatchOutcome.Failed`. `joinAccountFromThirdPartyRecoveryCode` upgrade POST failures now use `ACCOUNT_UPGRADE_FAILED`.
> 
> **Pixels:** `sync_setup.json5` gains `reason` on barcode/manual parse failures and expands `sync_setup_ended_failed` with the spec reason enum plus `timeout_stage`. `SyncPixels` adds matching `SetupFailureReason` / `TimeoutStage`, includes `source` on setup-failed events, fires `already_paired` for same-account `AlreadyConnected`, treats peer `PAIRING_REJECTED` as abandoned confirmation denial, and wires connect/exchange/login ViewModels to pass screen type and `unrecognized_code` on parse failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abdd8129a9e37020c24b120f439c7a523dcee94d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->