### PR TITLE
Fix internal privacy api-manipulation e2e for search-only omnibar

### DIFF
--- a/.maestro/privacy_tests_internal/1_-_Api_manipulation.yaml
+++ b/.maestro/privacy_tests_internal/1_-_Api_manipulation.yaml
@@ -43,10 +43,10 @@ tags:
       - pressKey: Back
       - pressKey: Back
       - pressKey: Back
-      # With native input enabled, the NTP widget auto-opens with its inputField
-      # focused — type into that directly instead of the (now hidden) omnibar.
-      - assertVisible:
-          id: "com.duckduckgo.mobile.android:id/inputField"
+      # In search-only mode (the default) the NTP uses the legacy omnibar, not
+      # the native input overlay — tap the text input directly to enter the URL.
+      - tapOn:
+          id: "omnibarTextInput"
       - inputText: "https://privacy-test-pages.site/content-scope-scripts/infra/pages/conditional-matching-experiments.html?automation=1"
       - pressKey: Enter
       - tapOn:


### PR DESCRIPTION

Task/Issue URL:  https://app.asana.com/1/137249556945/project/1212608036467427/task/1216395465778157?focus=true
Tech Design URL (if applicable): 

### Description
Same #9124 fallout as the autofill flows: the internal binary defaults to search-only mode, where the NTP now shows the legacy omnibar instead of the native input overlay, so the inputField assert/type no longer works. Tap omnibarTextInput directly to enter the URL.

### Steps to test this PR
rerun privacy tests: https://app.maestro.dev/project/proj_01htg54rdtfwx8rgbzv03cxkpf/maestro-test/flow/run_01kx3790r3ea9b67j70rbgbj61

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Maestro YAML change with no production code impact.
> 
> **Overview**
> Updates the internal **Api manipulation** Maestro flow so navigation URL entry matches **search-only** NTP behavior (the internal build default after related UI changes).
> 
> Instead of asserting and typing into the native NTP `inputField` overlay, the flow **taps `omnibarTextInput`** and enters the privacy test page URL there—same pattern as the autofill e2e fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd637304b547da7f2e9b06de99a13e06bfbab711. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->