### PR TITLE
Translations for sync exchange v2 work

### DIFF
--- a/sync/sync-impl/src/main/res/values-bg/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-bg/strings-sync.xml
@@ -249,4 +249,31 @@
     <string name="sync_chat_bottom_sheet_description">Намерете QR кода в приложението DuckDuckGo на другото устройство, като отворите Настройки › Sync &amp; Backup › Синхронизиране с друго устройство.</string>
     <string name="sync_chat_bottom_sheet_positive">Сканиране на QR код</string>
     <string name="sync_chat_bottom_sheet_negative">Не сега</string>
+
+    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
+    <string name="sync_v2_joiner_confirmation_title">Синхронизиране на данните?</string>
+    <string name="sync_v2_joiner_confirmation_positive">Синхронизиране сега</string>
+    <string name="sync_v2_joiner_confirmation_negative">Отмяна</string>
+
+    <string name="sync_v2_host_confirmation_title">Синхронизиране на данните?</string>
+    <string name="sync_v2_host_confirmation_positive">Синхронизиране сега</string>
+    <string name="sync_v2_host_confirmation_negative">Отмяна</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">„%1$s“ ще има достъп до синхронизираните Ви пароли в DuckDuckGo, данните за автоматично попълване и чатовете в Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">„%1$s“ ще има достъп до синхронизираните Ви чатове в Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">Другото устройство ще има достъп до синхронизираните Ви пароли в DuckDuckGo, данните за автоматично попълване и чатовете в Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">Другото устройство ще има достъп до синхронизираните Ви чатове в Duck.ai.</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
+    <string name="sync_v2_error_pairing_failed">Неуспешно синхронизиране.</string>
+    <string name="sync_v2_error_pairing_rejected">Синхронизирането е прекратено от другото Ви устройство.</string>
+    <string name="sync_v2_error_pairing_canceled">Синхронизирането е прекратено.</string>
+    <string name="sync_v2_error_upgrade_required">Актуализирайте браузъра DuckDuckGo и опитайте отново.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Синхронизирайте това устройство от вече свързан браузър DuckDuckGo на друго устройство</string>
+    <string name="sync_v2_error_try_again">Моля, опитайте отново.</string>
+    <string name="sync_v2_error_got_it">Разбрах</string>
+    <string name="sync_v2_already_paired_title">Вече е синхронизирано.</string>
+    <string name="sync_v2_already_paired_message">Тези устройства вече са свързани към „Sync &amp; Backup“.</string>
+
 </resources>

--- a/sync/sync-impl/src/main/res/values-cs/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-cs/strings-sync.xml
@@ -249,4 +249,31 @@
     <string name="sync_chat_bottom_sheet_description">QR kód najdeš v aplikaci DuckDuckGo na druhém zařízení v nabídce Nastavení › Sync &amp; Backup › Synchronizace s jiným zařízením.</string>
     <string name="sync_chat_bottom_sheet_positive">Naskenuj QR kód</string>
     <string name="sync_chat_bottom_sheet_negative">Teď ne</string>
+
+    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
+    <string name="sync_v2_joiner_confirmation_title">Synchronizovat data?</string>
+    <string name="sync_v2_joiner_confirmation_positive">Synchronizovat</string>
+    <string name="sync_v2_joiner_confirmation_negative">Zrušit</string>
+
+    <string name="sync_v2_host_confirmation_title">Synchronizovat data?</string>
+    <string name="sync_v2_host_confirmation_positive">Synchronizovat</string>
+    <string name="sync_v2_host_confirmation_negative">Zrušit</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">\"%1$s\" bude mít přístup k tvým synchronizovaným heslům z DuckDuckGo, údajům pro automatické vyplňování a chatům v Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">„%1$s“ bude mít přístup k tvým synchronizovaným chatům Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">Druhé zařízení bude mít přístup k tvým synchronizovaným heslům z DuckDuckGo, údajům pro automatické vyplňování a chatům v Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">Druhé zařízení bude mít přístup k tvým synchronizovaným chatům s Duck.ai.</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
+    <string name="sync_v2_error_pairing_failed">Synchronizace se nezdařila.</string>
+    <string name="sync_v2_error_pairing_rejected">Synchronizace byla zrušena na tvém druhém zařízení.</string>
+    <string name="sync_v2_error_pairing_canceled">Synchronizace byla zrušena.</string>
+    <string name="sync_v2_error_upgrade_required">Aktualizuj prohlížeč DuckDuckGo a zkus to znovu.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Synchronizuj toto zařízení z již připojeného prohlížeče DuckDuckGo na jiném zařízení</string>
+    <string name="sync_v2_error_try_again">Zkus to znovu.</string>
+    <string name="sync_v2_error_got_it">Rozumím</string>
+    <string name="sync_v2_already_paired_title">Už se synchronizuje.</string>
+    <string name="sync_v2_already_paired_message">Tato zařízení jsou již připojena k Sync &amp; Backup.</string>
+
 </resources>

--- a/sync/sync-impl/src/main/res/values-da/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-da/strings-sync.xml
@@ -249,4 +249,31 @@
     <string name="sync_chat_bottom_sheet_description">Find QR-koden i DuckDuckGo-appen på din anden enhed ved at gå til Indstillinger › Sync &amp; Backup › Synkroniser med en anden enhed.</string>
     <string name="sync_chat_bottom_sheet_positive">Scan QR-kode</string>
     <string name="sync_chat_bottom_sheet_negative">Ikke nu</string>
+
+    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
+    <string name="sync_v2_joiner_confirmation_title">Synkroniser dine data?</string>
+    <string name="sync_v2_joiner_confirmation_positive">Synkronisér nu</string>
+    <string name="sync_v2_joiner_confirmation_negative">Annuller</string>
+
+    <string name="sync_v2_host_confirmation_title">Synkroniser dine data?</string>
+    <string name="sync_v2_host_confirmation_positive">Synkronisér nu</string>
+    <string name="sync_v2_host_confirmation_negative">Annuller</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">\"%1$s\" vil kunne tilgå dine synkroniserede DuckDuckGo-adgangskoder, autofyldningsdata og Duck.ai-chats.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">\"%1$s\" vil kunne tilgå dine synkroniserede Duck.ai-chats.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">Den anden enhed vil kunne tilgå dine synkroniserede DuckDuckGo-adgangskoder, autofyldningsdata og Duck.ai-chats.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">Den anden enhed vil kunne tilgå dine synkroniserede Duck.ai-chats.</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
+    <string name="sync_v2_error_pairing_failed">Synkroniseringen mislykkedes.</string>
+    <string name="sync_v2_error_pairing_rejected">Synkronisering annulleret fra din anden enhed.</string>
+    <string name="sync_v2_error_pairing_canceled">Synkronisering annulleret.</string>
+    <string name="sync_v2_error_upgrade_required">Opdatér DuckDuckGo-browseren, og prøv igen.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Synkronisér denne enhed fra en allerede tilsluttet DuckDuckGo-browser på en anden enhed</string>
+    <string name="sync_v2_error_try_again">Prøv igen.</string>
+    <string name="sync_v2_error_got_it">Forstået</string>
+    <string name="sync_v2_already_paired_title">Allerede synkroniseret.</string>
+    <string name="sync_v2_already_paired_message">Disse enheder er allerede forbundet til Sync &amp; Backup.</string>
+
 </resources>

--- a/sync/sync-impl/src/main/res/values-de/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-de/strings-sync.xml
@@ -249,4 +249,31 @@
     <string name="sync_chat_bottom_sheet_description">Finde den QR-Code in der DuckDuckGo-App auf deinem anderen Gerät unter Einstellungen › Sync &amp; Backup › Mit anderem Gerät synchronisieren.</string>
     <string name="sync_chat_bottom_sheet_positive">QR-Code scannen</string>
     <string name="sync_chat_bottom_sheet_negative">Jetzt nicht</string>
