### PR TITLE
Disable onboarding CTAs on YouTube if ad blocking enabled

### DIFF
--- a/ad-blocking/ad-blocking-impl/build.gradle
+++ b/ad-blocking/ad-blocking-impl/build.gradle
@@ -67,6 +67,7 @@ dependencies {
     implementation project(path: ':feature-toggles-api')
     implementation project(':js-messaging-api')
     implementation project(':navigation-api')
+    implementation project(':onboarding-api')
     implementation project(':remote-messaging-api')
     implementation project(':settings-api')
     implementation project(path: ':statistics-api')

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingContextualCtaSuppressorPlugin.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingContextualCtaSuppressorPlugin.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl
+
+import android.net.Uri
+import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.onboarding.api.cta.ContextualCtaSuppressorPlugin
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+@ContributesMultibinding(AppScope::class)
+class AdBlockingContextualCtaSuppressorPlugin @Inject constructor(
+    private val statusChecker: AdBlockingStatusChecker,
+    private val feature: AdBlockingExtensionFeature,
+    private val domainMatcher: AdBlockingExtensionDomainMatcher,
+) : ContextualCtaSuppressorPlugin {
+
+    override suspend fun canShowCta(url: Uri): Boolean {
+        if (!feature.adBlockingUXImprovements().isEnabled()) return true
+        if (!statusChecker.canInject()) return true
+        return !domainMatcher.matches(url)
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingContextualCtaSuppressorPluginTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingContextualCtaSuppressorPluginTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl
+
+import android.annotation.SuppressLint
+import android.net.Uri
+import androidx.core.net.toUri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@SuppressLint("DenyListedApi") // setRawStoredState
+@RunWith(AndroidJUnit4::class)
+class AdBlockingContextualCtaSuppressorPluginTest {
+
+    private val statusChecker: AdBlockingStatusChecker = mock()
+    private val domainMatcher: AdBlockingExtensionDomainMatcher = mock()
+    private val feature = FakeFeatureToggleFactory.create(AdBlockingExtensionFeature::class.java)
+
+    private val plugin = AdBlockingContextualCtaSuppressorPlugin(statusChecker, feature, domainMatcher)
+
+    private val url = "https://www.youtube.com/watch?v=123".toUri()
+
+    @Test
+    fun whenPhase2DisabledThenCanShowCta() = runTest {
+        setPhase2(false)
+
+        assertTrue(plugin.canShowCta(url))
+    }
+
+    @Test
+    fun whenAdBlockingNotActiveThenCanShowCta() = runTest {
+        setPhase2(true)
+        whenever(statusChecker.canInject()).thenReturn(false)
+
+        assertTrue(plugin.canShowCta(url))
+    }
+
+    @Test
+    fun whenPhase2AndAdBlockingActiveOnNonMatchingDomainThenCanShowCta() = runTest {
+        setPhase2(true)
+        whenever(statusChecker.canInject()).thenReturn(true)
+        whenever(domainMatcher.matches(any<Uri>())).thenReturn(false)
+
+        assertTrue(plugin.canShowCta(url))
+    }
+
+    @Test
+    fun whenPhase2AndAdBlockingActiveOnMatchingDomainThenSuppress() = runTest {
+        setPhase2(true)
+        whenever(statusChecker.canInject()).thenReturn(true)
+        whenever(domainMatcher.matches(any<Uri>())).thenReturn(true)
+
+        assertFalse(plugin.canShowCta(url))
+    }
+
+    private fun setPhase2(enabled: Boolean) {
+        feature.adBlockingUXImprovements().setRawStoredState(Toggle.State(remoteEnableState = enabled))
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -64,6 +64,7 @@ import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.inputscreen.DuckAiOnboardingEndCtaVariant
 import com.duckduckgo.onboarding.api.LinearOnboardingOrchestrator
 import com.duckduckgo.onboarding.api.LinearOnboardingState
+import com.duckduckgo.onboarding.api.cta.ContextualCtaSuppressorPlugin
 import com.duckduckgo.onboarding.api.forPlan
 import com.duckduckgo.subscriptions.api.SubscriptionPromoCtaShownPlugin
 import com.duckduckgo.subscriptions.api.SubscriptionStatus
@@ -107,6 +108,7 @@ class CtaViewModel @Inject constructor(
     private val duckPlayer: DuckPlayer,
     private val brokenSitePrompt: BrokenSitePrompt,
     private val subscriptionPromoCtaShownPlugins: PluginPoint<SubscriptionPromoCtaShownPlugin>,
+    private val contextualCtaSuppressorPlugins: PluginPoint<ContextualCtaSuppressorPlugin>,
     private val onboardingBrandDesignUpdateToggles: OnboardingBrandDesignUpdateToggles,
     private val appTheme: AppTheme,
     private val deviceInfo: DeviceInfo,
@@ -581,6 +583,14 @@ class CtaViewModel @Inject constructor(
         val host = nonNullSite.domain
         if (host == null || userAllowListRepository.isDomainInUserAllowList(host) || isSiteNotAllowedForOnboarding(nonNullSite)) {
             return null
+        }
+
+        if (!areInContextDaxDialogsCompleted()) {
+            nonNullSite.uri?.let { uri ->
+                if (contextualCtaSuppressorPlugins.getPlugins().any { !it.canShowCta(uri) }) {
+                    return null
+                }
+            }
         }
 
         nonNullSite.let {

--- a/app/src/main/java/com/duckduckgo/app/plugins/ContextualCtaSuppressorPluginPoint.kt
+++ b/app/src/main/java/com/duckduckgo/app/plugins/ContextualCtaSuppressorPluginPoint.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.plugins
+
+import com.duckduckgo.anvil.annotations.ContributesPluginPoint
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.onboarding.api.cta.ContextualCtaSuppressorPlugin
+
+@ContributesPluginPoint(
+    scope = AppScope::class,
+    boundType = ContextualCtaSuppressorPlugin::class,
+)
+@Suppress("unused")
+interface UnusedContextualCtaSuppressorPluginPoint

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -865,6 +865,7 @@ class BrowserTabViewModelTest {
                     },
                     duckAiFeatureState = mockDuckAiFeatureState,
                     onboardingPixelSender = mockOnboardingPixelSender,
+                    contextualCtaSuppressorPlugins = mock(),
                 )
 
             accessibilitySettingsDataStore = AccessibilitySettingsSharedPreferences(context)

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -79,6 +79,7 @@ import com.duckduckgo.duckchat.api.inputscreen.DuckAiOnboardingEndCtaVariant
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.onboarding.api.LinearOnboardingOrchestrator
 import com.duckduckgo.onboarding.api.LinearOnboardingState
+import com.duckduckgo.onboarding.api.cta.ContextualCtaSuppressorPlugin
 import com.duckduckgo.subscriptions.api.SubscriptionPromoCtaShownPlugin
 import com.duckduckgo.subscriptions.api.SubscriptionStatus
 import com.duckduckgo.subscriptions.api.Subscriptions
@@ -148,6 +149,14 @@ class CtaViewModelTest {
     private val mockSubscriptionPromoCtaShownPlugin: SubscriptionPromoCtaShownPlugin = mock()
     private val mockSubscriptionPromoCtaShownPlugins: PluginPoint<SubscriptionPromoCtaShownPlugin> = mock {
         on { getPlugins() } doReturn listOf(mockSubscriptionPromoCtaShownPlugin)
+    }
+
+    private var canShowContextualCta = true
+    private val mockContextualCtaSuppressorPlugin: ContextualCtaSuppressorPlugin = mock {
+        onBlocking { canShowCta(any()) } doAnswer { canShowContextualCta }
+    }
+    private val mockContextualCtaSuppressorPlugins: PluginPoint<ContextualCtaSuppressorPlugin> = mock {
+        on { getPlugins() } doReturn listOf(mockContextualCtaSuppressorPlugin)
     }
 
     private val mockDuckChat: DuckChat = mock()
@@ -226,6 +235,7 @@ class CtaViewModelTest {
             duckPlayer = mockDuckPlayer,
             brokenSitePrompt = mockBrokenSitePrompt,
             subscriptionPromoCtaShownPlugins = mockSubscriptionPromoCtaShownPlugins,
+            contextualCtaSuppressorPlugins = mockContextualCtaSuppressorPlugins,
             onboardingBrandDesignUpdateToggles = mockOnboardingBrandDesignUpdateToggles,
             appTheme = mockAppTheme,
             deviceInfo = mockDeviceInfo,
@@ -387,6 +397,23 @@ class CtaViewModelTest {
 
     @Test
     fun whenRefreshCtaWhileBrowsingAndHideTipsIsTrueAndShouldShowBrokenSitePromptThenReturnBrokenSitePrompt() = runTest {
+        whenever(mockSettingsDataStore.hideTips).thenReturn(true)
+        val site = site(url = "http://www.facebook.com", entity = TdsEntity("Facebook", "Facebook", 9.0))
+        val detectedRefreshPatterns = setOf(RefreshPattern.THRICE_IN_20_SECONDS)
+        whenever(mockBrokenSitePrompt.shouldShowBrokenSitePrompt(any(), any())).thenReturn(true)
+
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = true,
+            site = site,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+        )
+        assertTrue(value is BrokenSitePromptDialogCta)
+    }
+
+    @Test
+    fun whenContextualCtaSuppressorPluginSuppressesButOnboardingCompletedThenReturnBrokenSitePrompt() = runTest {
+        canShowContextualCta = false
         whenever(mockSettingsDataStore.hideTips).thenReturn(true)
         val site = site(url = "http://www.facebook.com", entity = TdsEntity("Facebook", "Facebook", 9.0))
         val detectedRefreshPatterns = setOf(RefreshPattern.THRICE_IN_20_SECONDS)
@@ -997,6 +1024,37 @@ class CtaViewModelTest {
             detectedRefreshPatterns = detectedRefreshPatterns,
         )
         assertNull(value)
+    }
+
+    @Test
+    fun whenContextualCtaSuppressorPluginSuppressesThenReturnNull() = runTest {
+        canShowContextualCta = false
+        givenDaxOnboardingActive()
+        val site = site(url = "http://www.facebook.com", entity = TdsEntity("Facebook", "Facebook", 9.0))
+
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = true,
+            site = site,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+        )
+        assertNull(value)
+    }
+
+    @Test
+    fun whenContextualCtaSuppressorPluginDoesNotSuppressThenReturnCta() = runTest {
+        canShowContextualCta = true
+        givenDaxOnboardingActive()
+        val site = site(url = "http://www.facebook.com", entity = TdsEntity("Facebook", "Facebook", 9.0))
+
+        val value = testee.refreshCta(
+            coroutineRule.testDispatcher,
+            isBrowserShowing = true,
+            site = site,
+            detectedRefreshPatterns = detectedRefreshPatterns,
+        ) as OnboardingDaxDialogCta
+
+        assertTrue(value is OnboardingDaxDialogCta.DaxMainNetworkCta)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxDuckAiFireButtonBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxDuckAiFireButtonBrandDesignUpdateContextualCtaTest.kt
@@ -176,6 +176,7 @@ class DaxDuckAiFireButtonBrandDesignUpdateContextualCtaTest {
             },
             duckAiFeatureState = mock { on { showInputScreen } doReturn MutableStateFlow(true) },
             onboardingPixelSender = mock(),
+            contextualCtaSuppressorPlugins = mock(),
         )
     }
 

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateContextualCtaTest.kt
@@ -169,6 +169,7 @@ class DaxEndBrandDesignUpdateContextualCtaTest {
             },
             duckAiFeatureState = mock { on { showInputScreen } doReturn MutableStateFlow(true) },
             onboardingPixelSender = mock(),
+            contextualCtaSuppressorPlugins = mock(),
         )
     }
 

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxFireButtonBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxFireButtonBrandDesignUpdateContextualCtaTest.kt
@@ -166,6 +166,7 @@ class DaxFireButtonBrandDesignUpdateContextualCtaTest {
             },
             duckAiFeatureState = mock { on { showInputScreen } doReturn MutableStateFlow(true) },
             onboardingPixelSender = mock(),
+            contextualCtaSuppressorPlugins = mock(),
         )
     }
 

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCtaTest.kt
@@ -186,6 +186,7 @@ class DaxMainNetworkBrandDesignUpdateContextualCtaTest {
             },
             duckAiFeatureState = mock { on { showInputScreen } doReturn MutableStateFlow(true) },
             onboardingPixelSender = mock(),
+            contextualCtaSuppressorPlugins = mock(),
         )
     }
 

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxNoTrackersBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxNoTrackersBrandDesignUpdateContextualCtaTest.kt
@@ -175,6 +175,7 @@ class DaxNoTrackersBrandDesignUpdateContextualCtaTest {
             },
             duckAiFeatureState = mock { on { showInputScreen } doReturn MutableStateFlow(true) },
             onboardingPixelSender = mock(),
+            contextualCtaSuppressorPlugins = mock(),
         )
     }
 

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxSerpBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxSerpBrandDesignUpdateContextualCtaTest.kt
@@ -181,6 +181,7 @@ class DaxSerpBrandDesignUpdateContextualCtaTest {
             },
             duckAiFeatureState = mock { on { showInputScreen } doReturn MutableStateFlow(true) },
             onboardingPixelSender = mock(),
