### PR TITLE
re-align AI onboarding flow states

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -187,26 +187,33 @@ class CtaViewModel @Inject constructor(
     // Exposed for onboarding dev settings and tests. Used internally for completion checks
     @VisibleForTesting
     suspend fun requiredDaxOnboardingCtas(): List<CtaId> {
-        if (onboardingStore.isDuckAiOnboardingFlow()) {
-            return listOf(CtaId.DAX_DUCK_AI_FIRE_BUTTON)
-        }
-        return if (isSubscriptionCtaAvailable()) {
-            listOf(
-                CtaId.DAX_INTRO,
-                CtaId.DAX_DIALOG_SERP,
-                CtaId.DAX_DIALOG_TRACKERS_FOUND,
-                CtaId.DAX_FIRE_BUTTON,
-                CtaId.DAX_END,
-                CtaId.DAX_INTRO_PRIVACY_PRO,
-            )
-        } else {
-            listOf(
-                CtaId.DAX_INTRO,
-                CtaId.DAX_DIALOG_SERP,
-                CtaId.DAX_DIALOG_TRACKERS_FOUND,
-                CtaId.DAX_FIRE_BUTTON,
-                CtaId.DAX_END,
-            )
+        return when {
+            onboardingStore.isDuckAiOnboardingFlow() -> {
+                mutableListOf(CtaId.DAX_DUCK_AI_FIRE_BUTTON, CtaId.DAX_DUCK_AI_END).also {
+                    if (isSubscriptionCtaAvailable()) {
+                        it.add(CtaId.DAX_INTRO_PRIVACY_PRO)
+                    }
+                }
+            }
+            isSubscriptionCtaAvailable() -> {
+                listOf(
+                    CtaId.DAX_INTRO,
+                    CtaId.DAX_DIALOG_SERP,
+                    CtaId.DAX_DIALOG_TRACKERS_FOUND,
+                    CtaId.DAX_FIRE_BUTTON,
+                    CtaId.DAX_END,
+                    CtaId.DAX_INTRO_PRIVACY_PRO,
+                )
+            }
+            else -> {
+                listOf(
+                    CtaId.DAX_INTRO,
+                    CtaId.DAX_DIALOG_SERP,
+                    CtaId.DAX_DIALOG_TRACKERS_FOUND,
+                    CtaId.DAX_FIRE_BUTTON,
+                    CtaId.DAX_END,
+                )
+            }
         }
     }
 
@@ -228,10 +235,6 @@ class CtaViewModel @Inject constructor(
                 if (canSendPixel) {
                     pixel.fire(it, cta.pixelShownParameters())
                 }
-            }
-            if (cta is DaxDuckAiEndBubbleCta || cta is DaxDuckAiEndBrandDesignUpdateBubbleCta) {
-                // Native-input bubble path: mirror prepareAndMarkDuckAiEndCtaForInputScreen's side-effects.
-                completeStageIfDaxOnboardingCompleted()
             }
             if (cta is DaxCta && cta.markAsReadOnShow) {
                 dismissedCtaDao.insert(DismissedCta(cta.ctaId))
@@ -308,8 +311,8 @@ class CtaViewModel @Inject constructor(
             val shouldShow = canShowDuckAiEndCta() && !settingsDataStore.hideTips
             if (!shouldShow) return@withContext DuckAiOnboardingEndCtaVariant.NONE
 
+            setInputToggleStateForDuckAiEndCta()
             dismissedCtaDao.insert(DismissedCta(CtaId.DAX_DUCK_AI_END))
-            completeStageIfDaxOnboardingCompleted()
             if (canSendShownPixel(onboardingStore, Pixel.PixelValues.DUCK_AI_END_CTA)) {
                 val journey = addCtaToHistory(onboardingStore, appInstallStore, Pixel.PixelValues.DUCK_AI_END_CTA)
                 pixel.fire(AppPixelName.ONBOARDING_DAX_CTA_SHOWN, mapOf(Pixel.PixelParameter.CTA_SHOWN to journey))
@@ -330,6 +333,7 @@ class CtaViewModel @Inject constructor(
             } else {
                 pixel.fire(AppPixelName.ONBOARDING_DAX_CTA_DISMISS_BUTTON, params)
             }
+            completeStageIfDaxOnboardingCompleted()
         }
     }
 
@@ -416,6 +420,12 @@ class CtaViewModel @Inject constructor(
         }
     }
 
+    private suspend fun setInputToggleStateForDuckAiEndCta() {
+        // AI flows always default the toggle on and offer no choice, so we apply the real setting here,
+        // just before the End CTA renders.
+        duckChat.setInputScreenUserSetting(true)
+    }
+
     private suspend fun getHomeCta(): Cta? {
         return when {
             // Duck.ai onboarding end
@@ -424,17 +434,20 @@ class CtaViewModel @Inject constructor(
                     // Legacy path: the input screen auto-launches with the end CTA. Suppress home
                     // CTAs until that flow runs (see prepareAndMarkDuckAiEndCtaForInputScreen).
                     null
-                } else if (isBrandDesignUpdateEnabled()) {
-                    DaxDuckAiEndBrandDesignUpdateBubbleCta(
-                        onboardingStore = onboardingStore,
-                        appInstallStore = appInstallStore,
-                        isLightTheme = appTheme.isLightModeEnabled(),
-                        deviceInfo = deviceInfo,
-                        isCustomAiOnboardingFlow = customAiOnboarding.isEnabled(),
-                        onboardingImprovementsV2Enabled = isOnboardingImprovementsV2Enabled(),
-                    )
                 } else {
-                    DaxDuckAiEndBubbleCta(onboardingStore, appInstallStore)
+                    setInputToggleStateForDuckAiEndCta()
+                    if (isBrandDesignUpdateEnabled()) {
+                        DaxDuckAiEndBrandDesignUpdateBubbleCta(
+                            onboardingStore = onboardingStore,
+                            appInstallStore = appInstallStore,
+                            isLightTheme = appTheme.isLightModeEnabled(),
+                            deviceInfo = deviceInfo,
+                            isCustomAiOnboardingFlow = customAiOnboarding.isEnabled(),
+                            onboardingImprovementsV2Enabled = isOnboardingImprovementsV2Enabled(),
+                        )
+                    } else {
+                        DaxDuckAiEndBubbleCta(onboardingStore, appInstallStore)
+                    }
                 }
             }
 
@@ -534,17 +547,7 @@ class CtaViewModel @Inject constructor(
     private suspend fun canShowSubscriptionCta(): Boolean {
         if (hideTips() || daxDialogSubscriptionShown() || !isSubscriptionCtaAvailable()) return false
 
-        return if (onboardingStore.isDuckAiOnboardingFlow()) {
-            // Duck.ai flow: the DAX_ONBOARDING stage completes right after the fire-button CTA
-            // (so the input-mode toggle can be enabled), which makes daxOnboardingActive() false
-            // on home. Gate on the duck.ai end CTA having been shown to preserve ordering:
-            // fire button -> end CTA -> privacy pro.
-            duckAiEndShown()
-        } else {
-            // Regular search flow: privacy pro is part of requiredDaxOnboardingCtas, so the stage
-            // stays active until it's dismissed and daxOnboardingActive() carries the gating.
-            daxOnboardingActive()
-        }
+        return daxOnboardingActive()
     }
 
     @WorkerThread
@@ -723,8 +726,8 @@ class CtaViewModel @Inject constructor(
     suspend fun areBubbleDaxDialogsCompleted(): Boolean {
         return withContext(dispatchers.io()) {
             val isLastContextDialogShown = when {
-                onboardingStore.isDuckAiOnboardingFlow() -> duckAiEndShown()
                 isSubscriptionCtaAvailable() -> daxDialogSubscriptionShown()
+                onboardingStore.isDuckAiOnboardingFlow() -> duckAiEndShown()
                 else -> daxDialogEndShown()
             }
             isLastContextDialogShown || hideTips() || !userStageStore.daxOnboardingActive()

--- a/app/src/main/java/com/duckduckgo/app/onboarding/DuckAiOnboardingDemo.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/DuckAiOnboardingDemo.kt
@@ -53,15 +53,23 @@ class RealDuckAiOnboardingDemo @Inject constructor(
     override suspend fun arm() {
         withContext(dispatchers.io()) {
             onboardingStore.setDuckAiOnboardingFlow()
-            listOf(
-                CtaId.DAX_INTRO,
-                CtaId.DAX_DIALOG_SERP,
-                CtaId.DAX_DIALOG_TRACKERS_FOUND,
-                CtaId.DAX_FIRE_BUTTON,
-                CtaId.DAX_END,
-            ).forEach { dismissedCtaDao.insert(DismissedCta(it)) }
+            PRE_DISMISSED_CTAS.forEach { dismissedCtaDao.insert(DismissedCta(it)) }
         }
     }
 
     override fun isActive(): Boolean = onboardingStore.isDuckAiOnboardingFlow()
+
+    companion object {
+        /**
+         * Standard DAX onboarding CTAs the Duck.ai flow pre-dismisses when armed, so only the Duck.ai
+         * demo CTAs (and the trailing Privacy Pro bubble) drive the flow.
+         */
+        val PRE_DISMISSED_CTAS = listOf(
+            CtaId.DAX_INTRO,
+            CtaId.DAX_DIALOG_SERP,
+            CtaId.DAX_DIALOG_TRACKERS_FOUND,
+            CtaId.DAX_FIRE_BUTTON,
+            CtaId.DAX_END,
+        )
+    }
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingInputScreenSelectionObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingInputScreenSelectionObserver.kt
@@ -63,6 +63,7 @@ class OnboardingInputScreenSelectionObserver @Inject constructor(
         }
             .distinctUntilChanged()
             .drop(1)
+            .filter { canProcess() }
             .onEach { (isInputScreenCosmeticallyEnabled, isInputScreenEnabled) ->
                 if (isInputScreenCosmeticallyEnabled != isInputScreenEnabled) return@onEach
 
@@ -79,7 +80,9 @@ class OnboardingInputScreenSelectionObserver @Inject constructor(
         userStageStore.userAppStageFlow()
             .distinctUntilChanged()
             .drop(1)
-            .filter { it == AppStage.ESTABLISHED }
+            .filter {
+                canProcess() && it == AppStage.ESTABLISHED
+            }
             .onEach {
                 val selection = onboardingStore.getInputScreenSelection()
                 if (!onboardingStore.isInputScreenSelectionOverriddenByUser() && selection != null) {
@@ -88,5 +91,12 @@ class OnboardingInputScreenSelectionObserver @Inject constructor(
             }
             .flowOn(dispatchers.io())
             .launchIn(appCoroutineScope)
+    }
+
+    private fun canProcess(): Boolean{
+         // AI flows enable the real setting themselves, just-in-time before the End CTA, so a
+         // pre-ESTABLISHED match there is expected rather than a user override. Detection only
+         // applies to flows that defer the setting to ESTABLISHED (i.e. non-AI flows).
+        return !onboardingStore.isDuckAiOnboardingFlow()
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingInputScreenSelectionObserver.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingInputScreenSelectionObserver.kt
@@ -93,10 +93,10 @@ class OnboardingInputScreenSelectionObserver @Inject constructor(
             .launchIn(appCoroutineScope)
     }
 
-    private fun canProcess(): Boolean{
-         // AI flows enable the real setting themselves, just-in-time before the End CTA, so a
-         // pre-ESTABLISHED match there is expected rather than a user override. Detection only
-         // applies to flows that defer the setting to ESTABLISHED (i.e. non-AI flows).
+    private fun canProcess(): Boolean {
+        // AI flows enable the real setting themselves, just-in-time before the End CTA, so a
+        // pre-ESTABLISHED match there is expected rather than a user override. Detection only
+        // applies to flows that defer the setting to ESTABLISHED (i.e. non-AI flows).
         return !onboardingStore.isDuckAiOnboardingFlow()
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -38,6 +38,7 @@ import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.global.install.AppInstallStore
 import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.onboarding.CustomAiOnboardingStore
+import com.duckduckgo.app.onboarding.RealDuckAiOnboardingDemo
 import com.duckduckgo.app.onboarding.store.AppStage
 import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.onboarding.store.UserStageStore
@@ -358,6 +359,34 @@ class CtaViewModelTest {
         givenShownDaxOnboardingCtas(requiredDaxOnboardingCtas)
         testee.onUserDismissedCta(DaxBubbleCta.DaxEndCta(mockOnboardingStore, mockAppInstallStore))
         verify(mockUserStageStore).stageCompleted(AppStage.DAX_ONBOARDING)
+    }
+
+    @Test
+    fun whenDuckAiEndCtaInteractionAndAllDuckAiOnboardingCtasShownThenStageCompleted() = runTest {
+        givenDaxOnboardingActive()
+        whenever(mockOnboardingStore.isDuckAiOnboardingFlow()).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_DUCK_AI_FIRE_BUTTON)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_DUCK_AI_END)).thenReturn(true)
+        whenever(mockSubscriptions.isEligible()).thenReturn(false)
+
+        testee.onDuckAiEndCtaInteraction(okClicked = false)
+
+        verify(mockUserStageStore).stageCompleted(AppStage.DAX_ONBOARDING)
+    }
+
+    @Test
+    fun whenDuckAiEndCtaInteractionAndPrivacyProStillPendingThenStageNotCompleted() = runTest {
+        givenDaxOnboardingActive()
+        whenever(mockOnboardingStore.isDuckAiOnboardingFlow()).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_DUCK_AI_FIRE_BUTTON)).thenReturn(true)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_DUCK_AI_END)).thenReturn(true)
+        whenever(mockSubscriptions.isEligible()).thenReturn(true)
+        whenever(mockSubscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
+        whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
+
+        testee.onDuckAiEndCtaInteraction(okClicked = false)
+
+        verify(mockUserStageStore, times(0)).stageCompleted(any())
     }
 
     @Test
@@ -905,9 +934,34 @@ class CtaViewModelTest {
     }
 
     @Test
-    fun whenDuckAiOnboardingFlowAndDuckAiEndShownAndSubscriptionAvailableThenRefreshCtaOnHomeReturnsSubscriptionCta() = runTest {
-        givenDaxOnboardingCompleted()
+    fun whenDuckAiOnboardingFlowThenRequiredDaxOnboardingCtasAreDuckAiFireAndEnd() = runTest {
         whenever(mockOnboardingStore.isDuckAiOnboardingFlow()).thenReturn(true)
+        whenever(mockSubscriptions.isEligible()).thenReturn(false)
+
+        val result = testee.requiredDaxOnboardingCtas()
+
+        assertEquals(listOf(CtaId.DAX_DUCK_AI_FIRE_BUTTON, CtaId.DAX_DUCK_AI_END), result)
+    }
+
+    @Test
+    fun whenDuckAiOnboardingFlowAndSubscriptionAvailableThenRequiredDaxOnboardingCtasIncludePrivacyProLast() = runTest {
+        whenever(mockOnboardingStore.isDuckAiOnboardingFlow()).thenReturn(true)
+        whenever(mockSubscriptions.isEligible()).thenReturn(true)
+        whenever(mockSubscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
+        whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
+
+        val result = testee.requiredDaxOnboardingCtas()
+
+        assertEquals(
+            listOf(CtaId.DAX_DUCK_AI_FIRE_BUTTON, CtaId.DAX_DUCK_AI_END, CtaId.DAX_INTRO_PRIVACY_PRO),
+            result,
+        )
+    }
+
+    @Test
+    fun whenDuckAiOnboardingFlowAndDuckAiEndShownAndSubscriptionAvailableThenRefreshCtaOnHomeReturnsSubscriptionCta() = runTest {
+        givenDaxOnboardingActive()
+        givenDuckAiOnboardingFlowArmed()
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_DUCK_AI_FIRE_BUTTON)).thenReturn(true)
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_DUCK_AI_END)).thenReturn(true)
         whenever(mockSubscriptions.isEligible()).thenReturn(true)
@@ -923,8 +977,8 @@ class CtaViewModelTest {
 
     @Test
     fun whenDuckAiOnboardingFlowAndDuckAiEndNotShownThenRefreshCtaOnHomeSuppressedEvenIfSubscriptionAvailable() = runTest {
-        givenDaxOnboardingCompleted()
-        whenever(mockOnboardingStore.isDuckAiOnboardingFlow()).thenReturn(true)
+        givenDaxOnboardingActive()
+        givenDuckAiOnboardingFlowArmed()
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_DUCK_AI_FIRE_BUTTON)).thenReturn(true)
         whenever(mockDismissedCtaDao.exists(CtaId.DAX_DUCK_AI_END)).thenReturn(false)
         whenever(mockSubscriptions.isEligible()).thenReturn(true)
@@ -949,6 +1003,22 @@ class CtaViewModelTest {
         val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
         assertFalse(value is DaxBubbleCta.DaxSubscriptionCta)
         assertFalse(value is DaxSubscriptionBrandDesignUpdateBubbleCta)
+    }
+
+    @Test
+    fun whenDuckAiOnboardingFlowAndSubscriptionAvailableThenBubbleDaxDialogsCompletedGatedOnPrivacyPro() = runTest {
+        givenDaxOnboardingActive()
+        whenever(mockOnboardingStore.isDuckAiOnboardingFlow()).thenReturn(true)
+        whenever(mockSubscriptions.isEligible()).thenReturn(true)
+        whenever(mockSubscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
+        whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_DUCK_AI_END)).thenReturn(true)
+
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_PRIVACY_PRO)).thenReturn(false)
+        assertFalse(testee.areBubbleDaxDialogsCompleted())
+
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_PRIVACY_PRO)).thenReturn(true)
+        assertTrue(testee.areBubbleDaxDialogsCompleted())
     }
 
     @Test
@@ -1449,6 +1519,25 @@ class CtaViewModelTest {
         verify(mockDismissedCtaDao, never()).insert(DismissedCta(CtaId.DAX_DUCK_AI_END))
     }
 
+    @Test
+    fun whenPrepareDuckAiEndCtaAndEligibleThenInputScreenUserSettingEnabled() = runTest {
+        givenCanShowDuckAiEndCta()
+
+        testee.prepareAndMarkDuckAiEndCtaForInputScreen()
+
+        verify(mockDuckChat).setInputScreenUserSetting(true)
+    }
+
+    @Test
+    fun whenPrepareDuckAiEndCtaAndAlreadyShownThenInputScreenUserSettingNotApplied() = runTest {
+        givenCanShowDuckAiEndCta()
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_DUCK_AI_END)).thenReturn(true)
+
+        testee.prepareAndMarkDuckAiEndCtaForInputScreen()
+
+        verify(mockDuckChat, never()).setInputScreenUserSetting(any())
+    }
+
     // region DAX_DUCK_AI_END home bubble (nativeInputField path)
 
     @Test