+
+    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
+    <string name="sync_v2_joiner_confirmation_title">Deine Daten synchronisieren?</string>
+    <string name="sync_v2_joiner_confirmation_positive">Jetzt synchronisieren</string>
+    <string name="sync_v2_joiner_confirmation_negative">Abbrechen</string>
+
+    <string name="sync_v2_host_confirmation_title">Deine Daten synchronisieren?</string>
+    <string name="sync_v2_host_confirmation_positive">Jetzt synchronisieren</string>
+    <string name="sync_v2_host_confirmation_negative">Abbrechen</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">„%1$s“ kann auf deine synchronisierten DuckDuckGo-Passwörter, Autofill-Daten und Duck.ai-Chats zugreifen.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">„%1$s“ kann auf deine synchronisierten Duck.ai-Chats zugreifen.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">Das andere Gerät kann auf deine synchronisierten DuckDuckGo-Passwörter, Autofill-Daten und Duck.ai-Chats zugreifen.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">Das andere Gerät kann auf deine synchronisierten Duck.ai-Chats zugreifen.</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
+    <string name="sync_v2_error_pairing_failed">Synchronisation fehlgeschlagen.</string>
+    <string name="sync_v2_error_pairing_rejected">Die Synchronisierung auf deinem anderen Gerät wurde abgebrochen.</string>
+    <string name="sync_v2_error_pairing_canceled">Die Synchronisierung wurde abgebrochen.</string>
+    <string name="sync_v2_error_upgrade_required">Aktualisiere den DuckDuckGo-Browser und versuche es erneut.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Bitte synchronisiere dieses Gerät mit einem bereits verbundenen DuckDuckGo-Browser auf einem anderen Gerät</string>
+    <string name="sync_v2_error_try_again">Bitte versuche es noch einmal.</string>
+    <string name="sync_v2_error_got_it">Verstanden</string>
+    <string name="sync_v2_already_paired_title">Bereits synchronisiert.</string>
+    <string name="sync_v2_already_paired_message">Diese Geräte sind bereits mit Sync &amp; Backup verbunden.</string>
+
 </resources>

--- a/sync/sync-impl/src/main/res/values-el/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-el/strings-sync.xml
@@ -249,4 +249,31 @@
     <string name="sync_chat_bottom_sheet_description">Βρες τον κωδικό QR στην εφαρμογή DuckDuckGo στην άλλη συσκευή σου μεταβαίνοντας στις Ρυθμίσεις › Sync &amp; Backup › Συγχρονισμός με άλλη συσκευή.</string>
     <string name="sync_chat_bottom_sheet_positive">Σάρωση κωδικού QR</string>
     <string name="sync_chat_bottom_sheet_negative">Όχι τώρα</string>
+
+    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
+    <string name="sync_v2_joiner_confirmation_title">Να συγχρονιστούν τα δεδομένα σου;</string>
+    <string name="sync_v2_joiner_confirmation_positive">Συγχρονισμός τώρα</string>
+    <string name="sync_v2_joiner_confirmation_negative">Ακύρωση</string>
+
+    <string name="sync_v2_host_confirmation_title">Να συγχρονιστούν τα δεδομένα σου;</string>
+    <string name="sync_v2_host_confirmation_positive">Συγχρονισμός τώρα</string>
+    <string name="sync_v2_host_confirmation_negative">Ακύρωση</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">Το «%1$s» θα έχει πρόσβαση στους συγχρονισμένους κωδικούς πρόσβασης DuckDuckGo, στα δεδομένα αυτόματης συμπλήρωσης και στις συνομιλίες Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">Το «%1$s» θα έχει πρόσβαση στις συγχρονισμένες συνομιλίες Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">Η άλλη συσκευή θα έχει πρόσβαση στους συγχρονισμένους κωδικούς πρόσβασης DuckDuckGo, στα δεδομένα αυτόματης συμπλήρωσης και στις συνομιλίες Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">Η άλλη συσκευή θα έχει πρόσβαση στις συγχρονισμένες συνομιλίες Duck.ai.</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
+    <string name="sync_v2_error_pairing_failed">Ο συγχρονισμός απέτυχε.</string>
+    <string name="sync_v2_error_pairing_rejected">Ο συγχρονισμός ακυρώθηκε από την άλλη συσκευή σου.</string>
+    <string name="sync_v2_error_pairing_canceled">Ο συγχρονισμός ακυρώθηκε.</string>
+    <string name="sync_v2_error_upgrade_required">Ενημέρωσε το πρόγραμμα περιήγησης DuckDuckGo και δοκίμασε ξανά.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Συγχρόνισε αυτήν τη συσκευή από ένα ήδη συνδεδεμένο πρόγραμμα περιήγησης DuckDuckGo σε άλλη συσκευή</string>
+    <string name="sync_v2_error_try_again">Δοκίμασε ξανά.</string>
+    <string name="sync_v2_error_got_it">Κατάλαβα</string>
+    <string name="sync_v2_already_paired_title">Έχει γίνει ήδη συγχρονισμός.</string>
+    <string name="sync_v2_already_paired_message">Αυτές οι συσκευές είναι ήδη συνδεδεμένες στο Sync &amp; Backup.</string>
+
 </resources>

--- a/sync/sync-impl/src/main/res/values-es/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-es/strings-sync.xml
@@ -249,4 +249,31 @@
     <string name="sync_chat_bottom_sheet_description">Encuentra el código QR en la aplicación DuckDuckGo de tu otro dispositivo yendo a Ajustes › Sync &amp; Backup › Sincronizar con otro dispositivo.</string>
     <string name="sync_chat_bottom_sheet_positive">Escanear código QR</string>
     <string name="sync_chat_bottom_sheet_negative">Ahora no</string>
+
+    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
+    <string name="sync_v2_joiner_confirmation_title">¿Sincronizar tus datos?</string>
+    <string name="sync_v2_joiner_confirmation_positive">Sincroniza ahora</string>
+    <string name="sync_v2_joiner_confirmation_negative">Cancelar</string>
+
+    <string name="sync_v2_host_confirmation_title">¿Sincronizar tus datos?</string>
+    <string name="sync_v2_host_confirmation_positive">Sincroniza ahora</string>
+    <string name="sync_v2_host_confirmation_negative">Cancelar</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">«%1$s» podrá acceder a tus contraseñas sincronizadas de DuckDuckGo, a los datos de autocompletado y a los chats de Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">«%1$s» podrá acceder a tus chats sincronizados de Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">El otro dispositivo podrá acceder a tus contraseñas sincronizadas de DuckDuckGo, a los datos de autocompletado y a los chats de Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">El otro dispositivo podrá acceder a tus chats sincronizados de Duck.ai.</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
+    <string name="sync_v2_error_pairing_failed">La sincronización falló.</string>
+    <string name="sync_v2_error_pairing_rejected">Sincronización cancelada desde tu otro dispositivo.</string>
+    <string name="sync_v2_error_pairing_canceled">Sincronización cancelada.</string>
+    <string name="sync_v2_error_upgrade_required">Actualiza el navegador DuckDuckGo e inténtalo de nuevo.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Sincroniza este dispositivo desde un navegador DuckDuckGo ya conectado en otro dispositivo</string>
+    <string name="sync_v2_error_try_again">Inténtalo de nuevo.</string>
+    <string name="sync_v2_error_got_it">Entendido</string>
+    <string name="sync_v2_already_paired_title">Ya está sincronizado.</string>
+    <string name="sync_v2_already_paired_message">Estos dispositivos ya están conectados a Sync &amp; Backup.</string>
+
 </resources>

--- a/sync/sync-impl/src/main/res/values-et/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-et/strings-sync.xml
@@ -249,4 +249,31 @@
     <string name="sync_chat_bottom_sheet_description">Leia QR-kood oma teises seadmes DuckDuckGo rakendusest, minnes menüüsse Seaded › Sync &amp; Backup › Sünkrooni teise seadmega.</string>
     <string name="sync_chat_bottom_sheet_positive">Skanni QR-kood</string>
     <string name="sync_chat_bottom_sheet_negative">Mitte praegu</string>
