### PR TITLE
Support edge-to-edge in ad-blocking, autofill & ADS gallery

### DIFF
--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsActivity.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsActivity.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.adblocking.impl.ui
 
 import android.os.Bundle
+import android.view.View
 import androidx.appcompat.widget.Toolbar
 import com.duckduckgo.adblocking.impl.databinding.ActivityAdBlockingSettingsBinding
 import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
@@ -39,8 +40,13 @@ class AdBlockingSettingsActivity : BaseAdBlockingSettingsActivity() {
     override val duckPlayerEntry: DaxListItem get() = binding.duckPlayerEntry
     override val duckPlayerDescription: DaxTextView get() = binding.duckPlayerDescription
 
+    override val rootView: View get() = binding.root
+    override val appBarLayout: View get() = binding.includeToolbar.appBarLayout
+    override val contentScrollView: View get() = binding.contentScrollView
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        maybeEnableEdgeToEdge()
         setContentView(binding.root)
         configure()
     }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsV2Activity.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsV2Activity.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.adblocking.impl.ui
 
 import android.os.Bundle
+import android.view.View
 import androidx.appcompat.widget.Toolbar
 import com.duckduckgo.adblocking.api.duckplayer.PrivatePlayerMode.Disabled
 import com.duckduckgo.adblocking.api.duckplayer.PrivatePlayerMode.Enabled
