### PR TITLE
submit onboarding input preview search query on IME action

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -29,6 +29,7 @@ import android.content.Intent
 import android.graphics.Typeface
 import android.graphics.drawable.AnimatedVectorDrawable
 import android.os.Bundle
+import android.text.InputType
 import android.util.TypedValue
 import android.view.ContextThemeWrapper
 import android.view.LayoutInflater
@@ -36,6 +37,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.animation.OvershootInterpolator
 import android.view.animation.PathInterpolator
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.Toast
@@ -2501,10 +2504,21 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
                 }
             }
 
-        previewContent.inputModeDemoActionIcon.setOnClickListener {
+        val submitQuery = {
             val query = previewContent.inputText.text?.toString().orEmpty().trim()
             if (query.isNotEmpty()) {
                 viewModel.onInputModeDemoQuerySubmitted(query, isChat = currentInputMode == InputMode.CHAT, fromSuggestion = false)
+            }
+        }
+
+        previewContent.inputModeDemoActionIcon.setOnClickListener { submitQuery() }
+
+        previewContent.inputText.setOnEditorActionListener { _, actionId, _ ->
+            if (actionId == EditorInfo.IME_ACTION_SEARCH) {
+                submitQuery()
+                true
+            } else {
+                false
             }
         }
 
@@ -2512,14 +2526,26 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
             InputMode.SEARCH -> {
                 previewContent.inputText.minLines = 1
                 previewContent.inputText.maxLines = 1
+                previewContent.inputText.inputType = InputType.TYPE_CLASS_TEXT
+                previewContent.inputText.imeOptions = EditorInfo.IME_ACTION_SEARCH
                 previewContent.inputText.setHint(R.string.preOnboardingInputModeDemoSearchHint)
                 previewContent.inputModeDemoActionIcon.setImageResource(CommonR.drawable.ic_find_search_24)
             }
             InputMode.CHAT -> {
                 previewContent.inputText.minLines = 3
                 previewContent.inputText.maxLines = 3
+                previewContent.inputText.inputType = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_MULTI_LINE
+                previewContent.inputText.imeOptions = EditorInfo.IME_ACTION_UNSPECIFIED
                 previewContent.inputText.setHint(R.string.preOnboardingInputModeDemoChatHint)
                 previewContent.inputModeDemoActionIcon.setImageResource(CommonR.drawable.ic_arrow_right_24)
+            }
+        }
+
+        // Toggling modes changes inputType/imeOptions while the EditText may be focused with the keyboard shown;
+        // restart input so the IME picks up the new action/Enter behavior immediately.
+        if (previewContent.inputText.hasFocus()) {
+            context?.let { ctx ->
+                ContextCompat.getSystemService(ctx, InputMethodManager::class.java)?.restartInput(previewContent.inputText)
             }
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1216390436059004?focus=true
Tech Design URL (if applicable): 

### Description
Change IME action type for input preview search tab to submit the query.

### Steps to test this PR

_search -> IME_
- [x] Clean install the app.
- [x] Reach the input preview step.
- [x] Verify that typing and clicking the IME 'search' action submits the query.

_search -> icon_
- [ ] Clean install the app.
- [ ] Reach the input preview step.
- [x] Verify that typing and clicking the magnifying glass icon in the input box submits the query.

_chat -> IME_
- [ ] Clean install the app.
- [ ] Reach the input preview step.
- [ ] Switch to chat tab.
- [x] Verify that typing and clicking the IME 'return' action creates a new line.

_chat -> icon_
- [ ] Clean install the app.
- [ ] Reach the input preview step.
- [ ] Switch to chat tab.
- [x] Verify that typing and clicking the arrow icon in the input box submits the prompt.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized onboarding UI and keyboard behavior only; submission still goes through the existing `onInputModeDemoQuerySubmitted` path.
> 
> **Overview**
> On the brand-design **input screen preview** step, typed queries can now be submitted from the keyboard on the **Search** tab, not only via the magnifying-glass icon.
> 
> `setInputScreenPreviewInputMode` pulls shared **submit** logic into a `submitQuery` lambda used by the action icon and by an `OnEditorActionListener` when `IME_ACTION_SEARCH` fires. **Search** mode sets single-line text with `imeOptions = IME_ACTION_SEARCH`; **Chat** mode uses multi-line input with `IME_ACTION_UNSPECIFIED` so the IME **Return** key inserts a new line while the arrow icon still submits.
> 
> When users switch Search/Chat while the field is focused, `InputMethodManager.restartInput` refreshes the keyboard so the updated IME action and Enter behavior apply immediately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 733152d4d48b8dcc76742b64c0d5c0c9407dfba5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->