@@ -1483,6 +1572,29 @@ class CtaViewModelTest {
         val cta = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
 
         assertNull(cta)
+    }
+
+    @Test
+    fun whenNativeInputActiveAndCanShowDuckAiEndCtaThenInputScreenUserSettingEnabledJustInTime() = runTest {
+        givenDaxOnboardingActive()
+        givenCanShowDuckAiEndCta()
+        showInputScreenFlow.value = false
+
+        testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+
+        verify(mockDuckChat).setInputScreenUserSetting(true)
+    }
+
+    @Test
+    fun whenInputScreenEnabledAndCanShowDuckAiEndCtaThenGetHomeCtaDoesNotApplyInputScreenUserSetting() = runTest {
+        givenDaxOnboardingActive()
+        givenCanShowDuckAiEndCta()
+        showInputScreenFlow.value = true
+
+        testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
+
+        // The legacy input-screen path applies the toggle in prepareAndMarkDuckAiEndCtaForInputScreen, not here.
+        verify(mockDuckChat, never()).setInputScreenUserSetting(any())
     }
 
     @Test
@@ -2020,4 +2132,12 @@ class CtaViewModelTest {
         isCustomAiOnboardingFlow = false,
         onboardingImprovementsV2Enabled = true,
     )
+
+    private fun givenDuckAiOnboardingFlowArmed() {
+        // Mirrors RealDuckAiOnboardingDemo.arm()
+        whenever(mockOnboardingStore.isDuckAiOnboardingFlow()).thenReturn(true)
+        RealDuckAiOnboardingDemo.PRE_DISMISSED_CTAS.forEach {
+            whenever(mockDismissedCtaDao.exists(it)).thenReturn(true)
+        }
+    }
 }