+            contextualCtaSuppressorPlugins = mock(),
         )
     }
 

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxSiteSuggestionsBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxSiteSuggestionsBrandDesignUpdateContextualCtaTest.kt
@@ -189,6 +189,7 @@ class DaxSiteSuggestionsBrandDesignUpdateContextualCtaTest {
             },
             duckAiFeatureState = mock { on { showInputScreen } doReturn MutableStateFlow(true) },
             onboardingPixelSender = mock(),
+            contextualCtaSuppressorPlugins = mock(),
         )
     }
 

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxTrackersBlockedBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxTrackersBlockedBrandDesignUpdateContextualCtaTest.kt
@@ -167,6 +167,7 @@ class DaxTrackersBlockedBrandDesignUpdateContextualCtaTest {
             },
             duckAiFeatureState = mock { on { showInputScreen } doReturn MutableStateFlow(true) },
             onboardingPixelSender = mock(),
+            contextualCtaSuppressorPlugins = mock(),
         )
     }
 

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/OnboardingDaxDialogTests.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/OnboardingDaxDialogTests.kt
@@ -17,6 +17,8 @@
 package com.duckduckgo.app.cta.ui
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.core.net.toUri
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.adblocking.api.duckplayer.DuckPlayer
 import com.duckduckgo.app.browser.DuckDuckGoUrlDetector
 import com.duckduckgo.app.cta.db.DismissedCtaDao