+
+    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
+    <string name="sync_v2_joiner_confirmation_title">Kas sünkroonida andmed?</string>
+    <string name="sync_v2_joiner_confirmation_positive">Sünkrooni kohe</string>
+    <string name="sync_v2_joiner_confirmation_negative">Tühista</string>
+
+    <string name="sync_v2_host_confirmation_title">Kas sünkroonida andmed?</string>
+    <string name="sync_v2_host_confirmation_positive">Sünkrooni kohe</string>
+    <string name="sync_v2_host_confirmation_negative">Tühista</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">„%1$s” pääseb ligi sinu sünkroonitud DuckDuckGo paroolidele, automaatse täitmise andmetele ja Duck.ai vestlustele.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">„%1$s“ pääseb ligi sinu sünkroonitud Duck.ai vestlustele.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">Teine seade pääseb ligi sinu sünkroonitud DuckDuckGo paroolidele, automaatse täitmise andmetele ja Duck.ai vestlustele.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">Teine seade pääseb ligi sinu sünkroonitud Duck.ai vestlustele.</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
+    <string name="sync_v2_error_pairing_failed">Sünkroonimine nurjus.</string>
+    <string name="sync_v2_error_pairing_rejected">Sünkroonimine tühistati sinu teisest seadmest.</string>
+    <string name="sync_v2_error_pairing_canceled">Sünkroonimine tühistati.</string>
+    <string name="sync_v2_error_upgrade_required">Värskenda DuckDuckGo brauserit ja proovi uuesti.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Sünkrooni see seade juba ühendatud DuckDuckGo brauserist mõnes teises seadmes</string>
+    <string name="sync_v2_error_try_again">Proovi uuesti.</string>
+    <string name="sync_v2_error_got_it">Sain aru</string>
+    <string name="sync_v2_already_paired_title">Juba sünkroonitud.</string>
+    <string name="sync_v2_already_paired_message">Need seadmed on juba Sync &amp; Backupiga ühendatud.</string>
+
 </resources>

--- a/sync/sync-impl/src/main/res/values-fi/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-fi/strings-sync.xml
@@ -249,4 +249,31 @@
     <string name="sync_chat_bottom_sheet_description">Etsi QR-koodi DuckDuckGo-sovelluksesta toisella laitteellasi siirtymällä kohtaan Asetukset › Sync &amp; Backup › Synkronoi toisen laitteen kanssa.</string>
     <string name="sync_chat_bottom_sheet_positive">Skannaa QR-koodi</string>
     <string name="sync_chat_bottom_sheet_negative">Ei nyt</string>
+
+    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
+    <string name="sync_v2_joiner_confirmation_title">Synkronoidaanko tietosi?</string>
+    <string name="sync_v2_joiner_confirmation_positive">Synkronoi nyt</string>
+    <string name="sync_v2_joiner_confirmation_negative">Peruuta</string>
+
+    <string name="sync_v2_host_confirmation_title">Synkronoidaanko tietosi?</string>
+    <string name="sync_v2_host_confirmation_positive">Synkronoi nyt</string>
+    <string name="sync_v2_host_confirmation_negative">Peruuta</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">\"%1$s\" voi käyttää synkronoituja DuckDuckGo-salasanojasi, automaattisen täytön tietojasi ja Duck.ai-keskustelujasi.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">\"%1$s\" voi käyttää synkronoituja Duck.ai-keskustelujasi.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">Toinen laite voi käyttää synkronoituja DuckDuckGo-salasanojasi, automaattisen täytön tietojasi ja Duck.ai-keskustelujasi.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">Toinen laite voi käyttää synkronoituja Duck.ai-keskustelujasi.</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
+    <string name="sync_v2_error_pairing_failed">Synkronointi epäonnistui.</string>
+    <string name="sync_v2_error_pairing_rejected">Synkronointi peruutettu toisesta laitteestasi.</string>
+    <string name="sync_v2_error_pairing_canceled">Synkronointi peruutettu.</string>
+    <string name="sync_v2_error_upgrade_required">Päivitä DuckDuckGo-selain ja yritä uudelleen.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Synkronoi tämä laite jo yhdistetystä DuckDuckGo-selaimesta toisella laitteella</string>
+    <string name="sync_v2_error_try_again">Yritä uudelleen.</string>
+    <string name="sync_v2_error_got_it">Selvä</string>
+    <string name="sync_v2_already_paired_title">Jo synkronoitu.</string>
+    <string name="sync_v2_already_paired_message">Nämä laitteet on jo kytketty Sync &amp; Backupiin.</string>
+
 </resources>

--- a/sync/sync-impl/src/main/res/values-fr/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-fr/strings-sync.xml
@@ -249,4 +249,31 @@
     <string name="sync_chat_bottom_sheet_description">Trouvez le code QR sur l\'application DuckDuckGo installée sur votre autre appareil en allant dans Paramètres › Sync &amp; Backup › « Synchroniser avec un autre appareil ».</string>
     <string name="sync_chat_bottom_sheet_positive">Scanner le code QR</string>
     <string name="sync_chat_bottom_sheet_negative">Pas maintenant</string>
+
+    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
+    <string name="sync_v2_joiner_confirmation_title">Synchroniser vos données ?</string>
+    <string name="sync_v2_joiner_confirmation_positive">Synchroniser maintenant</string>
+    <string name="sync_v2_joiner_confirmation_negative">Annuler</string>
+
+    <string name="sync_v2_host_confirmation_title">Synchroniser tes données ?</string>
+    <string name="sync_v2_host_confirmation_positive">Synchroniser maintenant</string>
+    <string name="sync_v2_host_confirmation_negative">Annuler</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">« %1$s » pourra accéder à vos mots de passe DuckDuckGo, données de saisie automatique et discussions Duck.ai synchronisés.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">« %1$s » pourra accéder à vos discussions Duck.ai synchronisées.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">L\'autre appareil pourra accéder à vos mots de passe DuckDuckGo, données de saisie automatique et discussions Duck.ai synchronisés.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">L\'autre appareil pourra accéder à vos discussions Duck.ai synchronisées.</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
+    <string name="sync_v2_error_pairing_failed">Échec de la synchronisation.</string>
+    <string name="sync_v2_error_pairing_rejected">La synchronisation a été annulée depuis votre autre appareil.</string>
+    <string name="sync_v2_error_pairing_canceled">Synchronisation annulée.</string>
+    <string name="sync_v2_error_upgrade_required">Mettez à jour votre navigateur DuckDuckGo et réessayez.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Veuillez synchroniser cet appareil à partir d\'un navigateur DuckDuckGo déjà connecté sur un autre appareil</string>
+    <string name="sync_v2_error_try_again">Veuillez réessayer.</string>
+    <string name="sync_v2_error_got_it">J\'ai compris</string>
+    <string name="sync_v2_already_paired_title">Déjà synchronisé.</string>
+    <string name="sync_v2_already_paired_message">Ces appareils sont déjà connectés à Sync &amp; Backup.</string>
+
 </resources>

--- a/sync/sync-impl/src/main/res/values-hr/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-hr/strings-sync.xml
@@ -249,4 +249,31 @@
     <string name="sync_chat_bottom_sheet_description">Pronađi QR kôd u aplikaciji DuckDuckGo na drugom uređaju tako da odeš na Postavke › Sync &amp; Backup › Sinkroniziraj s drugim uređajem.</string>
     <string name="sync_chat_bottom_sheet_positive">Skeniraj QR kôd</string>
     <string name="sync_chat_bottom_sheet_negative">Ne sada</string>
+
+    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
+    <string name="sync_v2_joiner_confirmation_title">Sinkroniziraj svoje podatke?</string>
+    <string name="sync_v2_joiner_confirmation_positive">Sinkroniziraj</string>
+    <string name="sync_v2_joiner_confirmation_negative">Otkaži</string>
+
+    <string name="sync_v2_host_confirmation_title">Sinkroniziraj svoje podatke?</string>
+    <string name="sync_v2_host_confirmation_positive">Sinkroniziraj</string>
+    <string name="sync_v2_host_confirmation_negative">Otkaži</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">\"%1$s\" će moći pristupiti tvojim sinkroniziranim DuckDuckGo lozinkama, podacima za automatsko popunjavanje i Duck.ai čavrljanjima.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">\"%1$s\" će moći pristupiti tvojim sinkroniziranim Duck.ai čavrljanjima.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">Drugi uređaj će moći pristupiti tvojim sinkroniziranim DuckDuckGo lozinkama, podacima za automatsko popunjavanje i Duck.ai čavrljanjima.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">Drugi uređaj će moći pristupiti tvojim sinkroniziranim Duck.ai čavrljanjima.</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
+    <string name="sync_v2_error_pairing_failed">Sinkronizacija nije uspjela.</string>
+    <string name="sync_v2_error_pairing_rejected">Sinkronizacija je otkazana s tvog drugog uređaja.</string>
+    <string name="sync_v2_error_pairing_canceled">Sinkronizacija je otkazana.</string>
+    <string name="sync_v2_error_upgrade_required">Ažuriraj DuckDuckGo preglednik i pokušaj ponovno.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Sinkroniziraj ovaj uređaj s već povezanog DuckDuckGo preglednika na drugom uređaju</string>
+    <string name="sync_v2_error_try_again">Pokušaj ponovno.</string>
+    <string name="sync_v2_error_got_it">Shvatio/la sam</string>
+    <string name="sync_v2_already_paired_title">Već sinkronizirano.</string>
+    <string name="sync_v2_already_paired_message">Ovi su uređaji već povezani s uslugom Sync &amp; Backup.</string>
+
 </resources>

