### PR TITLE
Support edge to edge in internal settings

### DIFF
--- a/anrs/anrs-internal/src/main/java/com/duckduckgo/app/anr/internal/feature/CrashANRsInternalSettingsActivity.kt
+++ b/anrs/anrs-internal/src/main/java/com/duckduckgo/app/anr/internal/feature/CrashANRsInternalSettingsActivity.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.app.anr.internal.databinding.ActivityCrashAnrInternalSetti
 import com.duckduckgo.app.anr.internal.feature.CrashANRsInternalScreens.InternalCrashSettings
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
@@ -35,14 +36,25 @@ class CrashANRsInternalSettingsActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var settings: PluginPoint<CrashANRsSettingPlugin>
 
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val binding: ActivityCrashAnrInternalSettingsBinding by viewBinding()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
         setupToolbar(binding.toolbar)
 
         setupUiElementState()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.appBar)
+        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.contentScrollView)
     }
 
     private fun setupUiElementState() {

--- a/anrs/anrs-internal/src/main/res/layout/activity_crash_anr_internal_settings.xml
+++ b/anrs/anrs-internal/src/main/res/layout/activity_crash_anr_internal_settings.xml
@@ -43,6 +43,7 @@
     </com.google.android.material.appbar.AppBarLayout>
 
     <ScrollView
+            android:id="@+id/contentScrollView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_marginTop="64dp"

--- a/anrs/anrs-internal/src/main/res/layout/activity_crash_anr_internal_settings.xml
+++ b/anrs/anrs-internal/src/main/res/layout/activity_crash_anr_internal_settings.xml
@@ -46,7 +46,7 @@
             android:id="@+id/contentScrollView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_marginTop="64dp"
+            app:layout_constraintTop_toBottomOf="@id/appBar"
             tools:ignore="Overdraw">
 
         <LinearLayout

--- a/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/VpnInternalSettingsActivity.kt
+++ b/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/VpnInternalSettingsActivity.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.common.utils.extensions.isDdgApp
 import com.duckduckgo.common.utils.extensions.safeGetInstalledApplications
 import com.duckduckgo.di.scopes.ActivityScope
@@ -76,6 +77,9 @@ class VpnInternalSettingsActivity : DuckDuckGoActivity() {
 
     @Inject lateinit var dispatchers: DispatcherProvider
 
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val binding: ActivityVpnInternalSettingsBinding by viewBinding()
     private var debugLoggingReceiver: DebugLoggingReceiver? = null
     private var installedApps: Sequence<ApplicationInfo> = emptySequence()
@@ -91,7 +95,9 @@ class VpnInternalSettingsActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
         setupToolbar(binding.includeToolbar.toolbar)
 
         setupAppTrackerExceptionRules()
@@ -101,6 +107,12 @@ class VpnInternalSettingsActivity : DuckDuckGoActivity() {
         setupForceUpdateBlocklist()
         setupUiElementsState()
         setupAppProtectionSection()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.contentScrollView)
     }
 
     override fun onDestroy() {

--- a/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/rules/ExceptionRulesDebugActivity.kt
+++ b/app-tracking-protection/vpn-internal/src/main/java/com/duckduckgo/vpn/internal/feature/rules/ExceptionRulesDebugActivity.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.common.utils.extensions.safeGetInstalledApplications
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.mobile.android.vpn.stats.AppTrackerBlockingStatsRepository
@@ -58,6 +59,9 @@ class ExceptionRulesDebugActivity : DuckDuckGoActivity(), RuleTrackerView.RuleTr
     @Inject
     lateinit var dispatchers: DispatcherProvider
 
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val binding: ActivityExceptionRulesDebugBinding by viewBinding()
 
     private val refreshTickerJob = ConflatedJob()
@@ -65,7 +69,9 @@ class ExceptionRulesDebugActivity : DuckDuckGoActivity(), RuleTrackerView.RuleTr
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
 
         binding.appRule.isVisible = false
         binding.progress.isVisible = true
@@ -152,6 +158,10 @@ class ExceptionRulesDebugActivity : DuckDuckGoActivity(), RuleTrackerView.RuleTr
                 delay(TimeUnit.SECONDS.toMillis(5))
             }
         }
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applySystemBarInsets(binding.root)
     }
 
     override fun onTrackerClicked(

--- a/app-tracking-protection/vpn-internal/src/main/res/layout/activity_vpn_internal_settings.xml
+++ b/app-tracking-protection/vpn-internal/src/main/res/layout/activity_vpn_internal_settings.xml
@@ -27,6 +27,7 @@
             layout="@layout/include_default_toolbar"/>
 
     <ScrollView
+            android:id="@+id/contentScrollView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             tools:ignore="Overdraw">

--- a/app/src/internal/java/com/duckduckgo/app/audit/AuditSettingsActivity.kt
+++ b/app/src/internal/java/com/duckduckgo/app/audit/AuditSettingsActivity.kt
@@ -41,12 +41,17 @@ import com.duckduckgo.app.browser.databinding.ActivityAuditSettingsBinding
 import com.duckduckgo.app.browser.mode.InAppNavigation
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.di.scopes.ActivityScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
 
 @InjectWith(ActivityScope::class)
 class AuditSettingsActivity : DuckDuckGoActivity() {
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
 
     private val binding: ActivityAuditSettingsBinding by viewBinding()
 
@@ -54,11 +59,19 @@ class AuditSettingsActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
         setupToolbar(binding.includeToolbar.toolbar)
 
         configureUiEventHandlers()
         observeViewModel()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.contentScrollView)
     }
 
     override fun onDestroy() {

--- a/app/src/internal/java/com/duckduckgo/app/browser/webview/WebViewDevSettingsActivity.kt
+++ b/app/src/internal/java/com/duckduckgo/app/browser/webview/WebViewDevSettingsActivity.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.app.browser.webview.WebViewDevSettingsViewModel.ViewState
 import com.duckduckgo.app.clipboard.ClipboardInteractor
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.common.utils.playstore.PlayStoreAndroidUtils.Companion.PLAY_STORE_PACKAGE
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
@@ -50,17 +51,28 @@ class WebViewDevSettingsActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var clipboardManager: ClipboardInteractor
 
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val binding: ActivityWebViewDevSettingsBinding by viewBinding()
 
     private lateinit var webViewDebugLauncher: ActivityResultLauncher<Intent>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
         setupToolbar(binding.includeToolbar.toolbar)
         registerActivityResultLauncher()
         configureListeners()
         observeViewModel()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.contentScrollView)
     }
 
     private fun observeViewModel() {

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/DevSettingsActivity.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/DevSettingsActivity.kt
@@ -49,6 +49,7 @@ import com.duckduckgo.app.dev.settings.tabs.DevTabsActivity
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.menu.PopupMenu
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.privacy.config.internal.PrivacyConfigInternalSettingsActivity
@@ -61,6 +62,9 @@ class DevSettingsActivity : DuckDuckGoActivity() {
 
     @Inject
     lateinit var webContentDebuggingFeature: WebContentDebuggingFeature
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
 
     private val binding: ActivityDevSettingsBinding by viewBinding()
 
@@ -80,11 +84,19 @@ class DevSettingsActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
         setupToolbar(binding.includeToolbar.toolbar)
 
         configureUiEventHandlers()
         observeViewModel()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.contentScrollView)
     }
 
     override fun onStart() {

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/customtabs/CustomTabsInternalSettingsActivity.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/customtabs/CustomTabsInternalSettingsActivity.kt
@@ -39,23 +39,36 @@ import com.duckduckgo.app.browser.databinding.ActivityCustomTabsInternalSettings
 import com.duckduckgo.app.browser.defaultbrowsing.DefaultBrowserSystemSettings
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.di.scopes.ActivityScope
 import logcat.LogPriority.WARN
 import logcat.logcat
+import javax.inject.Inject
 
 @InjectWith(ActivityScope::class)
 class CustomTabsInternalSettingsActivity : DuckDuckGoActivity() {
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
 
     private val binding: ActivityCustomTabsInternalSettingsBinding by viewBinding()
     private lateinit var defaultAppActivityResultLauncher: ActivityResultLauncher<Intent>
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
         setupToolbar(binding.toolbar)
         registerActivityResultLauncher()
         configureListeners()
         updateDefaultBrowserLabel()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.appBar)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.defaultBrowser, drawBehindGestureNav = false)
     }
 
     private fun registerActivityResultLauncher() {

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/notifications/NotificationsActivity.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/notifications/NotificationsActivity.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.app.notification.NotificationFactory
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.listitem.TwoLineListItem
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.common.utils.notification.checkPermissionAndNotify
 import com.duckduckgo.di.scopes.ActivityScope
 import kotlinx.coroutines.flow.launchIn
@@ -47,15 +48,26 @@ class NotificationsActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var factory: NotificationFactory
 
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val binding: ActivityNotificationsBinding by viewBinding()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
         setupToolbar(binding.includeToolbar.toolbar)
 
         observeViewState()
         observeCommands()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.contentScrollView)
     }
 
     private fun observeViewState() {

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/onboarding/OnboardingDevSettingsActivity.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/onboarding/OnboardingDevSettingsActivity.kt
@@ -28,14 +28,19 @@ import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.listitem.OneLineListItem
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
 
 @InjectWith(ActivityScope::class)
 @ContributeToActivityStarter(OnboardingDevSettingsScreen::class)
 class OnboardingDevSettingsActivity : DuckDuckGoActivity() {
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
 
     private val binding: ActivityOnboardingDevSettingsBinding by viewBinding()
     private val viewModel: OnboardingDevSettingsViewModel by bindViewModel()
@@ -53,11 +58,19 @@ class OnboardingDevSettingsActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
         setupToolbar(binding.includeToolbar.toolbar)
 
         configureUiEventHandlers()
         observeViewModel()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.contentScrollView)
     }
 
     override fun onStart() {

--- a/app/src/internal/java/com/duckduckgo/app/dev/settings/tabs/DevTabsActivity.kt
+++ b/app/src/internal/java/com/duckduckgo/app/dev/settings/tabs/DevTabsActivity.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.app.dev.settings.tabs.DevTabsViewModel.ViewState
 import com.duckduckgo.app.notification.NotificationFactory
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.di.scopes.ActivityScope
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.flow.launchIn
@@ -47,11 +48,16 @@ class DevTabsActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var factory: NotificationFactory
 
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val binding: ActivityDevTabsBinding by viewBinding()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
         setupToolbar(binding.includeToolbar.toolbar)
 
         binding.addTabsButton.setOnClickListener {
@@ -88,6 +94,12 @@ class DevTabsActivity : DuckDuckGoActivity() {
 
         observeViewState()
         observeCommands()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.contentLayout, drawBehindGestureNav = false)
     }
 
     private fun observeViewState() {

--- a/app/src/internal/res/layout/activity_audit_settings.xml
+++ b/app/src/internal/res/layout/activity_audit_settings.xml
@@ -27,6 +27,7 @@
         layout="@layout/include_default_toolbar" />
 
     <ScrollView
+        android:id="@+id/contentScrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">

--- a/app/src/internal/res/layout/activity_dev_settings.xml
+++ b/app/src/internal/res/layout/activity_dev_settings.xml
@@ -27,6 +27,7 @@
         layout="@layout/include_default_toolbar" />
 
     <ScrollView
+        android:id="@+id/contentScrollView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">

--- a/app/src/internal/res/layout/activity_dev_tabs.xml
+++ b/app/src/internal/res/layout/activity_dev_tabs.xml
@@ -27,6 +27,7 @@
         layout="@layout/include_default_toolbar" />
 
     <LinearLayout
+        android:id="@+id/contentLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical">

--- a/app/src/internal/res/layout/activity_notifications.xml
+++ b/app/src/internal/res/layout/activity_notifications.xml
@@ -27,6 +27,7 @@
         layout="@layout/include_default_toolbar" />
 
     <ScrollView
+        android:id="@+id/contentScrollView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">

--- a/app/src/internal/res/layout/activity_onboarding_dev_settings.xml
+++ b/app/src/internal/res/layout/activity_onboarding_dev_settings.xml
@@ -27,6 +27,7 @@
         layout="@layout/include_default_toolbar" />
 
     <ScrollView
+        android:id="@+id/contentScrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">

--- a/app/src/internal/res/layout/activity_web_view_dev_settings.xml
+++ b/app/src/internal/res/layout/activity_web_view_dev_settings.xml
@@ -27,6 +27,7 @@
         layout="@layout/include_default_toolbar" />
 
     <ScrollView
+        android:id="@+id/contentScrollView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -6496,6 +6496,7 @@ class BrowserTabFragment :
                     HomeScreenWidgetBottomSheetDialog(
                         context = requireContext(),
                         isLightModeEnabled = appTheme.isLightModeEnabled(),
+                        edgeToEdgeProvider = edgeToEdgeProvider,
                     )
                 widgetBottomSheetDialog.eventListener =
                     object : HomeScreenWidgetBottomSheetDialog.EventListener {

--- a/app/src/main/java/com/duckduckgo/app/browser/ui/dialogs/widgetprompt/HomeScreenWidgetBottomSheetDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/ui/dialogs/widgetprompt/HomeScreenWidgetBottomSheetDialog.kt
@@ -21,15 +21,27 @@ import android.content.Context
 import android.view.LayoutInflater
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.BottomSheetHomeScreenWidgetBinding
+import com.duckduckgo.common.ui.applyBottomSystemBarInsetPadding
 import com.duckduckgo.common.ui.setRoundCorners
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.duckduckgo.mobile.android.R as CommonR
 
 @SuppressLint("NoBottomSheetDialog")
 class HomeScreenWidgetBottomSheetDialog(
     context: Context,
     isLightModeEnabled: Boolean,
-) : BottomSheetDialog(context) {
+    edgeToEdgeProvider: EdgeToEdgeProvider,
+) : BottomSheetDialog(
+    context,
+    if (edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BOTTOM_SHEETS)) {
+        CommonR.style.Widget_DuckDuckGo_BottomSheetDialog_EdgeToEdge
+    } else {
+        0
+    },
+) {
 
     private val binding: BottomSheetHomeScreenWidgetBinding =
         BottomSheetHomeScreenWidgetBinding.inflate(LayoutInflater.from(context))
@@ -42,6 +54,10 @@ class HomeScreenWidgetBottomSheetDialog(
         // especially in landscape aspect-ratios. If the dialog started as collapsed, the drag would interfere with internal scroll.
         this.behavior.state = BottomSheetBehavior.STATE_EXPANDED
         this.behavior.isDraggable = false
+
+        if (edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BOTTOM_SHEETS)) {
+            binding.dialogRootView.applyBottomSystemBarInsetPadding()
+        }
 
         setOnShowListener { dialogInterface ->
             (dialogInterface as BottomSheetDialog).setRoundCorners()

--- a/app/src/main/res/layout/bottom_sheet_home_screen_widget.xml
+++ b/app/src/main/res/layout/bottom_sheet_home_screen_widget.xml
@@ -27,6 +27,7 @@
     and the rest is added to the layout below.-->
 
     <LinearLayout
+        android:id="@+id/dialogRootView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@drawable/rounded_top_corners_bottom_sheet_drawable"

--- a/attributed-metrics/attributed-metrics-internal/src/main/java/com/duckduckgo/app/attributed/metrics/internal/ui/AttributedMetricsDevSettingsActivity.kt
+++ b/attributed-metrics/attributed-metrics-internal/src/main/java/com/duckduckgo/app/attributed/metrics/internal/ui/AttributedMetricsDevSettingsActivity.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.attributed.metrics.internal.databinding.ActivityAttributedMetricsDevSettingsBinding
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
@@ -63,16 +64,27 @@ class AttributedMetricsDevSettingsActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var settingsPlugins: PluginPoint<AttributedMetricsSettingPlugin>
 
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val dateETFormat = SimpleDateFormat("yyyy-MM-dd", Locale.US).apply {
         timeZone = TimeZone.getTimeZone("America/New_York")
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
         setupToolbar(binding.includeToolbar.toolbar)
         setupViews()
         setupPlugins()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.contentScrollView)
     }
 
     private fun setupPlugins() {

--- a/attributed-metrics/attributed-metrics-internal/src/main/res/layout/activity_attributed_metrics_dev_settings.xml
+++ b/attributed-metrics/attributed-metrics-internal/src/main/res/layout/activity_attributed_metrics_dev_settings.xml
@@ -12,6 +12,7 @@
         android:layout_height="wrap_content" />
 
     <ScrollView
+        android:id="@+id/contentScrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/settings/AutofillSettingsActivity.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/settings/AutofillSettingsActivity.kt
@@ -122,6 +122,9 @@ class AutofillSettingsActivity : DuckDuckGoActivity() {
         edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
         // Inset the scrolling content directly (the ViewSwitcher's "available" child), not the ViewSwitcher container.
         edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.autofillAvailable.root)
+        // The "unavailable"/"disabled" child hosts its own fragment-provided scrolling content; inset the container
+        // so it still reserves nav-bar space in every mode (its last visible content clears the bar).
+        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.autofillUnsupported.root)
     }
 
     private fun sendLaunchPixel(savedInstanceState: Bundle?) {

--- a/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
+++ b/autofill/autofill-internal/src/main/java/com/duckduckgo/autofill/internal/AutofillInternalSettingsActivity.kt
@@ -67,6 +67,7 @@ import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.common.utils.extensions.launchAutofillProviderSystemSettings
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.feature.toggles.api.Toggle
@@ -142,6 +143,9 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var inBrowserImportPromoPreviousPromptsStore: InternalInBrowserPromoStore
 
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private var passwordImportWatcher = ConflatedJob()
 
     // used to output duration of import
@@ -214,7 +218,9 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
         setupToolbar(binding.includeToolbar.toolbar)
         configureUiEventHandlers()
         refreshInstallationDaySettings()
@@ -672,6 +678,12 @@ class AutofillInternalSettingsActivity : DuckDuckGoActivity() {
         cookieManager.flush()
 
         Toast.makeText(this, R.string.autofillDevSettingsGoogleLogoutSuccess, Toast.LENGTH_SHORT).show()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.contentScrollView)
     }
 
     companion object {

--- a/autofill/autofill-internal/src/main/res/layout/activity_autofill_internal_settings.xml
+++ b/autofill/autofill-internal/src/main/res/layout/activity_autofill_internal_settings.xml
@@ -14,21 +14,27 @@
   ~ limitations under the License.
   -->
 
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     tools:context=".AutofillInternalSettingsActivity"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <include
+        android:id="@+id/includeToolbar"
+        layout="@layout/include_default_toolbar" />
+
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/contentScrollView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical">
-
-        <include
-            android:id="@+id/includeToolbar"
-            layout="@layout/include_default_toolbar" />
 
         <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
             android:id="@+id/accessAutofillSystemSettingsButton"
@@ -348,4 +354,5 @@
             app:secondaryText="@string/autofillDevSettingsDeclineCounterResetInstruction" />
 
     </LinearLayout>
-</androidx.core.widget.NestedScrollView>
+    </androidx.core.widget.NestedScrollView>
+</LinearLayout>

--- a/duckchat/duckchat-internal/src/main/java/com/duckduckgo/duckchat/internal/DuckAiDevActivity.kt
+++ b/duckchat/duckchat-internal/src/main/java/com/duckduckgo/duckchat/internal/DuckAiDevActivity.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.listitem.TwoLineListItem
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckchat.internal.databinding.ActivityDuckAiDevBinding
@@ -31,11 +32,16 @@ class DuckAiDevActivity : DuckDuckGoActivity() {
 
     @Inject lateinit var plugins: PluginPoint<DuckAiDevCapabilityPlugin>
 
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val binding: ActivityDuckAiDevBinding by viewBinding()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
         setupToolbar(binding.toolbar)
 
         plugins.getPlugins().forEach { plugin ->
@@ -48,5 +54,11 @@ class DuckAiDevActivity : DuckDuckGoActivity() {
             }
             binding.capabilitiesContainer.addView(item)
         }
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.appBar)
+        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.contentScrollView)
     }
 }

