### PR TITLE
Android: Hide option to Upgrade for users not eligible to purchase from FE

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
@@ -41,11 +41,13 @@ import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.LimitsHandler
 import com.duckduckgo.duckchat.impl.voice.VoiceSessionStateManager
 import com.duckduckgo.js.messaging.api.JsCallbackData
 import com.duckduckgo.js.messaging.api.SubscriptionEventData
+import com.duckduckgo.subscriptions.api.Subscriptions
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import logcat.logcat
 import org.json.JSONArray
 import org.json.JSONObject
@@ -110,6 +112,7 @@ class RealDuckChatJSHelper @Inject constructor(
     private val nativeInputStatePublisher: NativeInputStatePublisher,
     private val appInstall: AppInstall,
     private val appBuildConfig: AppBuildConfig,
+    private val subscriptions: Subscriptions,
 ) : DuckChatJSHelper {
 
     private val registerOpenedJob = ConflatedJob()
@@ -397,6 +400,7 @@ class RealDuckChatJSHelper @Inject constructor(
         mode: Mode,
         browserMode: BrowserMode,
     ): JsCallbackData {
+        val supportsSubscription = withContext(dispatcherProvider.io()) { subscriptions.isEligible() }
         val jsonPayload =
             JSONObject().apply {
                 put(PLATFORM, ANDROID)
@@ -418,6 +422,7 @@ class RealDuckChatJSHelper @Inject constructor(
                     duckChat.isDuckChatContextualModeEnabled() &&
                         duckChat.areMultipleContentAttachmentsEnabled(),
                 )
+                put(SUPPORTS_SUBSCRIPTION, supportsSubscription)
                 put(INSTALL_TYPE, if (appBuildConfig.isAppReinstall()) INSTALL_TYPE_RETURNING else INSTALL_TYPE_NEW)
                 getInstallAgeBucket()?.let { put(INSTALL_AGE, it) }
             }.also { logcat { "DuckChat-Sync: getAIChatNativeConfigValues $it" } }
@@ -604,6 +609,7 @@ class RealDuckChatJSHelper @Inject constructor(
         private const val SUPPORTS_PAGE_CONTEXT = "supportsPageContext"
         private const val SUPPORTS_MULTIPLE_PAGE_CONTEXT = "supportsMultipleContexts"
         private const val SUPPORTS_NATIVE_STORAGE = "supportsNativeStorage"
+        private const val SUPPORTS_SUBSCRIPTION = "supportsSubscription"
         private const val INSTALL_TYPE = "installType"
         private const val INSTALL_TYPE_NEW = "new"
         private const val INSTALL_TYPE_RETURNING = "returning"

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
@@ -400,7 +400,14 @@ class RealDuckChatJSHelper @Inject constructor(
         mode: Mode,
         browserMode: BrowserMode,
     ): JsCallbackData {
-        val supportsSubscription = withContext(dispatcherProvider.io()) { subscriptions.isEligible() }
+        val supportsSubscription = withContext(dispatcherProvider.io()) {
+            runCatching {
+                subscriptions.isEligible()
+            }.getOrElse {
+                logcat { "DuckChat-Sync: failed to resolve purchase eligibility, defaulting to not eligible: ${it.message}" }
+                false
+            }
+        }
         val jsonPayload =
             JSONObject().apply {
                 put(PLATFORM, ANDROID)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
@@ -695,6 +695,23 @@ class RealDuckChatJSHelperTest {
     }
 
     @Test
+    fun whenGetAIChatNativeConfigValuesAndEligibilityCheckThrowsThenSupportsSubscriptionIsFalse() = runTest {
+        val method = "getAIChatNativeConfigValues"
+
+        whenever(mockSubscriptions.isEligible()).thenThrow(RuntimeException("Error"))
+
+        val result = testee.processJsCallbackMessage(
+            "aiChat",
+            method,
+            "123",
+            null,
+            pageContext = viewModel.updatedPageContext,
+        )
+
+        assertFalse(result!!.params.getBoolean("supportsSubscription"))
+    }
+
+    @Test
     fun whenGetAIChatNativeConfigValuesAndDuckChatFeatureEnabledAndFullScreenModeEnabledAndModeFullThenReturnCorrectData() = runTest {
         val featureName = "aiChat"
         val method = "getAIChatNativeConfigValues"

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
@@ -43,6 +43,7 @@ import com.duckduckgo.duckchat.impl.voice.VoiceSessionStateManager
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.js.messaging.api.JsCallbackData
+import com.duckduckgo.subscriptions.api.Subscriptions
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -92,6 +93,9 @@ class RealDuckChatJSHelperTest {
     private val mockAppBuildConfig: AppBuildConfig = mock {
         onBlocking { isAppReinstall() } doReturn false
     }
+    private val mockSubscriptions: Subscriptions = mock {
+        onBlocking { isEligible() } doReturn false
+    }
     private val testee = RealDuckChatJSHelper(
         duckChat = mockDuckChat,
         duckChatPixels = mockDuckChatPixels,
@@ -107,6 +111,7 @@ class RealDuckChatJSHelperTest {
         nativeInputStatePublisher = mockNativeInputStatePublisher,
         appInstall = mockAppInstall,
         appBuildConfig = mockAppBuildConfig,
+        subscriptions = mockSubscriptions,
     )
     private val viewModel =
         object {
@@ -301,6 +306,7 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", false)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", false)
+            put("supportsSubscription", false)
             put("installType", "new")
             put("installAge", 0)
         }
@@ -641,6 +647,7 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", false)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", false)
+            put("supportsSubscription", false)
             put("installType", "new")
             put("installAge", 0)
         }
@@ -651,6 +658,40 @@ class RealDuckChatJSHelperTest {
         assertEquals(expected.method, result.method)
         assertEquals(expected.featureName, result.featureName)
         assertEquals(expected.params.toString(), result.params.toString())
+    }
+
+    @Test
+    fun whenGetAIChatNativeConfigValuesAndSubscriptionEligibleThenSupportsSubscriptionIsTrue() = runTest {
+        val method = "getAIChatNativeConfigValues"
+
+        whenever(mockSubscriptions.isEligible()).thenReturn(true)
+
+        val result = testee.processJsCallbackMessage(
+            "aiChat",
+            method,
+            "123",
+            null,
+            pageContext = viewModel.updatedPageContext,
+        )
+
+        assertTrue(result!!.params.getBoolean("supportsSubscription"))
+    }
+
+    @Test
+    fun whenGetAIChatNativeConfigValuesAndSubscriptionNotEligibleThenSupportsSubscriptionIsFalse() = runTest {
+        val method = "getAIChatNativeConfigValues"
+
+        whenever(mockSubscriptions.isEligible()).thenReturn(false)
+
+        val result = testee.processJsCallbackMessage(
+            "aiChat",
+            method,
+            "123",
+            null,
+            pageContext = viewModel.updatedPageContext,
+        )
+
+        assertFalse(result!!.params.getBoolean("supportsSubscription"))
     }
 
     @Test
@@ -686,6 +727,7 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", false)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", false)
+            put("supportsSubscription", false)
             put("installType", "new")
             put("installAge", 0)
         }
@@ -844,6 +886,7 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", true)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", false)
+            put("supportsSubscription", false)
             put("installType", "new")
             put("installAge", 0)
         }
@@ -891,6 +934,7 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", true)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", true)
+            put("supportsSubscription", false)
             put("installType", "new")
             put("installAge", 0)
         }
