### PR TITLE
Submit strings for translation

### DIFF
--- a/ad-blocking/ad-blocking-impl/src/main/res/values-bg/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-bg/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo премахва рекламите на видеоклипове в YouTube, за да можете да гледате видеоклипове без прекъсване. <annotation type="learn_more_link">Научете повече</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Отваря видеоклипове в режим на киносалон без разсейване, който предотвратява влиянието на гледаното съдържание върху емисията в YouTube.</string>
+    <string name="ad_blocking_settings_title_v2">Блокиране на реклами</string>
+    <string name="ad_blocking_settings_header_description">Блокира инвазивните тракери, преди да се заредят, като ефективно елиминира рекламите, които разчитат на проследяването</string>
+    <string name="contingencyMessageTitle">Блокирането на реклами в YouTube е недостъпно</string>
+    <string name="contingencyMessageContent">Блокирането на реклами е засегнато от скорошни промени в YouTube. Работим за отстраняване на тези проблеми и оценяваме Вашето разбиране</string>
+    <string name="contingencyMessagePrimaryButton">Разбрах</string>
+    <string name="contingencyMessageCloseContentDescription">Затваряне</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-cs/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-cs/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo blokuje při sledování videí na YouTube reklamy, takže se můžeš dívat bez přerušení. <annotation type="learn_more_link">Další informace</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Otevírá videa v režimu kina, který brání tomu, aby sledovaná videa ovlivňovala tvůj feed na YouTube.</string>
+    <string name="ad_blocking_settings_title_v2">Blokování reklam</string>
+    <string name="ad_blocking_settings_header_description">Zablokuje invazivní trackery ještě před jejich načtením, čímž účinně eliminuje reklamy, které spoléhají na sledování.</string>
+    <string name="contingencyMessageTitle">Blokování reklam na YouTube není k dispozici</string>
+    <string name="contingencyMessageContent">Blokování reklam bylo ovlivněno nedávnými změnami na YouTube. Problémy se snažíme opravit. Děkujeme za pochopení.</string>
+    <string name="contingencyMessagePrimaryButton">Rozumím</string>
+    <string name="contingencyMessageCloseContentDescription">Zavřít</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-da/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-da/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo blokerer videoannoncer på YouTube, så du kan se videoer uden afbrydelser. <annotation type="learn_more_link">Læs mere</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Åbner videoer i en distraktionsfri biograftilstand, der forhindrer, at det, du ser, påvirker dit YouTube-feed.</string>
+    <string name="ad_blocking_settings_title_v2">Annonceblokering</string>
+    <string name="ad_blocking_settings_header_description">Vi blokerer invasive trackere, før de indlæses, hvilket effektivt eliminerer annoncer, der er afhængige af sporing</string>
+    <string name="contingencyMessageTitle">Blokering af YouTube-annoncer ikke tilgængelig</string>
+    <string name="contingencyMessageContent">Annonceblokering er påvirket af de seneste ændringer i YouTube. Vi arbejder på at løse disse problemer og sætter pris på din forståelse</string>
+    <string name="contingencyMessagePrimaryButton">Forstået</string>
+    <string name="contingencyMessageCloseContentDescription">Luk</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-de/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-de/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo blockiert Video-Werbung auf YouTube, sodass du Videos ohne Unterbrechungen ansehen kannst. <annotation type="learn_more_link">Mehr erfahren</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Öffnet Videos in einem ablenkungsfreien Theatermodus, der verhindert, dass das, was du ansiehst, deinen YouTube-Feed beeinflusst.</string>
+    <string name="ad_blocking_settings_title_v2">Werbeblockierung</string>
+    <string name="ad_blocking_settings_header_description">Blockiert invasive Tracker, bevor sie geladen werden, und eliminiert so effektiv Werbung, die auf Tracking basiert.</string>
+    <string name="contingencyMessageTitle">YouTube-Werbeblocker nicht verfügbar</string>
+    <string name="contingencyMessageContent">Die Werbeblockierung wurde durch die jüngsten Änderungen bei YouTube beeinträchtigt. Vielen Dank für dein Verständnis, während wir daran arbeiten, diese Probleme zu beheben.</string>
+    <string name="contingencyMessagePrimaryButton">Verstanden</string>
+    <string name="contingencyMessageCloseContentDescription">Schließen</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-el/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-el/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">Το DuckDuckGo αποκλείει τις διαφημίσεις βίντεο στο YouTube, ώστε να μπορείς να βλέπεις βίντεο χωρίς διακοπές. <annotation type="learn_more_link">Μάθε περισσότερα</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Ανοίγει βίντεο σε λειτουργία κινηματογράφου χωρίς περισπάσεις, η οποία εμποδίζει το περιεχόμενο που παρακολουθείς να επηρεάσει τη ροή σου στο YouTube.</string>
+    <string name="ad_blocking_settings_title_v2">Αποκλεισμός διαφημίσεων</string>
+    <string name="ad_blocking_settings_header_description">Αποκλείει επεμβατικά προγράμματα παρακολούθησης προτού φορτώσουν, εξαλείφοντας αποτελεσματικά διαφημίσεις που βασίζονται σε παρακολούθηση</string>
+    <string name="contingencyMessageTitle">Ο αποκλεισμός διαφημίσεων στο YouTube δεν είναι διαθέσιμος</string>
+    <string name="contingencyMessageContent">Ο αποκλεισμός διαφημίσεων έχει επηρεαστεί από τις πρόσφατες αλλαγές στο YouTube. Προσπαθούμε να διορθώσουμε αυτά τα προβλήματα και εκτιμούμε την κατανόησή σου</string>
+    <string name="contingencyMessagePrimaryButton">Κατάλαβα</string>
+    <string name="contingencyMessageCloseContentDescription">Κλείσιμο</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-es/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-es/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo bloquea los anuncios de vídeo en YouTube, para que puedas ver vídeos sin interrupciones. <annotation type="learn_more_link">Más información</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Abre vídeos en modo teatro sin distracciones que impide que lo que ves influya en tu feed de YouTube.</string>
+    <string name="ad_blocking_settings_title_v2">Bloqueo de anuncios</string>
+    <string name="ad_blocking_settings_header_description">Bloquea los rastreadores invasivos antes de que se carguen, eliminando de manera efectiva los anuncios que se basan en el rastreo</string>
+    <string name="contingencyMessageTitle">El bloqueo de anuncios en YouTube no está disponible</string>
+    <string name="contingencyMessageContent">El bloqueo de anuncios se ha visto afectado por los cambios recientes en YouTube. Estamos trabajando para solucionar estos problemas y agradecemos tu comprensión</string>
+    <string name="contingencyMessagePrimaryButton">Entendido</string>
+    <string name="contingencyMessageCloseContentDescription">Cerrar</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-et/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-et/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo blokeerib YouTube\'is videoreklaamid, nii et saad videoid katkestusteta vaadata. <annotation type="learn_more_link">Lisateave</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Avab videod segajatevabas kinorežiimis, mis hoiab ära selle, et vaadatav sisu mõjutaks sinu YouTube’i voogu.</string>
+    <string name="ad_blocking_settings_title_v2">Reklaamide blokeerimine</string>
+    <string name="ad_blocking_settings_header_description">Blokeerib invasiivsed jälgijad enne nende laadimist, kõrvaldades tõhusalt reklaamid, mis tuginevad jälgimisele</string>
+    <string name="contingencyMessageTitle">YouTube\'i reklaamiblokeerija pole saadaval</string>
+    <string name="contingencyMessageContent">YouTube\'i hiljutised muudatused on mõjutanud reklaamide blokeerimist. Töötame nende probleemide lahendamise nimel ja täname sind mõistva suhtumise eest</string>
+    <string name="contingencyMessagePrimaryButton">Sain aru</string>
+    <string name="contingencyMessageCloseContentDescription">Sulge</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-fi/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-fi/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo estää videomainokset YouTubessa, joten voit katsoa videoita keskeytyksettä. <annotation type="learn_more_link">Lue lisää</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Avaa videot häiriöttömässä teatteritilassa, jolloin katsomasi sisältö ei vaikuta YouTube-syötteeseesi.</string>
+    <string name="ad_blocking_settings_title_v2">Mainosten esto</string>
+    <string name="ad_blocking_settings_header_description">Estää tunkeilevat seurantaohjelmat ennen niiden latautumista, mikä eliminoi tehokkaasti seurantaa käyttävät mainokset</string>
+    <string name="contingencyMessageTitle">YouTube-mainosten esto ei ole käytettävissä</string>
+    <string name="contingencyMessageContent">YouTuben viimeaikaiset muutokset ovat vaikuttaneet mainosten estämiseen. Pyrimme korjaamaan nämä ongelmat. Kiitos ymmärryksestä.</string>
+    <string name="contingencyMessagePrimaryButton">Selvä</string>
+    <string name="contingencyMessageCloseContentDescription">Sulje</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-fr/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-fr/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo bloque les publicités vidéo sur YouTube, afin que vous puissiez regarder des vidéos sans interruption. <annotation type="learn_more_link">En savoir plus</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Ouvre les vidéos en mode « Salle de projection sans distractions », ce qui empêche ce que vous regardez d\'influencer votre fil d\'actualité YouTube.</string>
+    <string name="ad_blocking_settings_title_v2">Blocage des publicités</string>
+    <string name="ad_blocking_settings_header_description">Bloque les traqueurs invasifs avant leur chargement, ce qui permet d\'éliminer efficacement les publicités reposant sur le pistage</string>
+    <string name="contingencyMessageTitle">Blocage des publicités sur YouTube indisponible</string>
+    <string name="contingencyMessageContent">Les récents changements apportés à YouTube ont affecté le blocage des publicités. Nous nous efforçons de résoudre ces problèmes et vous remercions de votre compréhension.</string>
+    <string name="contingencyMessagePrimaryButton">J\'ai compris</string>
+    <string name="contingencyMessageCloseContentDescription">Fermer</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-hr/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-hr/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo blokira video oglase na YouTubeu, tako da videozapise možeš gledati bez prekida. <annotation type="learn_more_link">Saznaj više</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Otvara videozapise u kino načinu rada bez ometanja koji sprječava da ono što gledaš utječe na tvoj YouTube feed.</string>
+    <string name="ad_blocking_settings_title_v2">Blokiranje oglasa</string>
+    <string name="ad_blocking_settings_header_description">Blokira invazivne alate za praćenje prije nego što se učitaju, učinkovito eliminirajući oglase koji se oslanjaju na praćenje</string>
+    <string name="contingencyMessageTitle">Blokiranje oglasa na YouTubeu nije dostupno</string>
+    <string name="contingencyMessageContent">Blokiranje oglasa pogođeno je nedavnim promjenama na YouTubeu. Radimo na rješavanju tih problema i cijenimo tvoje razumijevanje</string>
+    <string name="contingencyMessagePrimaryButton">Shvaćam</string>
+    <string name="contingencyMessageCloseContentDescription">Zatvori</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-hu/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-hu/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">A DuckDuckGo blokkolja a videohirdetéseket a YouTube-on, így megszakítás nélkül nézhetsz videókat. <annotation type="learn_more_link">További információk</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Zavaró elemektől mentes, mozis nézetben nyitja meg a videókat, így a nézett tartalom nem befolyásolja a YouTube-hírfolyamodat.</string>
+    <string name="ad_blocking_settings_title_v2">Hirdetésblokkolás</string>
+    <string name="ad_blocking_settings_header_description">Még betöltés előtt blokkolja az invazív nyomkövetőket, így hatékonyan kiküszöböljük a nyomkövetésre épülő hirdetéseket</string>
+    <string name="contingencyMessageTitle">YouTube-hirdetésblokkolás nem érhető el</string>
+    <string name="contingencyMessageContent">A hirdetésblokkolást érintették a YouTube legutóbbi módosításai. Dolgozunk a problémák megoldásán, és köszönjük a megértésedet.</string>
+    <string name="contingencyMessagePrimaryButton">Értem</string>
+    <string name="contingencyMessageCloseContentDescription">Bezárás</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-it/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-it/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo blocca gli annunci video su YouTube, così puoi guardare video senza interruzioni. <annotation type="learn_more_link">Ulteriori informazioni</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Apre i video in una modalità cinema senza distrazioni che impedisce a ciò che guardi di influenzare il tuo feed di YouTube.</string>
+    <string name="ad_blocking_settings_title_v2">Blocco degli annunci</string>
+    <string name="ad_blocking_settings_header_description">Blocca i sistemi di tracciamento prima che vengano caricati, eliminando di fatto gli annunci che si basano sul tracciamento</string>
+    <string name="contingencyMessageTitle">Blocco degli annunci su YouTube non disponibile</string>
+    <string name="contingencyMessageContent">Il blocco degli annunci è stato influenzato dalle recenti modifiche a YouTube. Stiamo lavorando per risolvere questi problemi. Grazie per la comprensione</string>
+    <string name="contingencyMessagePrimaryButton">Ho capito</string>
+    <string name="contingencyMessageCloseContentDescription">Chiudi</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-lt/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-lt/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">„DuckDuckGo“ blokuoja vaizdo įrašų reklamas platformoje „YouTube“, todėl galite žiūrėti vaizdo įrašus be trukdžių. <annotation type="learn_more_link">Sužinokite daugiau</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Atidaro vaizdo įrašus neblaškančiu kino teatro režimu, kad tai, ką žiūri, nedarytų įtakos tavo „YouTube“ srautui.</string>
+    <string name="ad_blocking_settings_title_v2">Reklamų blokavimas</string>
+    <string name="ad_blocking_settings_header_description">Blokuoja įkyrias sekimo priemones dar prieš jas įkeliant, todėl veiksmingai pašalina sekimu pagrįstas reklamas</string>
+    <string name="contingencyMessageTitle">„YouTube“ reklamų blokavimas nepasiekiamas</string>
+    <string name="contingencyMessageContent">Naujausi „YouTube“ pakeitimai paveikė reklamų blokavimą. Sprendžiame šias problemas ir dėkojame už supratingumą</string>
+    <string name="contingencyMessagePrimaryButton">Supratau</string>
+    <string name="contingencyMessageCloseContentDescription">Uždaryti</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-lv/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-lv/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo bloķē videoreklāmas pakalpojumā YouTube, lai tu varētu skatīties videoklipus bez pārtraukumiem. <annotation type="learn_more_link">Uzzināt vairāk</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Atver videoklipus teātra režīmā bez uzmanības novēršanas, kas neļauj skatītajam ietekmēt tavu YouTube plūsmu.</string>
+    <string name="ad_blocking_settings_title_v2">Reklāmu bloķēšana</string>
+    <string name="ad_blocking_settings_header_description">Bloķē uzmācīgus izsekotājus, pirms tie tiek ielādēti, tādējādi efektīvi novēršot izsekošanā balstītās reklāmas.</string>
+    <string name="contingencyMessageTitle">YouTube reklāmu bloķēšana nav pieejama</string>
+    <string name="contingencyMessageContent">Reklāmu bloķēšanu ir ietekmējušas nesenās izmaiņas pakalpojumā YouTube. Mēs jau strādājam pie šo problēmu novēršanas un novērtējam tavu sapratni.</string>
+    <string name="contingencyMessagePrimaryButton">Sapratu</string>
+    <string name="contingencyMessageCloseContentDescription">Aizvērt</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-nb/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-nb/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo blokkerer videoannonser på YouTube, slik at du kan se videoer uten avbrudd. <annotation type="learn_more_link">Finn ut mer</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Åpner videoer i en distraksjonsfri kinomodus som hindrer at det du ser på påvirker YouTube-feeden din.</string>
+    <string name="ad_blocking_settings_title_v2">Annonseblokkering</string>
+    <string name="ad_blocking_settings_header_description">Blokkerer invaderende sporere før de blir lastet inn, og dette eliminerer også annonser som er basert på sporing</string>
+    <string name="contingencyMessageTitle">Annonseblokkering på YouTube er ikke tilgjengelig</string>
+    <string name="contingencyMessageContent">Annonseblokkering har blitt påvirket av nylige endringer på YouTube. Vi jobber med å løse disse problemene og takker for tålmodigheten</string>
+    <string name="contingencyMessagePrimaryButton">Den er grei</string>
+    <string name="contingencyMessageCloseContentDescription">Lukk</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-nl/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-nl/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo blokkeert videoadvertenties op YouTube, zodat je video\'s zonder onderbreking kunt bekijken. <annotation type="learn_more_link">Meer informatie</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Opent video\'s in een afleidingsvrije theatermodus die voorkomt dat wat je bekijkt je YouTube-feed beïnvloedt.</string>
+    <string name="ad_blocking_settings_title_v2">Advertentieblokkering</string>
+    <string name="ad_blocking_settings_header_description">Blokkeert invasieve trackers voordat ze worden geladen, waardoor advertenties die afhankelijk zijn van tracking effectief worden geëlimineerd</string>
+    <string name="contingencyMessageTitle">YouTube-advertentieblokkering niet beschikbaar</string>
+    <string name="contingencyMessageContent">Door recente wijzigingen in YouTube werkt advertentieblokkering niet meer naar behoren. We werken aan een oplossing voor deze problemen. Bedankt voor je begrip.</string>
+    <string name="contingencyMessagePrimaryButton">Ik snap het</string>
+    <string name="contingencyMessageCloseContentDescription">Sluiten</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-pl/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-pl/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo blokuje reklamy wideo na YouTube, dzięki czemu możesz oglądać filmy bez przerw. <annotation type="learn_more_link">Dowiedz się więcej</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Otwiera filmy w trybie kinowym bez rozpraszania uwagi, który zapobiega wpływowi oglądania na Twój kanał YouTube.</string>
+    <string name="ad_blocking_settings_title_v2">Blokowanie reklam</string>
+    <string name="ad_blocking_settings_header_description">Blokuje inwazyjne mechanizmy śledzące przed ich załadowaniem, skutecznie eliminując reklamy, które opierają się na śledzeniu</string>
+    <string name="contingencyMessageTitle">Blokowanie reklam na YouTube jest niedostępne</string>
+    <string name="contingencyMessageContent">Niedawne zmiany na YouTube wpłynęły na blokowanie reklam. Pracujemy nad rozwiązaniem tych problemów i dziękujemy za zrozumienie.</string>
+    <string name="contingencyMessagePrimaryButton">Rozumiem</string>
+    <string name="contingencyMessageCloseContentDescription">Zamknij</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-pt/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-pt/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">O DuckDuckGo bloqueia anúncios de vídeo no YouTube para que possas ver vídeos sem interrupções. <annotation type="learn_more_link">Sabe mais</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Abre vídeos num modo de cinema sem distrações que impede que os vídeos que vês influenciem o teu feed do YouTube.</string>
+    <string name="ad_blocking_settings_title_v2">Bloqueio de anúncios</string>
+    <string name="ad_blocking_settings_header_description">Bloqueia os rastreadores invasivos antes de serem carregados, eliminando eficazmente os anúncios que usam rastreio</string>
+    <string name="contingencyMessageTitle">Bloqueio de anúncios do YouTube indisponível</string>
+    <string name="contingencyMessageContent">O bloqueio de anúncios foi afetado por alterações recentes ao YouTube. Estamos a trabalhar para resolver estes problemas e agradecemos a tua compreensão.</string>
+    <string name="contingencyMessagePrimaryButton">Entendido</string>
+    <string name="contingencyMessageCloseContentDescription">Fechar</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-ro/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-ro/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo blochează reclamele video pe YouTube, astfel încât să poți viziona videoclipuri fără întrerupere. <annotation type="learn_more_link">Află mai multe</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Deschide videoclipurile într-un mod cinematografic fără distrageri, care te împiedică să influențezi fluxul de YouTube prin ceea ce vizionezi.</string>
+    <string name="ad_blocking_settings_title_v2">Blocarea reclamelor</string>
+    <string name="ad_blocking_settings_header_description">Blochează tehnologiile de urmărire invazive înainte de a se încărca, eliminând eficient reclamele care se bazează pe urmărire</string>
+    <string name="contingencyMessageTitle">Blocarea reclamelor pe YouTube este indisponibilă</string>
+    <string name="contingencyMessageContent">Blocarea reclamelor a fost afectată de modificările recente aduse YouTube. Lucrăm pentru a remedia aceste probleme și apreciem înțelegerea ta</string>
+    <string name="contingencyMessagePrimaryButton">Am înțeles</string>
+    <string name="contingencyMessageCloseContentDescription">Închide</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-ru/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-ru/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo блокирует видеорекламу на YouTube, чтобы вы могли смотреть видео без перерывов. <annotation type="learn_more_link">Подробнее</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Проигрыватель Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Открывает видео в режиме кинотеатра без отвлекающих элементов, чтобы просмотренные видео не влияли на вашу ленту YouTube.</string>
+    <string name="ad_blocking_settings_title_v2">Блокировка рекламы</string>
+    <string name="ad_blocking_settings_header_description">Блокирует навязчивые трекеры до их загрузки, устраняя рекламу с отслеживанием</string>
+    <string name="contingencyMessageTitle">Блокировка рекламы на YouTube недоступна</string>
+    <string name="contingencyMessageContent">Недавние изменения на YouTube повлияли на работу блокировки рекламы. Мы занимаемся решением этой проблемы и благодарим вас за понимание.</string>
+    <string name="contingencyMessagePrimaryButton">Понятно</string>
+    <string name="contingencyMessageCloseContentDescription">Закрыть</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-sk/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-sk/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo blokuje videoreklamy na YouTube, takže môžeš sledovať videá bez prerušenia. <annotation type="learn_more_link">Zisti viac</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Otvára videá v režime kina bez rušivých vplyvov, ktorý zabraňuje tomu, aby sledované položky ovplyvňovali tvoj kanál YouTube.</string>
+    <string name="ad_blocking_settings_title_v2">Blokovanie reklám</string>
+    <string name="ad_blocking_settings_header_description">Blokuje invazívne sledovače skôr, než sa načítajú, čím efektívne eliminuje reklamy, ktoré sa spoliehajú na sledovanie.</string>
+    <string name="contingencyMessageTitle">Blokovanie reklám na YouTube nie je k dispozícii</string>
+    <string name="contingencyMessageContent">Blokovanie reklám bolo ovplyvnené nedávnymi zmenami na YouTube. Na odstránení týchto problémov pracujeme. Ďakujeme za pochopenie.</string>
+    <string name="contingencyMessagePrimaryButton">Rozumiem</string>
+    <string name="contingencyMessageCloseContentDescription">Zatvoriť</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-sl/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-sl/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo blokira video oglase na YouTubu, tako da si lahko videoposnetke ogledate brez prekinitev. <annotation type="learn_more_link">Več o tem</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Videoposnetke odpre v načinu zasebnega kina, ki preprečuje, da bi vsebina, ki jo gledate, vplivala na vaša priporočila v YouTubu.</string>
+    <string name="ad_blocking_settings_title_v2">Blokiranje oglasov</string>
+    <string name="ad_blocking_settings_header_description">Blokira invazivne sledilnike, še preden se naložijo, s čimer učinkovito odstrani oglase, ki temeljijo na sledenju</string>
+    <string name="contingencyMessageTitle">Blokiranje oglasov na YouTubu ni na voljo</string>
+    <string name="contingencyMessageContent">Nedavne spremembe na YouTubu so vplivale na delovanje funkcije blokiranja oglasov. Prizadevamo si za odpravljanje teh težav in cenimo vaše razumevanje.</string>
+    <string name="contingencyMessagePrimaryButton">Razumem</string>
+    <string name="contingencyMessageCloseContentDescription">Zapri</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-sv/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-sv/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo blockerar videoannonser på YouTube, så du kan titta på videor utan avbrott. <annotation type="learn_more_link">Läs mer</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Öppnar videor i ett störningsfritt visningsläge som förhindrar att det du tittar på påverkar ditt YouTube-flöde.</string>
+    <string name="ad_blocking_settings_title_v2">Annonsblockering</string>
+    <string name="ad_blocking_settings_header_description">Blockerar invasiva spårare innan de läses in, vilket i stort sett eliminerar annonser som bygger på spårning</string>
+    <string name="contingencyMessageTitle">Annonsblockering på YouTube är inte tillgänglig</string>
+    <string name="contingencyMessageContent">De senaste ändringarna på YouTube har påverkat annonsblockeringen. Vi jobbar på att lösa problemen och tackar för din förståelse.</string>
+    <string name="contingencyMessagePrimaryButton">Jag förstår</string>
+    <string name="contingencyMessageCloseContentDescription">Stäng</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-tr/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-tr/strings-ad-blocking.xml
@@ -23,4 +23,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo, YouTube\'daki video reklamlarını engelleyerek videoları kesintisiz izlemenizi sağlar. <annotation type="learn_more_link">Daha fazla bilgi</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Videoları, izlediğiniz içeriğin YouTube akışınızı etkilemesini engelleyen, dikkat dağıtıcı unsurlardan arındırılmış bir sinema moduyla açar.</string>
+    <string name="ad_blocking_settings_title_v2">Reklam Engelleme</string>
+    <string name="ad_blocking_settings_header_description">İstilacı izleyicileri yüklenmeden önce engelleyerek, izlemeye dayalı reklamları etkili bir şekilde ortadan kaldırır</string>
+    <string name="contingencyMessageTitle">YouTube\'da Reklam Engelleme Kullanılamıyor</string>
+    <string name="contingencyMessageContent">YouTube\'da yapılan son değişiklikler reklam engelleme özelliğini etkiledi. Bu sorunları çözmeye çalışıyoruz. Anlayışınız için teşekkür ederiz</string>
+    <string name="contingencyMessagePrimaryButton">Anladım</string>
+    <string name="contingencyMessageCloseContentDescription">Kapat</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values/donottranslate.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values/donottranslate.xml
@@ -15,10 +15,5 @@
   -->
 
 <resources>
