### PR TITLE
Use legacy omnibar in search-only mode

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -735,7 +735,7 @@ class BrowserTabFragment :
                 newState: Int,
             ) {
                 if (newState == RecyclerView.SCROLL_STATE_DRAGGING) {
-                    if (nativeInputManager.isNativeInputEnabled()) {
+                    if (nativeInputManager.isNativeInputActive()) {
                         hideKeyboardImmediatelyRetainFocus()
                     } else {
                         hideKeyboardRetainFocus()
@@ -2852,7 +2852,7 @@ class BrowserTabFragment :
             }
 
             is Command.ShowKeyboard -> {
-                if (nativeInputManager.isNativeInputEnabled()) {
+                if (nativeInputManager.isNativeInputActive()) {
                     // Surface the native input widget so its onEnterComplete focuses the input
                     // and brings up the keyboard via the same path as a manual omnibar tap.
                     // Skip if the widget is already attached — Command.ShowKeyboard can fire
@@ -2871,7 +2871,7 @@ class BrowserTabFragment :
             }
 
             is Command.DropAddressBarFocus -> {
-                if (nativeInputManager.isNativeInputEnabled()) {
+                if (nativeInputManager.isNativeInputActive()) {
                     nativeInputManager.hideNativeInput()
                 } else {
                     hideKeyboard()
@@ -2984,7 +2984,7 @@ class BrowserTabFragment :
             is Command.CancelIncomingAutofillRequest -> injectAutofillCredentials(it.url, null)
             is Command.LaunchAutofillSettings -> launchAutofillManagementScreen(it.privacyProtectionEnabled)
             is Command.EditWithSelectedQuery -> {
-                if (nativeInputManager.isNativeInputEnabled()) {
+                if (nativeInputManager.isNativeInputActive()) {
                     nativeInputManager.setText(it.query)
                 } else {
                     omnibar.setText(it.query)
@@ -4085,7 +4085,7 @@ class BrowserTabFragment :
                     hasFocus: Boolean,
                     query: String,
                 ) {
-                    if (nativeInputManager.isNativeInputEnabled()) return
+                    if (nativeInputManager.isNativeInputActive()) return
                     onOmnibarTextFocusChanged(hasFocus, query)
                 }
 
@@ -4101,12 +4101,12 @@ class BrowserTabFragment :
                 }
 
                 override fun onOmnibarTextChanged(state: OmnibarTextState) {
-                    if (nativeInputManager.isNativeInputEnabled()) return
+                    if (nativeInputManager.isNativeInputActive()) return
                     onUserEnteredText(state.text, state.hasFocus)
                 }
 
                 override fun onShowSuggestions(state: OmnibarTextState) {
-                    if (nativeInputManager.isNativeInputEnabled()) return
+                    if (nativeInputManager.isNativeInputActive()) return
                     viewModel.triggerAutocomplete(
                         state.text,
                         state.hasFocus,

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -5605,7 +5605,10 @@ class BrowserTabViewModel @Inject constructor(
         }
 
         when {
-            duckAiFeatureState.showContextualMode.value && !isNtp -> {
+            // Contextual chat is about the page you're viewing, so it's only offered from the
+            // unfocused omnibar. Once the omnibar is focused (composing), fall through to full-screen
+            // Duck.ai.
+            duckAiFeatureState.showContextualMode.value && !isNtp && !hasFocus -> {
                 command.value = Command.ShowDuckAIContextualMode(tabId)
             }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -175,7 +175,7 @@ class RealNativeInputManager @Inject constructor(
     private lateinit var layoutCoordinator: NativeInputLayoutCoordinator
     private var isNativeInputFieldEnabled: Boolean = false
     private var isNativeChatInputEnabled: Boolean = false
-    private var availableInputMode: NativeInputState.InputMode = NativeInputState.InputMode.SEARCH_ONLY
+    private var inputModeCapability: NativeInputState.InputMode = NativeInputState.InputMode.SEARCH_ONLY
     private var isExiting: Boolean = false
     private var isPickingImage: Boolean = false
     private var duckAiToolbarHidden: Boolean = false
@@ -218,8 +218,8 @@ class RealNativeInputManager @Inject constructor(
                 }
             }
             .launchIn(lifecycleOwner.lifecycleScope)
-        duckChatInputModeState.availableInputMode
-            .onEach { availableInputMode = it }
+        duckChatInputModeState.inputModeCapability
+            .onEach { inputModeCapability = it }
             .launchIn(lifecycleOwner.lifecycleScope)
     }
 
@@ -229,7 +229,7 @@ class RealNativeInputManager @Inject constructor(
         if (!isNativeInputFieldEnabled) return false
         // Duck.ai always uses the native input; the browser omnibar only does so outside search-only.
         val inDuckAi = ::omnibarController.isInitialized && omnibarController.isDuckAiMode()
-        return inDuckAi || availableInputMode != NativeInputState.InputMode.SEARCH_ONLY
+        return inDuckAi || inputModeCapability != NativeInputState.InputMode.SEARCH_ONLY
     }
 
     override fun isChatTabSelected(): Boolean {

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -47,8 +47,10 @@ import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.DuckChatInputModeState
 import com.duckduckgo.duckchat.api.InputMode
 import com.duckduckgo.duckchat.api.NativeInputEventListener
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InteractionLock
 import com.duckduckgo.duckchat.api.toChatIdOrNull
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.NativeInputWidget
@@ -111,6 +113,13 @@ interface NativeInputManager {
 
     fun isNativeInputEnabled(): Boolean
 
+    /**
+     * Whether the native input should actually be used for the current context, as opposed to the
+     * legacy omnibar. True when the field is enabled AND either we're in Duck.ai or the config is not
+     * search-only. In search-only mode the browser omnibar falls back to the legacy text input.
+     */
+    fun isNativeInputActive(): Boolean
+
     /** True when the widget is shown with the chat tab selected. */
     fun isChatTabSelected(): Boolean
 
@@ -156,6 +165,7 @@ class RealNativeInputManager @Inject constructor(
     private val globalActivityStarter: GlobalActivityStarter,
     private val queryUrlPredictor: QueryUrlPredictor,
     private val duckAiFeatureState: DuckAiFeatureState,
+    private val duckChatInputModeState: DuckChatInputModeState,
     private val pixel: Pixel,
     private val nativeInputStateBugKillSwitch: NativeInputStateBugKillSwitch,
     private val nativeInputEventListener: NativeInputEventListener,
@@ -165,6 +175,7 @@ class RealNativeInputManager @Inject constructor(
     private lateinit var layoutCoordinator: NativeInputLayoutCoordinator
     private var isNativeInputFieldEnabled: Boolean = false
     private var isNativeChatInputEnabled: Boolean = false
+    private var availableInputMode: NativeInputState.InputMode = NativeInputState.InputMode.SEARCH_ONLY
     private var isExiting: Boolean = false
     private var isPickingImage: Boolean = false
     private var duckAiToolbarHidden: Boolean = false
@@ -207,9 +218,19 @@ class RealNativeInputManager @Inject constructor(
                 }
             }
             .launchIn(lifecycleOwner.lifecycleScope)
+        duckChatInputModeState.availableInputMode
+            .onEach { availableInputMode = it }
+            .launchIn(lifecycleOwner.lifecycleScope)
     }
 
     override fun isNativeInputEnabled(): Boolean = isNativeInputFieldEnabled
+
+    override fun isNativeInputActive(): Boolean {
+        if (!isNativeInputFieldEnabled) return false
+        // Duck.ai always uses the native input; the browser omnibar only does so outside search-only.
+        val inDuckAi = ::omnibarController.isInitialized && omnibarController.isDuckAiMode()
+        return inDuckAi || availableInputMode != NativeInputState.InputMode.SEARCH_ONLY
+    }
 
     override fun isChatTabSelected(): Boolean {
         if (!::rootView.isInitialized) return false

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -269,13 +269,13 @@ class OmnibarLayoutViewModel @Inject constructor(
     ) {
         /**
          * The Duck.ai entry icon shows the chevron-down (contextual sheet) variant when the native
-         * input field setting is enabled and we're not on the new-tab page — tapping it then opens
-         * the contextual sheet. In every other case it falls back to the standard chat icon, whose
-         * tap opens Duck.ai in full screen. Derived from the flag + viewMode rather than a stored
-         * flag so it can't drift out of sync with other state-update paths.
+         * input field setting is enabled, we're not on the new-tab page, and Duck.ai is available in
+         * the address bar (not search-only) — tapping it then opens the contextual sheet. In every
+         * other case (including search-only) it falls back to the standard chat icon. Derived from
+         * flags + viewMode rather than a stored flag so it can't drift out of sync.
          */
         val showContextualSheetIcon: Boolean
-            get() = isNativeInputEnabled && viewMode !is NewTab
+            get() = isNativeInputEnabled && viewMode !is NewTab && !isSearchOnly
 
         /**
          * The click catcher routes an omnibar tap to the native input overlay. Shown when the

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -269,13 +269,13 @@ class OmnibarLayoutViewModel @Inject constructor(
     ) {
         /**
          * The Duck.ai entry icon shows the chevron-down (contextual sheet) variant when the native
-         * input field setting is enabled, we're not on the new-tab page, and Duck.ai is available in
-         * the address bar (not search-only) — tapping it then opens the contextual sheet. In every
-         * other case (including search-only) it falls back to the standard chat icon, whose tap opens
-         * Duck.ai in full screen. Derived from flags + viewMode so it can't drift out of sync.
+         * input field setting is enabled and we're not on the new-tab page — tapping it then opens
+         * the contextual sheet. In every other case it falls back to the standard chat icon, whose
+         * tap opens Duck.ai in full screen. Derived from the flag + viewMode rather than a stored
+         * flag so it can't drift out of sync with other state-update paths.
          */
         val showContextualSheetIcon: Boolean
-            get() = isNativeInputEnabled && viewMode !is NewTab && !isSearchOnly
+            get() = isNativeInputEnabled && viewMode !is NewTab
 
         /**
          * The click catcher routes an omnibar tap to the native input overlay. Shown when the

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -341,12 +341,12 @@ class OmnibarLayoutViewModel @Inject constructor(
             duckAiFeatureState.showInputScreen,
             duckChat.observeNativeInputFieldUserSettingEnabled(),
             duckChat.observeNativeChatInputEnabled(),
-            duckChatInputModeState.availableInputMode,
-        ) { inputScreenEnabled, nativeInputEnabled, nativeChatInputEnabled, availableInputMode ->
+            duckChatInputModeState.inputModeCapability,
+        ) { inputScreenEnabled, nativeInputEnabled, nativeChatInputEnabled, inputModeCapability ->
             _viewState.update {
                 it.copy(
                     inputScreenEnabled = inputScreenEnabled,
-                    isSearchOnly = availableInputMode == NativeInputState.InputMode.SEARCH_ONLY,
+                    isSearchOnly = inputModeCapability == NativeInputState.InputMode.SEARCH_ONLY,
                     isNativeInputEnabled = nativeInputEnabled,
                     isNativeChatInputEnabled = nativeChatInputEnabled,
                 )

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -269,13 +269,13 @@ class OmnibarLayoutViewModel @Inject constructor(
     ) {
         /**
          * The Duck.ai entry icon shows the chevron-down (contextual sheet) variant when the native
-         * input field setting is enabled and we're not on the new-tab page — tapping it then opens
-         * the contextual sheet. In every other case it falls back to the standard chat icon, whose
-         * tap opens Duck.ai in full screen. Derived from the flag + viewMode rather than a stored
-         * flag so it can't drift out of sync with other state-update paths.
+         * input field setting is enabled, we're not on the new-tab page, and Duck.ai is available in
+         * the address bar (not search-only) — tapping it then opens the contextual sheet. In every
+         * other case (including search-only) it falls back to the standard chat icon, whose tap opens
+         * Duck.ai in full screen. Derived from flags + viewMode so it can't drift out of sync.
          */
         val showContextualSheetIcon: Boolean
-            get() = isNativeInputEnabled && viewMode !is NewTab
+            get() = isNativeInputEnabled && viewMode !is NewTab && !isSearchOnly
 
         /**
          * The click catcher routes an omnibar tap to the native input overlay. Shown when the

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -68,6 +68,8 @@ import com.duckduckgo.common.utils.isLocalUrl
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.DuckChatInputModeState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.privacy.dashboard.impl.pixels.PrivacyDashboardPixels
 import com.duckduckgo.serp.logos.api.SerpEasterEggLogosToggles
@@ -110,6 +112,7 @@ class OmnibarLayoutViewModel @Inject constructor(
     private val browserMenuHighlight: BrowserMenuHighlight,
     private val duckChat: DuckChat,
     private val duckAiFeatureState: DuckAiFeatureState,
+    private val duckChatInputModeState: DuckChatInputModeState,
     private val addressDisplayFormatter: AddressDisplayFormatter,
     private val settingsDataStore: SettingsDataStore,
     private val urlDisplayRepository: UrlDisplayRepository,
@@ -252,7 +255,8 @@ class OmnibarLayoutViewModel @Inject constructor(
         val trackersBlocked: Int = 0,
         val previouslyTrackersBlocked: Int = 0,
         val showShadows: Boolean = false,
-        val showTextInputClickCatcher: Boolean = false,
+        val inputScreenEnabled: Boolean = false,
+        val isSearchOnly: Boolean = false,
         val showFindInPage: Boolean = false,
         val showDuckAIHeader: Boolean = false,
         val showDuckAISidebar: Boolean = false,
@@ -272,6 +276,16 @@ class OmnibarLayoutViewModel @Inject constructor(
          */
         val showContextualSheetIcon: Boolean
             get() = isNativeInputEnabled && viewMode !is NewTab
+
+        /**
+         * The click catcher routes an omnibar tap to the native input overlay. Shown when the
+         * input-screen feature is on, or the native field is on and we should use it for the current
+         * context — i.e. we're in Duck.ai (always UTI) or not in search-only. In search-only the
+         * browser omnibar keeps the catcher hidden so its text input stays focusable and a tap
+         * focuses it directly. Derived from flags + viewMode so it can't drift out of sync.
+         */
+        val showTextInputClickCatcher: Boolean
+            get() = inputScreenEnabled || (isNativeInputEnabled && (viewMode is ViewMode.DuckAI || !isSearchOnly))
 
         fun shouldUpdateOmnibarText(
             isFullUrlEnabled: Boolean,
@@ -327,10 +341,12 @@ class OmnibarLayoutViewModel @Inject constructor(
             duckAiFeatureState.showInputScreen,
             duckChat.observeNativeInputFieldUserSettingEnabled(),
             duckChat.observeNativeChatInputEnabled(),
-        ) { inputScreenEnabled, nativeInputEnabled, nativeChatInputEnabled ->
+            duckChatInputModeState.availableInputMode,
+        ) { inputScreenEnabled, nativeInputEnabled, nativeChatInputEnabled, availableInputMode ->
             _viewState.update {
                 it.copy(
-                    showTextInputClickCatcher = inputScreenEnabled || nativeInputEnabled,
+                    inputScreenEnabled = inputScreenEnabled,
+                    isSearchOnly = availableInputMode == NativeInputState.InputMode.SEARCH_ONLY,
                     isNativeInputEnabled = nativeInputEnabled,
                     isNativeChatInputEnabled = nativeChatInputEnabled,
                 )

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -8509,6 +8509,27 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenOnDuckChatOmnibarButtonClickedUnfocusedWithContextualModeThenShowsContextualSheet() {
+        mockDuckAiContextualModeFlow.value = true
+
+        testee.onDuckChatOmnibarButtonClicked(query = "example", hasFocus = false, isNtp = false)
+
+        verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+        assertTrue(commandCaptor.allValues.any { it is Command.ShowDuckAIContextualMode })
+    }
+
+    @Test
+    fun whenOnDuckChatOmnibarButtonClickedFocusedWithContextualModeThenOpensDuckChatNotContextualSheet() {
+        mockDuckAiContextualModeFlow.value = true
+
+        testee.onDuckChatOmnibarButtonClicked(query = "example", hasFocus = true, isNtp = false)
+
+        verify(mockDuckChat).openDuckChatWithAutoPrompt(query = "example")
+        verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
+        assertFalse(commandCaptor.allValues.any { it is Command.ShowDuckAIContextualMode })
+    }
+
+    @Test
     fun whenOnDuckChatOmnibarButtonClickedWithFocusAndUrlQueryThenNavigateInsteadOfOpeningDuckChat() {
         whenever(mockQueryUrlPredictor.isUrl("bbc.com")).thenReturn(true)
         whenever(mockOmnibarConverter.convertQueryToUrl("bbc.com", null)).thenReturn("https://bbc.com")

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
@@ -87,7 +87,7 @@ class RealNativeInputManagerTest {
 
     @Before
     fun setUp() {
-        whenever(duckChatInputModeState.availableInputMode)
+        whenever(duckChatInputModeState.inputModeCapability)
             .thenReturn(MutableStateFlow(NativeInputState.InputMode.SEARCH_AND_DUCK_AI))
         testee = RealNativeInputManager(
             duckChat,

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
@@ -37,7 +37,9 @@ import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.DuckChatInputModeState
 import com.duckduckgo.duckchat.api.NativeInputEventListener
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.voice.api.VoiceSearchAvailability
@@ -71,6 +73,7 @@ class RealNativeInputManagerTest {
     private val globalActivityStarter: GlobalActivityStarter = mock()
     private val queryUrlPredictor: QueryUrlPredictor = mock()
     private val duckAiFeatureState: DuckAiFeatureState = mock()
+    private val duckChatInputModeState: DuckChatInputModeState = mock()
     private val pixel: Pixel = mock()
     private val nativeInputEventListener: NativeInputEventListener = mock()
     private val nativeInputStateBugKillSwitch = FakeFeatureToggleFactory.create(NativeInputStateBugKillSwitch::class.java)
@@ -84,6 +87,8 @@ class RealNativeInputManagerTest {
 
     @Before
     fun setUp() {
+        whenever(duckChatInputModeState.availableInputMode)
+            .thenReturn(MutableStateFlow(NativeInputState.InputMode.SEARCH_AND_DUCK_AI))
         testee = RealNativeInputManager(
             duckChat,
             animator,
@@ -91,6 +96,7 @@ class RealNativeInputManagerTest {
             globalActivityStarter,
             queryUrlPredictor,
             duckAiFeatureState,
+            duckChatInputModeState,
             pixel,
             nativeInputStateBugKillSwitch,
             nativeInputEventListener,

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -1655,18 +1655,6 @@ class OmnibarLayoutViewModelTest {
     }
 
     @Test
-    fun whenNativeInputEnabledButSearchOnlyThenShowContextualSheetIconFalse() = runTest {
-        nativeInputFieldSettingFlow.value = true
-        availableInputModeFlow.value = NativeInputState.InputMode.SEARCH_ONLY
-
-        testee.viewState.test {
-            val viewState = expectMostRecentItem()
-            assertFalse(viewState.showContextualSheetIcon)
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
     fun `when input text click catcher clicked and no URL then input screen launched with draft query`() = runTest {
         testee.onInputStateChanged(query = "draft", hasFocus = false, clearQuery = false, deleteLastCharacter = false)
 

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -99,7 +99,7 @@ class OmnibarLayoutViewModelTest {
     private val duckChat: DuckChat = mock()
     private val duckAiFeatureState: DuckAiFeatureState = mock()
     private val duckChatInputModeState: DuckChatInputModeState = mock()
-    private val availableInputModeFlow = MutableStateFlow(NativeInputState.InputMode.SEARCH_AND_DUCK_AI)
+    private val inputModeCapabilityFlow = MutableStateFlow(NativeInputState.InputMode.SEARCH_AND_DUCK_AI)
     private val duckAiShowOmnibarShortcutOnNtpAndOnFocusFlow = MutableStateFlow(true)
     private val duckAiShowOmnibarShortcutInAllStatesFlow = MutableStateFlow(true)
     private val duckAiShowInputScreenFlow = MutableStateFlow(false)
@@ -152,7 +152,7 @@ class OmnibarLayoutViewModelTest {
         whenever(duckAiFeatureState.showInputScreen).thenReturn(duckAiShowInputScreenFlow)
         whenever(duckChat.observeNativeInputFieldUserSettingEnabled()).thenReturn(nativeInputFieldSettingFlow)
         whenever(duckChat.observeNativeChatInputEnabled()).thenReturn(nativeChatInputEnabledFlow)
-        whenever(duckChatInputModeState.availableInputMode).thenReturn(availableInputModeFlow)
+        whenever(duckChatInputModeState.inputModeCapability).thenReturn(inputModeCapabilityFlow)
         whenever(duckChat.activeVoiceChatSessions).thenReturn(activeVoiceSessionsFlow)
         whenever(duckChat.observeInputScreenUserSettingEnabled()).thenReturn(inputScreenUserSettingFlow)
         whenever(serpEasterEggLogosToggles.setFavourite()).thenReturn(mock())
@@ -1632,7 +1632,7 @@ class OmnibarLayoutViewModelTest {
     @Test
     fun whenNativeInputFieldEnabledButSearchOnlyThenShowClickCatcherFalse() = runTest {
         nativeInputFieldSettingFlow.value = true
-        availableInputModeFlow.value = NativeInputState.InputMode.SEARCH_ONLY
+        inputModeCapabilityFlow.value = NativeInputState.InputMode.SEARCH_ONLY
 
         testee.viewState.test {
             val viewState = expectMostRecentItem()
@@ -1644,7 +1644,7 @@ class OmnibarLayoutViewModelTest {
     @Test
     fun whenSearchOnlyButInDuckAiViewModeThenShowClickCatcherTrue() = runTest {
         nativeInputFieldSettingFlow.value = true
-        availableInputModeFlow.value = NativeInputState.InputMode.SEARCH_ONLY
+        inputModeCapabilityFlow.value = NativeInputState.InputMode.SEARCH_ONLY
         testee.onViewModeChanged(ViewMode.DuckAI)
 
         testee.viewState.test {
@@ -1657,7 +1657,7 @@ class OmnibarLayoutViewModelTest {
     @Test
     fun whenSearchOnlyThenShowContextualSheetIconFalse() = runTest {
         nativeInputFieldSettingFlow.value = true
-        availableInputModeFlow.value = NativeInputState.InputMode.SEARCH_ONLY
+        inputModeCapabilityFlow.value = NativeInputState.InputMode.SEARCH_ONLY
 
         testee.viewState.test {
             val viewState = expectMostRecentItem()

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -42,6 +42,8 @@ import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.baseHost
 import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.DuckChatInputModeState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.FakeToggleStore
@@ -96,6 +98,8 @@ class OmnibarLayoutViewModelTest {
 
     private val duckChat: DuckChat = mock()
     private val duckAiFeatureState: DuckAiFeatureState = mock()
+    private val duckChatInputModeState: DuckChatInputModeState = mock()
+    private val availableInputModeFlow = MutableStateFlow(NativeInputState.InputMode.SEARCH_AND_DUCK_AI)
     private val duckAiShowOmnibarShortcutOnNtpAndOnFocusFlow = MutableStateFlow(true)
     private val duckAiShowOmnibarShortcutInAllStatesFlow = MutableStateFlow(true)
     private val duckAiShowInputScreenFlow = MutableStateFlow(false)
@@ -148,6 +152,7 @@ class OmnibarLayoutViewModelTest {
         whenever(duckAiFeatureState.showInputScreen).thenReturn(duckAiShowInputScreenFlow)
         whenever(duckChat.observeNativeInputFieldUserSettingEnabled()).thenReturn(nativeInputFieldSettingFlow)
         whenever(duckChat.observeNativeChatInputEnabled()).thenReturn(nativeChatInputEnabledFlow)
+        whenever(duckChatInputModeState.availableInputMode).thenReturn(availableInputModeFlow)
         whenever(duckChat.activeVoiceChatSessions).thenReturn(activeVoiceSessionsFlow)
         whenever(duckChat.observeInputScreenUserSettingEnabled()).thenReturn(inputScreenUserSettingFlow)
         whenever(serpEasterEggLogosToggles.setFavourite()).thenReturn(mock())
@@ -199,6 +204,7 @@ class OmnibarLayoutViewModelTest {
             browserMenuHighlight = browserMenuHighlight,
             duckChat = duckChat,
             duckAiFeatureState = duckAiFeatureState,
+            duckChatInputModeState = duckChatInputModeState,
             addressDisplayFormatter = mockAddressDisplayFormatter,
             settingsDataStore = settingsDataStore,
             urlDisplayRepository = urlDisplayRepository,
@@ -1615,6 +1621,31 @@ class OmnibarLayoutViewModelTest {
     @Test
     fun whenNativeInputFieldEnabledThenShowClickCatcherTrue() = runTest {
         nativeInputFieldSettingFlow.value = true
+
+        testee.viewState.test {
+            val viewState = expectMostRecentItem()
+            assertTrue(viewState.showTextInputClickCatcher)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenNativeInputFieldEnabledButSearchOnlyThenShowClickCatcherFalse() = runTest {
+        nativeInputFieldSettingFlow.value = true
+        availableInputModeFlow.value = NativeInputState.InputMode.SEARCH_ONLY
+
+        testee.viewState.test {
+            val viewState = expectMostRecentItem()
+            assertFalse(viewState.showTextInputClickCatcher)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenSearchOnlyButInDuckAiViewModeThenShowClickCatcherTrue() = runTest {
+        nativeInputFieldSettingFlow.value = true
+        availableInputModeFlow.value = NativeInputState.InputMode.SEARCH_ONLY
+        testee.onViewModeChanged(ViewMode.DuckAI)
 
         testee.viewState.test {
             val viewState = expectMostRecentItem()

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -1655,6 +1655,18 @@ class OmnibarLayoutViewModelTest {
     }
 
     @Test
+    fun whenSearchOnlyThenShowContextualSheetIconFalse() = runTest {
+        nativeInputFieldSettingFlow.value = true
+        availableInputModeFlow.value = NativeInputState.InputMode.SEARCH_ONLY
+
+        testee.viewState.test {
+            val viewState = expectMostRecentItem()
+            assertFalse(viewState.showContextualSheetIcon)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `when input text click catcher clicked and no URL then input screen launched with draft query`() = runTest {
         testee.onInputStateChanged(query = "draft", hasFocus = false, clearQuery = false, deleteLastCharacter = false)
 

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -1655,6 +1655,18 @@ class OmnibarLayoutViewModelTest {
     }
 
     @Test
+    fun whenNativeInputEnabledButSearchOnlyThenShowContextualSheetIconFalse() = runTest {
+        nativeInputFieldSettingFlow.value = true
+        availableInputModeFlow.value = NativeInputState.InputMode.SEARCH_ONLY
+
+        testee.viewState.test {
+            val viewState = expectMostRecentItem()
+            assertFalse(viewState.showContextualSheetIcon)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `when input text click catcher clicked and no URL then input screen launched with draft query`() = runTest {
         testee.onInputStateChanged(query = "draft", hasFocus = false, clearQuery = false, deleteLastCharacter = false)
 

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModel.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModel.kt
@@ -32,6 +32,8 @@ import com.duckduckgo.browsermode.api.BrowserModeDataProvider
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.DuckChatInputModeState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.newtabpage.api.EscapeHatchTarget
 import com.duckduckgo.newtabpage.api.EscapeHatchTargetResolver
 import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
@@ -57,6 +59,7 @@ class NewTabReturnHatchViewModel @Inject constructor(
     private val tabRepositoryProvider: BrowserModeDataProvider<TabRepository>,
     private val dispatchers: DispatcherProvider,
     private val duckChat: DuckChat,
+    private val duckChatInputModeState: DuckChatInputModeState,
     private val duckDuckGoUrlDetector: DuckDuckGoUrlDetector,
     private val ntpAfterIdleManager: NtpAfterIdleManager,
     private val escapeHatchTargetResolver: EscapeHatchTargetResolver,
@@ -116,10 +119,19 @@ class NewTabReturnHatchViewModel @Inject constructor(
     // repository (burned, closed, or purged), so every live ViewModel instance stays in sync without
     // per-instance burn tracking. For a Fire target, visibility tracks the fire repo's flowTabs,
     // while the activity-mode repo supplies the tabs count shown in the tab button.
+    // The tabs button shows only when native input is enabled AND the address bar isn't search-only.
+    // In search-only the hatch mirrors the legacy chrome, which has no tabs entry here.
+    private val shouldShowTabsButton: Flow<Boolean> = combine(
+        duckChat.observeNativeInputFieldUserSettingEnabled(),
+        duckChatInputModeState.inputModeCapability,
+    ) { nativeInputEnabled, capability ->
+        nativeInputEnabled && capability != NativeInputState.InputMode.SEARCH_ONLY
+    }
+
     val viewState = snapshotTarget.flatMapLatest { target ->
         if (target == null) {
-            combine(currentTabRepository.flowTabs, duckChat.observeNativeInputFieldUserSettingEnabled()) { tabs, nativeInputEnabled ->
-                ViewState(shouldShow = false, tabs = tabs.size, showTabsButton = nativeInputEnabled)
+            combine(currentTabRepository.flowTabs, shouldShowTabsButton) { tabs, showTabs ->
+                ViewState(shouldShow = false, tabs = tabs.size, showTabsButton = showTabs)
             }
         } else {
             val isFireTarget = target.mode == BrowserMode.FIRE
@@ -127,9 +139,9 @@ class NewTabReturnHatchViewModel @Inject constructor(
                 pendingClose,
                 tabRepositoryProvider.forMode(target.mode).flowTabs,
                 currentTabRepository.flowTabs,
-                duckChat.observeNativeInputFieldUserSettingEnabled(),
+                shouldShowTabsButton,
                 ntpAfterIdleManager.returnToLastTabEnabled,
-            ) { closed, targetTabs, activityTabs, nativeInputEnabled, returnToLastTabEnabled ->
+            ) { closed, targetTabs, activityTabs, showTabs, returnToLastTabEnabled ->
                 val tab = targetTabs.firstOrNull { it.tabId == target.tabId }
                 if (!closed && tab != null && returnToLastTabEnabled) {
                     val url = if (isFireTarget) "" else tab.url.orEmpty()
@@ -143,10 +155,10 @@ class NewTabReturnHatchViewModel @Inject constructor(
                         isDuckChat = url.isNotEmpty() && duckChat.isDuckChatUrl(Uri.parse(url)),
                         isSerp = url.isNotEmpty() && duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(url),
                         tabs = activityTabs.size,
-                        showTabsButton = nativeInputEnabled,
+                        showTabsButton = showTabs,
                     )
                 } else {
-                    ViewState(shouldShow = false, tabs = activityTabs.size, showTabsButton = nativeInputEnabled)
+                    ViewState(shouldShow = false, tabs = activityTabs.size, showTabsButton = showTabs)
                 }
             }
         }

--- a/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModelTest.kt
+++ b/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModelTest.kt
@@ -29,6 +29,8 @@ import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.browsermode.api.BrowserModeDataProvider
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.api.DuckChat
+import com.duckduckgo.duckchat.api.DuckChatInputModeState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.newtabpage.api.EscapeHatchTarget
 import com.duckduckgo.newtabpage.api.EscapeHatchTargetResolver
 import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
@@ -57,6 +59,8 @@ class NewTabReturnHatchViewModelTest {
 
     private val mockTabRepository: TabRepository = mock()
     private val mockDuckChat: DuckChat = mock()
+    private val mockDuckChatInputModeState: DuckChatInputModeState = mock()
+    private val inputModeCapabilityFlow = MutableStateFlow(NativeInputState.InputMode.SEARCH_AND_DUCK_AI)
     private val mockDuckDuckGoUrlDetector: DuckDuckGoUrlDetector = mock()
     private val mockNtpAfterIdleManager: NtpAfterIdleManager = mock()
     private val mockPixel: Pixel = mock()
@@ -83,12 +87,14 @@ class NewTabReturnHatchViewModelTest {
         whenever(mockNtpAfterIdleManager.isAfterIdleReturn).thenReturn(afterIdleReturnFlow)
         whenever(mockNtpAfterIdleManager.returnToLastTabEnabled).thenReturn(returnToLastTabEnabledFlow)
         whenever(mockDuckChat.observeNativeInputFieldUserSettingEnabled()).thenReturn(nativeInputEnabledFlow)
+        whenever(mockDuckChatInputModeState.inputModeCapability).thenReturn(inputModeCapabilityFlow)
 
         testee = NewTabReturnHatchViewModel(
             currentTabRepository = mockTabRepository,
             tabRepositoryProvider = tabRepositoryProvider,
             dispatchers = coroutinesTestRule.testDispatcherProvider,
             duckChat = mockDuckChat,
+            duckChatInputModeState = mockDuckChatInputModeState,
             duckDuckGoUrlDetector = mockDuckDuckGoUrlDetector,
             ntpAfterIdleManager = mockNtpAfterIdleManager,
             escapeHatchTargetResolver = mockResolver,
@@ -305,6 +311,18 @@ class NewTabReturnHatchViewModelTest {
     @Test
     fun whenNativeInputDisabledThenShowTabsButtonIsFalse() = runTest {
         nativeInputEnabledFlow.value = false
+        val tab = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
+
+        testee.viewState.test {
+            returnFromIdleWith(tab)
+            assertFalse(expectMostRecentItem().showTabsButton)
+        }
+    }
+
+    @Test
+    fun whenNativeInputEnabledButSearchOnlyThenShowTabsButtonIsFalse() = runTest {
+        nativeInputEnabledFlow.value = true
+        inputModeCapabilityFlow.value = NativeInputState.InputMode.SEARCH_ONLY
         val tab = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
 
         testee.viewState.test {

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChatInputModeState.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChatInputModeState.kt
@@ -59,7 +59,7 @@ interface DuckChatInputModeState {
      * current config and is known even when no widget is attached — so callers can decide whether to use
      * the native input for the browser omnibar at all. Emits on subscription and on every settings change.
      */
-    val availableInputMode: StateFlow<NativeInputState.InputMode>
+    val inputModeCapability: StateFlow<NativeInputState.InputMode>
 }
 
 /**

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChatInputModeState.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChatInputModeState.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.duckchat.api
 
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import kotlinx.coroutines.flow.StateFlow
 
 /**
@@ -48,6 +49,17 @@ interface DuckChatInputModeState {
      * [displayedMode] when you also need to know which tab is showing.
      */
     val inputQuery: StateFlow<String>
+
+    /**
+     * Whether the current configuration offers the Search↔Duck.ai toggle in the address bar
+     * ([NativeInputState.InputMode.SEARCH_AND_DUCK_AI]) or is search-only
+     * ([NativeInputState.InputMode.SEARCH_ONLY]).
+     *
+     * Unlike [displayedMode] (the selected tab, pushed by a live widget), this is the capability of the
+     * current config and is known even when no widget is attached — so callers can decide whether to use
+     * the native input for the browser omnibar at all. Emits on subscription and on every settings change.
+     */
+    val availableInputMode: StateFlow<NativeInputState.InputMode>
 }
 
 /**

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -942,11 +942,10 @@ class RealDuckChat @Inject constructor(
             // Mirrors NativeInputModeWidgetViewModel.getInputMode: the address bar offers the
             // Search↔Duck.ai toggle only when Duck.ai is on (feature + user) and the address-bar
             // Duck.ai setting is on; otherwise it is search-only.
-            val searchOnly = !(isDuckChatFeatureEnabled && isDuckChatUserEnabled && inputScreenUserSettingEnabled)
-            _availableInputMode.value = if (searchOnly) {
-                NativeInputState.InputMode.SEARCH_ONLY
-            } else {
+            _availableInputMode.value = if (isDuckChatFeatureEnabled && isDuckChatUserEnabled && inputScreenUserSettingEnabled) {
                 NativeInputState.InputMode.SEARCH_AND_DUCK_AI
+            } else {
+                NativeInputState.InputMode.SEARCH_ONLY
             }
 
             val showInputScreen =
@@ -1002,9 +1001,7 @@ class RealDuckChat @Inject constructor(
                 isDuckChatFeatureEnabled && isDuckChatUserEnabled && duckChatFeature.contextualMode().isEnabled()
                 )
 
-            // Contextual chat is part of the Search & Duck.ai experience; in search-only the omnibar
-            // Duck.ai button opens full-screen Duck.ai instead of the contextual sheet.
-            isContextualModeEnabled = showContextualMode && isContextualModeKillSwitch && !searchOnly
+            isContextualModeEnabled = showContextualMode && isContextualModeKillSwitch
             _showContextualMode.emit(isContextualModeEnabled)
 
             isAutomaticContextAttachmentEnabled = isContextualModeEnabled &&

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -942,10 +942,11 @@ class RealDuckChat @Inject constructor(
             // Mirrors NativeInputModeWidgetViewModel.getInputMode: the address bar offers the
             // Search↔Duck.ai toggle only when Duck.ai is on (feature + user) and the address-bar
             // Duck.ai setting is on; otherwise it is search-only.
-            _availableInputMode.value = if (isDuckChatFeatureEnabled && isDuckChatUserEnabled && inputScreenUserSettingEnabled) {
-                NativeInputState.InputMode.SEARCH_AND_DUCK_AI
-            } else {
+            val searchOnly = !(isDuckChatFeatureEnabled && isDuckChatUserEnabled && inputScreenUserSettingEnabled)
+            _availableInputMode.value = if (searchOnly) {
                 NativeInputState.InputMode.SEARCH_ONLY
+            } else {
+                NativeInputState.InputMode.SEARCH_AND_DUCK_AI
             }
 
             val showInputScreen =
@@ -1001,7 +1002,9 @@ class RealDuckChat @Inject constructor(
                 isDuckChatFeatureEnabled && isDuckChatUserEnabled && duckChatFeature.contextualMode().isEnabled()
                 )
 
-            isContextualModeEnabled = showContextualMode && isContextualModeKillSwitch
+            // Contextual chat is part of the Search & Duck.ai experience; in search-only the omnibar
+            // Duck.ai button opens full-screen Duck.ai instead of the contextual sheet.
+            isContextualModeEnabled = showContextualMode && isContextualModeKillSwitch && !searchOnly
             _showContextualMode.emit(isContextualModeEnabled)
 
             isAutomaticContextAttachmentEnabled = isContextualModeEnabled &&

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -416,7 +416,7 @@ class RealDuckChat @Inject constructor(
     private val _allowDuckAiAsDigitalAssistant = MutableStateFlow(false)
     private val _displayedMode = MutableStateFlow(InputMode.SEARCH)
     private val _inputQuery = MutableStateFlow("")
-    private val _availableInputMode = MutableStateFlow(NativeInputState.InputMode.SEARCH_ONLY)
+    private val _inputModeCapability = MutableStateFlow(NativeInputState.InputMode.SEARCH_ONLY)
 
     private val jsonAdapter: JsonAdapter<DuckChatSettingJson> by lazy {
         moshi.adapter(DuckChatSettingJson::class.java)
@@ -868,7 +868,7 @@ class RealDuckChat @Inject constructor(
         _inputQuery.value = query
     }
 
-    override val availableInputMode: StateFlow<NativeInputState.InputMode> = _availableInputMode.asStateFlow()
+    override val inputModeCapability: StateFlow<NativeInputState.InputMode> = _inputModeCapability.asStateFlow()
 
     private suspend fun hasActiveSession(): Boolean {
         val now = System.currentTimeMillis()
@@ -942,7 +942,7 @@ class RealDuckChat @Inject constructor(
             // Mirrors NativeInputModeWidgetViewModel.getInputMode: the address bar offers the
             // Search↔Duck.ai toggle only when Duck.ai is on (feature + user) and the address-bar
             // Duck.ai setting is on; otherwise it is search-only.
-            _availableInputMode.value = if (isDuckChatFeatureEnabled && isDuckChatUserEnabled && inputScreenUserSettingEnabled) {
+            _inputModeCapability.value = if (isDuckChatFeatureEnabled && isDuckChatUserEnabled && inputScreenUserSettingEnabled) {
                 NativeInputState.InputMode.SEARCH_AND_DUCK_AI
             } else {
                 NativeInputState.InputMode.SEARCH_ONLY

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -41,6 +41,7 @@ import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.DuckChatInputModeState
 import com.duckduckgo.duckchat.api.DuckChatSettingsNoParams
 import com.duckduckgo.duckchat.api.InputMode
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.impl.feature.AIChatImageUploadFeature
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestionsStore
@@ -415,6 +416,7 @@ class RealDuckChat @Inject constructor(
     private val _allowDuckAiAsDigitalAssistant = MutableStateFlow(false)
     private val _displayedMode = MutableStateFlow(InputMode.SEARCH)
     private val _inputQuery = MutableStateFlow("")
+    private val _availableInputMode = MutableStateFlow(NativeInputState.InputMode.SEARCH_ONLY)
 
     private val jsonAdapter: JsonAdapter<DuckChatSettingJson> by lazy {
         moshi.adapter(DuckChatSettingJson::class.java)
@@ -866,6 +868,8 @@ class RealDuckChat @Inject constructor(
         _inputQuery.value = query
     }
 
+    override val availableInputMode: StateFlow<NativeInputState.InputMode> = _availableInputMode.asStateFlow()
+
     private suspend fun hasActiveSession(): Boolean {
         val now = System.currentTimeMillis()
         val lastSession = duckChatFeatureRepository.lastSessionTimestamp()
@@ -933,9 +937,20 @@ class RealDuckChat @Inject constructor(
             isNativeInputFieldEnabled = _nativeInputFieldEnabled.value
             isNativeChatInputEnabled = isNativeInputFieldEnabled && duckChatFeature.nativeChatInput().isEnabled()
             _nativeChatInputEnabled.value = isNativeChatInputEnabled
+            val inputScreenUserSettingEnabled = duckChatFeatureRepository.isInputScreenUserSettingEnabled()
+
+            // Mirrors NativeInputModeWidgetViewModel.getInputMode: the address bar offers the
+            // Search↔Duck.ai toggle only when Duck.ai is on (feature + user) and the address-bar
+            // Duck.ai setting is on; otherwise it is search-only.
+            _availableInputMode.value = if (isDuckChatFeatureEnabled && isDuckChatUserEnabled && inputScreenUserSettingEnabled) {
+                NativeInputState.InputMode.SEARCH_AND_DUCK_AI
+            } else {
+                NativeInputState.InputMode.SEARCH_ONLY
+            }
+
             val showInputScreen =
                 isInputScreenFeatureAvailable() && isDuckChatFeatureEnabled && isDuckChatUserEnabled &&
-                    duckChatFeatureRepository.isInputScreenUserSettingEnabled() && !isNativeInputFieldEnabled
+                    inputScreenUserSettingEnabled && !isNativeInputFieldEnabled
             _showInputScreen.emit(showInputScreen)
 
             _showInputScreenAutomaticallyOnNewTab.value = showInputScreen && duckAiInputScreenOpenAutomaticallyEnabled

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -231,7 +231,7 @@ class RealDuckChatTest {
         testee.onPrivacyConfigDownloaded()
         advanceUntilIdle()
 
-        assertEquals(NativeInputState.InputMode.SEARCH_AND_DUCK_AI, testee.availableInputMode.value)
+        assertEquals(NativeInputState.InputMode.SEARCH_AND_DUCK_AI, testee.inputModeCapability.value)
     }
 
     @Test
@@ -243,7 +243,7 @@ class RealDuckChatTest {
         testee.onPrivacyConfigDownloaded()
         advanceUntilIdle()
 
-        assertEquals(NativeInputState.InputMode.SEARCH_ONLY, testee.availableInputMode.value)
+        assertEquals(NativeInputState.InputMode.SEARCH_ONLY, testee.inputModeCapability.value)
     }
 
     @Test
@@ -255,7 +255,7 @@ class RealDuckChatTest {
         testee.onPrivacyConfigDownloaded()
         advanceUntilIdle()
 
-        assertEquals(NativeInputState.InputMode.SEARCH_ONLY, testee.availableInputMode.value)
+        assertEquals(NativeInputState.InputMode.SEARCH_ONLY, testee.inputModeCapability.value)
     }
 
     @Test
@@ -267,7 +267,7 @@ class RealDuckChatTest {
         testee.onPrivacyConfigDownloaded()
         advanceUntilIdle()
 
-        assertEquals(NativeInputState.InputMode.SEARCH_ONLY, testee.availableInputMode.value)
+        assertEquals(NativeInputState.InputMode.SEARCH_ONLY, testee.inputModeCapability.value)
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -1541,15 +1541,6 @@ class RealDuckChatTest {
     }
 
     @Test
-    fun `when contextual mode enabled but search-only, then showContextualMode emits false`() = runTest {
-        duckChatFeature.contextualMode().setRawStoredState(State(enable = true))
-        whenever(mockDuckChatFeatureRepository.isInputScreenUserSettingEnabled()).thenReturn(false)
-        testee.onPrivacyConfigDownloaded()
-
-        assertFalse(testee.showContextualMode.value)
-    }
-
-    @Test
     fun `when contextual mode enabled, isDuckChatContextualModeEnabled returns true`() = runTest {
         duckChatFeature.contextualMode().setRawStoredState(State(enable = true))
         duckChatFeature.contextualModeKillSwitch().setRawStoredState(State(enable = true))

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -36,6 +36,7 @@ import com.duckduckgo.cookies.api.CookieManagerProvider
 import com.duckduckgo.duckchat.api.DuckAiHostProvider
 import com.duckduckgo.duckchat.api.DuckChatSettingsNoParams
 import com.duckduckgo.duckchat.api.InputMode
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.impl.feature.AIChatImageUploadFeature
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatSuggestionsStore
@@ -219,6 +220,54 @@ class RealDuckChatTest {
         testee.onPrivacyConfigDownloaded()
 
         assertFalse(testee.isEnabled())
+    }
+
+    @Test
+    fun whenFeatureAndUserAndInputScreenSettingEnabledThenAvailableInputModeIsSearchAndDuckAi() = runTest {
+        duckChatFeature.self().setRawStoredState(State(true))
+        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
+        whenever(mockDuckChatFeatureRepository.isInputScreenUserSettingEnabled()).thenReturn(true)
+
+        testee.onPrivacyConfigDownloaded()
+        advanceUntilIdle()
+
+        assertEquals(NativeInputState.InputMode.SEARCH_AND_DUCK_AI, testee.availableInputMode.value)
+    }
+
+    @Test
+    fun whenInputScreenUserSettingDisabledThenAvailableInputModeIsSearchOnly() = runTest {
+        duckChatFeature.self().setRawStoredState(State(true))
+        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
+        whenever(mockDuckChatFeatureRepository.isInputScreenUserSettingEnabled()).thenReturn(false)
+
+        testee.onPrivacyConfigDownloaded()
+        advanceUntilIdle()
+
+        assertEquals(NativeInputState.InputMode.SEARCH_ONLY, testee.availableInputMode.value)
+    }
+
+    @Test
+    fun whenDuckChatUserDisabledThenAvailableInputModeIsSearchOnly() = runTest {
+        duckChatFeature.self().setRawStoredState(State(true))
+        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(false)
+        whenever(mockDuckChatFeatureRepository.isInputScreenUserSettingEnabled()).thenReturn(true)
+
+        testee.onPrivacyConfigDownloaded()
+        advanceUntilIdle()
+
+        assertEquals(NativeInputState.InputMode.SEARCH_ONLY, testee.availableInputMode.value)
+    }
+
+    @Test
+    fun whenDuckChatFeatureDisabledThenAvailableInputModeIsSearchOnly() = runTest {
+        duckChatFeature.self().setRawStoredState(State(false))
+        whenever(mockDuckChatFeatureRepository.isDuckChatUserEnabled()).thenReturn(true)
+        whenever(mockDuckChatFeatureRepository.isInputScreenUserSettingEnabled()).thenReturn(true)
+
+        testee.onPrivacyConfigDownloaded()
+        advanceUntilIdle()
+
+        assertEquals(NativeInputState.InputMode.SEARCH_ONLY, testee.availableInputMode.value)
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -1541,6 +1541,15 @@ class RealDuckChatTest {
     }
 
     @Test
+    fun `when contextual mode enabled but search-only, then showContextualMode emits false`() = runTest {
+        duckChatFeature.contextualMode().setRawStoredState(State(enable = true))
+        whenever(mockDuckChatFeatureRepository.isInputScreenUserSettingEnabled()).thenReturn(false)
+        testee.onPrivacyConfigDownloaded()
+
+        assertFalse(testee.showContextualMode.value)
+    }
+
+    @Test
     fun `when contextual mode enabled, isDuckChatContextualModeEnabled returns true`() = runTest {
         duckChatFeature.contextualMode().setRawStoredState(State(enable = true))
         duckChatFeature.contextualModeKillSwitch().setRawStoredState(State(enable = true))

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -244,8 +244,8 @@ class FakeDuckChatInternal(
 
     override val inputQuery: StateFlow<String> = _inputQuery.asStateFlow()
 
-    val availableInputModeFlow = MutableStateFlow(NativeInputState.InputMode.SEARCH_ONLY)
-    override val availableInputMode: StateFlow<NativeInputState.InputMode> = availableInputModeFlow.asStateFlow()
+    val inputModeCapabilityFlow = MutableStateFlow(NativeInputState.InputMode.SEARCH_ONLY)
+    override val inputModeCapability: StateFlow<NativeInputState.InputMode> = inputModeCapabilityFlow.asStateFlow()
 
     override fun setInputQuery(query: String) {
         _inputQuery.value = query

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -20,6 +20,7 @@ import android.net.Uri
 import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.duckchat.api.DuckChatInputModeState
 import com.duckduckgo.duckchat.api.InputMode
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.impl.ChatState
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
@@ -242,6 +243,9 @@ class FakeDuckChatInternal(
     private val _inputQuery = MutableStateFlow("")
 
     override val inputQuery: StateFlow<String> = _inputQuery.asStateFlow()
+
+    val availableInputModeFlow = MutableStateFlow(NativeInputState.InputMode.SEARCH_ONLY)
+    override val availableInputMode: StateFlow<NativeInputState.InputMode> = availableInputModeFlow.asStateFlow()
 
     override fun setInputQuery(query: String) {
         _inputQuery.value = query

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinderTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinderTest.kt
@@ -332,7 +332,7 @@ class NativeInputChatSuggestionsBinderTest {
     private val inputModeState = object : DuckChatInputModeState {
         override val displayedMode: StateFlow<InputMode> = MutableStateFlow(InputMode.SEARCH)
         override val inputQuery: StateFlow<String> = inputQueryFlow
-        override val availableInputMode: StateFlow<NativeInputState.InputMode> =
+        override val inputModeCapability: StateFlow<NativeInputState.InputMode> =
             MutableStateFlow(NativeInputState.InputMode.SEARCH_ONLY)
     }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinderTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputChatSuggestionsBinderTest.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.duckchat.api.DuckChatInputModeState
 import com.duckduckgo.duckchat.api.InputMode
 import com.duckduckgo.duckchat.api.inputscreen.NativeInputChatTabItem
 import com.duckduckgo.duckchat.api.inputscreen.NativeInputChatTabItemPlugin
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenConfigResolver
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatHistoryShortcutAdapter
@@ -331,6 +332,8 @@ class NativeInputChatSuggestionsBinderTest {
     private val inputModeState = object : DuckChatInputModeState {
         override val displayedMode: StateFlow<InputMode> = MutableStateFlow(InputMode.SEARCH)
         override val inputQuery: StateFlow<String> = inputQueryFlow
+        override val availableInputMode: StateFlow<NativeInputState.InputMode> =
+            MutableStateFlow(NativeInputState.InputMode.SEARCH_ONLY)
     }
 
     private fun binderWith(vararg plugins: NativeInputChatTabItemPlugin): NativeInputChatSuggestionsBinder =


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1216289701927063?focus=true

### Description

When the native input field (`nativeInputField`) is enabled it was always shown, for both search-only and Search & Duck.ai configurations. In **search-only** mode (Duck.ai off in the address bar) the browser omnibar should behave like the legacy omnibar — tapping it focuses the text input directly instead of opening the native input overlay. Duck.ai still uses the native input.

Mechanism:
- Adds `availableInputMode` (`SEARCH_ONLY` / `SEARCH_AND_DUCK_AI`) to `DuckChatInputModeState`, computed once in `RealDuckChat.cacheUserSettings()` so it is known without a widget attached (mirrors the widget's `getInputMode`).
- `OmnibarLayoutViewModel` hides the click catcher for the browser omnibar in search-only (derived, viewMode-aware — kept on in Duck.ai), so the legacy `omnibarTextInput` stays focusable and a tap focuses it directly.
- `NativeInputManager.isNativeInputActive()` = field enabled AND (in Duck.ai OR not search-only); the native-input routing guards in `BrowserTabFragment` use it.

### Steps to test this PR

_Search-only mode_
- [x] With native input enabled, set the address bar to search only (Settings → Duck.ai → address bar "Search only")
- [x] Tap the omnibar → the legacy text input focuses directly (keyboard + Fire/Tabs/Menu chrome), no native input overlay appears
- [x] Type then clear the text → behaves like the legacy omnibar
- [x] Verify on both top and bottom address bar positions

_Search & Duck.ai / Duck.ai_
- [x] Set the address bar to Search & Duck.ai → tapping the omnibar opens the native input (unchanged)
- [x] Open a Duck.ai page → the native input still shows

### UI changes

Behavioral change only: in search-only the omnibar opens the legacy text input instead of the native input overlay. No new UI elements.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core omnibar focus, keyboard, and Duck.ai entry routing; behavior is flag-driven with broad test coverage but affects a high-traffic user path.
> 
> **Overview**
> In **search-only** address bar mode (native input field on, Duck.ai off in the bar), the browser omnibar now behaves like the legacy text field instead of always routing through the native input overlay.
> 
> **`inputModeCapability`** (`SEARCH_ONLY` vs `SEARCH_AND_DUCK_AI`) is added on `DuckChatInputModeState` and set in `RealDuckChat.cacheUserSettings()` from feature + user + address-bar Duck.ai settings, so the mode is known without an attached widget.
> 
> **`NativeInputManager.isNativeInputActive()`** gates whether native input actually drives the UI: enabled field plus either Duck.ai view mode or not search-only. `BrowserTabFragment` switches keyboard/focus/edit paths from `isNativeInputEnabled()` to this.
> 
> **`OmnibarLayoutViewModel`** derives **`showTextInputClickCatcher`** and **`showContextualSheetIcon`** from search-only (click catcher stays on in Duck.ai view mode). Contextual Duck.ai from the omnibar button requires **unfocused** omnibar (`!hasFocus`). NTP return hatch hides the tabs button in search-only.
> 
> Tests cover capability emission, click catcher, contextual vs full-screen Duck.ai, and hatch tabs visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97429e8b4c1b0f2311b9e30d6d4e4e2d88c83a38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->