### PR TITLE
Update content scope scripts to version 15.11.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/adsjsContentScope.js
@@ -2203,7 +2203,7 @@
       if (isJSONObject(value)) {
         value = value[path[i]];
       } else if (isJSONArray(value)) {
-        value = value[Number.parseInt(path[i])];
+        value = value[Number.parseInt(path[i], 10)];
       } else {
         value = void 0;
       }
@@ -2211,8 +2211,7 @@
     }
     return value;
   }
-  function setIn(object, path, value) {
-    let createPath = arguments.length > 3 && arguments[3] !== void 0 ? arguments[3] : false;
+  function setIn(object, path, value, createPath = false) {
     if (path.length === 0) {
       return value;
     }
@@ -2254,7 +2253,7 @@
       }
       const updatedObject = shallowClone(object);
       if (isJSONArray(updatedObject)) {
-        updatedObject.splice(Number.parseInt(key2), 1);
+        updatedObject.splice(Number.parseInt(key2, 10), 1);
       }
       if (isJSONObject(updatedObject)) {
         delete updatedObject[key2];
@@ -2273,7 +2272,7 @@
         throw new TypeError(`Array expected at path ${JSON.stringify(parentPath)}`);
       }
       const updatedItems = shallowClone(items);
-      updatedItems.splice(Number.parseInt(index), 0, value);
+      updatedItems.splice(Number.parseInt(index, 10), 0, value);
       return updatedItems;
     });
   }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -17,11 +17,20 @@
     if (typeof require !== "undefined") return require.apply(this, arguments);
     throw Error('Dynamic require of "' + x2 + '" is not supported');
   });
-  var __esm = (fn, res) => function __init() {
-    return fn && (res = (0, fn[__getOwnPropNames(fn)[0]])(fn = 0)), res;
+  var __esm = (fn, res, err) => function __init() {
+    if (err) throw err[0];
+    try {
+      return fn && (res = (0, fn[__getOwnPropNames(fn)[0]])(fn = 0)), res;
+    } catch (e) {
+      throw err = [e], e;
+    }
   };
   var __commonJS = (cb, mod) => function __require2() {
-    return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+    try {
+      return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+    } catch (e) {
+      throw mod = 0, e;
+    }
   };
   var __copyProps = (to, from, except, desc) => {
     if (from && typeof from === "object" || typeof from === "function") {
@@ -3761,7 +3770,7 @@
       if (isJSONObject(value)) {
         value = value[path[i]];
       } else if (isJSONArray(value)) {
-        value = value[Number.parseInt(path[i])];
+        value = value[Number.parseInt(path[i], 10)];
       } else {
         value = void 0;
       }
@@ -3769,8 +3778,7 @@
     }
     return value;
   }
-  function setIn(object, path, value) {
-    let createPath = arguments.length > 3 && arguments[3] !== void 0 ? arguments[3] : false;
+  function setIn(object, path, value, createPath = false) {
     if (path.length === 0) {
       return value;
     }
@@ -3812,7 +3820,7 @@
       }
       const updatedObject = shallowClone(object);
       if (isJSONArray(updatedObject)) {
-        updatedObject.splice(Number.parseInt(key2), 1);
+        updatedObject.splice(Number.parseInt(key2, 10), 1);
       }
       if (isJSONObject(updatedObject)) {
         delete updatedObject[key2];
@@ -3831,7 +3839,7 @@
         throw new TypeError(`Array expected at path ${JSON.stringify(parentPath)}`);
       }
       const updatedItems = shallowClone(items);
-      updatedItems.splice(Number.parseInt(index), 0, value);
+      updatedItems.splice(Number.parseInt(index, 10), 0, value);
       return updatedItems;
     });
   }
@@ -8616,17 +8624,39 @@
       img.src = svgDataUrl;
     });
   }
