### PR TITLE
Hide chevron and disable click for actionless card list items

### DIFF
--- a/remote-messaging/remote-messaging-api/src/main/java/com/duckduckgo/remote/messaging/api/RemoteMessage.kt
+++ b/remote-messaging/remote-messaging-api/src/main/java/com/duckduckgo/remote/messaging/api/RemoteMessage.kt
@@ -33,7 +33,7 @@ import com.duckduckgo.remote.messaging.api.JsonActionType.PLAYSTORE
 import com.duckduckgo.remote.messaging.api.JsonActionType.SHARE
 import com.duckduckgo.remote.messaging.api.JsonActionType.URL
 
-data class RemoteMessage constructor(
+data class RemoteMessage(
     val id: String,
     val content: Content,
     val matchingRules: List<Int>,
@@ -196,7 +196,7 @@ sealed class CardItem {
      * Represents both TWO_LINE_LIST_ITEM and FEATURED_TWO_LINE_SINGLE_ACTION_LIST_ITEM.
      * The [type] field determines the visual styling.
      */
-    data class ListItem constructor(
+    data class ListItem(
         override val id: String,
         override val type: CardItemType,
         override val titleText: String,

--- a/remote-messaging/remote-messaging-api/src/main/java/com/duckduckgo/remote/messaging/api/RemoteMessage.kt
+++ b/remote-messaging/remote-messaging-api/src/main/java/com/duckduckgo/remote/messaging/api/RemoteMessage.kt
@@ -33,7 +33,7 @@ import com.duckduckgo.remote.messaging.api.JsonActionType.PLAYSTORE
 import com.duckduckgo.remote.messaging.api.JsonActionType.SHARE
 import com.duckduckgo.remote.messaging.api.JsonActionType.URL
 
-data class RemoteMessage(
+data class RemoteMessage constructor(
     val id: String,
     val content: Content,
     val matchingRules: List<Int>,
@@ -196,13 +196,13 @@ sealed class CardItem {
      * Represents both TWO_LINE_LIST_ITEM and FEATURED_TWO_LINE_SINGLE_ACTION_LIST_ITEM.
      * The [type] field determines the visual styling.
      */
-    data class ListItem(
+    data class ListItem constructor(
         override val id: String,
         override val type: CardItemType,
         override val titleText: String,
         val descriptionText: String,
         val placeholder: Placeholder,
-        val primaryAction: Action,
+        val primaryAction: Action?,
         val primaryActionText: String = "",
         val matchingRules: List<Int>,
         val exclusionRules: List<Int>,

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/CardItemAdapter.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/CardItemAdapter.kt
@@ -71,7 +71,7 @@ class CardItemAdapter {
                     titleText = json.titleText,
                     descriptionText = json.descriptionText ?: "",
                     placeholder = json.placeholder?.let { Content.Placeholder.from(it) } ?: Content.Placeholder.ANNOUNCE,
-                    primaryAction = json.primaryAction ?: throw IllegalArgumentException("ListItem requires primaryAction"),
+                    primaryAction = json.primaryAction,
                     primaryActionText = json.primaryActionText ?: "",
                     matchingRules = json.matchingRules ?: emptyList(),
                     exclusionRules = json.exclusionRules ?: emptyList(),

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/JsonRemoteMessageMapper.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/mappers/JsonRemoteMessageMapper.kt
@@ -122,8 +122,7 @@ private val twoLineListItemMapper: (JsonListItem, Set<MessageActionMapperPlugin>
         titleText = jsonItem.titleText.failIfEmpty(),
         descriptionText = jsonItem.descriptionText.orEmpty().failIfEmpty(),
         placeholder = jsonItem.placeholder.orEmpty().asPlaceholder(),
-        primaryAction = jsonItem.primaryAction?.toAction(actionMappers)
-            ?: throw IllegalStateException("CardItem primaryAction cannot be null"),
+        primaryAction = jsonItem.primaryAction?.toAction(actionMappers),
         primaryActionText = jsonItem.primaryActionText.orEmpty(),
         matchingRules = jsonItem.matchingRules.orEmpty(),
         exclusionRules = jsonItem.exclusionRules.orEmpty(),

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/modal/cardslist/CardsListAdapter.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/modal/cardslist/CardsListAdapter.kt
@@ -216,7 +216,6 @@ class CardsListAdapter @Inject constructor() : ListAdapter<ModalListItem, CardsL
                 )
                 if (item.primaryAction != null) {
                     binding.endImage.show()
-                    binding.action.isClickable = true
                     binding.action.setOnClickListener {
                         listener.onItemClicked(item)
                     }

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/modal/cardslist/CardsListAdapter.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/modal/cardslist/CardsListAdapter.kt
@@ -171,8 +171,16 @@ class CardsListAdapter @Inject constructor() : ListAdapter<ModalListItem, CardsL
                     item.placeholder,
                     createGlideListener(imageLoadListener, ImageLoadSource.CardItem(item.id)),
                 )
-                binding.listItemContainer.setOnClickListener {
-                    listener.onItemClicked(item)
+                if (item.primaryAction != null) {
+                    binding.endImage.show()
+                    binding.listItemContainer.isClickable = true
+                    binding.listItemContainer.setOnClickListener {
+                        listener.onItemClicked(item)
+                    }
+                } else {
+                    binding.endImage.gone()
+                    binding.listItemContainer.setOnClickListener(null)
+                    binding.listItemContainer.isClickable = false
                 }
             }
         }
@@ -206,8 +214,16 @@ class CardsListAdapter @Inject constructor() : ListAdapter<ModalListItem, CardsL
                     item.placeholder,
                     createGlideListener(imageLoadListener, ImageLoadSource.CardItem(item.id)),
                 )
-                binding.action.setOnClickListener {
-                    listener.onItemClicked(item)
+                if (item.primaryAction != null) {
+                    binding.endImage.show()
+                    binding.action.isClickable = true
+                    binding.action.setOnClickListener {
+                        listener.onItemClicked(item)
+                    }
+                } else {
+                    binding.endImage.gone()
+                    binding.action.setOnClickListener(null)
+                    binding.action.isClickable = false
                 }
             }
         }

--- a/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/modal/cardslist/CardsListRemoteMessageViewModel.kt
+++ b/remote-messaging/remote-messaging-impl/src/main/java/com/duckduckgo/remote/messaging/impl/modal/cardslist/CardsListRemoteMessageViewModel.kt
@@ -191,12 +191,13 @@ class CardsListRemoteMessageViewModel @Inject constructor(
     }
 
     override fun onItemClicked(item: CardItem.ListItem) {
-        viewModelScope.launch {
-            val message = lastRemoteMessageSeen ?: return@launch
-            val action = item.primaryAction
-            val command = commandActionMapper.asCommand(action)
-            _command.send(command)
-            cardsListPixelHelper.fireCardItemClickedPixel(message, item)
+        item.primaryAction?.let { action ->
+            viewModelScope.launch {
+                val message = lastRemoteMessageSeen ?: return@launch
+                val command = commandActionMapper.asCommand(action)
+                _command.send(command)
+                cardsListPixelHelper.fireCardItemClickedPixel(message, item)
+            }
         }
     }
 

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/CardsListMessageMapperTest.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/CardsListMessageMapperTest.kt
@@ -208,7 +208,7 @@ class CardsListMessageMapperTest {
     }
 
     @Test
-    fun whenCardsListMessageWithListItemMissingActionThenMessageIsFiltered() {
+    fun whenCardsListMessageWithListItemMissingActionThenListItemActionIsNull() {
         val listItemsWithNullAction = listOf(
             JsonListItem(
                 id = "item1",
@@ -216,7 +216,7 @@ class CardsListMessageMapperTest {
                 titleText = "Feature",
                 descriptionText = "Description",
                 placeholder = "ImageAI",
-                primaryAction = null, // Null action should cause failure
+                primaryAction = null,
             ),
         )
 
@@ -229,8 +229,12 @@ class CardsListMessageMapperTest {
 
         val remoteMessages = jsonMessages.mapToRemoteMessage(Locale.US, messageActionPlugins)
 
-        // Message should be filtered out due to null action in list item
-        assertEquals(0, remoteMessages.size)
+        // Message is kept; the list item is kept with a null action instead
+        assertEquals(1, remoteMessages.size)
+        val content = remoteMessages.first().content as Content.CardsList
+        assertEquals(1, content.listItems.size)
+        val listItem = content.listItems.first() as CardItem.ListItem
+        assertNull(listItem.primaryAction)
     }
 
     @Test

--- a/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/modal/cardslist/CardsListRemoteMessageViewModelTest.kt
+++ b/remote-messaging/remote-messaging-impl/src/test/java/com/duckduckgo/remote/messaging/impl/modal/cardslist/CardsListRemoteMessageViewModelTest.kt
@@ -475,6 +475,50 @@ class CardsListRemoteMessageViewModelTest {
     }
 
     @Test
+    fun whenOnItemClickedWithNullPrimaryActionThenNoCommandEmittedAndNoPixelFired() = runTest {
+        val messageId = "message-123"
+        val cardItem = CardItem.ListItem(
+            id = "item1",
+            titleText = "Test Card",
+            descriptionText = "Description",
+            primaryAction = null,
+            placeholder = Content.Placeholder.DDG_ANNOUNCE,
+            type = CardItemType.TWO_LINE_LIST_ITEM,
+            matchingRules = emptyList(),
+            exclusionRules = emptyList(),
+        )
+        val cardsList = Content.CardsList(
+            titleText = "Test Cards",
+            descriptionText = "Description",
+            placeholder = Content.Placeholder.DDG_ANNOUNCE,
+            listItems = listOf(cardItem),
+            primaryActionText = "Action",
+            primaryAction = Action.Dismiss,
+        )
+        val message = RemoteMessage(
+            id = messageId,
+            content = cardsList,
+            matchingRules = emptyList(),
+            exclusionRules = emptyList(),
+            surfaces = listOf(Surface.MODAL),
+        )
+        whenever(remoteMessagingRepository.getMessageById(eq(messageId))).thenReturn(message)
+
+        viewModel.init(messageId)
+
+        viewModel.commands.test {
+            viewModel.onItemClicked(cardItem)
+
+            expectNoEvents()
+
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        verify(commandActionMapper, never()).asCommand(any())
+        verify(cardsListPixelHelper, never()).fireCardItemClickedPixel(any(), any())
+    }
+
+    @Test
     fun whenOnItemClickedMultipleTimesThenMultipleCommandsEmittedAndPixelsFired() = runTest {
         val messageId = "message-123"
         val itemAction1 = Action.Url("https://example1.com")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1216450148456767?focus=true
Tech Design URL (if applicable): 

### Description

Cards List remote messages render each item's action as a chevron plus a tap target driven by `CardItem.ListItem.primaryAction`, which was previously non-nullable. When the JSON config was missing an action for a list item, the client threw and either dropped that item's parsing or dropped the whole message.

This makes `CardItem.ListItem.primaryAction` nullable end-to-end (data model, JSON mapper, local Moshi cache adapter), so an actionless item is rendered normally — title, description, image — but with its chevron hidden and the row non-clickable, instead of the item or message being silently dropped.

### Steps to test this PR

_Cards List remote message with a mix of actionable and actionless items_
- [x] Apply the following patch
[whats_new.patch](https://github.com/user-attachments/files/29888851/whats_new.patch)
- [x] Clean install the app and skip onboarding
- [x] Background/ foreground the app
- [x] The “What’s new” modal should be displayed
- [x] Confirm items with an action still show the chevron and perform the action on tap
- [x] Confirm the actionless item renders normally, has no chevron, and tapping it does nothing (no ripple, no navigation)
- [x] Confirm the message is no longer dropped entirely just because one item lacks an action

### UI changes
<img width="1080" height="2280" alt="Screenshot_20260710_142755" src="https://github.com/user-attachments/assets/30c836ce-38b8-4780-892b-d6c935488351" />



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to remote messaging cards list parsing and presentation; no auth, payments, or shared critical paths beyond nullable handling at call sites.
> 
> **Overview**
> **Cards list items can omit `primaryAction` without breaking the whole message.** `CardItem.ListItem.primaryAction` is now nullable across the API model, JSON mapping, and Moshi cache adapter; missing actions no longer throw or drop the item/message.
> 
> **UI and interaction:** Rows and featured items **hide the chevron** and **turn off click handling** when there is no action. The view model **skips commands and click pixels** for those taps.
> 
> Tests now assert a message with a null-action list item is **kept** with `primaryAction == null`, plus coverage that clicks do nothing in that case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a8a17eea766deb2705fd8aa9f058dcac0799b6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->