--- a/sync/sync-impl/src/main/res/values-hu/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-hu/strings-sync.xml
@@ -249,4 +249,31 @@
     <string name="sync_chat_bottom_sheet_description">A másik eszközödön keresd meg a QR-kódot a DuckDuckGo alkalmazás Beállítások › Sync &amp; Backup › Szinkronizálás másik eszközzel menüpontjában.</string>
     <string name="sync_chat_bottom_sheet_positive">QR-kód beolvasása</string>
     <string name="sync_chat_bottom_sheet_negative">Most nem</string>
+
+    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
+    <string name="sync_v2_joiner_confirmation_title">Szinkronizálod az adataidat?</string>
+    <string name="sync_v2_joiner_confirmation_positive">Szinkronizálás</string>
+    <string name="sync_v2_joiner_confirmation_negative">Mégsem</string>
+
+    <string name="sync_v2_host_confirmation_title">Szinkronizálod az adataidat?</string>
+    <string name="sync_v2_host_confirmation_positive">Szinkronizálás</string>
+    <string name="sync_v2_host_confirmation_negative">Mégsem</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">A(z) „%1$s” hozzáférhet a szinkronizált DuckDuckGo-jelszavaidhoz, az automatikus kitöltési adataidhoz és a Duck.ai-csevegéseidhez.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">A(z) „%1$s” hozzáférhet a szinkronizált Duck.ai-csevegéseidhez.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">A másik eszköz hozzáférhet a szinkronizált DuckDuckGo-jelszavaidhoz, az automatikus kitöltési adataidhoz és a Duck.ai-csevegéseidhez.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">A másik eszköz hozzáférhet a szinkronizált Duck.ai-csevegéseidhez.</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
+    <string name="sync_v2_error_pairing_failed">A szinkronizálás sikertelen.</string>
+    <string name="sync_v2_error_pairing_rejected">A szinkronizálás megszakítva a másik eszközödről.</string>
+    <string name="sync_v2_error_pairing_canceled">A szinkronizálás megszakítva.</string>
+    <string name="sync_v2_error_upgrade_required">Frissítsd a DuckDuckGo böngészőt, és próbálkozz újra.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Szinkronizáld ezt az eszközt egy másik eszközön már csatlakoztatott DuckDuckGo böngészőből.</string>
+    <string name="sync_v2_error_try_again">Próbálkozz újra.</string>
+    <string name="sync_v2_error_got_it">Értem</string>
+    <string name="sync_v2_already_paired_title">Már szinkronizálva.</string>
+    <string name="sync_v2_already_paired_message">Ezek az eszközök már csatlakoztatva vannak a Sync &amp; Backup funkcióhoz.</string>
+
 </resources>

--- a/sync/sync-impl/src/main/res/values-it/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-it/strings-sync.xml
@@ -249,4 +249,31 @@
     <string name="sync_chat_bottom_sheet_description">Trova il codice QR nell\'app DuckDuckGo sull\'altro dispositivo andando su Impostazioni › Sync &amp; Backup › Sincronizza con un altro dispositivo.</string>
     <string name="sync_chat_bottom_sheet_positive">Scansiona il codice QR</string>
     <string name="sync_chat_bottom_sheet_negative">Non adesso</string>
+
+    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
+    <string name="sync_v2_joiner_confirmation_title">Sincronizzare i tuoi dati?</string>
+    <string name="sync_v2_joiner_confirmation_positive">Sincronizza adesso</string>
+    <string name="sync_v2_joiner_confirmation_negative">Annulla</string>
+
+    <string name="sync_v2_host_confirmation_title">Sincronizzare i tuoi dati?</string>
+    <string name="sync_v2_host_confirmation_positive">Sincronizza adesso</string>
+    <string name="sync_v2_host_confirmation_negative">Annulla</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">\"%1$s\" potrà accedere alle tue password sincronizzate di DuckDuckGo, ai dati di compilazione automatica e alle chat di Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">\"%1$s\" potrà accedere alle tue chat sincronizzate di Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">L\'altro dispositivo potrà accedere alle tue password sincronizzate di DuckDuckGo, ai dati di compilazione automatica e alle chat di Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">L\'altro dispositivo potrà accedere alle tue chat sincronizzate di Duck.ai.</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
+    <string name="sync_v2_error_pairing_failed">Sincronizzazione non riuscita.</string>
+    <string name="sync_v2_error_pairing_rejected">Sincronizzazione annullata dall\'altro dispositivo.</string>
+    <string name="sync_v2_error_pairing_canceled">Sincronizzazione annullata.</string>
+    <string name="sync_v2_error_upgrade_required">Aggiorna il browser DuckDuckGo e riprova.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Sincronizza questo dispositivo da un browser DuckDuckGo già connesso su un altro dispositivo</string>
+    <string name="sync_v2_error_try_again">Riprova.</string>
+    <string name="sync_v2_error_got_it">Ho capito</string>
+    <string name="sync_v2_already_paired_title">Già sincronizzato.</string>
+    <string name="sync_v2_already_paired_message">Questi dispositivi sono già connessi a Sync &amp; Backup.</string>
+
 </resources>

--- a/sync/sync-impl/src/main/res/values-lt/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-lt/strings-sync.xml
@@ -249,4 +249,31 @@
     <string name="sync_chat_bottom_sheet_description">Kitame įrenginyje esančioje programėlėje „DuckDuckGo“ rasite QR kodą nuėję į Nustatymai › Sync &amp; Backup › Sinchronizuoti su kitu įrenginiu.</string>
     <string name="sync_chat_bottom_sheet_positive">Nuskaityti QR kodą</string>
     <string name="sync_chat_bottom_sheet_negative">Ne dabar</string>
+
+    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
+    <string name="sync_v2_joiner_confirmation_title">Sinchronizuoti duomenis?</string>
+    <string name="sync_v2_joiner_confirmation_positive">Sinchronizuoti dabar</string>
+    <string name="sync_v2_joiner_confirmation_negative">Atšaukti</string>
+
+    <string name="sync_v2_host_confirmation_title">Sinchronizuoti duomenis?</string>
+    <string name="sync_v2_host_confirmation_positive">Sinchronizuoti dabar</string>
+    <string name="sync_v2_host_confirmation_negative">Atšaukti</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">„%1$s“ turės prieigą prie tavo sinchronizuotų „DuckDuckGo“ slaptažodžių, automatinio pildymo duomenų ir „Duck.ai“ pokalbių.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">„%1$s“ turės prieigą prie tavo sinchronizuotų „Duck.ai“ pokalbių.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">Kitas įrenginys turės prieigą prie tavo sinchronizuotų „DuckDuckGo“ slaptažodžių, automatinio pildymo duomenų ir „Duck.ai“ pokalbių.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">Kitas įrenginys turės prieigą prie tavo sinchronizuotų „Duck.ai“ pokalbių.</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
+    <string name="sync_v2_error_pairing_failed">Sinchronizavimas nepavyko.</string>
+    <string name="sync_v2_error_pairing_rejected">Sinchronizavimas atšauktas iš kito tavo įrenginio.</string>
+    <string name="sync_v2_error_pairing_canceled">Sinchronizavimas atšauktas.</string>
+    <string name="sync_v2_error_upgrade_required">Atnaujink „DuckDuckGo“ naršyklę ir bandyk dar kartą.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Sinchronizuok šį įrenginį naudodamas jau prijungtą „DuckDuckGo“ naršyklę kitame įrenginyje.</string>
+    <string name="sync_v2_error_try_again">Bandyk dar kartą.</string>
+    <string name="sync_v2_error_got_it">Supratau</string>
+    <string name="sync_v2_already_paired_title">Jau sinchronizuota.</string>
+    <string name="sync_v2_already_paired_message">Šie įrenginiai jau prijungti prie „Sync &amp; Backup“.</string>
+
 </resources>

