### PR TITLE
Android/Duck.Ai: Hide keyboard when input is unfocused in the duck.ai chat page

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -579,7 +579,11 @@ class NativeInputModeWidget @JvmOverloads constructor(
             // setToggleVisible — e.g. re-show the toggle after the keyboard has been dismissed.
             // Only animate on focus-gain — focus-loss pairs with an instant setToggleVisible hide,
             // and animating the padding shrink afterwards looks like a two-step collapse.
-            if (hasFocus) beginFocusTransition()
+            if (hasFocus) {
+                beginFocusTransition()
+            } else if (isDuckAiPageContext()) {
+                hideKeyboard()
+            }
             updateBottomRowVisibility()
             applyVerticalPaddingForFocus()
             nativeInputState?.let { updateFireButtonVisibility(it) }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1213881875984009/task/1216387294797152?focus=true
Tech Design URL (if applicable): 

### Description
- On the Duck.ai chat page, dismiss the keyboard when the native input loses focus (e.g. tapping the chat content above the input), instead of leaving the IME lingering over the conversation with no focused field.
- Hides the keyboard from the input's focus-change listener on focus loss, gated to Duck.ai contexts (DUCK_AI and DUCK_AI_CONTEXTUAL) via isDuckAiPageContext(). The browser omnibar and full-screen input screen are unaffected.

### Steps to test this PR
  1. Duck.ai full-page chat (DUCK_AI context) — focus lost by tapping chat content
  - [ ] Open a Duck.ai chat page so the native input is shown
  - [ ] Tap the input field — keyboard IS shown and the field has focus
  - [ ] Tap the conversation content area above the input (scroll/tap a message)
  - [ ] Input field loses focus
  - [ ] Keyboard IS hidden
  - [ ] Bottom row (controls) collapses / toggle row updates in sync with the keyboard dismissal

  2. Submit from Duck.ai chat (regression)
  - [ ] In a Duck.ai chat, type a message and submit
  - [ ] Keyboard IS hidden after submission (single dismissal, no flicker)

  3. Re-focus after dismissal (regression)
  - [ ] After the keyboard hides on focus loss (case 1), tap the input field again
  - [ ] Field regains focus and keyboard IS shown again
  - [ ] No show/hide loop or flicker occurs

  Regression checks
  - [ ] Full-screen input screen (search/Duck.ai entry omnibar) — keyboard show/hide behavior is unchanged (uses the base InputModeWidget, not affected)
  - [ ] Duck.ai chat enter animation (bottom omnibar) still raises the keyboard on entry
  - [ ] Toggle row visibility on the browser omnibar is unchanged when focus changes



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, context-gated UI change in the native input focus listener; browser omnibar and full-screen input are unaffected.
> 
> **Overview**
> On **Duck.ai full-page and contextual chat** (`DUCK_AI` / `DUCK_AI_CONTEXTUAL`), tapping away from the native input (e.g. the conversation) now **dismisses the IME** when the field loses focus, instead of leaving the keyboard over the thread with no focused editor.
> 
> The behavior is wired in `NativeInputModeWidget`’s input **focus-change listener**: focus gain still runs `beginFocusTransition()` only; on focus loss, **`hideKeyboard()`** runs when `isDuckAiPageContext()` is true. Existing bottom-row padding and visibility updates on focus change are unchanged. **Browser omnibar** and other non–Duck.ai-page contexts are not gated in, so their keyboard behavior stays as before; submit still hides the keyboard via `submitMessage()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c45915bbd902685756fda01d22dff4846b41b73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->