### PR TITLE
Update PIR broker bundle - 2026-07-13

### DIFF
--- a/pir/pir-impl/src/main/assets/brokers/centeda.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/centeda.com.json
@@ -1,7 +1,7 @@
 {
   "name": "Centeda",
   "url": "centeda.com",
-  "version": "0.91.0",
+  "version": "0.92.0",
   "addedDatetime": 1677736800000,
   "optOutUrl": "https://centeda.com/ng/control/privacy",
   "steps": [
@@ -225,5 +225,5 @@
     "maintenanceScan": 120,
     "maxAttempts": -1
   },
-  "removedAt": null
+  "removedAt": 1783342151487
 }

--- a/pir/pir-impl/src/main/assets/brokers/mugshotlook.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/mugshotlook.com.json
@@ -1,7 +1,7 @@
 {
   "name": "MugshotLook",
   "url": "mugshotlook.com",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "parent": "privatereports.com",
   "optOutUrl": "https://www.mugshotlook.com/api/helper/optOutLight/search",
   "steps": [
@@ -12,7 +12,7 @@
         {
           "actionType": "navigate",
           "url": "https://www.mugshotlook.com/api/helper/optOutLight/search",
-          "id": "88ee28d0-e747-46bd-a4c4-493603935126"
+          "id": "07902ac5-c9ab-40da-a5b3-210dab3b3e43"
         },
         {
           "actionType": "expectation",
@@ -22,7 +22,7 @@
               "selector": "#pageForm"
             }
           ],
-          "id": "e9f535f8-e54e-40f6-a0d2-9f6c385bd0e5"
+          "id": "9394505c-09a3-4d3d-a4b9-be962ada81fe"
         },
         {
           "actionType": "fillForm",
@@ -46,7 +46,7 @@
               "selector": "select[name='state']"
             }
           ],
-          "id": "178153eb-8fdf-4c22-b3c2-034b70677394"
+          "id": "7f1a1a69-4700-4901-b111-8196ab6819df"
         },
         {
           "actionType": "click",
@@ -56,7 +56,7 @@
               "selector": "#pageFormSubmitBtn"
             }
           ],
-          "id": "5db69b2f-c141-409f-a975-8507397b3009"
+          "id": "dbc87b8c-c6a3-40b5-8612-1c035eb58ff4"
         },
         {
           "_comment": "Turnstile auto-completes (there are two sequential turnstiles). This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
@@ -67,17 +67,7 @@
               "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
             }
           ],
-          "id": "cft-43f45274-51a4-4ce7-9218-d2550073cc07"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": ".header"
-            }
-          ],
-          "id": "3a1b536b-7d08-4489-a3b0-e35b5c8a3ee6"
+          "id": "cft-662cf736-05c4-4eef-aeaa-e27b1f31d2e3"
         },
         {
           "actionType": "expectation",
@@ -87,58 +77,76 @@
               "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]"
             }
           ],
-          "id": "be11d724-549b-4620-bcdd-2250569b4d86"
+          "id": "795977ce-d1a9-4a22-935c-696e2fa7ee52"
         },
         {
-          "actionType": "condition",
-          "_comment": "captcha is not always present at this stage",
-          "expectations": [
+          "actionType": "getCaptchaInfo",
+          "captchaType": "image",
+          "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//*[local-name()='svg']",
+          "id": "a4cdf374-883c-40d5-ae9c-5246bd801c04"
+        },
+        {
+          "actionType": "solveCaptcha",
+          "captchaType": "image",
+          "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//input",
+          "id": "50560f66-6aa5-4078-ae13-4311585ebe40"
+        },
+        {
+          "actionType": "click",
+          "elements": [
             {
-              "type": "element",
-              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]"
+              "type": "button",
+              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//button"
             }
           ],
-          "actions": [
-            {
-              "actionType": "getCaptchaInfo",
-              "captchaType": "image",
-              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//*[local-name()='svg']",
-              "id": "dd8e0ac7-e54b-4f01-89db-6b1840108119"
-            },
-            {
-              "actionType": "solveCaptcha",
-              "captchaType": "image",
-              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//input",
-              "id": "f6c2395d-3df4-4f96-b06a-6eff640e572b"
-            },
-            {
-              "actionType": "click",
-              "failSilently": true,
-              "elements": [
-                {
-                  "type": "button",
-                  "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//button"
-                }
-              ],
-              "id": "06de7b66-5c0a-4d10-825e-28df89dcbd97"
-            }
-          ],
-          "id": "acb647eb-ae04-4afa-bac5-4bf2373376ea"
+          "id": "67502891-51de-4379-bd77-23d3c56a0919"
         },
         {
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": ".header"
+              "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]"
             }
           ],
-          "id": "116cc890-4471-4e36-ad3f-98894392e6d1"
+          "id": "096aff87-35e4-4cc7-a31d-7fd4d7d0343f"
+        },
+        {
+          "actionType": "getCaptchaInfo",
+          "captchaType": "basic-math",
+          "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]//img[starts-with(@src, 'data:')]",
+          "id": "b9edaf17-eb4d-4e17-84ef-fdbffad923f9"
+        },
+        {
+          "actionType": "solveCaptcha",
+          "captchaType": "basic-math",
+          "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]//input",
+          "id": "1609574f-4136-4537-81b0-30c4a8fef9cc"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]//button"
+            }
+          ],
+          "id": "6cc69c9a-d973-480d-9e68-7c17d3ac0c79"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//h2[contains(text(), 'Select the person')]"
+            }
+          ],
+          "id": "a2c28817-499d-4c1a-a622-499922bc410d"
         },
         {
           "actionType": "extract",
           "selector": "//h2[contains(text(), 'Select the person')]/following-sibling::div/div",
-          "noResultsSelector": "//p[contains(text(), 'unable to find')]|//p[contains(text(), 'Too many')]",
+          "noResultsSelector": "//h1[contains(text(), 'unable to find')]",
           "profile": {
             "name": {
               "selector": ".//span[contains(text(), 'Name')]/following-sibling::span[1]"
@@ -154,7 +162,7 @@
               "identifierType": "hash"
             }
           },
-          "id": "3ecc7abc-8bfc-40db-80b0-e7087b99bcef"
+          "id": "21c075ac-82ef-4051-b47a-b900983f83ee"
         }
       ]
     },