-  function imageToBase64(imageElement) {
-    const canvas = document.createElement("canvas");
-    const ctx = canvas.getContext("2d");
-    if (!ctx) {
-      throw Error("[imageToBase64] Could not get 2D context from canvas");
+  var MAX_CAPTCHA_IMAGE_BYTES = 5 * 1024 * 1024;
+  async function imageToBase64(imageElement) {
+    const src = imageElement.currentSrc || imageElement.src;
+    if (src.startsWith("data:") && src.includes(";base64,")) {
+      const base64Data = src.slice(src.indexOf(",") + 1);
+      const padding = base64Data.endsWith("==") ? 2 : base64Data.endsWith("=") ? 1 : 0;
+      const decodedBytes = Math.floor(base64Data.length * 3 / 4) - padding;
+      if (decodedBytes > MAX_CAPTCHA_IMAGE_BYTES) {
+        throw new Error(`[imageToBase64] captcha image exceeds ${MAX_CAPTCHA_IMAGE_BYTES} bytes: ${decodedBytes}`);
+      }
+      return src;
     }
-    canvas.width = imageElement.width;
-    canvas.height = imageElement.height;
-    ctx.drawImage(imageElement, 0, 0, canvas.width, canvas.height);
-    const base64String = canvas.toDataURL("image/jpeg");
-    return base64String;
+    const response = await fetch(src, { credentials: "omit" });
+    if (!response.ok) {
+      throw new Error(`[imageToBase64] failed to fetch image from ${src}: ${response.status} ${response.statusText}`);
+    }
+    const contentLength = Number(response.headers.get("content-length"));
+    if (contentLength > MAX_CAPTCHA_IMAGE_BYTES) {
+      throw new Error(`[imageToBase64] captcha image exceeds ${MAX_CAPTCHA_IMAGE_BYTES} bytes: ${contentLength}`);
+    }
+    const blob = await response.blob();
+    if (blob.size > MAX_CAPTCHA_IMAGE_BYTES) {
+      throw new Error(`[imageToBase64] captcha image exceeds ${MAX_CAPTCHA_IMAGE_BYTES} bytes: ${blob.size}`);
+    }
+    return await new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onloadend = () => resolve(
+        /** @type {string} */
+        reader.result
+      );
+      reader.onerror = () => reject(reader.error);
+      reader.readAsDataURL(blob);
+    });
   }
 
   // src/features/broker-protection/captcha-services/providers/image.js
@@ -8652,7 +8682,7 @@
         return await svgToBase64Jpg(captchaImageElement);
       }
       if (isImgElement(captchaImageElement)) {
-        return imageToBase64(captchaImageElement);
+        return await imageToBase64(captchaImageElement);
       }
       return PirError.create(
         `[ImageProvider.getCaptchaIdentifier] could not extract Base64 from image with tag name: ${captchaImageElement.tagName}`

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -17,11 +17,20 @@
     if (typeof require !== "undefined") return require.apply(this, arguments);
     throw Error('Dynamic require of "' + x2 + '" is not supported');
   });
-  var __esm = (fn, res) => function __init() {
-    return fn && (res = (0, fn[__getOwnPropNames(fn)[0]])(fn = 0)), res;
+  var __esm = (fn, res, err) => function __init() {
+    if (err) throw err[0];
+    try {
+      return fn && (res = (0, fn[__getOwnPropNames(fn)[0]])(fn = 0)), res;
+    } catch (e) {
+      throw err = [e], e;
+    }
   };
   var __commonJS = (cb, mod) => function __require2() {
-    return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+    try {
+      return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+    } catch (e) {
+      throw mod = 0, e;
+    }
   };
   var __copyProps = (to, from, except, desc) => {
     if (from && typeof from === "object" || typeof from === "function") {
@@ -3730,7 +3739,7 @@
       if (isJSONObject(value)) {
         value = value[path[i]];
       } else if (isJSONArray(value)) {
-        value = value[Number.parseInt(path[i])];
+        value = value[Number.parseInt(path[i], 10)];
       } else {
         value = void 0;
       }
@@ -3738,8 +3747,7 @@
     }
     return value;
   }
-  function setIn(object, path, value) {
-    let createPath = arguments.length > 3 && arguments[3] !== void 0 ? arguments[3] : false;
+  function setIn(object, path, value, createPath = false) {
     if (path.length === 0) {
       return value;
     }
@@ -3781,7 +3789,7 @@
       }
       const updatedObject = shallowClone(object);
       if (isJSONArray(updatedObject)) {
-        updatedObject.splice(Number.parseInt(key2), 1);
+        updatedObject.splice(Number.parseInt(key2, 10), 1);
       }
       if (isJSONObject(updatedObject)) {
         delete updatedObject[key2];
@@ -3800,7 +3808,7 @@
         throw new TypeError(`Array expected at path ${JSON.stringify(parentPath)}`);
       }
       const updatedItems = shallowClone(items);
-      updatedItems.splice(Number.parseInt(index), 0, value);
+      updatedItems.splice(Number.parseInt(index, 10), 0, value);
       return updatedItems;
     });
   }
