### PR TITLE
UTI: top nav bar with text-driven visibility

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1514,6 +1514,8 @@ class BrowserTabFragment :
                 },
                 onCustomizeResponsesClicked = { viewModel.onCustomizeResponsesClicked() },
                 onFireButtonPressed = { onFireButtonPressed() },
+                onTabSwitcherPressed = { onTabsButtonPressed() },
+                onBrowserMenuPressed = { onBrowserMenuButtonPressed() },
                 onVoiceSearchPressed = { isChatTab ->
                     val mode = if (isChatTab) VoiceSearchMode.DUCK_AI else VoiceSearchMode.SEARCH
                     webView?.onPause()

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1229,11 +1229,19 @@ class BrowserTabFragment :
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 
+        val omnibarType = settingsDataStore.omnibarType
         omnibar = Omnibar(
-            omnibarType = settingsDataStore.omnibarType,
+            omnibarType = omnibarType,
             binding = binding,
         )
-        nativeInputManager.init(omnibar, binding.rootView, viewLifecycleOwner) {
+
+        val nativeInputRoot = if (omnibarType == OmnibarType.SINGLE_BOTTOM){
+            binding.rootView
+        } else {
+            binding.includeInputFieldNavBarRoot
+        }
+
+        nativeInputManager.init(omnibar, binding.rootView, binding.includeInputFieldNavBarRoot, viewLifecycleOwner) {
             nativeInputManager.hideNativeInput()
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1235,13 +1235,7 @@ class BrowserTabFragment :
             binding = binding,
         )
 
-        val nativeInputRoot = if (omnibarType == OmnibarType.SINGLE_BOTTOM){
-            binding.rootView
-        } else {
-            binding.includeInputFieldNavBarRoot
-        }
-
-        nativeInputManager.init(omnibar, binding.rootView, binding.includeInputFieldNavBarRoot, viewLifecycleOwner) {
+        nativeInputManager.init(omnibar, binding.rootView, viewLifecycleOwner) {
             nativeInputManager.hideNativeInput()
         }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
@@ -55,6 +55,15 @@ interface NativeInputAnimator {
         onCancel: () -> Unit = {},
         onComplete: () -> Unit,
     )
+    fun animateNavBarVisibility(
+        navBarView: View,
+        widgetView: View,
+        isBottom: Boolean,
+        heightPx: Int,
+        show: Boolean,
+        animate: Boolean,
+        onComplete: () -> Unit = {},
+    )
     fun cancelAnimation()
     fun applyLayoutTransitions(widgetView: View)
     fun applyLayoutTransitions(widgetView: View, isBottom: Boolean)
@@ -65,6 +74,7 @@ interface NativeInputAnimator {
 class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
 
     private var transitionAnimator: ValueAnimator? = null
+    private var navBarAnimator: ValueAnimator? = null
     private var animationCleanup: (() -> Unit)? = null
     private var pendingPreDraw: Pair<View, ViewTreeObserver.OnPreDrawListener>? = null
 
@@ -157,6 +167,61 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         }
     }
 
+    override fun animateNavBarVisibility(
+        navBarView: View,
+        widgetView: View,
+        isBottom: Boolean,
+        heightPx: Int,
+        show: Boolean,
+        animate: Boolean,
+        onComplete: () -> Unit,
+    ) {
+        navBarAnimator?.cancel()
+        navBarAnimator = null
+
+        val hiddenY = -heightPx.toFloat()
+        val ridesWidget = !isBottom
+        val endBar = if (show) 0f else hiddenY
+
+        if (!animate) {
+            navBarView.translationY = endBar
+            navBarView.visibility = if (show) View.VISIBLE else View.GONE
+            if (ridesWidget) widgetView.translationY = endBar
+            onComplete()
+            return
+        }
+
+        navBarView.visibility = View.VISIBLE
+        val startBar = navBarView.translationY
+        val startWidget = if (ridesWidget) widgetView.translationY else 0f
+        val endWidget = if (ridesWidget) endBar else 0f
+
+        navBarAnimator = ValueAnimator.ofFloat(0f, 1f).apply {
+            duration = ANIMATION_DURATION_MS
+            interpolator = FastOutSlowInInterpolator()
+            addUpdateListener { anim ->
+                val f = anim.animatedFraction
+                navBarView.translationY = lerpF(startBar, endBar, f)
+                if (ridesWidget) widgetView.translationY = lerpF(startWidget, endWidget, f)
+            }
+            addListener(object : AnimatorListenerAdapter() {
+                private var cancelled = false
+                override fun onAnimationCancel(animation: Animator) {
+                    cancelled = true
+                }
+                override fun onAnimationEnd(animation: Animator) {
+                    navBarAnimator = null
+                    if (cancelled) return
+                    navBarView.translationY = endBar
+                    if (ridesWidget) widgetView.translationY = endWidget
+                    if (!show) navBarView.visibility = View.GONE
+                    onComplete()
+                }
+            })
+            start()
+        }
+    }
+
     private fun snapshotBeforeExit(widgetCard: View, omnibarCard: View, isBottom: Boolean): ExitSnapshot {
         val preSurface = visibleSurfacePosition(widgetCard)
         val omnibarPosition = visibleSurfacePosition(omnibarCard)
@@ -236,6 +301,8 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         animationCleanup = null
         transitionAnimator?.cancel()
         transitionAnimator = null
+        navBarAnimator?.cancel()
+        navBarAnimator = null
     }
 
     override fun applyLayoutTransitions(widgetView: View) {

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -30,7 +30,6 @@ import com.google.android.material.card.MaterialCardView
 
 class NativeInputLayoutCoordinator(
     private val rootView: ViewGroup,
-    private val topNavRootView: ViewGroup,
     private val omnibarState: OmnibarState,
 ) {
     private data class Padding(val left: Int, val top: Int, val right: Int, val bottom: Int)

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -30,6 +30,7 @@ import com.google.android.material.card.MaterialCardView
 
 class NativeInputLayoutCoordinator(
     private val rootView: ViewGroup,
+    private val topNavRootView: ViewGroup,
     private val omnibarState: OmnibarState,
 ) {
     private data class Padding(val left: Int, val top: Int, val right: Int, val bottom: Int)
@@ -165,6 +166,7 @@ class NativeInputLayoutCoordinator(
 
     fun configureContentOffset(widgetView: View, isBottom: Boolean) {
         data class Target(val view: View, val basePadding: Padding)
+
         val newTabContent =
             rootView.findViewById<View?>(R.id.newTabPage)
                 ?: rootView.findViewById(R.id.includeNewBrowserTab)

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -48,6 +48,9 @@ class NativeInputLayoutCoordinator(
      */
     private var isWidgetAnimating: Boolean = false
 
+    private var navBarInsetPx: Int = 0
+    private var reapplyContentOffset: (() -> Unit)? = null
+
     fun buildWidgetLayoutParams(isBottom: Boolean, topInsetPx: Int = 0): ViewGroup.LayoutParams {
         return CoordinatorLayout.LayoutParams(
             ViewGroup.LayoutParams.MATCH_PARENT,
@@ -176,6 +179,7 @@ class NativeInputLayoutCoordinator(
     }
 
     fun configureContentOffset(widgetView: View, isBottom: Boolean, navBarInsetPx: Int = 0) {
+        this.navBarInsetPx = navBarInsetPx
         data class Target(val view: View, val basePadding: Padding)
 
         val newTabContent =
@@ -253,7 +257,7 @@ class NativeInputLayoutCoordinator(
             } else {
                 0
             }
-            return contentTopInset(isBottom, logoOnly, navBarInsetPx, widgetTopOffsetPx)
+            return contentTopInset(isBottom, logoOnly, this@NativeInputLayoutCoordinator.navBarInsetPx, widgetTopOffsetPx)
         }
 
         fun computeDeltaBottom(view: View, anchorTopInWindow: Int): Int {
@@ -300,6 +304,7 @@ class NativeInputLayoutCoordinator(
             applyOffsetWithBottom(anchorTopInWindow = cardVisualTopInWindow, anchorBottomInWindow = cardVisualBottomInWindow)
         }
 
+        reapplyContentOffset = { applyOffset() }
         widgetView.post { applyOffset() }
         val layoutListener =
             View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
@@ -329,6 +334,7 @@ class NativeInputLayoutCoordinator(
                     ntpGroup?.layoutTransition = previousNtpTransition
                     pendingContentLayoutTransition = null
                     widgetAnimationFrameHandler = null
+                    reapplyContentOffset = null
                     isWidgetAnimating = false
                     targets.forEach { target ->
                         applyPadding(target.view, target.basePadding, deltaTop = 0, deltaBottom = 0)
@@ -340,6 +346,15 @@ class NativeInputLayoutCoordinator(
                 }
             },
         )
+    }
+
+    /**
+     * Updates the nav bar top-inset used by the (already-registered) content-offset listeners and
+     * re-applies immediately. Cheap: no new listeners — unlike re-calling [configureContentOffset].
+     */
+    fun updateNavBarInset(px: Int) {
+        navBarInsetPx = px
+        reapplyContentOffset?.invoke()
     }
 
     fun onWidgetAnimationFrame(card: View) {

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -48,12 +48,24 @@ class NativeInputLayoutCoordinator(
      */
     private var isWidgetAnimating: Boolean = false
 
-    fun buildWidgetLayoutParams(isBottom: Boolean): ViewGroup.LayoutParams {
+    fun buildWidgetLayoutParams(isBottom: Boolean, topInsetPx: Int = 0): ViewGroup.LayoutParams {
         return CoordinatorLayout.LayoutParams(
             ViewGroup.LayoutParams.MATCH_PARENT,
             ViewGroup.LayoutParams.WRAP_CONTENT,
         ).apply {
             gravity = if (isBottom) Gravity.BOTTOM else Gravity.TOP
+            // In top mode the persistent nav bar occupies the top strip, so offset the widget below it
+            // instead of overlapping. Bottom mode sits at the bottom and needs no offset.
+            topMargin = if (isBottom) 0 else topInsetPx
+        }
+    }
+
+    fun buildNavBarLayoutParams(heightPx: Int): ViewGroup.LayoutParams {
+        return CoordinatorLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            heightPx,
+        ).apply {
+            gravity = Gravity.TOP
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -175,7 +175,7 @@ class NativeInputLayoutCoordinator(
         }
     }
 
-    fun configureContentOffset(widgetView: View, isBottom: Boolean) {
+    fun configureContentOffset(widgetView: View, isBottom: Boolean, navBarInsetPx: Int = 0) {
         data class Target(val view: View, val basePadding: Padding)
 
         val newTabContent =
@@ -246,9 +246,14 @@ class NativeInputLayoutCoordinator(
         }
 
         fun computeDeltaTop(view: View, anchorBottomInWindow: Int): Int {
-            if (isBottom || isLogoOnlyContent(view)) return 0
-            val viewLocation = IntArray(2).also { view.getLocationInWindow(it) }
-            return maxOf(0, anchorBottomInWindow - viewLocation[1])
+            val logoOnly = isLogoOnlyContent(view)
+            val widgetTopOffsetPx = if (!logoOnly && !isBottom) {
+                val viewLocation = IntArray(2).also { view.getLocationInWindow(it) }
+                anchorBottomInWindow - viewLocation[1]
+            } else {
+                0
+            }
+            return contentTopInset(isBottom, logoOnly, navBarInsetPx, widgetTopOffsetPx)
         }
 
         fun computeDeltaBottom(view: View, anchorTopInWindow: Int): Int {
@@ -307,8 +312,9 @@ class NativeInputLayoutCoordinator(
         // Some offset inputs change without moving rootView/widgetView (hatch height, logo visibility,
         // NTP reflow), which the per-view listeners miss. The window-shared viewTreeObserver fires on
         // every global layout pass — broad by design; kept cheap via the isWidgetAnimating skip and
-        // no-op applyPadding.
-        val ntpContentView = newTabContent?.takeIf { !isBottom }
+        // no-op applyPadding. Needed in both modes: bottom mode's nav bar top inset also flips with
+        // logo-only transitions (hatch/RMF/AppTP banner appearing).
+        val ntpContentView = newTabContent
         val globalLayoutListener =
             ViewTreeObserver.OnGlobalLayoutListener {
                 if (isWidgetAnimating) return@OnGlobalLayoutListener
@@ -391,3 +397,20 @@ class NativeInputLayoutCoordinator(
  */
 internal fun isLogoOnly(logoVisible: Boolean, hatchHeightPx: Int, onboardingCtaVisible: Boolean, sectionsVisible: Boolean): Boolean =
     logoVisible && hatchHeightPx <= 0 && !onboardingCtaVisible && !sectionsVisible
+
+/**
+ * The top padding the NTP/browser content needs to clear the input-mode chrome.
+ *
+ * - Logo-only content is never inset, so the centered logo doesn't shift between Search and the taller
+ *   Duck.ai tab (and it can't collide with the short top nav bar anyway).
+ * - Bottom mode: the widget sits at the bottom, so the only top chrome is the persistent nav bar — inset by
+ *   [navBarInsetPx] so the content isn't drawn under it.
+ * - Top mode: the widget sits below the nav bar, so [widgetTopOffsetPx] (content top → widget bottom) already
+ *   accounts for the nav bar; clamp negatives to zero.
+ */
+internal fun contentTopInset(isBottom: Boolean, isLogoOnly: Boolean, navBarInsetPx: Int, widgetTopOffsetPx: Int): Int =
+    when {
+        isLogoOnly -> 0
+        isBottom -> navBarInsetPx
+        else -> maxOf(0, widgetTopOffsetPx)
+    }

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -140,7 +140,7 @@ class NativeInputLayoutCoordinator(
             // rides the widget up via translationY (a render transform, not a layout change), so .bottom
             // alone would offset for the old nav-bar-shown position and leave a gap the size of the nav bar.
             // Bottom mode's nav bar doesn't ride the widget, so its offset stays layout-based.
-            val topOffset = autocompleteTopOffset(isBottom, widgetView.bottom + widgetView.translationY.toInt(), autoCompleteList.top)
+            val topOffset = autocompleteTopOffset(isBottom, widgetView.bottom + widgetView.translationY.toInt(), autoCompleteList.top, navBarInsetPx)
             val bottomOffset = autocompleteBottomOffset(isBottom, autoCompleteList.bottom, widgetView.top)
             applyPadding(deltaTop = topOffset, deltaBottom = bottomOffset)
         }
@@ -445,13 +445,15 @@ internal fun contentTopInset(isBottom: Boolean, isLogoOnly: Boolean, navBarInset
     }
 
 /**
- * Top padding the autocomplete list needs to sit below the input widget (top mode only; bottom mode
- * clears the widget from below). [widgetVisualBottomPx] must be the widget's on-screen bottom — its layout
- * bottom plus translationY — because the nav bar hide slides the widget up via translationY, and a
- * layout-only bottom would leave a gap the size of the nav bar once the bar is gone.
+ * Top padding the autocomplete list needs to clear the top chrome.
+ * - Top mode: sit below the input widget. [widgetVisualBottomPx] must be the widget's on-screen bottom —
+ *   its layout bottom plus translationY — because the nav bar hide slides the widget up via translationY,
+ *   and a layout-only bottom would leave a gap the size of the nav bar once the bar is gone.
+ * - Bottom mode: the widget is at the bottom, so the only top chrome is the nav bar — inset by
+ *   [navBarInsetPx] (zero when the bar is hidden) so the suggestions aren't drawn under it.
  */
-internal fun autocompleteTopOffset(isBottom: Boolean, widgetVisualBottomPx: Int, autoCompleteListTopPx: Int): Int =
-    if (isBottom) 0 else maxOf(0, widgetVisualBottomPx - autoCompleteListTopPx)
+internal fun autocompleteTopOffset(isBottom: Boolean, widgetVisualBottomPx: Int, autoCompleteListTopPx: Int, navBarInsetPx: Int): Int =
+    if (isBottom) navBarInsetPx else maxOf(0, widgetVisualBottomPx - autoCompleteListTopPx)
 
 /**
  * Bottom counterpart of [autocompleteTopOffset]: in bottom mode the list clears the widget from below.

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -384,7 +384,11 @@ class NativeInputLayoutCoordinator(
     fun applyForcedBottomTranslation(widgetView: View, isBottom: Boolean) {
         val shouldForce = isBottom && !omnibarState.isOmnibarBottom()
         if (!shouldForce) {
-            widgetView.translationY = 0f
+            // Only reset bottom-anchored widgets. A top-anchored widget's translationY is owned by the
+            // nav bar visibility — the widget rides up by the nav bar height when the bar hides — so
+            // zeroing it here (this runs a frame after attach) would clobber that ride-up and leave a
+            // gap under the top chrome when reopening with prefilled text.
+            if (isBottom) widgetView.translationY = 0f
             return
         }
         fun applyOffset() {

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -50,6 +50,7 @@ class NativeInputLayoutCoordinator(
 
     private var navBarInsetPx: Int = 0
     private var reapplyContentOffset: (() -> Unit)? = null
+    private var reapplyAutocompleteOffset: (() -> Unit)? = null
 
     fun buildWidgetLayoutParams(isBottom: Boolean, topInsetPx: Int = 0): ViewGroup.LayoutParams {
         return CoordinatorLayout.LayoutParams(
@@ -135,11 +136,16 @@ class NativeInputLayoutCoordinator(
         }
 
         fun applyForWidgetPosition() {
-            val topOffset = if (isBottom) 0 else maxOf(0, widgetView.bottom - autoCompleteList.top)
-            val bottomOffset = if (isBottom) maxOf(0, autoCompleteList.bottom - widgetView.top) else 0
+            // Top mode uses the widget's on-screen bottom (layout bottom + translationY): the nav bar hide
+            // rides the widget up via translationY (a render transform, not a layout change), so .bottom
+            // alone would offset for the old nav-bar-shown position and leave a gap the size of the nav bar.
+            // Bottom mode's nav bar doesn't ride the widget, so its offset stays layout-based.
+            val topOffset = autocompleteTopOffset(isBottom, widgetView.bottom + widgetView.translationY.toInt(), autoCompleteList.top)
+            val bottomOffset = autocompleteBottomOffset(isBottom, autoCompleteList.bottom, widgetView.top)
             applyPadding(deltaTop = topOffset, deltaBottom = bottomOffset)
         }
 
+        reapplyAutocompleteOffset = { applyForWidgetPosition() }
         widgetView.post { applyForWidgetPosition() }
         val layoutListener =
             View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
@@ -154,6 +160,7 @@ class NativeInputLayoutCoordinator(
 
                 override fun onViewDetachedFromWindow(v: View) {
                     applyPadding(deltaTop = 0, deltaBottom = 0)
+                    reapplyAutocompleteOffset = null
                     restoreFloats.forEach { it() }
                     v.removeOnLayoutChangeListener(layoutListener)
                     autoCompleteList.removeOnLayoutChangeListener(layoutListener)
@@ -355,6 +362,9 @@ class NativeInputLayoutCoordinator(
     fun updateNavBarInset(px: Int) {
         navBarInsetPx = px
         reapplyContentOffset?.invoke()
+        // Recompute the autocomplete offset too: the nav bar toggle rides the widget via translationY,
+        // which fires no layout listener, so this is the only signal that the widget's screen edges moved.
+        reapplyAutocompleteOffset?.invoke()
     }
 
     fun onWidgetAnimationFrame(card: View) {
@@ -429,3 +439,19 @@ internal fun contentTopInset(isBottom: Boolean, isLogoOnly: Boolean, navBarInset
         isBottom -> navBarInsetPx
         else -> maxOf(0, widgetTopOffsetPx)
     }
+
+/**
+ * Top padding the autocomplete list needs to sit below the input widget (top mode only; bottom mode
+ * clears the widget from below). [widgetVisualBottomPx] must be the widget's on-screen bottom — its layout
+ * bottom plus translationY — because the nav bar hide slides the widget up via translationY, and a
+ * layout-only bottom would leave a gap the size of the nav bar once the bar is gone.
+ */
+internal fun autocompleteTopOffset(isBottom: Boolean, widgetVisualBottomPx: Int, autoCompleteListTopPx: Int): Int =
+    if (isBottom) 0 else maxOf(0, widgetVisualBottomPx - autoCompleteListTopPx)
+
+/**
+ * Bottom counterpart of [autocompleteTopOffset]: in bottom mode the list clears the widget from below.
+ * Layout-based [widgetTopPx] is fine here — the bottom-mode nav bar doesn't ride the widget.
+ */
+internal fun autocompleteBottomOffset(isBottom: Boolean, autoCompleteListBottomPx: Int, widgetTopPx: Int): Int =
+    if (isBottom) maxOf(0, autoCompleteListBottomPx - widgetTopPx) else 0

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -235,11 +235,19 @@ class RealNativeInputManager @Inject constructor(
                 }
             }
             .launchIn(lifecycleOwner.lifecycleScope)
+        // Re-evaluate an already-attached nav bar when the mode/flag change: switching to Search-only
+        // (or turning the flag off) while the input is open must hide it, not leave it up until teardown.
         duckChatInputModeState.inputModeCapability
-            .onEach { inputModeCapability = it }
+            .onEach {
+                inputModeCapability = it
+                refreshNavBarVisibility()
+            }
             .launchIn(lifecycleOwner.lifecycleScope)
         duckChat.observeNativeInputNavBarEnabled()
-            .onEach { isNavBarFeatureEnabled = it }
+            .onEach {
+                isNavBarFeatureEnabled = it
+                refreshNavBarVisibility()
+            }
             .launchIn(lifecycleOwner.lifecycleScope)
     }
 
@@ -531,7 +539,7 @@ class RealNativeInputManager @Inject constructor(
         }
         attachWidget(widgetView, navBarView, isBottom, tabId)
         applyNavBarVisibility(
-            show = shouldShowNavBar(isBrowserContext = navBarView != null, isInputEmpty = prefillText.isEmpty()),
+            show = navBarShouldBeVisible(isInputEmpty = prefillText.isEmpty()),
             animate = false,
         )
         lifecycleOwner.lifecycleScope.launch {
@@ -618,7 +626,7 @@ class RealNativeInputManager @Inject constructor(
             },
             onInputTextEmptyChanged = { isEmpty ->
                 applyNavBarVisibility(
-                    show = shouldShowNavBar(isBrowserContext = navBarRoot != null, isInputEmpty = isEmpty),
+                    show = navBarShouldBeVisible(isInputEmpty = isEmpty),
                     animate = true,
                 )
             },
@@ -866,6 +874,23 @@ class RealNativeInputManager @Inject constructor(
             autoCompleteList.gone()
             focusedView?.gone()
         }
+    }
+
+    /** Current on-screen visibility the nav bar should have, combining the create-time gate with the
+     *  empty-field rule so a live mode/flag change (e.g. Search & Duck.ai → Search-only) hides it. */
+    private fun navBarShouldBeVisible(isInputEmpty: Boolean): Boolean =
+        shouldCreateNavBar(isNavBarFeatureEnabled, omnibarController.isDuckAiMode(), inputModeCapability) &&
+            shouldShowNavBar(isBrowserContext = navBarRoot != null, isInputEmpty = isInputEmpty)
+
+    /** Re-applies the nav bar visibility for the current input state; no-op when no bar is attached. */
+    private fun refreshNavBarVisibility() {
+        if (navBarRoot == null) return
+        applyNavBarVisibility(show = navBarShouldBeVisible(isInputEmpty = currentInputEmpty()), animate = true)
+    }
+
+    private fun currentInputEmpty(): Boolean {
+        val widget = widgetRoot?.let { widgetFrom(it) } ?: return true
+        return widget.text.isNullOrEmpty()
     }
 
     /**

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -650,6 +650,7 @@ class RealNativeInputManager @Inject constructor(
     }
 
     private fun removeWidget(): Boolean {
+        animator.cancelAnimation()
         var removed = false
         rootView.findViewById<View?>(R.id.inputModeTopRoot)?.let {
             rootView.removeView(it)
@@ -869,6 +870,7 @@ class RealNativeInputManager @Inject constructor(
         val widget = widgetRoot ?: return
         if (!shouldAnimateNavBar(navBarShown, show)) return
         navBarShown = show
+        val navBarInset = if (show) navBarHeightPx else 0
         animator.animateNavBarVisibility(
             navBarView = navBar,
             widgetView = widget,
@@ -876,8 +878,12 @@ class RealNativeInputManager @Inject constructor(
             heightPx = navBarHeightPx,
             show = show,
             animate = animate,
+            // Re-apply after the slide settles so the top-mode "show" case (widget rides down to its
+            // final position) recomputes the offset from where the widget actually lands.
+            onComplete = { layoutCoordinator.updateNavBarInset(navBarInset) },
         )
-        layoutCoordinator.configureContentOffset(widget, navBarIsBottom, navBarInsetPx = if (show) navBarHeightPx else 0)
+        // Apply immediately too, so the inset tracks the toggle without waiting for the animation.
+        layoutCoordinator.updateNavBarInset(navBarInset)
     }
 
     private fun attachWidget(widgetView: View, navBarView: View?, isBottom: Boolean, tabId: String) {

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -30,6 +30,7 @@ import android.widget.FrameLayout
 import androidx.core.net.toUri
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.map
 import androidx.recyclerview.widget.RecyclerView
@@ -40,6 +41,7 @@ import com.duckduckgo.app.pixels.AppPixelName
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.model.TabEntity
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion
+import com.duckduckgo.browser.ui.tabs.TabSwitcherButton
 import com.duckduckgo.common.ui.view.getColorFromAttr
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
@@ -91,6 +93,8 @@ class NativeInputCallbacks(
     val onClearAutocomplete: () -> Unit,
     val onStopTapped: () -> Unit,
     val onFireButtonPressed: () -> Unit = {},
+    val onTabSwitcherPressed: () -> Unit = {},
+    val onBrowserMenuPressed: () -> Unit = {},
     val onVoiceSearchPressed: (isChatTab: Boolean) -> Unit = {},
     val onCameraCaptureRequested: (ValueCallback<Array<Uri>>) -> Unit = {},
     val onFilePickerRequested: (ValueCallback<Array<Uri>>, List<String>) -> Unit = { _, _ -> },
@@ -188,6 +192,8 @@ class RealNativeInputManager @Inject constructor(
     private var floatingSubmitContainer: View? = null
     private var widgetRoot: View? = null
     private var navBarRoot: View? = null
+    private var navBarTabCountLiveData: LiveData<Int>? = null
+    private var navBarTabCountObserver: Observer<Int>? = null
     private var lastCallbacks: NativeInputCallbacks? = null
 
     private val interactionLockSource = MutableStateFlow(InteractionLock.Unlocked)
@@ -487,6 +493,7 @@ class RealNativeInputManager @Inject constructor(
         val navBarView = createNavBarView(layoutInflater)
         val prefillText = query.ifEmpty { omnibarController.getText() }
         bindWidget(widgetView, lifecycleOwner, tabs, currentTabUrl, callbacks, isBottom)
+        bindNavBar(navBarView, widgetView, lifecycleOwner, tabs, callbacks)
         if (!omnibarController.isDuckAiMode() && prefillText.isNotEmpty()) {
             // Restore the cache before setting text — triggerAutocomplete preserves the
             // current searchResults, so a stale cache (post-submit reset, or overwritten by
@@ -641,6 +648,9 @@ class RealNativeInputManager @Inject constructor(
             rootView.removeView(it)
             navBarRoot = null
         }
+        navBarTabCountObserver?.let { existing -> navBarTabCountLiveData?.removeObserver(existing) }
+        navBarTabCountObserver = null
+        navBarTabCountLiveData = null
         floatingSubmitContainer?.let {
             (it.parent as? ViewGroup)?.removeView(it)
             floatingSubmitContainer = null
@@ -664,6 +674,47 @@ class RealNativeInputManager @Inject constructor(
 
     private fun createNavBarView(layoutInflater: LayoutInflater): View {
         return layoutInflater.inflate(R.layout.input_mode_widget_nav_bar, rootView, false)
+    }
+
+    private fun bindNavBar(
+        navBarView: View,
+        widgetView: View,
+        lifecycleOwner: LifecycleOwner,
+        tabs: LiveData<List<TabEntity>>,
+        callbacks: NativeInputCallbacks,
+    ) {
+        bindInputModeNavBar(
+            navBarView = navBarView,
+            // Matches the widget's Back handler: drop input focus so the IME hide sticks, then close.
+            onBack = {
+                widgetFrom(widgetView)?.clearInputFocus()
+                hideNativeInput()
+            },
+            onFire = callbacks.onFireButtonPressed,
+            onTabs = callbacks.onTabSwitcherPressed,
+            onBrowserMenu = callbacks.onBrowserMenuPressed,
+        )
+        bindNavBarTabCount(navBarView, lifecycleOwner, tabs)
+    }
+
+    /**
+     * Mirrors [NativeInputWidget.bindTabCount]: the fragment's viewLifecycleOwner is reused across
+     * show/hide cycles, so the previous observer is removed before re-observing — otherwise each cycle
+     * stacks an observer that keeps updating a detached nav bar button.
+     */
+    private fun bindNavBarTabCount(
+        navBarView: View,
+        lifecycleOwner: LifecycleOwner,
+        tabs: LiveData<List<TabEntity>>,
+    ) {
+        val tabsButton = navBarView.findViewById<TabSwitcherButton?>(R.id.inputFieldTabsMenu) ?: return
+        navBarTabCountObserver?.let { existing -> navBarTabCountLiveData?.removeObserver(existing) }
+        val tabCount = tabs.map { it.size }
+        val observer = Observer<Int> { count -> tabsButton.count = count }
+        navBarTabCountLiveData = tabCount
+        navBarTabCountObserver = observer
+        tabCount.observe(lifecycleOwner, observer)
+        tabsButton.count = tabCount.value ?: 0
     }
 
     private fun bindWidget(
@@ -806,7 +857,7 @@ class RealNativeInputManager @Inject constructor(
             configure(tabId = tabId, isDuckAiMode = omnibarController.isDuckAiMode(), isBottom = isBottom)
         }
 
-        applyWindowChrome(widgetView, isBottom)
+        applyWindowChrome(widgetView, isBottom, navBarHeightPx)
 
         if (!startEnterAnimation(widgetView, isBottom)) {
             animator.applyLayoutTransitions(widgetView, isBottom)
@@ -835,7 +886,7 @@ class RealNativeInputManager @Inject constructor(
         }
     }
 
-    private fun applyWindowChrome(widgetView: View, isBottom: Boolean) {
+    private fun applyWindowChrome(widgetView: View, isBottom: Boolean, navBarHeightPx: Int) {
         widgetView.translationZ = WIDGET_ELEVATION_DP.toPx()
         if (isBottom) {
             rootView.findViewById<View?>(R.id.navigationBar)?.gone()
@@ -857,7 +908,7 @@ class RealNativeInputManager @Inject constructor(
             }
         }
         layoutCoordinator.configureAutocompleteLayout(widgetView, isBottom)
-        layoutCoordinator.configureContentOffset(widgetView, isBottom)
+        layoutCoordinator.configureContentOffset(widgetView, isBottom, navBarHeightPx)
         widgetView.post { layoutCoordinator.applyForcedBottomTranslation(widgetView, isBottom) }
     }
 
@@ -1021,6 +1072,23 @@ class RealNativeInputManager @Inject constructor(
         private const val FADE_OUT_DURATION_MS = 150L
         private const val DUCK_AI_FEATURE_PAGE = "duckai"
     }
+}
+
+/**
+ * Wires the persistent input-mode nav bar's controls to their actions. Pure view wiring (findViewById +
+ * setOnClickListener) kept out of the manager so it can be unit-tested without the full attach path.
+ */
+internal fun bindInputModeNavBar(
+    navBarView: View,
+    onBack: () -> Unit,
+    onFire: () -> Unit,
+    onTabs: () -> Unit,
+    onBrowserMenu: () -> Unit,
+) {
+    navBarView.findViewById<View?>(R.id.inputModeWidgetNavBack)?.setOnClickListener { onBack() }
+    navBarView.findViewById<View?>(R.id.inputFieldFireButton)?.setOnClickListener { onFire() }
+    navBarView.findViewById<View?>(R.id.inputFieldTabsMenu)?.setOnClickListener { onTabs() }
+    navBarView.findViewById<View?>(R.id.inputFieldBrowserMenu)?.setOnClickListener { onBrowserMenu() }
 }
 
 internal data class VoiceButtonAvailability(

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -892,6 +892,11 @@ class RealNativeInputManager @Inject constructor(
         this.navBarIsBottom = isBottom
         if (navBarView != null) {
             rootView.addView(navBarView, layoutCoordinator.buildNavBarLayoutParams(navBarHeightPx))
+            // Bottom omnibar only: the autocomplete list overlaps the top strip and would draw over the
+            // bar (e.g. the Duck.ai tab's suggestions), so float it above. Top omnibar has no such overlap,
+            // and the elevation shadow there would tint the bar's background so it no longer matches the
+            // content — leave it flat.
+            if (isBottom) navBarView.translationZ = WIDGET_ELEVATION_DP.toPx()
         }
         // Top mode offsets the widget below the nav bar so it isn't overlapped; bottom mode is unaffected.
         rootView.addView(widgetView, layoutCoordinator.buildWidgetLayoutParams(isBottom, topInsetPx = navBarHeightPx))

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -235,12 +235,18 @@ class RealNativeInputManager @Inject constructor(
                 }
             }
             .launchIn(lifecycleOwner.lifecycleScope)
-        // Re-evaluate an already-attached nav bar when the mode/flag change: switching to Search-only
-        // (or turning the flag off) while the input is open must hide it, not leave it up until teardown.
         duckChatInputModeState.inputModeCapability
             .onEach {
                 inputModeCapability = it
-                refreshNavBarVisibility()
+                // A live switch to Search-only means the browser no longer uses native input. Tear down an
+                // open widget so the legacy omnibar returns instead of lingering as a toggle-less widget
+                // until the user closes and refocuses (hideNativeInput no-ops when nothing is shown).
+                // Otherwise re-evaluate the nav bar for the new mode.
+                if (!isNativeInputActive()) {
+                    hideNativeInput(animate = false)
+                } else {
+                    refreshNavBarVisibility()
+                }
             }
             .launchIn(lifecycleOwner.lifecycleScope)
         duckChat.observeNativeInputNavBarEnabled()

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -185,6 +185,7 @@ class RealNativeInputManager @Inject constructor(
     private lateinit var layoutCoordinator: NativeInputLayoutCoordinator
     private var isNativeInputFieldEnabled: Boolean = false
     private var isNativeChatInputEnabled: Boolean = false
+    private var isNavBarFeatureEnabled: Boolean = false
     private var inputModeCapability: NativeInputState.InputMode = NativeInputState.InputMode.SEARCH_ONLY
     private var isExiting: Boolean = false
     private var isPickingImage: Boolean = false
@@ -236,6 +237,9 @@ class RealNativeInputManager @Inject constructor(
             .launchIn(lifecycleOwner.lifecycleScope)
         duckChatInputModeState.inputModeCapability
             .onEach { inputModeCapability = it }
+            .launchIn(lifecycleOwner.lifecycleScope)
+        duckChat.observeNativeInputNavBarEnabled()
+            .onEach { isNavBarFeatureEnabled = it }
             .launchIn(lifecycleOwner.lifecycleScope)
     }
 
@@ -494,8 +498,13 @@ class RealNativeInputManager @Inject constructor(
         val isBottom = omnibarController.isDuckAiMode() || omnibarController.isOmnibarBottom()
         val widgetView = createWidgetView(layoutInflater, isBottom)
         // The nav bar belongs to browser input only. Duck.ai (and, via a separate manager, contextual)
-        // never show it.
-        val navBarView = if (!omnibarController.isDuckAiMode()) createNavBarView(layoutInflater) else null
+        // never show it. Gated behind the nativeInputNavBar flag and Search & Duck.ai mode — search-only
+        // users, or users without the flag, never get it.
+        val navBarView = if (shouldCreateNavBar(isNavBarFeatureEnabled, omnibarController.isDuckAiMode(), inputModeCapability)) {
+            createNavBarView(layoutInflater)
+        } else {
+            null
+        }
         val prefillText = query.ifEmpty { omnibarController.getText() }
         bindWidget(widgetView, lifecycleOwner, tabs, currentTabUrl, callbacks, isBottom)
         if (navBarView != null) bindNavBar(navBarView, widgetView, lifecycleOwner, tabs, callbacks)
@@ -1177,6 +1186,15 @@ internal fun computeVoiceButtonAvailability(
         voiceChatAvailable = isDuckAiTabSelected && isVoiceChatEntryEnabled,
     )
 }
+
+/**
+ * Whether to create the nav bar for this input session. It's a browser-input affordance gated behind the
+ * [nativeInputNavBar][com.duckduckgo.duckchat.impl.feature.DuckChatFeature.nativeInputNavBar] flag and the
+ * Search & Duck.ai input mode: search-only users, Duck.ai/contextual input, or a disabled flag never get it.
+ * Once created, per-state visibility is decided by [shouldShowNavBar].
+ */
+internal fun shouldCreateNavBar(featureEnabled: Boolean, isDuckAiMode: Boolean, inputMode: NativeInputState.InputMode): Boolean =
+    featureEnabled && !isDuckAiMode && inputMode == NativeInputState.InputMode.SEARCH_AND_DUCK_AI
 
 /**
  * The persistent input-mode nav bar is shown only for browser input and only while the input field

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -702,11 +702,10 @@ class RealNativeInputManager @Inject constructor(
     ) {
         bindInputModeNavBar(
             navBarView = navBarView,
-            // Matches the widget's Back handler: drop input focus so the IME hide sticks, then close.
-            onBack = {
-                widgetFrom(widgetView)?.clearInputFocus()
-                hideNativeInput()
-            },
+            // Route through the widget's Back handler so it drops focus (IME hide sticks), closes, and
+            // fires the same back-button pixel — telemetry stays consistent whether the user taps this
+            // nav bar back (empty field) or the toggle-row back (with text).
+            onBack = { widgetFrom(widgetView)?.onBackPressed() },
             onFire = callbacks.onFireButtonPressed,
             onTabs = callbacks.onTabSwitcherPressed,
             onBrowserMenu = callbacks.onBrowserMenuPressed,
@@ -724,7 +723,7 @@ class RealNativeInputManager @Inject constructor(
         lifecycleOwner: LifecycleOwner,
         tabs: LiveData<List<TabEntity>>,
     ) {
-        val tabsButton = navBarView.findViewById<TabSwitcherButton?>(R.id.inputFieldTabsMenu) ?: return
+        val tabsButton = navBarView.findViewById<TabSwitcherButton?>(R.id.inputModeWidgetNavTabs) ?: return
         navBarTabCountObserver?.let { existing -> navBarTabCountLiveData?.removeObserver(existing) }
         val tabCount = tabs.map { it.size }
         val observer = Observer<Int> { count -> tabsButton.count = count }
@@ -1133,9 +1132,9 @@ internal fun bindInputModeNavBar(
     onBrowserMenu: () -> Unit,
 ) {
     navBarView.findViewById<View?>(R.id.inputModeWidgetNavBack)?.setOnClickListener { onBack() }
-    navBarView.findViewById<View?>(R.id.inputFieldFireButton)?.setOnClickListener { onFire() }
-    navBarView.findViewById<View?>(R.id.inputFieldTabsMenu)?.setOnClickListener { onTabs() }
-    navBarView.findViewById<View?>(R.id.inputFieldBrowserMenu)?.setOnClickListener { onBrowserMenu() }
+    navBarView.findViewById<View?>(R.id.inputModeWidgetNavFire)?.setOnClickListener { onFire() }
+    navBarView.findViewById<View?>(R.id.inputModeWidgetNavTabs)?.setOnClickListener { onTabs() }
+    navBarView.findViewById<View?>(R.id.inputModeWidgetNavMenu)?.setOnClickListener { onBrowserMenu() }
 }
 
 internal data class VoiceButtonAvailability(

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -192,6 +192,9 @@ class RealNativeInputManager @Inject constructor(
     private var floatingSubmitContainer: View? = null
     private var widgetRoot: View? = null
     private var navBarRoot: View? = null
+    private var navBarShown: Boolean? = null
+    private var navBarHeightPx: Int = 0
+    private var navBarIsBottom: Boolean = false
     private var navBarTabCountLiveData: LiveData<Int>? = null
     private var navBarTabCountObserver: Observer<Int>? = null
     private var lastCallbacks: NativeInputCallbacks? = null
@@ -490,10 +493,12 @@ class RealNativeInputManager @Inject constructor(
         }
         val isBottom = omnibarController.isDuckAiMode() || omnibarController.isOmnibarBottom()
         val widgetView = createWidgetView(layoutInflater, isBottom)
-        val navBarView = createNavBarView(layoutInflater)
+        // The nav bar belongs to browser input only. Duck.ai (and, via a separate manager, contextual)
+        // never show it.
+        val navBarView = if (!omnibarController.isDuckAiMode()) createNavBarView(layoutInflater) else null
         val prefillText = query.ifEmpty { omnibarController.getText() }
         bindWidget(widgetView, lifecycleOwner, tabs, currentTabUrl, callbacks, isBottom)
-        bindNavBar(navBarView, widgetView, lifecycleOwner, tabs, callbacks)
+        if (navBarView != null) bindNavBar(navBarView, widgetView, lifecycleOwner, tabs, callbacks)
         if (!omnibarController.isDuckAiMode() && prefillText.isNotEmpty()) {
             // Restore the cache before setting text — triggerAutocomplete preserves the
             // current searchResults, so a stale cache (post-submit reset, or overwritten by
@@ -516,6 +521,10 @@ class RealNativeInputManager @Inject constructor(
             }
         }
         attachWidget(widgetView, navBarView, isBottom, tabId)
+        applyNavBarVisibility(
+            show = shouldShowNavBar(isBrowserContext = navBarView != null, isInputEmpty = prefillText.isEmpty()),
+            animate = false,
+        )
         lifecycleOwner.lifecycleScope.launch {
             if (isDuckAiSettingsUrl(currentTabUrl.firstOrNull())) widgetView.gone()
         }
@@ -598,6 +607,12 @@ class RealNativeInputManager @Inject constructor(
                     callbacks.onDuckAiQuerySubmitted(query)
                 }
             },
+            onInputTextEmptyChanged = { isEmpty ->
+                applyNavBarVisibility(
+                    show = shouldShowNavBar(isBrowserContext = navBarRoot != null, isInputEmpty = isEmpty),
+                    animate = true,
+                )
+            },
         )
         widget.onChangeModelSubmitted = { modelId -> callbacks.onChangeModelSubmitted(modelId) }
         widget.onBack = {
@@ -648,6 +663,7 @@ class RealNativeInputManager @Inject constructor(
             rootView.removeView(it)
             navBarRoot = null
         }
+        navBarShown = null
         navBarTabCountObserver?.let { existing -> navBarTabCountLiveData?.removeObserver(existing) }
         navBarTabCountObserver = null
         navBarTabCountLiveData = null
@@ -843,10 +859,35 @@ class RealNativeInputManager @Inject constructor(
         }
     }
 
-    private fun attachWidget(widgetView: View, navBarView: View, isBottom: Boolean, tabId: String) {
+    /**
+     * Shows/hides the persistent nav bar. No-op when there is no bar (non-browser context) or the bar
+     * is already in the target state. On change it slides the bar (and, in top mode, the widget) and
+     * reflows content to clear or reclaim the bar strip.
+     */
+    private fun applyNavBarVisibility(show: Boolean, animate: Boolean) {
+        val navBar = navBarRoot ?: return
+        val widget = widgetRoot ?: return
+        if (!shouldAnimateNavBar(navBarShown, show)) return
+        navBarShown = show
+        animator.animateNavBarVisibility(
+            navBarView = navBar,
+            widgetView = widget,
+            isBottom = navBarIsBottom,
+            heightPx = navBarHeightPx,
+            show = show,
+            animate = animate,
+        )
+        layoutCoordinator.configureContentOffset(widget, navBarIsBottom, navBarInsetPx = if (show) navBarHeightPx else 0)
+    }
+
+    private fun attachWidget(widgetView: View, navBarView: View?, isBottom: Boolean, tabId: String) {
         // Inflated from a ?attr/actionBarSize height, so layoutParams carries the resolved nav bar height.
-        val navBarHeightPx = navBarView.layoutParams?.height?.takeIf { it > 0 } ?: 0
-        rootView.addView(navBarView, layoutCoordinator.buildNavBarLayoutParams(navBarHeightPx))
+        val navBarHeightPx = navBarView?.layoutParams?.height?.takeIf { it > 0 } ?: 0
+        this.navBarHeightPx = navBarHeightPx
+        this.navBarIsBottom = isBottom
+        if (navBarView != null) {
+            rootView.addView(navBarView, layoutCoordinator.buildNavBarLayoutParams(navBarHeightPx))
+        }
         // Top mode offsets the widget below the nav bar so it isn't overlapped; bottom mode is unaffected.
         rootView.addView(widgetView, layoutCoordinator.buildWidgetLayoutParams(isBottom, topInsetPx = navBarHeightPx))
         widgetRoot = widgetView
@@ -857,7 +898,7 @@ class RealNativeInputManager @Inject constructor(
             configure(tabId = tabId, isDuckAiMode = omnibarController.isDuckAiMode(), isBottom = isBottom)
         }
 
-        applyWindowChrome(widgetView, isBottom, navBarHeightPx)
+        applyWindowChrome(widgetView, isBottom)
 
         if (!startEnterAnimation(widgetView, isBottom)) {
             animator.applyLayoutTransitions(widgetView, isBottom)
@@ -886,7 +927,7 @@ class RealNativeInputManager @Inject constructor(
         }
     }
 
-    private fun applyWindowChrome(widgetView: View, isBottom: Boolean, navBarHeightPx: Int) {
+    private fun applyWindowChrome(widgetView: View, isBottom: Boolean) {
         widgetView.translationZ = WIDGET_ELEVATION_DP.toPx()
         if (isBottom) {
             rootView.findViewById<View?>(R.id.navigationBar)?.gone()
@@ -908,7 +949,7 @@ class RealNativeInputManager @Inject constructor(
             }
         }
         layoutCoordinator.configureAutocompleteLayout(widgetView, isBottom)
-        layoutCoordinator.configureContentOffset(widgetView, isBottom, navBarHeightPx)
+        layoutCoordinator.configureContentOffset(widgetView, isBottom)
         widgetView.post { layoutCoordinator.applyForcedBottomTranslation(widgetView, isBottom) }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -637,6 +637,10 @@ class RealNativeInputManager @Inject constructor(
             rootView.removeView(it)
             removed = true
         }
+        rootView.findViewById<View?>(R.id.inputModeWidgetNavLayout)?.let {
+            rootView.removeView(it)
+            navBarRoot = null
+        }
         floatingSubmitContainer?.let {
             (it.parent as? ViewGroup)?.removeView(it)
             floatingSubmitContainer = null
@@ -789,8 +793,11 @@ class RealNativeInputManager @Inject constructor(
     }
 
     private fun attachWidget(widgetView: View, navBarView: View, isBottom: Boolean, tabId: String) {
-        rootView.addView(navBarView, layoutCoordinator.buildWidgetLayoutParams(false))
-        rootView.addView(widgetView, layoutCoordinator.buildWidgetLayoutParams(isBottom))
+        // Inflated from a ?attr/actionBarSize height, so layoutParams carries the resolved nav bar height.
+        val navBarHeightPx = navBarView.layoutParams?.height?.takeIf { it > 0 } ?: 0
+        rootView.addView(navBarView, layoutCoordinator.buildNavBarLayoutParams(navBarHeightPx))
+        // Top mode offsets the widget below the nav bar so it isn't overlapped; bottom mode is unaffected.
+        rootView.addView(widgetView, layoutCoordinator.buildWidgetLayoutParams(isBottom, topInsetPx = navBarHeightPx))
         widgetRoot = widgetView
         navBarRoot = navBarView
 

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -107,7 +107,6 @@ interface NativeInputManager {
     fun init(
         omnibar: Omnibar,
         rootView: ViewGroup,
-        topNavRootView: ViewGroup,
         lifecycleOwner: LifecycleOwner,
         onDisabled: () -> Unit = {},
     )
@@ -188,6 +187,7 @@ class RealNativeInputManager @Inject constructor(
     private var duckAiToolbarHidden: Boolean = false
     private var floatingSubmitContainer: View? = null
     private var widgetRoot: View? = null
+    private var navBarRoot: View? = null
     private var lastCallbacks: NativeInputCallbacks? = null
 
     private val interactionLockSource = MutableStateFlow(InteractionLock.Unlocked)
@@ -200,13 +200,12 @@ class RealNativeInputManager @Inject constructor(
     override fun init(
         omnibar: Omnibar,
         rootView: ViewGroup,
-        topNavRootView: ViewGroup,
         lifecycleOwner: LifecycleOwner,
         onDisabled: () -> Unit,
     ) {
         this.omnibarController = RealNativeInputOmnibarController(omnibar, rootView, nativeInputStateBugKillSwitch)
         this.rootView = rootView
-        this.layoutCoordinator = NativeInputLayoutCoordinator(rootView, topNavRootView, this.omnibarController)
+        this.layoutCoordinator = NativeInputLayoutCoordinator(rootView, this.omnibarController)
         duckChat.observeNativeInputFieldUserSettingEnabled()
             .onEach { isEnabled ->
                 if (isNativeInputFieldEnabled && !isEnabled) onDisabled()
@@ -485,6 +484,7 @@ class RealNativeInputManager @Inject constructor(
         }
         val isBottom = omnibarController.isDuckAiMode() || omnibarController.isOmnibarBottom()
         val widgetView = createWidgetView(layoutInflater, isBottom)
+        val navBarView = createNavBarView(layoutInflater)
         val prefillText = query.ifEmpty { omnibarController.getText() }
         bindWidget(widgetView, lifecycleOwner, tabs, currentTabUrl, callbacks, isBottom)
         if (!omnibarController.isDuckAiMode() && prefillText.isNotEmpty()) {
@@ -508,7 +508,7 @@ class RealNativeInputManager @Inject constructor(
                 }
             }
         }
-        attachWidget(widgetView, isBottom, tabId)
+        attachWidget(widgetView, navBarView, isBottom, tabId)
         lifecycleOwner.lifecycleScope.launch {
             if (isDuckAiSettingsUrl(currentTabUrl.firstOrNull())) widgetView.gone()
         }
@@ -658,6 +658,10 @@ class RealNativeInputManager @Inject constructor(
         return layoutInflater.inflate(layoutRes, rootView, false)
     }
 
+    private fun createNavBarView(layoutInflater: LayoutInflater): View {
+        return layoutInflater.inflate(R.layout.input_mode_widget_nav_bar, rootView, false)
+    }
+
     private fun bindWidget(
         widgetView: View,
         lifecycleOwner: LifecycleOwner,
@@ -784,9 +788,11 @@ class RealNativeInputManager @Inject constructor(
         }
     }
 
-    private fun attachWidget(widgetView: View, isBottom: Boolean, tabId: String) {
+    private fun attachWidget(widgetView: View, navBarView: View, isBottom: Boolean, tabId: String) {
+        rootView.addView(navBarView, layoutCoordinator.buildWidgetLayoutParams(false))
         rootView.addView(widgetView, layoutCoordinator.buildWidgetLayoutParams(isBottom))
         widgetRoot = widgetView
+        navBarRoot = navBarView
 
         widgetFrom(widgetView)?.apply {
             setWidgetRootView(widgetView)

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -1126,3 +1126,18 @@ internal fun computeVoiceButtonAvailability(
         voiceChatAvailable = isDuckAiTabSelected && isVoiceChatEntryEnabled,
     )
 }
+
+/**
+ * The persistent input-mode nav bar is shown only for browser input and only while the input field
+ * is empty (whitespace counts as text). Duck.ai and contextual input never show it.
+ */
+internal fun shouldShowNavBar(isBrowserContext: Boolean, isInputEmpty: Boolean): Boolean =
+    isBrowserContext && isInputEmpty
+
+/**
+ * Whether a visibility change is needed. [currentShown] is null before the first apply, which always
+ * applies (snaps to the resting state); otherwise apply only when the target differs — this makes
+ * repeated same-state callbacks (e.g. the prefill-driven emptiness callback) no-ops.
+ */
+internal fun shouldAnimateNavBar(currentShown: Boolean?, targetShown: Boolean): Boolean =
+    currentShown != targetShown

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -107,6 +107,7 @@ interface NativeInputManager {
     fun init(
         omnibar: Omnibar,
         rootView: ViewGroup,
+        topNavRootView: ViewGroup,
         lifecycleOwner: LifecycleOwner,
         onDisabled: () -> Unit = {},
     )
@@ -199,12 +200,13 @@ class RealNativeInputManager @Inject constructor(
     override fun init(
         omnibar: Omnibar,
         rootView: ViewGroup,
+        topNavRootView: ViewGroup,
         lifecycleOwner: LifecycleOwner,
         onDisabled: () -> Unit,
     ) {
         this.omnibarController = RealNativeInputOmnibarController(omnibar, rootView, nativeInputStateBugKillSwitch)
         this.rootView = rootView
-        this.layoutCoordinator = NativeInputLayoutCoordinator(rootView, this.omnibarController)
+        this.layoutCoordinator = NativeInputLayoutCoordinator(rootView, topNavRootView, this.omnibarController)
         duckChat.observeNativeInputFieldUserSettingEnabled()
             .onEach { isEnabled ->
                 if (isNativeInputFieldEnabled && !isEnabled) onDisabled()

--- a/app/src/main/res/layout/fragment_browser_tab.xml
+++ b/app/src/main/res/layout/fragment_browser_tab.xml
@@ -20,6 +20,19 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <LinearLayout
+        android:id="@+id/includeInputFieldNavBarRoot"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <include
+            android:id="@+id/includeInputFieldNavBar"
+            layout="@layout/input_mode_widget_nav_bar" />
+
+    </LinearLayout>
+
+
     <FrameLayout
         android:id="@+id/webViewFullScreenContainer"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_browser_tab.xml
+++ b/app/src/main/res/layout/fragment_browser_tab.xml
@@ -20,19 +20,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <LinearLayout
-        android:id="@+id/includeInputFieldNavBarRoot"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
-
-        <include
-            android:id="@+id/includeInputFieldNavBar"
-            layout="@layout/input_mode_widget_nav_bar" />
-
-    </LinearLayout>
-
-
     <FrameLayout
         android:id="@+id/webViewFullScreenContainer"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/input_mode_widget_nav_bar.xml
+++ b/app/src/main/res/layout/input_mode_widget_nav_bar.xml
@@ -42,17 +42,17 @@
         app:tint="?attr/daxColorPrimaryIcon" />
 
     <FrameLayout
-        android:id="@+id/inputFieldFireButton"
+        android:id="@+id/inputModeWidgetNavFire"
         android:layout_width="@dimen/toolbarIcon"
         android:layout_height="@dimen/toolbarIcon"
         android:background="@drawable/selectable_item_rounded_corner_background"
         android:contentDescription="@string/duckChatFireButtonContentDescription"
-        app:layout_constraintEnd_toStartOf="@id/inputFieldTabsMenu"
+        app:layout_constraintEnd_toStartOf="@id/inputModeWidgetNavTabs"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
         <ImageView
-            android:id="@+id/fireIconImageView"
+            android:id="@+id/inputModeWidgetNavFireIcon"
             android:layout_width="@dimen/bottomNavIcon"
             android:layout_height="@dimen/bottomNavIcon"
             android:layout_gravity="center"
@@ -62,15 +62,15 @@
     </FrameLayout>
 
     <com.duckduckgo.browser.ui.tabs.NewTabSwitcherButton
-        android:id="@+id/inputFieldTabsMenu"
+        android:id="@+id/inputModeWidgetNavTabs"
         android:layout_width="@dimen/toolbarIcon"
         android:layout_height="@dimen/toolbarIcon"
-        app:layout_constraintEnd_toStartOf="@id/inputFieldBrowserMenu"
+        app:layout_constraintEnd_toStartOf="@id/inputModeWidgetNavMenu"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
     <FrameLayout
-        android:id="@+id/inputFieldBrowserMenu"
+        android:id="@+id/inputModeWidgetNavMenu"
         android:layout_width="@dimen/toolbarIcon"
         android:layout_height="@dimen/toolbarIcon"
         android:background="@drawable/selectable_item_rounded_corner_background"
@@ -80,7 +80,7 @@
         app:layout_constraintTop_toTopOf="parent">
 
         <ImageView
-            android:id="@+id/browserMenuImageView"
+            android:id="@+id/inputModeWidgetNavMenuIcon"
             android:layout_width="@dimen/bottomNavIcon"
             android:layout_height="@dimen/bottomNavIcon"
             android:layout_gravity="center"
@@ -89,7 +89,7 @@
             android:src="@drawable/ic_menu_hamburger_24" />
 
         <View
-            android:id="@+id/browserMenuHighlight"
+            android:id="@+id/inputModeWidgetNavMenuHighlight"
             android:layout_width="7dp"
             android:layout_height="7dp"
             android:layout_gravity="end"

--- a/app/src/main/res/layout/input_mode_widget_nav_bar.xml
+++ b/app/src/main/res/layout/input_mode_widget_nav_bar.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/inputModeWidgetNavLayout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:theme="@style/Widget.DuckDuckGo.ToolbarTheme"
+    android:paddingStart="@dimen/keyline_2"
+    android:paddingEnd="@dimen/keyline_2">
+
+    <ImageView
+        android:id="@+id/inputModeWidgetNavBack"
+        android:layout_width="@dimen/toolbarIcon"
+        android:layout_height="@dimen/toolbarIcon"
+        android:layout_gravity="center"
+        android:background="@drawable/selectable_item_rounded_corner_background"
+        android:contentDescription="@string/back"
+        android:gravity="center"
+        android:padding="@dimen/keyline_2"
+        android:scaleType="center"
+        android:src="@drawable/ic_arrow_left_small_24"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:tint="?attr/daxColorPrimaryIcon" />
+
+    <FrameLayout
+        android:id="@+id/inputFieldFireButton"
+        android:layout_width="@dimen/toolbarIcon"
+        android:layout_height="@dimen/toolbarIcon"
+        android:background="@drawable/selectable_item_rounded_corner_background"
+        android:contentDescription="@string/duckChatFireButtonContentDescription"
+        app:layout_constraintEnd_toStartOf="@id/inputFieldTabsMenu"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:id="@+id/fireIconImageView"
+            android:layout_width="@dimen/bottomNavIcon"
+            android:layout_height="@dimen/bottomNavIcon"
+            android:layout_gravity="center"
+            android:importantForAccessibility="no"
+            android:scaleType="center"
+            android:src="@drawable/ic_fire_24" />
+    </FrameLayout>
+
+    <com.duckduckgo.browser.ui.tabs.NewTabSwitcherButton
+        android:id="@+id/inputFieldTabsMenu"
+        android:layout_width="@dimen/toolbarIcon"
+        android:layout_height="@dimen/toolbarIcon"
+        app:layout_constraintEnd_toStartOf="@id/inputFieldBrowserMenu"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <FrameLayout
+        android:id="@+id/inputFieldBrowserMenu"
+        android:layout_width="@dimen/toolbarIcon"
+        android:layout_height="@dimen/toolbarIcon"
+        android:background="@drawable/selectable_item_rounded_corner_background"
+        android:contentDescription="@string/duckChatBrowserMenuContentDescription"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageView
+            android:id="@+id/browserMenuImageView"
+            android:layout_width="@dimen/bottomNavIcon"
+            android:layout_height="@dimen/bottomNavIcon"
+            android:layout_gravity="center"
+            android:importantForAccessibility="no"
+            android:scaleType="center"
+            android:src="@drawable/ic_menu_vertical_24" />
+
+        <View
+            android:id="@+id/browserMenuHighlight"
+            android:layout_width="7dp"
+            android:layout_height="7dp"
+            android:layout_gravity="end"
+            android:layout_margin="@dimen/keyline_2"
+            android:background="@drawable/ic_dot_indicator_7"
+            android:visibility="gone" />
+
+    </FrameLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/input_mode_widget_nav_bar.xml
+++ b/app/src/main/res/layout/input_mode_widget_nav_bar.xml
@@ -86,7 +86,7 @@
             android:layout_gravity="center"
             android:importantForAccessibility="no"
             android:scaleType="center"
-            android:src="@drawable/ic_menu_vertical_24" />
+            android:src="@drawable/ic_menu_hamburger_24" />
 
         <View
             android:id="@+id/browserMenuHighlight"

--- a/app/src/main/res/layout/input_mode_widget_nav_bar.xml
+++ b/app/src/main/res/layout/input_mode_widget_nav_bar.xml
@@ -22,8 +22,8 @@
     android:layout_height="?attr/actionBarSize"
     android:background="?attr/daxColorToolbar"
     android:paddingStart="@dimen/keyline_2"
-    android:paddingTop="@dimen/keyline_1"
-    android:paddingEnd="@dimen/keyline_2">
+    android:paddingBottom="@dimen/keyline_1"
+    android:paddingEnd="@dimen/keyline_1">
 
     <ImageView
         android:id="@+id/inputModeWidgetNavBack"

--- a/app/src/main/res/layout/input_mode_widget_nav_bar.xml
+++ b/app/src/main/res/layout/input_mode_widget_nav_bar.xml
@@ -19,9 +19,10 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/inputModeWidgetNavLayout"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:theme="@style/Widget.DuckDuckGo.ToolbarTheme"
+    android:layout_height="?attr/actionBarSize"
+    android:background="?attr/daxColorToolbar"
     android:paddingStart="@dimen/keyline_2"
+    android:paddingTop="@dimen/keyline_1"
     android:paddingEnd="@dimen/keyline_2">
 
     <ImageView
@@ -37,6 +38,7 @@
         android:src="@drawable/ic_arrow_left_small_24"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:tint="?attr/daxColorPrimaryIcon" />
 
     <FrameLayout
@@ -46,6 +48,7 @@
         android:background="@drawable/selectable_item_rounded_corner_background"
         android:contentDescription="@string/duckChatFireButtonContentDescription"
         app:layout_constraintEnd_toStartOf="@id/inputFieldTabsMenu"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
         <ImageView
@@ -63,6 +66,7 @@
         android:layout_width="@dimen/toolbarIcon"
         android:layout_height="@dimen/toolbarIcon"
         app:layout_constraintEnd_toStartOf="@id/inputFieldBrowserMenu"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
     <FrameLayout
@@ -71,6 +75,7 @@
         android:layout_height="@dimen/toolbarIcon"
         android:background="@drawable/selectable_item_rounded_corner_background"
         android:contentDescription="@string/duckChatBrowserMenuContentDescription"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/AutocompleteOffsetTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/AutocompleteOffsetTest.kt
@@ -22,25 +22,30 @@ import org.junit.Test
 class AutocompleteOffsetTest {
 
     @Test
-    fun `bottom mode does not offset the list from the top`() {
-        assertEquals(0, autocompleteTopOffset(isBottom = true, widgetVisualBottomPx = 640, autoCompleteListTopPx = 304))
+    fun `bottom mode offsets the list below the nav bar when the bar is shown`() {
+        assertEquals(168, autocompleteTopOffset(isBottom = true, widgetVisualBottomPx = 640, autoCompleteListTopPx = 304, navBarInsetPx = 168))
     }
 
     @Test
-    fun `top mode offsets the list below the widget's visual bottom`() {
-        assertEquals(336, autocompleteTopOffset(isBottom = false, widgetVisualBottomPx = 640, autoCompleteListTopPx = 304))
+    fun `bottom mode does not offset the list when the nav bar is hidden`() {
+        assertEquals(0, autocompleteTopOffset(isBottom = true, widgetVisualBottomPx = 640, autoCompleteListTopPx = 304, navBarInsetPx = 0))
+    }
+
+    @Test
+    fun `top mode ignores the nav bar inset and offsets below the widget's visual bottom`() {
+        assertEquals(336, autocompleteTopOffset(isBottom = false, widgetVisualBottomPx = 640, autoCompleteListTopPx = 304, navBarInsetPx = 168))
     }
 
     @Test
     fun `top mode uses the visual bottom so a widget ridden up by the nav bar hide shrinks the offset`() {
         // Nav bar (168px) hidden: widget layout bottom 640 rides up via translationY -168 → visual bottom 472.
         // Using the layout bottom (640) would leave a 168px gap; the visual bottom removes it.
-        assertEquals(168, autocompleteTopOffset(isBottom = false, widgetVisualBottomPx = 472, autoCompleteListTopPx = 304))
+        assertEquals(168, autocompleteTopOffset(isBottom = false, widgetVisualBottomPx = 472, autoCompleteListTopPx = 304, navBarInsetPx = 0))
     }
 
     @Test
     fun `top mode clamps a negative offset to zero when the widget sits above the list`() {
-        assertEquals(0, autocompleteTopOffset(isBottom = false, widgetVisualBottomPx = 100, autoCompleteListTopPx = 304))
+        assertEquals(0, autocompleteTopOffset(isBottom = false, widgetVisualBottomPx = 100, autoCompleteListTopPx = 304, navBarInsetPx = 0))
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/AutocompleteOffsetTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/AutocompleteOffsetTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.nativeinput
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AutocompleteOffsetTest {
+
+    @Test
+    fun `bottom mode does not offset the list from the top`() {
+        assertEquals(0, autocompleteTopOffset(isBottom = true, widgetVisualBottomPx = 640, autoCompleteListTopPx = 304))
+    }
+
+    @Test
+    fun `top mode offsets the list below the widget's visual bottom`() {
+        assertEquals(336, autocompleteTopOffset(isBottom = false, widgetVisualBottomPx = 640, autoCompleteListTopPx = 304))
+    }
+
+    @Test
+    fun `top mode uses the visual bottom so a widget ridden up by the nav bar hide shrinks the offset`() {
+        // Nav bar (168px) hidden: widget layout bottom 640 rides up via translationY -168 → visual bottom 472.
+        // Using the layout bottom (640) would leave a 168px gap; the visual bottom removes it.
+        assertEquals(168, autocompleteTopOffset(isBottom = false, widgetVisualBottomPx = 472, autoCompleteListTopPx = 304))
+    }
+
+    @Test
+    fun `top mode clamps a negative offset to zero when the widget sits above the list`() {
+        assertEquals(0, autocompleteTopOffset(isBottom = false, widgetVisualBottomPx = 100, autoCompleteListTopPx = 304))
+    }
+
+    @Test
+    fun `top mode does not offset the list from the bottom`() {
+        assertEquals(0, autocompleteBottomOffset(isBottom = false, autoCompleteListBottomPx = 1447, widgetTopPx = 640))
+    }
+
+    @Test
+    fun `bottom mode offsets the list above the widget's top`() {
+        assertEquals(307, autocompleteBottomOffset(isBottom = true, autoCompleteListBottomPx = 1447, widgetTopPx = 1140))
+    }
+
+    @Test
+    fun `bottom mode clamps a negative bottom offset to zero`() {
+        assertEquals(0, autocompleteBottomOffset(isBottom = true, autoCompleteListBottomPx = 1000, widgetTopPx = 1140))
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/ContentTopInsetTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/ContentTopInsetTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.nativeinput
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ContentTopInsetTest {
+
+    @Test
+    fun `bottom mode insets content by the nav bar height so it clears the top nav bar`() {
+        assertEquals(NAV_BAR, contentTopInset(isBottom = true, isLogoOnly = false, navBarInsetPx = NAV_BAR, widgetTopOffsetPx = 0))
+    }
+
+    @Test
+    fun `bottom mode logo-only content is not inset`() {
+        assertEquals(0, contentTopInset(isBottom = true, isLogoOnly = true, navBarInsetPx = NAV_BAR, widgetTopOffsetPx = 0))
+    }
+
+    @Test
+    fun `top mode insets content below the widget which already clears the nav bar`() {
+        assertEquals(WIDGET_OFFSET, contentTopInset(isBottom = false, isLogoOnly = false, navBarInsetPx = NAV_BAR, widgetTopOffsetPx = WIDGET_OFFSET))
+    }
+
+    @Test
+    fun `top mode logo-only content is not inset`() {
+        assertEquals(0, contentTopInset(isBottom = false, isLogoOnly = true, navBarInsetPx = NAV_BAR, widgetTopOffsetPx = WIDGET_OFFSET))
+    }
+
+    @Test
+    fun `top mode clamps a negative widget offset to zero`() {
+        assertEquals(0, contentTopInset(isBottom = false, isLogoOnly = false, navBarInsetPx = NAV_BAR, widgetTopOffsetPx = -20))
+    }
+
+    private companion object {
+        private const val NAV_BAR = 56
+        private const val WIDGET_OFFSET = 120
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/InputModeNavBarBinderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/InputModeNavBarBinderTest.kt
@@ -46,9 +46,9 @@ class InputModeNavBarBinderTest {
 
     private fun navBarWithAllButtons(): View = FrameLayout(context).apply {
         addView(View(context).apply { id = R.id.inputModeWidgetNavBack })
-        addView(View(context).apply { id = R.id.inputFieldFireButton })
-        addView(View(context).apply { id = R.id.inputFieldTabsMenu })
-        addView(View(context).apply { id = R.id.inputFieldBrowserMenu })
+        addView(View(context).apply { id = R.id.inputModeWidgetNavFire })
+        addView(View(context).apply { id = R.id.inputModeWidgetNavTabs })
+        addView(View(context).apply { id = R.id.inputModeWidgetNavMenu })
     }
 
     @Test
@@ -69,7 +69,7 @@ class InputModeNavBarBinderTest {
         val navBar = navBarWithAllButtons()
         bind(navBar)
 
-        navBar.findViewById<View>(R.id.inputFieldFireButton).performClick()
+        navBar.findViewById<View>(R.id.inputModeWidgetNavFire).performClick()
 
         assertEquals(0, back)
         assertEquals(1, fire)
@@ -82,7 +82,7 @@ class InputModeNavBarBinderTest {
         val navBar = navBarWithAllButtons()
         bind(navBar)
 
-        navBar.findViewById<View>(R.id.inputFieldTabsMenu).performClick()
+        navBar.findViewById<View>(R.id.inputModeWidgetNavTabs).performClick()
 
         assertEquals(0, back)
         assertEquals(0, fire)
@@ -95,7 +95,7 @@ class InputModeNavBarBinderTest {
         val navBar = navBarWithAllButtons()
         bind(navBar)
 
-        navBar.findViewById<View>(R.id.inputFieldBrowserMenu).performClick()
+        navBar.findViewById<View>(R.id.inputModeWidgetNavMenu).performClick()
 
         assertEquals(0, back)
         assertEquals(0, fire)

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/InputModeNavBarBinderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/InputModeNavBarBinderTest.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.nativeinput
+
+import android.content.Context
+import android.view.View
+import android.widget.FrameLayout
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.app.browser.R
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class InputModeNavBarBinderTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private var back = 0
+    private var fire = 0
+    private var tabs = 0
+    private var menu = 0
+
+    private fun bind(navBar: View) = bindInputModeNavBar(
+        navBarView = navBar,
+        onBack = { back++ },
+        onFire = { fire++ },
+        onTabs = { tabs++ },
+        onBrowserMenu = { menu++ },
+    )
+
+    private fun navBarWithAllButtons(): View = FrameLayout(context).apply {
+        addView(View(context).apply { id = R.id.inputModeWidgetNavBack })
+        addView(View(context).apply { id = R.id.inputFieldFireButton })
+        addView(View(context).apply { id = R.id.inputFieldTabsMenu })
+        addView(View(context).apply { id = R.id.inputFieldBrowserMenu })
+    }
+
+    @Test
+    fun whenBackClickedThenOnlyOnBackInvoked() {
+        val navBar = navBarWithAllButtons()
+        bind(navBar)
+
+        navBar.findViewById<View>(R.id.inputModeWidgetNavBack).performClick()
+
+        assertEquals(1, back)
+        assertEquals(0, fire)
+        assertEquals(0, tabs)
+        assertEquals(0, menu)
+    }
+
+    @Test
+    fun whenFireClickedThenOnlyOnFireInvoked() {
+        val navBar = navBarWithAllButtons()
+        bind(navBar)
+
+        navBar.findViewById<View>(R.id.inputFieldFireButton).performClick()
+
+        assertEquals(0, back)
+        assertEquals(1, fire)
+        assertEquals(0, tabs)
+        assertEquals(0, menu)
+    }
+
+    @Test
+    fun whenTabsClickedThenOnlyOnTabsInvoked() {
+        val navBar = navBarWithAllButtons()
+        bind(navBar)
+
+        navBar.findViewById<View>(R.id.inputFieldTabsMenu).performClick()
+
+        assertEquals(0, back)
+        assertEquals(0, fire)
+        assertEquals(1, tabs)
+        assertEquals(0, menu)
+    }
+
+    @Test
+    fun whenBrowserMenuClickedThenOnlyOnBrowserMenuInvoked() {
+        val navBar = navBarWithAllButtons()
+        bind(navBar)
+
+        navBar.findViewById<View>(R.id.inputFieldBrowserMenu).performClick()
+
+        assertEquals(0, back)
+        assertEquals(0, fire)
+        assertEquals(0, tabs)
+        assertEquals(1, menu)
+    }
+
+    @Test
+    fun whenButtonsMissingThenBindingIsNullSafe() {
+        // Only the back button present; the binder must skip the absent views without crashing.
+        val navBar = FrameLayout(context).apply {
+            addView(View(context).apply { id = R.id.inputModeWidgetNavBack })
+        }
+
+        bind(navBar)
+        navBar.findViewById<View>(R.id.inputModeWidgetNavBack).performClick()
+
+        assertEquals(1, back)
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinatorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinatorTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.nativeinput
+
+import android.view.Gravity
+import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+
+@RunWith(AndroidJUnit4::class)
+class NativeInputLayoutCoordinatorTest {
+
+    private val coordinator = NativeInputLayoutCoordinator(
+        rootView = mock(),
+        omnibarState = mock(),
+    )
+
+    @Test
+    fun whenTopModeThenWidgetIsTopGravityAndOffsetBelowNavBar() {
+        val params = coordinator.buildWidgetLayoutParams(isBottom = false, topInsetPx = NAV_BAR_HEIGHT_PX) as CoordinatorLayout.LayoutParams
+
+        assertEquals(Gravity.TOP, params.gravity)
+        assertEquals(NAV_BAR_HEIGHT_PX, params.topMargin)
+    }
+
+    @Test
+    fun whenBottomModeThenWidgetIsBottomGravityAndNotOffset() {
+        val params = coordinator.buildWidgetLayoutParams(isBottom = true, topInsetPx = NAV_BAR_HEIGHT_PX) as CoordinatorLayout.LayoutParams
+
+        assertEquals(Gravity.BOTTOM, params.gravity)
+        assertEquals(0, params.topMargin)
+    }
+
+    @Test
+    fun whenTopModeWithoutInsetThenWidgetNotOffset() {
+        val params = coordinator.buildWidgetLayoutParams(isBottom = false) as CoordinatorLayout.LayoutParams
+
+        assertEquals(Gravity.TOP, params.gravity)
+        assertEquals(0, params.topMargin)
+    }
+
+    @Test
+    fun whenNavBarParamsThenTopGravityWithGivenHeightAndNoTopMargin() {
+        val params = coordinator.buildNavBarLayoutParams(heightPx = NAV_BAR_HEIGHT_PX) as CoordinatorLayout.LayoutParams
+
+        assertEquals(Gravity.TOP, params.gravity)
+        assertEquals(NAV_BAR_HEIGHT_PX, params.height)
+        assertEquals(0, params.topMargin)
+    }
+
+    private companion object {
+        private const val NAV_BAR_HEIGHT_PX = 56
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/NavBarVisibilityDecisionTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/NavBarVisibilityDecisionTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.nativeinput
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NavBarVisibilityDecisionTest {
+
+    @Test
+    fun `nav bar shows only in browser context with an empty field`() {
+        assertTrue(shouldShowNavBar(isBrowserContext = true, isInputEmpty = true))
+        assertFalse(shouldShowNavBar(isBrowserContext = true, isInputEmpty = false))
+        assertFalse(shouldShowNavBar(isBrowserContext = false, isInputEmpty = true))
+        assertFalse(shouldShowNavBar(isBrowserContext = false, isInputEmpty = false))
+    }
+
+    @Test
+    fun `animate whenever the target differs from the current shown state`() {
+        // Unknown current state (first apply) always animates/applies.
+        assertTrue(shouldAnimateNavBar(currentShown = null, targetShown = true))
+        assertTrue(shouldAnimateNavBar(currentShown = null, targetShown = false))
+        // Transitions apply.
+        assertTrue(shouldAnimateNavBar(currentShown = false, targetShown = true))
+        assertTrue(shouldAnimateNavBar(currentShown = true, targetShown = false))
+        // No-ops when already in the target state.
+        assertFalse(shouldAnimateNavBar(currentShown = true, targetShown = true))
+        assertFalse(shouldAnimateNavBar(currentShown = false, targetShown = false))
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/NavBarVisibilityDecisionTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/NavBarVisibilityDecisionTest.kt
@@ -16,11 +16,32 @@
 
 package com.duckduckgo.app.browser.nativeinput
 
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputMode
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class NavBarVisibilityDecisionTest {
+
+    @Test
+    fun `nav bar is created only with the flag on, in browser, and Search and Duck ai mode`() {
+        assertTrue(shouldCreateNavBar(featureEnabled = true, isDuckAiMode = false, inputMode = InputMode.SEARCH_AND_DUCK_AI))
+    }
+
+    @Test
+    fun `nav bar is not created when the flag is off`() {
+        assertFalse(shouldCreateNavBar(featureEnabled = false, isDuckAiMode = false, inputMode = InputMode.SEARCH_AND_DUCK_AI))
+    }
+
+    @Test
+    fun `nav bar is not created in search-only mode`() {
+        assertFalse(shouldCreateNavBar(featureEnabled = true, isDuckAiMode = false, inputMode = InputMode.SEARCH_ONLY))
+    }
+
+    @Test
+    fun `nav bar is not created in Duck ai conversation mode`() {
+        assertFalse(shouldCreateNavBar(featureEnabled = true, isDuckAiMode = true, inputMode = InputMode.SEARCH_AND_DUCK_AI))
+    }
 
     @Test
     fun `nav bar shows only in browser context with an empty field`() {

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputAnimatorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputAnimatorTest.kt
@@ -102,4 +102,52 @@ class RealNativeInputAnimatorTest {
 
         assertNotNull(margins)
     }
+
+    @Test
+    fun whenSnapShowInTopModeThenBarVisibleAndWidgetAtRest() {
+        val navBar = FrameLayout(context)
+        val widget = FrameLayout(context)
+
+        testee.animateNavBarVisibility(navBar, widget, isBottom = false, heightPx = 56, show = true, animate = false)
+
+        assertEquals(View.VISIBLE, navBar.visibility)
+        assertEquals(0f, navBar.translationY, 0f)
+        assertEquals(0f, widget.translationY, 0f)
+    }
+
+    @Test
+    fun whenSnapHideInTopModeThenBarGoneAndWidgetRidesUp() {
+        val navBar = FrameLayout(context)
+        val widget = FrameLayout(context)
+
+        testee.animateNavBarVisibility(navBar, widget, isBottom = false, heightPx = 56, show = false, animate = false)
+
+        assertEquals(View.GONE, navBar.visibility)
+        assertEquals(-56f, navBar.translationY, 0f)
+        assertEquals(-56f, widget.translationY, 0f)
+    }
+
+    @Test
+    fun whenSnapHideInBottomModeThenBarGoneAndWidgetUntouched() {
+        val navBar = FrameLayout(context)
+        val widget = FrameLayout(context).apply { translationY = 99f }
+
+        testee.animateNavBarVisibility(navBar, widget, isBottom = true, heightPx = 56, show = false, animate = false)
+
+        assertEquals(View.GONE, navBar.visibility)
+        assertEquals(-56f, navBar.translationY, 0f)
+        assertEquals(99f, widget.translationY, 0f)
+    }
+
+    @Test
+    fun whenSnapShowInBottomModeThenBarVisibleAndWidgetUntouched() {
+        val navBar = FrameLayout(context)
+        val widget = FrameLayout(context).apply { translationY = 99f }
+
+        testee.animateNavBarVisibility(navBar, widget, isBottom = true, heightPx = 56, show = true, animate = false)
+
+        assertEquals(View.VISIBLE, navBar.visibility)
+        assertEquals(0f, navBar.translationY, 0f)
+        assertEquals(99f, widget.translationY, 0f)
+    }
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
@@ -85,10 +85,11 @@ class RealNativeInputManagerTest {
 
     private lateinit var testee: RealNativeInputManager
 
+    private val inputModeCapabilityFlow = MutableStateFlow(NativeInputState.InputMode.SEARCH_AND_DUCK_AI)
+
     @Before
     fun setUp() {
-        whenever(duckChatInputModeState.inputModeCapability)
-            .thenReturn(MutableStateFlow(NativeInputState.InputMode.SEARCH_AND_DUCK_AI))
+        whenever(duckChatInputModeState.inputModeCapability).thenReturn(inputModeCapabilityFlow)
         whenever(duckChat.observeNativeInputNavBarEnabled()).thenReturn(MutableStateFlow(false))
         testee = RealNativeInputManager(
             duckChat,
@@ -127,6 +128,18 @@ class RealNativeInputManagerTest {
         showNativeInput()
 
         assertNotNull(rootView.findViewById<View?>(R.id.inputModeTopRoot))
+    }
+
+    @Test
+    fun whenInputModeBecomesSearchOnlyWhileWidgetShownThenWidgetRemoved() {
+        whenever(duckChat.observeNativeInputFieldUserSettingEnabled()).thenReturn(MutableStateFlow(true))
+        whenever(duckChat.observeNativeChatInputEnabled()).thenReturn(MutableStateFlow(false))
+        testee.init(omnibar, rootView, lifecycleOwner)
+        rootView.addView(View(context).apply { id = R.id.inputModeTopRoot })
+
+        inputModeCapabilityFlow.value = NativeInputState.InputMode.SEARCH_ONLY
+
+        assertNull(rootView.findViewById<View?>(R.id.inputModeTopRoot))
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
@@ -89,6 +89,7 @@ class RealNativeInputManagerTest {
     fun setUp() {
         whenever(duckChatInputModeState.inputModeCapability)
             .thenReturn(MutableStateFlow(NativeInputState.InputMode.SEARCH_AND_DUCK_AI))
+        whenever(duckChat.observeNativeInputNavBarEnabled()).thenReturn(MutableStateFlow(false))
         testee = RealNativeInputManager(
             duckChat,
             animator,

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
@@ -142,6 +142,20 @@ class RealNativeInputManagerTest {
         assertNull(rootView.findViewById<View?>(R.id.inputModeTopRoot))
     }
 
+    @Test
+    fun whenWidgetRemovedThenNavBarAlsoRemoved() {
+        whenever(duckChat.observeNativeInputFieldUserSettingEnabled()).thenReturn(MutableStateFlow(true))
+        whenever(duckChat.observeNativeChatInputEnabled()).thenReturn(MutableStateFlow(false))
+        whenever(omnibar.viewMode).thenReturn(Omnibar.ViewMode.DuckAI)
+        testee.init(omnibar, rootView, lifecycleOwner)
+        rootView.addView(View(context).apply { id = R.id.inputModeTopRoot })
+        rootView.addView(View(context).apply { id = R.id.inputModeWidgetNavLayout })
+
+        showNativeInput()
+
+        assertNull(rootView.findViewById<View?>(R.id.inputModeWidgetNavLayout))
+    }
+
     private fun showNativeInput() {
         testee.showNativeInput(
             tabId = "tab",

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModel.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModel.kt
@@ -121,11 +121,14 @@ class NewTabReturnHatchViewModel @Inject constructor(
     // while the activity-mode repo supplies the tabs count shown in the tab button.
     // The tabs button shows only when native input is enabled AND the address bar isn't search-only.
     // In search-only the hatch mirrors the legacy chrome, which has no tabs entry here.
+    // It is also hidden when the nav bar flag is on: those users get a tabs button in the input-mode
+    // nav bar instead, so the hatch shouldn't duplicate it.
     private val shouldShowTabsButton: Flow<Boolean> = combine(
         duckChat.observeNativeInputFieldUserSettingEnabled(),
         duckChatInputModeState.inputModeCapability,
-    ) { nativeInputEnabled, capability ->
-        nativeInputEnabled && capability != NativeInputState.InputMode.SEARCH_ONLY
+        duckChat.observeNativeInputNavBarEnabled(),
+    ) { nativeInputEnabled, capability, navBarEnabled ->
+        nativeInputEnabled && capability != NativeInputState.InputMode.SEARCH_ONLY && !navBarEnabled
     }
 
     val viewState = snapshotTarget.flatMapLatest { target ->

--- a/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModelTest.kt
+++ b/browser/browser-ui/src/test/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchViewModelTest.kt
@@ -76,6 +76,7 @@ class NewTabReturnHatchViewModelTest {
     // Starts false so each test controls the idle-return rising edge that captures the snapshot.
     private val afterIdleReturnFlow = MutableStateFlow(false)
     private val nativeInputEnabledFlow = MutableStateFlow(true)
+    private val navBarEnabledFlow = MutableStateFlow(false)
     private val returnToLastTabEnabledFlow = MutableStateFlow(true)
 
     private lateinit var testee: NewTabReturnHatchViewModel
@@ -87,6 +88,7 @@ class NewTabReturnHatchViewModelTest {
         whenever(mockNtpAfterIdleManager.isAfterIdleReturn).thenReturn(afterIdleReturnFlow)
         whenever(mockNtpAfterIdleManager.returnToLastTabEnabled).thenReturn(returnToLastTabEnabledFlow)
         whenever(mockDuckChat.observeNativeInputFieldUserSettingEnabled()).thenReturn(nativeInputEnabledFlow)
+        whenever(mockDuckChat.observeNativeInputNavBarEnabled()).thenReturn(navBarEnabledFlow)
         whenever(mockDuckChatInputModeState.inputModeCapability).thenReturn(inputModeCapabilityFlow)
 
         testee = NewTabReturnHatchViewModel(
@@ -311,6 +313,19 @@ class NewTabReturnHatchViewModelTest {
     @Test
     fun whenNativeInputDisabledThenShowTabsButtonIsFalse() = runTest {
         nativeInputEnabledFlow.value = false
+        val tab = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
+
+        testee.viewState.test {
+            returnFromIdleWith(tab)
+            assertFalse(expectMostRecentItem().showTabsButton)
+        }
+    }
+
+    @Test
+    fun whenNavBarFeatureEnabledInSearchAndDuckAiThenShowTabsButtonIsFalse() = runTest {
+        nativeInputEnabledFlow.value = true
+        inputModeCapabilityFlow.value = NativeInputState.InputMode.SEARCH_AND_DUCK_AI
+        navBarEnabledFlow.value = true
         val tab = TabEntity(tabId = "tab1", url = "https://example.com", title = "Example")
 
         testee.viewState.test {

--- a/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
+++ b/duckchat/duckchat-api/src/main/java/com/duckduckgo/duckchat/api/DuckChat.kt
@@ -117,6 +117,12 @@ interface DuckChat {
      */
     fun observeNativeChatInputEnabled(): Flow<Boolean>
 
+    /**
+     * Observes whether the native input top nav bar feature flag is enabled.
+     * This is only the flag; callers still gate on the input mode (Search & Duck.ai).
+     */
+    fun observeNativeInputNavBarEnabled(): Flow<Boolean>
+
     suspend fun isStandaloneMigrationCompleted(): Boolean
 
     /**

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -407,6 +407,7 @@ class RealDuckChat @Inject constructor(
     private val _showModelPickerEvents = MutableSharedFlow<String>(extraBufferCapacity = 1)
     private val _nativeInputFieldEnabled = MutableStateFlow(false)
     private val _nativeChatInputEnabled = MutableStateFlow(false)
+    private val _nativeInputNavBarEnabled = MutableStateFlow(false)
     private val _showInputScreenOnSystemSearchLaunch = MutableStateFlow(false)
     private val _showVoiceSearchToggle = MutableStateFlow(false)
     private val _showVoiceChatEntry = MutableStateFlow(false)
@@ -538,6 +539,8 @@ class RealDuckChat @Inject constructor(
     override fun observeNativeInputFieldUserSettingEnabled(): Flow<Boolean> = _nativeInputFieldEnabled.asStateFlow()
 
     override fun observeNativeChatInputEnabled(): Flow<Boolean> = _nativeChatInputEnabled.asStateFlow()
+
+    override fun observeNativeInputNavBarEnabled(): Flow<Boolean> = _nativeInputNavBarEnabled.asStateFlow()
 
     override fun observeShowInBrowserMenuUserSetting(): Flow<Boolean> = duckChatFeatureRepository.observeShowInBrowserMenu()
 
@@ -937,6 +940,7 @@ class RealDuckChat @Inject constructor(
             isNativeInputFieldEnabled = _nativeInputFieldEnabled.value
             isNativeChatInputEnabled = isNativeInputFieldEnabled && duckChatFeature.nativeChatInput().isEnabled()
             _nativeChatInputEnabled.value = isNativeChatInputEnabled
+            _nativeInputNavBarEnabled.value = duckChatFeature.nativeInputNavBar().isEnabled()
             val inputScreenUserSettingEnabled = duckChatFeatureRepository.isInputScreenUserSettingEnabled()
 
             // Mirrors NativeInputModeWidgetViewModel.getInputMode: the address bar offers the

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -155,6 +155,15 @@ interface DuckChatFeature {
     fun nativeChatInput(): Toggle
 
     /**
+     * @return `true` when the native input top nav bar (fire / tabs / menu) may be shown. This is a
+     * guardrail on top of the input mode: the bar shows only when this is enabled AND the address bar
+     * is in Search & Duck.ai mode. Search-only users, or users with this disabled, never see it.
+     * If the remote feature is not present defaults to `internal`.
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun nativeInputNavBar(): Toggle
+
+    /**
      * @return `true` when the Input Screen onboarding wide event should be sent
      * If the remote feature is not present defaults to `internal`
      */

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/view/InputModeWidget.kt
@@ -122,6 +122,7 @@ open class InputModeWidget @JvmOverloads constructor(
     var onVoiceInputAllowed: ((Boolean) -> Unit)? = null
     var onSearchTextChanged: ((String) -> Unit)? = null
     var onChatTextChanged: ((String) -> Unit)? = null
+    var onInputTextEmptyChanged: ((isEmpty: Boolean) -> Unit)? = null
     var tabAttachmentsEnabled: Boolean = false
     var onChatTagTextChanged: ((String, Int) -> Unit)? = null
     var onTabAttachmentRemoved: ((String) -> Unit)? = null
@@ -364,6 +365,7 @@ open class InputModeWidget @JvmOverloads constructor(
 
                 val isNullOrEmpty = text.isNullOrEmpty()
                 inputFieldClearText.isVisible = !isNullOrEmpty
+                onInputTextEmptyChanged?.invoke(isNullOrEmpty)
             }
 
             doAfterTextChanged { text ->

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -169,6 +169,7 @@ interface NativeInputWidget {
         onSearchTextChanged: (String) -> Unit,
         onSearchSubmitted: (String) -> Unit,
         onChatSubmitted: (String) -> Unit,
+        onInputTextEmptyChanged: (isEmpty: Boolean) -> Unit = {},
     )
 
     fun bindTabCount(
@@ -1226,6 +1227,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         onSearchTextChanged: (String) -> Unit,
         onSearchSubmitted: (String) -> Unit,
         onChatSubmitted: (String) -> Unit,
+        onInputTextEmptyChanged: (isEmpty: Boolean) -> Unit,
     ) {
         this.onSearchTextChanged = onSearchTextChanged
         this.onSearchSelected = { _ ->
@@ -1233,6 +1235,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         }
         this.onSearchSent = onSearchSubmitted
         this.onChatSent = onChatSubmitted
+        this.onInputTextEmptyChanged = onInputTextEmptyChanged
     }
 
     override fun bindTabCount(

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -527,6 +527,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
             updateSendButtonVisibility()
             updateVoiceButtonVisibility()
             updateNewLineButtonVisibility()
+            // The toggle-row back arrow flips with text presence (inverse of the nav bar).
+            nativeInputState?.let { updateBackButtons(it) }
         }
     }
 
@@ -739,8 +741,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     private fun updateBackButtons(state: NativeInputState) {
+        val hasText = !inputField.text.isNullOrEmpty()
         findViewById<View?>(R.id.inputModeWidgetBack)?.visibility =
-            if (state.shouldShowToggleRowBack()) VISIBLE else GONE
+            if (state.shouldShowToggleRowBack(hasText)) VISIBLE else GONE
         findViewById<View?>(R.id.inputModeUnifiedBack)?.visibility =
             if (state.shouldShowCardRowBack()) VISIBLE else GONE
         findViewById<View?>(R.id.inputModeWidgetBack)?.setBackgroundResource(
@@ -1621,8 +1624,11 @@ class NativeInputModeWidget @JvmOverloads constructor(
 internal fun NativeInputState.chatHintRes(): Int =
     if (chatId != null) R.string.native_input_chat_duck_mode_hint else R.string.native_input_chat_hint
 
-internal fun NativeInputState.shouldShowToggleRowBack(): Boolean =
-    toggleVisible && inputContext == NativeInputState.InputContext.BROWSER
+// Inverse of the top nav bar: the nav bar shows its own back arrow while the field is empty, so this
+// one shows only once there is text — the two are never visible at the same time (browser only; this
+// arrow never renders in Duck.ai / contextual, where toggleVisible is false).
+internal fun NativeInputState.shouldShowToggleRowBack(hasText: Boolean): Boolean =
+    toggleVisible && inputContext == NativeInputState.InputContext.BROWSER && hasText
 
 internal fun NativeInputState.shouldShowCardRowBack(): Boolean =
     !toggleVisible && inputContext == NativeInputState.InputContext.BROWSER

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -2347,6 +2347,7 @@ class DuckChatContextualViewModelTest {
         override fun observeAutomaticContextAttachmentUserSettingEnabled(): Flow<Boolean> = automaticContextAttachment
         override fun observeNativeInputFieldUserSettingEnabled(): Flow<Boolean> = nativeInputFieldSettingEnabled
         override fun observeNativeChatInputEnabled(): Flow<Boolean> = nativeChatInputEnabled
+        override fun observeNativeInputNavBarEnabled(): Flow<Boolean> = emptyFlow()
         override suspend fun isStandaloneMigrationCompleted(): Boolean = true
         override suspend fun setChatSuggestionsUserSetting(enabled: Boolean) = Unit
         override fun observeChatSuggestionsUserSettingEnabled(): Flow<Boolean> = flowOf(true)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChat.kt
@@ -38,6 +38,7 @@ class FakeDuckChat(
     private val automaticContextAttachmentUserSettingEnabled = MutableStateFlow(false)
     private val nativeInputFieldUserSettingEnabled = MutableStateFlow(false)
     private val nativeChatInputEnabled = MutableStateFlow(false)
+    private val nativeInputNavBarEnabled = MutableStateFlow(false)
     private val chatSuggestionsUserSettingEnabled = MutableStateFlow(true)
     var standaloneMigrationCompleted: Boolean = false
 
@@ -101,6 +102,10 @@ class FakeDuckChat(
 
     override fun observeNativeChatInputEnabled(): Flow<Boolean> {
         return nativeChatInputEnabled
+    }
+
+    override fun observeNativeInputNavBarEnabled(): Flow<Boolean> {
+        return nativeInputNavBarEnabled
     }
 
     override suspend fun isStandaloneMigrationCompleted(): Boolean {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -52,6 +52,7 @@ class FakeDuckChatInternal(
     private val cosmeticInputScreenUserSettingEnabled = MutableStateFlow<Boolean?>(null)
     private val nativeInputFieldUserSettingEnabled = MutableStateFlow(false)
     private val nativeChatInputEnabled = MutableStateFlow(false)
+    private val nativeInputNavBarEnabled = MutableStateFlow(false)
     private val automaticContextAttachmentUserSettingEnabled = MutableStateFlow<Boolean>(false)
     private val areMultipleContentAttachmentsEnabled = MutableStateFlow<Boolean>(false)
     private val chatSuggestionsUserSettingEnabled = MutableStateFlow(true)
@@ -97,6 +98,7 @@ class FakeDuckChatInternal(
     override fun observeAutomaticContextAttachmentUserSettingEnabled(): Flow<Boolean> = automaticContextAttachmentUserSettingEnabled
     override fun observeNativeInputFieldUserSettingEnabled(): Flow<Boolean> = nativeInputFieldUserSettingEnabled
     override fun observeNativeChatInputEnabled(): Flow<Boolean> = nativeChatInputEnabled
+    override fun observeNativeInputNavBarEnabled(): Flow<Boolean> = nativeInputNavBarEnabled
 
     override suspend fun isStandaloneMigrationCompleted(): Boolean = standaloneMigrationCompleted.value
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetBackButtonsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetBackButtonsTest.kt
@@ -29,18 +29,28 @@ import org.junit.Test
 class NativeInputModeWidgetBackButtonsTest {
 
     @Test
-    fun `toggle row back is shown when toggle visible and context is browser`() {
+    fun `toggle row back is shown when toggle visible, context is browser and there is text`() {
         val state = stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.BROWSER)
 
-        assertTrue(state.shouldShowToggleRowBack())
+        assertTrue(state.shouldShowToggleRowBack(hasText = true))
         assertFalse(state.shouldShowCardRowBack())
+    }
+
+    @Test
+    fun `toggle row back is hidden when toggle visible and context is browser but the field is empty`() {
+        // Inverse of the nav bar: when empty, the nav bar shows its own back arrow, so this one hides
+        // to avoid two back arrows at once.
+        val state = stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.BROWSER)
+
+        assertFalse(state.shouldShowToggleRowBack(hasText = false))
     }
 
     @Test
     fun `toggle row back is hidden when toggle visible and context is duck ai`() {
         val state = stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.DUCK_AI)
 
-        assertFalse(state.shouldShowToggleRowBack())
+        assertFalse(state.shouldShowToggleRowBack(hasText = true))
+        assertFalse(state.shouldShowToggleRowBack(hasText = false))
         assertFalse(state.shouldShowCardRowBack())
     }
 
@@ -48,14 +58,14 @@ class NativeInputModeWidgetBackButtonsTest {
     fun `toggle row back is hidden when toggle hidden and context is browser`() {
         val state = stateOf(InputMode.SEARCH_ONLY, InputContext.BROWSER)
 
-        assertFalse(state.shouldShowToggleRowBack())
+        assertFalse(state.shouldShowToggleRowBack(hasText = true))
     }
 
     @Test
     fun `toggle row back is hidden when toggle hidden and context is duck ai`() {
         val state = stateOf(InputMode.SEARCH_ONLY, InputContext.DUCK_AI)
 
-        assertFalse(state.shouldShowToggleRowBack())
+        assertFalse(state.shouldShowToggleRowBack(hasText = true))
     }
 
     @Test
@@ -80,8 +90,8 @@ class NativeInputModeWidgetBackButtonsTest {
 
     @Test
     fun `toggle row back is hidden in duck ai contextual context`() {
-        assertFalse(stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.DUCK_AI_CONTEXTUAL).shouldShowToggleRowBack())
-        assertFalse(stateOf(InputMode.SEARCH_ONLY, InputContext.DUCK_AI_CONTEXTUAL).shouldShowToggleRowBack())
+        assertFalse(stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.DUCK_AI_CONTEXTUAL).shouldShowToggleRowBack(hasText = true))
+        assertFalse(stateOf(InputMode.SEARCH_ONLY, InputContext.DUCK_AI_CONTEXTUAL).shouldShowToggleRowBack(hasText = true))
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1174433894299346/task/1216390319388562?focus=true
Tech Design URL (if applicable):

### Description

Adds a persistent top nav bar to the Unified Text Input (UTI) and wires the complementary visibility behaviours so the chrome around the input feels consistent.

**Feature flag / guardrail**
- Gated behind a new `nativeInputNavBar` sub-feature on `DuckChatFeature` (default **internal**), exposed through the `DuckChat` API as `observeNativeInputNavBarEnabled()`.
- The nav bar is created **only** when the flag is enabled **and** the address bar is in **Search & Duck.ai** mode. Users in **Search Only**, or with the flag disabled, never get it — regardless of anything else below.

**Nav bar visibility**
- The nav bar (back / fire / tab switcher / browser menu) is shown only for **browser** input (`InputContext.BROWSER`) and only while the input field is **empty**. Whitespace counts as text.
- Once the user types, the bar slides up and away; in top mode the input widget rides up with it to fill the space. Clearing the field reverses it.
- It is never shown in an active Duck.ai conversation or contextual input. It is shown for both omnibar positions (top and bottom).
- **Duck.ai tab (bottom omnibar):** when the Duck.ai tab is selected in the browser unified input, its suggestions span the top of the screen. The suggestions list is inset below the nav bar and the bar is floated above it (bottom omnibar only), so the bar stays visible instead of being covered.

**Toggle-row back arrow**
- The back arrow next to the Search/Duck.ai selector is the **inverse** of the nav bar: hidden while the field is empty (the nav bar shows its own back then), shown once there is text — so exactly one back arrow is ever visible, never two.

**NTP return hatch**
- When the nav bar flag is on (and Search & Duck.ai), the return hatch hides its own **tabs button** — those users get the tabs affordance from the nav bar, so the hatch would otherwise duplicate it. The hatch's fire and options (⋮) are unchanged.

**Notable internals**
- `configureContentOffset` registered its layout listeners additively; recomputing the offset per toggle would have stacked competing listeners and silently looped layout in bottom mode. Listeners now register once, with a cheap `updateNavBarInset(px)` for subsequent changes.
- The nav bar slide uses its own `ValueAnimator` (independent of the widget↔omnibar morph) with a cancellation guard.
- The nav bar back routes through the widget's `onBackPressed()` so it fires the same back-button pixel as the toggle-row back (consistent telemetry).
- The nav bar's fire/tabs/menu views use distinct `inputModeWidgetNav*` ids so the two views attached to the same parent don't share ids.
- Autocomplete/content offsets are computed from the widget's on-screen (translation-aware) bottom so the nav-bar ride-up in top mode, and prefilled reopens, don't leave a gap.

### Steps to test this PR

_Enable the feature_
- [x] Ensure the `nativeInputNavBar` flag is enabled (internal builds default to on).
- [x] Settings → AI Features → set the address bar mode to **"Toggle between Search and Duck.ai"**.

_Browser, top omnibar_
- [x] Focus the address bar with an empty field → the top nav bar (back / fire / tabs / menu) is shown; there is **no** back arrow next to the Search/Duck.ai selector.
- [x] Type any text → the nav bar slides up and the widget rises to the top; the back arrow next to the selector now appears.
- [x] Clear the field → the nav bar slides back down and the selector back arrow disappears.
- [x] Type only spaces → nav bar stays hidden (whitespace counts as text).
- [x] Re-open with a prefilled field → the nav bar starts hidden and the widget sits at the top with no gap, no flash.

_Browser, bottom omnibar_
- [x] Nav bar shown at the top, input widget at the bottom; typing hides the bar, clearing shows it. Confirm no layout churn over an NTP with favourites/RMF.
- [x] Select the **Duck.ai tab** → the nav bar stays visible and its suggestions sit below it (not covered).

_Search Only / flag off_
- [x] Set the address bar to **Search Only** (or disable the `nativeInputNavBar` flag) → no nav bar in any state.

_Duck.ai conversation / contextual_
- [x] No nav bar is shown in an active Duck.ai conversation or contextual input.

_Return hatch_
- [x] With the nav bar flag on and Search & Duck.ai, on an NTP showing the "Return to…" hatch → the hatch shows fire and options (⋮) but **no** tabs button.

### UI changes
| Before  | After |
| ------ | ----- |
| (no top nav bar) | (empty) nav bar shown, no selector back arrow; (typing) nav bar hidden, selector back arrow shown |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches browser chrome layout, animations, and NTP/hatch visibility with many edge cases (top vs bottom omnibar, prefilled text, mode/flag toggles); risk is UI regressions rather than security, mitigated by feature flag and extensive unit tests.
> 
> **Overview**
> Adds a **persistent top nav bar** (back, fire, tabs, menu) to unified native browser input, behind the new **`nativeInputNavBar`** flag and only in **Search & Duck.ai** mode—not in search-only, Duck.ai chat, or contextual input.
> 
> The bar is **visible only while the input field is empty**; typing slides it away (in top omnibar mode the widget rides up with it). Clearing text brings it back. The **toggle-row back arrow** is now the inverse: hidden when empty (nav bar back shows) and shown when there is text, so only one back control appears.
> 
> **`BrowserTabFragment`** wires tab switcher and browser menu into native input callbacks. **`NativeInputManager`** creates/binds the nav bar, observes the flag and input-mode changes (tearing down the widget on search-only), and drives visibility via **`animateNavBarVisibility`**. **`NativeInputLayoutCoordinator`** offsets widget, NTP/browser content, and autocomplete using nav-bar inset and translation-aware widget bounds; **`updateNavBarInset`** avoids stacking layout listeners.
> 
> The **NTP return hatch** hides its tabs button when the nav bar flag is on, avoiding duplicate tabs affordances. **`DuckChat`** exposes **`observeNativeInputNavBarEnabled()`**. Unit tests cover visibility rules, offsets, animator snap behavior, and nav bar wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 900b9ebe01a52e9d9d4ec72df80321c2190f61a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