--- a/pir/pir-impl/src/main/assets/brokers/peoplesearcher.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/peoplesearcher.com.json
@@ -1,7 +1,7 @@
 {
   "name": "PeopleSearcher",
   "url": "peoplesearcher.com",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "parent": "privatereports.com",
   "optOutUrl": "https://www.peoplesearcher.com/api/helper/optOutLight/search",
   "steps": [
@@ -12,7 +12,7 @@
         {
           "actionType": "navigate",
           "url": "https://www.peoplesearcher.com/api/helper/optOutLight/search",
-          "id": "5a163537-6f89-4652-9a87-0b8054e72bbf"
+          "id": "455eb22d-89ba-46f5-8bd9-ad623ef956a1"
         },
         {
           "actionType": "expectation",
@@ -22,7 +22,7 @@
               "selector": "#pageForm"
             }
           ],
-          "id": "6a0060da-1616-40b2-a307-1315490b5b2c"
+          "id": "461c5606-304b-44f5-a538-a8ee4e06c1a0"
         },
         {
           "actionType": "fillForm",
@@ -46,7 +46,7 @@
               "selector": "select[name='state']"
             }
           ],
-          "id": "5aa3746a-ff05-4c2e-bf33-90b6af8dc9c6"
+          "id": "4728b06a-f4fc-45cd-8198-5076914f808c"
         },
         {
           "actionType": "click",
@@ -56,7 +56,7 @@
               "selector": "#pageFormSubmitBtn"
             }
           ],
-          "id": "c21237ee-6988-4278-9c32-350f82424f35"
+          "id": "d13f3f5c-5a31-43ea-98bd-a454980c5886"
         },
         {
           "_comment": "Turnstile auto-completes (there are two sequential turnstiles). This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
@@ -67,17 +67,7 @@
               "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
             }
           ],
-          "id": "cft-69d7e91e-9c5d-4523-b625-2decd2b697a0"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": ".header"
-            }
-          ],
-          "id": "5ae1dce2-5e4e-4b1f-8649-878071d915c4"
+          "id": "cft-34cf6366-7c37-4176-acf3-1c3d5fd60833"
         },
         {
           "actionType": "expectation",
@@ -87,58 +77,76 @@
               "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]"
             }
           ],
-          "id": "f39d9b96-09a5-4e3d-a33f-bfaa191aa2c9"
+          "id": "c67ceb16-be63-4b66-861a-cc71043b9566"
         },
         {
-          "actionType": "condition",
-          "_comment": "captcha is not always present at this stage",
-          "expectations": [
+          "actionType": "getCaptchaInfo",
+          "captchaType": "image",
+          "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//*[local-name()='svg']",
+          "id": "6a89bef5-3ae3-42de-a81b-ca22d750e5c0"
+        },
+        {
+          "actionType": "solveCaptcha",
+          "captchaType": "image",
+          "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//input",
+          "id": "0095812c-d14a-4e25-8ecc-476ae880bc85"
+        },
+        {
+          "actionType": "click",
+          "elements": [
             {
-              "type": "element",
-              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]"
+              "type": "button",
+              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//button"
             }
           ],
-          "actions": [
-            {
-              "actionType": "getCaptchaInfo",
-              "captchaType": "image",
-              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//*[local-name()='svg']",
-              "id": "21b3db05-32f2-4089-b6f7-83854ea4e6b2"
-            },
-            {
-              "actionType": "solveCaptcha",
-              "captchaType": "image",
-              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//input",
-              "id": "8b257457-aa7e-4883-9019-13a1eaf72dc6"
-            },
-            {
-              "actionType": "click",
-              "failSilently": true,
-              "elements": [
-                {
-                  "type": "button",
-                  "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//button"
-                }
-              ],
-              "id": "ec410930-89bd-4f4d-93fa-73276decfa98"
-            }
-          ],
-          "id": "3534def6-b37a-45ce-a3e5-5095757952f0"
+          "id": "3a2ab4e9-2925-4efc-b008-93c88bb5e5ba"
         },
         {
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": ".header"
+              "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]"
             }
           ],
-          "id": "a8de391d-c7cb-4d89-9ac2-f47368c6f347"
+          "id": "7f10e183-9081-4d46-b604-e2aadc311f63"
+        },
+        {
+          "actionType": "getCaptchaInfo",
+          "captchaType": "basic-math",
+          "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]//img[starts-with(@src, 'data:')]",
+          "id": "75b449a8-0b27-4308-9bca-4bede41b5d7a"
+        },
+        {
+          "actionType": "solveCaptcha",
+          "captchaType": "basic-math",
+          "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]//input",
+          "id": "778f6b25-432e-4a84-989b-51b9f0decec3"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]//button"
+            }
+          ],
+          "id": "6ba335c5-8237-4e5d-9df0-702cf957c138"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//h2[contains(text(), 'Select the person')]"
+            }
+          ],
+          "id": "ca9c864a-0ab0-4955-bf38-e3a85b36fb5a"
         },
         {
           "actionType": "extract",
           "selector": "//h2[contains(text(), 'Select the person')]/following-sibling::div/div",
-          "noResultsSelector": "//p[contains(text(), 'unable to find')]|//p[contains(text(), 'Too many')]",
+          "noResultsSelector": "//h1[contains(text(), 'unable to find')]",
           "profile": {
             "name": {
               "selector": ".//span[contains(text(), 'Name')]/following-sibling::span[1]"
@@ -154,7 +162,7 @@
               "identifierType": "hash"
             }
           },
-          "id": "b235a497-3ceb-4dee-9704-dcda0349bd3a"
+          "id": "8bacf94c-e96d-4d15-b313-691aff7e2673"
         }
       ]
     },