-    <string name="ad_blocking_settings_title_v2">Ad Blocking</string>
-    <string name="ad_blocking_settings_header_description">Blocks invasive trackers before they load, effectively eliminating ads that rely on tracking</string>
-    <string name="contingencyMessageTitle">YouTube Ad Blocking Unavailable</string>
-    <string name="contingencyMessageContent">Ad Blocking has been affected by recent changes to YouTube. We\'re working to fix these issues and appreciate your understanding</string>
-    <string name="contingencyMessagePrimaryButton">Got It</string>
-    <string name="contingencyMessageCloseContentDescription">Close</string>
+
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values/strings-ad-blocking.xml
@@ -22,4 +22,10 @@
     <string name="ad_blocking_settings_description">DuckDuckGo blocks video ads on YouTube, so you can watch videos without interruption. <annotation type="learn_more_link">Learn more</annotation></string>
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Opens videos in a distraction-free theater mode that prevents what you watch from influencing your YouTube feed.</string>
+    <string name="ad_blocking_settings_title_v2">Ad Blocking</string>
+    <string name="ad_blocking_settings_header_description">Blocks invasive trackers before they load, effectively eliminating ads that rely on tracking</string>
+    <string name="contingencyMessageTitle">YouTube Ad Blocking Unavailable</string>
+    <string name="contingencyMessageContent">Ad Blocking has been affected by recent changes to YouTube. We\'re working to fix these issues and appreciate your understanding</string>
+    <string name="contingencyMessagePrimaryButton">Got It</string>
+    <string name="contingencyMessageCloseContentDescription">Close</string>
 </resources>


### PR DESCRIPTION
Task/Issue URL: 
Tech Design URL (if applicable): 

### Description

### Steps to test this PR
Wait for translations [job](https://dashboard.smartling.com/app/projects/b01b53ede/account-jobs/b01b53ede:oxhx88unw2yh) to finish

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-resource and localization-only changes with no application logic modified; risk is limited to copy or missing-locale fallbacks.
> 
> **Overview**
> Adds **Smartling translations** for six ad-blocking strings that were previously English-only in `donottranslate.xml`.
> 
> Those keys now live in the default `strings-ad-blocking.xml` and in **~22 locale** `values-*/strings-ad-blocking.xml` files. They cover the **v2 settings** screen (`ad_blocking_settings_title_v2`, `ad_blocking_settings_header_description`) and the **YouTube contingency bottom sheet** (`contingencyMessage*`).
> 
> The English copies were **removed from `donottranslate.xml`** so they follow the normal translation pipeline instead of staying untranslated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd2e2b17e3087413335c61d6bc058a8005056c33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->