--- a/app/src/test/java/com/duckduckgo/app/onboarding/DuckAiOnboardingDemoTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/DuckAiOnboardingDemoTest.kt
@@ -27,6 +27,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 
 class DuckAiOnboardingDemoTest {
@@ -57,6 +58,7 @@ class DuckAiOnboardingDemoTest {
         verify(dismissedCtaDao).insert(DismissedCta(CtaId.DAX_DIALOG_TRACKERS_FOUND))
         verify(dismissedCtaDao).insert(DismissedCta(CtaId.DAX_FIRE_BUTTON))
         verify(dismissedCtaDao).insert(DismissedCta(CtaId.DAX_END))
+        verifyNoMoreInteractions(dismissedCtaDao)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/onboarding/OnboardingInputScreenSelectionObserverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/OnboardingInputScreenSelectionObserverTest.kt
@@ -191,4 +191,57 @@ class OnboardingInputScreenSelectionObserverTest {
 
             verify(mockDuckChat, never()).setInputScreenUserSetting(any())
         }
+
+    @Test
+    fun whenDuckAiOnboardingFlowAndSettingEnabledBeforeEstablishedThenDoNotMarkAsOverriddenByUser() =
+        runTest {
+            whenever(mockOnboardingStore.isDuckAiOnboardingFlow()).thenReturn(true)
+            whenever(mockUserStageStore.userAppStageFlow()).thenReturn(userAppStageFlow)
+            whenever(mockUserStageStore.getUserAppStage()).thenReturn(AppStage.NEW)
+            whenever(mockOnboardingStore.getInputScreenSelection()).thenReturn(true)
+            whenever(mockDuckChat.observeInputScreenUserSettingEnabled()).thenReturn(inputScreenSettingFlow)
+            whenever(mockDuckChat.observeCosmeticInputScreenUserSettingEnabled()).thenReturn(cosmeticInputScreenSettingFlow)
+
+            OnboardingInputScreenSelectionObserver(
+                mockAppCoroutineScope,
+                dispatcherProvider,
+                mockUserStageStore,
+                mockOnboardingStore,
+                mockDuckChat,
+                mockInputScreenOnboardingWideEvent,
+            )
+
+            // AI flows enable the toggle themselves just-in-time before the End CTA, so an early match
+            // is expected rather than a user override.
+            cosmeticInputScreenSettingFlow.value = true
+            inputScreenSettingFlow.value = true
+
+            verify(mockOnboardingStore, never()).setInputScreenSelectionOverriddenByUser()
+            verify(mockInputScreenOnboardingWideEvent, never()).onInputScreenSettingEnabledBeforeInputScreenShown(any())
+        }
+
+    @Test
+    fun whenDuckAiOnboardingFlowAndUserStageIsEstablishedThenDoNotSetInputScreenUserSetting() =
+        runTest {
+            whenever(mockOnboardingStore.isDuckAiOnboardingFlow()).thenReturn(true)
+            whenever(mockUserStageStore.userAppStageFlow()).thenReturn(userAppStageFlow)
+            whenever(mockUserStageStore.getUserAppStage()).thenReturn(AppStage.NEW)
+            whenever(mockOnboardingStore.getInputScreenSelection()).thenReturn(true)
+            whenever(mockDuckChat.observeInputScreenUserSettingEnabled()).thenReturn(inputScreenSettingFlow)
+            whenever(mockDuckChat.observeCosmeticInputScreenUserSettingEnabled()).thenReturn(cosmeticInputScreenSettingFlow)
+
+            OnboardingInputScreenSelectionObserver(
+                mockAppCoroutineScope,
+                dispatcherProvider,
+                mockUserStageStore,
+                mockOnboardingStore,
+                mockDuckChat,
+                mockInputScreenOnboardingWideEvent,
+            )
+
+            userAppStageFlow.value = AppStage.ESTABLISHED
+
+            // AI flows already applied the real setting just-in-time, so the ESTABLISHED handler must not re-apply it.
+            verify(mockDuckChat, never()).setInputScreenUserSetting(any())
+        }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1216196262697685?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1208671518894266/task/1216340049398701?focus=true

### Description
Two coupled changes in the AI onboarding flows:
- Enable the toggle just-in-time, right before the End CTA is shown. This decouples "toggle is live" from `ESTABLISHED`.
- Require the `End` CTA again, so `ESTABLISHED` fires when it's dismissed, just like the base flow.

### Steps to test this PR
_setup_
- [x] Filter logcat by `package:mine appstage`

_search path_
- [x] Clean install the app
- [x] On input preview demo screen **select search** and submit a query
- [x] Verify `AppStage` transitions to `DAX_ONBOARDING`
- [x] On **try-a-site** step tap the address bar, verify input **toggle is not visible**
- [x] Continue until the last 'You've got it!' CTA
- [x] Verify address bar is **focused and toggle is not visible**
- [x] Verify `AppStage` **did not** transitions to `ESTABLISHED`
- [x] Dismiss the CTA, verify address bar loses focus and keyboard collapses
- [x] Verify `AppStage` **did** transitions to `ESTABLISHED`
- [x] Tap the address bar again, verify the **toggle is visible**

_chat path_
- [x] Clean install the app
- [x] On input preview demo screen **select Duck.ai** and submit a prompt
- [x] Continue until the last 'You've got it!' CTA
- [x] Verify `AppStage` **did not** transitions to `ESTABLISHED`
- [x] Verify address bar is **focused and toggle is visible**
- [x] Dismiss the CTA, verify address bar loses focus and keyboard collapses
- [x] Verify `AppStage` **did** transitions to `ESTABLISHED`
- [x] Tap the address bar again, verify the **toggle is visible**

_search-only path_
- [x] Clean install the app
- [x] On input selection screen pick **search-only**
- [x] Verify `AppStage` transitions to `DAX_ONBOARDING`
- [x] On **try-a-search** verify address bar is focused and **toggle is not visible**
- [x] Continue until the last 'You've got it!' CTA
- [x] Verify address bar is **focused and toggle is not visible**
- [x] Verify `AppStage` **did not** transitions to `ESTABLISHED`
- [x] Dismiss the CTA, verify address bar loses focus and keyboard collapses
- [x] Verify `AppStage` **did** transitions to `ESTABLISHED`
- [x] Tap the address bar again, verify the **toggle is not visible**

_subscriptions patch_
- [x] Apply this patch:
```diff
diff --git a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
index a559ebb59b..bdfe15b100 100644
--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -139,7 +139,7 @@ class CtaViewModel @Inject constructor(
     }
 
     private suspend fun isSubscriptionCtaAvailable(): Boolean =
-        subscriptions.isEligible() && hasNoSubscription() && extendedOnboardingFeatureToggles.privacyProCta().isEnabled()
+        true//subscriptions.isEligible() && hasNoSubscription() && extendedOnboardingFeatureToggles.privacyProCta().isEnabled()
 
     private suspend fun isBrandDesignUpdateEnabled(): Boolean = withContext(dispatchers.io()) {
         onboardingBrandDesignUpdateToggles.brandDesignUpdate().isEnabled()
```

_search path with subscription_
- [x] Clean install the app
- [x] On input preview demo screen **select search** and submit a query
- [x] Verify `AppStage` transitions to `DAX_ONBOARDING`
- [x] On **try-a-site** step tap the address bar, verify input **toggle is not visible**
- [x] Continue until the last 'You've got it!' CTA
- [x] Verify address bar is **focused and toggle is not visible**
- [x] Verify `AppStage` **did not** transitions to `ESTABLISHED`
- [x] Dismiss the CTA, verify address bar loses focus and keyboard collapses
- [x] Verify `AppStage` **did not** transitions to `ESTABLISHED`
- [x] Dismiss subscription promo.
- [x] Verify `AppStage` **did** transitions to `ESTABLISHED`
- [x] Tap the address bar again, verify the **toggle is visible**

_chat path with subscription_
- [x] Clean install the app
- [x] On input preview demo screen **select Duck.ai** and submit a prompt
- [x] Continue until the last 'You've got it!' CTA
- [x] Verify `AppStage` **did not** transitions to `ESTABLISHED`
- [x] Verify address bar is **focused and toggle is visible**
- [x] Dismiss the CTA, verify address bar loses focus and keyboard collapses
- [x] Verify `AppStage` **did not** transitions to `ESTABLISHED`
- [x] Dismiss subscription promo.
- [x] Verify `AppStage` **did** transitions to `ESTABLISHED`
- [x] Tap the address bar again, verify the **toggle is visible**

_custom AI onboarding patch_
- [x] Additionally apply this patch:
```diff
diff --git a/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt b/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
index 4f15d4c50e..1ab5fa5845 100644
--- a/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
@@ -101,6 +101,7 @@ class CustomAiOnboardingStoreImpl @Inject constructor(
     }
 
     override suspend fun resolve() = resolveMutex.withLock {
+        return@withLock true
         withContext(dispatcherProvider.io()) {
             // Ensure the install referrer (and therefore the processing function) has resolved before reading.
             withTimeoutOrNull(MAX_REFERRER_WAIT_TIME_MS) { referrerStateListener.get().waitForReferrerCode() }
@@ -118,6 +119,7 @@ class CustomAiOnboardingStoreImpl @Inject constructor(
     }
 
     override suspend fun isEnabled(): Boolean = resolveMutex.withLock {
+        return@withLock true
         withContext(dispatcherProvider.io()) {
             preferences.getBoolean(PREFS_KEY_ENABLED, false)
         }
```

_custom AI path with subscription_
- [x] Clean install the app
- [x] Continue until the last 'You've got it!' CTA
- [x] Verify `AppStage` **did not** transitions to `ESTABLISHED`
- [x] Verify address bar is **focused and toggle is visible**
- [x] Dismiss the CTA, verify address bar loses focus and keyboard collapses
- [x] Verify `AppStage` **did not** transitions to `ESTABLISHED`
- [x] Dismiss subscription promo.
- [x] Verify `AppStage` **did** transitions to `ESTABLISHED`
- [x] Tap the address bar again, verify the **toggle is visible**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when AppStage leaves DAX_ONBOARDING and when the input toggle is applied—user-visible onboarding ordering—but behavior is heavily covered by new unit tests and limited to onboarding/CTA paths.
> 
> **Overview**
> **Re-aligns Duck.ai onboarding** so the input-screen toggle turns on just before the “You've got it!” End CTA, and **`DAX_ONBOARDING` only completes after that CTA is dismissed** (matching search onboarding), including when Privacy Pro is still pending.
> 
> In **`CtaViewModel`**, Duck.ai **required CTAs** are now fire → end → optional Privacy Pro. **`duckChat.setInputScreenUserSetting(true)`** runs via `setInputToggleStateForDuckAiEndCta()` when the End CTA is prepared (legacy input screen) or shown on home (native input). **`completeStageIfDaxOnboardingCompleted()`** no longer runs when the End bubble is merely shown; it runs on **`onDuckAiEndCtaInteraction`** after dismiss/OK. Subscription promo gating is unified on **`daxOnboardingActive()`**, with **`areBubbleDaxDialogsCompleted()`** treating Privacy Pro as the last bubble when subscriptions are available.
> 
> **`OnboardingInputScreenSelectionObserver`** ignores Duck.ai flows so the just-in-time toggle is not treated as a user override or re-applied at **`ESTABLISHED`**. **`RealDuckAiOnboardingDemo`** exposes **`PRE_DISMISSED_CTAS`** for tests and demo arming.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b09cce6a5ded660de078f83a865f9d0742e41946. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->