### PR TITLE
Add the experiment flag and create the experiment manager to the "Add to Dock" and widget prompts in the onboarding

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingPromptsExperimentManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingPromptsExperimentManager.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding
+
+import com.duckduckgo.app.onboarding.OnboardingHomeScreenPromptsExperimentManager.OnboardingPromptExperimentVariant
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+interface OnboardingHomeScreenPromptsExperimentManager {
+
+    suspend fun enroll(): OnboardingPromptExperimentVariant?
+
+    enum class OnboardingPromptExperimentVariant {
+        CONTROL,
+        TREATMENT_DOCK_ONLY,
+        TREATMENT_WIDGET_ONLY,
+        TREATMENT_DOCK_AND_WIDGET,
+    }
+}
+
+@ContributesBinding(AppScope::class)
+class OnboardingHomeScreenPromptsExperimentManagerImpl @Inject constructor(
+    private val toggles: OnboardingPromptsToggles,
+    private val dispatcherProvider: DispatcherProvider,
+) : OnboardingHomeScreenPromptsExperimentManager {
+
+    override suspend fun enroll(): OnboardingPromptExperimentVariant? = withContext(dispatcherProvider.io()) {
+        val toggle = toggles.addToDockAndWidgetExperimentJul25()
+        toggle.enroll()
+        when {
+            toggle.isEnrolledAndEnabled(OnboardingPromptsToggles.OnboardingPromptsCohorts.TREATMENT_DOCK_AND_WIDGET) -> {
+                OnboardingPromptExperimentVariant.TREATMENT_DOCK_AND_WIDGET
+            }
+            toggle.isEnrolledAndEnabled(OnboardingPromptsToggles.OnboardingPromptsCohorts.TREATMENT_WIDGET_ONLY) -> {
+                OnboardingPromptExperimentVariant.TREATMENT_WIDGET_ONLY
+            }
+            toggle.isEnrolledAndEnabled(OnboardingPromptsToggles.OnboardingPromptsCohorts.TREATMENT_DOCK_ONLY) -> {
+                OnboardingPromptExperimentVariant.TREATMENT_DOCK_ONLY
+            }
+            toggle.isEnrolledAndEnabled(OnboardingPromptsToggles.OnboardingPromptsCohorts.CONTROL) -> {
+                OnboardingPromptExperimentVariant.CONTROL
+            }
+            else -> null
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingPromptsExperimentManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingPromptsExperimentManager.kt
@@ -16,14 +16,19 @@
 
 package com.duckduckgo.app.onboarding
 
-import com.duckduckgo.app.onboarding.OnboardingHomeScreenPromptsExperimentManager.OnboardingPromptExperimentVariant
+import com.duckduckgo.app.onboarding.OnboardingPromptsExperimentManager.OnboardingPromptExperimentVariant
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
 import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 
-interface OnboardingHomeScreenPromptsExperimentManager {
+interface OnboardingPromptsExperimentManager {
 
     suspend fun enroll(): OnboardingPromptExperimentVariant?
 
@@ -35,29 +40,60 @@ interface OnboardingHomeScreenPromptsExperimentManager {
     }
 }
 
-@ContributesBinding(AppScope::class)
-class OnboardingHomeScreenPromptsExperimentManagerImpl @Inject constructor(
+@ContributesBinding(AppScope::class, boundType = OnboardingPromptsExperimentManager::class)
+@ContributesMultibinding(AppScope::class, boundType = PrivacyConfigCallbackPlugin::class)
+@SingleInstanceIn(AppScope::class)
+class OnboardingPromptsExperimentManagerImpl @Inject constructor(
     private val toggles: OnboardingPromptsToggles,
     private val dispatcherProvider: DispatcherProvider,
-) : OnboardingHomeScreenPromptsExperimentManager {
+) : OnboardingPromptsExperimentManager, PrivacyConfigCallbackPlugin {
+
+    @Volatile
+    private var privacyPersisted: Boolean = false
 
     override suspend fun enroll(): OnboardingPromptExperimentVariant? = withContext(dispatcherProvider.io()) {
-        val toggle = toggles.addToDockAndWidgetExperimentJul25()
-        toggle.enroll()
-        when {
-            toggle.isEnrolledAndEnabled(OnboardingPromptsToggles.OnboardingPromptsCohorts.TREATMENT_DOCK_AND_WIDGET) -> {
-                OnboardingPromptExperimentVariant.TREATMENT_DOCK_AND_WIDGET
+        if (waitForPrivacyConfig()) {
+            val toggle = toggles.addToDockAndWidgetExperimentJul25()
+            toggle.enroll()
+            when {
+                toggle.isEnrolledAndEnabled(OnboardingPromptsToggles.OnboardingPromptsCohorts.TREATMENT_DOCK_AND_WIDGET) -> {
+                    OnboardingPromptExperimentVariant.TREATMENT_DOCK_AND_WIDGET
+                }
+
+                toggle.isEnrolledAndEnabled(OnboardingPromptsToggles.OnboardingPromptsCohorts.TREATMENT_WIDGET_ONLY) -> {
+                    OnboardingPromptExperimentVariant.TREATMENT_WIDGET_ONLY
+                }
+
+                toggle.isEnrolledAndEnabled(OnboardingPromptsToggles.OnboardingPromptsCohorts.TREATMENT_DOCK_ONLY) -> {
+                    OnboardingPromptExperimentVariant.TREATMENT_DOCK_ONLY
+                }
+
+                toggle.isEnrolledAndEnabled(OnboardingPromptsToggles.OnboardingPromptsCohorts.CONTROL) -> {
+                    OnboardingPromptExperimentVariant.CONTROL
+                }
+
+                else -> null
             }
-            toggle.isEnrolledAndEnabled(OnboardingPromptsToggles.OnboardingPromptsCohorts.TREATMENT_WIDGET_ONLY) -> {
-                OnboardingPromptExperimentVariant.TREATMENT_WIDGET_ONLY
-            }
-            toggle.isEnrolledAndEnabled(OnboardingPromptsToggles.OnboardingPromptsCohorts.TREATMENT_DOCK_ONLY) -> {
-                OnboardingPromptExperimentVariant.TREATMENT_DOCK_ONLY
-            }
-            toggle.isEnrolledAndEnabled(OnboardingPromptsToggles.OnboardingPromptsCohorts.CONTROL) -> {
-                OnboardingPromptExperimentVariant.CONTROL
-            }
-            else -> null
+        } else {
+            null
         }
+    }
+
+    private suspend fun waitForPrivacyConfig(): Boolean =
+        withTimeoutOrNull(PRIVACY_CONFIG_WAIT_TIMEOUT_MS) {
+            while (!privacyPersisted) {
+                delay(10)
+            }
+        } != null
+
+    override fun onPrivacyConfigPersisted() {
+        super.onPrivacyConfigPersisted()
+        privacyPersisted = true
+    }
+
+    override fun onPrivacyConfigDownloaded() = Unit
+
+    companion object {
+        private const val PRIVACY_CONFIG_WAIT_TIMEOUT_MS = 2000L
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingPromptsToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingPromptsToggles.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+import com.duckduckgo.feature.toggles.api.Toggle.State.CohortName
+
+/**
+ * Feature toggles for the "Add to Dock" + widget-prompt first-run onboarding experiment.
+ */
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "onboardingPrompts",
+)
+interface OnboardingPromptsToggles {
+
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun self(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun addToDockAndWidgetExperimentJul25(): Toggle
+
+    enum class OnboardingPromptsCohorts(override val cohortName: String) : CohortName {
+        CONTROL("control"),
+        TREATMENT_DOCK_ONLY("treatment_dock_only"),
+        TREATMENT_WIDGET_ONLY("treatment_widget_only"),
+        TREATMENT_DOCK_AND_WIDGET("treatment_dock_and_widget"),
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/onboarding/OnboardingPromptsExperimentManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/OnboardingPromptsExperimentManagerTest.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.onboarding
+
+import android.annotation.SuppressLint
+import com.duckduckgo.app.onboarding.OnboardingPromptsExperimentManager.OnboardingPromptExperimentVariant
+import com.duckduckgo.app.onboarding.OnboardingPromptsToggles.OnboardingPromptsCohorts
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+
+@SuppressLint("DenyListedApi")
+class OnboardingPromptsExperimentManagerTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val toggles: OnboardingPromptsToggles = FakeFeatureToggleFactory.create(OnboardingPromptsToggles::class.java)
+
+    private val testee = OnboardingPromptsExperimentManagerImpl(
+        toggles = toggles,
+        dispatcherProvider = coroutineRule.testDispatcherProvider,
+    )
+
+    @Test
+    fun whenPrivacyConfigNeverPersistedThenEnrollReturnsNull() = runTest {
+        givenCohortEnabled(winner = OnboardingPromptsCohorts.TREATMENT_DOCK_AND_WIDGET)
+
+        assertNull(testee.enroll())
+    }
+
+    @Test
+    fun whenExperimentDisabledThenEnrollReturnsNull() = runTest {
+        givenCohortEnabled(winner = null)
+
+        testee.onPrivacyConfigPersisted()
+
+        assertNull(testee.enroll())
+    }
+
+    @Test
+    fun whenEnrolledInControlThenEnrollReturnsControl() = runTest {
+        givenCohortEnabled(OnboardingPromptsCohorts.CONTROL)
+
+        testee.onPrivacyConfigPersisted()
+
+        assertEquals(OnboardingPromptExperimentVariant.CONTROL, testee.enroll())
+    }
+
+    @Test
+    fun whenEnrolledInTreatmentDockOnlyThenEnrollReturnsTreatmentDockOnly() = runTest {
+        givenCohortEnabled(OnboardingPromptsCohorts.TREATMENT_DOCK_ONLY)
+
+        testee.onPrivacyConfigPersisted()
+
+        assertEquals(OnboardingPromptExperimentVariant.TREATMENT_DOCK_ONLY, testee.enroll())
+    }
+
+    @Test
+    fun whenEnrolledInTreatmentWidgetOnlyThenEnrollReturnsTreatmentWidgetOnly() = runTest {
+        givenCohortEnabled(OnboardingPromptsCohorts.TREATMENT_WIDGET_ONLY)
+
+        testee.onPrivacyConfigPersisted()
+
+        assertEquals(OnboardingPromptExperimentVariant.TREATMENT_WIDGET_ONLY, testee.enroll())
+    }
+
+    @Test
+    fun whenEnrolledInTreatmentDockAndWidgetThenEnrollReturnsTreatmentDockAndWidget() = runTest {
+        givenCohortEnabled(OnboardingPromptsCohorts.TREATMENT_DOCK_AND_WIDGET)
+
+        testee.onPrivacyConfigPersisted()
+
+        assertEquals(OnboardingPromptExperimentVariant.TREATMENT_DOCK_AND_WIDGET, testee.enroll())
+    }
+
+    @Test
+    fun whenEnrollCalledTwiceThenSameCohortIsReturnedBothTimes() = runTest {
+        givenCohortEnabled(OnboardingPromptsCohorts.TREATMENT_WIDGET_ONLY)
+
+        testee.onPrivacyConfigPersisted()
+
+        val first = testee.enroll()
+        val second = testee.enroll()
+
+        assertEquals(first, second)
+    }
+
+    private fun givenCohortEnabled(winner: OnboardingPromptsCohorts?) {
+        toggles.addToDockAndWidgetExperimentJul25().setRawStoredState(
+            Toggle.State(
+                remoteEnableState = true,
+                enable = winner != null,
+                cohorts = OnboardingPromptsCohorts.values().map {
+                    Toggle.State.Cohort(name = it.cohortName, weight = if (it == winner) 1 else 0)
+                },
+            ),
+        )
+    }
+}


### PR DESCRIPTION
Task/Issue URL:https://app.asana.com/1/137249556945/project/1211724162604201/task/1216232144477358?focus=true
Tech Design URL (if applicable):https://app.asana.com/1/137249556945/project/1211724162604201/task/1216232144477346

### Description

Introduces the infrastructure for the "Add to Dock and Widget" onboarding prompts experiment (`addToDockAndWidgetExperimentJul25`). This includes:

- A new `OnboardingPromptsToggles` remote feature interface with a `self()` toggle and the `addToDockAndWidgetExperimentJul25` experiment toggle, backed by four cohorts: `CONTROL`, `TREATMENT_DOCK_ONLY`, `TREATMENT_WIDGET_ONLY`, and `TREATMENT_DOCK_AND_WIDGET`.
- A new `OnboardingPromptsExperimentManager` interface and its implementation, which handles enrolling users into the experiment and resolving their assigned variant.

### Steps to test this PR

_CI_ _passes_ 

### UI changes

| Before | After |
| --- | --- |
| N/A | N/A |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New isolated onboarding experiment plumbing with no user-facing behavior changes yet; enrollment follows existing privacy-config and feature-toggle patterns.
> 
> **Overview**
> Adds remote-feature infrastructure for the **Add to Dock** and **widget** first-run onboarding experiment (`addToDockAndWidgetExperimentJul25`), without wiring prompts into the UI yet.
> 
> **`OnboardingPromptsToggles`** exposes the `onboardingPrompts` feature with cohorts: control, dock-only, widget-only, and dock+widget.
> 
> **`OnboardingPromptsExperimentManager`** enrolls via the experiment toggle after privacy config is persisted (up to a 2s wait through `PrivacyConfigCallbackPlugin`), then returns the assigned variant or `null` if config never arrives or the experiment is off.
> 
> Unit tests cover timeout, disabled experiment, each cohort, and idempotent `enroll()` calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5b53e81eb221df938d7d8ac5c0728a93a8ce751. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->