### PR TITLE
Fire Mode: Burn Fire mode after last tab

### DIFF
--- a/PixelDefinitions/pixels/definitions/wide_data_clearing.json5
+++ b/PixelDefinitions/pixels/definitions/wide_data_clearing.json5
@@ -27,6 +27,7 @@
                     "nongranular_fire_dialog",
                     "single_tab_fire_dialog",
                     "app_shortcut",
+                    "fire_tabs_emptied",
                     "auto_foreground",
                     "auto_background",
                     "legacy_fire_dialog",

--- a/app/src/main/java/com/duckduckgo/app/fire/DataClearing.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/DataClearing.kt
@@ -173,10 +173,9 @@ class DataClearing @Inject constructor(
                 performFireModeClear()
 
                 if (shouldRestartIfRequired) {
-                    dataClearingWideEvent.finishSuccess() // If there is an open wide event, complete it before killing the process.
+                    dataClearingWideEvent.finishSuccess()
                     clearDataAction.killAndRestartProcess(notifyDataCleared = false)
                 }
-                // Regular data is untouched, so appUsedSinceLastClear (a Regular-clear flag) must not change.
             }
         }
     }
@@ -213,7 +212,7 @@ class DataClearing @Inject constructor(
             duckAiFeatureState.showClearDuckAIChatHistory.value
         val wasDataCleared = options.contains(FireClearOption.DATA) || wasDuckAiChatsCleared
         if (killProcessIfNeeded && wasDataCleared) {
-            dataClearingWideEvent.finishSuccess() // If there is an open wide event, complete it before killing the process.
+            dataClearingWideEvent.finishSuccess()
             clearDataAction.killProcess()
             return false
         } else {

--- a/app/src/main/java/com/duckduckgo/app/fire/DataClearing.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/DataClearing.kt
@@ -167,6 +167,7 @@ class DataClearing @Inject constructor(
             BrowserMode.REGULAR -> {
                 performFireModeClear()
                 clearRegularDataUsingManualFireOptions(shouldRestartIfRequired)
+                clearDataAction.setAppUsedSinceLastClearFlag(wasAppUsedSinceLastClear)
             }
             BrowserMode.FIRE -> {
                 performFireModeClear()
@@ -175,10 +176,9 @@ class DataClearing @Inject constructor(
                     dataClearingWideEvent.finishSuccess() // If there is an open wide event, complete it before killing the process.
                     clearDataAction.killAndRestartProcess(notifyDataCleared = false)
                 }
+                // Regular data is untouched, so appUsedSinceLastClear (a Regular-clear flag) must not change.
             }
         }
-
-        clearDataAction.setAppUsedSinceLastClearFlag(wasAppUsedSinceLastClear)
     }
 
     private suspend fun clearRegularDataUsingManualFireOptions(

--- a/app/src/main/java/com/duckduckgo/app/fire/wideevents/DataClearingWideEvent.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/wideevents/DataClearingWideEvent.kt
@@ -47,6 +47,7 @@ interface DataClearingWideEvent {
         NONGRANULAR_FIRE_DIALOG("nongranular_fire_dialog"),
         SINGLE_TAB_FIRE_DIALOG("single_tab_fire_dialog"),
         APP_SHORTCUT("app_shortcut"),
+        FIRE_TABS_EMPTIED("fire_tabs_emptied"),
         AUTO_FOREGROUND("auto_foreground"),
         AUTO_BACKGROUND("auto_background"),
         LEGACY_FIRE_DIALOG("legacy_fire_dialog"),

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -27,10 +27,13 @@ import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.browser.omnibar.OmnibarType
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.fire.promo.FireTabsPromos
+import com.duckduckgo.app.fire.ManualDataClearing
+import com.duckduckgo.app.fire.wideevents.DataClearingWideEvent
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppPixelName.TAB_MANAGER_GRID_VIEW_BUTTON_CLICKED
 import com.duckduckgo.app.pixels.AppPixelName.TAB_MANAGER_LIST_VIEW_BUTTON_CLICKED
 import com.duckduckgo.app.pixels.duckchat.createWasUsedBeforePixelParams
+import com.duckduckgo.app.settings.clear.FireClearOption
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.app.tabs.model.TabEntity
@@ -111,6 +114,8 @@ class TabSwitcherViewModel @Inject constructor(
     private val trackersAnimationInfoPanelPixels: TrackersAnimationInfoPanelPixels,
     private val omnibarRepository: OmnibarRepository,
     private val tabTitleResolver: TabTitleResolver,
+    private val dataClearing: ManualDataClearing,
+    private val dataClearingWideEvent: DataClearingWideEvent,
     @param:AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val fireTabsPromos: FireTabsPromos,
     private val remoteMessageModel: RemoteMessageModel,
@@ -288,6 +293,28 @@ class TabSwitcherViewModel @Inject constructor(
         _viewState.update { it.copy(isFireTabsPromoVisible = false) }
     }
 
+    // Runs on the app scope so the burn survives the activity recreate() that the Fire -> Regular
+    // mode switch triggers, otherwise the clear would be cancelled mid-flight.
+    private fun switchToRegularModeClearingFireData() {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            dataClearingWideEvent.start(
+                entryPoint = DataClearingWideEvent.EntryPoint.FIRE_TABS_EMPTIED,
+                clearOptions = setOf(FireClearOption.TABS, FireClearOption.DATA, FireClearOption.DUCKAI_CHATS),
+            )
+            try {
+                dataClearing.clearDataUsingManualFireOptions(
+                    shouldRestartIfRequired = false,
+                    browserMode = BrowserMode.FIRE,
+                )
+                dataClearingWideEvent.finishSuccess()
+            } catch (e: Exception) {
+                dataClearingWideEvent.finishFailure(e)
+                throw e
+            }
+        }
+        command.value = Command.SwitchToRegularMode
+    }
+
     suspend fun onTabSelected(tabId: String) {
         val mode = viewState.value.mode as? Selection ?: Normal
         if (mode is Selection) {
@@ -457,7 +484,7 @@ class TabSwitcherViewModel @Inject constructor(
                 if (fireModeAvailable && currentMode.value == BrowserMode.FIRE) {
                     // emptying all Fire tabs returns the user to Regular mode, matching the single-tab
                     // close path; the tab switcher stays open instead of closing with an undo snackbar
-                    command.value = Command.SwitchToRegularMode
+                    switchToRegularModeClearingFireData()
                 } else {
                     // the undo snackbar will be displayed when the tab switcher is closed
                     command.value = Command.CloseAndShowUndoMessage(tabIds)
@@ -486,7 +513,7 @@ class TabSwitcherViewModel @Inject constructor(
             val isLastTab = tabs.size == 1
             if (isLastTab && fireModeAvailable && currentMode.value == BrowserMode.FIRE) {
                 markTabAsDeletable(tab, swipeGestureUsed)
-                command.value = Command.SwitchToRegularMode
+                switchToRegularModeClearingFireData()
             } else if (isLastTab) {
                 // mark the tab as deletable, the undo snackbar will be shown after tab switcher is closed
                 markTabAsDeletable(tab, swipeGestureUsed)

--- a/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModel.kt
@@ -26,8 +26,8 @@ import com.duckduckgo.app.browser.api.OmnibarRepository
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.browser.omnibar.OmnibarType
 import com.duckduckgo.app.di.AppCoroutineScope
-import com.duckduckgo.app.fire.promo.FireTabsPromos
 import com.duckduckgo.app.fire.ManualDataClearing
+import com.duckduckgo.app.fire.promo.FireTabsPromos
 import com.duckduckgo.app.fire.wideevents.DataClearingWideEvent
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.pixels.AppPixelName.TAB_MANAGER_GRID_VIEW_BUTTON_CLICKED

--- a/app/src/test/java/com/duckduckgo/app/fire/DataClearingTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/fire/DataClearingTest.kt
@@ -1236,7 +1236,7 @@ class DataClearingTest {
 
         verify(mockDataClearingWideEvent).finishSuccess()
         verify(mockClearDataAction).killAndRestartProcess(notifyDataCleared = false)
-        verify(mockClearDataAction).setAppUsedSinceLastClearFlag(false)
+        verify(mockClearDataAction, never()).setAppUsedSinceLastClearFlag(any())
     }
 
     @Test
@@ -1247,7 +1247,7 @@ class DataClearingTest {
         testee.clearDataUsingManualFireOptions(shouldRestartIfRequired = false, wasAppUsedSinceLastClear = true, browserMode = BrowserMode.FIRE)
 
         verify(mockClearDataAction, never()).killAndRestartProcess(any(), any(), any())
-        verify(mockClearDataAction).setAppUsedSinceLastClearFlag(true)
+        verify(mockClearDataAction, never()).setAppUsedSinceLastClearFlag(any())
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -27,7 +27,10 @@ import com.duckduckgo.app.browser.api.OmnibarRepository
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.browser.omnibar.OmnibarType
 import com.duckduckgo.app.fire.promo.FireTabsPromos
+import com.duckduckgo.app.fire.ManualDataClearing
+import com.duckduckgo.app.fire.wideevents.DataClearingWideEvent
 import com.duckduckgo.app.pixels.AppPixelName
+import com.duckduckgo.app.settings.clear.FireClearOption
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
 import com.duckduckgo.app.statistics.store.StatisticsDataStore
@@ -170,6 +173,10 @@ class TabSwitcherViewModelTest {
 
     private val mockTabTitleResolver: TabTitleResolver = mock()
 
+    private val mockDataClearing: ManualDataClearing = mock()
+
+    private val mockDataClearingWideEvent: DataClearingWideEvent = mock()
+
     private val swipingTabsFeature = FakeFeatureToggleFactory.create(SwipingTabsFeature::class.java)
     private val swipingTabsFeatureProvider = SwipingTabsFeatureProvider(swipingTabsFeature)
 
@@ -247,6 +254,8 @@ class TabSwitcherViewModelTest {
             mockTrackersAnimationInfoPanelPixels,
             mockOmnibarFeatureRepository,
             mockTabTitleResolver,
+            mockDataClearing,
+            mockDataClearingWideEvent,
             coroutinesTestRule.testScope,
             fireTabsPromos,
             remoteMessageModel,
@@ -2081,6 +2090,15 @@ class TabSwitcherViewModelTest {
         verify(mockFireTabRepository).markDeletable(fireTab)
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
         assertEquals(Command.SwitchToRegularMode, commandCaptor.lastValue)
+        verify(mockDataClearingWideEvent).start(
+            entryPoint = DataClearingWideEvent.EntryPoint.FIRE_TABS_EMPTIED,
+            clearOptions = setOf(FireClearOption.TABS, FireClearOption.DATA, FireClearOption.DUCKAI_CHATS),
+        )
+        verify(mockDataClearing).clearDataUsingManualFireOptions(
+            shouldRestartIfRequired = false,
+            browserMode = BrowserMode.FIRE,
+        )
+        verify(mockDataClearingWideEvent).finishSuccess()
     }
 
     @Test
@@ -2107,6 +2125,39 @@ class TabSwitcherViewModelTest {
         verify(mockFireTabRepository).markDeletable(fireTabs.map { it.tabId })
         verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
         assertEquals(Command.SwitchToRegularMode, commandCaptor.lastValue)
+        verify(mockDataClearingWideEvent).start(
+            entryPoint = DataClearingWideEvent.EntryPoint.FIRE_TABS_EMPTIED,
+            clearOptions = setOf(FireClearOption.TABS, FireClearOption.DATA, FireClearOption.DUCKAI_CHATS),
+        )
+        verify(mockDataClearing).clearDataUsingManualFireOptions(
+            shouldRestartIfRequired = false,
+            browserMode = BrowserMode.FIRE,
+        )
+        verify(mockDataClearingWideEvent).finishSuccess()
+    }
+
+    @Test
+    fun `when toggling to regular mode with fire tabs present then does not clear fire data`() = runTest {
+        val fireTabs = listOf(
+            TabEntity("fire-1", url = "https://fire.example/1", position = 1),
+            TabEntity("fire-2", url = "https://fire.example/2", position = 2),
+        )
+        whenever(mockTabRepositoryProvider.forMode(BrowserMode.FIRE)).thenReturn(mockFireTabRepository)
+        whenever(mockFireTabRepository.flowTabs).thenReturn(flowOf(fireTabs))
+        whenever(mockFireTabRepository.flowSelectedTab).thenReturn(flowOf(fireTabs.first()))
+        whenever(mockFireTabRepository.flowDeletableTabs).thenReturn(flowOf(emptyList()))
+        whenever(mockFireTabRepository.tabSwitcherData).thenReturn(flowOf(tabSwitcherData))
+
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            testee.viewState.collect()
+        }
+        currentModeFlow.value = BrowserMode.FIRE
+        advanceUntilIdle()
+
+        testee.onBrowserModeToggled(BrowserMode.REGULAR)
+        advanceUntilIdle()
+
+        verify(mockDataClearing, never()).clearDataUsingManualFireOptions(any(), any(), any())
     }
 
     @Test
@@ -2136,6 +2187,8 @@ class TabSwitcherViewModelTest {
             mockTrackersAnimationInfoPanelPixels,
             mockOmnibarFeatureRepository,
             mockTabTitleResolver,
+            mockDataClearing,
+            mockDataClearingWideEvent,
             coroutinesTestRule.testScope,
             fireTabsPromos,
             remoteMessageModel,
@@ -2181,6 +2234,8 @@ class TabSwitcherViewModelTest {
             mockTrackersAnimationInfoPanelPixels,
             mockOmnibarFeatureRepository,
             mockTabTitleResolver,
+            mockDataClearing,
+            mockDataClearingWideEvent,
             coroutinesTestRule.testScope,
             fireTabsPromos,
             remoteMessageModel,
@@ -2250,6 +2305,8 @@ class TabSwitcherViewModelTest {
             mockTrackersAnimationInfoPanelPixels,
             mockOmnibarFeatureRepository,
             mockTabTitleResolver,
+            mockDataClearing,
+            mockDataClearingWideEvent,
             coroutinesTestRule.testScope,
             fireTabsPromos,
             remoteMessageModel,

--- a/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/tabs/ui/TabSwitcherViewModelTest.kt
@@ -26,8 +26,8 @@ import app.cash.turbine.test
 import com.duckduckgo.app.browser.api.OmnibarRepository
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.browser.omnibar.OmnibarType
-import com.duckduckgo.app.fire.promo.FireTabsPromos
 import com.duckduckgo.app.fire.ManualDataClearing
+import com.duckduckgo.app.fire.promo.FireTabsPromos
 import com.duckduckgo.app.fire.wideevents.DataClearingWideEvent
 import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.settings.clear.FireClearOption


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1216264460141747?focus=true

### Description

This PR implements automatic Fire mode data clearing after the last Fire mode tab is closed.

### Steps to test this PR

_Burn Fire data when the last Fire tab is closed_
- [ ] Open the tab switcher and switch to Fire mode
- [ ] Open one or more Fire tabs, log in to a site (or accept cookies), and send at least one Duck.ai message in Fire mode
- [ ] Close Fire tabs until one remains, then close the last one (X button or swipe)
- [ ] Confirm you return to Regular mode with the tab switcher still open (no undo snackbar)
- [ ] Switch back to Fire mode and confirm there are no previous Fire tabs
- [x] Revisit the site (logged out, cookies gone) and open Duck.ai (previous Fire chat history gone)

_Burn Fire data when closing all Fire tabs at once_
- [ ] In Fire mode with several tabs plus a site login and a Duck.ai chat, open the overflow menu and choose "Close all tabs", then confirm
- [x] Confirm you return to Regular mode with the tab switcher still open, and that Fire tabs, browsing data, and Duck.ai chats are all cleared

_Regular data is untouched_
- [ ] Have Regular tabs open and be logged in to a site in Regular mode before burning Fire data
- [x] After the Fire burn, confirm the Regular tabs and the Regular login/cookies are still there

_No burn on a manual mode switch_
- [ ] In Fire mode with tabs and data, manually switch Fire to Regular and back to Fire
- [x] Confirm the Fire tabs, browsing data, and Duck.ai chats are still present

_No burn when closing a non-last Fire tab_
- [ ] In Fire mode with 2 or more tabs, close a tab that is not the last one
- [x] Confirm you stay in Fire mode and the remaining tabs and data are intact

_Regular automatic clearing is not disturbed_
- [ ] In Settings, enable automatic data clearing
- [ ] Trigger a Fire burn by closing the last Fire tab, then background and relaunch the app as required by the setting
- [x] Confirm the Regular automatic clear still runs as configured 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an automatic Fire data-clear path tied to tab UI, but it is scoped to Fire mode empty-tab cases and reuses existing manual Fire clearing without process restart.
> 
> **Overview**
> Closing the **last** Fire tab or **close all** in Fire mode now triggers a full Fire burn (tabs, browsing data, Duck.ai chats) before switching back to Regular mode, while keeping the tab switcher open. The clear runs on the **app coroutine scope** so it is not cancelled by the activity `recreate()` from the mode switch, and uses a new wide-event entry point `fire_tabs_emptied`.
> 
> **Manual** Fire → Regular toggling with tabs still open does **not** run this burn. `DataClearing.clearDataUsingManualFireOptions` now only updates `setAppUsedSinceLastClearFlag` on the **Regular** path, not after Fire-mode manual clears (including this no-restart flow).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19aa647e487e702769a897afd215c45c635921e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