@@ -8585,17 +8593,39 @@
       img.src = svgDataUrl;
     });
   }
-  function imageToBase64(imageElement) {
-    const canvas = document.createElement("canvas");
-    const ctx = canvas.getContext("2d");
-    if (!ctx) {
-      throw Error("[imageToBase64] Could not get 2D context from canvas");
+  var MAX_CAPTCHA_IMAGE_BYTES = 5 * 1024 * 1024;
+  async function imageToBase64(imageElement) {
+    const src = imageElement.currentSrc || imageElement.src;
+    if (src.startsWith("data:") && src.includes(";base64,")) {
+      const base64Data = src.slice(src.indexOf(",") + 1);
+      const padding = base64Data.endsWith("==") ? 2 : base64Data.endsWith("=") ? 1 : 0;
+      const decodedBytes = Math.floor(base64Data.length * 3 / 4) - padding;
+      if (decodedBytes > MAX_CAPTCHA_IMAGE_BYTES) {
+        throw new Error(`[imageToBase64] captcha image exceeds ${MAX_CAPTCHA_IMAGE_BYTES} bytes: ${decodedBytes}`);
+      }
+      return src;
     }
-    canvas.width = imageElement.width;
-    canvas.height = imageElement.height;
-    ctx.drawImage(imageElement, 0, 0, canvas.width, canvas.height);
-    const base64String = canvas.toDataURL("image/jpeg");
-    return base64String;
+    const response = await fetch(src, { credentials: "omit" });
+    if (!response.ok) {
+      throw new Error(`[imageToBase64] failed to fetch image from ${src}: ${response.status} ${response.statusText}`);
+    }
+    const contentLength = Number(response.headers.get("content-length"));
+    if (contentLength > MAX_CAPTCHA_IMAGE_BYTES) {
+      throw new Error(`[imageToBase64] captcha image exceeds ${MAX_CAPTCHA_IMAGE_BYTES} bytes: ${contentLength}`);
+    }
+    const blob = await response.blob();
+    if (blob.size > MAX_CAPTCHA_IMAGE_BYTES) {
+      throw new Error(`[imageToBase64] captcha image exceeds ${MAX_CAPTCHA_IMAGE_BYTES} bytes: ${blob.size}`);
+    }
+    return await new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onloadend = () => resolve(
+        /** @type {string} */
+        reader.result
+      );
+      reader.onerror = () => reject(reader.error);
+      reader.readAsDataURL(blob);
+    });
   }
 
   // src/features/broker-protection/captcha-services/providers/image.js
@@ -8621,7 +8651,7 @@
         return await svgToBase64Jpg(captchaImageElement);
       }
       if (isImgElement(captchaImageElement)) {
-        return imageToBase64(captchaImageElement);
+        return await imageToBase64(captchaImageElement);
       }
       return PirError.create(
         `[ImageProvider.getCaptchaIdentifier] could not extract Base64 from image with tag name: ${captchaImageElement.tagName}`

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/contentScope.js
@@ -11,11 +11,20 @@
     throw TypeError(msg);
   };
   var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
-  var __esm = (fn, res) => function __init() {
-    return fn && (res = (0, fn[__getOwnPropNames(fn)[0]])(fn = 0)), res;
+  var __esm = (fn, res, err) => function __init() {
+    if (err) throw err[0];
+    try {
+      return fn && (res = (0, fn[__getOwnPropNames(fn)[0]])(fn = 0)), res;
+    } catch (e) {
+      throw err = [e], e;
+    }
   };
   var __commonJS = (cb, mod) => function __require() {
-    return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+    try {
+      return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+    } catch (e) {
+      throw mod = 0, e;
+    }
   };
   var __export = (target, all) => {
     for (var name in all)
@@ -3634,7 +3643,7 @@
       if (isJSONObject(value)) {
         value = value[path[i]];
       } else if (isJSONArray(value)) {
-        value = value[Number.parseInt(path[i])];
+        value = value[Number.parseInt(path[i], 10)];
       } else {
         value = void 0;
       }
@@ -3642,8 +3651,7 @@
     }
     return value;
   }
