### PR TITLE
Fix bottom omnibar mockup insets in edge-to-edge mode

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -911,6 +911,7 @@ open class BrowserActivity : DuckDuckGoActivity() {
             enableEdgeToEdge(statusBarStyle = barStyle, navigationBarStyle = barStyle)
             edgeToEdgeHandler.applyStatusBarAndHorizontalInsets(binding.root, installScrim = false)
             edgeToEdgeHandler.applyNavigationBarInsets(binding.navigationBarMockup.root)
+            edgeToEdgeHandler.applyNavigationBarInsets(binding.bottomMockupToolbar.appBarLayoutMockup)
             applyDisplayCutoutMode(resources.configuration.orientation)
         }
     }

--- a/app/src/main/res/layout/activity_browser.xml
+++ b/app/src/main/res/layout/activity_browser.xml
@@ -56,7 +56,7 @@
     <include
         android:id="@+id/bottomMockupToolbar"
         android:layout_width="match_parent"
-        android:layout_height="?attr/actionBarSize"
+        android:layout_height="wrap_content"
         android:layout_alignParentBottom="true"
         layout="@layout/include_omnibar_toolbar_mockup_bottom" />
 

--- a/app/src/main/res/layout/include_omnibar_toolbar_mockup_bottom.xml
+++ b/app/src/main/res/layout/include_omnibar_toolbar_mockup_bottom.xml
@@ -16,151 +16,159 @@
   ~ limitations under the License.
   -->
 
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/appBarLayoutMockup"
     android:layout_width="match_parent"
-    android:layout_height="?attr/actionBarSize"
+    android:layout_height="wrap_content"
     android:background="?daxColorToolbar"
     android:clipChildren="false">
 
-    <com.google.android.material.card.MaterialCardView
-        android:id="@+id/mockOmniBarContainerShadow"
-        app:cardCornerRadius="@dimen/largeShapeCornerRadius"
-        android:layout_width="0dp"
-        android:layout_height="match_parent"
-        android:layout_marginStart="@dimen/omnibarCardMarginHorizontal"
-        android:layout_marginEnd="@dimen/omnibarCardMarginEnd"
-        android:layout_marginTop="@dimen/omnibarCardMarginBottom"
-        android:layout_marginBottom="@dimen/omnibarCardMarginTop"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/iconsContainer"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/appBarLayoutMockupContainer"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?daxColorToolbar"
+        android:clipChildren="false">
 
         <com.google.android.material.card.MaterialCardView
-            android:id="@+id/omniBarContainerMockup"
-            style="@style/Widget.DuckDuckGo.OmnibarCardView"
-            android:layout_width="match_parent"
+            android:id="@+id/mockOmniBarContainerShadow"
+            android:layout_width="0dp"
             android:layout_height="match_parent"
