### PR TITLE
Fix CPM heuristic pixels

### DIFF
--- a/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/handlers/OptOutAndAutoconsentDoneMessageHandlerPlugin.kt
+++ b/autoconsent/autoconsent-impl/src/main/java/com/duckduckgo/autoconsent/impl/handlers/OptOutAndAutoconsentDoneMessageHandlerPlugin.kt
@@ -88,7 +88,7 @@ class OptOutAndAutoconsentDoneMessageHandlerPlugin @Inject constructor(
             val message: AutoconsentDoneMessage = parseAutoconsentDoneMessage(jsonString) ?: return
 
             when {
-                message.cmp == HEURISTIC_CMP -> autoconsentPixelManager.fireDailyPixel(AutoConsentPixel.AUTOCONSENT_DONE_HEURISTIC_DAILY)
+                message.cmp.startsWith(HEURISTIC_CMP) -> autoconsentPixelManager.fireDailyPixel(AutoConsentPixel.AUTOCONSENT_DONE_HEURISTIC_DAILY)
                 message.isCosmetic -> autoconsentPixelManager.fireDailyPixel(AutoConsentPixel.AUTOCONSENT_DONE_COSMETIC_DAILY)
                 else -> autoconsentPixelManager.fireDailyPixel(AutoConsentPixel.AUTOCONSENT_DONE_DAILY)
             }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201844467387842/task/1216513297304204?focus=true
Tech Design URL (if applicable): 

### Description
Based on top of https://github.com/duckduckgo/Android/pull/9123

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line analytics classification change; consent handling and callbacks are unchanged.
> 
> **Overview**
> When autoconsent finishes, the handler picks which daily pixel to fire based on the CMP id. **Heuristic** completions now use `message.cmp.startsWith("HEURISTIC")` instead of an exact `== "HEURISTIC"` check, so variant CMP strings (e.g. prefixed or suffixed ids from the bundle) still count toward `AUTOCONSENT_DONE_HEURISTIC_DAILY` instead of falling through to the generic or cosmetic pixel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08bd323c87ebc63f26d235356fb19efff9fbf916. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->