### PR TITLE
[Drift Audit] Update URL classification rule to match isUrl() and the useUrlPredictor flag

### DIFF
--- a/.cursor/rules/architecture.mdc
+++ b/.cursor/rules/architecture.mdc
@@ -339,19 +339,38 @@ Use `screenName` to opt into deeplink support:
 
 ## URL vs. Search Classification
 
-Use `QueryUrlPredictor` (from `browser-api`) to decide whether a string is a navigable URL or a search query. Do **not** use `UriString.isWebUrl()` for this — it uses a regex that is too permissive (e.g. `bbc.comcomcomcom` passes).
+Use `QueryUrlPredictor` (from `browser-api`) to decide whether a string is a navigable URL or a search query. Do **not** call `UriString.isWebUrl()` directly for this — it uses a regex that is too permissive (e.g. `bbc.comcomcomcom` passes).
+
+For a simple boolean decision, call `isUrl(query)` — it handles the feature-flag gate, the readiness check, and the fallback for you:
 
 ```kotlin
-private fun isNavigate(query: String): Boolean =
-    if (queryUrlPredictor.isReady()) {
-        queryUrlPredictor.classify(query) is Decision.Navigate
+private fun isNavigate(query: String): Boolean = queryUrlPredictor.isUrl(query)
+```
+
+Under the hood `isUrl` uses the native predictor only when the `useUrlPredictor` remote flag is enabled **and** the native library is ready; otherwise it falls back to `UriString.isWebUrl(query)`:
+
+```kotlin
+override fun isUrl(query: String): Boolean =
+    if (androidBrowserConfigFeature.useUrlPredictor().isEnabled() && isReady()) {
+        classify(query) is Decision.Navigate
     } else {
-        UriString.isWebUrl(query)  // fallback while native lib initialises
+        UriString.isWebUrl(query)
     }
 ```
 
+When you need the resolved value (not just a boolean), call `classify(query)` directly and guard it with `isReady()` yourself — `classify` does not check the feature flag:
+
+```kotlin
+if (queryUrlPredictor.isReady()) {
+    when (val decision = queryUrlPredictor.classify(query)) {
+        is Decision.Navigate -> open(decision.url)
+        is Decision.Search -> search(decision.query)
+    }
+}
+```
+
 - `Decision` is a sealed interface with `Navigate(url)` and `Search(query)` — both are data classes.
-- `isReady()` is false briefly at startup while the native library loads; always guard with a `UriString.isWebUrl` fallback.
+- Classification via the native predictor is gated behind the `useUrlPredictor` remote flag (`AndroidBrowserConfigFeature`). When it is disabled — or briefly at startup while `isReady()` is still false — `isUrl` falls back to `UriString.isWebUrl`.
 - `QueryUrlPredictor` lives in `browser-api` and is injectable at `AppScope`. `Decision` is exported transitively via `browser-api`'s `api` dep on `url-predictor-android`.
 
 ---


### PR DESCRIPTION
Task/Issue URL: (app.asana.com/redacted)
Tech Design URL (if applicable):

### Description
`.cursor/rules/architecture.mdc` — "URL vs. Search Classification".

**What the doc described:** it taught a hand-rolled classification helper — `if (queryUrlPredictor.isReady()) { classify(query) is Decision.Navigate } else { UriString.isWebUrl(query) }` — and stated that the `isWebUrl` fallback exists only "while the native library loads" (i.e. the sole fallback trigger is `isReady()`).

**The code change that invalidated it:** `QueryUrlPredictor` (in `browser-api`) now exposes a first-class `isUrl(query): Boolean` convenience method, and the implementation gates the native predictor behind a `useUrlPredictor` remote feature flag:

```kotlin
// app/src/main/java/com/duckduckgo/app/browser/omnibar/QueryUrlPredictor.kt
override fun isUrl(query: String): Boolean =
    if (androidBrowserConfigFeature.useUrlPredictor().isEnabled() && isReady()) {
        classify(query) is Decision.Navigate
    } else {
        UriString.isWebUrl(query)
    }
```

`isUrl()` is what the recent search-only / unified-omnibar work calls — `BrowserTabViewModel`, `NativeInputManager`, and `InputScreenViewModel` all use `queryUrlPredictor.isUrl(...)` rather than the manual pattern. Two facts had drifted:
- The idiomatic entry point is now `isUrl()`, not a hand-rolled `isReady()`/`classify()`/`isWebUrl()` block.
- Classification is gated on the `useUrlPredictor` flag (`AndroidBrowserConfigFeature`) in addition to native-lib readiness. The doc implied readiness was the only fallback trigger; the fallback also fires whenever the flag is disabled.