--- a/pir/pir-impl/src/main/assets/brokers/peoplesearchnow.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/peoplesearchnow.com.json
@@ -1,7 +1,7 @@
 {
   "name": "People Search Now",
   "url": "peoplesearchnow.com",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "parent": "peoplefinders.com",
   "addedDatetime": 1705989600000,
   "optOutUrl": "https://www.peoplesearchnow.com/opt-out",
@@ -17,11 +17,11 @@
         },
         {
           "actionType": "expectation",
-          "_comment": "detect Cloudflare verification UI - challenge pages expose Cloudflare challenge scripts, Turnstile controls, or captcha response fields instead of normal result cards",
+          "_comment": "detect Cloudflare verification UI - challenge pages expose Cloudflare challenge scripts (the _cf_chl_opt inline script is present in the static HTML before the challenge-platform script is injected), Turnstile controls, or captcha response fields, and hard block pages render div#cf-error-details",
           "expectations": [
             {
               "type": "element",
-              "selector": "//body[not(.//script[contains(@src,'/cdn-cgi/challenge-platform/')] or .//script[contains(@src,'challenges.cloudflare.com/turnstile')] or .//input[@name='cf-turnstile-response'] or .//iframe[contains(@src,'challenges.cloudflare.com')])]"
+              "selector": "//body[not(.//script[contains(@src,'/cdn-cgi/challenge-platform/')] or .//script[contains(., '_cf_chl_opt')] or .//script[contains(@src,'challenges.cloudflare.com/turnstile')] or .//input[@name='cf-turnstile-response'] or .//iframe[contains(@src,'challenges.cloudflare.com')] or .//div[@id='cf-error-details'])]"
             }
           ],
           "id": "b00ba411-0253-42ad-bbc4-b4b0940df3a7"

--- a/pir/pir-impl/src/main/assets/brokers/privatereports.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/privatereports.com.json
@@ -1,7 +1,7 @@
 {
   "name": "PrivateReports",
   "url": "privatereports.com",
-  "version": "0.996.1",
+  "version": "0.997.0",
   "optOutUrl": "https://www.privatereports.com/api/helper/optOutLight/search",
   "steps": [
     {
@@ -73,72 +73,79 @@
           "expectations": [
             {
               "type": "element",
-              "selector": ".header"
-            }
-          ],
-          "id": "99db0f13-8684-4e59-ba7a-56d994f3e37e"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "element",
               "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]"
             }
           ],
           "id": "6d9a398c-b73d-496a-bd2d-38d725f89b5e"
         },
         {
-          "actionType": "condition",
-          "_comment": "captcha is not always present at this stage",
-          "expectations": [
+          "actionType": "getCaptchaInfo",
+          "captchaType": "image",
+          "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//*[local-name()='svg']",
+          "id": "1f123c7a-aef4-ae11-bccc-0a11b2c3d4e5"
+        },
+        {
+          "actionType": "solveCaptcha",
+          "captchaType": "image",
+          "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//input",
+          "id": "8793bcd5-e0a6-4c23-a202-26441c35ff6a"
+        },
+        {
+          "actionType": "click",
+          "elements": [
             {
-              "type": "element",
-              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]",
-              "failSilently": true
+              "type": "button",
+              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//button"
             }
           ],
-          "actions": [
-            {
-              "actionType": "getCaptchaInfo",
-              "captchaType": "image",
-              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//*[local-name()='svg']",
-              "id": "1f123c7a-aef4-ae11-bccc-0a11b2c3d4e5"
-            },
-            {
-              "actionType": "solveCaptcha",
-              "captchaType": "image",
-              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//input",
-              "id": "8793bcd5-e0a6-4c23-a202-26441c35ff6a"
-            },
-            {
-              "actionType": "click",
-              "failSilently": true,
-              "elements": [
-                {
-                  "type": "button",
-                  "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//button"
-                }
-              ],
-              "id": "b12b0603-0ef9-4de6-97e9-0fd426b7cae1"
-            }
-          ],
-          "id": "9b7a7b96-9ef5-470d-8479-1bedca58b188"
+          "id": "b12b0603-0ef9-4de6-97e9-0fd426b7cae1"
         },
         {
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": ".header"
+              "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]"
             }
           ],
-          "id": "cc46f244-d6c8-421b-8e94-02bcde556f5b"
+          "id": "b8755244-76cc-467b-90e6-d545d3f985b6"
+        },
+        {
+          "actionType": "getCaptchaInfo",
+          "captchaType": "basic-math",
+          "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]//img[starts-with(@src, 'data:')]",
+          "id": "a2d1b8a4-2973-40d3-820f-1451daff0d5d"
+        },
+        {
+          "actionType": "solveCaptcha",
+          "captchaType": "basic-math",
+          "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]//input",
+          "id": "9cb73518-0935-4325-9031-a04d8dc2fb3b"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]//button"
+            }
+          ],
+          "id": "bd23fa8a-7ab8-4a5a-a076-112666f3e2e1"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//h2[contains(text(), 'Select the person')]"
+            }
+          ],
+          "id": "e8630131-ee9f-4100-a691-2d9de7aefaba"
         },
         {
           "actionType": "extract",
           "selector": "//h2[contains(text(), 'Select the person')]/following-sibling::div/div",
-          "noResultsSelector": "//p[contains(text(), 'unable to find')]|//p[contains(text(), 'Too many')]",
+          "noResultsSelector": "//h1[contains(text(), 'unable to find')]",
           "profile": {
             "name": {
               "selector": ".//span[contains(text(), 'Name')]/following-sibling::span[1]"
@@ -165,7 +172,7 @@
         {
           "actionType": "navigate",
           "url": "https://www.privatereports.com/api/helper/optOutLight/search",
-          "id": "14fbe352-5ff1-4b48-a50a-454aa1c8aec4"
+          "id": "ee6bd15e-5721-45d3-a832-8068744d612d"
         },
         {
           "actionType": "expectation",
@@ -175,7 +182,7 @@
               "selector": "#pageForm"
             }
           ],
-          "id": "75f9fc71-1f4d-495a-b0c8-5b8df0f24e98"
+          "id": "3ba9becd-8619-4dfa-9d07-c69c1e2237e5"
         },
         {
           "actionType": "fillForm",
@@ -199,7 +206,7 @@
               "selector": "select[name='state']"
             }
           ],
-          "id": "a541b4f0-1d03-40f4-8bef-dd6edba7e0c3"
+          "id": "39d9bb44-d7f5-4e98-ad96-d98bbc1f6f76"
         },
         {
           "actionType": "click",
@@ -209,7 +216,7 @@
               "selector": "#pageFormSubmitBtn"
             }
           ],
-          "id": "c91a389d-3079-4537-9d39-f7b8a49ebec4"
+          "id": "d66f174b-d372-4084-80e0-05a3a2970361"
         },
         {
           "_comment": "Turnstile auto-completes (there are two sequential turnstiles). This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
@@ -220,17 +227,7 @@
               "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
             }
           ],
-          "id": "cft-44601f5a-1243-434b-b1ef-974254ccb679"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": ".header"
-            }
-          ],
-          "id": "0af33833-87a8-40d8-835e-347bcf1d0f00"
+          "id": "cft-239f0d73-9586-466b-a0ba-ded853a52f9c"
         },
         {
           "actionType": "expectation",
@@ -240,54 +237,71 @@
               "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]"
             }
           ],
