### PR TITLE
[Quick Win] Reduce object allocations in the tracker detection

### DIFF
--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/DomainsReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/DomainsReferenceTest.kt
@@ -36,7 +36,6 @@ import com.duckduckgo.app.fakes.UserAllowListRepositoryFake
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.privacy.db.PrivacyProtectionCountDao
-import com.duckduckgo.app.privacy.db.UserAllowListDao
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.surrogates.ResourceSurrogateLoader
 import com.duckduckgo.app.surrogates.ResourceSurrogatesImpl
@@ -103,7 +102,6 @@ class DomainsReferenceTest(private val testCase: TestCase) {
     private val resourceSurrogates = ResourceSurrogatesImpl()
 
     private var webView: WebView = mock()
-    private val mockUserAllowListDao: UserAllowListDao = mock()
     private val mockContentBlocking: ContentBlocking = mock()
     private val mockTrackerAllowlist: TrackerAllowlist = mock()
     private val mockRequestBlocklist: RequestBlocklist = mock()
@@ -246,7 +244,7 @@ class DomainsReferenceTest(private val testCase: TestCase) {
         entityLookup = TdsEntityLookup(tdsEntityDao, tdsDomainEntityDao)
         val trackerDetectorImpl = TrackerDetectorImpl(
             entityLookup,
-            mockUserAllowListDao,
+            mockUserAllowListRepository,
             mockContentBlocking,
             mockTrackerAllowlist,
             mockAdClickManager,

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/RequestBlocklistReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/RequestBlocklistReferenceTest.kt
@@ -300,7 +300,7 @@ class RequestBlocklistReferenceTest(private val testCase: TestCase) {
         entityLookup = TdsEntityLookup(tdsEntityDao, tdsDomainEntityDao)
         val trackerDetectorImpl = TrackerDetectorImpl(
             entityLookup,
-            userAllowlistDao,
+            userAllowListRepository,
             contentBlocking,
             trackerAllowlist,
             mockAdClickManager,

--- a/app/src/androidTest/java/com/duckduckgo/app/referencetests/SurrogatesReferenceTest.kt
+++ b/app/src/androidTest/java/com/duckduckgo/app/referencetests/SurrogatesReferenceTest.kt
@@ -37,7 +37,6 @@ import com.duckduckgo.app.fakes.UserAllowListRepositoryFake
 import com.duckduckgo.app.global.db.AppDatabase
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
 import com.duckduckgo.app.privacy.db.PrivacyProtectionCountDao
-import com.duckduckgo.app.privacy.db.UserAllowListDao
 import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.surrogates.ResourceSurrogateLoader
 import com.duckduckgo.app.surrogates.ResourceSurrogatesImpl
@@ -105,7 +104,6 @@ class SurrogatesReferenceTest(private val testCase: TestCase) {
     private val resourceSurrogates = ResourceSurrogatesImpl()
 
     private var webView: WebView = mock()
-    private val mockUserAllowListDao: UserAllowListDao = mock()
     private val mockContentBlocking: ContentBlocking = mock()
     private val mockTrackerAllowlist: TrackerAllowlist = mock()
     private val mockRequestBlocklist: RequestBlocklist = mock()
@@ -241,7 +239,7 @@ class SurrogatesReferenceTest(private val testCase: TestCase) {
         entityLookup = TdsEntityLookup(tdsEntityDao, tdsDomainEntityDao)
         val trackerDetectorImpl = TrackerDetectorImpl(
             entityLookup,
-            mockUserAllowListDao,
+            mockUserAllowListRepository,
             mockContentBlocking,
             mockTrackerAllowlist,
             mockAdClickManager,

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewRequestInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewRequestInterceptor.kt
@@ -440,29 +440,19 @@ class WebViewRequestInterceptor(
         documentUrl: Uri?,
         webViewClientListener: WebViewClientListener?,
         checkFirstParty: Boolean = true,
-    ): TrackingEvent? {
-        val url = request.url
-        if (request.isForMainFrame || documentUrl == null) {
-            return null
-        }
-
-        val trackingEvent = trackerDetector.evaluate(url, documentUrl, checkFirstParty, request.requestHeaders) ?: return null
-        webViewClientListener?.trackerDetected(trackingEvent)
-        return trackingEvent
-    }
-
-    private fun trackingEvent(
-        request: WebResourceRequest,
-        documentUrl: Uri?,
-        webViewClientListener: WebViewClientListener?,
-        checkFirstParty: Boolean = true,
-        url: String = request.url.toString(),
+        uncloakedHost: String? = null,
     ): TrackingEvent? {
         if (request.isForMainFrame || documentUrl == null) {
             return null
         }
 
-        val trackingEvent = trackerDetector.evaluate(url, documentUrl, checkFirstParty, request.requestHeaders) ?: return null
+        // When a CNAME-cloaked host has been uncloaked, evaluate that host (String overload);
+        // otherwise evaluate the request URL directly (Uri overload).
+        val trackingEvent = if (uncloakedHost != null) {
+            trackerDetector.evaluate(uncloakedHost, documentUrl, checkFirstParty, request.requestHeaders)
+        } else {
+            trackerDetector.evaluate(request.url, documentUrl, checkFirstParty, request.requestHeaders)
+        } ?: return null
         webViewClientListener?.trackerDetected(trackingEvent)
         return trackingEvent
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewRequestInterceptor.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewRequestInterceptor.kt
@@ -446,8 +446,6 @@ class WebViewRequestInterceptor(
             return null
         }
 
-        // When a CNAME-cloaked host has been uncloaked, evaluate that host (String overload);
-        // otherwise evaluate the request URL directly (Uri overload).
         val trackingEvent = if (uncloakedHost != null) {
             trackerDetector.evaluate(uncloakedHost, documentUrl, checkFirstParty, request.requestHeaders)
         } else {

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/Client.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/Client.kt
@@ -41,7 +41,11 @@ interface Client {
         val categories: List<String>? = null,
         val surrogate: String? = null,
         val isATracker: Boolean,
-    )
+    ) {
+        companion object {
+            val NO_MATCH = Result(matches = false, isATracker = false)
+        }
+    }
 
     val name: ClientName
 

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TdsClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TdsClient.kt
@@ -61,7 +61,7 @@ class TdsClient(
         documentUrl: Uri,
         requestHeaders: Map<String, String>,
     ): Client.Result {
-        val compiled = findCompiledTracker(host(url)) ?: return Client.Result(matches = false, isATracker = false)
+        val compiled = findCompiledTracker(host(url)) ?: return Client.Result.NO_MATCH
         val matches = matchesTrackerEntry(compiled, url, documentUrl, requestHeaders)
         return Client.Result(
             matches = matches.shouldBlock,
@@ -77,7 +77,7 @@ class TdsClient(
         documentUrl: Uri,
         requestHeaders: Map<String, String>,
     ): Client.Result {
-        val compiled = findCompiledTracker(url.host) ?: return Client.Result(matches = false, isATracker = false)
+        val compiled = findCompiledTracker(url.host) ?: return Client.Result.NO_MATCH
         val matches = matchesTrackerEntry(compiled, url.toString(), documentUrl, requestHeaders)
         return Client.Result(
             matches = matches.shouldBlock,

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TdsClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TdsClient.kt
@@ -114,6 +114,9 @@ class TdsClient(
         documentUrl: Uri,
         requestHeaders: Map<String, String>,
     ): MatchedResult {
+        // The request type depends only on (url, requestHeaders), so it is invariant across rules. Computing it once.
+        var type: String? = null
+        var typeResolved = false
         compiled.rules.forEach { compiledRule ->
             val rule = compiledRule.rule
             val regex = if (precompileRegex) {
@@ -122,7 +125,10 @@ class TdsClient(
                 ".*${rule.rule}.*".toRegex()
             }
             if (url.matches(regex)) {
-                val type = urlToTypeMapper.map(url, requestHeaders)
+                if (!typeResolved) {
+                    type = urlToTypeMapper.map(url, requestHeaders)
+                    typeResolved = true
+                }
 
                 if (rule.options != null) {
                     if (!matchedDomainAndTypes(rule.options.domains, rule.options.types, documentUrl, type)) {

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TdsEntityLookup.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TdsEntityLookup.kt
@@ -38,22 +38,14 @@ class TdsEntityLookup @Inject constructor(
     var entities: List<TdsEntity> = emptyList()
 
     @WorkerThread
-    override fun entityForUrl(url: String): Entity? {
-        val uri = url.toUri()
-        val host = uri.baseHost ?: return null
-
-        // try searching for exact domain
-        val direct = lookUpEntityInDatabase(host)
-        if (direct != null) return direct
-
-        // remove the first subdomain, and try again
-        val parentDomain = uri.removeSubdomain() ?: return null
-        return entityForUrl(parentDomain)
-    }
+    override fun entityForUrl(url: String): Entity? = entityForUri(url.toUri()) { it.baseHost }
 
     @WorkerThread
-    override fun entityForUrl(uri: Uri): Entity? {
-        val host = uri.host ?: return null
+    override fun entityForUrl(url: Uri): Entity? = entityForUri(url) { it.host }
+
+    @WorkerThread
+    private fun entityForUri(uri: Uri, hostSelector: (Uri) -> String?): Entity? {
+        val host = hostSelector(uri) ?: return null
 
         // try searching for exact domain
         val direct = lookUpEntityInDatabase(host)
@@ -61,7 +53,7 @@ class TdsEntityLookup @Inject constructor(
 
         // remove the first subdomain, and try again
         val parentDomain = uri.removeSubdomain() ?: return null
-        return entityForUrl(parentDomain.toUri())
+        return entityForUri(parentDomain.toUri(), hostSelector)
     }
 
     @WorkerThread

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TdsEntityLookup.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TdsEntityLookup.kt
@@ -44,7 +44,7 @@ class TdsEntityLookup @Inject constructor(
     override fun entityForUrl(url: Uri): Entity? = entityForUri(url) { it.host }
 
     @WorkerThread
-    private fun entityForUri(uri: Uri, hostSelector: (Uri) -> String?): Entity? {
+    private tailrec fun entityForUri(uri: Uri, hostSelector: (Uri) -> String?): Entity? {
         val host = hostSelector(uri) ?: return null
 
         // try searching for exact domain

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDetectorImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDetectorImpl.kt
@@ -21,7 +21,7 @@ import androidx.annotation.VisibleForTesting
 import com.duckduckgo.adclick.api.AdClickManager
 import com.duckduckgo.app.browser.UriString.Companion.removePort
 import com.duckduckgo.app.browser.UriString.Companion.sameOrSubdomainPair
-import com.duckduckgo.app.privacy.db.UserAllowListDao
+import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.trackerdetection.Client.ClientType.BLOCKING
 import com.duckduckgo.app.trackerdetection.model.Entity
 import com.duckduckgo.app.trackerdetection.model.TrackerStatus
@@ -43,7 +43,7 @@ import javax.inject.Inject
 @SingleInstanceIn(AppScope::class)
 class TrackerDetectorImpl @Inject constructor(
     private val entityLookup: EntityLookup,
-    private val userAllowListDao: UserAllowListDao,
+    private val userAllowListRepository: UserAllowListRepository,
     private val contentBlocking: ContentBlocking,
     private val trackerAllowlist: TrackerAllowlist,
     private val adClickManager: AdClickManager,
@@ -88,7 +88,7 @@ class TrackerDetectorImpl @Inject constructor(
         val urlNetwork = entityLookup.entityForUrl(url)
         val sameEntity = sameNetwork(urlNetwork, documentUrl)
         val entity = if (result.entityName != null) entityLookup.entityForName(result.entityName) else urlNetwork
-        val isDocumentInAllowedList = userAllowListDao.isDocumentAllowListed(documentUrl)
+        val isDocumentInAllowedList = userAllowListRepository.isDocumentAllowListed(documentUrl)
 
         return evaluate(documentUrlString, urlString, result, sameEntity, isDocumentInAllowedList, entity)
     }
@@ -113,7 +113,7 @@ class TrackerDetectorImpl @Inject constructor(
         val urlNetwork = entityLookup.entityForUrl(url)
         val sameEntity = sameNetwork(urlNetwork, documentUrl)
         val entity = if (result.entityName != null) entityLookup.entityForName(result.entityName) else urlNetwork
-        val isDocumentInAllowedList = userAllowListDao.isDocumentAllowListed(documentUrl)
+        val isDocumentInAllowedList = userAllowListRepository.isDocumentAllowListed(documentUrl)
 
         return evaluate(documentUrlString, url, result, sameEntity, isDocumentInAllowedList, entity)
     }
@@ -189,9 +189,9 @@ class TrackerDetectorImpl @Inject constructor(
         get() = clients.count()
 }
 
-private fun UserAllowListDao.isDocumentAllowListed(document: Uri?): Boolean {
+private fun UserAllowListRepository.isDocumentAllowListed(document: Uri?): Boolean {
     document?.host?.let {
-        return contains(it)
+        return isDomainInUserAllowList(it)
     }
     return false
 }

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDetectorImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDetectorImpl.kt
@@ -85,8 +85,9 @@ class TrackerDetectorImpl @Inject constructor(
         val result = blockingClients
             .firstNotNullOfOrNull { it.matches(cleanedUrl, documentUrl, requestHeaders) } ?: Client.Result.NO_MATCH
 
-        val sameEntity = sameNetworkName(url, documentUrl)
-        val entity = if (result.entityName != null) entityLookup.entityForName(result.entityName) else entityLookup.entityForUrl(url)
+        val urlNetwork = entityLookup.entityForUrl(url)
+        val sameEntity = sameNetwork(urlNetwork, documentUrl)
+        val entity = if (result.entityName != null) entityLookup.entityForName(result.entityName) else urlNetwork
         val isDocumentInAllowedList = userAllowListDao.isDocumentAllowListed(documentUrl)
 
         return evaluate(documentUrlString, urlString, result, sameEntity, isDocumentInAllowedList, entity)
@@ -109,8 +110,9 @@ class TrackerDetectorImpl @Inject constructor(
         val result = blockingClients
             .firstNotNullOfOrNull { it.matches(cleanedUrl, documentUrl, requestHeaders) } ?: Client.Result.NO_MATCH
 
-        val sameEntity = sameNetworkName(documentUrl, url)
-        val entity = if (result.entityName != null) entityLookup.entityForName(result.entityName) else entityLookup.entityForUrl(url)
+        val urlNetwork = entityLookup.entityForUrl(url)
+        val sameEntity = sameNetwork(urlNetwork, documentUrl)
+        val entity = if (result.entityName != null) entityLookup.entityForName(result.entityName) else urlNetwork
         val isDocumentInAllowedList = userAllowListDao.isDocumentAllowListed(documentUrl)
 
         return evaluate(documentUrlString, url, result, sameEntity, isDocumentInAllowedList, entity)
@@ -168,22 +170,18 @@ class TrackerDetectorImpl @Inject constructor(
     ): Boolean =
         sameOrSubdomainPair(firstUrl, secondUrl)
 
-    private fun sameNetworkName(
-        first: Uri,
-        second: String,
-    ): Boolean {
-        val firstNetwork = entityLookup.entityForUrl(first) ?: return false
-        val secondNetwork = entityLookup.entityForUrl(second) ?: return false
-        return firstNetwork.name == secondNetwork.name
-    }
-
-    private fun sameNetworkName(
-        url: Uri,
+    /**
+     * Whether the request URL and the document belong to the same entity. The request URL's entity
+     * ([urlNetwork]) is resolved once by the caller and passed in, so it is not looked up again here;
+     * the document's entity is only resolved when the request URL actually maps to an entity.
+     */
+    private fun sameNetwork(
+        urlNetwork: Entity?,
         documentUrl: Uri,
     ): Boolean {
-        val firstNetwork = entityLookup.entityForUrl(url) ?: return false
-        val secondNetwork = entityLookup.entityForUrl(documentUrl) ?: return false
-        return firstNetwork.name == secondNetwork.name
+        if (urlNetwork == null) return false
+        val documentNetwork = entityLookup.entityForUrl(documentUrl) ?: return false
+        return urlNetwork.name == documentNetwork.name
     }
 
     @VisibleForTesting

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDetectorImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDetectorImpl.kt
@@ -126,11 +126,14 @@ class TrackerDetectorImpl @Inject constructor(
         isDocumentInAllowedList: Boolean,
         entity: Entity?,
     ): TrackingEvent {
-        val isSiteAContentBlockingException = contentBlocking.isAnException(documentUrlString)
         val isInAdClickAllowList = adClickManager.isExemption(documentUrlString, urlString)
         val isInTrackerAllowList = trackerAllowlist.isAnException(documentUrlString, urlString)
         val isATrackerAllowed = result.isATracker && !result.matches
-        val shouldBlock = result.matches && !isSiteAContentBlockingException && !isInTrackerAllowList && !isInAdClickAllowList && !sameEntity
+        val shouldBlock = result.matches &&
+            !sameEntity &&
+            !isInTrackerAllowList &&
+            !isInAdClickAllowList &&
+            !contentBlocking.isAnException(documentUrlString)
 
         val status = when {
             sameEntity -> TrackerStatus.SAME_ENTITY_ALLOWED

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDetectorImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDetectorImpl.kt
@@ -76,7 +76,7 @@ class TrackerDetectorImpl @Inject constructor(
 
         val result = clients
             .filter { it.name.type == BLOCKING }
-            .firstNotNullOfOrNull { it.matches(cleanedUrl, documentUrl, requestHeaders) } ?: Client.Result(matches = false, isATracker = false)
+            .firstNotNullOfOrNull { it.matches(cleanedUrl, documentUrl, requestHeaders) } ?: Client.Result.NO_MATCH
 
         val sameEntity = sameNetworkName(url, documentUrl)
         val entity = if (result.entityName != null) entityLookup.entityForName(result.entityName) else entityLookup.entityForUrl(url)
@@ -101,7 +101,7 @@ class TrackerDetectorImpl @Inject constructor(
 
         val result = clients
             .filter { it.name.type == BLOCKING }
-            .firstNotNullOfOrNull { it.matches(cleanedUrl, documentUrl, requestHeaders) } ?: Client.Result(matches = false, isATracker = false)
+            .firstNotNullOfOrNull { it.matches(cleanedUrl, documentUrl, requestHeaders) } ?: Client.Result.NO_MATCH
 
         val sameEntity = sameNetworkName(documentUrl, url)
         val entity = if (result.entityName != null) entityLookup.entityForName(result.entityName) else entityLookup.entityForUrl(url)

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDetectorImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDetectorImpl.kt
@@ -52,11 +52,19 @@ class TrackerDetectorImpl @Inject constructor(
     private val clients = CopyOnWriteArrayList<Client>()
 
     /**
+     * We're only interested in [BLOCKING] clients. Recomputed only when [addClient] runs. Evaluation reads
+     * this directly instead of filtering [clients] on every request.
+     */
+    @Volatile
+    private var blockingClients: List<Client> = emptyList()
+
+    /**
      * Adds a new client. If the client's name matches an existing client, old client is replaced
      */
     override fun addClient(client: Client) {
         clients.removeAll { client.name == it.name }
         clients.add(client)
+        blockingClients = clients.filter { it.name.type == BLOCKING }
     }
 
     override fun evaluate(
@@ -74,8 +82,7 @@ class TrackerDetectorImpl @Inject constructor(
             return null
         }
 
-        val result = clients
-            .filter { it.name.type == BLOCKING }
+        val result = blockingClients
             .firstNotNullOfOrNull { it.matches(cleanedUrl, documentUrl, requestHeaders) } ?: Client.Result.NO_MATCH
 
         val sameEntity = sameNetworkName(url, documentUrl)
@@ -99,8 +106,7 @@ class TrackerDetectorImpl @Inject constructor(
             return null
         }
 
-        val result = clients
-            .filter { it.name.type == BLOCKING }
+        val result = blockingClients
             .firstNotNullOfOrNull { it.matches(cleanedUrl, documentUrl, requestHeaders) } ?: Client.Result.NO_MATCH
 
         val sameEntity = sameNetworkName(documentUrl, url)

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDetectorImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDetectorImpl.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.app.trackerdetection
 import android.net.Uri
 import androidx.annotation.VisibleForTesting
 import com.duckduckgo.adclick.api.AdClickManager
+import com.duckduckgo.app.browser.UriString.Companion.removePort
 import com.duckduckgo.app.browser.UriString.Companion.sameOrSubdomainPair
 import com.duckduckgo.app.privacy.db.UserAllowListDao
 import com.duckduckgo.app.trackerdetection.Client.ClientType.BLOCKING
@@ -34,7 +35,6 @@ import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
 import logcat.LogPriority.VERBOSE
 import logcat.logcat
-import java.net.URI
 import java.util.concurrent.CopyOnWriteArrayList
 import javax.inject.Inject
 
@@ -91,7 +91,7 @@ class TrackerDetectorImpl @Inject constructor(
         checkFirstParty: Boolean,
         requestHeaders: Map<String, String>,
     ): TrackingEvent? {
-        val cleanedUrl = removePortFromUrl(url)
+        val cleanedUrl = removePort(url)
         val documentUrlString = documentUrl.toString()
 
         if (checkFirstParty && firstParty(documentUrl, cleanedUrl)) {
@@ -147,15 +147,6 @@ class TrackerDetectorImpl @Inject constructor(
                 .build()
         } else {
             uri
-        }
-    }
-
-    private fun removePortFromUrl(url: String): String {
-        return try {
-            val uri = Uri.parse(url)
-            URI(uri.scheme, uri.host, uri.path, uri.fragment).toString()
-        } catch (e: Exception) {
-            url
         }
     }
 

--- a/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDetectorImpl.kt
+++ b/app/src/main/java/com/duckduckgo/app/trackerdetection/TrackerDetectorImpl.kt
@@ -173,11 +173,6 @@ class TrackerDetectorImpl @Inject constructor(
     ): Boolean =
         sameOrSubdomainPair(firstUrl, secondUrl)
 
-    /**
-     * Whether the request URL and the document belong to the same entity. The request URL's entity
-     * ([urlNetwork]) is resolved once by the caller and passed in, so it is not looked up again here;
-     * the document's entity is only resolved when the request URL actually maps to an entity.
-     */
     private fun sameNetwork(
         urlNetwork: Entity?,
         documentUrl: Uri,

--- a/app/src/test/java/com/duckduckgo/app/global/UriStringTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/global/UriStringTest.kt
@@ -19,7 +19,9 @@ package com.duckduckgo.app.global
 import androidx.core.net.toUri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.app.browser.UriString.Companion.isWebUrl
+import com.duckduckgo.app.browser.UriString.Companion.removePort
 import com.duckduckgo.app.browser.UriString.Companion.sameOrSubdomain
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -433,5 +435,35 @@ class UriStringTest {
     @Test
     fun whenUrlContainsSingleQuoteThenIsFalse() {
         assertFalse(isWebUrl("example'.com"))
+    }
+
+    @Test
+    fun whenUrlHasPortThenPortIsRemoved() {
+        assertEquals("http://example.com/path", removePort("http://example.com:8080/path"))
+    }
+
+    @Test
+    fun whenUrlHasPortAndFragmentThenPortIsRemovedAndFragmentKept() {
+        assertEquals("https://example.com/path#section", removePort("https://example.com:443/path#section"))
+    }
+
+    @Test
+    fun whenUrlHasPortAndQueryThenPortIsRemovedAndQueryKept() {
+        assertEquals("https://example.com/path?query=1", removePort("https://example.com:8080/path?query=1"))
+    }
+
+    @Test
+    fun whenUrlHasNoPortThenUrlIsReturnedUnchanged() {
+        assertEquals("http://example.com/path?query=1", removePort("http://example.com/path?query=1"))
+    }
+
+    @Test
+    fun whenUrlHasNoPortAndNoPathThenUrlIsReturnedUnchanged() {
+        assertEquals("https://example.com", removePort("https://example.com"))
+    }
+
+    @Test
+    fun whenUrlIsNotParseableThenOriginalIsReturned() {
+        assertEquals("not a url", removePort("not a url"))
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/TrackerDetectorClientTypeTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/TrackerDetectorClientTypeTest.kt
@@ -20,7 +20,7 @@ import android.net.Uri
 import androidx.core.net.toUri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.adclick.api.AdClickManager
-import com.duckduckgo.app.privacy.db.UserAllowListDao
+import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.trackerdetection.model.TrackerStatus
 import com.duckduckgo.app.trackerdetection.model.TrackerType
 import com.duckduckgo.app.trackerdetection.model.TrackingEvent
@@ -41,14 +41,14 @@ class TrackerDetectorClientTypeTest {
 
     private val mockEntityLookup: EntityLookup = mock()
     private val mockBlockingClient: Client = mock()
-    private val mockUserAllowListDao: UserAllowListDao = mock()
+    private val mockUserAllowListRepository: UserAllowListRepository = mock()
     private val mockContentBlocking: ContentBlocking = mock()
     private val mockTrackerAllowlist: TrackerAllowlist = mock()
     private val mockAdClickManager: AdClickManager = mock()
 
     private val testee = TrackerDetectorImpl(
         mockEntityLookup,
-        mockUserAllowListDao,
+        mockUserAllowListRepository,
         mockContentBlocking,
         mockTrackerAllowlist,
         mockAdClickManager,
@@ -56,7 +56,7 @@ class TrackerDetectorClientTypeTest {
 
     @Before
     fun before() {
-        whenever(mockUserAllowListDao.contains(any())).thenReturn(false)
+        whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)
 
         whenever(mockBlockingClient.matches(eq(Url.BLOCKED), any<Uri>(), anyMap())).thenReturn(Client.Result(matches = true, isATracker = true))
         whenever(mockBlockingClient.matches(eq(Url.UNLISTED), any<Uri>(), anyMap())).thenReturn(Client.Result(matches = false, isATracker = false))

--- a/app/src/test/java/com/duckduckgo/app/trackerdetection/TrackerDetectorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/trackerdetection/TrackerDetectorTest.kt
@@ -20,7 +20,7 @@ import android.net.Uri
 import androidx.core.net.toUri
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.adclick.api.AdClickManager
-import com.duckduckgo.app.privacy.db.UserAllowListDao
+import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.trackerdetection.Client.ClientName
 import com.duckduckgo.app.trackerdetection.Client.ClientName.EASYLIST
 import com.duckduckgo.app.trackerdetection.Client.ClientName.EASYPRIVACY
@@ -43,14 +43,14 @@ import org.mockito.kotlin.whenever
 class TrackerDetectorTest {
 
     private val mockEntityLookup: EntityLookup = mock()
-    private val mockUserAllowListDao: UserAllowListDao = mock()
+    private val mockUserAllowListRepository: UserAllowListRepository = mock()
     private val mockContentBlocking: ContentBlocking = mock()
     private val mockTrackerAllowlist: TrackerAllowlist = mock()
     private val mockAdClickManager: AdClickManager = mock()
 
     private val trackerDetector = TrackerDetectorImpl(
         mockEntityLookup,
-        mockUserAllowListDao,
+        mockUserAllowListRepository,
         mockContentBlocking,
         mockTrackerAllowlist,
         mockAdClickManager,
@@ -260,7 +260,7 @@ class TrackerDetectorTest {
 
     @Test
     fun whenSiteIsNotUserAllowListedAndAllClientsMatchThenEvaluateReturnsBlockedTrackingEvent() {
-        whenever(mockUserAllowListDao.contains("example.com")).thenReturn(false)
+        whenever(mockUserAllowListRepository.isDomainInUserAllowList("example.com")).thenReturn(false)
         trackerDetector.addClient(alwaysMatchingClient(CLIENT_A))
         trackerDetector.addClient(alwaysMatchingClient(CLIENT_B))
         val expected = TrackingEvent(
@@ -282,7 +282,7 @@ class TrackerDetectorTest {
 
     @Test
     fun whenSiteIsNotUserAllowListedAndAllClientsMatchThenEvaluateReturnsBlockedTrackingEvent2() {
-        whenever(mockUserAllowListDao.contains("example.com")).thenReturn(false)
+        whenever(mockUserAllowListRepository.isDomainInUserAllowList("example.com")).thenReturn(false)
         trackerDetector.addClient(alwaysMatchingClient(CLIENT_A))
         trackerDetector.addClient(alwaysMatchingClient(CLIENT_B))
         val expected = TrackingEvent(
@@ -304,7 +304,7 @@ class TrackerDetectorTest {
 
     @Test
     fun whenSiteIsUserAllowListedAndAllClientsMatchThenEvaluateReturnsUnblockedTrackingEvent() {
-        whenever(mockUserAllowListDao.contains("example.com")).thenReturn(true)
+        whenever(mockUserAllowListRepository.isDomainInUserAllowList("example.com")).thenReturn(true)
         trackerDetector.addClient(alwaysMatchingClient(CLIENT_A))
         trackerDetector.addClient(alwaysMatchingClient(CLIENT_B))
         val expected = TrackingEvent(
@@ -326,7 +326,7 @@ class TrackerDetectorTest {
 
     @Test
     fun whenSiteIsUserAllowListedAndAllClientsMatchThenEvaluateReturnsUnblockedTrackingEvent2() {
-        whenever(mockUserAllowListDao.contains("example.com")).thenReturn(true)
+        whenever(mockUserAllowListRepository.isDomainInUserAllowList("example.com")).thenReturn(true)
         trackerDetector.addClient(alwaysMatchingClient(CLIENT_A))
         trackerDetector.addClient(alwaysMatchingClient(CLIENT_B))
         val expected = TrackingEvent(
@@ -348,7 +348,7 @@ class TrackerDetectorTest {
 
     @Test
     fun whenSiteIsNotUserAllowListedAndSomeClientsMatchThenEvaluateReturnsBlockedTrackingEvent() {
-        whenever(mockUserAllowListDao.contains("example.com")).thenReturn(false)
+        whenever(mockUserAllowListRepository.isDomainInUserAllowList("example.com")).thenReturn(false)
         trackerDetector.addClient(alwaysMatchingClient(CLIENT_B))
         val expected = TrackingEvent(
             documentUrl = "http://example.com/index.com",
@@ -369,7 +369,7 @@ class TrackerDetectorTest {
 
     @Test
     fun whenSiteIsNotUserAllowListedAndSomeClientsMatchThenEvaluateReturnsBlockedTrackingEvent2() {
-        whenever(mockUserAllowListDao.contains("example.com")).thenReturn(false)
+        whenever(mockUserAllowListRepository.isDomainInUserAllowList("example.com")).thenReturn(false)
         trackerDetector.addClient(alwaysMatchingClient(CLIENT_B))
         val expected = TrackingEvent(
             documentUrl = "http://example.com/index.com",
@@ -390,7 +390,7 @@ class TrackerDetectorTest {
 
     @Test
     fun whenSiteIsUserAllowListedAndSomeClientsMatchThenEvaluateReturnsUnblockedTrackingEvent() {
-        whenever(mockUserAllowListDao.contains("example.com")).thenReturn(true)
+        whenever(mockUserAllowListRepository.isDomainInUserAllowList("example.com")).thenReturn(true)
         trackerDetector.addClient(alwaysMatchingClient(CLIENT_B))
         val expected = TrackingEvent(
             documentUrl = "http://example.com/index.com",
@@ -411,7 +411,7 @@ class TrackerDetectorTest {
 
     @Test
     fun whenSiteIsUserAllowListedAndSomeClientsMatchThenEvaluateReturnsUnblockedTrackingEvent2() {
-        whenever(mockUserAllowListDao.contains("example.com")).thenReturn(true)
+        whenever(mockUserAllowListRepository.isDomainInUserAllowList("example.com")).thenReturn(true)
         trackerDetector.addClient(alwaysMatchingClient(CLIENT_B))
         val expected = TrackingEvent(
             documentUrl = "http://example.com/index.com",
@@ -474,7 +474,7 @@ class TrackerDetectorTest {
 
     @Test
     fun whenSiteIsNotUserAllowListedAndSomeClientsMatchWithSurrogateThenEvaluateReturnsBlockedTrackingEventWithSurrogate() {
-        whenever(mockUserAllowListDao.contains("example.com")).thenReturn(false)
+        whenever(mockUserAllowListRepository.isDomainInUserAllowList("example.com")).thenReturn(false)
         trackerDetector.addClient(alwaysMatchingClientWithSurrogate(CLIENT_A))
         val expected = TrackingEvent(
             documentUrl = "http://example.com/index.com",
@@ -495,7 +495,7 @@ class TrackerDetectorTest {
 
     @Test
     fun whenSiteIsNotUserAllowListedAndSomeClientsMatchWithSurrogateThenEvaluateReturnsBlockedTrackingEventWithSurrogate2() {
-        whenever(mockUserAllowListDao.contains("example.com")).thenReturn(false)
+        whenever(mockUserAllowListRepository.isDomainInUserAllowList("example.com")).thenReturn(false)
         trackerDetector.addClient(alwaysMatchingClientWithSurrogate(CLIENT_A))
         val expected = TrackingEvent(
             documentUrl = "http://example.com/index.com",

--- a/browser-api/src/main/java/com/duckduckgo/app/browser/UriString.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/browser/UriString.kt
@@ -54,6 +54,27 @@ class UriString {
 
         fun host(uriString: String): String? = Uri.parse(uriString).baseHost
 
+        /**
+         * Strips the port from [url], leaving the rest of the URL (scheme, host, path, query and
+         * fragment) intact.
+         *
+         * The reconstruction is only performed when a port is actually present; URLs without a
+         * port (the common case) are returned unchanged, avoiding unnecessary allocations.
+         * On any parsing failure the original [url] is returned.
+         */
+        fun removePort(url: String): String {
+            return try {
+                val uri = Uri.parse(url)
+                if (uri.port == -1) {
+                    url
+                } else {
+                    uri.buildUpon().authority(uri.host).build().toString()
+                }
+            } catch (e: Exception) {
+                url
+            }
+        }
+
         fun sameOrSubdomain(
             child: String,
             parent: String,

--- a/browser-api/src/main/java/com/duckduckgo/app/browser/UriString.kt
+++ b/browser-api/src/main/java/com/duckduckgo/app/browser/UriString.kt
@@ -57,10 +57,6 @@ class UriString {
         /**
          * Strips the port from [url], leaving the rest of the URL (scheme, host, path, query and
          * fragment) intact.
-         *
-         * The reconstruction is only performed when a port is actually present; URLs without a
-         * port (the common case) are returned unchanged, avoiding unnecessary allocations.
-         * On any parsing failure the original [url] is returned.
          */
         fun removePort(url: String): String {
             return try {

--- a/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackerallowlist/RealTrackerAllowlist.kt
+++ b/privacy-config/privacy-config-impl/src/main/java/com/duckduckgo/privacy/config/impl/features/trackerallowlist/RealTrackerAllowlist.kt
@@ -16,7 +16,6 @@
 
 package com.duckduckgo.privacy.config.impl.features.trackerallowlist
 
-import androidx.core.net.toUri
 import com.duckduckgo.app.browser.UriString
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.FeatureToggle
@@ -27,7 +26,6 @@ import com.duckduckgo.privacy.config.store.features.trackerallowlist.CompiledRul
 import com.duckduckgo.privacy.config.store.features.trackerallowlist.TrackerAllowlistRepository
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
-import java.net.URI
 import javax.inject.Inject
 
 @ContributesBinding(AppScope::class)
@@ -61,7 +59,7 @@ class RealTrackerAllowlist @Inject constructor(
     ): Boolean {
         val host = UriString.host(url) ?: return false
         val rules = findRulesForHost(host, trackerAllowlistRepository.rulesByDomain) ?: return false
-        val cleanedUrl = removePortFromUrl(url)
+        val cleanedUrl = UriString.removePort(url)
         return rules.any { compiledRule ->
             val regex = compiledRule.regex ?: return@any false
             if (!cleanedUrl.matches(regex)) return@any false
@@ -88,19 +86,10 @@ class RealTrackerAllowlist @Inject constructor(
         documentUrl: String,
         trackerAllowlist: TrackerAllowlistEntity,
     ): Boolean {
-        val cleanedUrl = removePortFromUrl(url)
+        val cleanedUrl = UriString.removePort(url)
         return trackerAllowlist.rules.any {
             val regex = ".*${it.rule}.*".toRegex()
             cleanedUrl.matches(regex) && (it.domains.contains("<all>") || it.domains.any { domain -> UriString.sameOrSubdomain(documentUrl, domain) })
-        }
-    }
-
-    private fun removePortFromUrl(url: String): String {
-        return try {
-            val uri = url.toUri()
-            URI(uri.scheme, uri.host, uri.path, uri.fragment).toString()
-        } catch (e: Exception) {
-            url
         }
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200581511062568/task/1213811553375344?focus=true
Tech Design URL (if applicable):

### Description

Performance improvements related to tracker-detection. TrackerDetector.evaluate() runs once for every network request (every subresource of every page), so redundant work and allocations there add up across a browsing session. This PR removes wasted work without changing behaviour.

Changes:

- Removed a per-request DB query. The user allow-list check called UserAllowListDao.contains(host) on every request. It now uses the in-memory UserAllowListRepository, matching how CloakedCnameDetector already works. Same match semantics, no DB round-trip.
- Skip the content-blocking exception scan for non-blocked requests. contentBlocking.isAnException() (which scans the content-blocking / unprotected-temporary exception lists) was evaluated eagerly but only affects the block decision. It's now the last operand of the shouldBlock short-circuit, so it runs only for a request actually about to be blocked and is skipped for non-tracker path.
- Resolve the request URL's entity once per evaluation instead of twice (it was looked up both for the same-entity check and for the returned TrackingEvent).
- Resolve the request type once per tracker match in TdsClient, instead of recomputing UrlToTypeMapper.map() for every matching rule.
- Precompute the blocking-client list in addClient instead of rebuilding it (a new list + lambda) on every request.
- Reuse a shared Client.Result.NO_MATCH constant instead of allocating an identical result object on the non-match path.
- Earlier refactors on this branch: dedupe the trackingEvent overloads, entity-lookup methods, and URL port-removal logic.

All changes are behaviour-preserving; existing unit tests cover the matching/status logic and were updated where the allow-list dependency changed.

### Steps to test this PR

- [x] Run the unit tests: all should pass.
- [x] Install the app and browse a few tracker-heavy sites; confirm the Privacy Dashboard still lists blocked trackers and shows the correct counts/companies.
- [x] Disable protections for a site (add it to the allow-list) and confirm its trackers are no longer blocked (status USER_ALLOWED), then re-enable and confirm blocking resumes.
- [x] Verify a site with a tracker-allowlist / ad-click exemption still loads and reports the expected allowed status (not blocked).
- [x] Confirm CNAME-cloaked trackers are still detected and blocked.

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes run on every network request in core tracker-blocking logic; behavior is intended to be unchanged but regressions would affect privacy protections and allow-list semantics.
> 
> **Overview**
> Cuts redundant work in the **tracker-detection hot path** (`TrackerDetector.evaluate` and related clients), which runs for every subresource request.
> 
> **`TrackerDetectorImpl`** now uses the in-memory **`UserAllowListRepository`** instead of **`UserAllowListDao`**, caches the **blocking-client list** when clients are added, reuses **`Client.Result.NO_MATCH`**, resolves the request URL’s **entity once** for same-entity vs returned entity, and evaluates **`contentBlocking.isAnException` only as the last `shouldBlock` operand** so non-blocked requests skip that scan. **`TdsClient`** maps request type **once per tracker match** instead of per rule. **`TdsEntityLookup`** dedupes string/Uri entity walks via a shared **`entityForUri`** tailrec helper.
> 
> **`UriString.removePort`** is centralized (with unit tests); **`RealTrackerAllowlist`** and string-based evaluation use it instead of local port-stripping. **`WebViewRequestInterceptor`** merges duplicate **`trackingEvent`** overloads behind an optional **`uncloakedHost`** for CNAME re-evaluation.
> 
> Reference and unit tests are updated to inject **`UserAllowListRepository`** mocks/fakes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a794791ddf5a38f5ea869655ed67d8eff8bbbfb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->