@@ -29,15 +31,20 @@ import com.duckduckgo.app.cta.model.CtaId.DAX_FIRE_BUTTON
 import com.duckduckgo.app.cta.model.CtaId.DAX_INTRO_PRIVACY_PRO
 import com.duckduckgo.app.cta.model.CtaId.DAX_INTRO_VISIT_SITE
 import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.onboarding.store.AppStage
 import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.onboarding.store.UserStageStore
 import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardingFeatureToggles
 import com.duckduckgo.app.onboardingbranddesignupdate.OnboardingBrandDesignUpdateToggles
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
+import com.duckduckgo.app.privacy.model.HttpsStatus
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.model.AggregateTabProvider
+import com.duckduckgo.app.trackerdetection.model.Entity
+import com.duckduckgo.app.trackerdetection.model.TdsEntity
+import com.duckduckgo.app.trackerdetection.model.TrackingEvent
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.duckduckgo.brokensite.api.BrokenSitePrompt
 import com.duckduckgo.common.test.CoroutineTestRule
@@ -49,6 +56,7 @@ import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.onboarding.api.LinearOnboardingOrchestrator
 import com.duckduckgo.onboarding.api.LinearOnboardingState
+import com.duckduckgo.onboarding.api.cta.ContextualCtaSuppressorPlugin
 import com.duckduckgo.subscriptions.api.SubscriptionPromoCtaShownPlugin
 import com.duckduckgo.subscriptions.api.SubscriptionStatus
 import com.duckduckgo.subscriptions.api.Subscriptions
