### PR TITLE
PIR: Handle PIR profile reappearance on maintenance scans

### DIFF
--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -267,6 +267,20 @@
             }
         ]
     },
+    "m_dbp_optoutjob_reappeared": {
+        "description": "Fired when a previously-removed profile reappears in a later scan, reverting its opt-out job record from REMOVED back to REQUESTED.",
+        "owners": ["karlenDimla", "landomen"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count_short", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "data_broker",
+                "description": "The URL of the data broker on which the profile reappeared",
+                "type": "string"
+            }
+        ]
+    },
     "m_dbp_engagement_dau": {
         "description": "Pixel for PIR daily active users.",
         "owners": ["karlenDimla", "landomen"],

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirRunStateHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirRunStateHandler.kt
@@ -684,10 +684,16 @@ class RealPirRunStateHandler @Inject constructor(
                          * - We update the optOut status to REMOVED
                          * - We store the new extracted profiles (if profile query is not deprecated). We ignore the ones that already exist.
                          * - Update the corresponding ScanJobRecord
+                         * For every stored extractedProfile that reappears in the results and whose opt-out was previously
+                         * REMOVED, we revert it back to REQUESTED and report a reappearance pixel.
                          */
                         jobRecordUpdater.markRemovedOptOutJobRecords(it, brokerName, state.profileQueryId)
 
                         if (it.isNotEmpty()) {
+                            jobRecordUpdater.markReappearedOptOutJobRecords(it, brokerName, state.profileQueryId)
+                                .forEach { _ ->
+                                    pixelSender.reportBrokerOptOutProfileReappeared(state.broker.url)
+                                }
                             jobRecordUpdater.updateScanMatchesFound(it, brokerName, state.profileQueryId)
                             repository.saveNewExtractedProfiles(it)
                         } else {

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixel.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixel.kt
@@ -166,6 +166,11 @@ enum class PirPixel(
         type = Count,
     ),
 
+    PIR_BROKER_CUSTOM_STATS_OPTOUT_PROFILE_REAPPEARED(
+        baseName = "m_dbp_optoutjob_reappeared",
+        type = Count,
+    ),
+
     PIR_ENGAGEMENT_DAU(
         baseName = "m_dbp_engagement_dau",
         type = Count,

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_BROKER_CUSTOM_STATS_42DAY_CON
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_BROKER_CUSTOM_STATS_42DAY_UNCONFIRMED_OPTOUT
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_BROKER_CUSTOM_STATS_7DAY_CONFIRMED_OPTOUT
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_BROKER_CUSTOM_STATS_7DAY_UNCONFIRMED_OPTOUT
+import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_BROKER_CUSTOM_STATS_OPTOUT_PROFILE_REAPPEARED
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_BROKER_CUSTOM_STATS_OPTOUT_SUBMIT_SUCCESSRATE
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_BUNDLE_BROKER_JSON_FAILURE
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_BUNDLE_BROKER_JSON_LOADED
@@ -417,6 +418,12 @@ interface PirPixelSender {
      * Emits a pixel when an opt-out is unconfirmed within 42 days.
      */
     fun reportBrokerOptOutUnconfirmed42Days(brokerUrl: String)
+
+    /**
+     * Fired when a previously-removed profile reappears in a later scan, causing its opt-out job
+     * record to be reverted from REMOVED back to REQUESTED.
+     */
+    fun reportBrokerOptOutProfileReappeared(brokerUrl: String)
 
     /**
      * Emits a daily pixel to report that the user is eligible to run PIR.
@@ -1053,6 +1060,14 @@ class RealPirPixelSender @Inject constructor(
         )
 
         enqueueFire(PIR_BROKER_CUSTOM_STATS_42DAY_UNCONFIRMED_OPTOUT, params)
+    }
+
+    override fun reportBrokerOptOutProfileReappeared(brokerUrl: String) {
+        val params = mapOf(
+            PARAM_KEY_BROKER to brokerUrl,
+        )
+
+        enqueueFire(PIR_BROKER_CUSTOM_STATS_OPTOUT_PROFILE_REAPPEARED, params)
     }
 
     override fun reportCanRunPir() {

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/JobRecordUpdater.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/JobRecordUpdater.kt
@@ -110,6 +110,26 @@ interface JobRecordUpdater {
     )
 
     /**
+     * This method compares the [newExtractedProfiles] from the ones currently stored locally and
+     * associated to [brokerName] and [profileQueryId]. For every stored [ExtractedProfile] that IS
+     * part of the [newExtractedProfiles] and whose associated [OptOutJobRecord] is currently
+     * [OptOutJobStatus.REMOVED], we treat it as a reappearance: we revert the status back to
+     * [OptOutJobStatus.REQUESTED] and clear [OptOutJobRecord.optOutRemovedDateInMillis].
+     *
+     * This method should be called before we store [newExtractedProfiles] locally.
+     *
+     * @param newExtractedProfiles Newly [ExtractedProfile]s for the [brokerName] and [profileQueryId]
+     * @param brokerName The name of the broker associated with the scan job.
+     * @param profileQueryId The ID of the [ProfileQuery] related to the scan job.
+     * @return The list of [OptOutJobRecord]s that were reverted due to reappearance.
+     */
+    suspend fun markReappearedOptOutJobRecords(
+        newExtractedProfiles: List<ExtractedProfile>,
+        brokerName: String,
+        profileQueryId: Long,
+    ): List<OptOutJobRecord>
+
+    /**
      * Updates the [OptOutJobRecord] associated with a given [extractedProfileId].
      *
      * This method should be called when the opt-out attempt has been STARTED.
@@ -413,6 +433,62 @@ class RealJobRecordUpdater @Inject constructor(
                         },
                 )
             }
+        }
+    }
+
+    override suspend fun markReappearedOptOutJobRecords(
+        newExtractedProfiles: List<ExtractedProfile>,
+        brokerName: String,
+        profileQueryId: Long,
+    ): List<OptOutJobRecord> {
+        return withContext(dispatcherProvider.io()) {
+            if (newExtractedProfiles.isEmpty()) {
+                return@withContext emptyList()
+            }
+
+            val storedExtractedProfiles =
+                repository.getExtractedProfiles(brokerName, profileQueryId)
+
+            if (storedExtractedProfiles.isEmpty()) {
+                return@withContext emptyList()
+            }
+
+            val newKeys =
+                newExtractedProfiles
+                    .asSequence()
+                    .map { it.toKey() }
+                    .toHashSet()
+
+            val reappearedExtractedProfiles =
+                storedExtractedProfiles
+                    .asSequence()
+                    .filter { it.toKey() in newKeys }
+                    .toList()
+
+            logcat { "PIR-JOB-RECORD: Reappeared Profiles $reappearedExtractedProfiles" }
+
+            reappearedExtractedProfiles.mapNotNull { extractedProfile ->
+                revertReappearedOptOutJobRecord(extractedProfile.dbId)
+            }
+        }
+    }
+
+    private suspend fun revertReappearedOptOutJobRecord(extractedProfileId: Long): OptOutJobRecord? {
+        return withContext(dispatcherProvider.io()) {
+            // Only scan-confirmed removals should be reverted. Deprecated records (including
+            // REMOVED_BY_USER, which is always deprecated) are excluded by getValidOptOutJobRecord,
+            // and the status check guards against reverting anything that isn't currently REMOVED.
+            val record = schedulingRepository.getValidOptOutJobRecord(extractedProfileId)
+                ?.takeIf { it.status == OptOutJobStatus.REMOVED }
+                ?: return@withContext null
+
+            val updatedRecord = record.copy(
+                status = OptOutJobStatus.REQUESTED,
+                optOutRemovedDateInMillis = 0L,
+            )
+            schedulingRepository.saveOptOutJobRecord(updatedRecord)
+            logcat { "PIR-JOB-RECORD: OptOutRecord for $extractedProfileId reappeared, reverting to $updatedRecord" }
+            updatedRecord
         }
     }
 

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/RealPirRunStateHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/RealPirRunStateHandlerTest.kt
@@ -380,6 +380,8 @@ class RealPirRunStateHandlerTest {
                     email = "john@example.com",
                     fullName = "John Michael Doe",
                 )
+            whenever(mockJobRecordUpdater.markReappearedOptOutJobRecords(any(), any(), any()))
+                .thenReturn(emptyList())
 
             testee.handleState(state)
 
@@ -400,6 +402,69 @@ class RealPirRunStateHandlerTest {
                 testProfileQueryId,
             )
             inOrder.verify(mockRepository).saveNewExtractedProfiles(listOf(expectedExtractedProfile))
+        }
+
+    @Test
+    fun whenHandleBrokerScanActionSucceededWithReappearedProfileThenMarksReappearedAndReportsPixelPerRevertedRecord() =
+        runTest {
+            val extractedResponse =
+                ExtractedResponse(
+                    actionID = "extract123",
+                    actionType = "extract",
+                    response = listOf(testScriptExtractedProfile),
+                )
+            val state =
+                BrokerScanActionSucceeded(
+                    broker = testBroker,
+                    profileQueryId = testProfileQueryId,
+                    pirSuccessResponse = extractedResponse,
+                )
+            val expectedExtractedProfile =
+                ExtractedProfile(
+                    profileUrl = "https://example.com/profile/123",
+                    profileQueryId = testProfileQueryId,
+                    brokerName = testBrokerName,
+                    name = "John Doe",
+                    alternativeNames = listOf("Johnny", "J. Doe"),
+                    age = "30",
+                    addresses =
+                    listOf(
+                        AddressCityState(
+                            city = "New York",
+                            state = "NY",
+                            fullAddress = "123 Main St",
+                        ),
+                    ),
+                    phoneNumbers = listOf("555-1234"),
+                    relatives = listOf("Jane Doe"),
+                    identifier = "id123",
+                    reportId = "report123",
+                    email = "john@example.com",
+                    fullName = "John Michael Doe",
+                )
+            val revertedRecord =
+                OptOutJobRecord(
+                    brokerName = testBrokerName,
+                    userProfileId = testProfileQueryId,
+                    extractedProfileId = testExtractedProfileId,
+                    status = OptOutJobStatus.REQUESTED,
+                )
+            whenever(
+                mockJobRecordUpdater.markReappearedOptOutJobRecords(
+                    newExtractedProfiles = listOf(expectedExtractedProfile),
+                    brokerName = testBrokerName,
+                    profileQueryId = testProfileQueryId,
+                ),
+            ).thenReturn(listOf(revertedRecord))
+
+            testee.handleState(state)
+
+            verify(mockJobRecordUpdater).markReappearedOptOutJobRecords(
+                newExtractedProfiles = listOf(expectedExtractedProfile),
+                brokerName = testBrokerName,
+                profileQueryId = testProfileQueryId,
+            )
+            verify(mockPixelSender).reportBrokerOptOutProfileReappeared(testBroker.url)
         }
 
     @Test

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealJobRecordUpdaterTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealJobRecordUpdaterTest.kt
@@ -517,6 +517,91 @@ class RealJobRecordUpdaterTest {
         }
 
     @Test
+    fun whenMarkReappearedProfilesWithReappearedRemovedProfileThenRevertsToRequestedAndClearsRemovedDate() =
+        runTest {
+            // Stored profile1 was previously marked REMOVED; the new scan re-finds it -> reappearance
+            val storedProfiles = listOf(testExtractedProfile1)
+            val newProfiles = listOf(testExtractedProfile1.copy(dbId = 0L))
+
+            val removedOptOutJobRecord = testOptOutJobRecord.copy(
+                extractedProfileId = 100L,
+                status = OptOutJobStatus.REMOVED,
+                optOutRemovedDateInMillis = 3000L,
+            )
+
+            whenever(mockRepository.getExtractedProfiles(testBrokerName, testProfileQueryId))
+                .thenReturn(storedProfiles)
+            whenever(mockSchedulingRepository.getValidOptOutJobRecord(100L))
+                .thenReturn(removedOptOutJobRecord)
+
+            val result = toTest.markReappearedOptOutJobRecords(newProfiles, testBrokerName, testProfileQueryId)
+
+            val expectedRecord = removedOptOutJobRecord.copy(
+                status = OptOutJobStatus.REQUESTED,
+                optOutRemovedDateInMillis = 0L,
+            )
+            verify(mockSchedulingRepository).saveOptOutJobRecord(expectedRecord)
+            assertEquals(listOf(expectedRecord), result)
+        }
+
+    @Test
+    fun whenMarkReappearedProfilesWithReappearedNonRemovedProfileThenDoesNotUpdate() =
+        runTest {
+            // Profile reappears but its opt-out job is still REQUESTED (not REMOVED) -> nothing to revert
+            val storedProfiles = listOf(testExtractedProfile1)
+            val newProfiles = listOf(testExtractedProfile1.copy(dbId = 0L))
+
+            val requestedOptOutJobRecord = testOptOutJobRecord.copy(
+                extractedProfileId = 100L,
+                status = OptOutJobStatus.REQUESTED,
+            )
+            whenever(mockRepository.getExtractedProfiles(testBrokerName, testProfileQueryId))
+                .thenReturn(storedProfiles)
+            whenever(mockSchedulingRepository.getValidOptOutJobRecord(100L))
+                .thenReturn(requestedOptOutJobRecord)
+
+            val result = toTest.markReappearedOptOutJobRecords(newProfiles, testBrokerName, testProfileQueryId)
+
+            verify(mockSchedulingRepository, never()).saveOptOutJobRecord(any())
+            assertEquals(emptyList<OptOutJobRecord>(), result)
+        }
+
+    @Test
+    fun whenMarkReappearedProfilesWithRemovedProfileNotInNewResultsThenDoesNotUpdate() =
+        runTest {
+            // Stored profile1 (REMOVED) is NOT in the new scan results -> stays removed, not a reappearance
+            val storedProfiles = listOf(testExtractedProfile1)
+            val newProfiles = listOf(testExtractedProfile2.copy(dbId = 0L))
+
+            whenever(mockRepository.getExtractedProfiles(testBrokerName, testProfileQueryId))
+                .thenReturn(storedProfiles)
+
+            val result = toTest.markReappearedOptOutJobRecords(newProfiles, testBrokerName, testProfileQueryId)
+
+            verify(mockSchedulingRepository, never()).getValidOptOutJobRecord(any(), any())
+            verify(mockSchedulingRepository, never()).saveOptOutJobRecord(any())
+            assertEquals(emptyList<OptOutJobRecord>(), result)
+        }
+
+    @Test
+    fun whenMarkReappearedProfilesWithReappearedProfileButNoJobRecordThenSkipsThatProfile() =
+        runTest {
+            val storedProfiles = listOf(testExtractedProfile1)
+            val newProfiles = listOf(testExtractedProfile1.copy(dbId = 0L))
+
+            whenever(mockRepository.getExtractedProfiles(testBrokerName, testProfileQueryId))
+                .thenReturn(storedProfiles)
+            whenever(mockSchedulingRepository.getValidOptOutJobRecord(100L))
+                .thenReturn(null)
+
+            val result = toTest.markReappearedOptOutJobRecords(newProfiles, testBrokerName, testProfileQueryId)
+
+            verify(mockSchedulingRepository).getValidOptOutJobRecord(100L)
+            verify(mockSchedulingRepository, never()).saveOptOutJobRecord(any())
+            assertEquals(emptyList<OptOutJobRecord>(), result)
+        }
+
+    @Test
     fun whenMarkOptOutAsWaitingForEmailConfirmationAndJobRecordExistsThenUpdatesStatusToPendingEmailConfirmation() =
         runTest {
             whenever(mockSchedulingRepository.getValidOptOutJobRecord(testExtractedProfileId))


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216387860516593?focus=true
Tech Design URL (if applicable): N/A

### Description
Implements the missing profile reappearance handling on maintenance scans that exists on other platforms.

### Steps to test this PR

- [x] Check-out this branch and apply the patch below
- [x] Run a scan that will find profiles - wait until it completes all opt-outs are submitted
- [x] Go to PIR Dev Settings -> Scan -> long press the Debug scan button which runs the code below that marks all profiles as removed
- [ ] (Optional) Verify in the DB all opt out records have status REMOVED
- [x] Without clearing any data run a debug scan on one of the brokers for which the extracted profile was found (alternatively you can also trigger a full scan via the dashboard by editing the profile but this is simpler)
- [x] Verify you see `m_dbp_optoutjob_reappeared` in log cat -  that means that the profile was marked as re-appeared
- [ ] (Optional) Verify in the DB all opt out records have status REQUESTED again

```
Index: pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirDevScanActivity.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirDevScanActivity.kt b/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirDevScanActivity.kt
--- a/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirDevScanActivity.kt	(revision 35fe63de02080f2fed0caed12bf75e4fc51d95b1)
+++ b/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirDevScanActivity.kt	(date 1783610673576)
@@ -40,6 +40,7 @@
 import com.duckduckgo.pir.impl.models.Address
 import com.duckduckgo.pir.impl.models.ExtractedProfile
 import com.duckduckgo.pir.impl.models.ProfileQuery
+import com.duckduckgo.pir.impl.models.scheduling.JobRecord.OptOutJobRecord.OptOutJobStatus
 import com.duckduckgo.pir.impl.notifications.PirNotificationManager
 import com.duckduckgo.pir.impl.scan.PirForegroundScanService
 import com.duckduckgo.pir.impl.scan.PirRemoteWorkerService
@@ -54,6 +55,7 @@
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import logcat.logcat
 import javax.inject.Inject
 
@@ -197,6 +199,38 @@
             }
         }
 
+        // Long-press "Run scan" to simulate a maintenance scan that failed to re-find the currently
+        // stored profiles: every valid opt-out job record is forced to REMOVED (with a removed date).
+        // Then tap "Run scan" normally on a broker that still lists the profile to exercise the
+        // reappearance path in RealPirRunStateHandler.handleBrokerScanActionSucceeded:
+        //   - opt-out status reverts REMOVED -> REQUESTED and optOutRemovedDateInMillis is cleared
+        //   - an m_dbp_optoutjob_reappeared pixel is fired per reverted record
+        // Observe: `adb logcat | grep -E "PIR-JOB-RECORD|reappeared"`
+        binding.debugScan.setOnLongClickListener {
+            lifecycleScope.launch {
+                val forced = withContext(dispatcherProvider.io()) {
+                    val records = pirSchedulingRepository.getAllValidOptOutJobRecords()
+                    records.forEach { record ->
+                        pirSchedulingRepository.saveOptOutJobRecord(
+                            record.copy(
+                                status = OptOutJobStatus.REMOVED,
+                                optOutRemovedDateInMillis = currentTimeProvider.currentTimeMillis(),
+                            ),
+                        )
+                        logcat { "PIR-TEST: forced opt-out ${record.extractedProfileId} -> REMOVED" }
+                    }
+                    records
+                }
+                Toast.makeText(
+                    this@PirDevScanActivity,
+                    "Forced ${forced.size} opt-out record(s) to REMOVED. Now tap Run scan to re-find them.",
+                    Toast.LENGTH_LONG,
+                ).show()
+            }
+            true
+        }
+
         binding.debugForceKill.setOnClickListener {
             killRunningWork()
         }

```

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes opt-out job state during scheduled/maintenance scans; incorrect matching could wrongly re-queue opt-outs or miss reappearances, though guards limit reverts to scan-confirmed REMOVED records on valid job records.
> 
> **Overview**
> Adds **profile reappearance** handling on successful broker scan extract results, aligning Android with other PIR platforms.
> 
> When maintenance scans return profiles that were already stored but whose opt-out job was **REMOVED** (no longer seen on a prior scan), **`markReappearedOptOutJobRecords`** detects the overlap, reverts those records to **REQUESTED**, clears **`optOutRemovedDateInMillis`**, and only touches valid non-deprecated records still in **REMOVED** status. **`RealPirRunStateHandler`** invokes this after **`markRemovedOptOutJobRecords`** and before persisting new matches, firing **`m_dbp_optoutjob_reappeared`** once per reverted record via **`reportBrokerOptOutProfileReappeared`**.
> 
> Pixel wiring includes the new definition, **`PIR_BROKER_CUSTOM_STATS_OPTOUT_PROFILE_REAPPEARED`**, and unit tests for the updater and handler paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35fe63de02080f2fed0caed12bf75e4fc51d95b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->