--- a/duckchat/duckchat-internal/src/main/java/com/duckduckgo/duckchat/internal/DuckAiUrlSettingsActivity.kt
+++ b/duckchat/duckchat-internal/src/main/java/com/duckduckgo/duckchat/internal/DuckAiUrlSettingsActivity.kt
@@ -28,23 +28,30 @@ import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckchat.internal.DuckAiUrlSettingsViewModel.Command.RestartApp
 import com.duckduckgo.duckchat.internal.DuckAiUrlSettingsViewModel.Command.ShowMessage
 import com.duckduckgo.duckchat.internal.databinding.ActivityDuckAiUrlSettingsBinding
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
 import kotlin.system.exitProcess
 
 @InjectWith(ActivityScope::class)
 class DuckAiUrlSettingsActivity : DuckDuckGoActivity() {
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
 
     private val binding: ActivityDuckAiUrlSettingsBinding by viewBinding()
     private val viewModel: DuckAiUrlSettingsViewModel by bindViewModel()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
         setupToolbar(binding.toolbar)
         title = getString(R.string.devSettingsDuckAiUrlOverrideTitle)
 
@@ -60,6 +67,12 @@ class DuckAiUrlSettingsActivity : DuckDuckGoActivity() {
             .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
             .onEach { processCommand(it) }
             .launchIn(lifecycleScope)
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.appBar)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.reset, drawBehindGestureNav = false)
     }
 
     private fun configureViews() {

--- a/duckchat/duckchat-internal/src/main/res/layout/activity_duck_ai_dev.xml
+++ b/duckchat/duckchat-internal/src/main/res/layout/activity_duck_ai_dev.xml
@@ -5,6 +5,7 @@
     android:layout_height="match_parent">
 
     <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
@@ -16,6 +17,7 @@
     </com.google.android.material.appbar.AppBarLayout>
 
     <ScrollView
+        android:id="@+id/contentScrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">

--- a/feature-toggles/feature-toggles-internal/src/main/java/com/duckduckgo/examplefeature/internal/ui/FeatureToggleInventoryActivity.kt
+++ b/feature-toggles/feature-toggles-internal/src/main/java/com/duckduckgo/examplefeature/internal/ui/FeatureToggleInventoryActivity.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.view.dialog.ActionBottomSheetDialog
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.common.utils.text.TextChangedWatcher
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.di.scopes.AppScope
@@ -68,6 +69,9 @@ class FeatureToggleInventoryActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var moshi: Moshi
 
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val featureNameFilter = MutableStateFlow("")
     private val allToggles = MutableStateFlow<List<Toggle>?>(null)
 
@@ -92,7 +96,9 @@ class FeatureToggleInventoryActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
         setupToolbar(binding.includeToolbar.toolbar)
         setupRecyclerView()
         binding.searchName.addTextChangedListener(searchTextWatcher)
@@ -103,6 +109,12 @@ class FeatureToggleInventoryActivity : DuckDuckGoActivity() {
                 launch { observeFilteredToggles() }
             }
         }
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.recyclerView)
     }
 
     private fun setupRecyclerView() {

--- a/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/feature/NetPInternalSettingsActivity.kt
+++ b/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/feature/NetPInternalSettingsActivity.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.navigation.api.GlobalActivityStarter
@@ -88,6 +89,9 @@ class NetPInternalSettingsActivity : DuckDuckGoActivity() {
 
     @Inject lateinit var netPInternalEnvDataStore: NetPInternalEnvDataStore
 
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val job = ConflatedJob()
 
     private val exportPcapFile = registerForActivityResult(ExportPcapContract()) { data ->
@@ -115,11 +119,19 @@ class NetPInternalSettingsActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
         setupToolbar(binding.toolbar)
 
         setupUiElementState()
         setupConfigSection()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.appBar)
+        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.contentScrollView)
     }
 
     override fun onDestroy() {

--- a/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/feature/system_apps/NetPSystemAppsExclusionListActivity.kt
+++ b/network-protection/network-protection-internal/src/main/java/com/duckduckgo/networkprotection/internal/feature/system_apps/NetPSystemAppsExclusionListActivity.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.common.utils.extensions.safeGetInstalledApplications
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.networkprotection.api.NetworkProtectionState
@@ -48,13 +49,18 @@ class NetPSystemAppsExclusionListActivity : DuckDuckGoActivity(), SystemAppView.
     @Inject
     lateinit var networkProtectionState: NetworkProtectionState
 
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private var initialExclusionList: Int? = null
 
     private val binding: ActivityNetpInternalSystemAppsExclusionBinding by viewBinding()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
 
         binding.progress.isVisible = true
 
@@ -92,6 +98,10 @@ class NetPSystemAppsExclusionListActivity : DuckDuckGoActivity(), SystemAppView.
         if (initialExclusionList != exclusionListProvider.getExclusionList().hashCode()) {
             networkProtectionState.restart()
         }
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applySystemBarInsets(binding.root)
     }
 
     companion object {

--- a/network-protection/network-protection-internal/src/main/res/layout/activity_netp_internal_settings.xml
+++ b/network-protection/network-protection-internal/src/main/res/layout/activity_netp_internal_settings.xml
@@ -43,9 +43,10 @@
     </com.google.android.material.appbar.AppBarLayout>
 
     <ScrollView
+        android:id="@+id/contentScrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginTop="64dp"
+        app:layout_constraintTop_toBottomOf="@id/appBar"
         tools:ignore="Overdraw">
 
         <LinearLayout

--- a/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirDevBrokerConfigActivity.kt
+++ b/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirDevBrokerConfigActivity.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
 import com.duckduckgo.pir.impl.brokers.BrokerJsonUpdater
@@ -58,6 +59,9 @@ class PirDevBrokerConfigActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var dispatcherProvider: DispatcherProvider
 
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val binding: ActivityPirInternalBrokerConfigBinding by viewBinding()
     private lateinit var dropDownAdapter: ArrayAdapter<String>
     private val brokerOptions = mutableListOf<Broker>()
@@ -65,10 +69,18 @@ class PirDevBrokerConfigActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
         setupToolbar(binding.toolbar)
         setupViews()
         loadBrokers()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.appBar)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.resetAllConfigsButton, drawBehindGestureNav = false)
     }
 
     private fun setupViews() {

--- a/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirDevEmailActivity.kt
+++ b/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirDevEmailActivity.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
@@ -59,6 +60,9 @@ class PirDevEmailActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var dispatcherProvider: DispatcherProvider
 
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val binding: ActivityPirInternalEmailBinding by viewBinding()
 
     private lateinit var spinnerAdapter: ArrayAdapter<String>
@@ -67,10 +71,18 @@ class PirDevEmailActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
         setupToolbar(binding.toolbar)
         setupViews()
         loadEmailJobs()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.appBar)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.viewEmailResults, drawBehindGestureNav = false)
     }
 
     private fun setupViews() {

--- a/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirDevOptOutActivity.kt
+++ b/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirDevOptOutActivity.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
@@ -58,6 +59,9 @@ class PirDevOptOutActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var repository: PirRepository
 
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private lateinit var optOutAdapter: ArrayAdapter<String>
     private lateinit var dropDownAdapter: ArrayAdapter<String>
     private val binding: ActivityPirInternalOptoutBinding by viewBinding()
@@ -66,10 +70,18 @@ class PirDevOptOutActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
         setupToolbar(binding.toolbar)
         setupViews()
         bindViews()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.appBar)
