### PR TITLE
Use CompletableDeferred and rename onboarding experiment cohorts

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingPromptsExperimentManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingPromptsExperimentManager.kt
@@ -23,7 +23,7 @@ import com.duckduckgo.privacy.config.api.PrivacyConfigCallbackPlugin
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
@@ -48,8 +48,7 @@ class OnboardingPromptsExperimentManagerImpl @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
 ) : OnboardingPromptsExperimentManager, PrivacyConfigCallbackPlugin {
 
-    @Volatile
-    private var privacyPersisted: Boolean = false
+    private val privacyPersisted = CompletableDeferred<Unit>()
 
     override suspend fun enroll(): OnboardingPromptExperimentVariant? = withContext(dispatcherProvider.io()) {
         if (waitForPrivacyConfig()) {
@@ -81,14 +80,12 @@ class OnboardingPromptsExperimentManagerImpl @Inject constructor(
 
     private suspend fun waitForPrivacyConfig(): Boolean =
         withTimeoutOrNull(PRIVACY_CONFIG_WAIT_TIMEOUT_MS) {
-            while (!privacyPersisted) {
-                delay(10)
-            }
+            privacyPersisted.await()
         } != null
 
     override fun onPrivacyConfigPersisted() {
         super.onPrivacyConfigPersisted()
-        privacyPersisted = true
+        privacyPersisted.complete(Unit)
     }
 
     override fun onPrivacyConfigDownloaded() = Unit

--- a/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingPromptsToggles.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/OnboardingPromptsToggles.kt
@@ -39,8 +39,8 @@ interface OnboardingPromptsToggles {
 
     enum class OnboardingPromptsCohorts(override val cohortName: String) : CohortName {
         CONTROL("control"),
-        TREATMENT_DOCK_ONLY("treatment_dock_only"),
-        TREATMENT_WIDGET_ONLY("treatment_widget_only"),
-        TREATMENT_DOCK_AND_WIDGET("treatment_dock_and_widget"),
+        TREATMENT_DOCK_ONLY("treatmentDockOnly"),
+        TREATMENT_WIDGET_ONLY("treatmentWidgetOnly"),
+        TREATMENT_DOCK_AND_WIDGET("treatmentDockAndWidget"),
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211724162604201/task/1216396240881948?focus=true
Tech Design URL (if applicable):

### Description

Follow-up to #9125 addressing post-merge review comments:

- Removed the polling loop that waited for the privacy config to be persisted and replaced it with a `CompletableDeferred`.
- Renamed the experiment cohort names so they no longer use underscores (they use camelCase now).

### Steps to test this PR

_CI passes_

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Cohort string renames must match remote privacy-config values or users may fail enrollment into the intended treatment arms; the sync change is behavior-preserving aside from efficiency.
> 
> **Overview**
> **Onboarding experiment enrollment** now waits for privacy config persistence via a `CompletableDeferred` instead of polling a `@Volatile` flag every 10ms; the existing 2s timeout in `waitForPrivacyConfig()` is unchanged, and `onPrivacyConfigPersisted()` completes the deferred.
> 
> **Remote cohort identifiers** for the dock/widget onboarding experiment were updated from underscore strings (`treatment_dock_only`, etc.) to camelCase (`treatmentDockOnly`, `treatmentWidgetOnly`, `treatmentDockAndWidget`) in `OnboardingPromptsCohorts`; enum constant names and enrollment logic are the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c95193f59b099f794f8f40bb135c3c18d1cc17b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->