### PR TITLE
Fix AppTP unregister crash

### DIFF
--- a/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/DnsChangeCallback.kt
+++ b/app-tracking-protection/vpn-impl/src/main/java/com/duckduckgo/mobile/android/vpn/service/DnsChangeCallback.kt
@@ -44,6 +44,7 @@ class DnsChangeCallback @Inject constructor(
         context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager?
     }
     private var lastDns: List<InetAddress>? = null
+    private var registered: Boolean = false
 
     override fun onLinkPropertiesChanged(network: Network, linkProperties: LinkProperties) {
         logcat { "onLinkPropertiesChanged: $linkProperties" }
@@ -68,22 +69,27 @@ class DnsChangeCallback @Inject constructor(
     }
 
     internal fun register() {
+        if (registered) return
         kotlin.runCatching {
             val request = NetworkRequest.Builder().apply {
                 addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
                 addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
             }.build()
             connectivityManager?.registerNetworkCallback(request, this)
+            registered = true
         }.onFailure {
             logcat(ERROR) { it.asLog() }
         }
     }
 
     internal fun unregister() {
+        if (!registered) return
         kotlin.runCatching {
             connectivityManager?.unregisterNetworkCallback(this)
         }.onFailure {
             logcat(ERROR) { it.asLog() }
+        }.also {
+            registered = false
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200204095367872/task/1216284733725748?focus=true
Tech Design URL (if applicable): 

### Description

- Fixes a crash when disabling AppTP

### Steps to test this PR

- [ ] Enable AppTP
- [ ] Disable AppTP
- [ ] Verify AppTP is disabled without crash


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small lifecycle guard around VPN DNS monitoring; no auth or data-path changes, only prevents invalid ConnectivityManager unregister calls.
> 
> **Overview**
> Fixes a crash when disabling App Tracking Protection by tracking whether the DNS network callback was actually registered with `ConnectivityManager`.
> 
> **`DnsChangeCallback`** now keeps a `registered` flag: `register()` returns early if already registered and sets the flag after a successful register; `unregister()` skips work when not registered and clears the flag after attempting unregister (including on failure). That avoids calling `unregisterNetworkCallback` when the callback was never registered—for example when AppTP stops without having taken the NgVpnNetworkStack + DNS path that registers the listener.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a96c4f45d2302041de56ea55e4451a3ad8c4f3e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->