-          "id": "d059eb01-9fda-46d2-8759-50370c724392"
+          "id": "4661fde9-a2b3-4737-a6e8-04abcd52dd9d"
         },
         {
-          "actionType": "condition",
-          "_comment": "captcha is not always present at this stage",
-          "expectations": [
+          "actionType": "getCaptchaInfo",
+          "captchaType": "image",
+          "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//*[local-name()='svg']",
+          "id": "28daef47-0f65-470d-842a-a24f4bc7f450"
+        },
+        {
+          "actionType": "solveCaptcha",
+          "captchaType": "image",
+          "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//input",
+          "id": "fdee849f-750d-4c38-bb2e-1c9d1323a370"
+        },
+        {
+          "actionType": "click",
+          "elements": [
             {
-              "type": "element",
-              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]",
-              "failSilently": true
+              "type": "button",
+              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//button"
             }
           ],
-          "actions": [
-            {
-              "actionType": "getCaptchaInfo",
-              "captchaType": "image",
-              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//*[local-name()='svg']",
-              "id": "8fcffef9-0af4-47b4-9fee-55f7c7ca0079"
-            },
-            {
-              "actionType": "solveCaptcha",
-              "captchaType": "image",
-              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//input",
-              "id": "a1978d37-638a-4917-b7b6-39504adcb803"
-            },
-            {
-              "actionType": "click",
-              "failSilently": true,
-              "elements": [
-                {
-                  "type": "button",
-                  "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//button"
-                }
-              ],
-              "id": "e94074e2-930a-442f-970e-10e088a9002f"
-            }
-          ],
-          "id": "35643322-f1fd-45fd-83e6-9b7c63d62053"
+          "id": "ee7cd4ca-07b6-4490-8112-cd6582723469"
         },
         {
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": ".header"
+              "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]"
             }
           ],
-          "id": "4d557643-bf75-4fdc-9f1d-1f47723293bd"
+          "id": "7b081c3a-cc08-4922-b849-ffefc3b721d1"
+        },
+        {
+          "actionType": "getCaptchaInfo",
+          "captchaType": "basic-math",
+          "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]//img[starts-with(@src, 'data:')]",
+          "id": "110404fa-06c3-4c69-b85e-57e0dd5e2303"
+        },
+        {
+          "actionType": "solveCaptcha",
+          "captchaType": "basic-math",
+          "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]//input",
+          "id": "e532f947-c6cf-470f-b4fb-9dfc648b2184"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]//button"
+            }
+          ],
+          "id": "5cf2cbdf-0e25-49af-89e0-7b5497c1e482"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//h2[contains(text(), 'Select the person')]"
+            }
+          ],
+          "id": "2a4c2673-8e72-4e8c-95ab-481a86421dfb"
         },
         {
           "actionType": "click",
@@ -368,6 +382,81 @@
           "id": "d9a240ff-2e91-4232-b247-6764d5b7db8f"
         },
         {
+          "_comment": "Turnstile auto-completes. This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
+            }
+          ],
+          "id": "cft-a4a2d933-1880-4e4d-9b72-8e34c429ba53"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]"
+            }
+          ],
+          "id": "ad035257-2b44-4c48-a012-1ac20bb54659"
+        },
+        {
+          "actionType": "getCaptchaInfo",
+          "captchaType": "image",
+          "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//*[local-name()='svg']",
+          "id": "f09c5855-e04e-42cf-9a49-4a8c6f8ae058"
+        },
+        {
+          "actionType": "solveCaptcha",
+          "captchaType": "image",
+          "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//input",
+          "id": "a60b20ce-0b68-41ec-bbd5-beaaf3b1c8e8"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//button"
+            }
+          ],
+          "id": "12517d5c-a7f7-4a38-bb6b-b9ed3bf5408c"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]"
+            }
+          ],
+          "id": "316a7e0a-af1f-4c5e-8614-f4d326fa3dd9"
+        },
+        {
+          "actionType": "getCaptchaInfo",
+          "captchaType": "basic-math",
+          "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]//img[starts-with(@src, 'data:')]",
+          "id": "8477f1e0-1bc7-4cc5-9894-b7e2681b90b9"
+        },
+        {
+          "actionType": "solveCaptcha",
+          "captchaType": "basic-math",
+          "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]//input",
+          "id": "04440dfa-863f-4d9a-89ba-28b2282a41bb"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]//button"
+            }
+          ],
+          "id": "b4e41f44-b879-42aa-846d-a02f870ea65b"
+        },
+        {
           "actionType": "expectation",
           "expectations": [
             {
@@ -383,14 +472,47 @@
           "id": "d0cf178e-ffb5-4966-9312-25eef0f78731"
         },
         {
+          "_comment": "Turnstile auto-completes. This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": ".header"
+              "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
             }
           ],
-          "id": "7e8a82ae-d3b9-4c29-999a-1e2c25a04416"
+          "id": "cft-203fd0d5-805e-40a0-9478-0e793fdc0a8f"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]"
+            }
+          ],
+          "id": "8d6e9ab4-579a-4875-841f-b5f888093f37"
+        },
+        {
+          "actionType": "getCaptchaInfo",
+          "captchaType": "image",
+          "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//*[local-name()='svg']",
+          "id": "0906664c-099e-46bc-b8aa-62bda03c6273"
+        },
+        {
+          "actionType": "solveCaptcha",
+          "captchaType": "image",
+          "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//input",
+          "id": "ea4bded6-af20-4f67-85b9-2e402980f06f"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//button"
+            }
+          ],
+          "id": "00731d9d-3da4-4b54-8601-6d50a343cc8f"
         },
         {
           "actionType": "expectation",

--- a/pir/pir-impl/src/main/assets/brokers/publicsearcher.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/publicsearcher.com.json
@@ -1,7 +1,7 @@
 {
   "name": "PublicSearcher",
   "url": "publicsearcher.com",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "parent": "privatereports.com",
   "optOutUrl": "https://www.publicsearcher.com/api/helper/optOutLight/search",
   "steps": [
@@ -12,7 +12,7 @@
         {
           "actionType": "navigate",
           "url": "https://www.publicsearcher.com/api/helper/optOutLight/search",
-          "id": "331b4f4e-5534-43f5-90f8-589c89d59a8d"
+          "id": "2f986497-b5f0-45da-b672-799052d3e3b0"
         },
         {
           "actionType": "expectation",
@@ -22,7 +22,7 @@
               "selector": "#pageForm"
             }
           ],
-          "id": "7f069b71-df6f-4044-86a5-fe1d13956071"
+          "id": "40b74f48-4010-46ab-9f55-a7e71d164afb"
         },
         {
           "actionType": "fillForm",
@@ -46,7 +46,7 @@
               "selector": "select[name='state']"
             }
           ],
-          "id": "92ae2b11-0952-4a81-ac0b-2c02a1a9c2d5"
+          "id": "f13d20f6-10cc-4902-b0c3-b88e69d574b4"
         },
         {
           "actionType": "click",
@@ -56,7 +56,7 @@
               "selector": "#pageFormSubmitBtn"
             }
           ],