@@ -935,6 +979,7 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", false)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", false)
+            put("supportsSubscription", false)
             put("installType", "new")
             put("installAge", 0)
         }
@@ -979,6 +1024,7 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", false)
             put("supportsNativeStorage", true)
             put("supportsMultipleContexts", false)
+            put("supportsSubscription", false)
             put("installType", "new")
             put("installAge", 0)
         }
@@ -1290,6 +1336,7 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", false)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", false)
+            put("supportsSubscription", false)
             put("installType", "new")
             put("installAge", 0)
         }
@@ -1331,6 +1378,7 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", false)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", false)
+            put("supportsSubscription", false)
             put("installType", "new")
             put("installAge", 0)
         }
@@ -1372,6 +1420,7 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", false)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", false)
+            put("supportsSubscription", false)
             put("installType", "new")
             put("installAge", 0)
         }
@@ -1414,6 +1463,7 @@ class RealDuckChatJSHelperTest {
             put("supportsPageContext", false)
             put("supportsNativeStorage", false)
             put("supportsMultipleContexts", false)
+            put("supportsSubscription", false)
             put("installType", "new")
             put("installAge", 0)
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1216422924320698?focus=true 
Tech Design URL (if applicable): 

### Description
 Added a supportsSubscription flag to the `getAIChatNativeConfigValues` payload sent to the Duck.ai webview, so the frontend can gate subscription-related UI. (https://app.asana.com/1/137249556945/task/1216422924320686?focus=true)

### Steps to test this PR
Set Duck.ai url to : https://euw-serp-dev-testing21.duck.ai/ (Via internal Settings > Duck.ai)

_User is eligible and has no susbcription (you can use the staging patch if you are not eligible_
- [x] Open app
- [x] Verify you can see the purchase subscription in settings
- [x] Open a duck.ai chat and click on sidebar
- [x] Verify you see Upgrade from the list
- [x] Verify Clicking “Upgrade" routes you to upgrade path
- [x] Click on Settings & More
- [x] Verify you see Upgrade from the menu items
- [x] Verify Clicking “Upgrade" routes you to upgrade path

_User is eligible and has susbcription_
- [x] Open app
- [x]  Verify you have an active subscription
- [x] Open a duck.ai chat and click on sidebar
- [x] Verify you do not see Upgrade from the list
- [x] Click on Settings & More
- [x] Verify you do not  see Upgrade from the menu items

_User is NOT eligible_
- [x] Open app
- [x] Verify you do NOT see the purchase subscription in settings
- [x] Open a duck.ai chat and click on sidebar
- [x] Verify you do not see Upgrade from the list
- [x] Click on Settings & More
- [x] Verify you do not see Upgrade from the menu items



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wires subscription purchase eligibility into the JS bridge; incorrect `isEligible()` behavior would show or hide upgrade UI wrongly, though failures default to hiding purchase options.
> 
> **Overview**
> Adds **`supportsSubscription`** to the `getAIChatNativeConfigValues` JSON the native app sends to the Duck.ai webview, driven by **`Subscriptions.isEligible()`** on the IO dispatcher so the frontend can hide Upgrade and other purchase UI for users who cannot buy.
> 
> Eligibility failures are caught and logged; the flag defaults to **`false`** so ineligible users never see subscription prompts by mistake. **`RealDuckChatJSHelper`** now takes **`Subscriptions`** via DI, and unit tests cover eligible, ineligible, and error paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5796468eb732d9935f01c2c28433b9bda1dbd31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->