**How the doc now reads:** it recommends `isUrl(query)` for a boolean decision (showing the real implementation, flag gate included), keeps `classify()` + `isReady()` for callers that need the resolved `Decision` (noting `classify` does not check the flag), and corrects the fallback note to mention both the `useUrlPredictor` flag and readiness. The `Decision` shape and `browser-api`/`AppScope` facts were verified against the code and left unchanged.

Note: I could not confirm the exact merged PR that introduced `isUrl()`/`useUrlPredictor` via commit history (integrity-filtered), but the omnibar/URL-classification area was heavily touched by recent search-only-omnibar changes, and the current code plainly diverges from the doc.

🤖 AI-docs Drift Auditor

### Steps to test this PR
- [ ] Read the updated rule doc against `QueryUrlPredictor` (`browser-api` interface + app-side `QueryUrlPredictorImpl.isUrl`) and its callers (`BrowserTabViewModel`, `NativeInputManager`, `InputScreenViewModel`) and confirm it now matches.

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |




> [!NOTE]
> <details>
> <summary><b>🔒 Integrity filter blocked 20 items</b></summary>
>
> The following items were blocked because they don't meet the GitHub integrity level.
>
> - [#8891](https://github.com/duckduckgo/Android/pull/8891) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#8811](https://github.com/duckduckgo/Android/pull/8811) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#8809](https://github.com/duckduckgo/Android/pull/8809) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#8942](https://github.com/duckduckgo/Android/pull/8942) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#9102](https://github.com/duckduckgo/Android/pull/9102) `list_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/duckduckgo/Android/commit/6e44d94fb6d2a12c6acabb5e8b2f9bbe846c8747](https://github.com/duckduckgo/Android/commit/6e44d94fb6d2a12c6acabb5e8b2f9bbe846c8747) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/duckduckgo/Android/commit/ec630a07b625e269d6558cca25a6b10dd632c01e](https://github.com/duckduckgo/Android/commit/ec630a07b625e269d6558cca25a6b10dd632c01e) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/duckduckgo/Android/commit/abd06580efe0309005f71d392ddb8cbadc294a11](https://github.com/duckduckgo/Android/commit/abd06580efe0309005f71d392ddb8cbadc294a11) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/duckduckgo/Android/commit/a0e9b3c6dc387dc3074bb7ade0cf9a25a8f4787c](https://github.com/duckduckgo/Android/commit/a0e9b3c6dc387dc3074bb7ade0cf9a25a8f4787c) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/duckduckgo/Android/commit/34d1fbf4679010c15af38861aee46a1e04a289fb](https://github.com/duckduckgo/Android/commit/34d1fbf4679010c15af38861aee46a1e04a289fb) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/duckduckgo/Android/commit/d67731315aa7a37d10299d8130569f9e718d34fd](https://github.com/duckduckgo/Android/commit/d67731315aa7a37d10299d8130569f9e718d34fd) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/duckduckgo/Android/commit/b7dc05f8cdf5fdd6be1ffd988dceb6a0eb807a52](https://github.com/duckduckgo/Android/commit/b7dc05f8cdf5fdd6be1ffd988dceb6a0eb807a52) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/duckduckgo/Android/commit/4e94f9aa3102e1fac51543b56ca924faebf0629e](https://github.com/duckduckgo/Android/commit/4e94f9aa3102e1fac51543b56ca924faebf0629e) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/duckduckgo/Android/commit/f713425eb84cb2c2ae36f9e0b9fdb8eb9116c668](https://github.com/duckduckgo/Android/commit/f713425eb84cb2c2ae36f9e0b9fdb8eb9116c668) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/duckduckgo/Android/commit/5f01f62a925cc6549be3f505fad02aef18a00c57](https://github.com/duckduckgo/Android/commit/5f01f62a925cc6549be3f505fad02aef18a00c57) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [https://github.com/duckduckgo/Android/commit/18f4a1649c34b6d77eba1e9e0cf148468953e8c2](https://github.com/duckduckgo/Android/commit/18f4a1649c34b6d77eba1e9e0cf148468953e8c2) `list_commits`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - ... and 4 more items
>
> To allow these resources, lower `min-integrity` in your GitHub frontmatter:
>
> ```yaml
> tools:
>   github:
>     min-integrity: approved  # merged | approved | unapproved | none
> ```
>
> </details>


> Generated by [AI-docs Semantic Drift Audit](https://github.com/duckduckgo/Android/actions/runs/29073572514/agentic_workflow) · [◷](https://github.com/search?q=repo%3Aduckduckgo%2FAndroid+%22gh-aw-workflow-id%3A+drift-audit%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: AI-docs Semantic Drift Audit, engine: claude, model: auto, id: 29073572514, workflow_id: drift-audit, run: https://github.com/duckduckgo/Android/actions/runs/29073572514 -->

<!-- gh-aw-workflow-id: drift-audit -->