### PR TITLE
Add funnel origins to native subscription purchase entry points

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -956,7 +956,10 @@ class RealNativeInputManager @Inject constructor(
     }
 
     private fun launchPurchase() {
-        globalActivityStarter.start(rootView.context, SubscriptionPurchase(featurePage = DUCK_AI_FEATURE_PAGE))
+        globalActivityStarter.start(
+            rootView.context,
+            SubscriptionPurchase(origin = PURCHASE_ORIGIN, featurePage = DUCK_AI_FEATURE_PAGE),
+        )
     }
 
     /**
@@ -987,6 +990,7 @@ class RealNativeInputManager @Inject constructor(
         private const val WIDGET_ELEVATION_DP = 8f
         private const val FADE_OUT_DURATION_MS = 150L
         private const val DUCK_AI_FEATURE_PAGE = "duckai"
+        private const val PURCHASE_ORIGIN = "funnel_duckai_android__freelabel"
     }
 }
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/RestoreSubscriptionActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/RestoreSubscriptionActivity.kt
@@ -154,17 +154,20 @@ class RestoreSubscriptionActivity : DuckDuckGoActivity() {
     }
 
     private fun goToSubscriptions() {
-        startSubscriptionsWebViewActivity(url = subscriptionsUrlProvider.buyUrl)
+        startSubscriptionsWebViewActivity(
+            url = subscriptionsUrlProvider.buyUrl,
+            origin = PURCHASE_VIEW_PLANS_ORIGIN,
+        )
     }
 
     private fun goToSubscriptionsWelcomePage() {
         startSubscriptionsWebViewActivity(url = subscriptionsUrlProvider.welcomeUrl)
     }
 
-    private fun startSubscriptionsWebViewActivity(url: String) {
+    private fun startSubscriptionsWebViewActivity(url: String, origin: String? = null) {
         globalActivityStarter.start(
             context = this,
-            params = SubscriptionsWebViewActivityWithParams(url),
+            params = SubscriptionsWebViewActivityWithParams(url = url, origin = origin),
         )
     }
 
@@ -218,5 +221,9 @@ class RestoreSubscriptionActivity : DuckDuckGoActivity() {
             is FinishAndGoToOnboarding -> finishAndGoToOnboarding()
             is FinishAndGoToSubscriptionSettings -> finishAndGoToSubscriptionSettings()
         }
+    }
+
+    companion object {
+        private const val PURCHASE_VIEW_PLANS_ORIGIN = "funnel_restore_android__viewplans"
     }
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionSettingsActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionSettingsActivity.kt
@@ -382,6 +382,7 @@ class SubscriptionSettingsActivity : DuckDuckGoActivity() {
             context = this,
             params = SubscriptionsWebViewActivityWithParams(
                 url = subscriptionsUrlProvider.buyUrl,
+                origin = PURCHASE_VIEW_PLANS_ORIGIN,
             ),
         )
     }
@@ -470,5 +471,7 @@ class SubscriptionSettingsActivity : DuckDuckGoActivity() {
         // const val MANAGE_URL = "https://duckduckgo.com/subscriptions/manage"
         const val LEARN_MORE_URL = "https://duckduckgo.com/duckduckgo-help-pages/privacy-pro/adding-email"
         const val PRIVACY_POLICY_URL = "https://duckduckgo.com/pro/privacy-terms"
+
+        private const val PURCHASE_VIEW_PLANS_ORIGIN = "funnel_subscriptionsettings_android__viewplans"
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211391679843270/task/1216397261064720?focus=true                                                     
Tech Design URL (if applicable):                                                                                                                                   
                                                                                                                                                                     
### Description                                                                                                                                                    
Three native entry points launched the subscription purchase WebView with a `null` origin, so the `subscription-purchase` wide event recorded an empty `context.name` and those funnels could not be attributed.
                                                                                                                                                                     
  - **Duck.ai omnibar free-tier "Upgrade" pill** (`NativeInputManager`) → `funnel_duckai_android__freelabel` (only reachable for free users, gated in                
  `NativeInputOmnibarController.updateTierTitle`)                                                                                                                    
  - **Subscription settings "View Plans"** for expired/inactive users (`SubscriptionSettingsActivity`) → `funnel_subscriptionsettings_android__viewplans`            
  - **Restore → "Subscription not found" → "View Plans"** (`RestoreSubscriptionActivity`) → `funnel_restore_android__viewplans`                                      
                                                                                                                                                                     
  Out of scope by design: switch/upgrade-only surfaces (e.g. the active-subscriber "View all plans", which routes to the plan-switch flow, not purchase) and         
  FE-controlled origins                                                                                                   
                                                                                                                                                                     
  ### Steps to test this PR                                                                                                                                          
                                                                                                                                                                     
  _Duck.ai free-tier upgrade pill_                                                                                                                                   
  - [x] As a non-subscriber, open Duck.ai and tap the "Upgrade" pill in the omnibar header                                                                           
  - [x] Confirm the purchase flow opens and the `wide_subscription-purchase` event carries `context.name = funnel_duckai_android__freelabel`                         
                                                                                                                                                                     
  _Subscription settings "View Plans" (expired/inactive)_                                                                                                            
  - [x] With an expired/inactive subscription, open Subscription Settings and tap "View Plans"                                                                       
  - [x] Confirm the `wide_subscription-purchase` event carries `context.name = funnel_subscriptionsettings_android__viewplans`                                       
                                                                                                                                                                     
  _Restore "Subscription not found"_                                                                                                                                 
  - [x] Start the restore flow with an account that has no subscription, then tap "View Plans" in the "Subscription not found" dialog                                
  - [x] Confirm the `wide_subscription-purchase` event carries `context.name = funnel_restore_android__viewplans`                                                    
                                                                                                                                                                     
  ### UI changes    
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only parameter wiring on existing purchase navigation; no changes to billing, auth, or subscription state logic.
> 
> **Overview**
> Native subscription purchase flows previously launched with a **null** `origin`, so `wide_subscription-purchase` events had an empty `context.name` and those funnels could not be attributed.
> 
> This PR threads **distinct funnel origin strings** into three Android entry points: Duck.ai omnibar **Upgrade** (`funnel_duckai_android__freelabel` via `SubscriptionPurchase`), subscription settings **View Plans** for expired/inactive users (`funnel_subscriptionsettings_android__viewplans`), and restore **Subscription not found → View Plans** (`funnel_restore_android__viewplans` through an optional `origin` on `startSubscriptionsWebViewActivity`). Plan-switch and other non-purchase routes are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c76fb2ccda182995057dbffdc015e20d488ba435. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->