--- a/sync/sync-impl/src/main/res/values-lv/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-lv/strings-sync.xml
@@ -249,4 +249,31 @@
     <string name="sync_chat_bottom_sheet_description">Atrodi QR kodu DuckDuckGo lietotnē savā otrā ierīcē, dodoties uz Iestatījumi › Sync &amp; Backup › Sinhronizēt ar citu ierīci.</string>
     <string name="sync_chat_bottom_sheet_positive">Kvadrātkoda skenēšana</string>
     <string name="sync_chat_bottom_sheet_negative">Ne tagad</string>
+
+    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
+    <string name="sync_v2_joiner_confirmation_title">Vai sinhronizēt datus?</string>
+    <string name="sync_v2_joiner_confirmation_positive">Sinhronizēt tagad</string>
+    <string name="sync_v2_joiner_confirmation_negative">Atcelt</string>
+
+    <string name="sync_v2_host_confirmation_title">Vai sinhronizēt datus?</string>
+    <string name="sync_v2_host_confirmation_positive">Sinhronizēt tagad</string>
+    <string name="sync_v2_host_confirmation_negative">Atcelt</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">“%1$s” varēs piekļūt tavām sinhronizētajām DuckDuckGo parolēm, automātiskās aizpildīšanas datiem un Duck.ai tērzēšanām.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">“%1$s” varēs piekļūt tavām sinhronizētajām Duck.ai tērzēšanām.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">Otra ierīce varēs piekļūt tavām sinhronizētajām DuckDuckGo parolēm, automātiskās aizpildīšanas datiem un Duck.ai tērzēšanām.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">Otra ierīce varēs piekļūt tavām sinhronizētajām Duck.ai tērzēšanām.</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
+    <string name="sync_v2_error_pairing_failed">Sinhronizācija neizdevās.</string>
+    <string name="sync_v2_error_pairing_rejected">Sinhronizācija atcelta otrā ierīcē.</string>
+    <string name="sync_v2_error_pairing_canceled">Sinhronizācija atcelta.</string>
+    <string name="sync_v2_error_upgrade_required">Atjaunini DuckDuckGo pārlūkprogrammu un mēģini vēlreiz.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Lūdzu, sinhronizē šo ierīci no jau pievienotas DuckDuckGo pārlūkprogrammas citā ierīcē</string>
+    <string name="sync_v2_error_try_again">Lūdzu, mēģini vēlreiz.</string>
+    <string name="sync_v2_error_got_it">Sapratu</string>
+    <string name="sync_v2_already_paired_title">Jau sinhronizēts.</string>
+    <string name="sync_v2_already_paired_message">Šīs ierīces jau ir savienotas ar Sync &amp; Backup.</string>
+
 </resources>

--- a/sync/sync-impl/src/main/res/values-nb/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-nb/strings-sync.xml
@@ -249,4 +249,31 @@
     <string name="sync_chat_bottom_sheet_description">Finn QR-koden på DuckDuckGo-appen på den andre enheten din ved å gå til Innstillinger › Sync &amp; Backup › Synkroniser med en annen enhet.</string>
     <string name="sync_chat_bottom_sheet_positive">Skann QR-kode</string>
     <string name="sync_chat_bottom_sheet_negative">Ikke nå</string>
+
+    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
+    <string name="sync_v2_joiner_confirmation_title">Vil du synkronisere dataene dine?</string>
+    <string name="sync_v2_joiner_confirmation_positive">Synkroniser nå</string>
+    <string name="sync_v2_joiner_confirmation_negative">Avbryt</string>
+
+    <string name="sync_v2_host_confirmation_title">Vil du synkronisere dataene dine?</string>
+    <string name="sync_v2_host_confirmation_positive">Synkroniser nå</string>
+    <string name="sync_v2_host_confirmation_negative">Avbryt</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">«%1$s» får tilgang til dine synkroniserte DuckDuckGo-passord, autofylldata og Duck.ai-chatter.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">«%1$s» får tilgang til dine synkroniserte Duck.ai-chatter.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">Den andre enheten får tilgang til dine synkroniserte DuckDuckGo-passord, autofylldata og Duck.ai-chatter.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">Den andre enheten får tilgang til dine synkroniserte Duck.ai-chatter.</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
+    <string name="sync_v2_error_pairing_failed">Synkroniseringen mislyktes.</string>
+    <string name="sync_v2_error_pairing_rejected">Synkroniseringen er avbrutt fra den andre enheten.</string>
+    <string name="sync_v2_error_pairing_canceled">Synkronisering avbrutt.</string>
+    <string name="sync_v2_error_upgrade_required">Oppdater DuckDuckGo-nettleseren og prøv igjen.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Synkroniser denne enheten fra en allerede tilkoblet DuckDuckGo-nettleser på en annen enhet</string>
+    <string name="sync_v2_error_try_again">Prøv igjen.</string>
+    <string name="sync_v2_error_got_it">Den er grei</string>
+    <string name="sync_v2_already_paired_title">Allerede synkronisert.</string>
+    <string name="sync_v2_already_paired_message">Disse enhetene er allerede koblet til Sync &amp; Backup.</string>
+
 </resources>

--- a/sync/sync-impl/src/main/res/values-nl/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-nl/strings-sync.xml
@@ -249,4 +249,31 @@
     <string name="sync_chat_bottom_sheet_description">Zoek de QR-code in de DuckDuckGo-app op je andere apparaat door op dat apparaat naar \'Instellingen\' › \'Sync &amp; Backup\' › \'Synchroniseren\' te gaan.</string>
     <string name="sync_chat_bottom_sheet_positive">QR-code scannen</string>
     <string name="sync_chat_bottom_sheet_negative">Niet nu</string>
+
+    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
+    <string name="sync_v2_joiner_confirmation_title">Je gegevens synchroniseren?</string>
+    <string name="sync_v2_joiner_confirmation_positive">Nu synchroniseren</string>
+    <string name="sync_v2_joiner_confirmation_negative">Annuleren</string>
+
+    <string name="sync_v2_host_confirmation_title">Je gegevens synchroniseren?</string>
+    <string name="sync_v2_host_confirmation_positive">Nu synchroniseren</string>
+    <string name="sync_v2_host_confirmation_negative">Annuleren</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">“%1$s” kan je gesynchroniseerde DuckDuckGo-wachtwoorden, autofill-gegevens en Duck.ai-chats openen.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">\"%1$s\" heeft toegang tot je gesynchroniseerde Duck.ai-chats.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">Het andere apparaat krijgt toegang tot je gesynchroniseerde DuckDuckGo-wachtwoorden, autofill-gegevens en Duck.ai-chats.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">Het andere apparaat krijgt toegang tot je gesynchroniseerde Duck.ai-chats.</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
+    <string name="sync_v2_error_pairing_failed">Synchronisatie is mislukt.</string>
+    <string name="sync_v2_error_pairing_rejected">Synchronisatie geannuleerd vanaf je andere apparaat.</string>
+    <string name="sync_v2_error_pairing_canceled">Synchronisatie geannuleerd.</string>
+    <string name="sync_v2_error_upgrade_required">Werk de DuckDuckGo-browser bij en probeer het opnieuw.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Synchroniseer dit apparaat via een DuckDuckGo-browser die al op een ander apparaat is verbonden</string>
+    <string name="sync_v2_error_try_again">Probeer het opnieuw.</string>
+    <string name="sync_v2_error_got_it">Ik snap het</string>
+    <string name="sync_v2_already_paired_title">Al gesynchroniseerd.</string>
+    <string name="sync_v2_already_paired_message">Deze apparaten zijn al verbonden met Sync &amp; Backup.</string>
+
 </resources>

--- a/sync/sync-impl/src/main/res/values-pl/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-pl/strings-sync.xml
@@ -249,4 +249,31 @@
     <string name="sync_chat_bottom_sheet_description">Znajdź kod QR w aplikacji DuckDuckGo na innym urządzeniu, przechodząc do Ustawienia › Sync &amp; Backup › Synchronizuj z innym urządzeniem.</string>
     <string name="sync_chat_bottom_sheet_positive">Zeskanuj kod QR</string>
     <string name="sync_chat_bottom_sheet_negative">Nie teraz</string>
