### PR TITLE
Fix autofill e2e flows broken by search-only legacy omnibar

### DIFF
--- a/.maestro/autofill/3_autofill_prompted_to_save_creds_on_form.yaml
+++ b/.maestro/autofill/3_autofill_prompted_to_save_creds_on_form.yaml
@@ -13,7 +13,7 @@ tags:
         - runFlow: ../shared/skip_all_onboarding.yaml
 
         - tapOn:
-            id: "inputField"
+            id: "omnibarTextInput"
         - inputText: "fill.dev/form/login-simple"
         - pressKey: enter
 

--- a/.maestro/autofill/backfillingUsername/multi_step_login_username_backfilled.yaml
+++ b/.maestro/autofill/backfillingUsername/multi_step_login_username_backfilled.yaml
@@ -17,7 +17,7 @@ tags:
 
       # get to autofill form
       - tapOn:
-          id: "inputField"
+          id: "omnibarTextInput"
       - inputText: "https://autofill.me/form/login-simple"
       - pressKey: Enter
 

--- a/.maestro/autofill/backfillingUsername/multi_step_login_username_backfilled_for_an_update.yaml
+++ b/.maestro/autofill/backfillingUsername/multi_step_login_username_backfilled_for_an_update.yaml
@@ -20,7 +20,7 @@ tags:
 
       # get to autofill form
       - tapOn:
-          id: "inputField"
+          id: "omnibarTextInput"
       - inputText: "https://autofill.me/form/login-simple"
       - pressKey: Enter
       - runFlow: ../steps/decline_autofill_prompt.yaml

--- a/.maestro/autofill/backfillingUsername/multi_step_login_username_not_backfilled_if_provided_explicitly.yaml
+++ b/.maestro/autofill/backfillingUsername/multi_step_login_username_not_backfilled_if_provided_explicitly.yaml
@@ -17,7 +17,7 @@ tags:
 
       # get to autofill form
       - tapOn:
-          id: "inputField"
+          id: "omnibarTextInput"
       - inputText: "https://autofill.me/form/login-simple"
       - pressKey: Enter
 

--- a/.maestro/autofill/backfillingUsername/multi_step_registration_username_backfilled_password_autogenerated.yaml
+++ b/.maestro/autofill/backfillingUsername/multi_step_registration_username_backfilled_password_autogenerated.yaml
@@ -17,7 +17,7 @@ tags:
 
       # get to autofill form
       - tapOn:
-          id: "inputField"
+          id: "omnibarTextInput"
       - inputText: "https://autofill.me/form/registration-username"
       - pressKey: Enter
 

--- a/.maestro/autofill/backfillingUsername/multi_step_registration_username_backfilled_password_manually_entered.yaml
+++ b/.maestro/autofill/backfillingUsername/multi_step_registration_username_backfilled_password_manually_entered.yaml
@@ -17,7 +17,7 @@ tags:
 
       # get to autofill form
       - tapOn:
-          id: "inputField"
+          id: "omnibarTextInput"
       - inputText: "https://autofill.me/form/registration-username"
       - pressKey: Enter
 

--- a/.maestro/autofill/backfillingUsername/password_reset_flow_autogenerated_password.yaml
+++ b/.maestro/autofill/backfillingUsername/password_reset_flow_autogenerated_password.yaml
@@ -17,7 +17,7 @@ tags:
 
       # get to autofill login form
       - tapOn:
-          id: "inputField"
+          id: "omnibarTextInput"
       - inputText: "https://autofill.me/form/login-simple"
       - pressKey: Enter
 
@@ -35,7 +35,7 @@ tags:
 
       # get to password reset form
       - tapOn:
-          id: "com.duckduckgo.mobile.android:id/omnibarTextInputClickCatcher"
+          id: "omnibarTextInput"
       - eraseText
       - inputText: "https://autofill.me/form/change-password"
       - pressKey: Enter