+        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.optOutList)
     }
 
     private fun setupViews() {

--- a/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirDevScanActivity.kt
+++ b/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirDevScanActivity.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
@@ -90,6 +91,9 @@ class PirDevScanActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var pirDatabaseExporter: PirDatabaseExporter
 
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val binding: ActivityPirInternalScanBinding by viewBinding()
     private val recordStringBuilder = StringBuilder()
     private lateinit var dropDownAdapter: ArrayAdapter<String>
@@ -98,10 +102,18 @@ class PirDevScanActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
         setupToolbar(binding.toolbar)
         setupViews()
         bindViews()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.appBar)
+        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.contentScrollView)
     }
 
     private fun bindViews() {

--- a/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirDevSettingsActivity.kt
+++ b/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirDevSettingsActivity.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
@@ -64,15 +65,26 @@ class PirDevSettingsActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var pirDashboardUrlProvider: PirDashboardUrlProvider
 
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val binding: ActivityPirInternalSettingsBinding by viewBinding()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
         setupToolbar(binding.toolbar)
         setupViews()
         bindViews()
         pirNotificationManager.createNotificationChannel()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.appBar)
+        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.contentScrollView)
     }
 
     private fun setupViews() {

--- a/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirDevWebViewActivity.kt
+++ b/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirDevWebViewActivity.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
 import com.duckduckgo.navigation.api.getActivityParams
@@ -54,13 +55,18 @@ class PirDevWebViewActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var pirSchedulingRepository: PirSchedulingRepository
 
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val binding: ActivityPirInternalWebviewBinding by viewBinding()
     private val params: PirDevWebViewScreenParams?
         get() = intent.getActivityParams(PirDevWebViewScreenParams::class.java)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
 
         when (val screenParams = params) {
             is PirDevWebViewScreenParams.PirDevEmailWebViewScreenParams -> runDebugEmail(screenParams)
@@ -120,6 +126,11 @@ class PirDevWebViewActivity : DuckDuckGoActivity() {
                 finish()
             }
         }
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyStatusBarAndHorizontalInsets(binding.root)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.pirDevWebView, drawBehindGestureNav = true)
     }
 }
 