-  function setIn(object, path, value) {
-    let createPath = arguments.length > 3 && arguments[3] !== void 0 ? arguments[3] : false;
+  function setIn(object, path, value, createPath = false) {
     if (path.length === 0) {
       return value;
     }
@@ -3685,7 +3693,7 @@
       }
       const updatedObject = shallowClone(object);
       if (isJSONArray(updatedObject)) {
-        updatedObject.splice(Number.parseInt(key2), 1);
+        updatedObject.splice(Number.parseInt(key2, 10), 1);
       }
       if (isJSONObject(updatedObject)) {
         delete updatedObject[key2];
@@ -3704,7 +3712,7 @@
         throw new TypeError(`Array expected at path ${JSON.stringify(parentPath)}`);
       }
       const updatedItems = shallowClone(items);
-      updatedItems.splice(Number.parseInt(index), 0, value);
+      updatedItems.splice(Number.parseInt(index, 10), 0, value);
       return updatedItems;
     });
   }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiChatHistory.js
@@ -2167,7 +2167,7 @@
       if (isJSONObject(value)) {
         value = value[path[i]];
       } else if (isJSONArray(value)) {
-        value = value[Number.parseInt(path[i])];
+        value = value[Number.parseInt(path[i], 10)];
       } else {
         value = void 0;
       }
@@ -2175,8 +2175,7 @@
     }
     return value;
   }
-  function setIn(object, path, value) {
-    let createPath = arguments.length > 3 && arguments[3] !== void 0 ? arguments[3] : false;
+  function setIn(object, path, value, createPath = false) {
     if (path.length === 0) {
       return value;
     }
@@ -2218,7 +2217,7 @@
       }
       const updatedObject = shallowClone(object);
       if (isJSONArray(updatedObject)) {
-        updatedObject.splice(Number.parseInt(key2), 1);
+        updatedObject.splice(Number.parseInt(key2, 10), 1);
       }
       if (isJSONObject(updatedObject)) {
         delete updatedObject[key2];
@@ -2237,7 +2236,7 @@
         throw new TypeError(`Array expected at path ${JSON.stringify(parentPath)}`);
       }
       const updatedItems = shallowClone(items);
-      updatedItems.splice(Number.parseInt(index), 0, value);
+      updatedItems.splice(Number.parseInt(index, 10), 0, value);
       return updatedItems;
     });
   }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiDataClearing.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/duckAiDataClearing.js
@@ -2167,7 +2167,7 @@
       if (isJSONObject(value)) {
         value = value[path[i]];
       } else if (isJSONArray(value)) {
-        value = value[Number.parseInt(path[i])];
+        value = value[Number.parseInt(path[i], 10)];
       } else {
         value = void 0;
       }
@@ -2175,8 +2175,7 @@
     }
     return value;
   }
-  function setIn(object, path, value) {
-    let createPath = arguments.length > 3 && arguments[3] !== void 0 ? arguments[3] : false;
+  function setIn(object, path, value, createPath = false) {
     if (path.length === 0) {
       return value;
     }
@@ -2218,7 +2217,7 @@
       }
       const updatedObject = shallowClone(object);
       if (isJSONArray(updatedObject)) {
-        updatedObject.splice(Number.parseInt(key2), 1);
+        updatedObject.splice(Number.parseInt(key2, 10), 1);
       }
       if (isJSONObject(updatedObject)) {
         delete updatedObject[key2];
@@ -2237,7 +2236,7 @@
         throw new TypeError(`Array expected at path ${JSON.stringify(parentPath)}`);
       }
       const updatedItems = shallowClone(items);
-      updatedItems.splice(Number.parseInt(index), 0, value);
+      updatedItems.splice(Number.parseInt(index, 10), 0, value);
       return updatedItems;
     });
   }

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/pages/duckplayer/dist/index.js
@@ -6,9 +6,12 @@
   var __getOwnPropNames = Object.getOwnPropertyNames;
   var __getProtoOf = Object.getPrototypeOf;
   var __hasOwnProp = Object.prototype.hasOwnProperty;
