### PR TITLE
Android: Fix subscription upsell eligibility Duck.ai model dropdown menu

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -675,8 +675,12 @@ class RealNativeInputManager @Inject constructor(
                 onCameraCaptureRequested = callbacks.onCameraCaptureRequested,
                 onFilePickerRequested = callbacks.onFilePickerRequested,
             )
-            onPaidTierChanged = { isPaid ->
-                val tier = if (isPaid) DuckAiTier.Paid else DuckAiTier.Free
+            onPaidTierChanged = { isPaid, isSubscriptionEligible ->
+                val tier = when {
+                    isPaid -> DuckAiTier.Paid
+                    isSubscriptionEligible -> DuckAiTier.Free
+                    else -> DuckAiTier.FreeNoUpgrade
+                }
                 omnibarController.updateTierTitle(tier) {
                     fireChatHeaderUpgradeTapped(tier)
                     launchPurchase()

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
@@ -40,6 +40,7 @@ import com.google.android.material.card.MaterialCardView
 
 sealed class DuckAiTier {
     data object Free : DuckAiTier()
+    data object FreeNoUpgrade : DuckAiTier()
     data object Paid : DuckAiTier()
     data object Unknown : DuckAiTier()
 }
@@ -179,6 +180,8 @@ class RealNativeInputOmnibarController(
     private fun applyTierText(omnibarView: View) {
         val aiTitle = omnibarView.findViewById<TextView?>(R.id.aiTitle)
         val freePill = omnibarView.findViewById<View?>(R.id.duckAIFreePill)
+        val freePillUpgrade = omnibarView.findViewById<View?>(R.id.duckAIFreePillUpgrade)
+        val freePillChevron = omnibarView.findViewById<View?>(R.id.duckAIFreePillChevron)
         if (!tierVisible) {
             aiTitle?.gone()
             freePill?.gone()
@@ -194,7 +197,18 @@ class RealNativeInputOmnibarController(
             is DuckAiTier.Free -> {
                 aiTitle?.gone()
                 freePill?.show()
+                freePillUpgrade?.show()
+                freePillChevron?.show()
+                freePill?.isClickable = true
                 freePill?.setOnClickListener { currentUpgradeClick?.invoke() }
+            }
+            is DuckAiTier.FreeNoUpgrade -> {
+                aiTitle?.gone()
+                freePill?.show()
+                freePillUpgrade?.gone()
+                freePillChevron?.gone()
+                freePill?.setOnClickListener(null)
+                freePill?.isClickable = false
             }
             is DuckAiTier.Paid, is DuckAiTier.Unknown -> {
                 freePill?.gone()

--- a/app/src/main/res/layout/view_omnibar.xml
+++ b/app/src/main/res/layout/view_omnibar.xml
@@ -625,6 +625,7 @@
                         app:typography="body2_bold" />
 
                     <ImageView
+                        android:id="@+id/duckAIFreePillChevron"
                         android:layout_width="14dp"
                         android:layout_height="14dp"
                         android:layout_marginStart="2dp"

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputOmnibarControllerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputOmnibarControllerTest.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.app.browser.omnibar.Omnibar
 import com.duckduckgo.app.browser.omnibar.OmnibarView
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
@@ -50,6 +51,8 @@ class RealNativeInputOmnibarControllerTest {
 
     private val aiTitle = TextView(context).apply { id = R.id.aiTitle }
     private val duckAIFreePill = View(context).apply { id = R.id.duckAIFreePill }
+    private val duckAIFreePillUpgrade = View(context).apply { id = R.id.duckAIFreePillUpgrade }
+    private val duckAIFreePillChevron = View(context).apply { id = R.id.duckAIFreePillChevron }
 
     private val omnibarView = object : FrameLayout(context), OmnibarView by mock() {}.apply {
         addView(fireIconMenu)
@@ -58,6 +61,8 @@ class RealNativeInputOmnibarControllerTest {
         addView(browserMenu)
         addView(aiTitle)
         addView(duckAIFreePill)
+        addView(duckAIFreePillUpgrade)
+        addView(duckAIFreePillChevron)
     }
 
     @Test
@@ -108,6 +113,21 @@ class RealNativeInputOmnibarControllerTest {
         testee.hideBackground()
 
         assertEquals(View.VISIBLE, duckAIFreePill.visibility)
+    }
+
+    @Test
+    fun whenOverlayActiveAndTierFreeNoUpgradeThenPillShownButUpgradeAffordanceHidden() {
+        whenever(omnibar.omnibarView).thenReturn(omnibarView)
+        testee.updateTierTitle(DuckAiTier.FreeNoUpgrade) {}
+
+        testee.hideBackground()
+
+        // The "Free Plan" pill stays visible, but the upgrade CTA/chevron are gone and it isn't tappable.
+        assertEquals(View.VISIBLE, duckAIFreePill.visibility)
+        assertEquals(View.GONE, duckAIFreePillUpgrade.visibility)
+        assertEquals(View.GONE, duckAIFreePillChevron.visibility)
+        assertEquals(View.GONE, aiTitle.visibility)
+        assertFalse(duckAIFreePill.isClickable)
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
@@ -134,9 +134,18 @@ class RealDuckAiModelManager @Inject constructor(
             try {
                 val userTier = resolveUserTier()
                 val response = fetchModelsResponse()
+                val isSubscriptionEligible = runCatching {
+                    subscriptions.isEligible()
+                }.getOrElse {
+                    logcat { "Duck.ai Model Manager: failed to resolve purchase eligibility, defaulting to not eligible: ${it.message}" }
+                    false
+                }
                 val models = response.models
                     .map { resolveModel(it, userTier) }
                     .filterNot { it.accessTier.isEmpty() && !it.isAccessible }
+                    .filterNot {
+                        !it.isAccessible && !isSubscriptionEligible
+                    }
                 val attachmentLimits = resolveAttachmentLimits(response.attachmentLimits, userTier)
                 stateMutex.withLock {
                     val selectedModelId = validateAndPersistSelection(models)
@@ -283,7 +292,10 @@ class RealDuckAiModelManager @Inject constructor(
         )
     }
 
-    private fun resolveModel(remote: RemoteAIChatModel, userTier: UserTier): AIChatModel {
+    private fun resolveModel(
+        remote: RemoteAIChatModel,
+        userTier: UserTier,
+    ): AIChatModel {
         val accessTier = remote.accessTier.orEmpty()
         val isAccessible = if (accessTier.isEmpty()) {
             remote.entityHasAccess

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/DuckAiModelManager.kt
@@ -44,6 +44,7 @@ data class ModelState(
     val selectedModelId: String? = null,
     val selectedModelShortName: String? = null,
     val userTier: UserTier = UserTier.FREE,
+    val isSubscriptionEligible: Boolean = false,
     val attachmentLimits: AttachmentLimits = AttachmentLimits(),
     /** User's persisted global reasoning mode. Used for new chats. */
     val selectedReasoningMode: ReasoningMode? = null,
@@ -153,6 +154,7 @@ class RealDuckAiModelManager @Inject constructor(
                     val available = ReasoningResolver.availableModes(
                         supported = selectedModel?.supportedReasoningEfforts.orEmpty(),
                         effortAccess = selectedModel?.reasoningEffortAccess.orEmpty(),
+                        isEligible = isSubscriptionEligible,
                     )
                     val nextReasoningMode = validateAndPersistReasoningMode(_modelState.value.selectedReasoningMode, available)
 
@@ -161,6 +163,7 @@ class RealDuckAiModelManager @Inject constructor(
                         selectedModelId = selectedModelId,
                         selectedModelShortName = selectedModel?.shortName,
                         userTier = userTier,
+                        isSubscriptionEligible = isSubscriptionEligible,
                         attachmentLimits = attachmentLimits,
                         selectedReasoningMode = nextReasoningMode,
                         availableReasoningModes = available,
@@ -200,6 +203,7 @@ class RealDuckAiModelManager @Inject constructor(
                 val available = ReasoningResolver.availableModes(
                     supported = model.supportedReasoningEfforts,
                     effortAccess = model.reasoningEffortAccess,
+                    isEligible = _modelState.value.isSubscriptionEligible,
                 )
                 val nextReasoningMode = validateAndPersistReasoningMode(_modelState.value.selectedReasoningMode, available)
                 _modelState.value = _modelState.value.copy(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/Reasoning.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/models/Reasoning.kt
@@ -70,10 +70,14 @@ object ReasoningResolver {
      * for upsell routing. If no candidate is supported, the mode is omitted.
      *
      * When [effortAccess] does not contain an entry for a chosen effort, the mode is treated as accessible.
+     *
+     * When [isEligible] is false the user can't purchase a subscription, so inaccessible (gated) modes
+     * are dropped rather than shown as inert upsell rows. Mirrors the model filtering in the model manager.
      */
     fun availableModes(
         supported: List<ReasoningEffort>,
         effortAccess: List<ReasoningEffortAccess> = emptyList(),
+        isEligible: Boolean = true,
     ): List<AvailableReasoningMode> {
         val accessByEffort = effortAccess.associateBy { it.effort }
         return ReasoningMode.entries.mapNotNull { mode ->
@@ -84,7 +88,7 @@ object ReasoningResolver {
                 access == null || access.isAccessible
             } ?: supportedCandidates.first()
             AvailableReasoningMode(mode, chosen, accessByEffort[chosen])
-        }
+        }.filterNot { !it.isAccessible && !isEligible }
     }
 
     fun resolveMode(
@@ -110,6 +114,7 @@ object ReasoningResolver {
         val available = availableModes(
             supported = chatModel.supportedReasoningEfforts,
             effortAccess = chatModel.reasoningEffortAccess,
+            isEligible = modelState.isSubscriptionEligible,
         )
         val mode = modelState.chatScopedReasoningMode
             ?: ReasoningMode.from(chat.reasoningMode)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -371,6 +371,10 @@ class NativeInputModeWidgetViewModel @Inject constructor(
     val isPaidTier: Flow<Boolean> = subscriptions.getEntitlementStatus()
         .map { entitlements -> entitlements.any { it == Product.DuckAiPlus } }
 
+    val isSubscriptionEligible: Flow<Boolean> = modelManager.modelState
+        .map { it.isSubscriptionEligible }
+        .distinctUntilChanged()
+
     val chatSuggestionsUserEnabled: Flow<Boolean> = duckChatInternal.observeChatSuggestionsUserSettingEnabled()
 
     val defaultTogglePosition: Flow<DefaultTogglePosition> = duckChatInternal.observeDefaultTogglePosition()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
@@ -185,12 +185,13 @@ class ModelPickerViewModel @Inject constructor(
             }
             return
         }
-        val userTier = modelManager.modelState.value.userTier
+        val modelState = modelManager.modelState.value
+        val userTier = modelState.userTier
         val requiredTier = model.requiredTier ?: run {
             logcat { "Duck.ai picker: tapped model has no public required tier (id=${model.id}, accessTier=${model.accessTier}), ignoring." }
             return
         }
-        routeUpsell(userTier, requiredTier, surface.origin)?.let { upsell ->
+        routeUpsell(userTier, requiredTier, surface.origin, modelState.isSubscriptionEligible)?.let { upsell ->
             duckChatPixels.fireSubscriptionUpsellTriggered(
                 source = "model_picker",
                 currentTier = userTier.toParam(),

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -97,7 +97,7 @@ interface NativeInputWidget {
     var onVoiceSearchClick: (() -> Unit)?
     var onVoiceChatClick: (() -> Unit)?
     var onImageClick: (() -> Unit)?
-    var onPaidTierChanged: ((Boolean) -> Unit)?
+    var onPaidTierChanged: ((isPaid: Boolean, isSubscriptionEligible: Boolean) -> Unit)?
     var onAttachmentChooserStateChanged: ((Boolean) -> Unit)?
 
     /** Fired when the user picks a model in the model-change flow (→ submitChangeModelAction). */
@@ -307,7 +307,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         }
         onVoiceSearchClick?.invoke()
     }
-    override var onPaidTierChanged: ((Boolean) -> Unit)? = null
+    override var onPaidTierChanged: ((isPaid: Boolean, isSubscriptionEligible: Boolean) -> Unit)? = null
         set(value) {
             field = value
             if (value != null && isAttachedToWindow) observeTier()
@@ -1421,8 +1421,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     private fun observeTier() {
         tierJob?.cancel()
-        tierJob = viewModel.isPaidTier
-            .onEach { hasDuckAiPlus -> onPaidTierChanged?.invoke(hasDuckAiPlus) }
+        tierJob = combine(viewModel.isPaidTier, viewModel.isSubscriptionEligible) { isPaid, isEligible ->
+            isPaid to isEligible
+        }
+            .onEach { (isPaid, isEligible) -> onPaidTierChanged?.invoke(isPaid, isEligible) }
             .launchIn(findViewTreeLifecycleOwner()?.lifecycleScope ?: return)
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/PickerUpsell.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/PickerUpsell.kt
@@ -44,13 +44,16 @@ internal fun UpsellCommand.toFlowTypeParam(): String = when (this) {
 
 /**
  * Maps a (userTier, requiredTier) pair to the upsell flow that should fire, or `null` when no
- * native subscription flow applies (FREE-required gating, or a tier transition we don't route).
+ * native subscription flow applies: the user can't purchase a subscription ([isEligible] is false),
+ * FREE-required gating, or a tier transition we don't route.
  */
 internal fun routeUpsell(
     userTier: UserTier,
     requiredTier: UserTier,
     origin: String,
+    isEligible: Boolean,
 ): UpsellCommand? = when {
+    !isEligible -> null
     requiredTier == UserTier.FREE -> null
     userTier == UserTier.FREE -> UpsellCommand.LaunchPurchase(origin)
     userTier == UserTier.PLUS && requiredTier == UserTier.PRO -> UpsellCommand.LaunchUpgrade(origin)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerViewModel.kt
@@ -151,7 +151,7 @@ class ReasoningModePickerViewModel @Inject constructor(
             logcat { "Duck.ai reasoning picker: gated mode $mode has no public required tier, ignoring." }
             return
         }
-        routeUpsell(userTier, requiredTier, surface.origin)?.let { upsell ->
+        routeUpsell(userTier, requiredTier, surface.origin, modelState.isSubscriptionEligible)?.let { upsell ->
             duckChatPixels.fireSubscriptionUpsellTriggered(
                 source = "reasoning_picker",
                 currentTier = userTier.toParam(),

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/RealDuckAiModelManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/RealDuckAiModelManagerTest.kt
@@ -37,6 +37,7 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.stub
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
@@ -60,6 +61,7 @@ class RealDuckAiModelManagerTest {
     fun setUp() {
         whenever(subscriptions.getEntitlements()).thenReturn(entitlementFlow)
         whenever(duckAiHostProvider.getHost()).thenReturn("duck.ai")
+        subscriptions.stub { onBlocking { isEligible() }.thenReturn(true) }
     }
 
     private fun createManager(): RealDuckAiModelManager {
@@ -373,6 +375,94 @@ class RealDuckAiModelManagerTest {
 
         val ids = testee.modelState.value.models.map { it.id }
         assertEquals(listOf("visible"), ids)
+    }
+
+    @Test
+    fun whenUserNotEligibleToPurchaseThenInaccessiblePaidModelsFilteredOut() = runTest {
+        whenever(dataStore.getSelectedModel()).thenReturn(null)
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.INACTIVE)
+        whenever(subscriptions.isEligible()).thenReturn(false)
+        whenever(modelsService.getModels(any())).thenReturn(
+            AIChatModelsResponse(
+                listOf(
+                    remoteModel("free", accessTier = listOf("free"), entityHasAccess = true),
+                    remoteModel("plus", accessTier = listOf("plus", "pro"), entityHasAccess = false),
+                ),
+            ),
+        )
+
+        testee = createManager()
+        testee.fetchModels()
+
+        val ids = testee.modelState.value.models.map { it.id }
+        assertEquals(listOf("free"), ids)
+    }
+
+    @Test
+    fun whenUserEligibleToPurchaseThenInaccessiblePaidModelsRetainedForUpsell() = runTest {
+        whenever(dataStore.getSelectedModel()).thenReturn(null)
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.INACTIVE)
+        whenever(subscriptions.isEligible()).thenReturn(true)
+        whenever(modelsService.getModels(any())).thenReturn(
+            AIChatModelsResponse(
+                listOf(
+                    remoteModel("free", accessTier = listOf("free"), entityHasAccess = true),
+                    remoteModel("plus", accessTier = listOf("plus", "pro"), entityHasAccess = false),
+                ),
+            ),
+        )
+
+        testee = createManager()
+        testee.fetchModels()
+
+        val ids = testee.modelState.value.models.map { it.id }
+        assertEquals(listOf("free", "plus"), ids)
+    }
+
+    @Test
+    fun whenUserNotEligibleToPurchaseThenAccessibleModelsStillShown() = runTest {
+        // A subscribed user is "eligible" (isEligible() covers active subs), but even if eligibility
+        // resolved false, models the user already has access to must never be filtered out.
+        whenever(dataStore.getSelectedModel()).thenReturn(null)
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.AUTO_RENEWABLE)
+        whenever(subscriptions.getEntitlements()).thenReturn(flowOf(setOf(Entitlement(name = "plus", product = "Duck.ai"))))
+        whenever(subscriptions.isEligible()).thenReturn(false)
+        whenever(modelsService.getModels(any())).thenReturn(
+            AIChatModelsResponse(
+                listOf(
+                    remoteModel("free", accessTier = listOf("free", "plus", "pro"), entityHasAccess = true),
+                    remoteModel("plus", accessTier = listOf("plus", "pro"), entityHasAccess = true),
+                    remoteModel("pro", accessTier = listOf("pro"), entityHasAccess = false),
+                ),
+            ),
+        )
+
+        testee = createManager()
+        testee.fetchModels()
+
+        val ids = testee.modelState.value.models.map { it.id }
+        assertEquals(listOf("free", "plus"), ids)
+    }
+
+    @Test
+    fun whenEligibilityCheckThrowsThenFailsClosedAndInaccessiblePaidModelsFilteredOut() = runTest {
+        whenever(dataStore.getSelectedModel()).thenReturn(null)
+        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.INACTIVE)
+        whenever(subscriptions.isEligible()).thenThrow(RuntimeException("Error"))
+        whenever(modelsService.getModels(any())).thenReturn(
+            AIChatModelsResponse(
+                listOf(
+                    remoteModel("free", accessTier = listOf("free"), entityHasAccess = true),
+                    remoteModel("plus", accessTier = listOf("plus", "pro"), entityHasAccess = false),
+                ),
+            ),
+        )
+
+        testee = createManager()
+        testee.fetchModels()
+
+        val ids = testee.modelState.value.models.map { it.id }
+        assertEquals(listOf("free"), ids)
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/ReasoningResolverTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/models/ReasoningResolverTest.kt
@@ -222,6 +222,28 @@ class ReasoningResolverTest {
     }
 
     @Test
+    fun whenNotEligibleThenGatedModesAreHiddenAndAccessibleModesRemain() {
+        // FAST (free) stays; EXTENDED (gated) is dropped because the user can't purchase → no inert upsell row.
+        val access = listOf(
+            ReasoningEffortAccess(NONE, listOf("free", "plus", "pro"), isAccessible = true),
+            ReasoningEffortAccess(HIGH, listOf("pro"), isAccessible = false),
+        )
+        val result = ReasoningResolver.availableModes(listOf(NONE, HIGH), access, isEligible = false)
+        assertEquals(listOf(FAST), result.map { it.mode })
+    }
+
+    @Test
+    fun whenEligibleThenGatedModesAreRetainedForUpsell() {
+        val access = listOf(
+            ReasoningEffortAccess(NONE, listOf("free", "plus", "pro"), isAccessible = true),
+            ReasoningEffortAccess(HIGH, listOf("pro"), isAccessible = false),
+        )
+        val result = ReasoningResolver.availableModes(listOf(NONE, HIGH), access, isEligible = true)
+        assertEquals(listOf(FAST, EXTENDED_REASONING), result.map { it.mode })
+        assertEquals(false, result.single { it.mode == EXTENDED_REASONING }.isAccessible)
+    }
+
+    @Test
     fun whenAllAvailableModesGatedThenResolveReturnsNull() {
         // Model is accessible but every reasoning effort is gated to a higher tier → no fallback mode to auto-select.
         val available = listOf(

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
@@ -259,7 +259,7 @@ class ModelPickerViewModelTest {
 
     @Test
     fun whenFreeUserTapsGatedPlusModelThenUpsellPixelFiredAndModelSelectedNotFired() = runTest {
-        stateFlow.value = ModelState(userTier = UserTier.FREE)
+        stateFlow.value = ModelState(userTier = UserTier.FREE, isSubscriptionEligible = true)
         val model = plusModel("p")
 
         testee.onModelTapped(model, PickerSurface.MODEL_PICKER_ADDRESS_BAR)
@@ -324,7 +324,7 @@ class ModelPickerViewModelTest {
 
     @Test
     fun whenFreeUserTapsPlusModelFromAddressBarThenLaunchPurchaseCommandEmittedWithAddressBarOrigin() = runTest {
-        stateFlow.value = ModelState(userTier = UserTier.FREE)
+        stateFlow.value = ModelState(userTier = UserTier.FREE, isSubscriptionEligible = true)
         val model = plusModel("p")
 
         testee.commands.test {
@@ -340,7 +340,7 @@ class ModelPickerViewModelTest {
 
     @Test
     fun whenFreeUserTapsProModelFromDuckAiTabThenLaunchPurchaseCommandEmittedWithDuckAiOrigin() = runTest {
-        stateFlow.value = ModelState(userTier = UserTier.FREE)
+        stateFlow.value = ModelState(userTier = UserTier.FREE, isSubscriptionEligible = true)
         val model = proModel("pr")
 
         testee.commands.test {
@@ -356,7 +356,7 @@ class ModelPickerViewModelTest {
 
     @Test
     fun whenPlusUserTapsProModelFromAddressBarThenLaunchUpgradeCommandEmittedWithAddressBarOrigin() = runTest {
-        stateFlow.value = ModelState(userTier = UserTier.PLUS)
+        stateFlow.value = ModelState(userTier = UserTier.PLUS, isSubscriptionEligible = true)
         val model = proModel("pr")
 
         testee.commands.test {
@@ -372,7 +372,7 @@ class ModelPickerViewModelTest {
 
     @Test
     fun whenPlusUserTapsProModelFromDuckAiTabThenLaunchUpgradeCommandEmittedWithDuckAiOrigin() = runTest {
-        stateFlow.value = ModelState(userTier = UserTier.PLUS)
+        stateFlow.value = ModelState(userTier = UserTier.PLUS, isSubscriptionEligible = true)
         val model = proModel("pr")
 
         testee.commands.test {
@@ -384,6 +384,20 @@ class ModelPickerViewModelTest {
             )
             cancelAndConsumeRemainingEvents()
         }
+    }
+
+    @Test
+    fun whenNotEligibleUserTapsPlusModelThenNoCommandEmittedAndNoUpsellPixel() = runTest {
+        stateFlow.value = ModelState(userTier = UserTier.FREE, isSubscriptionEligible = false)
+        val model = plusModel("p")
+
+        testee.commands.test {
+            testee.onModelTapped(model, PickerSurface.MODEL_PICKER_ADDRESS_BAR)
+
+            expectNoEvents()
+            cancelAndConsumeRemainingEvents()
+        }
+        verify(duckChatPixels, never()).fireSubscriptionUpsellTriggered(any(), any(), any(), any())
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -143,6 +143,7 @@ class NativeInputModeWidgetViewModelTest {
     private val chatStateFlow = MutableStateFlow(ChatState.READY)
     private val chatSuggestionsUserEnabledFlow = MutableStateFlow(true)
     private val entitlementsFlow = MutableStateFlow<List<Product>>(emptyList())
+    private val modelStateFlow = MutableStateFlow(ModelState())
     private val showModelPickerEvents = MutableSharedFlow<String>(extraBufferCapacity = 1)
 
     private var fakePlugins: List<NativeInputPlugin> = emptyList()
@@ -161,6 +162,7 @@ class NativeInputModeWidgetViewModelTest {
         whenever(duckChatInternal.chatState).thenReturn(chatStateFlow)
         whenever(duckChatInternal.showModelPickerEvents).thenReturn(showModelPickerEvents)
         whenever(subscriptions.getEntitlementStatus()).thenReturn(entitlementsFlow)
+        whenever(modelManager.modelState).thenReturn(modelStateFlow)
         whenever(autoCompleteFactory.create(any())).thenReturn(autoComplete)
         whenever(autoCompleteSettings.autoCompleteSuggestionsEnabled).thenReturn(false)
         whenever(inputScreenConfigResolver.shouldShowInstalledApps()).thenReturn(false)
@@ -565,6 +567,20 @@ class NativeInputModeWidgetViewModelTest {
         entitlementsFlow.value = emptyList()
 
         assertFalse(testee.isPaidTier.firstOrNull()!!)
+    }
+
+    @Test
+    fun whenModelStateSubscriptionEligibleThenIsSubscriptionEligibleTrue() = runTest {
+        modelStateFlow.value = ModelState(isSubscriptionEligible = true)
+
+        assertTrue(testee.isSubscriptionEligible.firstOrNull()!!)
+    }
+
+    @Test
+    fun whenModelStateNotSubscriptionEligibleThenIsSubscriptionEligibleFalse() = runTest {
+        modelStateFlow.value = ModelState(isSubscriptionEligible = false)
+
+        assertFalse(testee.isSubscriptionEligible.firstOrNull()!!)
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ReasoningModePickerViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ReasoningModePickerViewModelTest.kt
@@ -211,6 +211,7 @@ class ReasoningModePickerViewModelTest {
     fun whenPlusUserTapsGatedModeRequiringProThenUpsellPixelFiredAndNoEffortPixel() = runTest {
         modelState.value = ModelState(
             userTier = UserTier.PLUS,
+            isSubscriptionEligible = true,
             availableReasoningModes = listOf(
                 AvailableReasoningMode(ReasoningMode.FAST, ReasoningEffort.NONE),
                 gatedExtended(requires = listOf("pro")),
@@ -234,6 +235,7 @@ class ReasoningModePickerViewModelTest {
     fun whenFreeUserTapsGatedModeRequiringPlusFromAddressBarThenLaunchPurchaseEmitted() = runTest {
         modelState.value = ModelState(
             userTier = UserTier.FREE,
+            isSubscriptionEligible = true,
             availableReasoningModes = listOf(
                 AvailableReasoningMode(ReasoningMode.FAST, ReasoningEffort.NONE),
                 gatedExtended(requires = listOf("plus", "pro")),
@@ -256,6 +258,7 @@ class ReasoningModePickerViewModelTest {
     fun whenFreeUserTapsGatedModeRequiringProFromDuckAiTabThenLaunchPurchaseEmittedWithDuckAiOrigin() = runTest {
         modelState.value = ModelState(
             userTier = UserTier.FREE,
+            isSubscriptionEligible = true,
             availableReasoningModes = listOf(
                 AvailableReasoningMode(ReasoningMode.FAST, ReasoningEffort.NONE),
                 gatedExtended(requires = listOf("pro")),
@@ -278,6 +281,7 @@ class ReasoningModePickerViewModelTest {
     fun whenPlusUserTapsGatedModeRequiringProFromAddressBarThenLaunchUpgradeEmitted() = runTest {
         modelState.value = ModelState(
             userTier = UserTier.PLUS,
+            isSubscriptionEligible = true,
             availableReasoningModes = listOf(
                 AvailableReasoningMode(ReasoningMode.FAST, ReasoningEffort.NONE),
                 gatedExtended(requires = listOf("pro")),
@@ -300,6 +304,7 @@ class ReasoningModePickerViewModelTest {
     fun whenPlusUserTapsGatedModeRequiringProFromDuckAiTabThenLaunchUpgradeEmittedWithDuckAiOrigin() = runTest {
         modelState.value = ModelState(
             userTier = UserTier.PLUS,
+            isSubscriptionEligible = true,
             availableReasoningModes = listOf(
                 AvailableReasoningMode(ReasoningMode.FAST, ReasoningEffort.NONE),
                 gatedExtended(requires = listOf("pro")),
@@ -316,6 +321,27 @@ class ReasoningModePickerViewModelTest {
             )
             cancelAndConsumeRemainingEvents()
         }
+    }
+
+    @Test
+    fun whenNotEligibleUserTapsGatedModeThenNoCommandEmittedAndNoUpsellPixel() = runTest {
+        modelState.value = ModelState(
+            userTier = UserTier.FREE,
+            isSubscriptionEligible = false,
+            availableReasoningModes = listOf(
+                AvailableReasoningMode(ReasoningMode.FAST, ReasoningEffort.NONE),
+                gatedExtended(requires = listOf("plus", "pro")),
+            ),
+        )
+        runCurrent()
+
+        testee.commands.test {
+            testee.onModeTapped(ReasoningMode.EXTENDED_REASONING, PickerSurface.REASONING_PICKER_ADDRESS_BAR)
+
+            expectNoEvents()
+            cancelAndConsumeRemainingEvents()
+        }
+        verify(duckChatPixels, never()).fireSubscriptionUpsellTriggered(any(), any(), any(), any())
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1213881875984009/task/1216387591818868?focus=true 
Tech Design URL (if applicable): 

### Description
-  Duck.ai model dropdown no longer shows Plus/Pro-only models to users who aren't eligible to purchase a subscription
- Reasoning dropdown no longer shows Plus/Pro-only reasoning modes to users who aren't eligible to purchase a subscription
- Upgrade option in the omnibar no longer shows Upgrade option

### Steps to test this PR

_User is eligible and has no susbcription (you can use the staging patch if you are not eligible_
- [x] Open app
- [x] Verify you can see the purchase subscription in settings
- [x] Open duck.ai chat tab and select model dropdown
- [x] Verify you see all models (pro and plus included) and clicking on paid ones route you correctly
- [x] Select on the lightning icon
- [x] Verify you see “Extended reasoning” and clicking on it route you correctly
- [x] Start a chat
- [x] Verify you see Free plan and an option to upgrade -> clicking routes you to upgrade

_User is eligible and has susbcription_
- [x] Open app
- [x] Verify you have an active suubscription
- [x] Open duck.ai chat tab and select model dropdown
- [x] Verify you see all models (pro and plus included) and clicking on paid ones works without any re-routing
- [x] Select on the lightning icon
- [x] Verify you see “Extended reasoning” and clicking  works without any re-routing
- [x] Start a chat
- [x] Verify you see “Duck.ai” on the omnibar

_User is NOT eligible_
- [x] Open app
- [x] Verify you dont have the susbcription option in settings
- [x] Open duck.ai chat tab and select model dropdown
- [x] Verify you see only the free models
- [x] Select on the lightning icon
- [x] Verify you DO NOT see “Extended reasoning” 
- [x] Start a chat
- [x] Verify you only see “Free plan” with no option to upgrade



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subscription eligibility, model/reasoning filtering, and purchase routing across Duck.ai surfaces; behavior changes for ineligible users but is covered by new unit tests and fails closed on eligibility errors.
> 
> **Overview**
> Duck.ai now gates **subscription upsell UI** on `Subscriptions.isEligible()`, not just tier.
> 
> **Model & reasoning pickers:** `fetchModels()` records eligibility in `ModelState` and drops inaccessible Plus/Pro models and gated reasoning modes when the user cannot buy; eligible free users still see them for upsell taps. `routeUpsell()` returns no command when ineligible, so model and reasoning pickers do not launch purchase flows or fire upsell pixels.
> 
> **Chat header:** `onPaidTierChanged` passes `(isPaid, isSubscriptionEligible)`. Ineligible free users get `DuckAiTier.FreeNoUpgrade`—the “Free Plan” pill stays visible but the upgrade label, chevron, and tap-to-purchase behavior are removed.
> 
> Eligibility lookup **fails closed** (treats as not eligible) on errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3c590f17626a5df9a3265236b3609f9f8fc8d91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->