-          "id": "f9e9b48c-a0e7-4bab-8344-76a04f0c4cb3"
+          "id": "ec7aa583-3925-40d0-811d-68bd5f11ce2b"
         },
         {
           "_comment": "Turnstile auto-completes (there are two sequential turnstiles). This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
@@ -67,17 +67,7 @@
               "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
             }
           ],
-          "id": "cft-48ab0132-8c30-4b1e-a731-7d0a736bb3f6"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": ".header"
-            }
-          ],
-          "id": "5b46e666-e1ae-48e4-ae39-4ffc025e332c"
+          "id": "cft-a85fc89d-dcb2-45b7-a8d0-8ca6c36cf3c0"
         },
         {
           "actionType": "expectation",
@@ -87,58 +77,76 @@
               "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]"
             }
           ],
-          "id": "bfa4006f-c1cc-4244-8259-d97470421077"
+          "id": "0a545607-adcc-41f5-b438-671879a1f9a0"
         },
         {
-          "actionType": "condition",
-          "_comment": "captcha is not always present at this stage",
-          "expectations": [
+          "actionType": "getCaptchaInfo",
+          "captchaType": "image",
+          "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//*[local-name()='svg']",
+          "id": "d70294f8-6e10-45a2-bfab-d5792c85cc91"
+        },
+        {
+          "actionType": "solveCaptcha",
+          "captchaType": "image",
+          "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//input",
+          "id": "1b29d94f-6cc3-4ef5-b2a8-cb138cfb7b19"
+        },
+        {
+          "actionType": "click",
+          "elements": [
             {
-              "type": "element",
-              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]"
+              "type": "button",
+              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//button"
             }
           ],
-          "actions": [
-            {
-              "actionType": "getCaptchaInfo",
-              "captchaType": "image",
-              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//*[local-name()='svg']",
-              "id": "c8b53a54-2719-465b-88c3-0eda49c9ce52"
-            },
-            {
-              "actionType": "solveCaptcha",
-              "captchaType": "image",
-              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//input",
-              "id": "88eb51cd-1af4-4dca-996c-0cafae0533e2"
-            },
-            {
-              "actionType": "click",
-              "failSilently": true,
-              "elements": [
-                {
-                  "type": "button",
-                  "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//button"
-                }
-              ],
-              "id": "47a5210d-7a5f-4336-9eb8-5aa97f6eb9fb"
-            }
-          ],
-          "id": "41c5e3f5-c852-4098-8306-550700e01736"
+          "id": "eeae1cb1-463f-4b27-9ddb-90f73f0b4268"
         },
         {
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": ".header"
+              "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]"
             }
           ],
-          "id": "eb63bfb5-c3fa-4c4e-a1be-86e9a7b31775"
+          "id": "5ae94bf5-cf55-4bc5-8e0a-4173ff96f91b"
+        },
+        {
+          "actionType": "getCaptchaInfo",
+          "captchaType": "basic-math",
+          "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]//img[starts-with(@src, 'data:')]",
+          "id": "f9225e1b-998a-49f4-9c37-2c2b02b99cf6"
+        },
+        {
+          "actionType": "solveCaptcha",
+          "captchaType": "basic-math",
+          "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]//input",
+          "id": "4b10e09f-95a8-44df-8b2c-8f1ffea114d1"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]//button"
+            }
+          ],
+          "id": "b9806307-79f0-49db-b89f-8f29bd061c61"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//h2[contains(text(), 'Select the person')]"
+            }
+          ],
+          "id": "6b00357d-1805-49f1-8ac6-a7c9eeca5ec8"
         },
         {
           "actionType": "extract",
           "selector": "//h2[contains(text(), 'Select the person')]/following-sibling::div/div",
-          "noResultsSelector": "//p[contains(text(), 'unable to find')]|//p[contains(text(), 'Too many')]",
+          "noResultsSelector": "//h1[contains(text(), 'unable to find')]",
           "profile": {
             "name": {
               "selector": ".//span[contains(text(), 'Name')]/following-sibling::span[1]"
@@ -154,7 +162,7 @@
               "identifierType": "hash"
             }
           },
-          "id": "a75cc46f-81dd-4257-b241-964632818184"
+          "id": "08bd68e2-fb82-46b0-9d50-3d1bb5f74040"
         }
       ]
     },

--- a/pir/pir-impl/src/main/assets/brokers/secretinfo.org.json
+++ b/pir/pir-impl/src/main/assets/brokers/secretinfo.org.json
@@ -1,7 +1,7 @@
 {
   "name": "SecretInfo",
   "url": "secretinfo.org",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "parent": "privatereports.com",
   "optOutUrl": "https://www.secretinfo.org/api/helper/optOutLight/search",
   "steps": [
@@ -12,7 +12,7 @@
         {
           "actionType": "navigate",
           "url": "https://www.secretinfo.org/api/helper/optOutLight/search",
-          "id": "0834d4a6-6613-4d00-bda0-8031242778b3"
+          "id": "7ad03584-0245-4fae-b4a3-25bc781e6bc5"
         },
         {
           "actionType": "expectation",
@@ -22,7 +22,7 @@
               "selector": "#pageForm"
             }
           ],
-          "id": "a2a57479-12e6-48c0-ae45-15b0ac441e9a"
+          "id": "fb7a7ecf-1b96-4cb7-af9f-c7f35a67d88e"
         },
         {
           "actionType": "fillForm",
@@ -46,7 +46,7 @@
               "selector": "select[name='state']"
             }
           ],
-          "id": "091fcc8d-0e7b-4c1e-8bec-9cf1ab7e423b"
+          "id": "32014c11-3920-4f30-a6c8-691194352313"
         },
         {
           "actionType": "click",
@@ -56,7 +56,7 @@
               "selector": "#pageFormSubmitBtn"
             }
           ],
-          "id": "99f4b4ad-31cc-4ae0-8f0f-2b04e1e8cfb1"
+          "id": "481ea734-fa07-43f4-9a58-cf1126d4a3b3"
         },
         {
           "_comment": "Turnstile auto-completes (there are two sequential turnstiles). This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
@@ -67,17 +67,7 @@
               "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
             }
           ],
-          "id": "cft-fe95410e-a7a7-49ed-ad02-11eadbcb1875"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": ".header"
-            }
-          ],
-          "id": "50ef537c-a958-4201-8a2a-2235bf2810c4"
+          "id": "cft-6adc30ae-8b22-4362-a9f8-d94d877a78ad"
         },
         {
           "actionType": "expectation",
@@ -87,58 +77,76 @@
               "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]"
             }
           ],
