### PR TITLE
Add view stub for ad blocking menu actions

### DIFF
--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/AdBlockingStatusChecker.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/domain/AdBlockingStatusChecker.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.adblocking.impl.domain
 
 import com.duckduckgo.adblocking.impl.AdBlockingSettingsRepository
 import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
+import com.duckduckgo.adblocking.impl.store.AdBlockingSessionStore
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
@@ -62,7 +63,10 @@ interface AdBlockingStatusChecker {
 
 sealed interface AdBlockingState {
     data object Uninitialized : AdBlockingState
-    data object Disabled : AdBlockingState
+    sealed interface Disabled : AdBlockingState {
+        data object Permanent : Disabled
+        data object UntilRelaunch : Disabled
+    }
     sealed interface Enabled : AdBlockingState {
         data object UserEnabled : Enabled
         data object Default : Enabled
@@ -83,6 +87,7 @@ sealed interface SettingsPlacement {
 class RealAdBlockingStatusChecker @Inject constructor(
     private val feature: AdBlockingExtensionFeature,
     private val settingsRepository: AdBlockingSettingsRepository,
+    private val sessionStore: AdBlockingSessionStore,
     @AppCoroutineScope appScope: CoroutineScope,
 ) : AdBlockingStatusChecker {
 
@@ -99,7 +104,7 @@ class RealAdBlockingStatusChecker @Inject constructor(
             return false
         }
         if (state.value !is AdBlockingState.Enabled) {
-            logcat { "User disabled ad blocking" }
+            logcat { "Ad blocking disabled" }
             return false
         }
         return true
@@ -109,10 +114,9 @@ class RealAdBlockingStatusChecker @Inject constructor(
         combine(
             feature.self().enabled(),
             feature.enableContingencyMode().enabled(),
-            settingsRepository.isEnabledFlow(),
-            feature.enabledByDefault().enabled(),
-        ) { killSwitchOn, contingencyModeOn, stored, enabledByDefault ->
-            killSwitchOn && !contingencyModeOn && (stored ?: enabledByDefault)
+            observeState(),
+        ) { killSwitchOn, contingencyModeOn, state ->
+            killSwitchOn && !contingencyModeOn && state is AdBlockingState.Enabled
         }
 
     override fun settingsPlacementFlow(): Flow<SettingsPlacement> =
@@ -131,15 +135,14 @@ class RealAdBlockingStatusChecker @Inject constructor(
         combine(
             settingsRepository.isEnabledFlow(),
             feature.enabledByDefault().enabled(),
-        ) { userSetting, enabledByDefault ->
-            when (userSetting) {
-                true -> AdBlockingState.Enabled.UserEnabled
-                false -> AdBlockingState.Disabled
-                null -> if (enabledByDefault) {
-                    AdBlockingState.Enabled.Default
-                } else {
-                    AdBlockingState.Disabled
-                }
+            sessionStore.observe(),
+        ) { userSetting, enabledByDefault, disabledUntilRelaunch ->
+            when {
+                disabledUntilRelaunch -> AdBlockingState.Disabled.UntilRelaunch
+                userSetting == true -> AdBlockingState.Enabled.UserEnabled
+                userSetting == false -> AdBlockingState.Disabled.Permanent
+                enabledByDefault -> AdBlockingState.Enabled.Default
+                else -> AdBlockingState.Disabled.Permanent
             }
         }
 

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingChoice.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingChoice.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.menu
+
+/**
+ * The three mutually-exclusive options offered by the YouTube ad-blocking child sheet.
+ */
+enum class AdBlockingChoice { ALWAYS_ON, DISABLE_UNTIL_RELAUNCH, ALWAYS_OFF }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuBottomSheetDialog.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuBottomSheetDialog.kt
@@ -18,12 +18,19 @@ package com.duckduckgo.adblocking.impl.menu
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.graphics.Color
 import android.view.LayoutInflater
+import androidx.core.graphics.drawable.toDrawable
+import com.duckduckgo.adblocking.impl.R
 import com.duckduckgo.adblocking.impl.databinding.BottomSheetAdBlockingMenuBinding
+import com.duckduckgo.common.ui.view.listitem.OneLineListItem
 import com.google.android.material.bottomsheet.BottomSheetDialog
 
 @SuppressLint("NoBottomSheetDialog")
-class AdBlockingMenuBottomSheetDialog(builderContext: Context) : BottomSheetDialog(builderContext) {
+class AdBlockingMenuBottomSheetDialog(
+    builderContext: Context,
+    private val selectedChoice: AdBlockingChoice,
+) : BottomSheetDialog(builderContext) {
 
     interface EventListener {
         fun onChoiceSelected(choice: AdBlockingChoice)
@@ -37,6 +44,10 @@ class AdBlockingMenuBottomSheetDialog(builderContext: Context) : BottomSheetDial
     init {
         setContentView(binding.root)
 
+        binding.adBlockingMenuAlwaysOn.setChecked(selectedChoice == AdBlockingChoice.ALWAYS_ON)
+        binding.adBlockingMenuDisableUntilRelaunch.setChecked(selectedChoice == AdBlockingChoice.DISABLE_UNTIL_RELAUNCH)
+        binding.adBlockingMenuAlwaysOff.setChecked(selectedChoice == AdBlockingChoice.ALWAYS_OFF)
+
         binding.adBlockingMenuCloseButton.setOnClickListener { dismiss() }
         binding.adBlockingMenuAlwaysOn.setOnClickListener { onChoiceSelected(AdBlockingChoice.ALWAYS_ON) }
         binding.adBlockingMenuDisableUntilRelaunch.setOnClickListener {
@@ -45,8 +56,16 @@ class AdBlockingMenuBottomSheetDialog(builderContext: Context) : BottomSheetDial
         binding.adBlockingMenuAlwaysOff.setOnClickListener { onChoiceSelected(AdBlockingChoice.ALWAYS_OFF) }
     }
 
-    private fun onChoiceSelected(choice: AdBlockingChoice) {
-        eventListener?.onChoiceSelected(choice)
+    private fun onChoiceSelected(selected: AdBlockingChoice) {
+        eventListener?.onChoiceSelected(selected)
         dismiss()
+    }
+
+    private fun OneLineListItem.setChecked(checked: Boolean) {
+        if (checked) {
+            setLeadingIconResource(R.drawable.check)
+        } else {
+            setLeadingIconDrawable(Color.TRANSPARENT.toDrawable())
+        }
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuBottomSheetDialog.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuBottomSheetDialog.kt
@@ -23,14 +23,26 @@ import android.view.LayoutInflater
 import androidx.core.graphics.drawable.toDrawable
 import com.duckduckgo.adblocking.impl.R
 import com.duckduckgo.adblocking.impl.databinding.BottomSheetAdBlockingMenuBinding
+import com.duckduckgo.common.ui.applyBottomSystemBarInsetPadding
 import com.duckduckgo.common.ui.view.listitem.OneLineListItem
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.duckduckgo.mobile.android.R as CommonR
 
 @SuppressLint("NoBottomSheetDialog")
 class AdBlockingMenuBottomSheetDialog(
     builderContext: Context,
     private val selectedChoice: AdBlockingChoice,
-) : BottomSheetDialog(builderContext) {
+    private val edgeToEdgeProvider: EdgeToEdgeProvider,
+) : BottomSheetDialog(
+    builderContext,
+    if (edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BOTTOM_SHEETS)) {
+        CommonR.style.Widget_DuckDuckGo_BottomSheetDialog_EdgeToEdge
+    } else {
+        0
+    },
+) {
 
     interface EventListener {
         fun onChoiceSelected(choice: AdBlockingChoice)
@@ -43,6 +55,10 @@ class AdBlockingMenuBottomSheetDialog(
 
     init {
         setContentView(binding.root)
+
+        if (edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BOTTOM_SHEETS)) {
+            binding.root.applyBottomSystemBarInsetPadding()
+        }
 
         binding.adBlockingMenuAlwaysOn.setChecked(selectedChoice == AdBlockingChoice.ALWAYS_ON)
         binding.adBlockingMenuDisableUntilRelaunch.setChecked(selectedChoice == AdBlockingChoice.DISABLE_UNTIL_RELAUNCH)

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuBottomSheetDialog.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuBottomSheetDialog.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.menu
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.view.LayoutInflater
+import com.duckduckgo.adblocking.impl.databinding.BottomSheetAdBlockingMenuBinding
+import com.google.android.material.bottomsheet.BottomSheetDialog
+
+@SuppressLint("NoBottomSheetDialog")
+class AdBlockingMenuBottomSheetDialog(builderContext: Context) : BottomSheetDialog(builderContext) {
+
+    interface EventListener {
+        fun onAlwaysOnClicked()
+        fun onDisableUntilRelaunchClicked()
+        fun onAlwaysOffClicked()
+    }
+
+    var eventListener: EventListener? = null
+
+    private val binding: BottomSheetAdBlockingMenuBinding =
+        BottomSheetAdBlockingMenuBinding.inflate(LayoutInflater.from(context))
+
+    init {
+        setContentView(binding.root)
+
+        binding.adBlockingMenuCloseButton.setOnClickListener { dismiss() }
+        binding.adBlockingMenuAlwaysOn.setOnClickListener {
+            eventListener?.onAlwaysOnClicked()
+            dismiss()
+        }
+        binding.adBlockingMenuDisableUntilRelaunch.setOnClickListener {
+            eventListener?.onDisableUntilRelaunchClicked()
+            dismiss()
+        }
+        binding.adBlockingMenuAlwaysOff.setOnClickListener {
+            eventListener?.onAlwaysOffClicked()
+            dismiss()
+        }
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuBottomSheetDialog.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuBottomSheetDialog.kt
@@ -26,9 +26,7 @@ import com.google.android.material.bottomsheet.BottomSheetDialog
 class AdBlockingMenuBottomSheetDialog(builderContext: Context) : BottomSheetDialog(builderContext) {
 
     interface EventListener {
-        fun onAlwaysOnClicked()
-        fun onDisableUntilRelaunchClicked()
-        fun onAlwaysOffClicked()
+        fun onChoiceSelected(choice: AdBlockingChoice)
     }
 
     var eventListener: EventListener? = null
@@ -40,17 +38,15 @@ class AdBlockingMenuBottomSheetDialog(builderContext: Context) : BottomSheetDial
         setContentView(binding.root)
 
         binding.adBlockingMenuCloseButton.setOnClickListener { dismiss() }
-        binding.adBlockingMenuAlwaysOn.setOnClickListener {
-            eventListener?.onAlwaysOnClicked()
-            dismiss()
-        }
+        binding.adBlockingMenuAlwaysOn.setOnClickListener { onChoiceSelected(AdBlockingChoice.ALWAYS_ON) }
         binding.adBlockingMenuDisableUntilRelaunch.setOnClickListener {
-            eventListener?.onDisableUntilRelaunchClicked()
-            dismiss()
+            onChoiceSelected(AdBlockingChoice.DISABLE_UNTIL_RELAUNCH)
         }
-        binding.adBlockingMenuAlwaysOff.setOnClickListener {
-            eventListener?.onAlwaysOffClicked()
-            dismiss()
-        }
+        binding.adBlockingMenuAlwaysOff.setOnClickListener { onChoiceSelected(AdBlockingChoice.ALWAYS_OFF) }
+    }
+
+    private fun onChoiceSelected(choice: AdBlockingChoice) {
+        eventListener?.onChoiceSelected(choice)
+        dismiss()
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuController.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuController.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.menu
+
+import com.duckduckgo.adblocking.impl.AdBlockingSettingsRepository
+import com.duckduckgo.adblocking.impl.domain.AdBlockingState
+import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
+import com.duckduckgo.adblocking.impl.store.AdBlockingSessionStore
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+interface AdBlockingMenuController {
+
+    /**
+     * The option currently in effect, used to place the checkmark on the matching sheet row.
+     */
+    fun currentChoice(): AdBlockingChoice
+
+    /**
+     * Applies the user's selection to the persisted setting and/or the session override.
+     */
+    fun onChoiceSelected(choice: AdBlockingChoice)
+
+    /**
+     * Enables ad blocking directly, without showing the choice sheet.
+     */
+    fun enable()
+}
+
+@ContributesBinding(AppScope::class)
+class RealAdBlockingMenuController @Inject constructor(
+    private val settingsRepository: AdBlockingSettingsRepository,
+    private val sessionStore: AdBlockingSessionStore,
+    private val statusChecker: AdBlockingStatusChecker,
+    @AppCoroutineScope private val appScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
+) : AdBlockingMenuController {
+
+    override fun currentChoice(): AdBlockingChoice = when (statusChecker.currentState()) {
+        is AdBlockingState.Enabled -> AdBlockingChoice.ALWAYS_ON
+        AdBlockingState.Disabled.UntilRelaunch -> AdBlockingChoice.DISABLE_UNTIL_RELAUNCH
+        else -> AdBlockingChoice.ALWAYS_OFF
+    }
+
+    override fun onChoiceSelected(choice: AdBlockingChoice) {
+        appScope.launch(dispatcherProvider.io()) {
+            when (choice) {
+                AdBlockingChoice.ALWAYS_ON -> {
+                    settingsRepository.setEnabled(true)
+                    sessionStore.clear()
+                }
+                AdBlockingChoice.DISABLE_UNTIL_RELAUNCH -> sessionStore.setDisabledUntilRelaunch()
+                AdBlockingChoice.ALWAYS_OFF -> {
+                    settingsRepository.setEnabled(false)
+                    sessionStore.clear()
+                }
+            }
+        }
+    }
+
+    override fun enable() = onChoiceSelected(AdBlockingChoice.ALWAYS_ON)
+}

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuItemView.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuItemView.kt
@@ -36,7 +36,6 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import logcat.logcat
 import javax.inject.Inject
 
 @InjectWith(ViewScope::class)
@@ -48,6 +47,9 @@ class AdBlockingMenuItemView @JvmOverloads constructor(
 
     @Inject
     lateinit var menuStateProvider: AdBlockingMenuStateProvider
+
+    @Inject
+    lateinit var menuController: AdBlockingMenuController
 
     @Inject
     lateinit var dispatcherProvider: DispatcherProvider
@@ -62,9 +64,11 @@ class AdBlockingMenuItemView @JvmOverloads constructor(
     private var url: Uri? = null
     private var onHostClick: (() -> Unit)? = null
     private var scope: CoroutineScope? = null
+    private var menuState: AdBlockingMenuState = AdBlockingMenuState.Hidden
 
     init {
         orientation = VERTICAL
+        isGone = true
         addView(menuItem)
     }
 
@@ -79,7 +83,10 @@ class AdBlockingMenuItemView @JvmOverloads constructor(
 
         val url = this.url ?: return
         menuItem.setOnClickListener {
-            showMenuBottomSheet()
+            when (menuState) {
+                AdBlockingMenuState.Disabled -> menuController.enable()
+                else -> showMenuBottomSheet()
+            }
             onHostClick?.invoke()
         }
 
@@ -99,16 +106,17 @@ class AdBlockingMenuItemView @JvmOverloads constructor(
     }
 
     private fun showMenuBottomSheet() {
-        AdBlockingMenuBottomSheetDialog(context).apply {
+        AdBlockingMenuBottomSheetDialog(context, menuController.currentChoice()).apply {
             eventListener = object : AdBlockingMenuBottomSheetDialog.EventListener {
                 override fun onChoiceSelected(choice: AdBlockingChoice) {
-                    logcat { "AdBlocking menu choice selected: $choice" }
+                    menuController.onChoiceSelected(choice)
                 }
             }
         }.show()
     }
 
     private fun render(state: AdBlockingMenuState) {
+        this.menuState = state
         when (state) {
             AdBlockingMenuState.Hidden -> isGone = true
             AdBlockingMenuState.Enabled -> {

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuItemView.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuItemView.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import logcat.logcat
 import javax.inject.Inject
 
 @InjectWith(ViewScope::class)
@@ -77,7 +78,10 @@ class AdBlockingMenuItemView @JvmOverloads constructor(
         super.onAttachedToWindow()
 
         val url = this.url ?: return
-        menuItem.setOnClickListener { onHostClick?.invoke() }
+        menuItem.setOnClickListener {
+            showMenuBottomSheet()
+            onHostClick?.invoke()
+        }
 
         scope?.cancel()
         scope = CoroutineScope(SupervisorJob() + dispatcherProvider.main()).also { scope ->
@@ -92,6 +96,24 @@ class AdBlockingMenuItemView @JvmOverloads constructor(
         scope?.cancel()
         scope = null
         super.onDetachedFromWindow()
+    }
+
+    private fun showMenuBottomSheet() {
+        AdBlockingMenuBottomSheetDialog(context).apply {
+            eventListener = object : AdBlockingMenuBottomSheetDialog.EventListener {
+                override fun onAlwaysOnClicked() {
+                    logcat { "AdBlocking menu: Always On" }
+                }
+
+                override fun onDisableUntilRelaunchClicked() {
+                    logcat { "AdBlocking menu: Disable Until Relaunch" }
+                }
+
+                override fun onAlwaysOffClicked() {
+                    logcat { "AdBlocking menu: Always Off" }
+                }
+            }
+        }.show()
     }
 
     private fun render(state: AdBlockingMenuState) {

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuItemView.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuItemView.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.view.MenuItemView
 import com.duckduckgo.common.ui.view.MenuItemViewSize
 import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ViewScope
 import dagger.android.support.AndroidSupportInjection
 import kotlinx.coroutines.CoroutineScope
@@ -53,6 +54,9 @@ class AdBlockingMenuItemView @JvmOverloads constructor(
 
     @Inject
     lateinit var dispatcherProvider: DispatcherProvider
+
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
 
     private val menuItem: MenuItemView by lazy {
         MenuItemView(context).apply {
@@ -106,7 +110,7 @@ class AdBlockingMenuItemView @JvmOverloads constructor(
     }
 
     private fun showMenuBottomSheet() {
-        AdBlockingMenuBottomSheetDialog(context, menuController.currentChoice()).apply {
+        AdBlockingMenuBottomSheetDialog(context, menuController.currentChoice(), edgeToEdgeProvider).apply {
             eventListener = object : AdBlockingMenuBottomSheetDialog.EventListener {
                 override fun onChoiceSelected(choice: AdBlockingChoice) {
                     menuController.onChoiceSelected(choice)

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuItemView.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuItemView.kt
@@ -101,16 +101,8 @@ class AdBlockingMenuItemView @JvmOverloads constructor(
     private fun showMenuBottomSheet() {
         AdBlockingMenuBottomSheetDialog(context).apply {
             eventListener = object : AdBlockingMenuBottomSheetDialog.EventListener {
-                override fun onAlwaysOnClicked() {
-                    logcat { "AdBlocking menu: Always On" }
-                }
-
-                override fun onDisableUntilRelaunchClicked() {
-                    logcat { "AdBlocking menu: Disable Until Relaunch" }
-                }
-
-                override fun onAlwaysOffClicked() {
-                    logcat { "AdBlocking menu: Always Off" }
+                override fun onChoiceSelected(choice: AdBlockingChoice) {
+                    logcat { "AdBlocking menu choice selected: $choice" }
                 }
             }
         }.show()

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/store/AdBlockingSessionStore.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/store/AdBlockingSessionStore.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.store
+
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+/**
+ * In-memory store for the "Disable Until Relaunch" ad-blocking override. It is deliberately not
+ * persisted, so it resets on process death — the disable therefore lasts only for the current app
+ * session ("until relaunch").
+ */
+interface AdBlockingSessionStore {
+    fun isDisabledUntilRelaunch(): Boolean
+    fun observe(): Flow<Boolean>
+    fun setDisabledUntilRelaunch()
+    fun clear()
+}
+
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealAdBlockingSessionStore @Inject constructor() : AdBlockingSessionStore {
+
+    private val disabled = MutableStateFlow(false)
+
+    override fun isDisabledUntilRelaunch(): Boolean = disabled.value
+
+    override fun observe(): Flow<Boolean> = disabled.asStateFlow()
+
+    override fun setDisabledUntilRelaunch() {
+        this.disabled.value = true
+    }
+
+    override fun clear() {
+        disabled.value = false
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsV2Activity.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsV2Activity.kt
@@ -18,7 +18,9 @@ package com.duckduckgo.adblocking.impl.ui
 
 import android.os.Bundle
 import android.view.View
+import android.widget.CompoundButton
 import androidx.appcompat.widget.Toolbar
+import androidx.core.view.isVisible
 import com.duckduckgo.adblocking.api.duckplayer.PrivatePlayerMode.Disabled
 import com.duckduckgo.adblocking.api.duckplayer.PrivatePlayerMode.Enabled
 import com.duckduckgo.adblocking.impl.R
@@ -51,6 +53,10 @@ class AdBlockingSettingsV2Activity : BaseAdBlockingSettingsActivity() {
     override val appBarLayout: View get() = binding.includeToolbar.appBarLayout
     override val contentScrollView: View get() = binding.contentScrollView
 
+    private val untilRelaunchToggleListener = CompoundButton.OnCheckedChangeListener { _, isChecked ->
+        viewModel.onBlockAdsToggled(isChecked)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         maybeEnableEdgeToEdge()
@@ -62,6 +68,11 @@ class AdBlockingSettingsV2Activity : BaseAdBlockingSettingsActivity() {
     override fun render(state: AdBlockingSettingsViewModel.ViewState) {
         super.render(state)
         binding.adBlockingStatusIndicator.setStatus(state.isStatusIndicatorOn)
+        binding.blockAdsToggle.isVisible = !state.disabledUntilRelaunch && !state.isContingencyMode
+        binding.blockAdsToggleUntilRelaunch.isVisible = state.disabledUntilRelaunch && !state.isContingencyMode
+        if (state.disabledUntilRelaunch) {
+            binding.blockAdsToggleUntilRelaunch.quietlySetIsChecked(state.isEnabled, untilRelaunchToggleListener)
+        }
         binding.duckPlayerEntry.setSecondaryText(
             when (state.duckPlayerMode) {
                 Enabled -> getString(R.string.duck_player_mode_always)
@@ -70,12 +81,10 @@ class AdBlockingSettingsV2Activity : BaseAdBlockingSettingsActivity() {
             },
         )
         if (state.isContingencyMode) {
-            binding.blockAdsToggle.gone()
             binding.adBlockingDescription.gone()
             binding.contingencyModeItem.show()
         } else {
             binding.contingencyModeItem.gone()
-            binding.blockAdsToggle.show()
         }
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsViewModel.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsViewModel.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.adblocking.impl.AdBlockingSettingsRepository
 import com.duckduckgo.adblocking.impl.domain.AdBlockingState
 import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
 import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
+import com.duckduckgo.adblocking.impl.store.AdBlockingSessionStore
 import com.duckduckgo.adblocking.impl.ui.AdBlockingSettingsViewModel.Command.OpenDuckPlayerSettings
 import com.duckduckgo.adblocking.impl.ui.AdBlockingSettingsViewModel.Command.OpenLearnMore
 import com.duckduckgo.anvil.annotations.ContributesViewModel
@@ -52,6 +53,7 @@ class AdBlockingSettingsViewModel @Inject constructor(
     statusChecker: AdBlockingStatusChecker,
     feature: AdBlockingExtensionFeature,
     private val repository: AdBlockingSettingsRepository,
+    private val sessionStore: AdBlockingSessionStore,
     private val pixel: Pixel,
     duckPlayer: DuckPlayer,
 ) : ViewModel() {
@@ -63,6 +65,7 @@ class AdBlockingSettingsViewModel @Inject constructor(
 
     data class ViewState(
         val isEnabled: Boolean = false,
+        val disabledUntilRelaunch: Boolean = false,
         val showConsentDescription: Boolean? = null,
         val duckPlayerMode: PrivatePlayerMode = AlwaysAsk,
         val isContingencyMode: Boolean = false,
@@ -83,7 +86,8 @@ class AdBlockingSettingsViewModel @Inject constructor(
         val isEnabled = state is AdBlockingState.Enabled
         val isContingencyMode = uxImprovements && contingencyModeOn
         ViewState(
-            isEnabled = isEnabled,
+            isEnabled = state is AdBlockingState.Enabled,
+            disabledUntilRelaunch = state is AdBlockingState.Disabled.UntilRelaunch,
             showConsentDescription = state !is AdBlockingState.Enabled.Default,
             isContingencyMode = isContingencyMode,
             isStatusIndicatorOn = isEnabled && !isContingencyMode,
@@ -103,6 +107,7 @@ class AdBlockingSettingsViewModel @Inject constructor(
     fun onBlockAdsToggled(enabled: Boolean) {
         viewModelScope.launch {
             repository.setEnabled(enabled)
+            sessionStore.clear()
             if (enabled) {
                 pixel.fire(AD_BLOCKING_ENABLED_DAILY, type = Pixel.PixelType.Daily())
                 pixel.fire(AD_BLOCKING_ENABLED_COUNT)

--- a/ad-blocking/ad-blocking-impl/src/main/res/drawable/check.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/drawable/check.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!--
+<!--
   ~ Copyright (c) 2026 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,13 +13,12 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-
-<resources>
-    <string name="ad_blocking_menu_disable">Disable YouTube Ad Blocking</string>
-    <string name="ad_blocking_menu_enable">Enable YouTube Ad Blocking</string>
-    <string name="ad_blocking_menu_title">YouTube Ad Blocking</string>
-    <string name="ad_blocking_menu_close_content_description">Close</string>
-    <string name="ad_blocking_menu_always_on">Always On</string>
-    <string name="ad_blocking_menu_disable_until_relaunch">Disable Until Relaunch</string>
-    <string name="ad_blocking_menu_always_off">Always Off</string>
-</resources>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M20.773,6.712C21.07,7.001 21.076,7.476 20.788,7.773L11.673,17.142C10.642,18.201 8.941,18.201 7.91,17.142L3.212,12.313C2.924,12.016 2.93,11.542 3.227,11.253C3.524,10.964 3.999,10.97 4.288,11.267L8.985,16.096C9.427,16.55 10.156,16.55 10.598,16.096L19.712,6.727C20.001,6.43 20.476,6.424 20.773,6.712Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"/>
+</vector>

--- a/ad-blocking/ad-blocking-impl/src/main/res/layout/activity_ad_blocking_settings_v2.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/layout/activity_ad_blocking_settings_v2.xml
@@ -87,6 +87,17 @@
                 app:primaryText="@string/ad_blocking_settings_toggle_title"
                 app:showSwitch="true" />
 
+            <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+                android:id="@+id/blockAdsToggleUntilRelaunch"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/keyline_1"
+                android:visibility="gone"
+                app:primaryText="@string/ad_blocking_settings_toggle_title"
+                app:secondaryText="@string/ad_blocking_settings_disabled_until_relaunch"
+                app:showSwitch="true"
+                tools:visibility="visible" />
+
             <com.duckduckgo.common.ui.view.text.DaxTextView
                 android:id="@+id/adBlockingDescription"
                 android:layout_width="match_parent"

--- a/ad-blocking/ad-blocking-impl/src/main/res/layout/bottom_sheet_ad_blocking_menu.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/layout/bottom_sheet_ad_blocking_menu.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingTop="@dimen/keyline_4"
+    android:paddingBottom="@dimen/keyline_4">
+
+    <com.duckduckgo.common.ui.view.text.DaxTextView
+        android:id="@+id/adBlockingMenuTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/keyline_5"
+        android:layout_marginTop="@dimen/bottomSheetTitleVerticalPadding"
+        android:text="@string/ad_blocking_menu_title"
+        app:layout_constraintEnd_toStartOf="@id/adBlockingMenuCloseButton"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:typography="h2" />
+
+    <ImageButton
+        android:id="@+id/adBlockingMenuCloseButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/keyline_4"
+        android:background="?attr/actionBarItemBackground"
+        android:contentDescription="@string/ad_blocking_menu_close_content_description"
+        android:src="@drawable/ic_close_24"
+        app:layout_constraintBottom_toBottomOf="@id/adBlockingMenuTitle"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/adBlockingMenuTitle" />
+
+    <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+        android:id="@+id/adBlockingMenuDivider"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/keyline_5"
+        app:defaultPadding="false"
+        app:layout_constraintTop_toBottomOf="@id/adBlockingMenuTitle" />
+
+    <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+        android:id="@+id/adBlockingMenuAlwaysOn"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/adBlockingMenuDivider"
+        app:leadingIcon="@drawable/check"
+        app:primaryText="@string/ad_blocking_menu_always_on" />
+
+    <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+        android:id="@+id/adBlockingMenuDisableUntilRelaunch"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/adBlockingMenuAlwaysOn"
+        app:leadingIcon="@drawable/check"
+        app:primaryText="@string/ad_blocking_menu_disable_until_relaunch" />
+
+    <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+        android:id="@+id/adBlockingMenuAlwaysOff"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/adBlockingMenuDisableUntilRelaunch"
+        app:leadingIcon="@drawable/check"
+        app:primaryText="@string/ad_blocking_menu_always_off" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values/donottranslate.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values/donottranslate.xml
@@ -22,4 +22,5 @@
     <string name="ad_blocking_menu_always_on">Always On</string>
     <string name="ad_blocking_menu_disable_until_relaunch">Disable Until Relaunch</string>
     <string name="ad_blocking_menu_always_off">Always Off</string>
+    <string name="ad_blocking_settings_disabled_until_relaunch">Disabled until relaunch</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingRefreshTriggerPluginTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingRefreshTriggerPluginTest.kt
@@ -46,7 +46,7 @@ class AdBlockingRefreshTriggerPluginTest {
     @Test
     fun whenStateChangesThenEmits() = runTest {
         plugin.observeRefreshRequests().test {
-            stateFlow.value = AdBlockingState.Disabled
+            stateFlow.value = AdBlockingState.Disabled.Permanent
 
             awaitItem()
             cancelAndConsumeRemainingEvents()
@@ -56,7 +56,7 @@ class AdBlockingRefreshTriggerPluginTest {
     @Test
     fun whenStateChangesMultipleTimesThenEmitsForEachChange() = runTest {
         plugin.observeRefreshRequests().test {
-            stateFlow.value = AdBlockingState.Disabled
+            stateFlow.value = AdBlockingState.Disabled.UntilRelaunch
             awaitItem()
 
             stateFlow.value = AdBlockingState.Enabled.UserEnabled

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/domain/RealAdBlockingMenuStateProviderTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/domain/RealAdBlockingMenuStateProviderTest.kt
@@ -104,7 +104,14 @@ class RealAdBlockingMenuStateProviderTest {
 
     @Test
     fun whenYoutubeAndDisabledThenDisabled() = runTest {
-        stateFlow.value = AdBlockingState.Disabled
+        stateFlow.value = AdBlockingState.Disabled.Permanent
+
+        assertEquals(AdBlockingMenuState.Disabled, provider.observe(youtubeUrl).first())
+    }
+
+    @Test
+    fun whenYoutubeAndDisabledUntilRelaunchThenDisabled() = runTest {
+        stateFlow.value = AdBlockingState.Disabled.UntilRelaunch
 
         assertEquals(AdBlockingMenuState.Disabled, provider.observe(youtubeUrl).first())
     }

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/domain/RealAdBlockingStatusCheckerTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/domain/RealAdBlockingStatusCheckerTest.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.adblocking.impl.domain
 
 import com.duckduckgo.adblocking.impl.AdBlockingSettingsRepository
 import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
+import com.duckduckgo.adblocking.impl.store.RealAdBlockingSessionStore
 import com.duckduckgo.feature.toggles.api.Toggle
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -78,10 +79,11 @@ class RealAdBlockingStatusCheckerTest {
             userEnabledFlow.value = enabled
         }
     }
+    private val sessionStore = RealAdBlockingSessionStore()
     private val testScope = CoroutineScope(UnconfinedTestDispatcher())
 
     private val checker by lazy {
-        RealAdBlockingStatusChecker(feature, settingsRepository, testScope)
+        RealAdBlockingStatusChecker(feature, settingsRepository, sessionStore, testScope)
     }
 
     @After
@@ -187,7 +189,7 @@ class RealAdBlockingStatusCheckerTest {
         userEnabledFlow.value = false
         enabledByDefaultFlow.value = true
 
-        assertEquals(AdBlockingState.Disabled, checker.currentState())
+        assertEquals(AdBlockingState.Disabled.Permanent, checker.currentState())
     }
 
     @Test
@@ -202,7 +204,7 @@ class RealAdBlockingStatusCheckerTest {
     fun whenUserHasNoPreferenceAndDefaultChangesThenCurrentStateReflectsIt() {
         userEnabledFlow.value = null
         enabledByDefaultFlow.value = false
-        assertEquals(AdBlockingState.Disabled, checker.currentState())
+        assertEquals(AdBlockingState.Disabled.Permanent, checker.currentState())
 
         enabledByDefaultFlow.value = true
         assertEquals(AdBlockingState.Enabled.Default, checker.currentState())
@@ -264,7 +266,7 @@ class RealAdBlockingStatusCheckerTest {
     fun whenUserHasDisabledThenObserveStateEmitsDisabled() = runTest {
         userEnabledFlow.value = false
 
-        assertEquals(AdBlockingState.Disabled, checker.observeState().first())
+        assertEquals(AdBlockingState.Disabled.Permanent, checker.observeState().first())
     }
 
     @Test
@@ -272,7 +274,7 @@ class RealAdBlockingStatusCheckerTest {
         userEnabledFlow.value = false
         enabledByDefaultFlow.value = true
 
-        assertEquals(AdBlockingState.Disabled, checker.observeState().first())
+        assertEquals(AdBlockingState.Disabled.Permanent, checker.observeState().first())
     }
 
     @Test
@@ -288,14 +290,14 @@ class RealAdBlockingStatusCheckerTest {
         userEnabledFlow.value = null
         enabledByDefaultFlow.value = false
 
-        assertEquals(AdBlockingState.Disabled, checker.observeState().first())
+        assertEquals(AdBlockingState.Disabled.Permanent, checker.observeState().first())
     }
 
     @Test
     fun whenNotSetAndDefaultFlowChangesThenObserveStateReflectsIt() = runTest {
         userEnabledFlow.value = null
         enabledByDefaultFlow.value = false
-        assertEquals(AdBlockingState.Disabled, checker.observeState().first())
+        assertEquals(AdBlockingState.Disabled.Permanent, checker.observeState().first())
 
         enabledByDefaultFlow.value = true
         assertEquals(AdBlockingState.Enabled.Default, checker.observeState().first())
@@ -312,7 +314,7 @@ class RealAdBlockingStatusCheckerTest {
     fun whenUserHasDisabledThenCurrentStateIsDisabled() {
         userEnabledFlow.value = false
 
-        assertEquals(AdBlockingState.Disabled, checker.currentState())
+        assertEquals(AdBlockingState.Disabled.Permanent, checker.currentState())
     }
 
     @Test
@@ -329,7 +331,7 @@ class RealAdBlockingStatusCheckerTest {
         assertEquals(AdBlockingState.Enabled.UserEnabled, checker.currentState())
 
         userEnabledFlow.value = false
-        assertEquals(AdBlockingState.Disabled, checker.currentState())
+        assertEquals(AdBlockingState.Disabled.Permanent, checker.currentState())
     }
 
     @Test
@@ -339,8 +341,52 @@ class RealAdBlockingStatusCheckerTest {
             override suspend fun setEnabled(enabled: Boolean) = Unit
         }
 
-        val checker = RealAdBlockingStatusChecker(feature, pendingRepository, testScope)
+        val checker = RealAdBlockingStatusChecker(feature, pendingRepository, sessionStore, testScope)
 
         assertEquals(AdBlockingState.Uninitialized, checker.currentState())
+    }
+
+    @Test
+    fun whenSessionDisabledThenCannotInjectEvenIfPersistedEnabled() {
+        userEnabledFlow.value = true
+        sessionStore.setDisabledUntilRelaunch()
+
+        assertFalse(checker.canInject())
+    }
+
+    @Test
+    fun whenSessionDisabledThenClearedThenCanInjectAgain() {
+        userEnabledFlow.value = true
+        sessionStore.setDisabledUntilRelaunch()
+        assertFalse(checker.canInject())
+
+        sessionStore.clear()
+        assertTrue(checker.canInject())
+    }
+
+    @Test
+    fun whenSessionDisabledThenObserveCanInjectEmitsFalse() = runTest {
+        userEnabledFlow.value = true
+        sessionStore.setDisabledUntilRelaunch()
+
+        assertFalse(checker.observeCanInject().first())
+    }
+
+    @Test
+    fun whenSessionDisabledThenObserveStateEmitsUntilRelaunchEvenIfPersistedEnabled() = runTest {
+        userEnabledFlow.value = true
+        sessionStore.setDisabledUntilRelaunch()
+
+        assertEquals(AdBlockingState.Disabled.UntilRelaunch, checker.observeState().first())
+    }
+
+    @Test
+    fun whenSessionClearedThenObserveStateReflectsPersistedAgain() = runTest {
+        userEnabledFlow.value = true
+        sessionStore.setDisabledUntilRelaunch()
+        assertEquals(AdBlockingState.Disabled.UntilRelaunch, checker.observeState().first())
+
+        sessionStore.clear()
+        assertEquals(AdBlockingState.Enabled.UserEnabled, checker.observeState().first())
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/menu/RealAdBlockingMenuControllerTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/menu/RealAdBlockingMenuControllerTest.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.menu
+
+import com.duckduckgo.adblocking.impl.AdBlockingSettingsRepository
+import com.duckduckgo.adblocking.impl.domain.AdBlockingState
+import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
+import com.duckduckgo.adblocking.impl.store.RealAdBlockingSessionStore
+import com.duckduckgo.common.test.CoroutineTestRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class RealAdBlockingMenuControllerTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val userEnabledFlow = MutableStateFlow<Boolean?>(true)
+    private val settingsRepository = object : AdBlockingSettingsRepository {
+        override fun isEnabledFlow(): Flow<Boolean?> = userEnabledFlow
+        override suspend fun setEnabled(enabled: Boolean) {
+            userEnabledFlow.value = enabled
+        }
+    }
+    private val sessionStore = RealAdBlockingSessionStore()
+    private val statusChecker: AdBlockingStatusChecker = mock {
+        on { currentState() } doReturn AdBlockingState.Enabled.UserEnabled
+    }
+
+    private val controller = RealAdBlockingMenuController(
+        settingsRepository,
+        sessionStore,
+        statusChecker,
+        coroutineRule.testScope,
+        coroutineRule.testDispatcherProvider,
+    )
+
+    @Test
+    fun whenStateIsUntilRelaunchThenChoiceIsDisableUntilRelaunch() {
+        whenever(statusChecker.currentState()).thenReturn(AdBlockingState.Disabled.UntilRelaunch)
+
+        assertEquals(AdBlockingChoice.DISABLE_UNTIL_RELAUNCH, controller.currentChoice())
+    }
+
+    @Test
+    fun whenStateIsUserEnabledThenChoiceIsAlwaysOn() {
+        whenever(statusChecker.currentState()).thenReturn(AdBlockingState.Enabled.UserEnabled)
+
+        assertEquals(AdBlockingChoice.ALWAYS_ON, controller.currentChoice())
+    }
+
+    @Test
+    fun whenStateIsEnabledByDefaultThenChoiceIsAlwaysOn() {
+        whenever(statusChecker.currentState()).thenReturn(AdBlockingState.Enabled.Default)
+
+        assertEquals(AdBlockingChoice.ALWAYS_ON, controller.currentChoice())
+    }
+
+    @Test
+    fun whenStateIsPermanentlyDisabledThenChoiceIsAlwaysOff() {
+        whenever(statusChecker.currentState()).thenReturn(AdBlockingState.Disabled.Permanent)
+
+        assertEquals(AdBlockingChoice.ALWAYS_OFF, controller.currentChoice())
+    }
+
+    @Test
+    fun whenAlwaysOnSelectedThenPersistsEnabledAndClearsSession() = runTest {
+        sessionStore.setDisabledUntilRelaunch()
+
+        controller.onChoiceSelected(AdBlockingChoice.ALWAYS_ON)
+
+        assertEquals(true, userEnabledFlow.value)
+        assertFalse(sessionStore.isDisabledUntilRelaunch())
+    }
+
+    @Test
+    fun whenDisableUntilRelaunchSelectedThenSetsSessionAndLeavesPersistedUntouched() = runTest {
+        userEnabledFlow.value = true
+
+        controller.onChoiceSelected(AdBlockingChoice.DISABLE_UNTIL_RELAUNCH)
+
+        assertTrue(sessionStore.isDisabledUntilRelaunch())
+        assertEquals(true, userEnabledFlow.value)
+    }
+
+    @Test
+    fun whenAlwaysOffSelectedThenPersistsDisabledAndClearsSession() = runTest {
+        sessionStore.setDisabledUntilRelaunch()
+
+        controller.onChoiceSelected(AdBlockingChoice.ALWAYS_OFF)
+
+        assertEquals(false, userEnabledFlow.value)
+        assertFalse(sessionStore.isDisabledUntilRelaunch())
+    }
+
+    @Test
+    fun whenEnableThenPersistsEnabledAndClearsSession() = runTest {
+        sessionStore.setDisabledUntilRelaunch()
+
+        controller.enable()
+
+        assertEquals(true, userEnabledFlow.value)
+        assertFalse(sessionStore.isDisabledUntilRelaunch())
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/pixels/AdBlockingStateReporterTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/pixels/AdBlockingStateReporterTest.kt
@@ -87,7 +87,7 @@ class AdBlockingStateReporterTest {
     @Test
     fun whenDisabledThenBothParamsFalse() {
         whenever(statusChecker.observeCanInject()).thenReturn(flowOf(false))
-        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled))
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled.Permanent))
 
         reporter.onResume(owner)
 

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/pixels/AdBlockingTelemetryPixelInterceptorTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/pixels/AdBlockingTelemetryPixelInterceptorTest.kt
@@ -63,7 +63,7 @@ class AdBlockingTelemetryPixelInterceptorTest {
 
     @Test
     fun whenDisabledAndPixelMatchesThenPixelIsDropped() {
-        whenever(statusChecker.currentState()).thenReturn(AdBlockingState.Disabled)
+        whenever(statusChecker.currentState()).thenReturn(AdBlockingState.Disabled.Permanent)
 
         val url = "$PIXEL_BASE/webTelemetry_youtubeInterference_day.buffering_android_phone"
         val response = interceptor.intercept(FakeChain(url))
@@ -85,7 +85,7 @@ class AdBlockingTelemetryPixelInterceptorTest {
 
     @Test
     fun whenNotConsentedAndPixelDoesNotMatchThenPixelProceeds() {
-        whenever(statusChecker.currentState()).thenReturn(AdBlockingState.Disabled)
+        whenever(statusChecker.currentState()).thenReturn(AdBlockingState.Disabled.Permanent)
 
         val url = "$PIXEL_BASE/m_unrelated_pixel_android_phone"
         val response = interceptor.intercept(FakeChain(url))

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/store/AdBlockingSessionStoreTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/store/AdBlockingSessionStoreTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.store
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AdBlockingSessionStoreTest {
+
+    private val store = RealAdBlockingSessionStore()
+
+    @Test
+    fun whenNewThenNotDisabled() {
+        assertFalse(store.isDisabledUntilRelaunch())
+    }
+
+    @Test
+    fun whenSetDisabledThenReportsDisabled() {
+        store.setDisabledUntilRelaunch()
+
+        assertTrue(store.isDisabledUntilRelaunch())
+    }
+
+    @Test
+    fun whenClearedThenResetsToNotDisabled() {
+        store.setDisabledUntilRelaunch()
+
+        store.clear()
+
+        assertFalse(store.isDisabledUntilRelaunch())
+    }
+
+    @Test
+    fun whenSetDisabledThenObserveEmitsTrue() = runTest {
+        store.setDisabledUntilRelaunch()
+
+        assertTrue(store.observe().first())
+    }
+
+    @Test
+    fun whenClearedThenObserveEmitsFalse() = runTest {
+        store.setDisabledUntilRelaunch()
+        store.clear()
+
+        assertFalse(store.observe().first())
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ui/AdBlockingProtectionsSettingsEntryViewModelTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ui/AdBlockingProtectionsSettingsEntryViewModelTest.kt
@@ -48,7 +48,7 @@ class AdBlockingProtectionsSettingsEntryViewModelTest {
     @Test
     fun whenPlacementIsProtectionsThenVisible() = runTest {
         whenever(statusChecker.settingsPlacementFlow()).thenReturn(flowOf(SettingsPlacement.Protections))
-        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled))
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled.Permanent))
 
         val viewModel = createViewModel()
         viewModel.onStart(lifecycleOwner)
@@ -61,7 +61,7 @@ class AdBlockingProtectionsSettingsEntryViewModelTest {
     @Test
     fun whenPlacementIsOtherThenNotVisible() = runTest {
         whenever(statusChecker.settingsPlacementFlow()).thenReturn(flowOf(SettingsPlacement.Other))
-        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled))
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled.Permanent))
 
         val viewModel = createViewModel()
         viewModel.onStart(lifecycleOwner)
@@ -74,7 +74,7 @@ class AdBlockingProtectionsSettingsEntryViewModelTest {
     @Test
     fun whenPlacementIsHiddenThenNotVisible() = runTest {
         whenever(statusChecker.settingsPlacementFlow()).thenReturn(flowOf(SettingsPlacement.Hidden))
-        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled))
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled.Permanent))
 
         val viewModel = createViewModel()
         viewModel.onStart(lifecycleOwner)
@@ -113,7 +113,7 @@ class AdBlockingProtectionsSettingsEntryViewModelTest {
     @Test
     fun whenStateIsDisabledThenStatusIsOff() = runTest {
         whenever(statusChecker.settingsPlacementFlow()).thenReturn(flowOf(SettingsPlacement.Protections))
-        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled))
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled.Permanent))
 
         val viewModel = createViewModel()
         viewModel.onStart(lifecycleOwner)

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsViewModelTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsViewModelTest.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.adblocking.impl.AdBlockingSettingsRepository
 import com.duckduckgo.adblocking.impl.domain.AdBlockingState
 import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
 import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
+import com.duckduckgo.adblocking.impl.store.RealAdBlockingSessionStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeToggleStore
@@ -60,12 +61,13 @@ class AdBlockingSettingsViewModelTest {
         .build()
         .create(AdBlockingExtensionFeature::class.java)
     private val repository: AdBlockingSettingsRepository = mock()
+    private val sessionStore = RealAdBlockingSessionStore()
     private val pixel: Pixel = mock()
     private val duckPlayer: DuckPlayer = mock()
 
     private fun createViewModel(duckPlayerMode: PrivatePlayerMode = AlwaysAsk): AdBlockingSettingsViewModel {
         whenever(duckPlayer.observeUserPreferences()).thenReturn(flowOf(userPreferences(duckPlayerMode)))
-        return AdBlockingSettingsViewModel(statusChecker, feature, repository, pixel, duckPlayer)
+        return AdBlockingSettingsViewModel(statusChecker, feature, repository, sessionStore, pixel, duckPlayer)
     }
 
     private fun setToggles(uxImprovements: Boolean, contingency: Boolean) {
@@ -100,12 +102,32 @@ class AdBlockingSettingsViewModelTest {
 
     @Test
     fun whenDisabledThenShowsConsentDescription() = runTest {
-        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled))
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled.Permanent))
 
         createViewModel().viewState.test {
             val state = expectMostRecentItem()
             assertFalse(state.isEnabled)
             assertEquals(true, state.showConsentDescription)
+        }
+    }
+
+    @Test
+    fun whenDisabledUntilRelaunchThenNotEnabledAndFlagSet() = runTest {
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled.UntilRelaunch))
+
+        createViewModel().viewState.test {
+            val state = expectMostRecentItem()
+            assertFalse(state.isEnabled)
+            assertTrue(state.disabledUntilRelaunch)
+        }
+    }
+
+    @Test
+    fun whenEnabledThenDisabledUntilRelaunchFlagNotSet() = runTest {
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Enabled.UserEnabled))
+
+        createViewModel().viewState.test {
+            assertFalse(expectMostRecentItem().disabledUntilRelaunch)
         }
     }
 
@@ -181,7 +203,7 @@ class AdBlockingSettingsViewModelTest {
 
     @Test
     fun whenDisabledThenStatusIndicatorOff() = runTest {
-        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled))
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled.Permanent))
         setToggles(uxImprovements = true, contingency = false)
 
         createViewModel().viewState.test {
@@ -191,7 +213,7 @@ class AdBlockingSettingsViewModelTest {
 
     @Test
     fun whenViewModelCreatedThenFiresSettingsOpenedPixels() = runTest {
-        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled))
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled.Permanent))
 
         createViewModel()
 
@@ -201,13 +223,23 @@ class AdBlockingSettingsViewModelTest {
 
     @Test
     fun whenBlockAdsToggledOnThenFiresEnabledPixels() = runTest {
-        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled))
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled.Permanent))
 
         createViewModel().onBlockAdsToggled(enabled = true)
 
         verify(repository).setEnabled(true)
         verify(pixel).fire(AdBlockingPixelNames.AD_BLOCKING_ENABLED_DAILY, type = Pixel.PixelType.Daily())
         verify(pixel).fire(AdBlockingPixelNames.AD_BLOCKING_ENABLED_COUNT)
+    }
+
+    @Test
+    fun whenBlockAdsToggledThenClearsSessionOverride() = runTest {
+        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled.UntilRelaunch))
+        sessionStore.setDisabledUntilRelaunch()
+
+        createViewModel().onBlockAdsToggled(enabled = true)
+
+        assertFalse(sessionStore.isDisabledUntilRelaunch())
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: 
Tech Design URL (if applicable): 

### Description
* Add view stub for ad blocking setting selection from browser menu entry
* Add logic to browser menu entry
  * If ad blocking enabled, clicking the item will show a bottom sheet, allowing users to change settings
      * Always On -> Unchanged
      * Disable until relaunch -> Disable but don't persist, next app start (after being killed) will re-enable the feature
      * Always off -> Equivalent to disabling in settings. A line below the toggle item in settings is added
  * If ad blocking disabled, clicking the item will enable ad blocking, no bottom sheet shown

### Steps to test this PR

_UX improvements RC flag disabled - no menu entry_
- [x] Fresh install
- [x] Open a YouTube video
- [x] Check no entry for YouTube ad blocking is shown


_adBlockingExtension RC flag disabled, UX improvements RC flag enabled - no menu entry_
- [x] Disable `adBlockingExtension` and enable `adBlockingUXImprovements`flags
- [x] Open a YouTube video
- [x] Check no entry for YouTube ad blocking is shown

_UX improvements RC flag enabled - menu entry on YT pages - test enable_
- [x] Enable `adBlockingExtension` and `adBlockingUXImprovements` RC flag
- [x] Open a YouTube video
- [x] Check "Enable YouTube Ad Blocking" is shown
- [x] Click it
- [x] Check no new bottom sheet appears
- [x] Check current page reloads
- [x] Check no logs for "Ad blocking disabled"
- [x] Open the menu again and check it now says "Disable YouTube Ad Blocking"
- [x] Open Ad Blocking settings
- [x] Check the toggle is enabled

_UX improvements RC flag enabled - menu entry on YT pages - test disable until relaunch_
- [x] From the previous scenario (RC flag enabled, ad blocking enabled), open a YouTube video
- [x] Click "Disable YouTube Ad Blocking"
- [x] Check a new bottom sheet appears with "Always On" selected
- [x] Click "Disable Until Relaunch"
- [x] Check current page reloads
- [x] Check logs for "Ad blocking disabled"
- [ ] Open the menu again and check "Disable until Relaunch" is selected
- [x] Open Ad Blocking settings
- [x] Check the toggle is disabled and "Disabled until relaunch" is displayed
- [x] Toggle the feature on and check that second line disappears
- [x] Toggle the feature off and check that second line still doesn't show
- [x] Toggle the feature on again
- [x] Select "Disable Until Relaunch" again from the browser menu
- [x] Close the app
- [x] Open it again and check ad blocking is now enabled

_UX improvements RC flag enabled - menu entry on YT pages - test disable_
- [x] From the previous test scenario (RC flags enabled, ad blocking enabled), open a YouTube video
- [x] Check logs for "Ad blocking disabled"
- [x] Check Enable YouTube Ad Blocking is shown
- [x] Click it
- [x] Check current page reloads
- [x] Check no logs for "Ad blocking disabled"
- [x] Open the menu again and check "Disable until Relaunch" is selected
- [x] Open Ad Blocking settings
- [x] Check the toggle is on

_UX improvements RC flag enabled - no menu entry on non-YT pages_
- [x] From the previous test scenario (RC flags enabled, ad blocking enabled), open wikipedia.org
- [x] Open browser menu
- [x] Check no entry is shown for ad blocking


### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when ad-blocking scripts inject and how user vs session preferences interact; mistakes could leave blocking on/off incorrectly until relaunch or persist the wrong setting.
> 
> **Overview**
> Adds a **“disable until relaunch”** path for YouTube ad blocking: an in-memory `AdBlockingSessionStore` overrides persisted settings for the current process, and `AdBlockingState` now distinguishes **permanent** vs **until-relaunch** disable. `AdBlockingStatusChecker` folds that session flag into `observeState()` / `observeCanInject()` so injection stops while the override is active.
> 
> The **browser menu** is wired end-to-end via `AdBlockingMenuController`: enabled state opens a bottom sheet with checkmarks for Always On / Disable Until Relaunch / Always Off; disabled state enables blocking in one tap without the sheet. Settings V2 shows a two-line toggle with **“Disabled until relaunch”** when that session override is active, and toggling from settings clears the session override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08fe59e866d30eb11915019340f25c4a8e2c4122. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

> [!NOTE]
> **Low Risk**
> UI-only scaffolding with no persistence or ad-blocking logic wired to choices yet; behavior change is limited to showing a sheet on menu tap.
> 
> **Overview**
> Tapping the YouTube ad-blocking browser menu item now opens a **child bottom sheet** with three choices—**Always On**, **Disable Until Relaunch**, and **Always Off**—instead of only forwarding the host click.
> 
> The sheet is implemented via `AdBlockingMenuBottomSheetDialog`, `AdBlockingChoice`, layout `bottom_sheet_ad_blocking_menu.xml`, and new copy/icons. Selection is surfaced through an `EventListener`; `AdBlockingMenuItemView` currently **logs the choice only** and does not yet apply settings or update blocking behavior (follow-up stack PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1674f476f960d224b718630887dfbf22a7959383. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->