### PR TITLE
Fix IME keyobard state when search-only native input programatically hidden

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -351,6 +351,13 @@ class RealNativeInputManager @Inject constructor(
         // Do not require isNativeInputFieldEnabled: teardown must still run after the setting flips
         // off (and after a paused animated hide left the widget attached).
 
+        // Clear focus before hiding the IME. In SEARCH_ONLY mode the input field still holds focus
+        // when the widget is dismissed, and a focused, attached EditText remains the IME target —
+        // the window re-requests the keyboard after the hide. Dropping focus first removes the
+        // target so the hide sticks. In SEARCH_AND_DUCK_AI the field has already lost focus, so
+        // this is a no-op there.
+        widgetFrom(widgetView)?.clearInputFocus()
+
         if (isNavigation) {
             widgetFrom(widgetView)?.let { widget ->
                 widget.saveLastUsedTogglePosition(isChat = widget.isChatTabSelected())
@@ -707,12 +714,6 @@ class RealNativeInputManager @Inject constructor(
         )
         widget.onChangeModelSubmitted = { modelId -> callbacks.onChangeModelSubmitted(modelId) }
         widget.onBack = {
-            // Clear focus before hiding the IME. In SEARCH_ONLY mode the input field still holds
-            // focus when Back is pressed, and a focused, attached EditText remains the IME target —
-            // the window re-requests the keyboard after the hide. Dropping focus first removes the
-            // target so the hide sticks. In SEARCH_AND_DUCK_AI the field has already lost focus, so
-            // this is a no-op there.
-            widget.clearInputFocus()
             hideNativeInput()
         }
         val previousOnChatSelected = widget.onChatSelected


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1216301005437164?focus=true
Tech Design URL (if applicable): 

### Description
Fixes regression from https://github.com/duckduckgo/Android/pull/8929 by extending a fix introduced in https://github.com/duckduckgo/Android/pull/8945 - it fixed the native input search-only state when a back button is used, but didn't apply the same fix for other programmatic sources that hide the native input widget.

### Steps to test this PR

_regression test: search path_
- [x] Clean install the app and go through onboarding.
- [x] In the Serarch / Duck.ai input step **keep search**.
- [x] Finish onboarding.
- [x] Verify that on the last step ('You've got this') the keyboard is visible and the address bar is focused (**no toggle**).
- [x] Verify that after clicking 'High five' both the keyboard and native input widget are collapsed.

_regression test: chat path_
- [x] Clean install the app and go through onboarding.
- [x] In the Serarch / Duck.ai input **select chat**.
- [x] Finish onboarding.
- [x] Verify that on the last step ('You've got this') the keyboard is visible and the address bar is focused (**with toggle**).
- [x] Verify that after clicking 'High five' both the keyboard and native input widget are collapsed.

_regression test: backing out from focused address_
- [x] Focus the address bar.
- [x] Use back button.
- [x] Verify both the keyboard and native input widget are collapsed.
- [x] Go to Settings -> AI Features -> Select 'Search'-only.
- [x] Go back to browser.
- [x] Focus the address bar.
- [x] Use back button.
- [x] Verify both the keyboard and native input widget are collapsed.

_regression test: backing out Duck.ai mode_
- [x] Click Duck.ai icon on the address bar.
- [x] Click full-screen icon.
- [x] Focus the input field.
- [x] Use back button.
- [x] Verify both the keyboard and native input widget are collapsed.
- [x] Focus the input field.
- [x] Use the 'x' button in the top left.
- [x] Verify both the keyboard and native input widget are collapsed (and Duck.ai mode is closed).

Apply below patch:
```diff
diff --git a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
index 1233367d2b..c4ffb959f7 100644
--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -139,7 +139,7 @@ class CtaViewModel @Inject constructor(
     }
 
     private suspend fun isSubscriptionCtaAvailable(): Boolean =
-        subscriptions.isEligible() && hasNoSubscription() && extendedOnboardingFeatureToggles.privacyProCta().isEnabled()
+        true//subscriptions.isEligible() && hasNoSubscription() && extendedOnboardingFeatureToggles.privacyProCta().isEnabled()
 
     private suspend fun isBrandDesignUpdateEnabled(): Boolean = withContext(dispatchers.io()) {
         onboardingBrandDesignUpdateToggles.brandDesignUpdate().isEnabled()
```

_test: search path with subscription_
- [x] Clean install the app and go through onboarding.
- [x] In the Serarch / Duck.ai input step **keep search**.
- [x] Finish onboarding.
- [x] Verify that on the last step ('You've got this') the keyboard is visible and the address bar is focused (**no toggle**).
- [x] Verify that after clicking 'High five' both the keyboard and native input widget are collapsed.
- [x] Verify the subscription promo is visible.

_test: chat path with subscription_
- [x] Clean install the app and go through onboarding.
- [x] In the Serarch / Duck.ai input **select chat**.
- [x] Finish onboarding.
- [x] Verify that on the last step ('You've got this') the keyboard is visible and the address bar is focused (**with toggle**).
- [x] Verify that after clicking 'High five' both the keyboard and native input widget are collapsed.
- [x] Verify the subscription promo is visible.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized input/IME teardown change with no security or data impact; behavior is intentionally aligned across all hide paths.
> 
> **Overview**
> Fixes a regression where the soft keyboard could pop back up after the native input widget was dismissed programmatically in **search-only** mode (e.g. onboarding “High five”), while back already behaved correctly.
> 
> **`clearInputFocus()`** now runs at the start of **`hideNativeInput()`** before teardown, so any caller that hides the widget drops IME focus first and the keyboard stays dismissed. The duplicate call was removed from **`widget.onBack`**, which only invokes **`hideNativeInput()`** anyway.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0f251084b7096d03613cdad9642a85390bb9cc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->