-          "id": "bff38cd3-f87d-4d9d-b405-d8d00bb00f14"
+          "id": "b401091c-b346-400e-939b-6b60383f148f"
         },
         {
-          "actionType": "condition",
-          "_comment": "captcha is not always present at this stage",
-          "expectations": [
+          "actionType": "getCaptchaInfo",
+          "captchaType": "image",
+          "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//*[local-name()='svg']",
+          "id": "6918eb8b-3e47-4db3-a2f0-e8779b3045f3"
+        },
+        {
+          "actionType": "solveCaptcha",
+          "captchaType": "image",
+          "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//input",
+          "id": "178680f9-9807-49f6-b0d6-66a79270fc91"
+        },
+        {
+          "actionType": "click",
+          "elements": [
             {
-              "type": "element",
-              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]"
+              "type": "button",
+              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//button"
             }
           ],
-          "actions": [
-            {
-              "actionType": "getCaptchaInfo",
-              "captchaType": "image",
-              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//*[local-name()='svg']",
-              "id": "c68b8c21-fdcb-46cc-b657-6ee3a7bc02b1"
-            },
-            {
-              "actionType": "solveCaptcha",
-              "captchaType": "image",
-              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//input",
-              "id": "29d92fc8-9746-4d1a-883d-7b045eb40b75"
-            },
-            {
-              "actionType": "click",
-              "failSilently": true,
-              "elements": [
-                {
-                  "type": "button",
-                  "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//button"
-                }
-              ],
-              "id": "9bc05a90-f6ae-48fd-b571-537ab510c80d"
-            }
-          ],
-          "id": "5266d408-836e-402f-b4b1-1b931b51aa39"
+          "id": "3e6812f0-392b-49da-b8b9-e45a6f544981"
         },
         {
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": ".header"
+              "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]"
             }
           ],
-          "id": "9d498876-8b9c-491c-a31a-4eec1accf33c"
+          "id": "854b3849-f924-4854-943c-8e23e9d9f2c5"
+        },
+        {
+          "actionType": "getCaptchaInfo",
+          "captchaType": "basic-math",
+          "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]//img[starts-with(@src, 'data:')]",
+          "id": "d2161868-cf31-4165-b125-bfab5a26a195"
+        },
+        {
+          "actionType": "solveCaptcha",
+          "captchaType": "basic-math",
+          "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]//input",
+          "id": "32dd5efb-e19e-434d-878d-fda045decf07"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]//button"
+            }
+          ],
+          "id": "368a7446-0d05-41a9-a2fd-a9ec3b7d482f"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//h2[contains(text(), 'Select the person')]"
+            }
+          ],
+          "id": "89854263-5fbc-4f5f-b859-113fe4e75086"
         },
         {
           "actionType": "extract",
           "selector": "//h2[contains(text(), 'Select the person')]/following-sibling::div/div",
-          "noResultsSelector": "//p[contains(text(), 'unable to find')]|//p[contains(text(), 'Too many')]",
+          "noResultsSelector": "//h1[contains(text(), 'unable to find')]",
           "profile": {
             "name": {
               "selector": ".//span[contains(text(), 'Name')]/following-sibling::span[1]"
@@ -154,7 +162,7 @@
               "identifierType": "hash"
             }
           },
-          "id": "2edfae8c-bbf5-469f-a052-68f75f0659b3"
+          "id": "9593882e-efba-455c-b9ce-d00b4976ba1a"
         }
       ]
     },

--- a/pir/pir-impl/src/main/assets/brokers/truepeoplesearch.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/truepeoplesearch.com.json
@@ -1,7 +1,7 @@
 {
   "name": "TruePeopleSearch",
   "url": "truepeoplesearch.com",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "parent": "peoplefinders.com",
   "addedDatetime": 1703138400000,
   "optOutUrl": "https://www.truepeoplesearch.com/removal",
@@ -28,11 +28,11 @@
         },
         {
           "actionType": "expectation",
-          "_comment": "detect Cloudflare verification UI - older blocks use form#captchaForm, newer blocks keep the page shell but show a Turnstile widget instead of results",
+          "_comment": "detect Cloudflare verification UI - older blocks use form#captchaForm, newer blocks keep the page shell but show a Turnstile widget instead of results (the _cf_chl_opt inline script is present in the static HTML before the challenge-platform script is injected), and hard block pages render div#cf-error-details",
           "expectations": [
             {
               "type": "element",
-              "selector": "//body[not(.//form[@id='captchaForm'] or .//script[contains(@src,'/cdn-cgi/challenge-platform/')] or .//script[contains(@src,'challenges.cloudflare.com/turnstile')] or .//input[@name='cf-turnstile-response'])]"
+              "selector": "//body[not(.//form[@id='captchaForm'] or .//script[contains(@src,'/cdn-cgi/challenge-platform/')] or .//script[contains(., '_cf_chl_opt')] or .//script[contains(@src,'challenges.cloudflare.com/turnstile')] or .//input[@name='cf-turnstile-response'] or .//div[@id='cf-error-details'])]"
             }
           ],
           "id": "9ea1684f-1953-45b7-954e-d1597a0c5063"

--- a/pir/pir-impl/src/main/assets/brokers/truthrecord.org.json
+++ b/pir/pir-impl/src/main/assets/brokers/truthrecord.org.json
@@ -1,7 +1,7 @@
 {
   "name": "TruthRecord",
   "url": "truthrecord.org",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "parent": "privatereports.com",
   "optOutUrl": "https://www.truthrecord.org/api/helper/optOutLight/search",
   "steps": [
@@ -12,7 +12,7 @@
         {
           "actionType": "navigate",
           "url": "https://www.truthrecord.org/api/helper/optOutLight/search",
-          "id": "07693f63-db90-42c7-b9aa-5cdaab2f6fff"
+          "id": "68957c56-bc98-4714-a193-22d34f37fbea"
         },
         {
           "actionType": "expectation",
@@ -22,7 +22,7 @@
               "selector": "#pageForm"
             }
           ],
-          "id": "3c5dc220-e58b-44ef-a846-576ed358f133"
+          "id": "83904dad-b92f-4d17-bc10-f682ff3020fe"
         },
         {
           "actionType": "fillForm",
@@ -46,7 +46,7 @@
               "selector": "select[name='state']"
             }
           ],