-            app:cardElevation="0dp">
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:orientation="horizontal">
-
-                <ImageView
-                    android:id="@+id/searchIconMockup"
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:gravity="center"
-                    android:importantForAccessibility="no"
-                    android:paddingVertical="6dp"
-                    android:paddingStart="10dp"
-                    android:paddingEnd="8dp"
-                    android:src="@drawable/ic_find_search_small_24" />
-
-                <com.duckduckgo.common.ui.view.text.DaxTextView
-                    android:id="@+id/omnibarTextInputMockup"
-                    android:layout_width="0dp"
-                    android:layout_height="match_parent"
-                    android:layout_weight="1"
-                    android:gravity="start|center"
-                    android:maxLines="1"
-                    android:paddingEnd="8dp"
-                    android:text="@string/search"
-                    android:textColor="?attr/daxColorSecondaryText" />
-
-                <ImageView
-                    android:id="@+id/aiChatIconMockup"
-                    android:layout_width="wrap_content"
-                    android:layout_height="match_parent"
-                    android:gravity="center"
-                    android:importantForAccessibility="no"
-                    android:paddingVertical="6dp"
-                    android:paddingHorizontal="10dp"
-                    android:src="@drawable/ic_ai_chat_24" />
-
-            </LinearLayout>
-
-        </com.google.android.material.card.MaterialCardView>
-
-    </com.google.android.material.card.MaterialCardView>
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/iconsContainer"
-        android:layout_width="wrap_content"
-        android:layout_height="@dimen/toolbarIcon"
-        android:layout_marginTop="@dimen/omnibarCardMarginBottom"
-        android:layout_marginBottom="@dimen/omnibarCardMarginTop"
-        android:layout_marginEnd="@dimen/keyline_1"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/mockOmniBarContainerShadow"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <com.duckduckgo.browser.ui.tabs.NewTabSwitcherButton
-            android:id="@+id/tabsMenu"
-            android:layout_width="@dimen/toolbarIcon"
-            android:layout_height="@dimen/toolbarIcon"
+            android:layout_marginStart="@dimen/omnibarCardMarginHorizontal"
+            android:layout_marginTop="@dimen/omnibarCardMarginBottom"
+            android:layout_marginEnd="@dimen/omnibarCardMarginEnd"
+            android:layout_marginBottom="@dimen/omnibarCardMarginTop"
+            app:cardCornerRadius="@dimen/largeShapeCornerRadius"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/browserMenu"
-            app:layout_constraintStart_toEndOf="@id/fireIconMenu"
-            app:layout_constraintTop_toTopOf="parent" />
-
-        <FrameLayout
-            android:id="@+id/browserMenu"
-            android:layout_width="@dimen/toolbarIcon"
-            android:layout_height="@dimen/toolbarIcon"
-            android:background="@drawable/selectable_item_rounded_corner_background"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/tabsMenu"
-            app:layout_constraintTop_toTopOf="parent">
-
-            <ImageView
-                android:id="@+id/browserMenuImageView"
-                android:layout_width="@dimen/bottomNavIcon"
-                android:layout_height="@dimen/bottomNavIcon"
-                android:layout_gravity="center"
-                android:contentDescription="@string/browserPopupMenu"
-                android:scaleType="center"
-                android:src="@drawable/ic_menu_vertical_24" />
-
-
-            <View
-                android:id="@+id/browserMenuHighlight"
-                android:layout_width="7dp"
-                android:layout_height="7dp"
-                android:layout_gravity="end"
-                android:layout_margin="@dimen/keyline_2"
-                android:background="@drawable/ic_dot_indicator_7"
-                android:visibility="gone" />
-
-        </FrameLayout>
-
-        <FrameLayout
-            android:id="@+id/fireIconMenu"
-            android:layout_width="@dimen/toolbarIcon"
-            android:layout_height="@dimen/toolbarIcon"
-            android:background="@drawable/selectable_item_rounded_corner_background"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/tabsMenu"
+            app:layout_constraintEnd_toStartOf="@id/iconsContainer"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 
-            <ImageView
-                android:id="@+id/fireIconImageView"
-                android:layout_width="@dimen/bottomNavIcon"
-                android:layout_height="@dimen/bottomNavIcon"
-                android:layout_gravity="center"
-                android:contentDescription="@string/fireMenu"
-                android:scaleType="center"
-                android:src="@drawable/ic_fire_24" />
-        </FrameLayout>
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/omniBarContainerMockup"
+                style="@style/Widget.DuckDuckGo.OmnibarCardView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:cardElevation="0dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:orientation="horizontal">
+
+                    <ImageView
+                        android:id="@+id/searchIconMockup"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:gravity="center"
+                        android:importantForAccessibility="no"
+                        android:paddingVertical="6dp"
+                        android:paddingStart="10dp"
+                        android:paddingEnd="8dp"
+                        android:src="@drawable/ic_find_search_small_24" />
+
+                    <com.duckduckgo.common.ui.view.text.DaxTextView
+                        android:id="@+id/omnibarTextInputMockup"
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        android:layout_weight="1"
+                        android:gravity="start|center"
+                        android:maxLines="1"
+                        android:paddingEnd="8dp"
+                        android:text="@string/search"
+                        android:textColor="?attr/daxColorSecondaryText" />
+
+                    <ImageView
+                        android:id="@+id/aiChatIconMockup"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:gravity="center"
+                        android:importantForAccessibility="no"
+                        android:paddingHorizontal="10dp"
+                        android:paddingVertical="6dp"
+                        android:src="@drawable/ic_ai_chat_24" />
+
+                </LinearLayout>
+
+            </com.google.android.material.card.MaterialCardView>
+
+        </com.google.android.material.card.MaterialCardView>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/iconsContainer"
+            android:layout_width="wrap_content"
+            android:layout_height="@dimen/toolbarIcon"
+            android:layout_marginTop="@dimen/omnibarCardMarginBottom"
+            android:layout_marginEnd="@dimen/keyline_1"
+            android:layout_marginBottom="@dimen/omnibarCardMarginTop"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/mockOmniBarContainerShadow"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <com.duckduckgo.browser.ui.tabs.NewTabSwitcherButton
+                android:id="@+id/tabsMenu"
+                android:layout_width="@dimen/toolbarIcon"
+                android:layout_height="@dimen/toolbarIcon"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/browserMenu"
+                app:layout_constraintStart_toEndOf="@id/fireIconMenu"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <FrameLayout
+                android:id="@+id/browserMenu"
+                android:layout_width="@dimen/toolbarIcon"
+                android:layout_height="@dimen/toolbarIcon"
+                android:background="@drawable/selectable_item_rounded_corner_background"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/tabsMenu"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <ImageView
+                    android:id="@+id/browserMenuImageView"
+                    android:layout_width="@dimen/bottomNavIcon"
+                    android:layout_height="@dimen/bottomNavIcon"
+                    android:layout_gravity="center"
+                    android:contentDescription="@string/browserPopupMenu"
+                    android:scaleType="center"
+                    android:src="@drawable/ic_menu_vertical_24" />
+
+
+                <View
+                    android:id="@+id/browserMenuHighlight"
+                    android:layout_width="7dp"
+                    android:layout_height="7dp"
+                    android:layout_gravity="end"
+                    android:layout_margin="@dimen/keyline_2"
+                    android:background="@drawable/ic_dot_indicator_7"
+                    android:visibility="gone" />
+
+            </FrameLayout>
+
+            <FrameLayout
+                android:id="@+id/fireIconMenu"
+                android:layout_width="@dimen/toolbarIcon"
+                android:layout_height="@dimen/toolbarIcon"
+                android:background="@drawable/selectable_item_rounded_corner_background"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/tabsMenu"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <ImageView
+                    android:id="@+id/fireIconImageView"
+                    android:layout_width="@dimen/bottomNavIcon"
+                    android:layout_height="@dimen/bottomNavIcon"
+                    android:layout_gravity="center"
+                    android:contentDescription="@string/fireMenu"
+                    android:scaleType="center"
+                    android:src="@drawable/ic_fire_24" />
+            </FrameLayout>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</FrameLayout>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216351726010644
Tech Design URL (if applicable): 