+
+    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
+    <string name="sync_v2_joiner_confirmation_title">Zsynchronizować Twoje dane?</string>
+    <string name="sync_v2_joiner_confirmation_positive">Synchronizuj teraz</string>
+    <string name="sync_v2_joiner_confirmation_negative">Anuluj</string>
+
+    <string name="sync_v2_host_confirmation_title">Zsynchronizować Twoje dane?</string>
+    <string name="sync_v2_host_confirmation_positive">Synchronizuj teraz</string>
+    <string name="sync_v2_host_confirmation_negative">Anuluj</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">„%1$s” będzie mieć dostęp do zsynchronizowanych haseł DuckDuckGo, danych automatycznego uzupełniania i czatów Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">„%1$s” będzie mieć dostęp do zsynchronizowanych danych Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">Drugie urządzenie będzie mieć dostęp do zsynchronizowanych haseł DuckDuckGo, danych automatycznego uzupełniania i czatów Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">Drugie urządzenie będzie mieć dostęp do zsynchronizowanych czatów Duck.ai.</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
+    <string name="sync_v2_error_pairing_failed">Synchronizacja nie powiodła się.</string>
+    <string name="sync_v2_error_pairing_rejected">Synchronizacja została anulowana na drugim urządzeniu.</string>
+    <string name="sync_v2_error_pairing_canceled">Synchronizacja anulowana.</string>
+    <string name="sync_v2_error_upgrade_required">Zaktualizuj przeglądarkę DuckDuckGo i spróbuj ponownie.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Zsynchronizuj to urządzenie za pomocą przeglądarki DuckDuckGo, która jest już połączona na innym urządzeniu</string>
+    <string name="sync_v2_error_try_again">Spróbuj ponownie.</string>
+    <string name="sync_v2_error_got_it">Rozumiem</string>
+    <string name="sync_v2_already_paired_title">Już zsynchronizowane.</string>
+    <string name="sync_v2_already_paired_message">Te urządzenia są już połączone z usługą Sync &amp; Backup.</string>
+
 </resources>

--- a/sync/sync-impl/src/main/res/values-pt/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-pt/strings-sync.xml
@@ -249,4 +249,31 @@
     <string name="sync_chat_bottom_sheet_description">Encontra o código QR na aplicação DuckDuckGo no teu outro dispositivo, indo a Definições › Sync &amp; Backup › Sincronizar com outro dispositivo.</string>
     <string name="sync_chat_bottom_sheet_positive">Ler código QR</string>
     <string name="sync_chat_bottom_sheet_negative">Agora não</string>
+
+    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
+    <string name="sync_v2_joiner_confirmation_title">Sincronizar os teus dados?</string>
+    <string name="sync_v2_joiner_confirmation_positive">Sincronizar agora</string>
+    <string name="sync_v2_joiner_confirmation_negative">Cancelar</string>
+
+    <string name="sync_v2_host_confirmation_title">Sincronizar os teus dados?</string>
+    <string name="sync_v2_host_confirmation_positive">Sincronizar agora</string>
+    <string name="sync_v2_host_confirmation_negative">Cancelar</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">\"%1$s\" poderá aceder às tuas palavras-passe sincronizadas do DuckDuckGo, aos dados de preenchimento automático e aos chats do Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">\"%1$s\" poderá aceder aos teus chats sincronizados no Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">O outro dispositivo poderá aceder às tuas palavras-passe sincronizadas do DuckDuckGo, aos dados de preenchimento automático e aos chats do Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">O outro dispositivo poderá aceder aos teus chats sincronizados no Duck.ai.</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
+    <string name="sync_v2_error_pairing_failed">A sincronização falhou.</string>
+    <string name="sync_v2_error_pairing_rejected">A sincronização foi cancelada no teu outro dispositivo.</string>
+    <string name="sync_v2_error_pairing_canceled">Sincronização cancelada.</string>
+    <string name="sync_v2_error_upgrade_required">Atualiza o navegador DuckDuckGo e tenta novamente.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Sincroniza este dispositivo a partir de um navegador DuckDuckGo já ligado noutro dispositivo</string>
+    <string name="sync_v2_error_try_again">Tenta novamente.</string>
+    <string name="sync_v2_error_got_it">Entendido</string>
+    <string name="sync_v2_already_paired_title">Já está sincronizado.</string>
+    <string name="sync_v2_already_paired_message">Estes dispositivos já estão ligados ao Sync &amp; Backup.</string>
+
 </resources>

--- a/sync/sync-impl/src/main/res/values-ro/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-ro/strings-sync.xml
@@ -249,4 +249,31 @@
     <string name="sync_chat_bottom_sheet_description">Găsește codul QR în aplicația DuckDuckGo de pe celălalt dispozitiv, accesând Setări › Sync &amp; Backup › Sincronizează cu un alt dispozitiv.</string>
     <string name="sync_chat_bottom_sheet_positive">Scanează codul QR</string>
     <string name="sync_chat_bottom_sheet_negative">Nu acum</string>
+
+    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
+    <string name="sync_v2_joiner_confirmation_title">Dorești să sincronizezi datele?</string>
+    <string name="sync_v2_joiner_confirmation_positive">Sincronizează acum</string>
+    <string name="sync_v2_joiner_confirmation_negative">Anulează</string>
+
+    <string name="sync_v2_host_confirmation_title">Dorești să sincronizezi datele?</string>
+    <string name="sync_v2_host_confirmation_positive">Sincronizează acum</string>
+    <string name="sync_v2_host_confirmation_negative">Anulează</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">„%1$s” va putea accesa parolele tale sincronizate din DuckDuckGo, datele de completare automată și conversațiile din Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">„%1$s” va putea accesa chaturile tale Duck.ai sincronizate.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">Celălalt dispozitiv va avea acces la parolele tale sincronizate din DuckDuckGo, la datele de completare automată și la chaturile Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">Celălalt dispozitiv va putea accesa chaturile tale Duck.ai sincronizate.</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
+    <string name="sync_v2_error_pairing_failed">Sincronizarea nu a reușit.</string>
+    <string name="sync_v2_error_pairing_rejected">Sincronizarea a fost anulată de pe celălalt dispozitiv.</string>
+    <string name="sync_v2_error_pairing_canceled">Sincronizare anulată.</string>
+    <string name="sync_v2_error_upgrade_required">Actualizează browserul DuckDuckGo și încearcă din nou.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Sincronizează acest dispozitiv dintr-un browser DuckDuckGo deja conectat pe un alt dispozitiv</string>
+    <string name="sync_v2_error_try_again">Încearcă din nou.</string>
+    <string name="sync_v2_error_got_it">Am înțeles</string>
+    <string name="sync_v2_already_paired_title">Deja sincronizat.</string>
+    <string name="sync_v2_already_paired_message">Aceste dispozitive sunt deja conectate la Sync &amp; Backup.</string>
+
 </resources>

--- a/sync/sync-impl/src/main/res/values-ru/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-ru/strings-sync.xml
@@ -249,4 +249,31 @@
     <string name="sync_chat_bottom_sheet_description">Найдите QR-код в приложении DuckDuckGo на другом устройстве: для этого перейдите в «Настройки» → «Sync &amp; Backup» → «Синхронизация с другим устройством».</string>
     <string name="sync_chat_bottom_sheet_positive">Сканировать QR-код</string>
     <string name="sync_chat_bottom_sheet_negative">Не сейчас</string>
+
+    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
+    <string name="sync_v2_joiner_confirmation_title">Синхронизировать данные?</string>
+    <string name="sync_v2_joiner_confirmation_positive">Синхронизировать</string>
+    <string name="sync_v2_joiner_confirmation_negative">Отменить</string>
+
+    <string name="sync_v2_host_confirmation_title">Синхронизировать данные?</string>
+    <string name="sync_v2_host_confirmation_positive">Синхронизировать</string>
+    <string name="sync_v2_host_confirmation_negative">Отменить</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">«%1$s» сможет получить доступ к синхронизированным паролям DuckDuckGo, данным автозаполнения и чатам Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">«%1$s» сможет получить доступ к вашим синхронизированным чатам Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">Другое устройство сможет получить доступ к вашим синхронизированным паролям DuckDuckGo, данным автозаполнения и чатам Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">Другое устройство сможет получить доступ к вашим синхронизированным чатам Duck.ai.</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
+    <string name="sync_v2_error_pairing_failed">Ошибка синхронизации.</string>
+    <string name="sync_v2_error_pairing_rejected">Синхронизация отменена с другого устройства.</string>
+    <string name="sync_v2_error_pairing_canceled">Синхронизация отменена.</string>
+    <string name="sync_v2_error_upgrade_required">Обновите браузер DuckDuckGo и повторите попытку.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Синхронизируйте это устройство с уже подключённым браузером DuckDuckGo на другом устройстве</string>
+    <string name="sync_v2_error_try_again">Повторите попытку.</string>
+    <string name="sync_v2_error_got_it">Понятно</string>
+    <string name="sync_v2_already_paired_title">Уже синхронизировано.</string>
+    <string name="sync_v2_already_paired_message">Эти устройства уже подключены к Sync &amp; Backup.</string>
+
 </resources>