-          "id": "a7f3df7f-7f72-45a8-9136-a253791bb936"
+          "id": "15b4a36f-1b7d-4f99-a6d9-1e602bfdb0ab"
         },
         {
           "actionType": "click",
@@ -56,7 +56,7 @@
               "selector": "#pageFormSubmitBtn"
             }
           ],
-          "id": "387b7d89-5762-4056-b716-c9ff0d27c775"
+          "id": "28e8131d-11f0-452c-baf5-4a2abb72942d"
         },
         {
           "_comment": "Turnstile auto-completes (there are two sequential turnstiles). This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
@@ -67,17 +67,7 @@
               "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
             }
           ],
-          "id": "cft-715cb574-a694-43b6-8c27-7afb04b4ad6d"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": ".header"
-            }
-          ],
-          "id": "1c2561d3-d767-401d-aef7-f16e8c9c3bd4"
+          "id": "cft-5c31954f-2549-4cbc-ae13-925e1bd6aad1"
         },
         {
           "actionType": "expectation",
@@ -87,58 +77,76 @@
               "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]"
             }
           ],
-          "id": "d3a20ab9-d1bc-40b6-964f-78c77b83f0ce"
+          "id": "01b021eb-decf-4da4-9f2a-8c8851a81646"
         },
         {
-          "actionType": "condition",
-          "_comment": "captcha is not always present at this stage",
-          "expectations": [
+          "actionType": "getCaptchaInfo",
+          "captchaType": "image",
+          "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//*[local-name()='svg']",
+          "id": "ee5e5f5a-fb29-4de3-9fcc-6b691042209f"
+        },
+        {
+          "actionType": "solveCaptcha",
+          "captchaType": "image",
+          "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//input",
+          "id": "e68c0777-7bc0-4d28-acd8-65ebfcb8dd3c"
+        },
+        {
+          "actionType": "click",
+          "elements": [
             {
-              "type": "element",
-              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]"
+              "type": "button",
+              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//button"
             }
           ],
-          "actions": [
-            {
-              "actionType": "getCaptchaInfo",
-              "captchaType": "image",
-              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//*[local-name()='svg']",
-              "id": "fb136c1e-f032-452d-9011-0f7a9b781175"
-            },
-            {
-              "actionType": "solveCaptcha",
-              "captchaType": "image",
-              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//input",
-              "id": "7aa13f78-7caf-499a-a529-451ea4ea2d2e"
-            },
-            {
-              "actionType": "click",
-              "failSilently": true,
-              "elements": [
-                {
-                  "type": "button",
-                  "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//button"
-                }
-              ],
-              "id": "5893f48f-6f8f-45d3-a0fe-11f32053c6e4"
-            }
-          ],
-          "id": "2a9e2856-da43-4a22-a80f-68feb7e8d24c"
+          "id": "a1780169-c68b-4f7b-86a9-6f6585444759"
         },
         {
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": ".header"
+              "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]"
             }
           ],
-          "id": "5defbbd7-c6de-4e7b-9ada-81e69f5dbdf1"
+          "id": "493d67c1-e48d-4bc7-8072-d5891776bc16"
+        },
+        {
+          "actionType": "getCaptchaInfo",
+          "captchaType": "basic-math",
+          "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]//img[starts-with(@src, 'data:')]",
+          "id": "218673fa-19d7-4f29-b7d1-fef3e71bfbd3"
+        },
+        {
+          "actionType": "solveCaptcha",
+          "captchaType": "basic-math",
+          "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]//input",
+          "id": "1fe2f061-50bc-48da-9abf-1b01caf7e864"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]//button"
+            }
+          ],
+          "id": "78c59409-9cc7-400d-b5bd-cba7067536a7"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//h2[contains(text(), 'Select the person')]"
+            }
+          ],
+          "id": "cd5a8990-5691-4313-b223-317bb46c1ae5"
         },
         {
           "actionType": "extract",
           "selector": "//h2[contains(text(), 'Select the person')]/following-sibling::div/div",
-          "noResultsSelector": "//p[contains(text(), 'unable to find')]|//p[contains(text(), 'Too many')]",
+          "noResultsSelector": "//h1[contains(text(), 'unable to find')]",
           "profile": {
             "name": {
               "selector": ".//span[contains(text(), 'Name')]/following-sibling::span[1]"
@@ -154,7 +162,7 @@
               "identifierType": "hash"
             }
           },
-          "id": "cd0f0aa3-fba2-4330-b4ab-6d7700aad9cb"
+          "id": "5c0cb149-e5e8-4331-b928-b419b3ffd99e"
         }
       ]
     },

--- a/pir/pir-impl/src/main/assets/brokers/weinform.org.json
+++ b/pir/pir-impl/src/main/assets/brokers/weinform.org.json
@@ -1,7 +1,7 @@
 {
   "name": "WeInform",
   "url": "weinform.org",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "parent": "privatereports.com",
   "optOutUrl": "https://www.weinform.org/api/helper/optOutLight/search",
   "steps": [
@@ -12,7 +12,7 @@
         {
           "actionType": "navigate",
           "url": "https://www.weinform.org/api/helper/optOutLight/search",
-          "id": "c89890c9-0b0b-49d5-b72a-152afebea3aa"
+          "id": "6005c1b2-ceb9-4a8e-b3ed-ef554c109b53"
         },
         {
           "actionType": "expectation",
@@ -22,7 +22,7 @@
               "selector": "#pageForm"
             }
           ],
-          "id": "65c4efa6-5543-4827-85ac-9beda826f3e9"
+          "id": "059c8bb8-31d0-446d-8b48-db89abe2c6cb"
         },
         {
           "actionType": "fillForm",
@@ -46,7 +46,7 @@
               "selector": "select[name='state']"
             }
           ],
-          "id": "9c021278-27a7-4711-8a1a-24d39ac88924"
+          "id": "ea812639-cc80-470b-9d71-bdcce866b2ce"
         },
         {
           "actionType": "click",
@@ -56,7 +56,7 @@
               "selector": "#pageFormSubmitBtn"
             }
           ],
-          "id": "20c9a47d-c2a0-4e33-a1a0-2bfe6f3efe46"
+          "id": "5d80bafa-0fee-4cb1-a86c-74f9194d935d"
         },
         {
           "_comment": "Turnstile auto-completes (there are two sequential turnstiles). This one should disappear after clicking, so we'll use a negative selector to ensure it's not present.",
@@ -67,17 +67,7 @@
               "selector": "//body[not(.//input[@name='cf-turnstile-response'])]"
             }
           ],