@@ -56,14 +64,19 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.whenever
 
+@RunWith(AndroidJUnit4::class)
 class OnboardingDaxDialogTests {
 
     private lateinit var testee: CtaViewModel
@@ -94,6 +107,14 @@ class OnboardingDaxDialogTests {
     private val mockOnboardingBrandDesignUpdateToggles: OnboardingBrandDesignUpdateToggles = mock()
     private val mockAppTheme: AppTheme = org.mockito.kotlin.mock { on { isLightModeEnabled() } doReturn true }
     private val mockDeviceInfo: DeviceInfo = mock()
+
+    private var canShowContextualCta = true
+    private val contextualCtaSuppressorPlugin: ContextualCtaSuppressorPlugin = org.mockito.kotlin.mock {
+        onBlocking { canShowCta(any()) } doAnswer { canShowContextualCta }
+    }
+    private val contextualCtaSuppressorPlugins = object : PluginPoint<ContextualCtaSuppressorPlugin> {
+        override fun getPlugins() = listOf(contextualCtaSuppressorPlugin)
+    }
 
     val mockEnabledToggle: Toggle = org.mockito.kotlin.mock { on { it.isEnabled() } doReturn true }
     val mockDisabledToggle: Toggle = org.mockito.kotlin.mock { on { it.isEnabled() } doReturn false }
@@ -128,6 +149,7 @@ class OnboardingDaxDialogTests {
             object : PluginPoint<SubscriptionPromoCtaShownPlugin> {
                 override fun getPlugins() = emptyList<SubscriptionPromoCtaShownPlugin>()
             },
+            contextualCtaSuppressorPlugins,
             mockOnboardingBrandDesignUpdateToggles,
             mockAppTheme,
             mockDeviceInfo,
@@ -345,5 +367,58 @@ class OnboardingDaxDialogTests {
         )
 
         assertFalse(result is SubscriptionPromoModalCta)
+    }
+
+    @Test
+    fun whenContextualCtaSuppressorPluginSuppressesThenRefreshCtaReturnsNull() = runTest {
+        canShowContextualCta = false
+        whenever(userStageStore.getUserAppStage()).thenReturn(AppStage.DAX_ONBOARDING)
+        val site = site(url = "http://www.facebook.com", entity = TdsEntity("Facebook", "Facebook", 9.0))
+
+        val result = testee.refreshCta(
+            coroutineRule.testDispatcherProvider.io(),
+            isBrowserShowing = true,
+            site = site,
+            detectedRefreshPatterns = emptySet(),
+        )
+
+        assertNull(result)
+    }
+
+    @Test
+    fun whenContextualCtaSuppressorPluginDoesNotSuppressThenRefreshCtaReturnsCta() = runTest {
+        canShowContextualCta = true
+        whenever(userStageStore.getUserAppStage()).thenReturn(AppStage.DAX_ONBOARDING)
+        val site = site(url = "http://www.facebook.com", entity = TdsEntity("Facebook", "Facebook", 9.0))
+
+        val result = testee.refreshCta(
+            coroutineRule.testDispatcherProvider.io(),
+            isBrowserShowing = true,
+            site = site,
+            detectedRefreshPatterns = emptySet(),
+        )
+
+        assertTrue(result is OnboardingDaxDialogCta.DaxMainNetworkCta)
+    }
+
+    private fun site(
+        url: String = "http://www.test.com",
+        https: HttpsStatus = HttpsStatus.SECURE,
+        trackerCount: Int = 0,
+        events: List<TrackingEvent> = emptyList(),
+        majorNetworkCount: Int = 0,
+        allTrackersBlocked: Boolean = true,
+        entity: Entity? = null,
+    ): Site {
+        val site: Site = mock()
+        whenever(site.url).thenReturn(url)
+        whenever(site.uri).thenReturn(url.toUri())
+        whenever(site.https).thenReturn(https)
+        whenever(site.entity).thenReturn(entity)
+        whenever(site.trackingEvents).thenReturn(events)
+        whenever(site.trackerCount).thenReturn(trackerCount)
+        whenever(site.majorNetworkCount).thenReturn(majorNetworkCount)
+        whenever(site.allTrackersBlocked).thenReturn(allTrackersBlocked)
+        return site
     }
 }

--- a/onboarding/onboarding-api/src/main/java/com/duckduckgo/onboarding/api/cta/ContextualCtaSuppressorPlugin.kt
+++ b/onboarding/onboarding-api/src/main/java/com/duckduckgo/onboarding/api/cta/ContextualCtaSuppressorPlugin.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.onboarding.api.cta
+
+import android.net.Uri
+
+interface ContextualCtaSuppressorPlugin {
+    /** Return false to suppress browser onboarding CTAs on the current page. */
+    suspend fun canShowCta(url: Uri): Boolean
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1215997424091037
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/481882893211075/task/1216109207838947

### Description

### Steps to test this PR

_Feature 1_
- [x] Apply _Patch 1: ad blocking enabled by default, UX improvements off_
- [x] Fresh install
- [x] Complete onboarding
- [x] Once in NTP, navigate to a YouTube video
- [x] Check onboarding CTA is shown

_Feature 2_
- [x] Apply _Patch 2: ad blocking enabled by default, UX improvements on_
- [x] Fresh install
- [x] Complete onboarding
- [x] Once in NTP, navigate to a YouTube video
- [x] Check onboarding CTA is shown

### Patches 

_Patch 1: ad blocking enabled by default, UX improvements off_
```
Subject: [PATCH] Ad blocking enabled by default
---
Index: ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionFeature.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionFeature.kt b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionFeature.kt
--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionFeature.kt	(revision 84da3077e418b6e665011e45d2a73cb1e5418e94)
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionFeature.kt	(date 1783525133105)
@@ -28,10 +28,10 @@
     /**
      * Kill-switch. When false, the feature is completely inaccessible.
      */
-    @Toggle.DefaultValue(Toggle.DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(Toggle.DefaultFeatureValue.TRUE)
     fun self(): Toggle
 
-    @Toggle.DefaultValue(Toggle.DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(Toggle.DefaultFeatureValue.TRUE)
     fun enabledByDefault(): Toggle
 
     /**
```

_Patch 2: ad blocking enabled by default, UX improvements on_
```
Subject: [PATCH] Ad blocking enabled by default with UX improvements
---
Index: ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionFeature.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionFeature.kt b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionFeature.kt
--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionFeature.kt	(revision 84da3077e418b6e665011e45d2a73cb1e5418e94)
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionFeature.kt	(date 1783525340171)
@@ -28,10 +28,10 @@
     /**
      * Kill-switch. When false, the feature is completely inaccessible.
      */
-    @Toggle.DefaultValue(Toggle.DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(Toggle.DefaultFeatureValue.TRUE)
     fun self(): Toggle
 
-    @Toggle.DefaultValue(Toggle.DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(Toggle.DefaultFeatureValue.TRUE)
     fun enabledByDefault(): Toggle
 
     /**
@@ -46,6 +46,6 @@
      * To be removed after phase 2 initial rollout
      *
      */
-    @Toggle.DefaultValue(Toggle.DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(Toggle.DefaultFeatureValue.TRUE)
     fun adBlockingUXImprovements(): Toggle
 }
```
### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to in-context DAX CTAs behind a new plugin API and ad-blocking feature toggles; no auth or data-path changes.
> 
> **Overview**
> Introduces a **plugin hook** so features can block in-browser DAX onboarding dialogs on specific URLs, avoiding overlap with ad-blocking UX on sites like YouTube.
> 
> **`ContextualCtaSuppressorPlugin`** lives in `onboarding-api`; the app registers a **`PluginPoint`** and **`CtaViewModel.getBrowserCta`** calls registered plugins **only while in-context DAX dialogs are still incomplete**. If any plugin returns `canShowCta(uri) == false`, contextual onboarding CTAs are skipped (post-onboarding flows such as broken-site prompt are unchanged).
> 
> **Ad-blocking** contributes **`AdBlockingContextualCtaSuppressorPlugin`**, which suppresses when **`adBlockingUXImprovements`** is on, injection is active (`canInject()`), and the URL matches **`AdBlockingExtensionDomainMatcher`** (e.g. YouTube). `ad-blocking-impl` adds an **`onboarding-api`** dependency.
> 
> Tests cover the ad-blocking plugin gates and `CtaViewModel` suppress / allow behavior; existing CTA tests wire a mock plugin point.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fac0c5dfcd1b44309b19b803bb3d4e5172ea45db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->