### Description

Fixes the bottom omnibar mockup toolbar (the placeholder shown briefly at startup before the real omnibar renders) when edge-to-edge is enabled.

The mockup used a fixed `?attr/actionBarSize` height. In edge-to-edge mode we apply the navigation-bar inset as bottom padding; on a fixed-height view that padding ate into the content box, squishing the mockup's omnibar card and shifting it upward so it no longer aligned with the real omnibar or cleared the navigation bar.

The fix keeps the height flexible on the outside and fixed on the inside.

Total height therefore becomes `actionBarSize` + navigation-bar inset, with the content kept at full action-bar height and the toolbar colour filling the nav-bar strip. When edge-to-edge is disabled no padding is added, so the `wrap_content` wrapper collapses to exactly `actionBarSize` — identical to the previous behaviour, so the legacy path is unaffected.

### Steps to test this PR

_Bottom omnibar mockup on edge-to-edge_
- [x] Enable the edge-to-edge browser feature flag and set the omnibar to the bottom position.
- [x] Use a device/emulator with 2/3-button navigation (visible nav bar).
- [x] Cold-launch the app and watch the transient mockup omnibar at startup.
- [x] Verify the mockup omnibar card is not squished/clipped and sits above the navigation bar, with the toolbar colour filling the nav-bar strip.
- [x] Switch to gesture navigation and repeat; confirm the mockup renders correctly.
- [x] Disable edge-to-edge and confirm the bottom mockup omnibar is unchanged (action-bar height, no regression).

### UI changes
Before/ after recordings were added to the task. 
