### PR TITLE
Fix :app unit-test OutOfMemoryError by raising fork heap and recycling the fork

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -197,6 +197,8 @@ android {
         animationsDisabled = true
         unitTests.all {
             jvmArgs '-XX:+TieredCompilation', '-XX:TieredStopAtLevel=1'
+            maxHeapSize = "2g"
+            forkEvery = 100
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1216304953018940
Tech Design URL (if applicable): N/A

### Description

The `:app` unit test task runs the whole test suite in a single forked JVM using Gradle's default test heap. No `maxHeapSize`, `forkEvery`, or `maxParallelForks` is configured anywhere in the module, and `org.gradle.jvmargs` in `gradle.properties` only sizes the Gradle daemon rather than the forked test process.

As the `:app` suite has grown, that single fork started exceeding the default heap and failing with `OutOfMemoryError`. Because one fork runs every class, the error surfaces in whichever class happens to be running when memory is exhausted, so the failures appear scattered across unrelated test classes rather than pointing at a single test.

This change:
- Raises the test fork heap to `2g` to give headroom for the current suite.
- Recycles the fork every 100 test classes via `forkEvery` so heap and metaspace cannot accumulate unbounded across the full run, keeping headroom as more tests are added over time.

### Steps to test this PR

_Unit tests_
- [ ] The `Unit tests` and `Unit tests (Metro)` CI jobs complete without `OutOfMemoryError` and pass.
- [ ] Optionally run `./gradlew :app:testPlayDebugUnitTest` locally and confirm it completes.

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/test configuration only; no runtime app, auth, or production code paths change.
> 
> **Overview**
> Addresses **OutOfMemoryError** failures in `:app` unit tests by configuring the forked test JVM in `app/build.gradle` under `testOptions.unitTests.all`.
> 
> **`maxHeapSize = "2g"`** gives the test process more heap than Gradle’s default (separate from `org.gradle.jvmargs` on the daemon). **`forkEvery = 100`** starts a fresh JVM after every 100 test classes so heap and metaspace do not grow unbounded across the full suite—reducing scattered OOMs that looked unrelated because one fork ran every class.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d09f1c7932dca133cc79f01da7b284826fec9e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->