### PR TITLE
Extract ad blocking domain matcher

### DIFF
--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionDomainMatcher.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionDomainMatcher.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl
+
+import android.net.Uri
+import androidx.core.net.toUri
+import com.duckduckgo.app.browser.Domain
+import com.duckduckgo.app.browser.UriString
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+/**
+ * Single source of truth for the domains the ad-blocking extension operates on. A subdomain
+ * match means `youtube.com` also covers `m.youtube.com`, `www.youtube.com`, etc.
+ */
+
+interface AdBlockingExtensionDomainMatcher {
+    fun matches(url: String?): Boolean
+
+    fun matches(uri: Uri): Boolean
+}
+
+@ContributesBinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
+class RealAdBlockingExtensionDomainMatcher @Inject constructor() : AdBlockingExtensionDomainMatcher {
+
+    override fun matches(url: String?): Boolean {
+        val uri = url?.toUri() ?: return false
+        return matches(uri)
+    }
+
+    override fun matches(uri: Uri): Boolean = DOMAINS.any { UriString.sameOrSubdomain(uri, it) }
+
+    private companion object {
+        val DOMAINS = listOf(
+            Domain("youtube.com"),
+            Domain("youtube-nocookie.com"),
+        )
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionJsInjectorPlugin.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionJsInjectorPlugin.kt
@@ -18,10 +18,7 @@ package com.duckduckgo.adblocking.impl
 
 import android.webkit.WebView
 import androidx.annotation.UiThread
-import androidx.core.net.toUri
 import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
-import com.duckduckgo.app.browser.Domain
-import com.duckduckgo.app.browser.UriString
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.browser.api.JsInjectorPlugin
@@ -42,6 +39,7 @@ import javax.inject.Inject
 class AdBlockingExtensionJsInjectorPlugin @Inject constructor(
     private val statusChecker: AdBlockingStatusChecker,
     repository: AdBlockingExtensionRepository,
+    private val domainMatcher: AdBlockingExtensionDomainMatcher,
     @AppCoroutineScope appScope: CoroutineScope,
 ) : JsInjectorPlugin {
 
@@ -61,8 +59,7 @@ class AdBlockingExtensionJsInjectorPlugin @Inject constructor(
             logcat { "Status checker rejected injection, skipping" }
             return
         }
-        val uri = url?.toUri() ?: return
-        if (domains.none { UriString.sameOrSubdomain(uri, it) }) {
+        if (!domainMatcher.matches(url)) {
             logcat { "No domains matching, skipping" }
             return
         }
@@ -83,9 +80,4 @@ class AdBlockingExtensionJsInjectorPlugin @Inject constructor(
             .takeUnless { it.isEmpty() }
             ?.sortedBy { it.name }
             ?.joinToString(separator = "\n") { it.content }
-
-    private val domains = listOf(
-        Domain("youtube.com"),
-        Domain("youtube-nocookie.com"),
-    )
 }

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionJsInjectorPluginTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/AdBlockingExtensionJsInjectorPluginTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.adblocking.impl
 
+import android.net.Uri
 import android.webkit.WebView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
@@ -35,6 +36,7 @@ import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
@@ -60,10 +62,18 @@ class AdBlockingExtensionJsInjectorPluginTest {
         Scriptlet(name = isolatedName, content = "console.log('a')"),
     )
 
+    private val mockDomainMatcher: AdBlockingExtensionDomainMatcher = mock() {
+        on {
+            matches(any<Uri>())
+        } doReturn true
+        on { matches(any<String>()) } doReturn true
+    }
+
     private val plugin by lazy {
         AdBlockingExtensionJsInjectorPlugin(
             statusChecker = statusChecker,
             repository = repository,
+            domainMatcher = mockDomainMatcher,
             appScope = testScope,
         )
     }
@@ -127,6 +137,7 @@ class AdBlockingExtensionJsInjectorPluginTest {
     @Test
     fun whenUrlHostNotInConfiguredDomainsThenScriptIsNotInjected() {
         scriptletsFlow.value = singleScriptlet
+        whenever(mockDomainMatcher.matches(any<String>())).thenReturn(false)
 
         plugin.onPageStarted(webView, url = "https://example.com/page", isDesktopMode = null)
 
@@ -164,6 +175,7 @@ class AdBlockingExtensionJsInjectorPluginTest {
     @Test
     fun whenUrlHasNoHostThenScriptIsNotInjected() {
         scriptletsFlow.value = singleScriptlet
+        whenever(mockDomainMatcher.matches(any<String>())).thenReturn(false)
 
         plugin.onPageStarted(webView, url = "data:text/html,<p>hi</p>", isDesktopMode = null)
 

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/RealAdBlockingExtensionDomainMatcherTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/RealAdBlockingExtensionDomainMatcherTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl
+
+import androidx.core.net.toUri
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RealAdBlockingExtensionDomainMatcherTest {
+
+    private val matcher = RealAdBlockingExtensionDomainMatcher()
+
+    @Test
+    fun whenUrlIsYouTubeThenMatches() {
+        assertTrue(matcher.matches("https://youtube.com/watch?v=123"))
+    }
+
+    @Test
+    fun whenUrlIsWwwYouTubeThenMatches() {
+        assertTrue(matcher.matches("https://www.youtube.com/watch?v=123"))
+    }
+
+    @Test
+    fun whenUrlIsMobileYouTubeThenMatches() {
+        assertTrue(matcher.matches("https://m.youtube.com/watch?v=123"))
+    }
+
+    @Test
+    fun whenUrlIsYouTubeNoCookieThenMatches() {
+        assertTrue(matcher.matches("https://youtube-nocookie.com/embed/123"))
+    }
+
+    @Test
+    fun whenUrlIsWwwYouTubeNoCookieThenMatches() {
+        assertTrue(matcher.matches("https://www.youtube-nocookie.com/embed/123"))
+    }
+
+    @Test
+    fun whenUrlIsNonMatchingHostThenDoesNotMatch() {
+        assertFalse(matcher.matches("https://example.com/watch?v=123"))
+    }
+
+    @Test
+    fun whenUrlOnlyContainsDomainAsPrefixThenDoesNotMatch() {
+        assertFalse(matcher.matches("https://youtube.com.evil.com/watch?v=123"))
+    }
+
+    @Test
+    fun whenUrlOnlyContainsDomainAsSuffixThenDoesNotMatch() {
+        assertFalse(matcher.matches("https://notyoutube.com/watch?v=123"))
+    }
+
+    @Test
+    fun whenUrlIsNullThenDoesNotMatch() {
+        assertFalse(matcher.matches(null))
+    }
+
+    @Test
+    fun whenUrlIsMalformedThenDoesNotMatch() {
+        assertFalse(matcher.matches("not a url"))
+    }
+
+    @Test
+    fun whenUriIsYouTubeThenMatches() {
+        assertTrue(matcher.matches("https://www.youtube.com/watch?v=123".toUri()))
+    }
+
+    @Test
+    fun whenUriIsNonMatchingHostThenDoesNotMatch() {
+        assertFalse(matcher.matches("https://example.com/watch?v=123".toUri()))
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216395466832011?focus=true
Tech Design URL (if applicable): 

### Description

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor with the same domain list and matching logic; risk is low if tests pass, since injection scope is unchanged.
> 
> **Overview**
> Moves YouTube domain allowlisting out of `AdBlockingExtensionJsInjectorPlugin` into a dedicated **`AdBlockingExtensionDomainMatcher`** (`RealAdBlockingExtensionDomainMatcher` via DI), so `youtube.com` / `youtube-nocookie.com` and subdomain rules live in one place.
> 
> The injector now gates script injection with `domainMatcher.matches(url)` instead of inline `UriString` checks. **Injector tests** mock the matcher for domain-related cases; **`RealAdBlockingExtensionDomainMatcherTest`** covers match behavior including subdomain and spoof-host edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18ff1152143bcda94187350fe83443e557f8516a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->