### PR TITLE
Fix flaky assertion in whenDownloadCancelledThenPartialFileIsDeleted

### DIFF
--- a/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/pdf/InlinePdfHandlerTest.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.feature.toggles.api.Toggle.State
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
@@ -369,7 +370,7 @@ class InlinePdfHandlerTest {
         }
 
         delay(100)
-        deferred.cancel()
+        deferred.cancelAndJoin()
 
         val cacheDir = File(
             InstrumentationRegistry.getInstrumentation().targetContext.cacheDir,


### PR DESCRIPTION

Task/Issue URL: https://app.asana.com/1/137249556945/task/1216333351276423?focus=true

### Description
deferred.cancel() only requests cancellation and returns immediately, racing the async cleanup in RealInlinePdfHandler's CancellationException handler that deletes the partial file. Use cancelAndJoin() so the test waits for cleanup to finish before asserting the cache dir is empty.

### Steps to test this PR
rerun the tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no production behavior modified.
> 
> **Overview**
> Fixes intermittent failures in **`whenDownloadCancelledThenPartialFileIsDeleted`** by synchronizing the test with async cleanup after cancel.
> 
> The test now uses **`cancelAndJoin()`** instead of **`cancel()`** so it waits for the download coroutine (and `RealInlinePdfHandler`'s `CancellationException` partial-file delete) to finish before asserting the PDF cache directory is empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32cf351f422eb9dde2755fd79de22936b1bab108. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->