### PR TITLE
Disable open new tab with long press in NTP

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1621,8 +1621,8 @@ class BrowserTabFragment :
         launch { viewModel.userLaunchingTabSwitcher(omnibar.viewMode, omnibar.getText().isEmpty() && omnibar.omnibarTextInput.hasFocus()) }
     }
 
-    private fun onTabsButtonLongPressed() {
-        launch { viewModel.onNewTabMenuItemClicked(longPress = true) }
+    private fun onTabsButtonLongPressed(): Boolean {
+        return viewModel.onNewTabMenuItemClicked(longPress = true)
     }
 
     private fun onUserSubmittedText(text: String) {
@@ -3927,8 +3927,8 @@ class BrowserTabFragment :
                     this@BrowserTabFragment.onTabsButtonPressed()
                 }
 
-                override fun onTabsButtonLongPressed() {
-                    this@BrowserTabFragment.onTabsButtonLongPressed()
+                override fun onTabsButtonLongPressed(): Boolean {
+                    return this@BrowserTabFragment.onTabsButtonLongPressed()
                 }
 
                 override fun onFireButtonPressed() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3593,6 +3593,10 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun onNewTabMenuItemClicked(longPress: Boolean = false) {
+        if (longPress && !currentBrowserViewState().browserShowing) {
+            return
+        }
+
         openNewTab()
 
         if (longPress) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3592,9 +3592,10 @@ class BrowserTabViewModel @Inject constructor(
         }
     }
 
-    fun onNewTabMenuItemClicked(longPress: Boolean = false) {
+
+    fun onNewTabMenuItemClicked(longPress: Boolean = false): Boolean {
         if (longPress && !currentBrowserViewState().browserShowing) {
-            return
+            return false
         }
 
         openNewTab()
@@ -3611,6 +3612,8 @@ class BrowserTabViewModel @Inject constructor(
                 }
             }
         }
+
+        return true
     }
 
     fun onNavigationBarNewTabButtonClicked() {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3593,7 +3593,9 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun onNewTabMenuItemClicked(longPress: Boolean = false): Boolean {
-        if (longPress && !currentBrowserViewState().browserShowing) {
+        val state = currentBrowserViewState()
+        val isOnNewTabPage = !state.browserShowing && !state.maliciousSiteBlocked && state.sslError == NONE
+        if (longPress && isOnNewTabPage) {
             return false
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3592,7 +3592,6 @@ class BrowserTabViewModel @Inject constructor(
         }
     }
 
-
     fun onNewTabMenuItemClicked(longPress: Boolean = false): Boolean {
         if (longPress && !currentBrowserViewState().browserShowing) {
             return false

--- a/app/src/main/java/com/duckduckgo/app/browser/navigation/bar/view/BrowserNavigationBarView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/navigation/bar/view/BrowserNavigationBarView.kt
@@ -182,7 +182,6 @@ class BrowserNavigationBarView @JvmOverloads constructor(
 
         binding.tabsButton.setOnLongClickListener {
             viewModel.onTabsButtonLongClicked()
-            true
         }
 
         binding.menuButton.setOnClickListener {

--- a/app/src/main/java/com/duckduckgo/app/browser/navigation/bar/view/BrowserNavigationBarViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/navigation/bar/view/BrowserNavigationBarViewModel.kt
@@ -107,9 +107,13 @@ class BrowserNavigationBarViewModel @Inject constructor(
         _commands.trySend(NotifyTabsButtonClicked)
     }
 
-    fun onTabsButtonLongClicked() {
+    fun onTabsButtonLongClicked(): Boolean {
+        if (_viewState.value.viewMode != Browser) {
+            return false
+        }
         pixel.fire(AppPixelName.BROWSER_NAV_TABS_LONG_PRESSED.pixelName)
         _commands.trySend(NotifyTabsButtonLongClicked)
+        return true
     }
 
     fun onMenuButtonClicked() {

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/Omnibar.kt
@@ -65,7 +65,7 @@ class Omnibar(
     interface ItemPressedListener {
         fun onTabsButtonPressed()
 
-        fun onTabsButtonLongPressed()
+        fun onTabsButtonLongPressed(): Boolean
 
         fun onFireButtonPressed()
 

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -572,8 +572,8 @@ class OmnibarLayout @JvmOverloads constructor(
             omnibarItemPressedListener?.onTabsButtonPressed()
         }
         tabsMenu.setOnLongClickListener {
-            omnibarItemPressedListener?.onTabsButtonLongPressed()
-            return@setOnLongClickListener true
+            val longPressHandled = omnibarItemPressedListener?.onTabsButtonLongPressed() ?: false
+            return@setOnLongClickListener longPressHandled
         }
         fireIconMenu.setOnClickListener {
             if (isAttachedToWindow) {

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -3437,6 +3437,34 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenUserRequestedToOpenNewTabByLongPressAndMaliciousSiteBlockedThenNewTabOpenedAndPixelFired() {
+        testee.browserViewState.value =
+            browserViewState().copy(
+                browserShowing = false,
+                maliciousSiteBlocked = true,
+            )
+
+        testee.onNewTabMenuItemClicked(longPress = true)
+
+        assertCommandIssued<Command.GenerateWebViewPreviewImage>()
+        verify(mockPixel).fire(AppPixelName.TAB_MANAGER_NEW_TAB_LONG_PRESSED)
+    }
+
+    @Test
+    fun whenUserRequestedToOpenNewTabByLongPressAndSslWarningShowingThenNewTabOpenedAndPixelFired() {
+        testee.browserViewState.value =
+            browserViewState().copy(
+                browserShowing = false,
+                sslError = EXPIRED,
+            )
+
+        testee.onNewTabMenuItemClicked(longPress = true)
+
+        assertCommandIssued<Command.GenerateWebViewPreviewImage>()
+        verify(mockPixel).fire(AppPixelName.TAB_MANAGER_NEW_TAB_LONG_PRESSED)
+    }
+
+    @Test
     fun whenUserRequestedToOpenNewTabByNormalClickAndAlreadyOnNewTabPageThenReturnsTrue() {
         setBrowserShowing(false)
 

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -3419,6 +3419,33 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenUserRequestedToOpenNewTabByLongPressAndBrowserShowingThenReturnsTrue() {
+        setBrowserShowing(true)
+
+        val handled = testee.onNewTabMenuItemClicked(longPress = true)
+
+        assertTrue(handled)
+    }
+
+    @Test
+    fun whenUserRequestedToOpenNewTabByLongPressAndAlreadyOnNewTabPageThenReturnsFalse() {
+        setBrowserShowing(false)
+
+        val handled = testee.onNewTabMenuItemClicked(longPress = true)
+
+        assertFalse(handled)
+    }
+
+    @Test
+    fun whenUserRequestedToOpenNewTabByNormalClickAndAlreadyOnNewTabPageThenReturnsTrue() {
+        setBrowserShowing(false)
+
+        val handled = testee.onNewTabMenuItemClicked(longPress = false)
+
+        assertTrue(handled)
+    }
+
+    @Test
     fun whenNewTabMenuItemClickedAndEmptyTabExistsAndInputScreenDisabledThenShowKeyboard() =
         runTest {
             swipingTabsFeature.self().setRawStoredState(State(enable = true))

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -3398,10 +3398,24 @@ class BrowserTabViewModelTest {
         }
 
     @Test
-    fun whenUserRequestedToOpenNewTabByLongPressThenPixelFired() {
+    fun whenUserRequestedToOpenNewTabByLongPressAndBrowserShowingThenNewTabOpenedAndPixelFired() {
+        setBrowserShowing(true)
+
         testee.onNewTabMenuItemClicked(longPress = true)
 
+        assertCommandIssued<Command.GenerateWebViewPreviewImage>()
         verify(mockPixel).fire(AppPixelName.TAB_MANAGER_NEW_TAB_LONG_PRESSED)
+    }
+
+    @Test
+    fun whenUserRequestedToOpenNewTabByLongPressAndAlreadyOnNewTabPageThenNoNewTabOpenedAndNoPixelFired() {
+        setBrowserShowing(false)
+
+        testee.onNewTabMenuItemClicked(longPress = true)
+
+        assertCommandNotIssued<Command.GenerateWebViewPreviewImage>()
+        assertCommandNotIssued<Command.LaunchNewTab>()
+        verify(mockPixel, never()).fire(AppPixelName.TAB_MANAGER_NEW_TAB_LONG_PRESSED)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/navigation/bar/view/BrowserNavigationBarViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/navigation/bar/view/BrowserNavigationBarViewModelTest.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.app.browser.menu.BrowserMenuHighlight
 import com.duckduckgo.app.browser.menu.BrowserViewMode
 import com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarViewModel.Command
 import com.duckduckgo.app.browser.navigation.bar.view.BrowserNavigationBarViewModel.EnabledState
+import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.app.tabs.model.TabRepository
@@ -35,6 +36,7 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -89,12 +91,45 @@ class BrowserNavigationBarViewModelTest {
     }
 
     @Test
-    fun `when Tabs button long clicked, then send view command`() = runTest {
+    fun `when Tabs button long clicked in Browser mode, then send view command`() = runTest {
+        testee.setViewMode(BrowserNavigationBarView.ViewMode.Browser)
+
         testee.onTabsButtonLongClicked()
 
         testee.commands.test {
             val command = awaitItem()
             Assert.assertEquals(Command.NotifyTabsButtonLongClicked, command)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when Tabs button long clicked in Browser mode, then returns true and fires pixel`() = runTest {
+        testee.setViewMode(BrowserNavigationBarView.ViewMode.Browser)
+
+        val handled = testee.onTabsButtonLongClicked()
+
+        Assert.assertTrue(handled)
+        verify(pixelMock).fire(AppPixelName.BROWSER_NAV_TABS_LONG_PRESSED.pixelName)
+    }
+
+    @Test
+    fun `when Tabs button long clicked in NewTab mode, then returns false and does not fire pixel`() = runTest {
+        testee.setViewMode(BrowserNavigationBarView.ViewMode.NewTab)
+
+        val handled = testee.onTabsButtonLongClicked()
+
+        Assert.assertFalse(handled)
+        verify(pixelMock, never()).fire(AppPixelName.BROWSER_NAV_TABS_LONG_PRESSED.pixelName)
+    }
+
+    @Test
+    fun `when Tabs button long clicked in NewTab mode, then does not send view command`() = runTest {
+        testee.setViewMode(BrowserNavigationBarView.ViewMode.NewTab)
+
+        testee.commands.test {
+            testee.onTabsButtonLongClicked()
+            expectNoEvents()
             cancelAndIgnoreRemainingEvents()
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1215861941732705?focus=true
Tech Design URL (if applicable): 

### Description
Disable opening a new tab with long press if already in a new tab

### Steps to test this PR

_New Tab Page_
- [x] Install from branch
- [x] Open a new tab
- [x] Long press in the new tab menu item
- [x] Verify it is disable and nothing happens

_Browser showing_
- [x] Navigate to any website or perform a search
- [x] Long press in the new tab menu item
- [x] Verify it opens a new tab

_Long Press Disabled_
- [x] Install from branch
- [x] Open a new tab
- [x] Long press in the new tab menu item
- [x] Verify haptic feedback is disabled

### No UI changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized tab-switcher gesture and analytics behavior with broad unit test coverage; no auth, data, or security surface.
> 
> **Overview**
> Long-pressing the tabs control to open a new tab is **no-op on the New Tab Page**, and the gesture no longer reports as handled so **haptic feedback is suppressed** when nothing happens.
> 
> `BrowserTabViewModel.onNewTabMenuItemClicked` now returns `false` for a long press when the tab is already on the NTP (`browserShowing` false, no malicious-site block, no SSL warning); it still opens a tab and fires `TAB_MANAGER_NEW_TAB_LONG_PRESSED` when a site is showing or those error states are active. The omnibar tabs menu wires its long-click listener to that boolean return value instead of always returning `true`.
> 
> On the bottom navigation bar, long press on tabs is **ignored in `NewTab` view mode** (no command, no `BROWSER_NAV_TABS_LONG_PRESSED` pixel, listener returns `false`); browser mode behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfb222a1c050bc9de4864485b5fc0b0b00a4cb79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->