-          "id": "cft-b371ee5f-8818-44f4-b36d-77b97fc4c69e"
-        },
-        {
-          "actionType": "expectation",
-          "expectations": [
-            {
-              "type": "element",
-              "selector": ".header"
-            }
-          ],
-          "id": "840e1115-7bab-4b9c-862c-311ba49a383f"
+          "id": "cft-b77785cc-bb08-4be6-87ac-bacdc71cae20"
         },
         {
           "actionType": "expectation",
@@ -87,58 +77,76 @@
               "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]"
             }
           ],
-          "id": "f8751aac-4d41-4aa9-89d2-35c80eaf2a6a"
+          "id": "98b30ce4-0207-40d3-97e2-f745ea988976"
         },
         {
-          "actionType": "condition",
-          "_comment": "captcha is not always present at this stage",
-          "expectations": [
+          "actionType": "getCaptchaInfo",
+          "captchaType": "image",
+          "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//*[local-name()='svg']",
+          "id": "dae7372d-eebd-41d5-999e-aadedb6c0290"
+        },
+        {
+          "actionType": "solveCaptcha",
+          "captchaType": "image",
+          "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//input",
+          "id": "3bcbbf93-31c6-4f32-9ea8-9149038c5e71"
+        },
+        {
+          "actionType": "click",
+          "elements": [
             {
-              "type": "element",
-              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]"
+              "type": "button",
+              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//button"
             }
           ],
-          "actions": [
-            {
-              "actionType": "getCaptchaInfo",
-              "captchaType": "image",
-              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//*[local-name()='svg']",
-              "id": "79a765f3-c1bb-4c2d-af18-071725f0ddee"
-            },
-            {
-              "actionType": "solveCaptcha",
-              "captchaType": "image",
-              "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//input",
-              "id": "4a2a35f3-3526-43fa-a24e-d519b8a000d6"
-            },
-            {
-              "actionType": "click",
-              "failSilently": true,
-              "elements": [
-                {
-                  "type": "button",
-                  "selector": "//div[.//*[local-name()='svg'] and .//input and .//button]//button"
-                }
-              ],
-              "id": "e5b42120-6dcf-4413-9139-523cbc71cc5a"
-            }
-          ],
-          "id": "ebe52f0a-0176-4853-8f9b-447868a05cd4"
+          "id": "c05e387a-5886-4976-817f-67ab9ffbed3c"
         },
         {
           "actionType": "expectation",
           "expectations": [
             {
               "type": "element",
-              "selector": ".header"
+              "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]"
             }
           ],
-          "id": "766ccef8-c27f-4dc7-9691-ba6377fd6fe6"
+          "id": "c20d72f8-f1d4-49fc-bae4-0e96a8e22a93"
+        },
+        {
+          "actionType": "getCaptchaInfo",
+          "captchaType": "basic-math",
+          "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]//img[starts-with(@src, 'data:')]",
+          "id": "d33eec7b-5d4d-4dd1-b374-ba3b4bad8bc5"
+        },
+        {
+          "actionType": "solveCaptcha",
+          "captchaType": "basic-math",
+          "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]//input",
+          "id": "a8d9453b-0acb-4753-a88e-0159bb62d88a"
+        },
+        {
+          "actionType": "click",
+          "elements": [
+            {
+              "type": "button",
+              "selector": "//div[.//img[starts-with(@src, 'data:')] and .//input and .//button]//button"
+            }
+          ],
+          "id": "74b0aa16-6145-4aa3-abe1-59c3240d2edf"
+        },
+        {
+          "actionType": "expectation",
+          "expectations": [
+            {
+              "type": "element",
+              "selector": "//h2[contains(text(), 'Select the person')]"
+            }
+          ],
+          "id": "d72a07a3-b7f9-407f-a812-1e98ea88f802"
         },
         {
           "actionType": "extract",
           "selector": "//h2[contains(text(), 'Select the person')]/following-sibling::div/div",
-          "noResultsSelector": "//p[contains(text(), 'unable to find')]|//p[contains(text(), 'Too many')]",
+          "noResultsSelector": "//h1[contains(text(), 'unable to find')]",
           "profile": {
             "name": {
               "selector": ".//span[contains(text(), 'Name')]/following-sibling::span[1]"
@@ -154,7 +162,7 @@
               "identifierType": "hash"
             }
           },
-          "id": "fd69267b-59ce-4b1a-ba94-e1fd3dd99474"
+          "id": "0319a59f-5978-4e9c-a62e-0ff90bbd4440"
         }
       ]
     },


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1216512587352318

## PIR Broker Bundle Update

Automated update of PIR broker JSON files from the remote bundle.

### Changes

**Updated (10):**
- centeda.com.json (0.91.0 → 0.92.0)
- mugshotlook.com.json (0.6.1 → 0.7.0)
- peoplesearcher.com.json (0.7.1 → 0.8.0)
- peoplesearchnow.com.json (0.6.0 → 0.7.0)
- privatereports.com.json (0.996.1 → 0.997.0)
- publicsearcher.com.json (0.6.1 → 0.7.0)
- secretinfo.org.json (0.5.1 → 0.6.0)
- truepeoplesearch.com.json (0.9.0 → 0.10.0)
- truthrecord.org.json (0.5.1 → 0.6.0)
- weinform.org.json (0.1.1 → 0.2.0)

### Checklist

- [ ] Verify broker changes look correct
- [ ] All tests must pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes drive live scan/opt-out automation for many brokers; incorrect captcha sequencing or selectors could cause failures, though scope is limited to broker JSON assets.
> 
> **Overview**
> Automated PIR broker JSON bundle refresh across **10 brokers**, mostly to match site UI and bot-protection changes.
> 
> **Centeda** is **retired**: `removedAt` is set (was `null`) with a minor version bump.
> 
> **PrivateReports network** (`privatereports.com` plus child sites such as mugshotlook, peoplesearcher, publicsearcher, secretinfo, truthrecord, weinform) updates scan flows after Turnstile: optional `condition` captcha blocks are replaced with a **fixed two-step** sequence—**image** captcha (SVG widget) then **`basic-math`** captcha (data-URI image)—each with explicit expectations, solve, and submit clicks. Result waiting moves from `.header` to **`Select the person`**, and **`noResultsSelector`** narrows to `//h1[contains(text(), 'unable to find')]`. **`privatereports.com` opt-out** gains the same captcha sequences after the removal form submit and again after **email confirmation** (before the opt-out confirmed heading).
> 
> **Peoplefinders-related scans** (`peoplesearchnow.com`, `truepeoplesearch.com`) extend Cloudflare “not on challenge page” checks to include inline **`_cf_chl_opt`** and hard-block **`div#cf-error-details`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a4fca3b962ba90517100ebd184f02b4101b6491. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->