--- a/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirResultsActivity.kt
+++ b/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirResultsActivity.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
 import com.duckduckgo.navigation.api.getActivityParams
@@ -57,6 +58,9 @@ class PirResultsActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var dispatcherProvider: DispatcherProvider
 
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val formatter = SimpleDateFormat("dd-MM-yyyy HH:mm:ss", Locale.getDefault())
     private val binding: ActivityPirInternalResultsBinding by viewBinding()
 
@@ -67,9 +71,17 @@ class PirResultsActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
         setupToolbar(binding.toolbar)
         bindViews()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.appBar)
+        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.scanLogList)
     }
 
     private fun bindViews() {

--- a/pir/pir-internal/src/main/res/layout/activity_pir_internal_scan.xml
+++ b/pir/pir-internal/src/main/res/layout/activity_pir_internal_scan.xml
@@ -39,6 +39,7 @@
     </com.google.android.material.appbar.AppBarLayout>
 
     <ScrollView
+        android:id="@+id/contentScrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:fillViewport="true">

--- a/pir/pir-internal/src/main/res/layout/activity_pir_internal_settings.xml
+++ b/pir/pir-internal/src/main/res/layout/activity_pir_internal_settings.xml
@@ -39,6 +39,7 @@
     </com.google.android.material.appbar.AppBarLayout>
 
     <ScrollView
+        android:id="@+id/contentScrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:fillViewport="true">

--- a/privacy-config/privacy-config-internal/src/main/java/com/duckduckgo/privacy/config/internal/PrivacyConfigInternalSettingsActivity.kt
+++ b/privacy-config/privacy-config-internal/src/main/java/com/duckduckgo/privacy/config/internal/PrivacyConfigInternalSettingsActivity.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.hide
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.privacy.config.impl.PrivacyConfigDownloader
 import com.duckduckgo.privacy.config.internal.PrivacyConfigInternalViewModel.Command
@@ -50,6 +51,9 @@ class PrivacyConfigInternalSettingsActivity : DuckDuckGoActivity() {
 
     @Inject lateinit var downloader: PrivacyConfigDownloader
 
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val binding: ActivityPrivacyConfigInternalSettingsBinding by viewBinding()
     private val viewModel: PrivacyConfigInternalViewModel by bindViewModel()
 
@@ -62,7 +66,9 @@ class PrivacyConfigInternalSettingsActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
         setupToolbar(binding.toolbar)
         configureViews()
         viewModel.start()
@@ -74,6 +80,12 @@ class PrivacyConfigInternalSettingsActivity : DuckDuckGoActivity() {
             .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
             .onEach { processCommand(it) }
             .launchIn(lifecycleScope)
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.appBar)
+        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.container)
     }
 
     private fun configureViews() {

--- a/privacy-config/privacy-config-internal/src/main/res/layout/activity_privacy_config_internal_settings.xml
+++ b/privacy-config/privacy-config-internal/src/main/res/layout/activity_privacy_config_internal_settings.xml
@@ -56,7 +56,7 @@
             android:id="@+id/container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginTop="64dp"
+        app:layout_constraintTop_toBottomOf="@id/appBar"
         tools:ignore="Overdraw">
 
         <LinearLayout

--- a/remote-messaging/remote-messaging-internal/src/main/java/com/duckduckgo/remote/messaging/internal/feature/RMFInternalSettingsActivity.kt
+++ b/remote-messaging/remote-messaging-internal/src/main/java/com/duckduckgo/remote/messaging/internal/feature/RMFInternalSettingsActivity.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
@@ -35,14 +36,25 @@ class RMFInternalSettingsActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var settings: PluginPoint<RmfSettingPlugin>
 
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val binding: ActivityRmfInternalSettingsBinding by viewBinding()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
         setupToolbar(binding.toolbar)
 
         setupUiElementState()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.appBar)