-  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
   var __commonJS = (cb, mod) => function __require() {
-    return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+    try {
+      return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+    } catch (e3) {
+      throw mod = 0, e3;
+    }
   };
   var __copyProps = (to, from, except, desc) => {
     if (from && typeof from === "object" || typeof from === "function") {
@@ -26,7 +29,6 @@
     isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
     mod
   ));
-  var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
 
   // ../node_modules/classnames/index.js
   var require_classnames = __commonJS({
@@ -3255,7 +3257,7 @@
   };
 
   // ../injected/src/features/duckplayer/util.js
-  var _VideoParams = class _VideoParams {
+  var VideoParams = class _VideoParams {
     /**
      * @param {string} id - the YouTube video ID
      * @param {string|null|undefined} time - an optional time
@@ -3264,6 +3266,8 @@
       this.id = id;
       this.time = time;
     }
+    static validVideoId = /^[a-zA-Z0-9-_]+$/;
+    static validTimestamp = /^[0-9hms]+$/;
     /**
      * @returns {string}
      */
@@ -3345,9 +3349,6 @@
       return new _VideoParams(id, time);
     }
   };
-  __publicField(_VideoParams, "validVideoId", /^[a-zA-Z0-9-_]+$/);
-  __publicField(_VideoParams, "validTimestamp", /^[0-9hms]+$/);
-  var VideoParams = _VideoParams;
 
   // pages/duckplayer/src/utils.js
   function createYoutubeURLForError(href, urlBase) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^14.95.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.10.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.11.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -63,7 +63,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#3eb45334aa29db79deae48e3548380e02d7ee53c",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#940664b5ae80b9d557760624138f2963d34a750a",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -72,7 +72,7 @@
         "types-generator"
       ],
       "dependencies": {
-        "immutable-json-patch": "^6.0.2",
+        "immutable-json-patch": "^6.0.3",
         "urlpattern-polyfill": "^10.1.0"
       }
     },
@@ -280,9 +280,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
-      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -659,9 +659,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.48.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
-      "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
+      "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -678,18 +678,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.4.7",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.7.tgz",
-      "integrity": "sha512-rNlAI8fKn/JckBMUSbNL/ES2kmDiurWaE49l+ikwEc9A6lFR7gMx9AhgQMQKBK4H5w4pKLH64JzZfB99uRsGNQ==",
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.8.tgz",
+      "integrity": "sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "7.4.7",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.4.7.tgz",
-      "integrity": "sha512-b4vI93uN1McPDbDrL9ptWIL3xIQPWd1x42ckiKVFJP2/krs2YeiJza1BZJa/z43oduI9+ZMj8QKTlHrwDO01Zw==",
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.4.8.tgz",
+      "integrity": "sha512-BhnfwjtvAhq2ea0vglBojLEvn2QtZFZenstPQt75O8RtSqf8Xgh2vh7ksD4afpKwqjUNKg9ze2f18C8KbmSy7A==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.4.7"
+        "tldts-core": "^7.4.8"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autoconsent": "^14.95.0",
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.0.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.10.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.11.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1216444686518658

- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [x] All tests must pass
- [x] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches injected privacy/broker-protection captcha image extraction (network fetch + size limits), which can affect opt-out flows if images fail to load or exceed limits; otherwise mostly vendored bundle churn from a routine dependency bump.
> 
> **Overview**
> Bumps **`@duckduckgo/content-scope-scripts`** from **15.10.0** to **15.11.0** in `package.json` / `package-lock.json` and refreshes the vendored **`node_modules/@duckduckgo/content-scope-scripts/build/android`** bundles shipped with the Android app.
> 
> The updated bundles include small runtime/build-output tweaks (e.g. **`Number.parseInt(..., 10)`**, default-parameter style for **`setIn`**, and try/catch around module init helpers) across several scripts. **Broker protection / autofill** captcha handling changes **`imageToBase64`** to an **async** path that **fetches** image URLs with **`credentials: "omit"`**, enforces a **5 MB** size cap, and uses **FileReader** instead of drawing to a canvas for non–data-URL images; **`ImageProvider.getCaptchaIdentifier`** now **awaits** that helper. **Duck Player**’s bundled script adjusts how **`VideoParams`** defines its static validation regexes.
> 
> Lockfile-only transitive bumps (e.g. **`immutable-json-patch`**, **`tldts`**, **`terser`**, **`@types/node`**) ride along with the install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7b9eef63bda8425bd42bdf37f96db3b5928de8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->