--- a/sync/sync-impl/src/main/res/values-sk/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-sk/strings-sync.xml
@@ -249,4 +249,31 @@
     <string name="sync_chat_bottom_sheet_description">Nájdi QR kód v aplikácii DuckDuckGo na svojom druhom zariadení tak, že prejdeš do časti Nastavenia › Sync &amp; Backup › „Synchronizovať s iným zariadením“.</string>
     <string name="sync_chat_bottom_sheet_positive">Skenovanie kódu QR</string>
     <string name="sync_chat_bottom_sheet_negative">Teraz nie</string>
+
+    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
+    <string name="sync_v2_joiner_confirmation_title">Chceš synchronizovať svoje dáta?</string>
+    <string name="sync_v2_joiner_confirmation_positive">Synchronizovať teraz</string>
+    <string name="sync_v2_joiner_confirmation_negative">Zrušiť</string>
+
+    <string name="sync_v2_host_confirmation_title">Chceš synchronizovať svoje dáta?</string>
+    <string name="sync_v2_host_confirmation_positive">Synchronizovať teraz</string>
+    <string name="sync_v2_host_confirmation_negative">Zrušiť</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">„%1$s“ bude mať prístup k tvojim synchronizovaným heslám DuckDuckGo, údajom automatického dopĺňania a četom Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">„%1$s“ bude mať prístup k tvojim synchronizovaným četom Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">Druhé zariadenie bude mať prístup k tvojim synchronizovaným heslám DuckDuckGo, údajom automatického dopĺňania a četom Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">Druhé zariadenie bude mať prístup k tvojim synchronizovaným četom Duck.ai.</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
+    <string name="sync_v2_error_pairing_failed">Synchronizácia sa nepodarila.</string>
+    <string name="sync_v2_error_pairing_rejected">Synchronizácia bola zrušená z tvojho druhého zariadenia.</string>
+    <string name="sync_v2_error_pairing_canceled">Synchronizácia bola zrušená.</string>
+    <string name="sync_v2_error_upgrade_required">Aktualizuj prehliadač DuckDuckGo a skús to znova.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Synchronizuj toto zariadenie z už pripojeného prehliadača DuckDuckGo na inom zariadení</string>
+    <string name="sync_v2_error_try_again">Skús to znova.</string>
+    <string name="sync_v2_error_got_it">Rozumiem</string>
+    <string name="sync_v2_already_paired_title">Už je to synchronizované.</string>
+    <string name="sync_v2_already_paired_message">Tieto zariadenia sú už pripojené k Sync &amp; Backup.</string>
+
 </resources>

--- a/sync/sync-impl/src/main/res/values-sl/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-sl/strings-sync.xml
@@ -249,4 +249,31 @@
     <string name="sync_chat_bottom_sheet_description">Poiščite kodo QR v aplikaciji DuckDuckGo v drugi napravi tako, da odprete Nastavitve › Sync &amp; Backup › Sinhronizacija z drugo napravo.</string>
     <string name="sync_chat_bottom_sheet_positive">Skeniranje kode QR</string>
     <string name="sync_chat_bottom_sheet_negative">Ne zdaj</string>
+
+    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
+    <string name="sync_v2_joiner_confirmation_title">Želite sinhronizirati svoje podatke?</string>
+    <string name="sync_v2_joiner_confirmation_positive">Sinhroniziraj zdaj</string>
+    <string name="sync_v2_joiner_confirmation_negative">Prekliči</string>
+
+    <string name="sync_v2_host_confirmation_title">Želite sinhronizirati svoje podatke?</string>
+    <string name="sync_v2_host_confirmation_positive">Sinhroniziraj zdaj</string>
+    <string name="sync_v2_host_confirmation_negative">Prekliči</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">Naprava »%1$s« bo lahko dostopala do tvojih sinhroniziranih gesel DuckDuckGo, podatkov za samodejno izpolnjevanje in klepetov Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">Naprava »%1$s« bo lahko dostopala do vaših sinhroniziranih klepetov Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">Druga naprava bo lahko dostopala do vaših sinhroniziranih gesel DuckDuckGo, podatkov za samodejno izpolnjevanje in klepetov Duck.ai.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">Druga naprava bo lahko dostopala do vaših sinhroniziranih klepetov Duck.ai.</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
+    <string name="sync_v2_error_pairing_failed">Sinhronizacija ni uspela.</string>
+    <string name="sync_v2_error_pairing_rejected">Sinhronizacija je bila preklicana iz vaše druge naprave.</string>
+    <string name="sync_v2_error_pairing_canceled">Sinhronizacija je bila preklicana.</string>
+    <string name="sync_v2_error_upgrade_required">Posodobite brskalnik DuckDuckGo in poskusite znova.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Sinhronizirajte to napravo iz že povezanega brskalnika DuckDuckGo v drugi napravi</string>
+    <string name="sync_v2_error_try_again">Poskusite znova.</string>
+    <string name="sync_v2_error_got_it">Razumem</string>
+    <string name="sync_v2_already_paired_title">Že sinhronizirano.</string>
+    <string name="sync_v2_already_paired_message">Te naprave so že povezane s storitvijo Sync &amp; Backup.</string>
+
 </resources>

--- a/sync/sync-impl/src/main/res/values-sv/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-sv/strings-sync.xml
@@ -249,4 +249,31 @@
     <string name="sync_chat_bottom_sheet_description">Hitta QR-koden i DuckDuckGo-appen på din andra enhet genom att gå till Inställningar › Sync &amp; Backup › Synkronisera med en annan enhet.</string>
     <string name="sync_chat_bottom_sheet_positive">Skanna QR-kod</string>
     <string name="sync_chat_bottom_sheet_negative">Inte nu</string>
+
+    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
+    <string name="sync_v2_joiner_confirmation_title">Synkronisera dina data?</string>
+    <string name="sync_v2_joiner_confirmation_positive">Synkronisera nu</string>
+    <string name="sync_v2_joiner_confirmation_negative">Avbryt</string>
+
+    <string name="sync_v2_host_confirmation_title">Synkronisera dina data?</string>
+    <string name="sync_v2_host_confirmation_positive">Synkronisera nu</string>
+    <string name="sync_v2_host_confirmation_negative">Avbryt</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">%1$s kommer att kunna komma åt dina synkroniserade DuckDuckGo-lösenord, automatiskt ifyllda data och Duck.ai-chattar.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">%1$s kommer att kunna komma åt dina synkroniserade Duck.ai-chattar.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">Den andra enheten kommer att kunna komma åt dina synkroniserade DuckDuckGo-lösenord, automatiskt ifyllda data och Duck.ai-chattar.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">Den andra enheten kommer att kunna komma åt dina synkade Duck.ai-chattar.</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
+    <string name="sync_v2_error_pairing_failed">Synkroniseringen misslyckades.</string>
+    <string name="sync_v2_error_pairing_rejected">Synkroniseringen avbröts från din andra enhet.</string>
+    <string name="sync_v2_error_pairing_canceled">Synkroniseringen avbröts.</string>
+    <string name="sync_v2_error_upgrade_required">Uppdatera DuckDuckGo-webbläsaren och försök igen.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Synkronisera den här enheten från en redan ansluten DuckDuckGo-webbläsare på en annan enhet</string>
+    <string name="sync_v2_error_try_again">Försök igen.</string>
+    <string name="sync_v2_error_got_it">Jag förstår</string>
+    <string name="sync_v2_already_paired_title">Redan synkroniserat.</string>
+    <string name="sync_v2_already_paired_message">Enheterna är redan anslutna till Sync &amp; Backup.</string>
+
 </resources>

