### PR TITLE
Android/Remove Chat History: Add missing / new pixels

### DIFF
--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -1429,5 +1429,26 @@
             { "key": "hide_ai_images", "type": "string", "description": "Whether AI-generated images are hidden", "enum": ["on", "off"] },
             { "key": "no_ai", "type": "boolean", "description": "Derived: duck_ai=false AND search_assist=0 AND hide_ai_images=on" }
         ]
+    },
+    "m_aichat_recent_chat_delete_button_tapped": {
+        "description": "Fired when user taps the delete (fire) icon on a recent chat row in the Duck.ai suggestions list",
+        "owners": ["karlenDimla"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_recent_chat_delete_confirmed": {
+        "description": "Fired when user confirms deletion of a recent chat from the Duck.ai suggestions list",
+        "owners": ["karlenDimla"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_aichat_recent_chat_delete_cancelled": {
+        "description": "Fired when user cancels deletion of a recent chat from the Duck.ai suggestions list",
+        "owners": ["karlenDimla"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": ["appVersion"]
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -478,6 +478,9 @@ open class BrowserActivity : DuckDuckGoActivity() {
                 FireDialog.EVENT_ON_CANCEL -> {
                     pendingDuckAiOnboardingFire = false
                     pixel.fire(FIRE_DIALOG_CANCEL)
+                    if (bundle.getString(FireDialog.RESULT_KEY_ORIGIN) == ORIGIN_CHAT_AUTOCOMPLETE) {
+                        currentTab?.onChatDeleteCancelled()
+                    }
                     currentTab?.onFireDialogVisibilityChanged(isVisible = false)
                     externalIntentProcessingState.onPendingSnackbarDisplayed()
                 }
@@ -495,6 +498,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
                 }
                 FireDialog.EVENT_ON_CHAT_CLEAR_COMPLETE -> {
                     if (bundle.getString(FireDialog.RESULT_KEY_ORIGIN) == ORIGIN_CHAT_AUTOCOMPLETE) {
+                        currentTab?.onChatDeleteConfirmed()
                         currentTab?.refreshAutoComplete()
                     }
                 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -6803,6 +6803,14 @@ class BrowserTabFragment :
     fun refreshAutoComplete() {
         nativeInputManager.refreshChatSuggestions()
     }
+
+    fun onChatDeleteConfirmed() {
+        nativeInputManager.onChatDeleteConfirmed()
+    }
+
+    fun onChatDeleteCancelled() {
+        nativeInputManager.onChatDeleteCancelled()
+    }
 }
 
 private class JsOrientationHandler {

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -138,6 +138,12 @@ interface NativeInputManager {
      */
     fun refreshChatSuggestions()
 
+    /** The user confirmed deleting a recent chat from the chat-autocomplete fire dialog. */
+    fun onChatDeleteConfirmed()
+
+    /** The user cancelled deleting a recent chat from the chat-autocomplete fire dialog. */
+    fun onChatDeleteCancelled()
+
     /** Lock the input field (making it non-interactive + dimmed).*/
     fun setInteractionLock(lock: InteractionLock)
 
@@ -231,6 +237,18 @@ class RealNativeInputManager @Inject constructor(
         if (!::rootView.isInitialized) return
         val widget = widgetFrom(rootView) ?: return
         widget.refreshChatSuggestions()
+    }
+
+    override fun onChatDeleteConfirmed() {
+        if (!::rootView.isInitialized) return
+        val widget = widgetFrom(rootView) ?: return
+        widget.onChatDeleteConfirmed()
+    }
+
+    override fun onChatDeleteCancelled() {
+        if (!::rootView.isInitialized) return
+        val widget = widgetFrom(rootView) ?: return
+        widget.onChatDeleteCancelled()
     }
 
     override fun handleDuckAiVoiceResult(query: String) {

--- a/app/src/main/java/com/duckduckgo/app/global/view/SingleTabFireDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/global/view/SingleTabFireDialog.kt
@@ -234,7 +234,7 @@ class SingleTabFireDialog : BottomSheetDialogFragment(), FireDialog {
             is Command.ClearingComplete -> onClearAllEvent(ClearAllEvent.ClearingFinished)
             is Command.OnShow -> sendFragmentResult(FireDialog.EVENT_ON_SHOW)
             is Command.OnCancel -> {
-                sendFragmentResult(FireDialog.EVENT_ON_CANCEL)
+                sendFragmentResult(FireDialog.EVENT_ON_CANCEL, arguments?.getString(ARG_ORIGIN))
                 dismiss()
             }
             is Command.OnClearStarted -> {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -191,6 +191,9 @@ interface DuckChatPixels {
     fun fireStopGenerationTapped()
     fun fireDuckAiChatHistorySuggestionClicked()
     fun fireDuckAiSearchDuckDuckGoSuggestionClicked()
+    fun fireRecentChatDeleteButtonTapped()
+    fun fireRecentChatDeleteConfirmed()
+    fun fireRecentChatDeleteCancelled()
     fun fireCustomizeResponsesSelected()
     fun fireOmnibarShown()
     fun fireOmnibarTextAreaFocused(landscape: Boolean)
@@ -693,6 +696,21 @@ class RealDuckChatPixels @Inject constructor(
         }
     }
 
+    override fun fireRecentChatDeleteButtonTapped() = fireCountAndDaily(
+        DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_DELETE_BUTTON_TAPPED_COUNT,
+        DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_DELETE_BUTTON_TAPPED_DAILY,
+    )
+
+    override fun fireRecentChatDeleteConfirmed() = fireCountAndDaily(
+        DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_DELETE_CONFIRMED_COUNT,
+        DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_DELETE_CONFIRMED_DAILY,
+    )
+
+    override fun fireRecentChatDeleteCancelled() = fireCountAndDaily(
+        DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_DELETE_CANCELLED_COUNT,
+        DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_DELETE_CANCELLED_DAILY,
+    )
+
     override fun fireOmnibarShown() = fireCountAndDaily(
         DUCK_CHAT_EXPERIMENTAL_OMNIBAR_SHOWN_COUNT,
         DUCK_CHAT_EXPERIMENTAL_OMNIBAR_SHOWN_DAILY,
@@ -917,6 +935,12 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_CHAT_RECENT_CHAT_SELECTED_DAILY("m_aichat_recent_chat_selected_daily"),
     DUCK_CHAT_RECENT_CHAT_SELECTED_PINNED_COUNT("m_aichat_recent_chat_selected_pinned_count"),
     DUCK_CHAT_RECENT_CHAT_SELECTED_PINNED_DAILY("m_aichat_recent_chat_selected_pinned_daily"),
+    DUCK_CHAT_RECENT_CHAT_DELETE_BUTTON_TAPPED_COUNT("m_aichat_recent_chat_delete_button_tapped_count"),
+    DUCK_CHAT_RECENT_CHAT_DELETE_BUTTON_TAPPED_DAILY("m_aichat_recent_chat_delete_button_tapped_daily"),
+    DUCK_CHAT_RECENT_CHAT_DELETE_CONFIRMED_COUNT("m_aichat_recent_chat_delete_confirmed_count"),
+    DUCK_CHAT_RECENT_CHAT_DELETE_CONFIRMED_DAILY("m_aichat_recent_chat_delete_confirmed_daily"),
+    DUCK_CHAT_RECENT_CHAT_DELETE_CANCELLED_COUNT("m_aichat_recent_chat_delete_cancelled_count"),
+    DUCK_CHAT_RECENT_CHAT_DELETE_CANCELLED_DAILY("m_aichat_recent_chat_delete_cancelled_daily"),
     AUTOCOMPLETE_DUCKAI_CLICK_CHAT_HISTORY("m_autocomplete_duckai_click_chat_history"),
     AUTOCOMPLETE_DUCKAI_CLICK_SEARCH_DUCKDUCKGO("m_autocomplete_duckai_click_search_duckduckgo"),
     DUCK_CHAT_VOICE_ENTRY_TAPPED_COUNT("m_aichat_voice_entry_tapped_count"),
@@ -1197,6 +1221,12 @@ class DuckChatParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin
             DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_SELECTED_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_SELECTED_PINNED_COUNT.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_SELECTED_PINNED_DAILY.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_DELETE_BUTTON_TAPPED_COUNT.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_DELETE_BUTTON_TAPPED_DAILY.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_DELETE_CONFIRMED_COUNT.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_DELETE_CONFIRMED_DAILY.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_DELETE_CANCELLED_COUNT.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_DELETE_CANCELLED_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.SYNC_AI_CHAT_ACTIVE.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_VOICE_ENTRY_TAPPED_COUNT.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_VOICE_ENTRY_TAPPED_DAILY.pixelName to PixelParameter.removeAtb(),

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -610,6 +610,18 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         duckChatPixels.fireDuckAiSearchDuckDuckGoSuggestionClicked()
     }
 
+    fun fireRecentChatDeleteButtonTappedPixel() {
+        duckChatPixels.fireRecentChatDeleteButtonTapped()
+    }
+
+    fun fireRecentChatDeleteConfirmedPixel() {
+        duckChatPixels.fireRecentChatDeleteConfirmed()
+    }
+
+    fun fireRecentChatDeleteCancelledPixel() {
+        duckChatPixels.fireRecentChatDeleteCancelled()
+    }
+
     fun buildChatSuggestionUrl(suggestion: ChatSuggestion): String =
         duckChatInternal.buildChatUrl(suggestion.chatId)
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -193,6 +193,12 @@ interface NativeInputWidget {
      */
     fun refreshChatSuggestions()
 
+    /** The user confirmed deleting a recent chat from the chat-autocomplete fire dialog. */
+    fun onChatDeleteConfirmed()
+
+    /** The user cancelled deleting a recent chat from the chat-autocomplete fire dialog. */
+    fun onChatDeleteCancelled()
+
     fun asView(): View
 }
 
@@ -1264,6 +1270,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
                     onChatSuggestionSelected(viewModel.buildChatSuggestionUrl(suggestion))
                 },
                 onChatSuggestionDeleteClicked = { suggestion ->
+                    viewModel.fireRecentChatDeleteButtonTappedPixel()
                     onChatSuggestionDelete(viewModel.buildChatSuggestionUrl(suggestion))
                 },
                 onChatUrlSuggestionClicked = { suggestion ->
@@ -1343,6 +1350,14 @@ class NativeInputModeWidget @JvmOverloads constructor(
     override fun refreshChatSuggestions() {
         if (chatSuggestionsBinding == null || !isChatTabSelected()) return
         refreshChatSuggestionsAction?.invoke()
+    }
+
+    override fun onChatDeleteConfirmed() {
+        viewModel.fireRecentChatDeleteConfirmedPixel()
+    }
+
+    override fun onChatDeleteCancelled() {
+        viewModel.fireRecentChatDeleteCancelledPixel()
     }
 
     override fun asView(): View = this

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
@@ -421,6 +421,36 @@ class RealDuckChatPixelsTest {
     }
 
     @Test
+    fun whenFireRecentChatDeleteButtonTappedThenCountAndDailyFired() = runTest {
+        testee.fireRecentChatDeleteButtonTapped()
+
+        advanceUntilIdle()
+
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_DELETE_BUTTON_TAPPED_COUNT)
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_DELETE_BUTTON_TAPPED_DAILY, type = Pixel.PixelType.Daily())
+    }
+
+    @Test
+    fun whenFireRecentChatDeleteConfirmedThenCountAndDailyFired() = runTest {
+        testee.fireRecentChatDeleteConfirmed()
+
+        advanceUntilIdle()
+
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_DELETE_CONFIRMED_COUNT)
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_DELETE_CONFIRMED_DAILY, type = Pixel.PixelType.Daily())
+    }
+
+    @Test
+    fun whenFireRecentChatDeleteCancelledThenCountAndDailyFired() = runTest {
+        testee.fireRecentChatDeleteCancelled()
+
+        advanceUntilIdle()
+
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_DELETE_CANCELLED_COUNT)
+        verify(mockPixel).fire(DuckChatPixelName.DUCK_CHAT_RECENT_CHAT_DELETE_CANCELLED_DAILY, type = Pixel.PixelType.Daily())
+    }
+
+    @Test
     fun whenFireSentPromptInChatThenCountAndDailyFired() = runTest {
         testee.fireSentPromptInChat()
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -1474,6 +1474,31 @@ class NativeInputModeWidgetViewModelTest {
 
     // endregion
 
+    // region fireRecentChatDeleteButtonTappedPixel
+
+    @Test
+    fun whenFireRecentChatDeleteButtonTappedPixelThenDelegatesToDuckChatPixels() {
+        testee.fireRecentChatDeleteButtonTappedPixel()
+
+        verify(duckChatPixels).fireRecentChatDeleteButtonTapped()
+    }
+
+    @Test
+    fun whenFireRecentChatDeleteConfirmedPixelThenDelegatesToDuckChatPixels() {
+        testee.fireRecentChatDeleteConfirmedPixel()
+
+        verify(duckChatPixels).fireRecentChatDeleteConfirmed()
+    }
+
+    @Test
+    fun whenFireRecentChatDeleteCancelledPixelThenDelegatesToDuckChatPixels() {
+        testee.fireRecentChatDeleteCancelledPixel()
+
+        verify(duckChatPixels).fireRecentChatDeleteCancelled()
+    }
+
+    // endregion
+
     // region duckai autocomplete-family pixels
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216105086737322?focus=true 
Tech Design URL (if applicable): 

### Description
Adds three count/daily pixels for the Duck.ai recent-chat delete flow (behind the `removeChatHistory` flag):
- `m_aichat_recent_chat_delete_button_tapped` — user taps the delete (fire) icon on a recent-chat row
- `m_aichat_recent_chat_delete_confirmed` — user confirms the deletion
-  `m_aichat_recent_chat_delete_cancelled` — user cancels the deletion

All three pixels send `appVersion` only (atb stripped via `DuckChatParamRemovalPlugin`), consistent with the sibling `m_aichat_recent_chat_*` pixels.

### Steps to test this PR
### Setup
  - [x] Use an **internal** build with pixel logging visible in logcat
  - [x] `removeChatHistory` remote flag **enabled**
  - [x] Have at least one recent Duck.ai chat so a recent-chat row appears in the Duck.ai input suggestions

  ### `removeChatHistory` enabled, `showClearDuckAIChatHistory` = true — tap delete icon
  - [x] Tapping the delete (fire) icon fires `m_aichat_recent_chat_delete_button_tapped_count`
  - [x] `m_aichat_recent_chat_delete_button_tapped_daily` fires on the first tap of the day
  - [x] The single-chat fire dialog opens with the singular "Delete this chat?" title
  - [x] Tapping the delete/confirm button in the fire dialog fires `m_aichat_recent_chat_delete_confirmed_count`
  - [x] `m_aichat_recent_chat_delete_confirmed_daily` fires on the first confirm of the day
  - [x] The selected chat is removed and the suggestions list refreshes (deleted chat no longer shown)

  ### Cancel deletion
  - [x] Tap the delete (fire) icon on a chat suggestion
  - [x] Dismissing the fire dialog (back press / tap outside) fires `m_aichat_recent_chat_delete_cancelled_count`
  - [x] `m_aichat_recent_chat_delete_cancelled_daily` fires on the first cancel of the day
  - [x] The chat is **not** deleted and remains in the suggestions list

  ### Pixel parameters
  - [x] Fired delete pixels include `appVersion`
  - [x] Fired delete pixels do **NOT** include `atb` (stripped via `DuckChatParamRemovalPlugin`)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry and thin callback plumbing only; no changes to deletion or storage behavior beyond when pixels fire.
> 
> **Overview**
> Adds **analytics for deleting a recent chat** from the Duck.ai omnibar suggestions list: tap delete, confirm, and cancel.
> 
> Three new pixel definitions (`m_aichat_recent_chat_delete_*`) are registered in **duck_chat.json5** and implemented in **DuckChatPixels** as count + daily pairs (with ATB stripped like other Duck Chat metrics). The delete icon fires on suggestion-row tap; confirm/cancel fire when the chat-autocomplete **fire dialog** completes or is dismissed.
> 
> **BrowserActivity** now forwards those dialog outcomes to the tab’s native input when origin is `ORIGIN_CHAT_AUTOCOMPLETE` (including calling `onChatDeleteConfirmed` / `onChatDeleteCancelled` on the widget). **SingleTabFireDialog** passes dialog **origin** on cancel so cancel analytics only run for this flow. Unit tests cover pixel firing and ViewModel delegation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a0ab0d85c0f9a9bb4920cf86ab17723fb303c52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->