### PR TITLE
Fix failing e2e due to revert to legacy for search only

### DIFF
--- a/.maestro/bookmarks/ensure_bookmarks_can_be_added_and_deleted.yaml
+++ b/.maestro/bookmarks/ensure_bookmarks_can_be_added_and_deleted.yaml
@@ -14,7 +14,7 @@ tags:
       - runFlow: ../shared/skip_all_onboarding.yaml
 
       - tapOn:
-          id: "inputField"
+          id: "omnibarTextInput"
       - inputText: "https://privacy-test-pages.site"
       - pressKey: Enter
       - tapOn:

--- a/.maestro/bookmarks/open_bookmark_and_navigate_back.yaml
+++ b/.maestro/bookmarks/open_bookmark_and_navigate_back.yaml
@@ -14,14 +14,13 @@ tags:
       - runFlow: ../shared/skip_all_onboarding.yaml
 
       - tapOn:
-            id: "inputField"
+            id: "omnibarTextInput"
       - inputText: "https://www.search-company.site/"
       - pressKey: Enter
       - assertVisible:
             text: "Search engine"
       - tapOn:
-            id: "omnibarTextInputClickCatcher"
-      - eraseText
+            id: "omnibarTextInput"
       - inputText: "https://privacy-test-pages.site"
       - pressKey: Enter
       - assertVisible:

--- a/.maestro/bookmarks/open_bookmark_in_folder_and_navigate_back.yaml
+++ b/.maestro/bookmarks/open_bookmark_in_folder_and_navigate_back.yaml
@@ -14,7 +14,7 @@ tags:
             - runFlow: ../shared/skip_all_onboarding.yaml
 
             - tapOn:
-                  id: "inputField"
+                  id: "omnibarTextInput"
             - inputText: "https://privacy-test-pages.site/"
             - pressKey: Enter
             - assertVisible:
@@ -26,8 +26,7 @@ tags:
             - tapOn:
                   text: "add bookmark"
             - tapOn:
-                  id: "omnibarTextInputClickCatcher"
-            - eraseText
+                  id: "omnibarTextInput"
             - inputText: "https://www.search-company.site/"
             - pressKey: Enter
             - assertVisible:

--- a/.maestro/browsing/visit_site.yaml
+++ b/.maestro/browsing/visit_site.yaml
@@ -14,15 +14,15 @@ tags:
       - runFlow: ../shared/skip_all_onboarding.yaml
 
       - assertVisible:
-          id: "inputField"
+          text: "Search"
       - tapOn:
-          id: "inputField"
+          id: "omnibarTextInput"
       - inputText: "https://privacy-test-pages.site"
       - pressKey: Enter
       - assertVisible:
           text: ".*Privacy Test Pages.*"
       - tapOn:
-          id: "omnibarTextInputClickCatcher"
+          id: "omnibarTextInput"
       - eraseText
       - assertVisible:
-          id: "inputField"
+          text: "Search"

--- a/.maestro/favorites/favorites_bookmarks_add.yaml
+++ b/.maestro/favorites/favorites_bookmarks_add.yaml
@@ -14,7 +14,7 @@ tags:
       - runFlow: ../shared/skip_all_onboarding.yaml
 
       - tapOn:
-          id: "inputField"
+          id: "omnibarTextInput"
       - inputText: "https://privacy-test-pages.site"
       - pressKey: Enter
       - tapOn:

--- a/.maestro/favorites/favorites_bookmarks_delete.yaml
+++ b/.maestro/favorites/favorites_bookmarks_delete.yaml
@@ -14,7 +14,7 @@ tags:
       - runFlow: ../shared/skip_all_onboarding.yaml
 
       - tapOn:
-          id: "inputField"
+          id: "omnibarTextInput"
       - inputText: "https://privacy-test-pages.site"
       - pressKey: Enter
       - tapOn:

--- a/.maestro/tabs/open_multiple_tabs.yaml
+++ b/.maestro/tabs/open_multiple_tabs.yaml
@@ -14,7 +14,7 @@ tags:
             - runFlow: ../shared/skip_all_onboarding.yaml
 
             - tapOn:
-                id: "inputField"
+                id: "omnibarTextInput"
             - inputText: "https://privacy-test-pages.site"
             - pressKey: Enter
             - runFlow: ../shared/browser_screen/click_on_tabs_button.yaml
@@ -24,7 +24,7 @@ tags:
                 text: "Privacy Test Pages - Home"
             - tapOn: "New Tab"
             - assertVisible:
-                id: "inputField"
+                id: "omnibarTextInput"
             - inputText: "https://www.search-company.site"
             - pressKey: Enter
             - assertVisible:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201462763415876/task/1216389520370555?focus=true
Tech Design URL (if applicable): N/A

### Description
- Revert 7 releaseTest Maestro flows from the native inputField selectors back to the legacy omnibarTextInput for omnibar interactions (bookmarks, favorites, tabs, and general browsing flows).
- These flows run on the play binary, whose default is search-only mode. After #9124 made search-only fall back to the legacy omnibar, inputField / omnibarTextInputClickCatcher are no longer present, so the flows failed at the first omnibar tap/assert.
- On loaded pages, the URL is now edited by tapping omnibarTextInput directly (dropping the omnibarTextInputClickCatcher + eraseText steps that only applied when the native input overlay was active).
- visit_site.yaml again asserts the legacy "Search" omnibar hint instead of inputField visibility.

The native-input unifiedInputTest flows (internal binary, forced into Search & Duck.ai) are unchanged and still use inputField.

### Steps to test this PR
https://github.com/duckduckgo/Android/actions/runs/28947366350/job/85884635242 should pass


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Maestro YAML updates; no production app or runtime behavior changes.
> 
> **Overview**
> Updates **release Maestro flows** so they target the omnibar again after a revert to the legacy search-only UI broke e2e.
> 
> **Omnibar interaction:** Replaces `inputField` with `omnibarTextInput` for taps and URL entry across bookmark, browsing, favorites, and multi-tab tests. Flows that cleared the bar via `omnibarTextInputClickCatcher` now tap `omnibarTextInput` directly and drop the extra erase step where it’s no longer needed.
> 
> **Empty omnibar checks:** In `visit_site.yaml`, visibility of the idle search field is asserted with `text: "Search"` instead of `inputField`, and post-erase checks use the same placeholder text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dddc042c10bad9880523995e3fd161bbddf0f028. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->