@@ -44,8 +45,13 @@ class AdBlockingSettingsV2Activity : BaseAdBlockingSettingsActivity() {
 
     override val learnMoreScreenTitle: Int = R.string.ad_blocking_settings_title_v2
 
+    override val rootView: View get() = binding.root
+    override val appBarLayout: View get() = binding.includeToolbar.appBarLayout
+    override val contentScrollView: View get() = binding.contentScrollView
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        maybeEnableEdgeToEdge()
         setContentView(binding.root)
         setTitle(R.string.ad_blocking_settings_title_v2)
         configure()

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/BaseAdBlockingSettingsActivity.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/BaseAdBlockingSettingsActivity.kt
@@ -33,6 +33,9 @@ import com.duckduckgo.common.ui.view.listitem.DaxListItem
 import com.duckduckgo.common.ui.view.listitem.OneLineListItem
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.view.text.DaxTextView
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import dev.zacsweers.metro.HasMemberInjections
 import kotlinx.coroutines.flow.launchIn
@@ -50,16 +53,34 @@ abstract class BaseAdBlockingSettingsActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var globalActivityStarter: GlobalActivityStarter
 
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     protected abstract val toolbar: Toolbar
     protected abstract val blockAdsToggle: OneLineListItem
     protected abstract val adBlockingDescription: DaxTextView
     protected abstract val duckPlayerEntry: DaxListItem
     protected abstract val duckPlayerDescription: DaxTextView
 
+    protected abstract val rootView: View
+    protected abstract val appBarLayout: View
+    protected abstract val contentScrollView: View
+
     protected open val learnMoreScreenTitle: Int = R.string.ad_blocking_settings_title
+
+    private val edgeToEdgeEnabled: Boolean by lazy { edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.SETTINGS) }
 
     private val blockAdsToggleListener = CompoundButton.OnCheckedChangeListener { _, isChecked ->
         viewModel.onBlockAdsToggled(isChecked)
+    }
+
+    protected fun maybeEnableEdgeToEdge() {
+        if (edgeToEdgeEnabled) {
+            enableTransparentEdgeToEdge()
+        }
     }
 
     protected fun configure() {
@@ -68,7 +89,17 @@ abstract class BaseAdBlockingSettingsActivity : DuckDuckGoActivity() {
         duckPlayerEntry.setClickListener { viewModel.onDuckPlayerClicked() }
         duckPlayerDescription.setOnClickListener { viewModel.onDuckPlayerClicked() }
 
+        if (edgeToEdgeEnabled) {
+            configureEdgeToEdgeInsets()
+        }
+
         observeViewModel()
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(rootView)
+        edgeToEdgeHandler.applyStatusBarInsets(appBarLayout)
+        edgeToEdgeHandler.applyNavigationBarInsets(contentScrollView, drawBehindGestureNav = true)
     }
 
     protected open fun render(state: AdBlockingSettingsViewModel.ViewState) {

--- a/ad-blocking/ad-blocking-impl/src/main/res/layout/activity_ad_blocking_settings.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/layout/activity_ad_blocking_settings.xml
@@ -26,6 +26,7 @@
         layout="@layout/include_default_toolbar" />
 
     <ScrollView
+        android:id="@+id/contentScrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">

--- a/ad-blocking/ad-blocking-impl/src/main/res/layout/activity_ad_blocking_settings_v2.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/layout/activity_ad_blocking_settings_v2.xml
@@ -26,6 +26,7 @@
         layout="@layout/include_default_toolbar" />
 
     <ScrollView
+        android:id="@+id/contentScrollView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/AppComponentsActivity.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/AppComponentsActivity.kt
@@ -16,10 +16,25 @@
 
 package com.duckduckgo.common.ui.internal.ui
 
+import android.app.UiModeManager
 import android.content.Context
 import android.content.Intent
+import android.content.res.Configuration
+import android.graphics.Color
+import android.os.Build
 import android.os.Bundle
+import android.util.TypedValue
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.view.WindowManager
+import android.widget.FrameLayout
+import androidx.activity.SystemBarStyle
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updateLayoutParams
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
@@ -32,6 +47,7 @@ import com.duckduckgo.common.ui.internal.ui.store.appComponentsDataStore
 import com.duckduckgo.common.ui.store.ThemingSharedPreferences
 import com.duckduckgo.common.ui.view.listitem.OneLineListItem
 import com.duckduckgo.common.utils.DefaultDispatcherProvider
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.google.android.material.tabs.TabLayout
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -62,6 +78,7 @@ class AppComponentsActivity : AppCompatActivity() {
     private lateinit var viewPager: ViewPager
     private lateinit var tabLayout: TabLayout
     private lateinit var darkThemeSwitch: OneLineListItem
+    private val edgeToEdgeHandler = EdgeToEdgeHandler()
 
     @Suppress("DenyListedApi")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -71,10 +88,13 @@ class AppComponentsActivity : AppCompatActivity() {
             selectedTheme
         }
         super.onCreate(savedInstanceState)
+        enableTransparentEdgeToEdge(isDarkTheme = isDarkThemeEnabled(selectedTheme))
         setContentView(R.layout.activity_app_components)
         viewPager = findViewById(R.id.view_pager)
         tabLayout = findViewById(R.id.tab_layout)
         darkThemeSwitch = findViewById(R.id.dark_theme_switch)
+
+        configureEdgeToEdgeInsets()
 
         tabLayout.setupWithViewPager(viewPager)
         val adapter = AppComponentsPagerAdapter(this, supportFragmentManager)
@@ -93,6 +113,57 @@ class AppComponentsActivity : AppCompatActivity() {
                 finish()
             }
         }
+    }
+
+    private fun isDarkThemeEnabled(selectedTheme: DuckDuckGoTheme): Boolean {
+        return when (selectedTheme) {
+            DuckDuckGoTheme.SYSTEM_DEFAULT -> {
+                val uiManager = getSystemService(Context.UI_MODE_SERVICE) as UiModeManager
+                uiManager.nightMode == UiModeManager.MODE_NIGHT_YES
+            }
+            DuckDuckGoTheme.DARK -> true
+            else -> false
+        }
+    }
+
+    private fun enableTransparentEdgeToEdge(isDarkTheme: Boolean) {
+        val barStyle = if (isDarkTheme) {
+            SystemBarStyle.dark(Color.TRANSPARENT)
+        } else {
+            SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT)
+        }
+        enableEdgeToEdge(statusBarStyle = barStyle, navigationBarStyle = barStyle)
+        if (Build.VERSION.SDK_INT >= 28) {
+            window.attributes = window.attributes.apply {
+                layoutInDisplayCutoutMode = if (resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE) {
+                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_NEVER
+                } else {
+                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT
+                }
+            }
+        }
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(findViewById<View>(R.id.app_components_root))
+        edgeToEdgeHandler.applyStatusBarInsets(findViewById<View>(R.id.app_bar_layout))
+        installNavigationBarScrim()
+    }
+
+    private fun installNavigationBarScrim() {
+        val typedValue = TypedValue()
+        if (!theme.resolveAttribute(android.R.attr.navigationBarColor, typedValue, true)) return
+        val content = findViewById<ViewGroup>(android.R.id.content)
+        val scrim = View(this).apply {
+            setBackgroundColor(typedValue.data)
+            layoutParams = FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, 0, Gravity.BOTTOM)
+        }
+        content.addView(scrim)
+        ViewCompat.setOnApplyWindowInsetsListener(scrim) { v, insets ->
+            v.updateLayoutParams { height = insets.getInsets(WindowInsetsCompat.Type.tappableElement()).bottom }
+            insets
+        }
+        ViewCompat.requestApplyInsets(scrim)
     }
 
     companion object {

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/AppComponentsActivity.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/AppComponentsActivity.kt
@@ -40,6 +40,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.viewpager.widget.ViewPager
 import com.duckduckgo.common.ui.DuckDuckGoTheme
+import com.duckduckgo.common.ui.applyBottomSystemBarInsetPadding
 import com.duckduckgo.common.ui.applyTheme
 import com.duckduckgo.common.ui.internal.R
 import com.duckduckgo.common.ui.internal.ui.store.AppComponentsPrefsDataStore
@@ -147,6 +148,7 @@ class AppComponentsActivity : AppCompatActivity() {
     private fun configureEdgeToEdgeInsets() {
         edgeToEdgeHandler.applyHorizontalSystemBarInsets(findViewById<View>(R.id.app_components_root))
         edgeToEdgeHandler.applyStatusBarInsets(findViewById<View>(R.id.app_bar_layout))
+        findViewById<View>(R.id.view_pager).applyBottomSystemBarInsetPadding()
         installNavigationBarScrim()
     }
 

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/AppComponentsActivity.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/AppComponentsActivity.kt
@@ -40,7 +40,6 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.viewpager.widget.ViewPager
 import com.duckduckgo.common.ui.DuckDuckGoTheme
-import com.duckduckgo.common.ui.applyBottomSystemBarInsetPadding
 import com.duckduckgo.common.ui.applyTheme
 import com.duckduckgo.common.ui.internal.R
 import com.duckduckgo.common.ui.internal.ui.store.AppComponentsPrefsDataStore
@@ -148,7 +147,7 @@ class AppComponentsActivity : AppCompatActivity() {
     private fun configureEdgeToEdgeInsets() {
         edgeToEdgeHandler.applyHorizontalSystemBarInsets(findViewById<View>(R.id.app_components_root))
         edgeToEdgeHandler.applyStatusBarInsets(findViewById<View>(R.id.app_bar_layout))
-        findViewById<View>(R.id.view_pager).applyBottomSystemBarInsetPadding()
+        edgeToEdgeHandler.applyNavigationBarInsets(viewPager, drawBehindGestureNav = true)
         installNavigationBarScrim()
     }
 

--- a/android-design-system/design-system-internal/src/main/res/layout/activity_app_components.xml
+++ b/android-design-system/design-system-internal/src/main/res/layout/activity_app_components.xml
@@ -17,6 +17,7 @@
 
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
                                                      xmlns:app="http://schemas.android.com/apk/res-auto"
+                                                     android:id="@+id/app_components_root"
                                                      android:layout_width="match_parent"
                                                      android:layout_height="match_parent">
 
@@ -27,6 +28,7 @@
         app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
 
     <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/app_bar_layout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:theme="@style/Widget.DuckDuckGo.ToolbarTheme"

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/dialog/ActionBottomSheetDialog.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/dialog/ActionBottomSheetDialog.kt
@@ -22,12 +22,14 @@ import android.view.LayoutInflater
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.core.content.ContextCompat
+import com.duckduckgo.common.ui.applyBottomSystemBarInsetPadding
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.mobile.android.databinding.BottomSheetActionBinding
 import com.google.android.material.bottomsheet.BottomSheetDialog
 
 @SuppressLint("NoBottomSheetDialog")
-class ActionBottomSheetDialog(builder: Builder) : BottomSheetDialog(builder.context) {
+class ActionBottomSheetDialog(builder: Builder) :
+    BottomSheetDialog(builder.context, com.duckduckgo.mobile.android.R.style.Widget_DuckDuckGo_BottomSheetDialog_EdgeToEdge) {
 
     abstract class EventListener {
         /** Sets a listener to be invoked when the bottom sheet is shown */
@@ -49,6 +51,7 @@ class ActionBottomSheetDialog(builder: Builder) : BottomSheetDialog(builder.cont
 
     init {
         setContentView(binding.root)
+        binding.root.applyBottomSystemBarInsetPadding()
 
         setOnDismissListener { builder.listener.onBottomSheetDismissed() }
         setOnShowListener { builder.listener.onBottomSheetShown() }

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/dialog/PromoBottomSheetDialog.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/view/dialog/PromoBottomSheetDialog.kt
@@ -20,12 +20,14 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.view.LayoutInflater
 import androidx.annotation.DrawableRes
+import com.duckduckgo.common.ui.applyBottomSystemBarInsetPadding
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.mobile.android.databinding.BottomSheetPromoBinding
 import com.google.android.material.bottomsheet.BottomSheetDialog
 
 @SuppressLint("NoBottomSheetDialog")
-class PromoBottomSheetDialog(builder: Builder) : BottomSheetDialog(builder.context) {
+class PromoBottomSheetDialog(builder: Builder) :
+    BottomSheetDialog(builder.context, com.duckduckgo.mobile.android.R.style.Widget_DuckDuckGo_BottomSheetDialog_EdgeToEdge) {
 
     abstract class EventListener {
         /** Sets a listener to be invoked when the bottom sheet is shown */
@@ -47,6 +49,7 @@ class PromoBottomSheetDialog(builder: Builder) : BottomSheetDialog(builder.conte
 
     init {
         setContentView(binding.root)
+        binding.root.applyBottomSystemBarInsetPadding()
 
         setOnDismissListener { builder.listener.onBottomSheetDismissed() }
         setOnShowListener { builder.listener.onBottomSheetShown() }

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/dialog/BookmarkAddedConfirmationDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/dialog/BookmarkAddedConfirmationDialog.kt
@@ -34,6 +34,7 @@ import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.app.bookmarks.BookmarkAddedDialogPlugin
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.BottomSheetAddBookmarkBinding
+import com.duckduckgo.common.ui.applyBottomSystemBarInsetPadding
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.utils.ConflatedJob
@@ -56,7 +57,11 @@ class BookmarkAddedConfirmationDialog(
     context: Context,
     private val bookmarkFolder: BookmarkFolder?,
     private val promoPlugins: PluginPoint<BookmarkAddedDialogPlugin>,
-) : BottomSheetDialog(context) {
+    private val edgeToEdgeEnabled: Boolean,
+) : BottomSheetDialog(
+    context,
+    if (edgeToEdgeEnabled) CommonR.style.Widget_DuckDuckGo_BottomSheetDialog_EdgeToEdge else 0,
+) {
 
     abstract class EventListener {
         /** Sets a listener to be invoked when favorite state is changed */
@@ -74,6 +79,9 @@ class BookmarkAddedConfirmationDialog(
 
     override fun show() {
         setContentView(binding.root)
+        if (edgeToEdgeEnabled) {
+            binding.root.applyBottomSystemBarInsetPadding()
+        }
 
         addInteractionListeners()
 

--- a/app/src/main/java/com/duckduckgo/app/bookmarks/dialog/BookmarkAddedConfirmationDialogFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/bookmarks/dialog/BookmarkAddedConfirmationDialogFactory.kt
@@ -18,6 +18,8 @@ package com.duckduckgo.app.bookmarks.dialog
 
 import android.content.Context
 import com.duckduckgo.app.bookmarks.BookmarkAddedDialogPlugin
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.savedsites.api.models.BookmarkFolder
@@ -32,8 +34,14 @@ interface BookmarkAddedConfirmationDialogFactory {
 @ContributesBinding(AppScope::class)
 class ReadyBookmarkAddedConfirmationDialogFactory @Inject constructor(
     private val plugins: PluginPoint<BookmarkAddedDialogPlugin>,
+    private val edgeToEdgeProvider: EdgeToEdgeProvider,
 ) : BookmarkAddedConfirmationDialogFactory {
     override fun create(context: Context, bookmarkFolder: BookmarkFolder?): BookmarkAddedConfirmationDialog {
-        return BookmarkAddedConfirmationDialog(context, bookmarkFolder, plugins)
+        return BookmarkAddedConfirmationDialog(
+            context,
+            bookmarkFolder,
+            plugins,
+            edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BOTTOM_SHEETS),
+        )
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1819,6 +1819,7 @@ class BrowserTabFragment :
                 pixel.fire(AppPixelName.BROWSING_MENU_USED_UNIQUE, type = Unique())
                 pixel.fire(AppPixelName.BROWSING_MENU_USED, type = Count)
             },
+            edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BOTTOM_SHEETS),
         )
 
         when (browserMode) {
@@ -5448,6 +5449,7 @@ class BrowserTabFragment :
                         viewModel.historicalPageSelected(stackIndex)
                     }
                 },
+                edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BOTTOM_SHEETS),
             ).show()
         }
     }
@@ -6369,6 +6371,7 @@ class BrowserTabFragment :
             privacyProSkippedOnboardingBottomSheet = PrivacyProSkippedOnboardingBottomSheetDialog(
                 context = requireContext(),
                 isFreeTrialCopy = configuration.isFreeTrialCopy,
+                edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BOTTOM_SHEETS),
             ).also { dialog ->
                 dialog.eventListener = object : PrivacyProSkippedOnboardingBottomSheetDialog.EventListener {
                     override fun onShown() {

--- a/app/src/main/java/com/duckduckgo/app/browser/history/NavigationHistorySheet.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/history/NavigationHistorySheet.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.app.browser.commands.Command.ShowBackNavigationHistory
 import com.duckduckgo.app.browser.databinding.NavigationHistoryPopupViewBinding
 import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.app.browser.history.NavigationHistoryAdapter.NavigationHistoryListener
+import com.duckduckgo.common.ui.applyBottomSystemBarInsetPadding
 import com.google.android.material.bottomsheet.BottomSheetDialog
 
 @SuppressLint("NoBottomSheetDialog")
@@ -35,7 +36,11 @@ class NavigationHistorySheet(
     private val tabId: String,
     private val history: ShowBackNavigationHistory,
     private val listener: NavigationHistorySheetListener,
-) : BottomSheetDialog(context) {
+    private val edgeToEdgeEnabled: Boolean,
+) : BottomSheetDialog(
+    context,
+    if (edgeToEdgeEnabled) com.duckduckgo.mobile.android.R.style.Widget_DuckDuckGo_BottomSheetDialog_EdgeToEdge else 0,
+) {
 
     private val binding = NavigationHistoryPopupViewBinding.inflate(LayoutInflater.from(context))
 
@@ -47,6 +52,9 @@ class NavigationHistorySheet(
         super.onCreate(savedInstanceState)
 
         setContentView(binding.root)
+        if (edgeToEdgeEnabled) {
+            binding.root.applyBottomSystemBarInsetPadding()
+        }
 
         binding.historyRecycler.also { recycler ->
             NavigationHistoryAdapter(

--- a/app/src/main/java/com/duckduckgo/app/browser/newaddressbaroption/NewAddressBarPickerBottomSheetDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newaddressbaroption/NewAddressBarPickerBottomSheetDialog.kt
@@ -35,6 +35,7 @@ import androidx.core.view.postDelayed
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.BottomSheetNewAddressBarPickerBinding
 import com.duckduckgo.app.onboardingquicksetup.ui.BrandDesignInputScreenPicker.Transition
+import com.duckduckgo.common.ui.applyBottomSystemBarInsetPadding
 import com.duckduckgo.common.ui.setRoundCorners
 import com.duckduckgo.common.ui.view.TypeAnimationTextView
 import com.duckduckgo.common.utils.extensions.html
@@ -58,7 +59,15 @@ class NewAddressBarPickerBottomSheetDialog(
     private val context: Context,
     private val isLightMode: Boolean,
     private val callback: NewAddressBarCallback?,
-) : BottomSheetDialog(onboardingThemedContext(context), R.style.Widget_DuckDuckGo_BottomSheetDialog_NewAddressBarPicker) {
+    private val edgeToEdgeEnabled: Boolean,
+) : BottomSheetDialog(
+    onboardingThemedContext(context),
+    if (edgeToEdgeEnabled) {
+        R.style.Widget_DuckDuckGo_BottomSheetDialog_NewAddressBarPicker_EdgeToEdge
+    } else {
+        R.style.Widget_DuckDuckGo_BottomSheetDialog_NewAddressBarPicker
+    },
+) {
 
     private val binding: BottomSheetNewAddressBarPickerBinding =
         BottomSheetNewAddressBarPickerBinding.inflate(LayoutInflater.from(context))
@@ -70,6 +79,9 @@ class NewAddressBarPickerBottomSheetDialog(
 
     init {
         setContentView(binding.root)
+        if (edgeToEdgeEnabled) {
+            binding.root.applyBottomSystemBarInsetPadding()
+        }
 
         this.behavior.isDraggable = false
         this.behavior.isHideable = false

--- a/app/src/main/java/com/duckduckgo/app/browser/newaddressbaroption/NewAddressBarPickerBottomSheetDialogFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newaddressbaroption/NewAddressBarPickerBottomSheetDialogFactory.kt
@@ -17,6 +17,8 @@
 package com.duckduckgo.app.browser.newaddressbaroption
 
 import android.content.Context
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.squareup.anvil.annotations.ContributesBinding
@@ -31,7 +33,9 @@ interface NewAddressBarPickerBottomSheetDialogFactory {
 }
 
 @ContributesBinding(AppScope::class)
-class RealNewAddressBarPickerBottomSheetDialogFactory @Inject constructor() : NewAddressBarPickerBottomSheetDialogFactory {
+class RealNewAddressBarPickerBottomSheetDialogFactory @Inject constructor(
+    private val edgeToEdgeProvider: EdgeToEdgeProvider,
+) : NewAddressBarPickerBottomSheetDialogFactory {
     override fun create(
         context: Context,
         isLightMode: Boolean,
@@ -41,5 +45,6 @@ class RealNewAddressBarPickerBottomSheetDialogFactory @Inject constructor() : Ne
             context = context,
             isLightMode = isLightMode,
             callback = callback,
+            edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BOTTOM_SHEETS),
         )
 }

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/PrivacyProSkippedOnboardingBottomSheetDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/PrivacyProSkippedOnboardingBottomSheetDialog.kt
@@ -24,6 +24,7 @@ import android.widget.FrameLayout
 import androidx.core.content.ContextCompat.getString
 import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.browser.databinding.BottomSheetPrivacyProSkippedOnboardingBinding
+import com.duckduckgo.common.ui.applyBottomSystemBarInsetPadding
 import com.duckduckgo.common.utils.extensions.html
 import com.duckduckgo.common.utils.extensions.preventWidows
 import com.google.android.material.bottomsheet.BottomSheetBehavior
@@ -37,7 +38,11 @@ import com.google.android.material.R as MaterialR
 class PrivacyProSkippedOnboardingBottomSheetDialog(
     private val context: Context,
     private val isFreeTrialCopy: Boolean,
-) : BottomSheetDialog(context) {
+    private val edgeToEdgeEnabled: Boolean,
+) : BottomSheetDialog(
+    context,
+    if (edgeToEdgeEnabled) CommonR.style.Widget_DuckDuckGo_BottomSheetDialog_EdgeToEdge else 0,
+) {
 
     private val binding: BottomSheetPrivacyProSkippedOnboardingBinding =
         BottomSheetPrivacyProSkippedOnboardingBinding.inflate(LayoutInflater.from(context))
@@ -46,6 +51,9 @@ class PrivacyProSkippedOnboardingBottomSheetDialog(
 
     init {
         setContentView(binding.root)
+        if (edgeToEdgeEnabled) {
+            binding.root.applyBottomSystemBarInsetPadding()
+        }
         this.behavior.state = BottomSheetBehavior.STATE_EXPANDED
         this.behavior.isDraggable = false
 

--- a/app/src/main/res/values/styles-new-address-bar-picker.xml
+++ b/app/src/main/res/values/styles-new-address-bar-picker.xml
@@ -13,9 +13,20 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   -->
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
     <style name="Widget.DuckDuckGo.BottomSheetDialog.NewAddressBarPicker" parent="Widget.DuckDuckGo.BottomSheetDialog">
         <item name="bottomSheetStyle">@style/Widget.DuckDuckGo.ModalBottomSheetStyle.NewAddressBarPicker</item>
+    </style>
+
+    <!-- Opt-in variant used when EdgeToEdgeBucket.BOTTOM_SHEETS is enabled: keeps the onboarding-backdrop
+         bottomSheetStyle but draws the sheet behind the transparent system bars. Content clears the nav bar
+         via View.applyBottomSystemBarInsetPadding(). -->
+    <style name="Widget.DuckDuckGo.BottomSheetDialog.NewAddressBarPicker.EdgeToEdge" parent="Widget.DuckDuckGo.BottomSheetDialog.NewAddressBarPicker">
+        <item name="enableEdgeToEdge">true</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:enforceNavigationBarContrast" tools:targetApi="q">false</item>
+        <item name="paddingBottomSystemWindowInsets">false</item>
     </style>
 
     <style name="Widget.DuckDuckGo.ModalBottomSheetStyle.NewAddressBarPicker" parent="Widget.DuckDuckGo.ModalBottomSheetStyle">

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillProviderChooseActivity.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillProviderChooseActivity.kt
@@ -50,6 +50,9 @@ import com.duckduckgo.common.ui.view.hideKeyboard
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.view.showKeyboard
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -75,6 +78,12 @@ class AutofillProviderChooseActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var pixel: Pixel
 
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private var assistStructure: AssistStructure? = null
 
     private val credentialId: Long?
@@ -92,11 +101,26 @@ class AutofillProviderChooseActivity : DuckDuckGoActivity() {
 
         assistStructure = IntentCompat.getParcelableExtra(intent, AutofillManager.EXTRA_ASSIST_STRUCTURE, AssistStructure::class.java)
 
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.AUTOFILL)
+        if (edgeToEdgeEnabled) {
+            enableTransparentEdgeToEdge()
+        }
+
         setContentView(binding.root)
         setupToolbar(binding.toolbar)
+
+        if (edgeToEdgeEnabled) {
+            configureEdgeToEdgeInsets()
+        }
+
         setTitle(R.string.autofill_service_select_password_activity)
         observeViewModel()
         pixel.fire(AUTOFILL_SERVICE_PASSWORDS_OPEN)
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.appBarLayout)
     }
 
     private fun observeViewModel() {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillSimpleCredentialsListFragment.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/service/AutofillSimpleCredentialsListFragment.kt
@@ -52,6 +52,9 @@ import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.FragmentViewModelFactory
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import kotlinx.coroutines.launch
@@ -93,6 +96,12 @@ class AutofillSimpleCredentialsListFragment : DuckDuckGoFragment(R.layout.fragme
     @Inject
     lateinit var pixel: Pixel
 
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     val viewModel by lazy {
         ViewModelProvider(requireActivity(), viewModelFactory)[AutofillProviderCredentialsListViewModel::class.java]
     }
@@ -107,6 +116,9 @@ class AutofillSimpleCredentialsListFragment : DuckDuckGoFragment(R.layout.fragme
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        if (edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.AUTOFILL)) {
+            edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.logins)
+        }
         configureRecyclerView()
         observeViewModel()
         configureToolbar()

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillManagementActivity.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/AutofillManagementActivity.kt
@@ -130,7 +130,6 @@ class AutofillManagementActivity : DuckDuckGoActivity(), PasswordsScreenPromotio
     private fun configureEdgeToEdgeInsets() {
         edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
         edgeToEdgeHandler.applyStatusBarInsets(binding.appBarLayout)
-        edgeToEdgeHandler.applyNavigationBarInsets(binding.fragmentContainerView, drawBehindGestureNav = true)
     }
 
     private fun sendLaunchPixel(savedInstanceState: Bundle?) {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementCredentialsMode.kt
@@ -69,6 +69,9 @@ import com.duckduckgo.common.ui.view.text.DaxTextInput
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.FragmentViewModelFactory
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.mobile.android.R.dimen
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -110,6 +113,12 @@ class AutofillManagementCredentialsMode : DuckDuckGoFragment(R.layout.fragment_a
 
     @Inject
     lateinit var stringBuilder: AutofillManagementStringBuilder
+
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
 
     // we need to revert the toolbar title when this fragment is destroyed, so will track its initial value
     private var initialActionBarTitle: String? = null
@@ -174,6 +183,9 @@ class AutofillManagementCredentialsMode : DuckDuckGoFragment(R.layout.fragment_a
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        if (edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.AUTOFILL)) {
+            edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.root)
+        }
         requireActivity().addMenuProvider(this)
         observeViewModel()
         configureUiEventHandlers()

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementDeviceUnsupportedMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementDeviceUnsupportedMode.kt
@@ -23,10 +23,20 @@ import android.view.ViewGroup
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.autofill.impl.databinding.FragmentAutofillManagementDeviceUnsupportedBinding
 import com.duckduckgo.common.ui.DuckDuckGoFragment
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.FragmentScope
+import javax.inject.Inject
 
 @InjectWith(FragmentScope::class)
 class AutofillManagementDeviceUnsupportedMode : DuckDuckGoFragment() {
+
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
 
     private lateinit var binding: FragmentAutofillManagementDeviceUnsupportedBinding
 
@@ -37,6 +47,16 @@ class AutofillManagementDeviceUnsupportedMode : DuckDuckGoFragment() {
     ): View {
         binding = FragmentAutofillManagementDeviceUnsupportedBinding.inflate(inflater, container, false)
         return binding.root
+    }
+
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+        if (edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.AUTOFILL)) {
+            edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.root)
+        }
     }
 
     companion object {

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementDisabledMode.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/credential/management/viewing/AutofillManagementDisabledMode.kt
@@ -34,6 +34,9 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.autofill.impl.databinding.FragmentAutofillManagementDisabledBinding
 import com.duckduckgo.common.ui.DuckDuckGoFragment
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.FragmentScope
 import logcat.LogPriority.WARN
 import logcat.asLog
@@ -45,6 +48,12 @@ class AutofillManagementDisabledMode : DuckDuckGoFragment() {
 
     @Inject
     lateinit var appBuildConfig: AppBuildConfig
+
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
 
     private lateinit var binding: FragmentAutofillManagementDisabledBinding
 
@@ -62,6 +71,9 @@ class AutofillManagementDisabledMode : DuckDuckGoFragment() {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
+        if (edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.AUTOFILL)) {
+            edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.root)
+        }
         binding.disabledCta.setOnClickListener {
             launchDeviceAuthEnrollment()
         }

--- a/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/settings/AutofillSettingsActivity.kt
+++ b/autofill/autofill-impl/src/main/java/com/duckduckgo/autofill/impl/ui/settings/AutofillSettingsActivity.kt
@@ -120,11 +120,7 @@ class AutofillSettingsActivity : DuckDuckGoActivity() {
     private fun configureEdgeToEdgeInsets() {
         edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
         edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
-        // Inset the scrolling content directly (the ViewSwitcher's "available" child), not the ViewSwitcher container.
         edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.autofillAvailable.root)
-        // The "unavailable"/"disabled" child hosts its own fragment-provided scrolling content; inset the container
-        // so it still reserves nav-bar space in every mode (its last visible content clears the bar).
-        edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.autofillUnsupported.root)
     }
 
     private fun sendLaunchPixel(savedInstanceState: Bundle?) {

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/browsermenu/BrowserMenuBottomSheet.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/browsermenu/BrowserMenuBottomSheet.kt
@@ -29,12 +29,15 @@ import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.browser.ui.R
 import com.duckduckgo.browser.ui.databinding.BottomSheetBrowserMenuBinding
 import com.duckduckgo.browser.ui.databinding.ViewBrowserMenuDuckaiSectionBinding
+import com.duckduckgo.common.ui.applyBottomSystemBarInsetPadding
 import com.duckduckgo.common.ui.setRoundCorners
 import com.duckduckgo.common.ui.view.MenuActionButtonView
 import com.duckduckgo.common.ui.view.MenuItemView
 import com.duckduckgo.common.ui.view.MenuItemViewSize
 import com.duckduckgo.common.ui.view.StatusIndicatorView
+import com.duckduckgo.common.ui.view.getColorFromAttr
 import com.duckduckgo.common.ui.view.gone
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.mobile.android.R.drawable
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
@@ -46,7 +49,11 @@ class BrowserMenuBottomSheet(
     private val faviconManager: FaviconManager,
     private val onDismissListener: () -> Unit,
     private val onMenuItemClickListener: () -> Unit,
-) : BottomSheetDialog(context) {
+    private val edgeToEdgeEnabled: Boolean,
+) : BottomSheetDialog(
+    context,
+    if (edgeToEdgeEnabled) com.duckduckgo.mobile.android.R.style.Widget_DuckDuckGo_BottomSheetDialog_EdgeToEdge else 0,
+) {
     private val binding = BottomSheetBrowserMenuBinding.inflate(LayoutInflater.from(context))
 
     // Duck.ai menu section, inflated once and inserted at the position decided on open (see placeDuckAiSection).
@@ -54,8 +61,14 @@ class BrowserMenuBottomSheet(
         ViewBrowserMenuDuckaiSectionBinding.inflate(LayoutInflater.from(context), binding.menuItemsContainer, false)
     }
 
+    // No-dep helper; instantiated directly (matches non-DI edge-to-edge call sites like AppComponentsActivity).
+    private val edgeToEdgeHandler = EdgeToEdgeHandler()
+
     init {
         setContentView(binding.root)
+        if (edgeToEdgeEnabled) {
+            binding.root.applyBottomSystemBarInsetPadding()
+        }
 
         // Set VPN menu item size to medium like other menu items
         binding.includeVpnMenuItem.vpnMenuItem
@@ -64,6 +77,12 @@ class BrowserMenuBottomSheet(
 
         setOnShowListener { dialogInterface ->
             (dialogInterface as BottomSheetDialog).setRoundCorners()
+            if (edgeToEdgeEnabled) {
+                edgeToEdgeHandler.applyNavigationBarScrim(
+                    binding.root,
+                    context.getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorSurface),
+                )
+            }
 
             behavior.apply {
                 isDraggable = true

--- a/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/browsermenu/BrowserMenuBottomSheetTest.kt
+++ b/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/browsermenu/BrowserMenuBottomSheetTest.kt
@@ -48,7 +48,7 @@ class BrowserMenuBottomSheetTest {
     fun setUp() {
         val appContext = ApplicationProvider.getApplicationContext<Application>()
         appContext.setTheme(MobileR.style.Theme_DuckDuckGo_Light)
-        dialog = BrowserMenuBottomSheet(appContext, mockFaviconManager, {}, {})
+        dialog = BrowserMenuBottomSheet(appContext, mockFaviconManager, {}, {}, edgeToEdgeEnabled = false)
         dialog.show()
     }
 

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeHandler.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeHandler.kt
@@ -22,6 +22,7 @@ import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
+import androidx.annotation.ColorInt
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.doOnAttach
@@ -262,6 +263,48 @@ class EdgeToEdgeHandler @Inject constructor() {
         ViewCompat.requestApplyInsets(view)
     }
 
+    /**
+     * Installs a navigation-bar scrim: a view sized to the bottom (tappable) navigation inset and filled with
+     * [scrimColor], added over the content so it renders behind the transparent navigation bar.
+     *
+     * Use for a surface whose own background does not reliably reach behind the navigation bar in every state —
+     * e.g. a collapsible/draggable BottomSheetDialog, whose sheet surface only extends behind the bar while it is
+     * settled expanded. The caller must already pad its content clear of the navigation bar (e.g. via
+     * applyBottomSystemBarInsetPadding) so the scrim only repaints the otherwise-empty strip; where the surface
+     * does cover the strip the scrim sits on top in the identical colour and is seamless. Idempotent per window;
+     * no scrim under gesture navigation (the tappable-element inset is 0 there), so the surface stays edge-to-edge
+     * behind the gesture pill.
+     *
+     * Unlike the status-bar scrim, the colour is passed in rather than resolved from a framework attr: the
+     * navigation-bar colour is transparent under the edge-to-edge themes, and `common-utils` can't reference the
+     * design-system surface attr.
+     *
+     * @param anchor Any view attached to the target window; its window content frame hosts the scrim.
+     * @param scrimColor The colour painted behind the navigation bar (typically the surface colour).
+     */
+    fun applyNavigationBarScrim(anchor: View, @ColorInt scrimColor: Int) {
+        val contentRoot = anchor.rootView?.findViewById<ViewGroup>(android.R.id.content) ?: return
+        if (contentRoot.findViewWithTag<View>(NAVIGATION_BAR_SCRIM_TAG) != null) return
+
+        val scrim = View(anchor.context).apply {
+            tag = NAVIGATION_BAR_SCRIM_TAG
+            setBackgroundColor(scrimColor)
+            layoutParams = FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, 0, Gravity.BOTTOM)
+        }
+        contentRoot.addView(scrim)
+
+        ViewCompat.setOnApplyWindowInsetsListener(scrim) { v, insets ->
+            // tappableElement (not navigationBars): the button-bar height under 2/3-button navigation, but 0 under
+            // gesture navigation — so no scrim is painted there and the surface stays edge-to-edge behind the pill.
+            val bottom = insets.getInsets(WindowInsetsCompat.Type.tappableElement()).bottom
+            if (v.layoutParams.height != bottom) {
+                v.updateLayoutParams { height = bottom }
+            }
+            insets
+        }
+        ViewCompat.requestApplyInsets(scrim)
+    }
+
     private fun View.applyInsets(apply: (WindowInsetsCompat) -> Unit) {
         ViewCompat.setOnApplyWindowInsetsListener(this) { _, insets ->
             apply(insets)
@@ -318,5 +361,6 @@ class EdgeToEdgeHandler @Inject constructor() {
 
     companion object {
         private const val STATUS_BAR_SCRIM_TAG = "edge_to_edge_status_bar_scrim"
+        private const val NAVIGATION_BAR_SCRIM_TAG = "edge_to_edge_navigation_bar_scrim"
     }
 }

--- a/dax-prompts/dax-prompts-impl/src/main/java/com/duckduckgo/daxprompts/impl/ui/DaxPromptBrowserComparisonActivity.kt
+++ b/dax-prompts/dax-prompts-impl/src/main/java/com/duckduckgo/daxprompts/impl/ui/DaxPromptBrowserComparisonActivity.kt
@@ -22,17 +22,13 @@ import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.content.res.Configuration
-import android.graphics.Color
 import android.os.Bundle
 import android.provider.Settings
-import android.view.WindowManager
 import android.widget.Toast
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.os.bundleOf
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowCompat
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -42,6 +38,9 @@ import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.daxprompts.api.DaxPromptBrowserComparisonParams
 import com.duckduckgo.daxprompts.api.LaunchSource
 import com.duckduckgo.daxprompts.impl.R
@@ -93,10 +92,27 @@ class DaxPromptBrowserComparisonActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var globalActivityStarter: GlobalActivityStarter
 
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.ONBOARDING)
+        if (edgeToEdgeEnabled) {
+            enableTransparentEdgeToEdge()
+        }
+
         setContentView(binding.root)
+        if (edgeToEdgeEnabled) {
+            // Full-bleed background on the root, no separate toolbar, everything else constrained to
+            // "parent" - a single root padding call clears the close button (top), the comparison card's
+            // buttons (bottom) and the guideline-percentage content (sides, landscape) all at once.
+            edgeToEdgeHandler.applySystemBarInsets(binding.daxPromptBrowserComparisonContainer)
+        }
 
         setupListeners()
         setupObservers()
@@ -108,7 +124,6 @@ class DaxPromptBrowserComparisonActivity : DuckDuckGoActivity() {
 
     override fun onResume() {
         super.onResume()
-        applyFullScreenFlags()
         markAsShown()
     }
 
@@ -172,16 +187,6 @@ class DaxPromptBrowserComparisonActivity : DuckDuckGoActivity() {
             logcat(WARN) { errorMessage }
             Toast.makeText(this, errorMessage, Toast.LENGTH_SHORT).show()
         }
-    }
-
-    private fun applyFullScreenFlags() {
-        window?.apply {
-            addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
-            WindowCompat.setDecorFitsSystemWindows(this, false)
-            statusBarColor = Color.TRANSPARENT
-            navigationBarColor = Color.BLACK
-        }
-        ViewCompat.requestApplyInsets(binding.daxPromptBrowserComparisonContainer)
     }
 
     private fun markAsShown() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryActivity.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryActivity.kt
@@ -21,9 +21,12 @@ import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.duckchat.api.DuckChatHistoryNoParams
 import com.duckduckgo.duckchat.impl.databinding.ActivityChatHistoryBinding
+import javax.inject.Inject
 
 /**
  * Thin host for chat-history-related fragments.
@@ -31,10 +34,17 @@ import com.duckduckgo.duckchat.impl.databinding.ActivityChatHistoryBinding
 @InjectWith(ActivityScope::class)
 @ContributeToActivityStarter(DuckChatHistoryNoParams::class, screenName = "duckai.history")
 class ChatHistoryActivity : DuckDuckGoActivity() {
+
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
     private val binding: ActivityChatHistoryBinding by viewBinding()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        if (edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.SETTINGS)) {
+            enableTransparentEdgeToEdge()
+        }
         setContentView(binding.root)
 
         if (savedInstanceState == null) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/ChatHistoryFragment.kt
@@ -37,6 +37,9 @@ import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.FragmentViewModelFactory
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.common.utils.extensions.hideKeyboard
 import com.duckduckgo.dataclearing.api.fire.FireDialog
 import com.duckduckgo.dataclearing.api.fire.FireDialogProvider
@@ -78,6 +81,12 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
     @Inject
     lateinit var browserNav: BrowserNav
 
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val binding: FragmentChatHistoryBinding by viewBinding()
     private val viewModel: ChatHistoryViewModel by lazy {
         ViewModelProvider(this, viewModelFactory)[ChatHistoryViewModel::class.java]
@@ -111,6 +120,12 @@ class ChatHistoryFragment : DuckDuckGoFragment(R.layout.fragment_chat_history) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        if (edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.SETTINGS)) {
+            edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+            edgeToEdgeHandler.applyStatusBarInsets(binding.appBarLayout)
+            edgeToEdgeHandler.applyScrollableNavigationBarInsets(binding.chatHistoryList)
+        }
 
         binding.toolbar.setNavigationIcon(com.duckduckgo.mobile.android.R.drawable.ic_arrow_left_24)
         binding.toolbar.setNavigationOnClickListener { requireActivity().onBackPressedDispatcher.onBackPressed() }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/RenameChatFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/history/RenameChatFragment.kt
@@ -27,6 +27,9 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoFragment
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.FragmentViewModelFactory
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.common.utils.extensions.hideKeyboard
 import com.duckduckgo.common.utils.text.TextChangedWatcher
 import com.duckduckgo.di.scopes.FragmentScope
@@ -43,6 +46,12 @@ class RenameChatFragment : DuckDuckGoFragment(R.layout.fragment_rename_chat) {
     @Inject
     lateinit var viewModelFactory: FragmentViewModelFactory
 
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     private val binding: FragmentRenameChatBinding by viewBinding()
     private val viewModel: RenameChatViewModel by lazy {
         ViewModelProvider(this, viewModelFactory)[RenameChatViewModel::class.java]
@@ -53,6 +62,11 @@ class RenameChatFragment : DuckDuckGoFragment(R.layout.fragment_rename_chat) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        if (edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.SETTINGS)) {
+            edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+            edgeToEdgeHandler.applyStatusBarInsets(binding.appBarLayout)
+        }
 
         binding.toolbar.setTitle(R.string.duck_ai_chat_history_rename_title)
         binding.toolbar.setNavigationIcon(com.duckduckgo.mobile.android.R.drawable.ic_arrow_left_24)

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksActivity.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/BookmarksActivity.kt
@@ -486,6 +486,7 @@ class BookmarksActivity : DuckDuckGoActivity(), BookmarksScreenPromotionPlugin.C
                     }
                 },
             )
+            .setEdgeToEdgeEnabled(edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BOTTOM_SHEETS))
         faviconPrompt.show()
     }
 

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/FaviconPromptSheet.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/bookmarks/FaviconPromptSheet.kt
@@ -19,13 +19,17 @@ package com.duckduckgo.savedsites.impl.bookmarks
 import android.annotation.SuppressLint
 import android.content.Context
 import android.view.LayoutInflater
+import com.duckduckgo.common.ui.applyBottomSystemBarInsetPadding
 import com.duckduckgo.saved.sites.impl.databinding.BottomSheetFaviconsPromptBinding
 import com.google.android.material.bottomsheet.BottomSheetDialog
 
 @SuppressLint("NoBottomSheetDialog")
 class FaviconPromptSheet(
     builder: Builder,
-) : BottomSheetDialog(builder.context) {
+) : BottomSheetDialog(
+    builder.context,
+    if (builder.edgeToEdgeEnabled) com.duckduckgo.mobile.android.R.style.Widget_DuckDuckGo_BottomSheetDialog_EdgeToEdge else 0,
+) {
 
     private val binding = BottomSheetFaviconsPromptBinding.inflate(LayoutInflater.from(context))
     internal class DefaultEventListener : EventListener()
@@ -36,6 +40,9 @@ class FaviconPromptSheet(
 
     init {
         setContentView(binding.root)
+        if (builder.edgeToEdgeEnabled) {
+            binding.root.applyBottomSystemBarInsetPadding()
+        }
         binding.faviconsPromptPrimaryCta.setOnClickListener {
             builder.listener.onFaviconsFetchingPromptDismissed(true)
             dismiss()
@@ -58,9 +65,15 @@ class FaviconPromptSheet(
     class Builder(val context: Context) {
         var dialog: BottomSheetDialog? = null
         var listener: EventListener = DefaultEventListener()
+        var edgeToEdgeEnabled: Boolean = false
 
         fun addEventListener(eventListener: EventListener): Builder {
             listener = eventListener
+            return this
+        }
+
+        fun setEdgeToEdgeEnabled(enabled: Boolean): Builder {
+            edgeToEdgeEnabled = enabled
             return this
         }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/chat/ChatSyncPromoChatTabItemPlugin.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/promotion/chat/ChatSyncPromoChatTabItemPlugin.kt
@@ -20,7 +20,10 @@ import android.annotation.SuppressLint
 import android.content.Context
 import androidx.recyclerview.widget.RecyclerView
 import com.duckduckgo.anvil.annotations.ContributesActivePlugin
+import com.duckduckgo.common.ui.applyBottomSystemBarInsetPadding
 import com.duckduckgo.common.ui.setRoundCorners
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.duckchat.api.DuckChatInputModeState
 import com.duckduckgo.duckchat.api.inputscreen.NativeInputChatTabItem
@@ -50,12 +53,13 @@ class ChatSyncPromoChatTabItemPlugin @Inject constructor(
     private val chatSyncPromotion: ChatSyncPromotion,
     private val duckChatInput: DuckChatInputModeState,
     private val activityStarter: GlobalActivityStarter,
+    private val edgeToEdgeProvider: EdgeToEdgeProvider,
 ) : NativeInputChatTabItemPlugin {
     override fun create(
         context: Context,
         scope: CoroutineScope,
     ): NativeInputChatTabItem {
-        val listener = ChatTabPluginAdapterListener(context, chatSyncPromotion, scope, activityStarter)
+        val listener = ChatTabPluginAdapterListener(context, chatSyncPromotion, scope, activityStarter, edgeToEdgeProvider)
         val adapter = ChatSyncPromoAdapter(listener)
 
         val showJob = scope.showPromotionBanner(adapter)
@@ -93,6 +97,7 @@ private class ChatTabPluginAdapterListener(
     private val promotion: ChatSyncPromotion,
     private val scope: CoroutineScope,
     private val activityStarter: GlobalActivityStarter,
+    private val edgeToEdgeProvider: EdgeToEdgeProvider,
 ) : ChatSyncPromoAdapter.Listener {
     private var didBannerShow = false
     private var isDialogShowing = false
@@ -108,6 +113,7 @@ private class ChatTabPluginAdapterListener(
                 onScanQrCodeClicked = {
                     activityStarter.start(context, SyncActivityWithAnotherDevice(source = "promotion_ai_chat"))
                 },
+                edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BOTTOM_SHEETS),
             )
             dialog.setOnDismissListener { isDialogShowing = false }
             dialog.show()
@@ -131,7 +137,11 @@ private class ChatTabPluginAdapterListener(
 private class ChatSyncPromoBottomSheetDialog(
     context: Context,
     onScanQrCodeClicked: () -> Unit,
-) : BottomSheetDialog(context) {
+    edgeToEdgeEnabled: Boolean,
+) : BottomSheetDialog(
+    context,
+    if (edgeToEdgeEnabled) com.duckduckgo.mobile.android.R.style.Widget_DuckDuckGo_BottomSheetDialog_EdgeToEdge else 0,
+) {
     init {
         val binding = DialogChatSyncPromoBinding.inflate(layoutInflater).apply {
             scanQrCodeButton.setOnClickListener {
@@ -142,6 +152,9 @@ private class ChatSyncPromoBottomSheetDialog(
             closeButton.setOnClickListener { dismiss() }
         }
         setContentView(binding.root)
+        if (edgeToEdgeEnabled) {
+            binding.root.applyBottomSystemBarInsetPadding()
+        }
 
         behavior.state = BottomSheetBehavior.STATE_EXPANDED
         behavior.isDraggable = false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212608036467427/task/1216426954295866?focus=true

### Description
Add transparent edge-to-edge to AdBlockingSettingsActivity (and V2, via the shared base), AutofillProviderChooseActivity, and the internal AppComponentsActivity gallery, following the EdgeToEdgeProvider / EdgeToEdgeHandler pattern.

Also fix a double navigation-bar inset on AutofillManagementActivity: the container and the list mode both padded the bottom, so the gap doubled in 2/3-button nav and with the IME. Bottom insets now live on each mode's own scroll view; the activity no longer pads the fragment container.

AppComponentsActivity hosts a legacy ViewPager that can't hold inset padding, so its 3-button navigation bar is kept opaque with a nav-bar scrim sized to the tappable inset (0 in gesture, so it stays edge-to-edge).

### Steps to test this PR
For each of the following, ensure: 
- Gesture nav is transparent
- 3-Button is opaque.
- status-bar colors are consistent with the background.

Activities:
- Youtube Ad Blocking 
- Passwords & autofill => passwords => Search (in 3-button, no extra padding is applied).
- AutofillProviderChooseActivity
- AppComponentsActivity

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide UI/inset changes across browser menus, autofill, and many bottom sheets; behavior is feature-flagged per bucket but regressions could affect layout under different nav modes and keyboards.
> 
> **Overview**
> Rolls out **transparent edge-to-edge** behind `EdgeToEdgeProvider` buckets across more activities and bottom sheets, using shared `EdgeToEdgeHandler` inset helpers (and bottom padding on sheet content).
> 
> **Settings / ad blocking / Duck AI:** Ad blocking settings (v1/v2 via `BaseAdBlockingSettingsActivity`), Duck AI chat history host and fragments, and `ChatHistoryActivity` enable transparent bars and apply horizontal, status, and scrollable nav insets when `SETTINGS` is on.
> 
> **Autofill:** `AutofillProviderChooseActivity` and password-management fragments get `AUTOFILL` insets; **`AutofillManagementActivity` stops padding the fragment container** so nav-bar bottom inset is applied only on each mode’s scrollable root (fixes doubled bottom gap with 3-button nav / IME).
> 
> **Bottom sheets (`BOTTOM_SHEETS`):** Browser menu, navigation history, bookmarks, address-bar picker, Privacy Pro promo, favicon prompt, sync chat promo, and design-system action/promo dialogs switch to the edge-to-edge bottom-sheet theme, **`applyBottomSystemBarInsetPadding()`** on content, and the browser menu adds **`applyNavigationBarScrim`** on show. Factories pass the bucket flag from `EdgeToEdgeProvider`.
> 
> **Other:** Internal **`AppComponentsActivity`** always uses transparent edge-to-edge with a **tappable-inset nav scrim** (opaque 3-button bar; gesture stays clear). **`DaxPromptBrowserComparisonActivity`** replaces manual system-bar flags with the `ONBOARDING` bucket pattern. **`EdgeToEdgeHandler`** gains **`applyNavigationBarScrim`** for sheets whose surface doesn’t reliably draw behind the nav bar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd1dcd63a2e5be592a6c352b09ccb73f9ab9bce3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->