### PR TITLE
Fix omnibar repopulating stale URL on back at NTP

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1935,9 +1935,6 @@ class BrowserTabViewModel @Inject constructor(
             }
             return true
         } else if (!skipHome && !isCustomTab) {
-            if (!duckAiFeatureState.showInputScreen.value) {
-                command.value = ShowKeyboard
-            }
             navigateHome()
             return true
         }

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -3684,11 +3684,20 @@ class BrowserTabViewModelTest {
     }
 
     @Test
-    fun whenUserPressesBackAndGoesToHomeThenKeyboardShown() {
+    fun whenUserPressesBackAndGoesToHomeThenKeyboardNotShown() {
         setupNavigation(isBrowsing = true, canGoBack = false, skipHome = false)
         testee.onUserPressedBack()
-        verify(mockCommandObserver, atLeastOnce()).onChanged(commandCaptor.capture())
-        assertTrue(commandCaptor.allValues.contains(Command.ShowKeyboard))
+        assertCommandNotIssued<ShowKeyboard>()
+    }
+
+    @Test
+    fun whenUserPressesBackAndGoesToHomeThenHomeShown() {
+        setupNavigation(isBrowsing = true, canGoBack = false, skipHome = false)
+
+        val result = testee.onUserPressedBack()
+
+        assertFalse(browserViewState().browserShowing)
+        assertTrue(result)
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212608036467427/task/1214503249202007?focus=true

### Description
When the unified input (Input Screen) toggle is off, returning home via back auto-focuses the legacy omnibar. The next back was routed to the focused field's onBackKeyPressed(), which restored the last-loaded url — resurrecting the previous site's address instead of letting the app exit.

Skip the url restore in NewTab mode, where there is no page to restore to.

### Steps to test this PR
- Launch browser NTP
- Search for something or visit a site.
- Hit back => Blank NTP. 
- Hit back => app exits.

### UI changes
| Before  | After |
| ------ | ----- |
|<img width="280" height="498" alt="before" src="https://github.com/user-attachments/assets/c3b8e16e-9dd9-4f8a-8507-780564c41e30" />|<img width="280" height="498" alt="after" src="https://github.com/user-attachments/assets/151e6c32-5924-4024-83b0-0bafdf9cf39a" />|



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to back-to-home navigation UX in BrowserTabViewModel with matching unit tests; no auth, data, or security surface.
> 
> **Overview**
> When the user presses back from a page and the tab navigates home (NTP), the view model **no longer issues `ShowKeyboard`** when the unified input screen is off. It only calls **`navigateHome()`**, so the legacy omnibar is not auto-focused on that transition.
> 
> This avoids the follow-on back handling where a focused omnibar restored the last-loaded URL instead of closing the IME or exiting the app. Tests now expect **no keyboard command** on back-to-home and assert **home is shown** (`browserShowing` false).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 473233614d323ce3965bb86bbbf0aaf2c9432af0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->