### PR TITLE
Downloads screen flickers when Notify Me View is shown

### DIFF
--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DownloadsActivity.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DownloadsActivity.kt
@@ -84,6 +84,7 @@ class DownloadsActivity : DuckDuckGoActivity() {
         get() = binding.searchBar
 
     private var searchMenuItem: MenuItem? = null
+    private var deleteAllMenuItem: MenuItem? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -136,6 +137,8 @@ class DownloadsActivity : DuckDuckGoActivity() {
 
     override fun onPrepareOptionsMenu(menu: Menu): Boolean {
         searchMenuItem = menu.findItem(R.id.action_search)
+        deleteAllMenuItem = menu.findItem(R.id.downloads_delete_all)
+        setMenuItemsVisibility(viewModel.viewState.value.hasDownloads)
         initializeSearchBar()
         return super.onPrepareOptionsMenu(menu)
     }
@@ -216,7 +219,12 @@ class DownloadsActivity : DuckDuckGoActivity() {
 
     private fun render(viewState: ViewState) {
         downloadsAdapter.updateData(viewState.filteredItems)
-        searchMenuItem?.isVisible = viewState.enableSearch
+        setMenuItemsVisibility(viewState.hasDownloads)
+    }
+
+    private fun setMenuItemsVisibility(hasDownloads: Boolean) {
+        searchMenuItem?.isVisible = hasDownloads
+        deleteAllMenuItem?.isVisible = hasDownloads
     }
 
     private fun setupRecyclerView() {

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DownloadsActivity.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DownloadsActivity.kt
@@ -216,12 +216,7 @@ class DownloadsActivity : DuckDuckGoActivity() {
 
     private fun render(viewState: ViewState) {
         downloadsAdapter.updateData(viewState.filteredItems)
-        searchMenuItem?.isVisible = itemsAvailable(viewState)
-    }
-
-    private fun itemsAvailable(viewState: ViewState): Boolean {
-        // The empty view is part of the list.
-        return viewState.filteredItems.size > 1
+        searchMenuItem?.isVisible = viewState.enableSearch
     }
 
     private fun setupRecyclerView() {

--- a/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DownloadsViewModel.kt
+++ b/downloads/downloads-impl/src/main/java/com/duckduckgo/downloads/impl/DownloadsViewModel.kt
@@ -59,7 +59,7 @@ class DownloadsViewModel @Inject constructor(
 ) : ViewModel(), DownloadsItemListener {
 
     data class ViewState(
-        val enableSearch: Boolean = false,
+        val hasDownloads: Boolean = false,
         val downloadItems: List<DownloadViewItem> = emptyList(),
         val filteredItems: List<DownloadViewItem> = emptyList(),
     )
@@ -92,7 +92,7 @@ class DownloadsViewModel @Inject constructor(
             else -> items.ifEmpty { listOf(Empty) }
         }
         val filteredItemsList = if (filter.isEmpty()) downloadItemsList else filtered(items, filter)
-        ViewState(enableSearch = items.isNotEmpty(), downloadItems = downloadItemsList, filteredItems = filteredItemsList)
+        ViewState(hasDownloads = items.any { it is Item }, downloadItems = downloadItemsList, filteredItems = filteredItemsList)
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), ViewState())
 
     fun commands(): Flow<Command> {

--- a/downloads/downloads-impl/src/main/res/layout/view_item_downloads_notify_me.xml
+++ b/downloads/downloads-impl/src/main/res/layout/view_item_downloads_notify_me.xml
@@ -19,6 +19,7 @@
     android:id="@+id/downloadsNotifyMe"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:visibility="gone"
     app:primaryText="@string/downloadsNotifyMeTitle"
     app:secondaryText="@string/downloadsNotifyMeSubtitle"
     app:sharedPrefsKeyForDismiss="key_component_dismissed_in_downloads" />

--- a/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/DownloadsViewModelTest.kt
+++ b/downloads/downloads-impl/src/test/java/com/duckduckgo/downloads/impl/DownloadsViewModelTest.kt
@@ -38,6 +38,7 @@ import com.duckduckgo.downloads.store.DownloadStatus.STARTED
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -74,6 +75,28 @@ class DownloadsViewModelTest {
                 mockNewDownloadState,
             )
         model
+    }
+
+    @Test
+    fun whenNoDownloadsThenHasDownloadsFalse() = runTest {
+        val list = emptyList<DownloadItem>()
+        whenever(mockDownloadsRepository.getDownloadsAsFlow()).thenReturn(flowOf(list))
+        testee.onItemVisibilityChanged(true)
+
+        testee.viewState.test {
+            assertFalse(awaitItem().hasDownloads)
+        }
+    }
+
+    @Test
+    fun whenAtLeastOneDownloadThenHasDownloadsTrue() = runTest {
+        val list = listOf(oneItem())
+        whenever(mockDownloadsRepository.getDownloadsAsFlow()).thenReturn(flowOf(list))
+        testee.onItemVisibilityChanged(true)
+
+        testee.viewState.test {
+            assertTrue(awaitItem().hasDownloads)
+        }
     }
 
     @Test
@@ -274,6 +297,8 @@ class DownloadsViewModelTest {
             assertEquals(3, items.downloadItems.size)
             assertEquals(1, items.filteredItems.size)
             assertTrue(items.filteredItems[0] is Empty)
+            // Search must stay available while filtering, even when the filter matches nothing.
+            assertTrue(items.hasDownloads)
         }
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200581511062568/task/1216398526052297
Tech Design URL (if applicable): 

### Description
Fixes a few small issues on the "Downloads" screen.

  - NotifyMe flicker: the "Notify me" card now starts hidden in XML (visibility="gone"), so it no longer flashes on screen load.
  - Toolbar menu on empty screen: search and "Delete All" are now gated on whether real downloads exist (hasDownloads = items.any { it is Item }), instead of a list-size check that counted the Empty/NotifyMe placeholders. With no downloads, both actions hide and the overflow (⋮) button disappears automatically.
  - Tests: added ViewModel coverage for hasDownloads (empty vs. populated, and stays true while a search filter matches nothing).

### Steps to test this PR

Setup

  1. Install from this branch, don't grant notifications permissions, skip onboarding.
  2. Ensure notification permission is not granted / the NotifyMe prompt is eligible to show.
  3. Start from a clean state with no downloads (fresh install, or delete all existing downloads first).

  A. Flicker - screen doesn't flicker anymore

  1. Open the Downloads screen via the browser overflow menu.
  2. Verify the screen renders cleanly — no flicker of the "Notify me" card as the screen loads.

  B. Toolbar actions - empty screen

  With no downloads present:
  1. Confirm the search icon is hidden.
  2. Confirm the overflow (⋮) menu button is hidden — there should be no toolbar actions at all 

  C. Toolbar actions — with downloads

  1. Download at least one file (e.g. save an image/PDF from a page).
  2. Return to / reopen the Downloads screen.
  3. Confirm the search icon appears.
  4. Confirm the ⋮ button appears, and tapping it shows "Delete All".

  D. Transition back to empty

  1. With one or more downloads present, tap ⋮ → Delete All.
  2. Confirm the list becomes empty and both the search icon and the ⋮ button disappear again (verifies the menu re-hides reactively, not just on first load).
  3. Tap the snackbar Undo → confirm downloads return and both actions reappear.

  E. Search-active edge case (guards the hasDownloads fix)

  1. With at least one download, tap the search icon and type a query that matches nothing.
  2. Confirm the list shows the empty/placeholder state but the search bar stays open and usable — the search action must not vanish just because the current filter has zero matches.
  3. Clear the query → the full download list returns.

  F. NotifyMe + empty interaction
  
  1. On the empty screen with the NotifyMe card visible (from setup), re-confirm no search icon and no ⋮ — the presence of the NotifyMe card alone must not enable the menu.
  2. Dismiss the NotifyMe card → confirm the toolbar is still action-free.


### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only visibility and view-state wiring in Downloads; no auth, data, or download deletion logic changes beyond when menu items show.
> 
> **Overview**
> Fixes **Downloads screen flicker** when the Notify Me prompt is eligible, and stabilizes **toolbar actions** so they reflect real downloads instead of list row count.
> 
> The Notify Me row layout now starts **`android:visibility="gone"`** so the card is not briefly shown before `NotifyMeView` decides whether it should appear.
> 
> **`ViewState.enableSearch`** is renamed to **`hasDownloads`**, set when the repository list contains at least one **`Item`** (not Notify Me / Empty / headers). **`DownloadsActivity`** uses that flag for both **search** and **delete all** menu visibility, replacing the old **`filteredItems.size > 1`** check that treated placeholder rows as downloads.
> 
> Tests cover **`hasDownloads`** with zero vs one download and assert search stays enabled when a filter matches nothing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4abd4bae9203dd84b584192f782a44723864fa07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->