--- a/sync/sync-impl/src/main/res/values-tr/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-tr/strings-sync.xml
@@ -249,4 +249,31 @@
     <string name="sync_chat_bottom_sheet_description">Diğer cihazınızdaki DuckDuckGo uygulamasında Ayarlar › Sync &amp; Backup › Başka Bir Cihazla Senkronize Et seçeneğine giderek QR kodunu bulun.</string>
     <string name="sync_chat_bottom_sheet_positive">QR kodunu tara</string>
     <string name="sync_chat_bottom_sheet_negative">Şimdi Değil</string>
+
+    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
+    <string name="sync_v2_joiner_confirmation_title">Verileriniz senkronize edilsin mi?</string>
+    <string name="sync_v2_joiner_confirmation_positive">Şimdi Senkronize Et</string>
+    <string name="sync_v2_joiner_confirmation_negative">İptal</string>
+
+    <string name="sync_v2_host_confirmation_title">Verileriniz senkronize edilsin mi?</string>
+    <string name="sync_v2_host_confirmation_positive">Şimdi Senkronize Et</string>
+    <string name="sync_v2_host_confirmation_negative">İptal</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">\"%1$s\", senkronize edilmiş DuckDuckGo şifrelerinize, otomatik doldurma verilerinize ve Duck.ai sohbetlerinize erişebilecek.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">\"%1$s\", senkronize edilmiş Duck.ai sohbetlerinize erişebilecek.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">Diğer cihaz, senkronize edilmiş DuckDuckGo şifrelerinize, otomatik doldurma verilerinize ve Duck.ai sohbetlerinize erişebilecek.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">Diğer cihaz, senkronize edilmiş Duck.ai sohbetlerinize erişebilecek.</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
+    <string name="sync_v2_error_pairing_failed">Senkronizasyon başarısız oldu.</string>
+    <string name="sync_v2_error_pairing_rejected">Diğer cihazınızdan senkronizasyon iptal edildi.</string>
+    <string name="sync_v2_error_pairing_canceled">Senkronizasyon iptal edildi.</string>
+    <string name="sync_v2_error_upgrade_required">DuckDuckGo tarayıcısını güncelleyin ve tekrar deneyin.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Lütfen bu cihazı, başka bir cihazda zaten bağlı olan bir DuckDuckGo tarayıcısından senkronize edin</string>
+    <string name="sync_v2_error_try_again">Lütfen tekrar deneyin.</string>
+    <string name="sync_v2_error_got_it">Anladım</string>
+    <string name="sync_v2_already_paired_title">Zaten senkronize edildi.</string>
+    <string name="sync_v2_already_paired_message">Bu cihazlar zaten Sync &amp; Backup\'a bağlı.</string>
+
 </resources>

--- a/sync/sync-impl/src/main/res/values/donottranslate.xml
+++ b/sync/sync-impl/src/main/res/values/donottranslate.xml
@@ -15,29 +15,5 @@
   -->
 
 <resources>
-    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
-    <string name="sync_v2_joiner_confirmation_title">Sync your data?</string>
-    <string name="sync_v2_joiner_confirmation_positive">Sync Now</string>
-    <string name="sync_v2_joiner_confirmation_negative">Cancel</string>
 
-    <string name="sync_v2_host_confirmation_title">Sync your data?</string>
-    <string name="sync_v2_host_confirmation_positive">Sync Now</string>
-    <string name="sync_v2_host_confirmation_negative">Cancel</string>
-
-    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
-    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">\"%1$s\" will be able to access your synced DuckDuckGo passwords, autofill data, and Duck.ai chats.</string>
-    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">\"%1$s\" will be able to access your synced Duck.ai chats.</string>
-    <string name="sync_v2_confirmation_message_unknown_peer_ddg">The other device will be able to access your synced DuckDuckGo passwords, autofill data, and Duck.ai chats.</string>
-    <string name="sync_v2_confirmation_message_unknown_peer_3p">The other device will be able to access your synced Duck.ai chats.</string>
-
-    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
-    <string name="sync_v2_error_pairing_failed">Sync failed.</string>
-    <string name="sync_v2_error_pairing_rejected">Sync canceled from your other device.</string>
-    <string name="sync_v2_error_pairing_canceled">Sync canceled.</string>
-    <string name="sync_v2_error_upgrade_required">Update the DuckDuckGo browser and try again.</string>
-    <string name="sync_v2_error_third_party_already_upgraded">Please Sync this device from an already-connected DuckDuckGo browser on another device</string>
-    <string name="sync_v2_error_try_again">Please try again.</string>
-    <string name="sync_v2_error_got_it">Got It</string>
-    <string name="sync_v2_already_paired_title">Already synced.</string>
-    <string name="sync_v2_already_paired_message">These devices are already connected to Sync &amp; Backup.</string>
 </resources>

--- a/sync/sync-impl/src/main/res/values/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values/strings-sync.xml
@@ -249,4 +249,31 @@
     <string name="sync_chat_bottom_sheet_description">Find the QR Code on the DuckDuckGo app on your other device by going to Settings › Sync &amp; Backup › Sync With Another Device.</string>
     <string name="sync_chat_bottom_sheet_positive">Scan QR code</string>
     <string name="sync_chat_bottom_sheet_negative">Not Now</string>
+
+    <!-- v2 Exchange confirmation prompts (spec §"Exchange Confirmations") -->
+    <string name="sync_v2_joiner_confirmation_title">Sync your data?</string>
+    <string name="sync_v2_joiner_confirmation_positive">Sync Now</string>
+    <string name="sync_v2_joiner_confirmation_negative">Cancel</string>
+
+    <string name="sync_v2_host_confirmation_title">Sync your data?</string>
+    <string name="sync_v2_host_confirmation_positive">Sync Now</string>
+    <string name="sync_v2_host_confirmation_negative">Cancel</string>
+
+    <!-- v2 consent-dialog data-access copy (kind-specific; shared by joiner & host) -->
+    <string name="sync_v2_confirmation_message_ddg" instruction="Placeholder is a peer device name, e.g. Samsung S23.">\"%1$s\" will be able to access your synced DuckDuckGo passwords, autofill data, and Duck.ai chats.</string>
+    <string name="sync_v2_confirmation_message_3p" instruction="Placeholder is a peer device name, e.g. Samsung S23.">\"%1$s\" will be able to access your synced Duck.ai chats.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_ddg">The other device will be able to access your synced DuckDuckGo passwords, autofill data, and Duck.ai chats.</string>
+    <string name="sync_v2_confirmation_message_unknown_peer_3p">The other device will be able to access your synced Duck.ai chats.</string>
+
+    <!-- v2 pairing terminal-outcome copy (interim, English-only). Spec 2026-06-17 (title-primary). -->
+    <string name="sync_v2_error_pairing_failed">Sync failed.</string>
+    <string name="sync_v2_error_pairing_rejected">Sync canceled from your other device.</string>
+    <string name="sync_v2_error_pairing_canceled">Sync canceled.</string>
+    <string name="sync_v2_error_upgrade_required">Update the DuckDuckGo browser and try again.</string>
+    <string name="sync_v2_error_third_party_already_upgraded">Please Sync this device from an already-connected DuckDuckGo browser on another device</string>
+    <string name="sync_v2_error_try_again">Please try again.</string>
+    <string name="sync_v2_error_got_it">Got It</string>
+    <string name="sync_v2_already_paired_title">Already synced.</string>
+    <string name="sync_v2_already_paired_message">These devices are already connected to Sync &amp; Backup.</string>
+
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1215945931943282?focus=true
Tech Design URL (if applicable): 

### Description
Translations for the sync exchange v2 copy changes.

### Steps to test this PR
- [ ] Lint should be passing when all translations available
- QA optional 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-resource-only changes with no behavior or security logic; main risk is translation/placeholder accuracy for user-facing sync consent copy.
> 
> **Overview**
> Adds **localized Android string resources** for Sync exchange v2 UI copy and fills gaps for downloads-related strings across many locales.
> 
> **Sync v2:** Moves `sync_v2_*` strings out of `donottranslate.xml` into default `strings-sync.xml` and adds the same keys (joiner/host confirmations, consent messages for DDG vs 3p peers, pairing errors, already-paired) to per-locale `strings-sync.xml` files.
> 
> **Downloads:** Adds `downloadsSearchHint` in `downloads-impl` locale files and adds `downloadsCannotOpenFileErrorMessage` to the main app `strings.xml` for the same language set (with minor formatting spacing).
> 
> No Kotlin or sync logic changes—resource-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60b8b7da8f36357535440f58d8dd785ef47c6733. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->