### PR TITLE
Fix privacy & security e2e flows broken by search-only omnibar

### DIFF
--- a/.maestro/privacy_tests/14_-_Single-site,_single-tab,_no-session-after-fire.yaml
+++ b/.maestro/privacy_tests/14_-_Single-site,_single-tab,_no-session-after-fire.yaml
@@ -11,6 +11,8 @@ tags:
             - launchApp:
                 clearState: true
             - runFlow: ../shared/skip_all_onboarding.yaml
+            - tapOn:
+                id: "omnibarTextInput"
             - inputText: "https://www.search-company.site/#ad-id-5"
             - pressKey: Enter
             - assertVisible:
@@ -52,14 +54,14 @@ tags:
             - action: back
             - action: back
             - tapOn:
-                id: "omnibarTextInputClickCatcher"
+                id: "omnibarTextInput"
             - copyTextFrom:
-                id: "inputField"
+                id: "omnibarTextInput"
             - action: back
             - runFlow: ../shared/browser_screen/click_on_fire_button.yaml
             - runFlow: ../shared/browser_screen/confirm_fire_dialog.yaml
             - tapOn:
-                id: "inputField"
+                id: "omnibarTextInput"
             - pasteText
             - pressKey: Enter
             - assertVisible:

--- a/.maestro/privacy_tests/6_-_Multi-tab.yaml
+++ b/.maestro/privacy_tests/6_-_Multi-tab.yaml
@@ -9,6 +9,8 @@ tags:
             - launchApp:
                 clearState: true
             - runFlow: ../shared/skip_all_onboarding.yaml
+            - tapOn:
+                id: "omnibarTextInput"
             - inputText: "https://www.search-company.site/#ad-id-5"
             - pressKey: Enter
             - assertVisible:
@@ -60,9 +62,9 @@ tags:
             - tapOn:
                 id: "com.duckduckgo.mobile.android:id/close"
             - assertVisible:
-                id: "com.duckduckgo.mobile.android:id/inputField"
+                id: "com.duckduckgo.mobile.android:id/omnibarTextInput"
             - tapOn:
-                id: "com.duckduckgo.mobile.android:id/inputField"
+                id: "com.duckduckgo.mobile.android:id/omnibarTextInput"
             - inputText: "https://www.publisher-company.site/product.html?p=200"
             - pressKey: Enter
             - assertVisible:

--- a/.maestro/security_tests/1_-_AddressBarSpoof,_basicauth.yaml
+++ b/.maestro/security_tests/1_-_AddressBarSpoof,_basicauth.yaml
@@ -10,7 +10,7 @@ tags:
                 clearState: true
             - runFlow: ../shared/skip_all_onboarding.yaml
             - tapOn:
-                id: "inputField"
+                id: "omnibarTextInput"
             # Test 1 - using line-separator (U+2028) character
             - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-basicauth-2028.html"
             - pressKey: Enter
@@ -21,7 +21,7 @@ tags:
                 id: "omnibarTextInput"
             - assertTrue: ${maestro.copiedText.indexOf("https://www.google.com") != 0}
             - tapOn:
-                id: "omnibarTextInputClickCatcher"
+                id: "omnibarTextInput"
             - eraseText
             # Test 2 - using paragraph-separator (U+2029) character
             - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-basicauth-2029.html"
@@ -32,7 +32,7 @@ tags:
                 id: "omnibarTextInput"
             - assertTrue: ${maestro.copiedText.indexOf("https://www.google.com") != 0}
             - tapOn:
-                id: "omnibarTextInputClickCatcher"
+                id: "omnibarTextInput"
             - eraseText
             # Test 3 - using repeated space character
             - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-basicauth-whitespace.html"

--- a/.maestro/security_tests/2_-_AddressBarSpoof,_aboutblank.yaml
+++ b/.maestro/security_tests/2_-_AddressBarSpoof,_aboutblank.yaml
@@ -10,7 +10,7 @@ tags:
                 clearState: true
             - runFlow: ../shared/skip_all_onboarding.yaml
             - tapOn:
-                id: "inputField"
+                id: "omnibarTextInput"
             - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-about-blank-rewrite.html"
             - pressKey: Enter
 
@@ -20,7 +20,7 @@ tags:
                 notVisible: "Not DDG."  # Spoofed content not visible
                 timeout: 10000
             - tapOn:
-                id: "omnibarTextInputClickCatcher"
+                id: "omnibarTextInput"
             - copyTextFrom:
-                id: "inputField"
+                id: "omnibarTextInput"
             - assertTrue: ${maestro.copiedText == "about:blank" || maestro.copiedText == "https://duckduckgo.com/"}

--- a/.maestro/security_tests/4_-_AddressBarSpoof,_b64_html.yaml
+++ b/.maestro/security_tests/4_-_AddressBarSpoof,_b64_html.yaml
@@ -11,7 +11,7 @@ tags:
             - runFlow: ../shared/skip_all_onboarding.yaml
             # Test 1
             - tapOn:
-                id: "inputField"
+                id: "omnibarTextInput"
             - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-open-b64-html.html"
             - pressKey: Enter
 
@@ -20,7 +20,7 @@ tags:
             - assertVisible: "Open in another app"
             - tapOn: "Cancel"
             - tapOn:
-                id: "omnibarTextInputClickCatcher"
+                id: "omnibarTextInput"
             - copyTextFrom:
-                id: "inputField"
+                id: "omnibarTextInput"
             - assertTrue: ${maestro.copiedText.indexOf("duckduckgo.com") == -1}

--- a/.maestro/security_tests/5_-_AddressBarSpoof,_downloadpath.yaml
+++ b/.maestro/security_tests/5_-_AddressBarSpoof,_downloadpath.yaml
@@ -11,7 +11,7 @@ tags:
             - runFlow: ../shared/skip_all_onboarding.yaml
             # Test 1
             - tapOn:
-                id: "inputField"
+                id: "omnibarTextInput"
             - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-js-download-url.html"
             - pressKey: Enter
 
@@ -33,7 +33,7 @@ tags:
             - tapOn: "Cancel"
             # Should redirect back to the last page.
             - tapOn:
-                id: "omnibarTextInputClickCatcher"
+                id: "omnibarTextInput"
             - copyTextFrom:
-                id: "inputField"
+                id: "omnibarTextInput"
             - assertTrue: ${maestro.copiedText.indexOf("https://staticcdn.duckduckgo.com") == -1}

--- a/.maestro/security_tests/6_-_AddressBarSpoof,_formaction.yaml
+++ b/.maestro/security_tests/6_-_AddressBarSpoof,_formaction.yaml
@@ -11,14 +11,14 @@ tags:
             - runFlow: ../shared/skip_all_onboarding.yaml
             # Test 1
             - tapOn:
-                id: "inputField"
+                id: "omnibarTextInput"
             - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-form-action.html"
             - pressKey: Enter
 
             - tapOn: "run"
             # Should do nothing - the navigation should be prevented.
             - tapOn:
-                id: "omnibarTextInputClickCatcher"
+                id: "omnibarTextInput"
             - copyTextFrom:
-                id: "inputField"
+                id: "omnibarTextInput"
             - assertTrue: ${maestro.copiedText == "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-form-action.html"}

--- a/.maestro/security_tests/7_-_AddressBarSpoof,_pagerewrite.yaml
+++ b/.maestro/security_tests/7_-_AddressBarSpoof,_pagerewrite.yaml
@@ -11,17 +11,17 @@ tags:
             - runFlow: ../shared/skip_all_onboarding.yaml
             # Test 1
             - tapOn:
-                id: "inputField"
+                id: "omnibarTextInput"
             - inputText: "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-js-page-rewrite.html"
             - pressKey: Enter
 
             - tapOn: "Start"
             # Assert the page wasn't rewritten to spoofed content while it is still
-            # visible, before opening the native input (which overlays the web view).
+            # visible, before interacting with the address bar.
             - assertNotVisible: "DDG."
             # Now check the address bar hasn't been updated too early resulting in spoofed content
             - tapOn:
-                id: "omnibarTextInputClickCatcher"
+                id: "omnibarTextInput"
             - copyTextFrom:
-                id: "inputField"
+                id: "omnibarTextInput"
             - assertTrue: ${maestro.copiedText == "https://privacy-test-pages.site/security/address-bar-spoofing/spoof-js-page-rewrite.html"}

--- a/.maestro/security_tests/8_-_AddressBarSpoof,_aboutblankemptyaddress.yaml
+++ b/.maestro/security_tests/8_-_AddressBarSpoof,_aboutblankemptyaddress.yaml
@@ -12,7 +12,7 @@ tags:
       - runFlow: ../shared/skip_all_onboarding.yaml
 
       - tapOn:
-          id: "inputField"
+          id: "omnibarTextInput"
       - inputText: "http://privacy-test-pages.site/security/address-bar-spoofing/spoof-about-blank-emptyaddress.html"
       - pressKey: Enter
 


### PR DESCRIPTION
Task/Issue URL:  https://app.asana.com/1/137249556945/project/1212608036467427/task/1216395465778157?focus=true
Tech Design URL (if applicable): 

### Description
#9016 migrated these flows to the native inputField, assuming it is always shown. #9124 then made search-only mode fall back to the legacy omnibar; privacyTest and securityTest run on the play binary (search-only default), so inputField / omnibarTextInputClickCatcher are no longer present and the flows fail at the first omnibar interaction.

Revert privacy tests 6 & 14 and security AddressBarSpoof 1,2,4,5,6,7,8 to the legacy omnibarTextInput, keeping #9016's non-selector improvements. Mirrors the release-flow fix merged in #9144.

### Steps to test this PR
rerun privacy & security tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only YAML selector updates with no production app or security logic changes.
> 
> **Overview**
> Updates **privacy** (tests 6 and 14) and **security** AddressBarSpoof flows (1, 2, 4–8) so Maestro taps and copies text from **`omnibarTextInput`** instead of **`inputField`** and **`omnibarTextInputClickCatcher`**.
> 
> On the play binary, **search-only** mode shows the legacy omnibar, so the native input selectors from #9016 are missing and flows failed on the first address-bar step. Several flows now **tap `omnibarTextInput` before `inputText`** so navigation URLs can be entered reliably.
> 
> This matches the release-flow fix in #9144; non-selector improvements from #9016 are kept (e.g. pagerewrite comment wording).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9cd4c2b8a2a75735f366ee0b879e898a6bb9866. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->