### PR TITLE
Update PIR broker bundle - 2026-07-06

### DIFF
--- a/pir/pir-impl/src/main/assets/brokers/peoplesearchnow.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/peoplesearchnow.com.json
@@ -1,7 +1,7 @@
 {
   "name": "People Search Now",
   "url": "peoplesearchnow.com",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "parent": "peoplefinders.com",
   "addedDatetime": 1705989600000,
   "optOutUrl": "https://www.peoplesearchnow.com/opt-out",
@@ -16,6 +16,17 @@
           "url": "https://peoplesearchnow.com/person/${firstName}-${lastName}_${city}_${state}/"
         },
         {
+          "actionType": "expectation",
+          "_comment": "detect Cloudflare verification UI - challenge pages expose Cloudflare challenge scripts, Turnstile controls, or captcha response fields instead of normal result cards",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//script[contains(@src,'/cdn-cgi/challenge-platform/')] or .//script[contains(@src,'challenges.cloudflare.com/turnstile')] or .//input[@name='cf-turnstile-response'] or .//iframe[contains(@src,'challenges.cloudflare.com')])]"
+            }
+          ],
+          "id": "b00ba411-0253-42ad-bbc4-b4b0940df3a7"
+        },
+        {
           "actionType": "extract",
           "id": "79098855-0459-4f26-877b-039700e098b3",
           "selector": ".result-search-block",
@@ -28,12 +39,12 @@
               "selector": ".//div[contains(@class, 'result-search-block-desc')]/p[span[text()='Approximate Age:']]/span[2]"
             },
             "addressCityState": {
-              "selector": ".//p[span[text()='Current Address:']]/span[@itemprop='address']",
+              "selector": "(.//div[contains(@class, 'result-search-block-desc')]//span[@itemprop='address'])[1]",
               "beforeText": "*",
               "afterText": ";"
             },
             "addressCityStateList": {
-              "selector": ".//p[span[text()='Used to Live:']]/span[@itemprop='address']/a",
+              "selector": "(.//div[contains(@class, 'result-search-block-desc')]//span[@itemprop='address'])[position() > 1]",
               "findElements": true,
               "beforeText": "*",
               "afterText": ";"

--- a/pir/pir-impl/src/main/assets/brokers/truepeoplesearch.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/truepeoplesearch.com.json
@@ -1,7 +1,7 @@
 {
   "name": "TruePeopleSearch",
   "url": "truepeoplesearch.com",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "parent": "peoplefinders.com",
   "addedDatetime": 1703138400000,
   "optOutUrl": "https://www.truepeoplesearch.com/removal",
@@ -28,11 +28,11 @@
         },
         {
           "actionType": "expectation",
-          "_comment": "detect CF internal captcha form - the site renders its own form#captchaForm with an h-captcha div wrapping a Cloudflare challenge iframe plus a Submit button",
+          "_comment": "detect Cloudflare verification UI - older blocks use form#captchaForm, newer blocks keep the page shell but show a Turnstile widget instead of results",
           "expectations": [
             {
               "type": "element",
-              "selector": "//body[not(.//form[@id='captchaForm'])]"
+              "selector": "//body[not(.//form[@id='captchaForm'] or .//script[contains(@src,'/cdn-cgi/challenge-platform/')] or .//script[contains(@src,'challenges.cloudflare.com/turnstile')] or .//input[@name='cf-turnstile-response'])]"
             }
           ],
           "id": "9ea1684f-1953-45b7-954e-d1597a0c5063"
@@ -43,7 +43,7 @@
           "expectations": [
             {
               "type": "element",
-              "selector": ".card-summary",
+              "selector": "(//div[contains(@class,'card-summary') and @data-detail-link and not(contains(@class,'d-none'))])[1]",
               "failSilently": true
             }
           ],
@@ -52,34 +52,30 @@
         {
           "actionType": "extract",
           "id": "267a0b26-dc67-4ed9-b5c4-a6de838765ed",
-          "selector": ".card-summary",
+          "selector": "//div[contains(@class,'card-summary') and @data-detail-link and not(contains(@class,'d-none'))]",
           "noResultsSelector": "//span[contains(text(), 'We could not find any records')]",
           "profile": {
             "name": {
-              "selector": ".h4"
+              "selector": ".content-header"
             },
             "age": {
-              "selector": ".//div[@class='h4']/following-sibling::div[1]",
-              "afterText": "Age "
+              "selector": ".//span[normalize-space()='Age']/following-sibling::span[contains(@class,'content-value')][1]"
             },
             "addressCityState": {
-              "selector": ".//div[@class='h4']/following-sibling::div[2]",
-              "afterText": "Lives in"
+              "selector": ".//span[normalize-space()='Age']/following-sibling::span[contains(@class,'content-value')][2]"
             },
             "addressCityStateList": {
-              "selector": ".//div[@class='h4']/following-sibling::div[3]",
-              "afterText": "Used to live in",
+              "selector": ".//span[normalize-space()='Used to live in']/following-sibling::span[contains(@class,'content-value')][1]",
               "separator": ",",
               "beforeText": "..."
             },
             "relativesList": {
-              "selector": ".//div[@class='h4']/following-sibling::div[4]",
-              "afterText": "Related to",
+              "selector": ".//span[normalize-space()='Related to']/following-sibling::span[contains(@class,'content-value')][1]",
               "separator": ",",
               "beforeText": "..."
             },
             "profileUrl": {
-              "selector": "a",
+              "selector": ".//a[contains(@class,'detail-link') and not(ancestor::div[contains(@class,'visible-mobile')])]",
               "identifierType": "path",
               "identifier": "https://www.truepeoplesearch.com/find/person/${id}"
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1216285926499743

## PIR Broker Bundle Update

Automated update of PIR broker JSON files from the remote bundle.

### Changes

**Updated (2):**
- peoplesearchnow.com.json (0.5.0 → 0.6.0)
- truepeoplesearch.com.json (0.8.0 → 0.9.0)

### Checklist

- [x] Verify broker changes look correct
- [x] All tests must pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Asset-only broker automation config changes; impact is limited to PIR scan/opt-out reliability for these two sites, not core app or data-store logic.
> 
> **Overview**
> Updates two PeopleFinders-family **PIR broker scan definitions** so automated scans keep working against current site markup and bot checks.
> 
> **People Search Now** (0.5.0 → **0.6.0**): Adds a post-navigation **Cloudflare/Turnstile** expectation so scans don’t parse challenge pages as results. **Address** fields now use indexed `itemprop='address'` nodes inside `result-search-block-desc` instead of label-based `Current Address` / `Used to Live` paragraphs.
> 
> **TruePeopleSearch** (0.8.0 → **0.9.0**): Broadens **Cloudflare** detection beyond `form#captchaForm` to challenge-platform scripts, Turnstile, and `cf-turnstile-response`. Result cards and profile fields move to **visible** `card-summary` rows with `data-detail-link`, **label + `content-value`** spans for age/addresses/relatives, and a non-mobile **`detail-link`** for profile URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3502f297f871d9b6a1a527dd4b3adcd663565c6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->