--- a/.maestro/autofill/backfillingUsername/password_reset_flow_for_existing_credential_generated_password.yaml
+++ b/.maestro/autofill/backfillingUsername/password_reset_flow_for_existing_credential_generated_password.yaml
@@ -17,7 +17,7 @@ tags:
 
       # get to autofill login form
       - tapOn:
-          id: "inputField"
+          id: "omnibarTextInput"
       - inputText: "https://autofill.me/form/login-simple"
       - pressKey: Enter
 
@@ -35,7 +35,7 @@ tags:
 
       # get to password reset form
       - tapOn:
-          id: "com.duckduckgo.mobile.android:id/omnibarTextInputClickCatcher"
+          id: "omnibarTextInput"
       - eraseText
       - inputText: "https://autofill.me/form/change-password"
       - pressKey: Enter

--- a/.maestro/autofill/backfillingUsername/password_reset_flow_for_existing_credential_manual_password.yaml
+++ b/.maestro/autofill/backfillingUsername/password_reset_flow_for_existing_credential_manual_password.yaml
@@ -20,7 +20,7 @@ tags:
 
       # get to autofill login form
       - tapOn:
-          id: "com.duckduckgo.mobile.android:id/inputField"
+          id: "omnibarTextInput"
       - inputText: "https://autofill.me/form/login-simple"
       - pressKey: Enter
       - runFlow: ../steps/decline_autofill_prompt.yaml
@@ -36,7 +36,7 @@ tags:
 
       # get to password reset form
       - tapOn:
-          id: "com.duckduckgo.mobile.android:id/omnibarTextInputClickCatcher"
+          id: "omnibarTextInput"
       - eraseText
       - inputText: "https://autofill.me/form/change-password"
       - pressKey: Enter

--- a/.maestro/autofill/passwordGeneration/autosaves_credential_when_password_generated_with_username.yaml
+++ b/.maestro/autofill/passwordGeneration/autosaves_credential_when_password_generated_with_username.yaml
@@ -17,7 +17,7 @@ tags:
 
       # get to autofill form
       - tapOn:
-          id: "inputField"
+          id: "omnibarTextInput"
       - inputText: "https://autofill.me/form/registration-username"
       - pressKey: Enter
 

--- a/.maestro/autofill/passwordGeneration/autosaves_credential_when_password_generated_without_username.yaml
+++ b/.maestro/autofill/passwordGeneration/autosaves_credential_when_password_generated_without_username.yaml
@@ -17,7 +17,7 @@ tags:
 
       # get to autofill form
       - tapOn:
-          id: "inputField"
+          id: "omnibarTextInput"
       - inputText: "https://autofill.me/form/registration-username"
       - pressKey: Enter
 


### PR DESCRIPTION

Task/Issue URL: https://app.asana.com/1/137249556945/project/1212608036467427/task/1216395465778149?focus=true
### Description
#9124 made search-only mode fall back to the legacy omnibar, so the native inputField / omnibarTextInputClickCatcher are no longer present. The autofill nightly builds the play binary (search-only default), so the flows migrated to inputField in #9023 fail at the first omnibar tap.

#9133 reverted the 7 releaseTest flows but missed all autofill flows. Revert the 11 autofill flows back to omnibarTextInput for omnibar interactions (initial NTP tap, plus the on-page URL edit in the three password_reset flows), matching the #9133 fix.

### Steps to test this PR
Rerun e2e tests workflows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Maestro YAML selector updates only; no app runtime or security behavior changes.
> 
> **Overview**
> Repairs **11 autofill Maestro flows** that were still targeting **`inputField`** / **`omnibarTextInputClickCatcher`** after search-only builds started using the **legacy omnibar**, so the first omnibar tap (and URL edits in password-reset scenarios) failed on nightly play binaries.
> 
> All affected **`tapOn`** steps now use **`omnibarTextInput`**, aligned with the earlier **releaseTest** fix in #9133. No production or autofill logic changes—test selectors only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dc34ad9dad22323ae4f03063f98630dad40479a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->