+        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.contentScrollView)
     }
 
     private fun setupUiElementState() {

--- a/remote-messaging/remote-messaging-internal/src/main/res/layout/activity_rmf_internal_settings.xml
+++ b/remote-messaging/remote-messaging-internal/src/main/res/layout/activity_rmf_internal_settings.xml
@@ -43,6 +43,7 @@
     </com.google.android.material.appbar.AppBarLayout>
 
     <ScrollView
+            android:id="@+id/contentScrollView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_marginTop="64dp"

--- a/remote-messaging/remote-messaging-internal/src/main/res/layout/activity_rmf_internal_settings.xml
+++ b/remote-messaging/remote-messaging-internal/src/main/res/layout/activity_rmf_internal_settings.xml
@@ -46,7 +46,7 @@
             android:id="@+id/contentScrollView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_marginTop="64dp"
+            app:layout_constraintTop_toBottomOf="@id/appBar"
             tools:ignore="Overdraw">
 
         <LinearLayout

--- a/saved-sites/saved-sites-internal/src/main/java/com/duckduckgo/savedsites/internal/SavedSitesInternalSettingsActivity.kt
+++ b/saved-sites/saved-sites-internal/src/main/java/com/duckduckgo/savedsites/internal/SavedSitesInternalSettingsActivity.kt
@@ -34,6 +34,7 @@ import com.duckduckgo.browser.api.ui.BrowserScreens
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.savedsites.api.service.ImportSavedSitesResult
@@ -67,6 +68,9 @@ class SavedSitesInternalSettingsActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var importFromGoogle: ImportFromGoogle
 
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val importBookmarksFileLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if (result.resultCode == RESULT_OK) {
@@ -80,7 +84,9 @@ class SavedSitesInternalSettingsActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
         setupToolbar(binding.includeToolbar.toolbar)
         configureImportBookmarksEventHandlers()
         setupBookmarksPreImportDialogResultListener()
@@ -223,6 +229,12 @@ class SavedSitesInternalSettingsActivity : DuckDuckGoActivity() {
 
     private fun String.showSnackbar(duration: Int = Snackbar.LENGTH_LONG) {
         Snackbar.make(binding.root, this, duration).show()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.contentScrollView)
     }
 
     companion object {

--- a/saved-sites/saved-sites-internal/src/main/res/layout/activity_saved_sites_internal_settings.xml
+++ b/saved-sites/saved-sites-internal/src/main/res/layout/activity_saved_sites_internal_settings.xml
@@ -14,21 +14,27 @@
   ~ limitations under the License.
   -->
 
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     tools:context=".SavedSitesInternalSettingsActivity"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <include
+        android:id="@+id/includeToolbar"
+        layout="@layout/include_default_toolbar" />
+
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/contentScrollView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical">
-
-        <include
-            android:id="@+id/includeToolbar"
-            layout="@layout/include_default_toolbar" />
 
         <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
             android:id="@+id/importBookmarksSectionTitle"
@@ -70,4 +76,5 @@
             app:primaryText="@string/savedSitesInternalSettingsViewBookmarks" />
 
     </LinearLayout>
-</androidx.core.widget.NestedScrollView>
+    </androidx.core.widget.NestedScrollView>
+</LinearLayout>

--- a/subscriptions/subscriptions-internal/src/main/java/com/duckduckgo/subscriptions/internal/SubscriptionsInternalSettingsActivity.kt
+++ b/subscriptions/subscriptions-internal/src/main/java/com/duckduckgo/subscriptions/internal/SubscriptionsInternalSettingsActivity.kt
@@ -21,6 +21,7 @@ import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
@@ -37,14 +38,25 @@ class SubscriptionsInternalSettingsActivity : DuckDuckGoActivity() {
 
     @Inject lateinit var globalActivityStarter: GlobalActivityStarter
 
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val binding: ActivitySubsInternalSettingsBinding by viewBinding()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
         setupToolbar(binding.toolbar)
 
         setupUiElementState()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.appBar)
+        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.contentScrollView)
     }
 
     private fun setupUiElementState() {

--- a/subscriptions/subscriptions-internal/src/main/res/layout/activity_subs_internal_settings.xml
+++ b/subscriptions/subscriptions-internal/src/main/res/layout/activity_subs_internal_settings.xml
@@ -43,9 +43,10 @@
     </com.google.android.material.appbar.AppBarLayout>
 
     <ScrollView
+            android:id="@+id/contentScrollView"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_marginTop="64dp"
+            app:layout_constraintTop_toBottomOf="@id/appBar"
             tools:ignore="Overdraw">
 
         <LinearLayout

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/SetupAccountActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/setup/SetupAccountActivity.kt
@@ -107,8 +107,10 @@ class SetupAccountActivity : DuckDuckGoActivity(), SyncSetupNavigationFlowListen
     }
 
     private fun configureEdgeToEdgeInsets() {
-        edgeToEdgeHandler.applyStatusBarAndHorizontalInsets(binding.root)
-        edgeToEdgeHandler.applyNavigationBarInsets(binding.fragmentContainerView, drawBehindGestureNav = false)
+        // This screen has no toolbar and its content is a full-bleed daxColorSurface fragment container. Pad that
+        // container on every edge so its surface background bleeds behind the transparent system bars: without this
+        // the status-bar scrim (daxColorBackground) would show a colour different from the surface body.
+        edgeToEdgeHandler.applySystemBarInsets(binding.fragmentContainerView)
     }
 
     override fun onSaveInstanceState(outState: Bundle) {

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
@@ -35,6 +35,7 @@ import com.duckduckgo.common.ui.view.hide
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.sync.impl.ui.SyncActivity
 import com.duckduckgo.sync.impl.ui.setup.SetupAccountActivity
@@ -72,6 +73,9 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var browserNav: BrowserNav
 
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val barcodeLauncher = registerForActivityResult(
         ScanContract(),
     ) { result: ScanIntentResult ->
@@ -95,7 +99,9 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
         setupToolbar(binding.includeToolbar.toolbar)
         observeUiEvents()
         configureListeners()
@@ -268,6 +274,12 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
             logcat(LogPriority.ERROR) { "Sync-ScopedToken: failed to encode QR: ${e.message}" }
             null
         }
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.contentScrollView)
     }
 
     private fun getScanOptions(): ScanOptions {

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugActivity.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncV2PairingDebugActivity.kt
@@ -32,6 +32,7 @@ import com.duckduckgo.common.ui.view.dialog.DaxAlertDialog
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.common.utils.extensions.hideKeyboard
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.sync.impl.exchange.v2.Role
@@ -57,6 +58,9 @@ class SyncV2PairingDebugActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var dispatcherProvider: DispatcherProvider
 
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val binding: ActivitySyncV2PairingDebugBinding by viewBinding()
     private val viewModel: SyncV2PairingDebugViewModel by bindViewModel()
 
@@ -67,13 +71,21 @@ class SyncV2PairingDebugActivity : DuckDuckGoActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge()
         setContentView(binding.root)
+        configureEdgeToEdgeInsets()
         setupToolbar(binding.includeToolbar.toolbar)
         configureListeners()
         observeViewState()
         observeConfirmations()
         observeTerminals()
         observeToasts()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.contentScrollView)
     }
 
     private fun configureListeners() {

--- a/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
+++ b/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
@@ -14,23 +14,29 @@
   ~ limitations under the License.
   -->
 
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:scrollbarAlwaysDrawVerticalTrack="true"
-    android:fadeScrollbars="false"
-    android:scrollbars="vertical">
+    android:orientation="vertical">
+
+    <include
+        android:id="@+id/includeToolbar"
+        layout="@layout/include_default_toolbar" />
+
+    <ScrollView
+        android:id="@+id/contentScrollView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scrollbarAlwaysDrawVerticalTrack="true"
+        android:fadeScrollbars="false"
+        android:scrollbars="vertical">
 
     <LinearLayout
         android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
-
-        <include
-            android:id="@+id/includeToolbar"
-            layout="@layout/include_default_toolbar" />
 
         <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
             android:id="@+id/launchSyncSettingsButton"
@@ -671,4 +677,5 @@
             android:text="@string/sync_internal_promotions_clear_history_chat_tab_page_promo" />
 
     </LinearLayout>
-</ScrollView>
+    </ScrollView>
+</LinearLayout>

--- a/sync/sync-internal/src/main/res/layout/activity_sync_v2_pairing_debug.xml
+++ b/sync/sync-internal/src/main/res/layout/activity_sync_v2_pairing_debug.xml
@@ -26,6 +26,7 @@
         layout="@layout/include_default_toolbar" />
 
     <ScrollView
+        android:id="@+id/contentScrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:fadeScrollbars="false"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212608036467427/task/1214047527401584?focus=true

### Description
- Fix followups mentioned in: https://app.asana.com/1/137249556945/project/1212608036467427/task/1216383876087503?focus=true
- Fix Add Widget promo bottomsheet that comes up right after onboarding in NTP.
- Support edge-to-edge in internal settings activities.

### Steps to test this PR
Test internal settings activities.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly internal/dev UI and layout inset changes with no production user-flow or security logic changes; risk is visual overlap or clipping on those screens if insets are wrong.
> 
> **Overview**
> Rolls out **transparent edge-to-edge** across internal and dev-only settings activities using the shared `EdgeToEdgeHandler` pattern: `enableTransparentEdgeToEdge()`, horizontal/status bar insets on the root and app bar, and scrollable or fixed navigation-bar insets on the main content.
> 
> **Layouts** drop hardcoded `layout_marginTop` under toolbars in favor of constraint/app-bar positioning, and add `contentScrollView` (or equivalent) IDs so inset helpers can target scrolling content. Several screens **move the toolbar outside** the scroll view (autofill internal, saved sites internal, sync internal) so status-bar padding applies correctly.
> 
> **Follow-up fixes** include insetting `AutofillSettingsActivity`’s unsupported/disabled `ViewSwitcher` child, **reworking** `SetupAccountActivity` to apply full system-bar insets on the full-bleed fragment container (avoiding a mismatched status-bar scrim), and **edge-to-edge** treatment for the home-screen widget prompt bottom sheet when the bottom-sheets bucket is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96a836b141d0c279b448a53327684d4335e404a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->