### PR TITLE
Maestro test for opening AI Features native screen from SERP

### DIFF
--- a/.github/workflows/e2e-nightly-non-blockers-suite.yml
+++ b/.github/workflows/e2e-nightly-non-blockers-suite.yml
@@ -125,6 +125,25 @@ jobs:
           asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
           test_suite_name: Android Design System (Nightly)
 
+      - name: SERP Flows
+        id: maestro-serp-flows
+        # Run regardless of earlier suite failures, but only if the internal binary uploaded.
+        if: ${{ !cancelled() && steps.maestro-upload-internal-binary.outcome == 'success' }}
+        uses: ./.github/actions/maestro-cloud-asana-reporter
+        timeout-minutes: 120
+        with:
+          maestro_api_key: ${{ secrets.ROBIN_API_KEY }}
+          maestro_project_id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
+          maestro_test_name: serp_${{ github.sha }}
+          maestro_timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
+          maestro_app_binary_id: ${{ steps.maestro-upload-internal-binary.outputs.maestro_app_binary_id }}
+          maestro_api_level: 34
+          maestro_include_tags: serpFlows
+          asana_pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana_project_id: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
+          asana_section_id: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
+          test_suite_name: SERP Flows
+
       - name: Create Asana task when workflow failed
         if: ${{ failure() && github.event_name != 'workflow_dispatch' }}
         id: create-failure-task

--- a/.maestro/serp/open_ai_features_from_serp.yaml
+++ b/.maestro/serp/open_ai_features_from_serp.yaml
@@ -1,0 +1,40 @@
+appId: com.duckduckgo.mobile.android
+androidWebViewHierarchy: devtools
+name: "AI Features: open native AI Features settings from the SERP menu"
+tags:
+  - serpFlows
+---
+- retry:
+    maxRetries: 3
+    commands:
+      - launchApp:
+          clearState: true
+          stopApp: true
+
+      - runFlow: ../shared/skip_all_onboarding.yaml
+
+      - assertVisible:
+          text: "Search"
+      - tapOn:
+          id: "omnibarTextInput"
+      - inputText: "https://duckduckgo.com"
+      - pressKey: Enter
+
+      # Tap the side-menu button *inside the web page* (top right, next to "Duck.ai"). This button does not have an id.
+      - tapOn:
+          text: "Menu"
+          index: 0
+
+      # Navigate the in-page settings: Settings > AI Features > Manage in Browser Settings.
+      - tapOn:
+          text: "Settings"
+      - tapOn:
+          text: "AI Features"
+      - tapOn:
+          text: "Manage in Browser Settings"
+
+      # "Manage in Browser Settings" deep-links into the native "AI Features" settings screen.
+      - assertVisible:
+          text: "AI Features"
+      - assertVisible:
+          text: "DuckDuckGo AI features are private and optional.*"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1216511037046844?focus=true
Tech Design URL (if applicable):

### Description

Added SERP Flows test suite and AI Features settings flow.

### Steps to test this PR

Manually triggered e2e flow passes (it's green ✅ ). See https://github.com/duckduckgo/Android/actions/runs/29260966011

### NO UI changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Maestro YAML and a CI workflow step; no production app or runtime behavior is modified.
> 
> **Overview**
> Adds **SERP Flows** to the nightly non-blocker Maestro workflow, running tests tagged `serpFlows` against the internal APK after upload (same pattern as Duck Player and Design System suites).
> 
> Introduces a new Maestro flow that loads duckduckgo.com in the app, opens the in-page SERP menu (**Settings → AI Features → Manage in Browser Settings**), and asserts the native **AI Features** settings screen appears. The flow uses `androidWebViewHierarchy: devtools` for webview interaction and retries up to three times.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d8fea0e190628bba8f3bf5197e657c93086d7a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->