### PR TITLE
Subscription Onboarding MVP

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserBrowserOnboardingViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserBrowserOnboardingViewModel.kt
@@ -74,6 +74,10 @@ class NewUserBrowserOnboardingViewModel @Inject constructor(
                 _commands.send(Command.HandOffToOnboardingActivity)
                 return
             }
+            else -> {
+                // Any other host is not this VM's screen (this VM only drives the new-user onboarding plan); ignore.
+                return
+            }
         }
         if (step is NewUserBrowserActivityStep) {
             when (val action = step.resolveAction()) {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModel.kt
@@ -449,6 +449,10 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
                                 _commands.send(Command.HandOffToBrowserActivity)
                                 return@onEach
                             }
+                            else -> {
+                                // Any other host is not this VM's screen (this VM only drives the new-user onboarding plan); ignore.
+                                return@onEach
+                            }
                         }
                         if (step is NewUserOnboardingActivityStep) {
                             applyDialog(step.resolveDialog(), state.stepIndicatorProgress())

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/subscriptions/onboarding/SubscriptionOnboardingDuckAiFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/subscriptions/onboarding/SubscriptionOnboardingDuckAiFragment.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.subscriptions.onboarding
+
+import android.os.Bundle
+import android.view.View
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.common.ui.DuckDuckGoFragment
+import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.duckchat.impl.R
+import com.duckduckgo.duckchat.impl.databinding.FragmentSubscriptionOnboardingDuckAiBinding
+import com.duckduckgo.duckchat.impl.subscriptions.onboarding.SubscriptionOnboardingDuckAiStepPlugin.Companion.DUCK_AI_STEP_ID
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepHost
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome.COMPLETED
+
+/**
+ * Duck.ai step of the native subscription onboarding: a placeholder screen with a primary button that
+ * completes the step. As the last step, completing it finishes the onboarding. Reports back through
+ * [SubscriptionOnboardingStepHost] so it stays decoupled from the host activity and the onboarding framework.
+ */
+@InjectWith(FragmentScope::class)
+class SubscriptionOnboardingDuckAiFragment : DuckDuckGoFragment(R.layout.fragment_subscription_onboarding_duck_ai) {
+
+    private val binding: FragmentSubscriptionOnboardingDuckAiBinding by viewBinding()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.subscriptionOnboardingDuckAiNextButton.setOnClickListener {
+            (requireActivity() as SubscriptionOnboardingStepHost).onStepFinished(DUCK_AI_STEP_ID, COMPLETED)
+        }
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/subscriptions/onboarding/SubscriptionOnboardingDuckAiFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/subscriptions/onboarding/SubscriptionOnboardingDuckAiFragment.kt
@@ -25,27 +25,27 @@ import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.databinding.FragmentSubscriptionOnboardingDuckAiBinding
 import com.duckduckgo.duckchat.impl.subscriptions.onboarding.SubscriptionOnboardingDuckAiStepPlugin.Companion.DUCK_AI_STEP_ID
-import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepHost
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingController
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome.COMPLETED
-import com.duckduckgo.subscriptions.api.requireSubscriptionOnboardingStepHost
+import javax.inject.Inject
 
 /**
  * Duck.ai step of the native subscription onboarding: a placeholder screen with a primary button that
  * completes the step. As the last step, completing it finishes the onboarding. Reports back through
- * [SubscriptionOnboardingStepHost] so it stays decoupled from the host activity and the onboarding framework.
+ * [SubscriptionOnboardingController] so it stays decoupled from the host activity and the onboarding framework.
  */
 @InjectWith(FragmentScope::class)
 class SubscriptionOnboardingDuckAiFragment : DuckDuckGoFragment(R.layout.fragment_subscription_onboarding_duck_ai) {
 
-    private val binding: FragmentSubscriptionOnboardingDuckAiBinding by viewBinding()
+    @Inject
+    lateinit var controller: SubscriptionOnboardingController
 
-    private val stepHost: SubscriptionOnboardingStepHost
-        get() = requireSubscriptionOnboardingStepHost()
+    private val binding: FragmentSubscriptionOnboardingDuckAiBinding by viewBinding()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.subscriptionOnboardingDuckAiNextButton.setOnClickListener {
-            stepHost.onStepFinished(DUCK_AI_STEP_ID, COMPLETED)
+            controller.onStepFinished(DUCK_AI_STEP_ID, COMPLETED)
         }
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/subscriptions/onboarding/SubscriptionOnboardingDuckAiFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/subscriptions/onboarding/SubscriptionOnboardingDuckAiFragment.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.duckchat.impl.databinding.FragmentSubscriptionOnboardingDu
 import com.duckduckgo.duckchat.impl.subscriptions.onboarding.SubscriptionOnboardingDuckAiStepPlugin.Companion.DUCK_AI_STEP_ID
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepHost
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome.COMPLETED
+import com.duckduckgo.subscriptions.api.requireSubscriptionOnboardingStepHost
 
 /**
  * Duck.ai step of the native subscription onboarding: a placeholder screen with a primary button that
@@ -38,10 +39,13 @@ class SubscriptionOnboardingDuckAiFragment : DuckDuckGoFragment(R.layout.fragmen
 
     private val binding: FragmentSubscriptionOnboardingDuckAiBinding by viewBinding()
 
+    private val stepHost: SubscriptionOnboardingStepHost
+        get() = requireSubscriptionOnboardingStepHost()
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.subscriptionOnboardingDuckAiNextButton.setOnClickListener {
-            (requireActivity() as SubscriptionOnboardingStepHost).onStepFinished(DUCK_AI_STEP_ID, COMPLETED)
+            stepHost.onStepFinished(DUCK_AI_STEP_ID, COMPLETED)
         }
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/subscriptions/onboarding/SubscriptionOnboardingDuckAiStepPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/subscriptions/onboarding/SubscriptionOnboardingDuckAiStepPlugin.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.duckchat.impl.subscriptions.onboarding
+
+import androidx.fragment.app.Fragment
+import com.duckduckgo.anvil.annotations.PriorityKey
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepPlugin
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+/** Duck.ai step of the subscription onboarding, contributed from `duckchat-impl`. */
+@ContributesMultibinding(AppScope::class)
+@PriorityKey(300)
+class SubscriptionOnboardingDuckAiStepPlugin @Inject constructor() : SubscriptionOnboardingStepPlugin {
+
+    override val stepId: String = DUCK_AI_STEP_ID
+
+    override suspend fun shouldShow(): Boolean = true
+
+    override fun createFragment(): Fragment = SubscriptionOnboardingDuckAiFragment()
+
+    companion object {
+        const val DUCK_AI_STEP_ID = "duck_ai"
+    }
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/subscriptions/onboarding/SubscriptionOnboardingDuckAiStepPlugin.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/subscriptions/onboarding/SubscriptionOnboardingDuckAiStepPlugin.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.duckchat.impl.subscriptions.onboarding
 import androidx.fragment.app.Fragment
 import com.duckduckgo.anvil.annotations.PriorityKey
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepPlugin
 import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
@@ -29,6 +30,8 @@ import javax.inject.Inject
 class SubscriptionOnboardingDuckAiStepPlugin @Inject constructor() : SubscriptionOnboardingStepPlugin {
 
     override val stepId: String = DUCK_AI_STEP_ID
+
+    override val titleResId: Int = R.string.subscriptionOnboardingDuckAiTitle
 
     override suspend fun shouldShow(): Boolean = true
 

--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_subscription_onboarding_duck_ai.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_subscription_onboarding_duck_ai.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/daxColorBackground"
+    android:padding="@dimen/keyline_4">
+
+    <com.duckduckgo.common.ui.view.text.DaxTextView
+        android:id="@+id/subscriptionOnboardingDuckAiText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="@string/subscriptionOnboardingDuckAiText"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:typography="h1" />
+
+    <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+        android:id="@+id/subscriptionOnboardingDuckAiNextButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/subscriptionOnboardingDuckAiNext"
+        app:daxButtonSize="large"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -20,6 +20,7 @@
     <string name="duck_chat_remove_chat_suggestion_content_description">Delete chat</string>
 
     <!-- Subscription onboarding - Duck.ai step (placeholder copy) -->
+    <string name="subscriptionOnboardingDuckAiTitle">Duck.ai step</string>
     <string name="subscriptionOnboardingDuckAiText">Duck.ai onboarding step</string>
     <string name="subscriptionOnboardingDuckAiNext">Next</string>
 

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -19,4 +19,8 @@
     <!-- Remove chat history suggestion -->
     <string name="duck_chat_remove_chat_suggestion_content_description">Delete chat</string>
 
+    <!-- Subscription onboarding - Duck.ai step (placeholder copy) -->
+    <string name="subscriptionOnboardingDuckAiText">Duck.ai onboarding step</string>
+    <string name="subscriptionOnboardingDuckAiNext">Next</string>
+
 </resources>

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/subscription/onboarding/SubscriptionOnboardingVpnFragment.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/subscription/onboarding/SubscriptionOnboardingVpnFragment.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.networkprotection.impl.subscription.onboarding.Subscriptio
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepHost
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome.COMPLETED
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome.SKIPPED
+import com.duckduckgo.subscriptions.api.requireSubscriptionOnboardingStepHost
 
 /**
  * VPN step of the native subscription onboarding: a placeholder screen with a primary button that completes
@@ -39,13 +40,16 @@ class SubscriptionOnboardingVpnFragment : DuckDuckGoFragment(R.layout.fragment_s
 
     private val binding: FragmentSubscriptionOnboardingVpnBinding by viewBinding()
 
+    private val stepHost: SubscriptionOnboardingStepHost
+        get() = requireSubscriptionOnboardingStepHost()
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.subscriptionOnboardingVpnNextButton.setOnClickListener {
-            (requireActivity() as SubscriptionOnboardingStepHost).onStepFinished(VPN_STEP_ID, COMPLETED)
+            stepHost.onStepFinished(VPN_STEP_ID, COMPLETED)
         }
         binding.subscriptionOnboardingVpnSkipButton.setOnClickListener {
-            (requireActivity() as SubscriptionOnboardingStepHost).onStepFinished(VPN_STEP_ID, SKIPPED)
+            stepHost.onStepFinished(VPN_STEP_ID, SKIPPED)
         }
     }
 }

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/subscription/onboarding/SubscriptionOnboardingVpnFragment.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/subscription/onboarding/SubscriptionOnboardingVpnFragment.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.networkprotection.impl.subscription.onboarding
+
+import android.os.Bundle
+import android.view.View
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.common.ui.DuckDuckGoFragment
+import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.networkprotection.impl.R
+import com.duckduckgo.networkprotection.impl.databinding.FragmentSubscriptionOnboardingVpnBinding
+import com.duckduckgo.networkprotection.impl.subscription.onboarding.SubscriptionOnboardingVpnStepPlugin.Companion.VPN_STEP_ID
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepHost
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome.COMPLETED
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome.SKIPPED
+
+/**
+ * VPN step of the native subscription onboarding: a placeholder screen with a primary button that completes
+ * the step and a secondary button that skips it. Reports back through [SubscriptionOnboardingStepHost] so it
+ * stays decoupled from the host activity and the onboarding framework.
+ */
+@InjectWith(FragmentScope::class)
+class SubscriptionOnboardingVpnFragment : DuckDuckGoFragment(R.layout.fragment_subscription_onboarding_vpn) {
+
+    private val binding: FragmentSubscriptionOnboardingVpnBinding by viewBinding()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.subscriptionOnboardingVpnNextButton.setOnClickListener {
+            (requireActivity() as SubscriptionOnboardingStepHost).onStepFinished(VPN_STEP_ID, COMPLETED)
+        }
+        binding.subscriptionOnboardingVpnSkipButton.setOnClickListener {
+            (requireActivity() as SubscriptionOnboardingStepHost).onStepFinished(VPN_STEP_ID, SKIPPED)
+        }
+    }
+}

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/subscription/onboarding/SubscriptionOnboardingVpnFragment.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/subscription/onboarding/SubscriptionOnboardingVpnFragment.kt
@@ -25,31 +25,31 @@ import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.networkprotection.impl.R
 import com.duckduckgo.networkprotection.impl.databinding.FragmentSubscriptionOnboardingVpnBinding
 import com.duckduckgo.networkprotection.impl.subscription.onboarding.SubscriptionOnboardingVpnStepPlugin.Companion.VPN_STEP_ID
-import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepHost
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingController
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome.COMPLETED
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome.SKIPPED
-import com.duckduckgo.subscriptions.api.requireSubscriptionOnboardingStepHost
+import javax.inject.Inject
 
 /**
  * VPN step of the native subscription onboarding: a placeholder screen with a primary button that completes
- * the step and a secondary button that skips it. Reports back through [SubscriptionOnboardingStepHost] so it
+ * the step and a secondary button that skips it. Reports back through [SubscriptionOnboardingController] so it
  * stays decoupled from the host activity and the onboarding framework.
  */
 @InjectWith(FragmentScope::class)
 class SubscriptionOnboardingVpnFragment : DuckDuckGoFragment(R.layout.fragment_subscription_onboarding_vpn) {
 
-    private val binding: FragmentSubscriptionOnboardingVpnBinding by viewBinding()
+    @Inject
+    lateinit var controller: SubscriptionOnboardingController
 
-    private val stepHost: SubscriptionOnboardingStepHost
-        get() = requireSubscriptionOnboardingStepHost()
+    private val binding: FragmentSubscriptionOnboardingVpnBinding by viewBinding()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.subscriptionOnboardingVpnNextButton.setOnClickListener {
-            stepHost.onStepFinished(VPN_STEP_ID, COMPLETED)
+            controller.onStepFinished(VPN_STEP_ID, COMPLETED)
         }
         binding.subscriptionOnboardingVpnSkipButton.setOnClickListener {
-            stepHost.onStepFinished(VPN_STEP_ID, SKIPPED)
+            controller.onStepFinished(VPN_STEP_ID, SKIPPED)
         }
     }
 }

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/subscription/onboarding/SubscriptionOnboardingVpnStepPlugin.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/subscription/onboarding/SubscriptionOnboardingVpnStepPlugin.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.networkprotection.impl.subscription.onboarding
 import androidx.fragment.app.Fragment
 import com.duckduckgo.anvil.annotations.PriorityKey
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.networkprotection.impl.R
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepPlugin
 import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
@@ -29,6 +30,8 @@ import javax.inject.Inject
 class SubscriptionOnboardingVpnStepPlugin @Inject constructor() : SubscriptionOnboardingStepPlugin {
 
     override val stepId: String = VPN_STEP_ID
+
+    override val titleResId: Int = R.string.subscriptionOnboardingVpnTitle
 
     override suspend fun shouldShow(): Boolean = true
 

--- a/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/subscription/onboarding/SubscriptionOnboardingVpnStepPlugin.kt
+++ b/network-protection/network-protection-impl/src/main/java/com/duckduckgo/networkprotection/impl/subscription/onboarding/SubscriptionOnboardingVpnStepPlugin.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.networkprotection.impl.subscription.onboarding
+
+import androidx.fragment.app.Fragment
+import com.duckduckgo.anvil.annotations.PriorityKey
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepPlugin
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+/** VPN step of the subscription onboarding, contributed from `network-protection-impl`. */
+@ContributesMultibinding(AppScope::class)
+@PriorityKey(200)
+class SubscriptionOnboardingVpnStepPlugin @Inject constructor() : SubscriptionOnboardingStepPlugin {
+
+    override val stepId: String = VPN_STEP_ID
+
+    override suspend fun shouldShow(): Boolean = true
+
+    override fun createFragment(): Fragment = SubscriptionOnboardingVpnFragment()
+
+    companion object {
+        const val VPN_STEP_ID = "vpn"
+    }
+}

--- a/network-protection/network-protection-impl/src/main/res/layout/fragment_subscription_onboarding_vpn.xml
+++ b/network-protection/network-protection-impl/src/main/res/layout/fragment_subscription_onboarding_vpn.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/daxColorBackground"
+    android:padding="@dimen/keyline_4">
+
+    <com.duckduckgo.common.ui.view.text.DaxTextView
+        android:id="@+id/subscriptionOnboardingVpnText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="@string/subscriptionOnboardingVpnText"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:typography="h1" />
+
+    <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+        android:id="@+id/subscriptionOnboardingVpnNextButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/subscriptionOnboardingVpnNext"
+        app:daxButtonSize="large"
+        app:layout_constraintBottom_toTopOf="@id/subscriptionOnboardingVpnSkipButton" />
+
+    <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
+        android:id="@+id/subscriptionOnboardingVpnSkipButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/keyline_2"
+        android:text="@string/subscriptionOnboardingVpnSkip"
+        app:daxButtonSize="large"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/network-protection/network-protection-impl/src/main/res/values/donottranslate.xml
+++ b/network-protection/network-protection-impl/src/main/res/values/donottranslate.xml
@@ -17,6 +17,7 @@
 <resources>
 
     <!-- Subscription onboarding - VPN step (placeholder copy) -->
+    <string name="subscriptionOnboardingVpnTitle">VPN step</string>
     <string name="subscriptionOnboardingVpnText">VPN onboarding setup</string>
     <string name="subscriptionOnboardingVpnNext">Next</string>
     <string name="subscriptionOnboardingVpnSkip">Not now</string>

--- a/network-protection/network-protection-impl/src/main/res/values/donottranslate.xml
+++ b/network-protection/network-protection-impl/src/main/res/values/donottranslate.xml
@@ -15,4 +15,10 @@
   -->
 
 <resources>
+
+    <!-- Subscription onboarding - VPN step (placeholder copy) -->
+    <string name="subscriptionOnboardingVpnText">VPN onboarding setup</string>
+    <string name="subscriptionOnboardingVpnNext">Next</string>
+    <string name="subscriptionOnboardingVpnSkip">Not now</string>
+
 </resources>

--- a/onboarding/onboarding-api/src/main/java/com/duckduckgo/onboarding/api/LinearOnboardingOrchestrator.kt
+++ b/onboarding/onboarding-api/src/main/java/com/duckduckgo/onboarding/api/LinearOnboardingOrchestrator.kt
@@ -150,6 +150,7 @@ interface LinearOnboardingStep {
 enum class LinearOnboardingHost {
     OnboardingActivity,
     BrowserActivity,
+    SubscriptionOnboardingActivity,
 }
 
 /** A marker for events. Concrete event types live with the plan provider. The orchestrator only routes them to [LinearOnboardingStep.transition]. */

--- a/onboarding/onboarding-api/src/main/java/com/duckduckgo/onboarding/api/LinearOnboardingOrchestrator.kt
+++ b/onboarding/onboarding-api/src/main/java/com/duckduckgo/onboarding/api/LinearOnboardingOrchestrator.kt
@@ -71,11 +71,13 @@ sealed interface LinearOnboardingState {
     /**
      * Paused on [currentStep], the [currentStepIndex]-th step of [currentPlan], waiting for the next event.
      * [currentPlan] is the frame on top of the stack and may be a side plan. [rootPlanId] is the root plan.
+     * [canGoBack] is true when an earlier step was shown in this run.
      */
     data class InProgress(
         override val rootPlanId: LinearOnboardingPlanId,
         val currentPlan: LinearOnboardingPlan,
         val currentStepIndex: Int,
+        val canGoBack: Boolean = false,
     ) : Started {
         val currentStep: LinearOnboardingStep
             get() = currentPlan.steps[currentStepIndex]
@@ -169,6 +171,9 @@ sealed interface LinearOnboardingTransition {
 
     /** Pop the top frame and advance the caller past the step that pushed it. */
     data object ReturnAndAdvance : LinearOnboardingTransition
+
+    /** Return to the previously shown step. No-op on the first shown step, where nothing earlier exists. */
+    data object GoBack : LinearOnboardingTransition
 
     /** End the entire flow as Skipped and clear the whole frame stack. */
     data object AbortPlan : LinearOnboardingTransition

--- a/onboarding/onboarding-impl/src/main/java/com/duckduckgo/onboarding/impl/LinearOnboardingOrchestratorImpl.kt
+++ b/onboarding/onboarding-impl/src/main/java/com/duckduckgo/onboarding/impl/LinearOnboardingOrchestratorImpl.kt
@@ -62,6 +62,10 @@ class LinearOnboardingOrchestratorImpl @Inject constructor() : LinearOnboardingO
     // Always reassigned wholesale and together with [_state], so the two can't drift.
     private var backStack: List<Frame> = emptyList()
 
+    // One snapshot of the committed [backStack] per step shown, in visit order; powers GoBack.
+    // Reassigned wholesale alongside [backStack] / [_state], and cleared on every terminal state.
+    private var history: List<List<Frame>> = emptyList()
+
     override suspend fun startPlan(plan: LinearOnboardingPlan) {
         // owner = current Job makes the mutex throw on a reentrant call instead of deadlocking; a genuinely
         // concurrent caller has a different Job and waits as usual.
@@ -96,6 +100,8 @@ class LinearOnboardingOrchestratorImpl @Inject constructor() : LinearOnboardingO
                     advance(caller, fromIndex = caller.last().index + 1)
                 }
 
+                LinearOnboardingTransition.GoBack -> goBack()
+
                 LinearOnboardingTransition.AbortPlan -> terminateSkipped(frames.first().plan)
 
                 LinearOnboardingTransition.Stay -> Unit
@@ -114,16 +120,34 @@ class LinearOnboardingOrchestratorImpl @Inject constructor() : LinearOnboardingO
             index++
         }
         if (index < top.plan.steps.size) {
-            // Set backStack and _state together (no suspension between) so they can't diverge.
-            backStack = frames.dropLast(1) + top.copy(index = index)
-            _state.value = LinearOnboardingState.InProgress(
-                rootPlanId = frames.first().plan.id,
-                currentPlan = top.plan,
-                currentStepIndex = index,
-            )
+            // Set backStack, history and _state together (no suspension between) so they can't diverge.
+            val committed = frames.dropLast(1) + top.copy(index = index)
+            backStack = committed
+            history = history + listOf(committed)
+            emitInProgress(committed)
         } else {
             terminateCompleted(frames.first().plan)
         }
+    }
+
+    // Returns to the previously shown step by restoring its snapshot. No-op on the first shown step.
+    private fun goBack() {
+        if (history.size <= 1) return
+        history = history.dropLast(1)
+        val previous = history.last()
+        backStack = previous
+        emitInProgress(previous)
+    }
+
+    // Publishes the InProgress position for the top frame; canGoBack is true once history holds an earlier step.
+    private fun emitInProgress(frames: List<Frame>) {
+        val top = frames.last()
+        _state.value = LinearOnboardingState.InProgress(
+            rootPlanId = frames.first().plan.id,
+            currentPlan = top.plan,
+            currentStepIndex = top.index,
+            canGoBack = history.size > 1,
+        )
     }
 
     // Clears the stack and emits the terminal state from a finally, so a throwing or cancelled callback still
@@ -136,6 +160,7 @@ class LinearOnboardingOrchestratorImpl @Inject constructor() : LinearOnboardingO
             result = rootPlan.result()
         } finally {
             backStack = emptyList()
+            history = emptyList()
             _state.value = LinearOnboardingState.Completed(rootPlanId = rootPlan.id, result = result)
         }
     }
@@ -145,6 +170,7 @@ class LinearOnboardingOrchestratorImpl @Inject constructor() : LinearOnboardingO
             rootPlan.onSkipped()
         } finally {
             backStack = emptyList()
+            history = emptyList()
             _state.value = LinearOnboardingState.Skipped(rootPlanId = rootPlan.id)
         }
     }

--- a/onboarding/onboarding-impl/src/test/java/com/duckduckgo/onboarding/impl/LinearOnboardingOrchestratorImplTest.kt
+++ b/onboarding/onboarding-impl/src/test/java/com/duckduckgo/onboarding/impl/LinearOnboardingOrchestratorImplTest.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.onboarding.api.LinearOnboardingStepId
 import com.duckduckgo.onboarding.api.LinearOnboardingTransition
 import com.duckduckgo.onboarding.api.LinearOnboardingTransition.AbortPlan
 import com.duckduckgo.onboarding.api.LinearOnboardingTransition.Advance
+import com.duckduckgo.onboarding.api.LinearOnboardingTransition.GoBack
 import com.duckduckgo.onboarding.api.LinearOnboardingTransition.ReturnAndAdvance
 import com.duckduckgo.onboarding.api.LinearOnboardingTransition.Stay
 import com.duckduckgo.onboarding.api.LinearOnboardingTransition.SwitchTo
@@ -48,6 +49,17 @@ class LinearOnboardingOrchestratorImplTest {
     }
 
     private object Next : LinearOnboardingEvent
+    private object Back : LinearOnboardingEvent
+
+    // A step that goes back on [Back] and advances on anything else, for exercising GoBack.
+    private fun backAwareStep(
+        id: String,
+        precondition: suspend () -> Boolean = { true },
+    ): LinearOnboardingStep = step(
+        id = id,
+        precondition = precondition,
+        transition = { event -> if (event is Back) GoBack else Advance },
+    )
 
     private fun step(
         id: String,
@@ -421,5 +433,111 @@ class LinearOnboardingOrchestratorImplTest {
         val state = testee.state.value
         assertEquals(Completed(rootPlanId = PLAN_ID), state)
         assertEquals(PLAN_ID, (state as Completed).rootPlanId)
+    }
+
+    @Test
+    fun `when on first step then can go back is false`() = runTest {
+        testee.startPlan(LinearOnboardingPlan(id = PLAN_ID, steps = listOf(step("a"), step("b"))))
+
+        assertEquals(false, (testee.state.value as InProgress).canGoBack)
+    }
+
+    @Test
+    fun `when advanced past first step then can go back is true`() = runTest {
+        testee.startPlan(LinearOnboardingPlan(id = PLAN_ID, steps = listOf(step("a"), step("b"))))
+
+        testee.onEvent(Next) // a -> b
+
+        val state = testee.state.value as InProgress
+        assertEquals("b", state.currentStep.id)
+        assertEquals(true, state.canGoBack)
+    }
+
+    @Test
+    fun `when go back then returns to previous step`() = runTest {
+        testee.startPlan(
+            LinearOnboardingPlan(id = PLAN_ID, steps = listOf(backAwareStep("a"), backAwareStep("b"))),
+        )
+
+        testee.onEvent(Next) // a -> b
+        testee.onEvent(Back) // b -> back to a
+
+        val state = testee.state.value as InProgress
+        assertEquals("a", state.currentStep.id)
+        // Back on the first shown step again would be a no-op.
+        assertEquals(false, state.canGoBack)
+    }
+
+    @Test
+    fun `when go back on first step then no op and state unchanged`() = runTest {
+        testee.startPlan(
+            LinearOnboardingPlan(id = PLAN_ID, steps = listOf(backAwareStep("a"), backAwareStep("b"))),
+        )
+
+        testee.onEvent(Back) // nothing earlier -> no-op
+
+        val state = testee.state.value as InProgress
+        assertEquals("a", state.currentStep.id)
+        assertEquals(false, state.canGoBack)
+    }
+
+    @Test
+    fun `when go back to a step whose precondition became false then it is still restored`() = runTest {
+        // "a" is eligible when first shown, then becomes ineligible (e.g. marked complete). History-based back
+        // must still restore it; a precondition-recomputing back could not.
+        var aEligible = true
+        testee.startPlan(
+            LinearOnboardingPlan(
+                id = PLAN_ID,
+                steps = listOf(backAwareStep("a", precondition = { aEligible }), backAwareStep("b")),
+            ),
+        )
+
+        testee.onEvent(Next) // a -> b
+        aEligible = false // "a" would now be skipped by a forward advance
+        testee.onEvent(Back) // b -> back to a, restored from history
+
+        assertEquals("a", (testee.state.value as InProgress).currentStep.id)
+    }
+
+    @Test
+    fun `when advance after go back then moves forward again`() = runTest {
+        testee.startPlan(
+            LinearOnboardingPlan(id = PLAN_ID, steps = listOf(backAwareStep("a"), backAwareStep("b"), backAwareStep("c"))),
+        )
+
+        testee.onEvent(Next) // a -> b
+        testee.onEvent(Next) // b -> c
+        testee.onEvent(Back) // c -> b
+        assertEquals("b", (testee.state.value as InProgress).currentStep.id)
+
+        testee.onEvent(Next) // b -> c again
+
+        val state = testee.state.value as InProgress
+        assertEquals("c", state.currentStep.id)
+        assertEquals(true, state.canGoBack)
+    }
+
+    @Test
+    fun `when go back across a switch to boundary then restores the caller step`() = runTest {
+        val sidePlan = LinearOnboardingPlan(id = SIDE_PLAN_ID, steps = listOf(backAwareStep("side")))
+        testee.startPlan(
+            LinearOnboardingPlan(
+                id = PLAN_ID,
+                steps = listOf(
+                    step("a", transition = { event -> if (event is Back) GoBack else SwitchTo(sidePlan) }),
+                    backAwareStep("b"),
+                ),
+            ),
+        )
+
+        testee.onEvent(Next) // a -> SwitchTo(side); now on "side"
+        assertEquals("side", (testee.state.value as InProgress).currentStep.id)
+
+        testee.onEvent(Back) // side -> back to caller step "a"
+
+        val state = testee.state.value as InProgress
+        assertEquals("a", state.currentStep.id)
+        assertEquals(PLAN_ID, state.rootPlanId)
     }
 }

--- a/subscriptions/subscriptions-api/build.gradle
+++ b/subscriptions/subscriptions-api/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation project(path: ':navigation-api')
     implementation project(':js-messaging-api')
     implementation KotlinX.coroutines.core
+    implementation AndroidX.fragment.ktx
 }
 
 android {

--- a/subscriptions/subscriptions-api/src/main/java/com/duckduckgo/subscriptions/api/SubscriptionOnboardingStepPlugin.kt
+++ b/subscriptions/subscriptions-api/src/main/java/com/duckduckgo/subscriptions/api/SubscriptionOnboardingStepPlugin.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.subscriptions.api
 
 import androidx.annotation.StringRes
 import androidx.fragment.app.Fragment
+import kotlinx.coroutines.flow.Flow
 
 /**
  * A single step in the native subscription onboarding flow, contributed from the feature module that owns
@@ -43,19 +44,6 @@ interface SubscriptionOnboardingStepPlugin {
     fun createFragment(): Fragment
 }
 
-/**
- * Implemented by the host activity (`SubscriptionOnboardingActivity`). A step's Fragment obtains it via
- * `requireActivity() as SubscriptionOnboardingStepHost` and calls back to drive the flow, so the Fragment
- * never depends on `subscriptions-impl` or the onboarding framework.
- */
-interface SubscriptionOnboardingStepHost {
-    /** The current step is done: advance to the next one, recording [outcome] for completion tracking. */
-    fun onStepFinished(stepId: String, outcome: SubscriptionOnboardingStepOutcome)
-
-    /** Leave the onboarding entirely (e.g. the Duck.ai step hands off to the chat). */
-    fun exitOnboarding()
-}
-
 /** How a step ended. Only [COMPLETED] is persisted as a completed step. */
 enum class SubscriptionOnboardingStepOutcome {
     COMPLETED,
@@ -63,10 +51,25 @@ enum class SubscriptionOnboardingStepOutcome {
 }
 
 /**
- * Resolves the [SubscriptionOnboardingStepHost] for a step fragment without assuming it is hosted directly by
- * an Activity: prefers a parent fragment, then the hosting context. Errors if neither implements the contract.
+ * Injected into each step so it can talk to its host without knowing what renders it: steps call the methods,
+ * the host observes [events].
  */
-fun Fragment.requireSubscriptionOnboardingStepHost(): SubscriptionOnboardingStepHost =
-    (parentFragment as? SubscriptionOnboardingStepHost)
-        ?: (activity as? SubscriptionOnboardingStepHost)
-        ?: error("Host must implement SubscriptionOnboardingStepHost")
+interface SubscriptionOnboardingController {
+    /** Events for the host to react to. */
+    val events: Flow<Event>
+
+    /** The current step finished with [outcome]. */
+    fun onStepFinished(stepId: String, outcome: SubscriptionOnboardingStepOutcome)
+
+    /** Go back to the previous step. */
+    fun onBack()
+
+    /** Leave onboarding entirely. */
+    fun exitOnboarding()
+
+    sealed interface Event {
+        data class StepFinished(val stepId: String, val outcome: SubscriptionOnboardingStepOutcome) : Event
+        data object Back : Event
+        data object Exit : Event
+    }
+}

--- a/subscriptions/subscriptions-api/src/main/java/com/duckduckgo/subscriptions/api/SubscriptionOnboardingStepPlugin.kt
+++ b/subscriptions/subscriptions-api/src/main/java/com/duckduckgo/subscriptions/api/SubscriptionOnboardingStepPlugin.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.api
+
+import androidx.fragment.app.Fragment
+
+/**
+ * A single step in the native subscription onboarding flow, contributed from the feature module that owns
+ * the step (e.g. the VPN step lives in the VPN module, the Duck.ai step in the Duck.ai module). Each feature
+ * module contributes one implementation as a multibinding; the host in `subscriptions-impl` collects them,
+ * orders them (by `@PriorityKey`), and turns them into linear-onboarding steps.
+ *
+ * Keeping this contract framework-agnostic (just a [Fragment] factory + an id) is what lets a step live in
+ * a different `-impl` module: the host never names the concrete Fragment class.
+ */
+interface SubscriptionOnboardingStepPlugin {
+    /** Stable id for this step. Also the key used to persist completion. */
+    val stepId: String
+
+    /** Whether this step should be shown to the current user (e.g. gated by feature flag / entitlement). Skipped when false. */
+    suspend fun shouldShow(): Boolean
+
+    /** Creates the full-screen Fragment for this step. Dagger injection happens when it attaches to the host. */
+    fun createFragment(): Fragment
+}
+
+/**
+ * Implemented by the host activity (`SubscriptionOnboardingActivity`). A step's Fragment obtains it via
+ * `requireActivity() as SubscriptionOnboardingStepHost` and calls back to drive the flow, so the Fragment
+ * never depends on `subscriptions-impl` or the onboarding framework.
+ */
+interface SubscriptionOnboardingStepHost {
+    /** The current step is done: advance to the next one, recording [outcome] for completion tracking. */
+    fun onStepFinished(stepId: String, outcome: SubscriptionOnboardingStepOutcome)
+
+    /** Leave the onboarding entirely (e.g. the Duck.ai step hands off to the chat). */
+    fun exitOnboarding()
+}
+
+/** How a step ended. Only [COMPLETED] is persisted as a completed step. */
+enum class SubscriptionOnboardingStepOutcome {
+    COMPLETED,
+    SKIPPED,
+}

--- a/subscriptions/subscriptions-api/src/main/java/com/duckduckgo/subscriptions/api/SubscriptionOnboardingStepPlugin.kt
+++ b/subscriptions/subscriptions-api/src/main/java/com/duckduckgo/subscriptions/api/SubscriptionOnboardingStepPlugin.kt
@@ -61,3 +61,12 @@ enum class SubscriptionOnboardingStepOutcome {
     COMPLETED,
     SKIPPED,
 }
+
+/**
+ * Resolves the [SubscriptionOnboardingStepHost] for a step fragment without assuming it is hosted directly by
+ * an Activity: prefers a parent fragment, then the hosting context. Errors if neither implements the contract.
+ */
+fun Fragment.requireSubscriptionOnboardingStepHost(): SubscriptionOnboardingStepHost =
+    (parentFragment as? SubscriptionOnboardingStepHost)
+        ?: (activity as? SubscriptionOnboardingStepHost)
+        ?: error("Host must implement SubscriptionOnboardingStepHost")

--- a/subscriptions/subscriptions-api/src/main/java/com/duckduckgo/subscriptions/api/SubscriptionOnboardingStepPlugin.kt
+++ b/subscriptions/subscriptions-api/src/main/java/com/duckduckgo/subscriptions/api/SubscriptionOnboardingStepPlugin.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.subscriptions.api
 
+import androidx.annotation.StringRes
 import androidx.fragment.app.Fragment
 
 /**
@@ -30,6 +31,10 @@ import androidx.fragment.app.Fragment
 interface SubscriptionOnboardingStepPlugin {
     /** Stable id for this step. Also the key used to persist completion. */
     val stepId: String
+
+    /** Title shown in the host's toolbar while this step is on screen. */
+    @get:StringRes
+    val titleResId: Int
 
     /** Whether this step should be shown to the current user (e.g. gated by feature flag / entitlement). Skipped when false. */
     suspend fun shouldShow(): Boolean

--- a/subscriptions/subscriptions-api/src/main/java/com/duckduckgo/subscriptions/api/SubscriptionScreens.kt
+++ b/subscriptions/subscriptions-api/src/main/java/com/duckduckgo/subscriptions/api/SubscriptionScreens.kt
@@ -23,4 +23,5 @@ sealed class SubscriptionScreens {
     data class RestoreSubscriptionScreenWithParams(val isOriginWeb: Boolean = true) : ActivityParams
     data class SubscriptionPurchase(val origin: String? = null, val featurePage: String? = null) : ActivityParams
     data class SubscriptionUpgrade(val origin: String? = null) : ActivityParams
+    data object SubscriptionOnboardingScreenWithEmptyParams : ActivityParams
 }

--- a/subscriptions/subscriptions-dummy-impl/src/main/java/com/duckduckgo/subscriptions/impl/DummySubscriptionOnboardingController.kt
+++ b/subscriptions/subscriptions-dummy-impl/src/main/java/com/duckduckgo/subscriptions/impl/DummySubscriptionOnboardingController.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingController
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingController.Event
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome
+import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import javax.inject.Inject
+
+@ContributesBinding(AppScope::class)
+class DummySubscriptionOnboardingController @Inject constructor() : SubscriptionOnboardingController {
+
+    override val events: Flow<Event> = emptyFlow()
+
+    override fun onStepFinished(stepId: String, outcome: SubscriptionOnboardingStepOutcome) {
+        // no-op
+    }
+
+    override fun onBack() {
+        // no-op
+    }
+
+    override fun exitOnboarding() {
+        // no-op
+    }
+}

--- a/subscriptions/subscriptions-impl/build.gradle
+++ b/subscriptions/subscriptions-impl/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     implementation project(':vpn-api')
     implementation project(':content-scope-scripts-api')
     implementation project(':duckchat-api')
+    implementation project(':onboarding-api')
     implementation project(':pir-api')
     implementation project(':attributed-metrics-api')
     implementation project(':privacy-dashboard-api')
@@ -96,6 +97,7 @@ dependencies {
     // Testing dependencies
     testImplementation project(':feature-toggles-test')
     testImplementation project(path: ':common-test')
+    testImplementation project(path: ':data-store-test')
     testImplementation "org.mockito.kotlin:mockito-kotlin:_"
     testImplementation Testing.junit4
     testImplementation AndroidX.archCore.testing

--- a/subscriptions/subscriptions-impl/src/main/AndroidManifest.xml
+++ b/subscriptions/subscriptions-impl/src/main/AndroidManifest.xml
@@ -31,6 +31,13 @@
                 android:screenOrientation="portrait" />
 
         <activity
+                android:name=".onboarding.SubscriptionOnboardingActivity"
+                android:exported="false"
+                android:label="@string/privacyPro"
+                android:parentActivityName="com.duckduckgo.app.settings.SettingsActivity"
+                android:screenOrientation="portrait" />
+
+        <activity
                 android:name=".ui.RestoreSubscriptionActivity"
                 android:exported="false"
                 android:label="@string/activityActivateSubscription"

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/RealSubscriptions.kt
@@ -306,6 +306,15 @@ interface SubscriptionsFeature {
 
     @Toggle.DefaultValue(defaultValue = DefaultFeatureValue.TRUE)
     fun schedulePaywallNotSeenPixels(): Toggle
+
+    /**
+     * When enabled, showing a native subscription onboarding purchase
+     * instead of redirecting the FE to /welcome.
+     *
+     * TODO: Change for experiment framework
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun onboardingSubscriptionExperiment(): Toggle
 }
 
 @ContributesBinding(AppScope::class)

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/RealSubscriptionOnboardingController.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/RealSubscriptionOnboardingController.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.onboarding
+
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingController
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingController.Event
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import javax.inject.Inject
+
+/**
+ * Relays step events to the host. AppScope so steps and the retained host ViewModel share one instance across
+ * configuration changes. SharedFlow with no replay: buffered, not delivered to later runs.
+ */
+@SingleInstanceIn(AppScope::class)
+@ContributesBinding(AppScope::class)
+class RealSubscriptionOnboardingController @Inject constructor() : SubscriptionOnboardingController {
+
+    private val _events = MutableSharedFlow<Event>(extraBufferCapacity = 10)
+    override val events: Flow<Event> = _events.asSharedFlow()
+
+    override fun onStepFinished(stepId: String, outcome: SubscriptionOnboardingStepOutcome) {
+        _events.tryEmit(Event.StepFinished(stepId, outcome))
+    }
+
+    override fun onBack() {
+        _events.tryEmit(Event.Back)
+    }
+
+    override fun exitOnboarding() {
+        _events.tryEmit(Event.Exit)
+    }
+}

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingActivity.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.onboarding
+
+import android.content.Intent
+import android.os.Bundle
+import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.browser.api.ui.BrowserScreens.SettingsScreenNoParams
+import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionOnboardingScreenWithEmptyParams
+import com.duckduckgo.subscriptions.impl.databinding.ActivitySubscriptionOnboardingBinding
+import javax.inject.Inject
+
+/**
+ * Entry point for the native subscription onboarding flow. Step 1 is a placeholder welcome screen; the primary
+ * button finishes to Settings.
+ *
+ * The multi-step flow driven by the LinearOnboardingOrchestrator (plan/steps/events, fragment-swapping) lands
+ * in a follow-up step.
+ */
+@InjectWith(ActivityScope::class)
+@ContributeToActivityStarter(SubscriptionOnboardingScreenWithEmptyParams::class, screenName = "subscriptions.onboarding")
+class SubscriptionOnboardingActivity : DuckDuckGoActivity() {
+
+    @Inject
+    lateinit var globalActivityStarter: GlobalActivityStarter
+
+    private val binding: ActivitySubscriptionOnboardingBinding by viewBinding()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(binding.root)
+
+        binding.subscriptionOnboardingWelcomeContinueButton.setOnClickListener {
+            finishToSettings()
+        }
+    }
+
+    private fun finishToSettings() {
+        globalActivityStarter.startIntent(this, SettingsScreenNoParams)?.let { intent ->
+            intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
+            startActivity(intent)
+        }
+        finish()
+    }
+}

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingActivity.kt
@@ -98,16 +98,22 @@ class SubscriptionOnboardingActivity : DuckDuckGoActivity(), SubscriptionOnboard
 
     private fun processCommand(command: Command) {
         when (command) {
-            is Command.ShowStep -> showStep(command.stepPlugin)
+            is Command.ShowStep -> showStep(command)
             is Command.FinishToSettings -> finishToSettings()
             is Command.Finish -> finish()
         }
     }
 
-    private fun showStep(stepPlugin: SubscriptionOnboardingStepPlugin) {
-        supportActionBar?.setTitle(stepPlugin.titleResId)
+    private fun showStep(command: Command.ShowStep) {
+        val navIcon = if (command.canGoBack) {
+            com.duckduckgo.mobile.android.R.drawable.ic_arrow_left_24
+        } else {
+            com.duckduckgo.mobile.android.R.drawable.ic_close_24
+        }
+        binding.includeToolbar.toolbar.setNavigationIcon(navIcon)
+        supportActionBar?.setTitle(command.stepPlugin.titleResId)
         supportFragmentManager.commit {
-            replace(binding.subscriptionOnboardingContainer.id, stepPlugin.createFragment(), stepPlugin.stepId)
+            replace(binding.subscriptionOnboardingContainer.id, command.stepPlugin.createFragment(), command.stepPlugin.stepId)
         }
     }
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingActivity.kt
@@ -31,8 +31,7 @@ import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
-import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepHost
-import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingController
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepPlugin
 import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionOnboardingScreenWithEmptyParams
 import com.duckduckgo.subscriptions.impl.databinding.ActivitySubscriptionOnboardingBinding
@@ -44,15 +43,18 @@ import javax.inject.Inject
 /**
  * Hosts the native subscription onboarding flow. It observes the orchestrator-driven state exposed by
  * [SubscriptionOnboardingViewModel] and swaps the current step's Fragment (supplied by the step's
- * [SubscriptionOnboardingStepPlugin], which may live in another module) into the container. Step
- * Fragments report back through [SubscriptionOnboardingStepHost].
+ * [SubscriptionOnboardingStepPlugin], which may live in another module) into the container. Steps report
+ * back through [SubscriptionOnboardingController].
  */
 @InjectWith(ActivityScope::class)
 @ContributeToActivityStarter(SubscriptionOnboardingScreenWithEmptyParams::class, screenName = "subscriptions.onboarding")
-class SubscriptionOnboardingActivity : DuckDuckGoActivity(), SubscriptionOnboardingStepHost {
+class SubscriptionOnboardingActivity : DuckDuckGoActivity() {
 
     @Inject
     lateinit var globalActivityStarter: GlobalActivityStarter
+
+    @Inject
+    lateinit var controller: SubscriptionOnboardingController
 
     private val viewModel: SubscriptionOnboardingViewModel by bindViewModel()
     private val binding: ActivitySubscriptionOnboardingBinding by viewBinding()
@@ -62,12 +64,12 @@ class SubscriptionOnboardingActivity : DuckDuckGoActivity(), SubscriptionOnboard
         setContentView(binding.root)
         setupToolbar(binding.includeToolbar.toolbar)
 
-        // Route the system back gesture (and the toolbar up arrow, via onOptionsItemSelected) through the ViewModel.
+        // System back and the toolbar up arrow both go through the controller.
         onBackPressedDispatcher.addCallback(
             this,
             object : OnBackPressedCallback(true) {
                 override fun handleOnBackPressed() {
-                    viewModel.onBack()
+                    controller.onBack()
                 }
             },
         )
@@ -86,14 +88,6 @@ class SubscriptionOnboardingActivity : DuckDuckGoActivity(), SubscriptionOnboard
             return true
         }
         return super.onOptionsItemSelected(item)
-    }
-
-    override fun onStepFinished(stepId: String, outcome: SubscriptionOnboardingStepOutcome) {
-        viewModel.onStepFinished(stepId, outcome)
-    }
-
-    override fun exitOnboarding() {
-        viewModel.onExit()
     }
 
     private fun processCommand(command: Command) {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingActivity.kt
@@ -18,6 +18,8 @@ package com.duckduckgo.subscriptions.impl.onboarding
 
 import android.content.Intent
 import android.os.Bundle
+import android.view.MenuItem
+import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.commit
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
@@ -58,6 +60,17 @@ class SubscriptionOnboardingActivity : DuckDuckGoActivity(), SubscriptionOnboard
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
+        setupToolbar(binding.includeToolbar.toolbar)
+
+        // Route the system back gesture (and the toolbar up arrow, via onOptionsItemSelected) through the ViewModel.
+        onBackPressedDispatcher.addCallback(
+            this,
+            object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    viewModel.onBack()
+                }
+            },
+        )
 
         viewModel.commands
             .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
@@ -65,6 +78,14 @@ class SubscriptionOnboardingActivity : DuckDuckGoActivity(), SubscriptionOnboard
             .launchIn(lifecycleScope)
 
         viewModel.start()
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            onBackPressedDispatcher.onBackPressed()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
     }
 
     override fun onStepFinished(stepId: String, outcome: SubscriptionOnboardingStepOutcome) {
@@ -84,6 +105,7 @@ class SubscriptionOnboardingActivity : DuckDuckGoActivity(), SubscriptionOnboard
     }
 
     private fun showStep(stepPlugin: SubscriptionOnboardingStepPlugin) {
+        supportActionBar?.setTitle(stepPlugin.titleResId)
         supportFragmentManager.commit {
             replace(binding.subscriptionOnboardingContainer.id, stepPlugin.createFragment(), stepPlugin.stepId)
         }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingActivity.kt
@@ -18,6 +18,10 @@ package com.duckduckgo.subscriptions.impl.onboarding
 
 import android.content.Intent
 import android.os.Bundle
+import androidx.fragment.app.commit
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.browser.api.ui.BrowserScreens.SettingsScreenNoParams
@@ -25,32 +29,63 @@ import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepHost
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepPlugin
 import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionOnboardingScreenWithEmptyParams
 import com.duckduckgo.subscriptions.impl.databinding.ActivitySubscriptionOnboardingBinding
+import com.duckduckgo.subscriptions.impl.onboarding.SubscriptionOnboardingViewModel.Command
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
 /**
- * Entry point for the native subscription onboarding flow. Step 1 is a placeholder welcome screen; the primary
- * button finishes to Settings.
- *
- * The multi-step flow driven by the LinearOnboardingOrchestrator (plan/steps/events, fragment-swapping) lands
- * in a follow-up step.
+ * Hosts the native subscription onboarding flow. It observes the orchestrator-driven state exposed by
+ * [SubscriptionOnboardingViewModel] and swaps the current step's Fragment (supplied by the step's
+ * [SubscriptionOnboardingStepPlugin], which may live in another module) into the container. Step
+ * Fragments report back through [SubscriptionOnboardingStepHost].
  */
 @InjectWith(ActivityScope::class)
 @ContributeToActivityStarter(SubscriptionOnboardingScreenWithEmptyParams::class, screenName = "subscriptions.onboarding")
-class SubscriptionOnboardingActivity : DuckDuckGoActivity() {
+class SubscriptionOnboardingActivity : DuckDuckGoActivity(), SubscriptionOnboardingStepHost {
 
     @Inject
     lateinit var globalActivityStarter: GlobalActivityStarter
 
+    private val viewModel: SubscriptionOnboardingViewModel by bindViewModel()
     private val binding: ActivitySubscriptionOnboardingBinding by viewBinding()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
 
-        binding.subscriptionOnboardingWelcomeContinueButton.setOnClickListener {
-            finishToSettings()
+        viewModel.commands
+            .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+            .onEach { processCommand(it) }
+            .launchIn(lifecycleScope)
+
+        viewModel.start()
+    }
+
+    override fun onStepFinished(stepId: String, outcome: SubscriptionOnboardingStepOutcome) {
+        viewModel.onStepFinished(stepId, outcome)
+    }
+
+    override fun exitOnboarding() {
+        viewModel.onExit()
+    }
+
+    private fun processCommand(command: Command) {
+        when (command) {
+            is Command.ShowStep -> showStep(command.stepPlugin)
+            is Command.FinishToSettings -> finishToSettings()
+            is Command.Finish -> finish()
+        }
+    }
+
+    private fun showStep(stepPlugin: SubscriptionOnboardingStepPlugin) {
+        supportFragmentManager.commit {
+            replace(binding.subscriptionOnboardingContainer.id, stepPlugin.createFragment(), stepPlugin.stepId)
         }
     }
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingActivityStep.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingActivityStep.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.onboarding
+
+import com.duckduckgo.onboarding.api.LinearOnboardingEvent
+import com.duckduckgo.onboarding.api.LinearOnboardingHost
+import com.duckduckgo.onboarding.api.LinearOnboardingStep
+import com.duckduckgo.onboarding.api.LinearOnboardingStepId
+import com.duckduckgo.onboarding.api.LinearOnboardingTransition
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepPlugin
+
+/**
+ * A [SubscriptionOnboardingActivity]-hosted step. Wraps the contributed [stepPlugin] (which owns the
+ * Fragment) with the linear-onboarding step contract. The activity renders `stepPlugin.createFragment()`;
+ * the orchestrator only sees the generic [LinearOnboardingStep].
+ */
+data class SubscriptionOnboardingActivityStep(
+    override val id: LinearOnboardingStepId,
+    override val host: LinearOnboardingHost = LinearOnboardingHost.SubscriptionOnboardingActivity,
+    override val precondition: suspend () -> Boolean = { true },
+    override val transition: suspend (LinearOnboardingEvent) -> LinearOnboardingTransition,
+    val stepPlugin: SubscriptionOnboardingStepPlugin,
+) : LinearOnboardingStep

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingEvent.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingEvent.kt
@@ -17,12 +17,17 @@
 package com.duckduckgo.subscriptions.impl.onboarding
 
 import com.duckduckgo.onboarding.api.LinearOnboardingEvent
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome
 
 /**
  * Events fed into the subscription onboarding orchestrator. A step's Fragment reports completion through
  * [com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepHost]; the host translates that into
- * [StepFinished] for the current step, which advances the plan.
+ * [StepFinished] for the current step, which advances the plan. The toolbar / system back becomes [BackPressed].
  */
 sealed interface SubscriptionOnboardingEvent : LinearOnboardingEvent {
-    data class StepFinished(val stepId: String) : SubscriptionOnboardingEvent
+    /** The current step finished with [outcome] (completed vs skipped). */
+    data class StepFinished(val stepId: String, val outcome: SubscriptionOnboardingStepOutcome) : SubscriptionOnboardingEvent
+
+    /** The user asked to go back (toolbar up arrow or system back). */
+    data object BackPressed : SubscriptionOnboardingEvent
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingEvent.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingEvent.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.onboarding
+
+import com.duckduckgo.onboarding.api.LinearOnboardingEvent
+
+/**
+ * Events fed into the subscription onboarding orchestrator. A step's Fragment reports completion through
+ * [com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepHost]; the host translates that into
+ * [StepFinished] for the current step, which advances the plan.
+ */
+sealed interface SubscriptionOnboardingEvent : LinearOnboardingEvent {
+    data class StepFinished(val stepId: String) : SubscriptionOnboardingEvent
+}

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingEvent.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingEvent.kt
@@ -20,8 +20,8 @@ import com.duckduckgo.onboarding.api.LinearOnboardingEvent
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome
 
 /**
- * Events fed into the subscription onboarding orchestrator. A step's Fragment reports completion through
- * [com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepHost]; the host translates that into
+ * Events fed into the subscription onboarding orchestrator. Steps report through
+ * [com.duckduckgo.subscriptions.api.SubscriptionOnboardingController]; the host ViewModel translates those into
  * [StepFinished] for the current step, which advances the plan. The toolbar / system back becomes [BackPressed].
  */
 sealed interface SubscriptionOnboardingEvent : LinearOnboardingEvent {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingPlanProvider.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingPlanProvider.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.onboarding
+
+import com.duckduckgo.common.utils.plugins.PluginPoint
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.onboarding.api.LinearOnboardingPlan
+import com.duckduckgo.onboarding.api.LinearOnboardingTransition.Advance
+import com.duckduckgo.onboarding.api.LinearOnboardingTransition.Stay
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepPlugin
+import com.duckduckgo.subscriptions.impl.onboarding.SubscriptionOnboardingEvent.StepFinished
+import com.duckduckgo.subscriptions.impl.store.SubscriptionOnboardingStepStore
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+/**
+ * Builds the linear-onboarding plan from the step plugins contributed across feature modules. Plugins are
+ * collected in `@PriorityKey` order, filtered by [SubscriptionOnboardingStepPlugin.shouldShow], and each
+ * becomes a [SubscriptionOnboardingActivityStep]. Already-completed steps are skipped on re-entry via the
+ * step precondition. Running off the end of the plan completes the run (the activity finishes to Settings).
+ */
+@SingleInstanceIn(AppScope::class)
+class SubscriptionOnboardingPlanProvider @Inject constructor(
+    private val stepPlugins: PluginPoint<SubscriptionOnboardingStepPlugin>,
+    private val stepStore: SubscriptionOnboardingStepStore,
+) {
+
+    suspend fun buildPlan(): LinearOnboardingPlan {
+        val steps = stepPlugins.getPlugins()
+            .filter { it.shouldShow() }
+            .map { stepPlugin -> activityStep(stepPlugin) }
+        return LinearOnboardingPlan(
+            id = SUBSCRIPTION_ONBOARDING_PLAN_ID,
+            steps = steps,
+        )
+    }
+
+    private fun activityStep(stepPlugin: SubscriptionOnboardingStepPlugin): SubscriptionOnboardingActivityStep =
+        SubscriptionOnboardingActivityStep(
+            id = stepPlugin.stepId,
+            stepPlugin = stepPlugin,
+            precondition = { !stepStore.isCompleted(stepPlugin.stepId) },
+            transition = { event ->
+                when {
+                    event is StepFinished && event.stepId == stepPlugin.stepId -> Advance
+                    else -> Stay
+                }
+            },
+        )
+
+    companion object {
+        const val SUBSCRIPTION_ONBOARDING_PLAN_ID = "subscription_onboarding"
+    }
+}

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingPlanProvider.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingPlanProvider.kt
@@ -20,8 +20,10 @@ import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.onboarding.api.LinearOnboardingPlan
 import com.duckduckgo.onboarding.api.LinearOnboardingTransition.Advance
+import com.duckduckgo.onboarding.api.LinearOnboardingTransition.GoBack
 import com.duckduckgo.onboarding.api.LinearOnboardingTransition.Stay
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepPlugin
+import com.duckduckgo.subscriptions.impl.onboarding.SubscriptionOnboardingEvent.BackPressed
 import com.duckduckgo.subscriptions.impl.onboarding.SubscriptionOnboardingEvent.StepFinished
 import com.duckduckgo.subscriptions.impl.store.SubscriptionOnboardingStepStore
 import dagger.SingleInstanceIn
@@ -57,6 +59,7 @@ class SubscriptionOnboardingPlanProvider @Inject constructor(
             transition = { event ->
                 when {
                     event is StepFinished && event.stepId == stepPlugin.stepId -> Advance
+                    event is BackPressed -> GoBack
                     else -> Stay
                 }
             },

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingStepPluginPoint.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingStepPluginPoint.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.onboarding
+
+import com.duckduckgo.anvil.annotations.ContributesPluginPoint
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepPlugin
+
+/**
+ * Declares the plugin point that collects every [SubscriptionOnboardingStepPlugin] contributed across
+ * feature modules. Feature modules contribute their step with `@ContributesMultibinding(AppScope::class)`
+ * and order it with `@PriorityKey(n)` (lower first).
+ */
+@ContributesPluginPoint(
+    scope = AppScope::class,
+    boundType = SubscriptionOnboardingStepPlugin::class,
+)
+private interface SubscriptionOnboardingStepPluginPoint

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingViewModel.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.onboarding.api.LinearOnboardingState
 import com.duckduckgo.onboarding.api.forPlan
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepPlugin
+import com.duckduckgo.subscriptions.impl.onboarding.SubscriptionOnboardingEvent.BackPressed
 import com.duckduckgo.subscriptions.impl.onboarding.SubscriptionOnboardingEvent.StepFinished
 import com.duckduckgo.subscriptions.impl.onboarding.SubscriptionOnboardingPlanProvider.Companion.SUBSCRIPTION_ONBOARDING_PLAN_ID
 import com.duckduckgo.subscriptions.impl.store.SubscriptionOnboardingStepStore
@@ -61,6 +62,9 @@ class SubscriptionOnboardingViewModel @Inject constructor(
 
     private var started = false
 
+    // Mirrors the current step's InProgress.canGoBack, so onBack() knows whether to go back or exit.
+    private var canGoBack = false
+
     fun start() {
         if (started) return
         started = true
@@ -78,6 +82,7 @@ class SubscriptionOnboardingViewModel @Inject constructor(
             is LinearOnboardingState.InProgress -> {
                 val step = state.currentStep
                 if (step is SubscriptionOnboardingActivityStep) {
+                    canGoBack = state.canGoBack
                     _commands.send(Command.ShowStep(step.stepPlugin))
                 }
             }
@@ -90,7 +95,18 @@ class SubscriptionOnboardingViewModel @Inject constructor(
         if (outcome == SubscriptionOnboardingStepOutcome.COMPLETED) {
             stepStore.setCompleted(stepId)
         }
-        viewModelScope.launch { orchestrator.onEvent(StepFinished(stepId)) }
+        viewModelScope.launch { orchestrator.onEvent(StepFinished(stepId, outcome)) }
+    }
+
+    fun onBack() {
+        viewModelScope.launch {
+            if (canGoBack) {
+                orchestrator.onEvent(BackPressed)
+            } else {
+                // Nothing earlier in the flow: back on the first step leaves onboarding.
+                _commands.send(Command.Finish)
+            }
+        }
     }
 
     fun onExit() {

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingViewModel.kt
@@ -52,7 +52,7 @@ class SubscriptionOnboardingViewModel @Inject constructor(
 ) : ViewModel() {
 
     sealed interface Command {
-        data class ShowStep(val stepPlugin: SubscriptionOnboardingStepPlugin) : Command
+        data class ShowStep(val stepPlugin: SubscriptionOnboardingStepPlugin, val canGoBack: Boolean) : Command
         data object FinishToSettings : Command
         data object Finish : Command
     }
@@ -83,11 +83,11 @@ class SubscriptionOnboardingViewModel @Inject constructor(
                 val step = state.currentStep
                 if (step is SubscriptionOnboardingActivityStep) {
                     canGoBack = state.canGoBack
-                    _commands.send(Command.ShowStep(step.stepPlugin))
+                    _commands.send(Command.ShowStep(step.stepPlugin, state.canGoBack))
                 }
             }
             is LinearOnboardingState.Completed -> _commands.send(Command.FinishToSettings)
-            is LinearOnboardingState.Skipped -> _commands.send(Command.Finish)
+            is LinearOnboardingState.Skipped -> _commands.send(Command.FinishToSettings)
         }
     }
 
@@ -103,8 +103,9 @@ class SubscriptionOnboardingViewModel @Inject constructor(
             if (canGoBack) {
                 orchestrator.onEvent(BackPressed)
             } else {
-                // Nothing earlier in the flow: back on the first step leaves onboarding.
-                _commands.send(Command.Finish)
+                // First step: exit onboarding. Launched standalone after purchase, so land on app settings.
+                // TODO when a subscription-settings entry point is added, exit should return there instead.
+                _commands.send(Command.FinishToSettings)
             }
         }
     }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingViewModel.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.onboarding
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.onboarding.api.LinearOnboardingOrchestrator
+import com.duckduckgo.onboarding.api.LinearOnboardingState
+import com.duckduckgo.onboarding.api.forPlan
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepPlugin
+import com.duckduckgo.subscriptions.impl.onboarding.SubscriptionOnboardingEvent.StepFinished
+import com.duckduckgo.subscriptions.impl.onboarding.SubscriptionOnboardingPlanProvider.Companion.SUBSCRIPTION_ONBOARDING_PLAN_ID
+import com.duckduckgo.subscriptions.impl.store.SubscriptionOnboardingStepStore
+import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Drives the native subscription onboarding: starts the plugin-built plan on the shared
+ * [LinearOnboardingOrchestrator] and translates its state (scoped to [SUBSCRIPTION_ONBOARDING_PLAN_ID]) into
+ * [Command]s the activity renders. Step Fragments report back through the host, which calls [onStepFinished]
+ * / [onExit].
+ */
+@ContributesViewModel(ActivityScope::class)
+class SubscriptionOnboardingViewModel @Inject constructor(
+    private val orchestrator: LinearOnboardingOrchestrator,
+    private val planProvider: SubscriptionOnboardingPlanProvider,
+    private val stepStore: SubscriptionOnboardingStepStore,
+) : ViewModel() {
+
+    sealed interface Command {
+        data class ShowStep(val stepPlugin: SubscriptionOnboardingStepPlugin) : Command
+        data object FinishToSettings : Command
+        data object Finish : Command
+    }
+
+    private val _commands = Channel<Command>(1, DROP_OLDEST)
+    val commands: Flow<Command> = _commands.receiveAsFlow()
+
+    private var started = false
+
+    fun start() {
+        if (started) return
+        started = true
+
+        viewModelScope.launch { orchestrator.startPlan(planProvider.buildPlan()) }
+
+        orchestrator.state
+            .forPlan(SUBSCRIPTION_ONBOARDING_PLAN_ID)
+            .onEach { handleState(it) }
+            .launchIn(viewModelScope)
+    }
+
+    private suspend fun handleState(state: LinearOnboardingState.Started) {
+        when (state) {
+            is LinearOnboardingState.InProgress -> {
+                val step = state.currentStep
+                if (step is SubscriptionOnboardingActivityStep) {
+                    _commands.send(Command.ShowStep(step.stepPlugin))
+                }
+            }
+            is LinearOnboardingState.Completed -> _commands.send(Command.FinishToSettings)
+            is LinearOnboardingState.Skipped -> _commands.send(Command.Finish)
+        }
+    }
+
+    fun onStepFinished(stepId: String, outcome: SubscriptionOnboardingStepOutcome) {
+        if (outcome == SubscriptionOnboardingStepOutcome.COMPLETED) {
+            stepStore.setCompleted(stepId)
+        }
+        viewModelScope.launch { orchestrator.onEvent(StepFinished(stepId)) }
+    }
+
+    fun onExit() {
+        viewModelScope.launch { _commands.send(Command.Finish) }
+    }
+}

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingViewModel.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.onboarding.api.LinearOnboardingOrchestrator
 import com.duckduckgo.onboarding.api.LinearOnboardingState
 import com.duckduckgo.onboarding.api.forPlan
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingController
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepPlugin
 import com.duckduckgo.subscriptions.impl.onboarding.SubscriptionOnboardingEvent.BackPressed
@@ -41,14 +42,15 @@ import javax.inject.Inject
 /**
  * Drives the native subscription onboarding: starts the plugin-built plan on the shared
  * [LinearOnboardingOrchestrator] and translates its state (scoped to [SUBSCRIPTION_ONBOARDING_PLAN_ID]) into
- * [Command]s the activity renders. Step Fragments report back through the host, which calls [onStepFinished]
- * / [onExit].
+ * [Command]s the activity renders. Steps report back through [SubscriptionOnboardingController], whose events
+ * this ViewModel observes and turns into orchestrator events / store writes.
  */
 @ContributesViewModel(ActivityScope::class)
 class SubscriptionOnboardingViewModel @Inject constructor(
     private val orchestrator: LinearOnboardingOrchestrator,
     private val planProvider: SubscriptionOnboardingPlanProvider,
     private val stepStore: SubscriptionOnboardingStepStore,
+    private val controller: SubscriptionOnboardingController,
 ) : ViewModel() {
 
     sealed interface Command {
@@ -62,7 +64,7 @@ class SubscriptionOnboardingViewModel @Inject constructor(
 
     private var started = false
 
-    // Mirrors the current step's InProgress.canGoBack, so onBack() knows whether to go back or exit.
+    // Mirrors the current step's InProgress.canGoBack; decides back vs exit on a Back event.
     private var canGoBack = false
 
     fun start() {
@@ -74,6 +76,10 @@ class SubscriptionOnboardingViewModel @Inject constructor(
         orchestrator.state
             .forPlan(SUBSCRIPTION_ONBOARDING_PLAN_ID)
             .onEach { handleState(it) }
+            .launchIn(viewModelScope)
+
+        controller.events
+            .onEach { handleControllerEvent(it) }
             .launchIn(viewModelScope)
     }
 
@@ -91,26 +97,24 @@ class SubscriptionOnboardingViewModel @Inject constructor(
         }
     }
 
-    fun onStepFinished(stepId: String, outcome: SubscriptionOnboardingStepOutcome) {
-        if (outcome == SubscriptionOnboardingStepOutcome.COMPLETED) {
-            stepStore.setCompleted(stepId)
-        }
-        viewModelScope.launch { orchestrator.onEvent(StepFinished(stepId, outcome)) }
-    }
-
-    fun onBack() {
-        viewModelScope.launch {
-            if (canGoBack) {
-                orchestrator.onEvent(BackPressed)
-            } else {
-                // First step: exit onboarding. Launched standalone after purchase, so land on app settings.
-                // TODO when a subscription-settings entry point is added, exit should return there instead.
-                _commands.send(Command.FinishToSettings)
+    private suspend fun handleControllerEvent(event: SubscriptionOnboardingController.Event) {
+        when (event) {
+            is SubscriptionOnboardingController.Event.StepFinished -> {
+                if (event.outcome == SubscriptionOnboardingStepOutcome.COMPLETED) {
+                    stepStore.setCompleted(event.stepId)
+                }
+                orchestrator.onEvent(StepFinished(event.stepId, event.outcome))
             }
+            SubscriptionOnboardingController.Event.Back -> {
+                if (canGoBack) {
+                    orchestrator.onEvent(BackPressed)
+                } else {
+                    // First step: nothing to go back to, so exit to app settings.
+                    // TODO: return to the launch source once a subscription-settings entry point exists.
+                    _commands.send(Command.FinishToSettings)
+                }
+            }
+            SubscriptionOnboardingController.Event.Exit -> _commands.send(Command.Finish)
         }
-    }
-
-    fun onExit() {
-        viewModelScope.launch { _commands.send(Command.Finish) }
     }
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/welcome/SubscriptionOnboardingWelcomeFragment.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/welcome/SubscriptionOnboardingWelcomeFragment.kt
@@ -22,30 +22,30 @@ import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoFragment
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.FragmentScope
-import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepHost
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingController
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome.COMPLETED
-import com.duckduckgo.subscriptions.api.requireSubscriptionOnboardingStepHost
 import com.duckduckgo.subscriptions.impl.R
 import com.duckduckgo.subscriptions.impl.databinding.FragmentSubscriptionOnboardingWelcomeBinding
 import com.duckduckgo.subscriptions.impl.onboarding.welcome.SubscriptionOnboardingWelcomeStepPlugin.Companion.WELCOME_STEP_ID
+import javax.inject.Inject
 
 /**
  * Step 1 of the native subscription onboarding: a placeholder welcome screen with a primary button that
- * completes the step. Reports back through [SubscriptionOnboardingStepHost] so it stays decoupled from the
+ * completes the step. Reports back through [SubscriptionOnboardingController] so it stays decoupled from the
  * host activity and the onboarding framework.
  */
 @InjectWith(FragmentScope::class)
 class SubscriptionOnboardingWelcomeFragment : DuckDuckGoFragment(R.layout.fragment_subscription_onboarding_welcome) {
 
-    private val binding: FragmentSubscriptionOnboardingWelcomeBinding by viewBinding()
+    @Inject
+    lateinit var controller: SubscriptionOnboardingController
 
-    private val stepHost: SubscriptionOnboardingStepHost
-        get() = requireSubscriptionOnboardingStepHost()
+    private val binding: FragmentSubscriptionOnboardingWelcomeBinding by viewBinding()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.subscriptionOnboardingWelcomeContinueButton.setOnClickListener {
-            stepHost.onStepFinished(WELCOME_STEP_ID, COMPLETED)
+            controller.onStepFinished(WELCOME_STEP_ID, COMPLETED)
         }
     }
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/welcome/SubscriptionOnboardingWelcomeFragment.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/welcome/SubscriptionOnboardingWelcomeFragment.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepHost
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome.COMPLETED
+import com.duckduckgo.subscriptions.api.requireSubscriptionOnboardingStepHost
 import com.duckduckgo.subscriptions.impl.R
 import com.duckduckgo.subscriptions.impl.databinding.FragmentSubscriptionOnboardingWelcomeBinding
 import com.duckduckgo.subscriptions.impl.onboarding.welcome.SubscriptionOnboardingWelcomeStepPlugin.Companion.WELCOME_STEP_ID
@@ -38,10 +39,13 @@ class SubscriptionOnboardingWelcomeFragment : DuckDuckGoFragment(R.layout.fragme
 
     private val binding: FragmentSubscriptionOnboardingWelcomeBinding by viewBinding()
 
+    private val stepHost: SubscriptionOnboardingStepHost
+        get() = requireSubscriptionOnboardingStepHost()
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.subscriptionOnboardingWelcomeContinueButton.setOnClickListener {
-            (requireActivity() as SubscriptionOnboardingStepHost).onStepFinished(WELCOME_STEP_ID, COMPLETED)
+            stepHost.onStepFinished(WELCOME_STEP_ID, COMPLETED)
         }
     }
 }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/welcome/SubscriptionOnboardingWelcomeFragment.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/welcome/SubscriptionOnboardingWelcomeFragment.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.onboarding.welcome
+
+import android.os.Bundle
+import android.view.View
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.common.ui.DuckDuckGoFragment
+import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepHost
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome.COMPLETED
+import com.duckduckgo.subscriptions.impl.R
+import com.duckduckgo.subscriptions.impl.databinding.FragmentSubscriptionOnboardingWelcomeBinding
+import com.duckduckgo.subscriptions.impl.onboarding.welcome.SubscriptionOnboardingWelcomeStepPlugin.Companion.WELCOME_STEP_ID
+
+/**
+ * Step 1 of the native subscription onboarding: a placeholder welcome screen with a primary button that
+ * completes the step. Reports back through [SubscriptionOnboardingStepHost] so it stays decoupled from the
+ * host activity and the onboarding framework.
+ */
+@InjectWith(FragmentScope::class)
+class SubscriptionOnboardingWelcomeFragment : DuckDuckGoFragment(R.layout.fragment_subscription_onboarding_welcome) {
+
+    private val binding: FragmentSubscriptionOnboardingWelcomeBinding by viewBinding()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.subscriptionOnboardingWelcomeContinueButton.setOnClickListener {
+            (requireActivity() as SubscriptionOnboardingStepHost).onStepFinished(WELCOME_STEP_ID, COMPLETED)
+        }
+    }
+}

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/welcome/SubscriptionOnboardingWelcomeStepPlugin.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/welcome/SubscriptionOnboardingWelcomeStepPlugin.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.onboarding.welcome
+
+import androidx.fragment.app.Fragment
+import com.duckduckgo.anvil.annotations.PriorityKey
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepPlugin
+import com.squareup.anvil.annotations.ContributesMultibinding
+import javax.inject.Inject
+
+/** Step 1 (Welcome) of the subscription onboarding, contributed from `subscriptions-impl` itself. */
+@ContributesMultibinding(AppScope::class)
+@PriorityKey(100)
+class SubscriptionOnboardingWelcomeStepPlugin @Inject constructor() : SubscriptionOnboardingStepPlugin {
+
+    override val stepId: String = WELCOME_STEP_ID
+
+    override suspend fun shouldShow(): Boolean = true
+
+    override fun createFragment(): Fragment = SubscriptionOnboardingWelcomeFragment()
+
+    companion object {
+        const val WELCOME_STEP_ID = "welcome"
+    }
+}

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/welcome/SubscriptionOnboardingWelcomeStepPlugin.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/onboarding/welcome/SubscriptionOnboardingWelcomeStepPlugin.kt
@@ -20,6 +20,7 @@ import androidx.fragment.app.Fragment
 import com.duckduckgo.anvil.annotations.PriorityKey
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepPlugin
+import com.duckduckgo.subscriptions.impl.R
 import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
 
@@ -29,6 +30,8 @@ import javax.inject.Inject
 class SubscriptionOnboardingWelcomeStepPlugin @Inject constructor() : SubscriptionOnboardingStepPlugin {
 
     override val stepId: String = WELCOME_STEP_ID
+
+    override val titleResId: Int = R.string.subscriptionOnboardingWelcomeTitle
 
     override suspend fun shouldShow(): Boolean = true
 

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/store/SubscriptionOnboardingStepStore.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/store/SubscriptionOnboardingStepStore.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.store
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.duckduckgo.data.store.api.SharedPreferencesProvider
+import com.duckduckgo.di.scopes.AppScope
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+/**
+ * Durable record of which subscription-onboarding steps a user has completed, keyed by step id. Lives
+ * outside the (in-memory) onboarding orchestrator so completion survives app kills and can be read by the
+ * summary step and by step preconditions (to skip already-completed steps on re-entry).
+ */
+@SingleInstanceIn(AppScope::class)
+class SubscriptionOnboardingStepStore @Inject constructor(
+    private val sharedPreferencesProvider: SharedPreferencesProvider,
+) {
+    private val preferences: SharedPreferences by lazy {
+        sharedPreferencesProvider.getSharedPreferences(FILENAME)
+    }
+
+    fun isCompleted(stepId: String): Boolean = completedSteps().contains(stepId)
+
+    fun setCompleted(stepId: String) {
+        preferences.edit { putStringSet(KEY_COMPLETED_STEPS, completedSteps() + stepId) }
+    }
+
+    fun completedSteps(): Set<String> =
+        preferences.getStringSet(KEY_COMPLETED_STEPS, emptySet()) ?: emptySet()
+
+    companion object {
+        const val FILENAME = "com.duckduckgo.subscriptions.onboarding.steps"
+        const val KEY_COMPLETED_STEPS = "KEY_COMPLETED_STEPS"
+    }
+}

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionWebViewViewModel.kt
@@ -152,6 +152,7 @@ class SubscriptionWebViewViewModel @Inject constructor(
                             JSONObject(PURCHASE_COMPLETED_JSON),
                         ),
                         isFreeTrial = it.isFreeTrial,
+                        launchOnboarding = subscriptionsFeature.onboardingSubscriptionExperiment().isEnabled(),
                     )
                 }
                 is CurrentPurchase.InProgress, CurrentPurchase.PreFlowInProgress -> InProgress
@@ -776,7 +777,11 @@ class SubscriptionWebViewViewModel @Inject constructor(
     sealed class PurchaseStateView {
         data object Inactive : PurchaseStateView()
         data object InProgress : PurchaseStateView()
-        data class Success(val subscriptionEventData: SubscriptionEventData, val isFreeTrial: Boolean) : PurchaseStateView()
+        data class Success(
+            val subscriptionEventData: SubscriptionEventData,
+            val isFreeTrial: Boolean,
+            val launchOnboarding: Boolean,
+        ) : PurchaseStateView()
         data object Waiting : PurchaseStateView()
         data object Recovered : PurchaseStateView()
         data object Failure : PurchaseStateView()

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/ui/SubscriptionsWebViewActivity.kt
@@ -81,6 +81,7 @@ import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
 import com.duckduckgo.navigation.api.getActivityParams
 import com.duckduckgo.pir.api.dashboard.PirDashboardWebViewScreen
 import com.duckduckgo.subscriptions.api.SubscriptionScreens.RestoreSubscriptionScreenWithParams
+import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionOnboardingScreenWithEmptyParams
 import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionPurchase
 import com.duckduckgo.subscriptions.api.SubscriptionScreens.SubscriptionUpgrade
 import com.duckduckgo.subscriptions.api.Subscriptions
@@ -627,11 +628,11 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
                 // NO OP
             }
             is PurchaseStateView.Waiting -> {
-                onPurchaseSuccess(null)
+                onPurchaseSuccess(subscriptionEventData = null, launchOnboarding = false)
             }
             is PurchaseStateView.Success -> {
                 pixelSender.reportPurchaseSuccessOrigin(params.origin, purchaseState.isFreeTrial)
-                onPurchaseSuccess(purchaseState.subscriptionEventData)
+                onPurchaseSuccess(purchaseState.subscriptionEventData, purchaseState.launchOnboarding)
             }
             is PurchaseStateView.Recovered -> {
                 onPurchaseRecovered()
@@ -657,7 +658,10 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
             .show()
     }
 
-    private fun onPurchaseSuccess(subscriptionEventData: SubscriptionEventData?) {
+    private fun onPurchaseSuccess(
+        subscriptionEventData: SubscriptionEventData?,
+        launchOnboarding: Boolean,
+    ) {
         TextAlertDialogBuilder(this)
             .setTitle(getString(string.purchaseCompletedTitle))
             .setMessage(getString(string.purchaseCompletedText))
@@ -665,10 +669,17 @@ class SubscriptionsWebViewActivity : DuckDuckGoActivity(), DownloadConfirmationD
             .addEventListener(
                 object : TextAlertDialogBuilder.EventListener() {
                     override fun onPositiveButtonClicked() {
-                        if (subscriptionEventData != null) {
-                            subscriptionJsMessaging.sendSubscriptionEvent(subscriptionEventData)
-                        } else {
-                            finishToSettings()
+                        when {
+                            launchOnboarding -> {
+                                globalActivityStarter.start(this@SubscriptionsWebViewActivity, SubscriptionOnboardingScreenWithEmptyParams)
+                                finish()
+                            }
+                            subscriptionEventData != null -> {
+                                subscriptionJsMessaging.sendSubscriptionEvent(subscriptionEventData)
+                            }
+                            else -> {
+                                finishToSettings()
+                            }
                         }
                     }
                 },

--- a/subscriptions/subscriptions-impl/src/main/res/layout/activity_subscription_onboarding.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/layout/activity_subscription_onboarding.xml
@@ -14,29 +14,8 @@
   ~ limitations under the License.
   -->
 
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<androidx.fragment.app.FragmentContainerView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/subscriptionOnboardingContainer"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?attr/daxColorBackground"
-    android:padding="@dimen/keyline_4">
-
-    <com.duckduckgo.common.ui.view.text.DaxTextView
-        android:id="@+id/subscriptionOnboardingWelcomeText"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center"
-        android:text="@string/subscriptionOnboardingWelcomeText"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:typography="h1" />
-
-    <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
-        android:id="@+id/subscriptionOnboardingWelcomeContinueButton"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/subscriptionOnboardingWelcomeContinue"
-        app:daxButtonSize="large"
-        app:layout_constraintBottom_toBottomOf="parent" />
-
-</androidx.constraintlayout.widget.ConstraintLayout>
+    android:background="?attr/daxColorBackground" />

--- a/subscriptions/subscriptions-impl/src/main/res/layout/activity_subscription_onboarding.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/layout/activity_subscription_onboarding.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/daxColorBackground"
+    android:padding="@dimen/keyline_4">
+
+    <com.duckduckgo.common.ui.view.text.DaxTextView
+        android:id="@+id/subscriptionOnboardingWelcomeText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="@string/subscriptionOnboardingWelcomeText"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:typography="h1" />
+
+    <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+        android:id="@+id/subscriptionOnboardingWelcomeContinueButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/subscriptionOnboardingWelcomeContinue"
+        app:daxButtonSize="large"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/subscriptions/subscriptions-impl/src/main/res/layout/activity_subscription_onboarding.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/layout/activity_subscription_onboarding.xml
@@ -14,8 +14,20 @@
   ~ limitations under the License.
   -->
 
-<androidx.fragment.app.FragmentContainerView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/subscriptionOnboardingContainer"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?attr/daxColorBackground" />
+    android:background="?attr/daxColorBackground">
+
+    <include
+        android:id="@+id/includeToolbar"
+        layout="@layout/include_default_toolbar" />
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/subscriptionOnboardingContainer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/subscriptions/subscriptions-impl/src/main/res/layout/fragment_subscription_onboarding_welcome.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/layout/fragment_subscription_onboarding_welcome.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="?attr/daxColorBackground"
+    android:padding="@dimen/keyline_4">
+
+    <com.duckduckgo.common.ui.view.text.DaxTextView
+        android:id="@+id/subscriptionOnboardingWelcomeText"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="@string/subscriptionOnboardingWelcomeText"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:typography="h1" />
+
+    <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+        android:id="@+id/subscriptionOnboardingWelcomeContinueButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/subscriptionOnboardingWelcomeContinue"
+        app:daxButtonSize="large"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/subscriptions/subscriptions-impl/src/main/res/values/donottranslate.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values/donottranslate.xml
@@ -40,6 +40,7 @@
     <string name="subscriptionExpirationReminderNotificationDescription">Try all your new premium protections before your trial ends!</string>
 
     <!-- Subscription Onboarding (English only, not translated) -->
+    <string name="subscriptionOnboardingWelcomeTitle">Welcome step</string>
     <string name="subscriptionOnboardingWelcomeText">Welcome to the new subscription onboarding flow</string>
     <string name="subscriptionOnboardingWelcomeContinue">Continue</string>
 

--- a/subscriptions/subscriptions-impl/src/main/res/values/donottranslate.xml
+++ b/subscriptions/subscriptions-impl/src/main/res/values/donottranslate.xml
@@ -39,4 +39,8 @@
     </plurals>
     <string name="subscriptionExpirationReminderNotificationDescription">Try all your new premium protections before your trial ends!</string>
 
+    <!-- Subscription Onboarding (English only, not translated) -->
+    <string name="subscriptionOnboardingWelcomeText">Welcome to the new subscription onboarding flow</string>
+    <string name="subscriptionOnboardingWelcomeContinue">Continue</string>
+
 </resources>

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingPlanProviderTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingPlanProviderTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.onboarding
+
+import androidx.fragment.app.Fragment
+import com.duckduckgo.common.utils.plugins.PluginPoint
+import com.duckduckgo.data.store.api.FakeSharedPreferencesProvider
+import com.duckduckgo.onboarding.api.LinearOnboardingEvent
+import com.duckduckgo.onboarding.api.LinearOnboardingTransition.Advance
+import com.duckduckgo.onboarding.api.LinearOnboardingTransition.Stay
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepPlugin
+import com.duckduckgo.subscriptions.impl.onboarding.SubscriptionOnboardingEvent.StepFinished
+import com.duckduckgo.subscriptions.impl.onboarding.SubscriptionOnboardingPlanProvider.Companion.SUBSCRIPTION_ONBOARDING_PLAN_ID
+import com.duckduckgo.subscriptions.impl.store.SubscriptionOnboardingStepStore
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SubscriptionOnboardingPlanProviderTest {
+
+    private val stepStore = SubscriptionOnboardingStepStore(FakeSharedPreferencesProvider())
+
+    @Test
+    fun whenPlanBuiltThenIdSetAndOnlyShownPluginsBecomeStepsInOrder() = runTest {
+        val plan = providerWith(
+            stubPlugin("welcome"),
+            stubPlugin("hidden", shouldShow = false),
+            stubPlugin("vpn"),
+        ).buildPlan()
+
+        assertEquals(SUBSCRIPTION_ONBOARDING_PLAN_ID, plan.id)
+        assertEquals(listOf("welcome", "vpn"), plan.steps.map { it.id })
+    }
+
+    @Test
+    fun whenStepFinishedForCurrentStepThenAdvancesOtherwiseStays() = runTest {
+        val step = providerWith(stubPlugin("welcome")).buildPlan().steps.single()
+
+        assertEquals(Advance, step.transition(StepFinished("welcome")))
+        assertEquals(Stay, step.transition(StepFinished("vpn")))
+        assertEquals(Stay, step.transition(object : LinearOnboardingEvent {}))
+    }
+
+    @Test
+    fun whenStepAlreadyCompletedThenItsPreconditionIsFalse() = runTest {
+        stepStore.setCompleted("welcome")
+
+        val steps = providerWith(stubPlugin("welcome"), stubPlugin("vpn")).buildPlan().steps
+
+        assertFalse(steps.first { it.id == "welcome" }.precondition())
+        assertTrue(steps.first { it.id == "vpn" }.precondition())
+    }
+
+    private fun providerWith(vararg stepPlugins: SubscriptionOnboardingStepPlugin) =
+        SubscriptionOnboardingPlanProvider(pluginPoint(stepPlugins.toList()), stepStore)
+
+    private fun pluginPoint(stepPlugins: List<SubscriptionOnboardingStepPlugin>) =
+        object : PluginPoint<SubscriptionOnboardingStepPlugin> {
+            override fun getPlugins(): Collection<SubscriptionOnboardingStepPlugin> = stepPlugins
+        }
+
+    private fun stubPlugin(id: String, shouldShow: Boolean = true) =
+        object : SubscriptionOnboardingStepPlugin {
+            override val stepId: String = id
+            override suspend fun shouldShow(): Boolean = shouldShow
+            override fun createFragment(): Fragment = Fragment()
+        }
+}

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingPlanProviderTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/onboarding/SubscriptionOnboardingPlanProviderTest.kt
@@ -21,8 +21,11 @@ import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.data.store.api.FakeSharedPreferencesProvider
 import com.duckduckgo.onboarding.api.LinearOnboardingEvent
 import com.duckduckgo.onboarding.api.LinearOnboardingTransition.Advance
+import com.duckduckgo.onboarding.api.LinearOnboardingTransition.GoBack
 import com.duckduckgo.onboarding.api.LinearOnboardingTransition.Stay
+import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepOutcome.COMPLETED
 import com.duckduckgo.subscriptions.api.SubscriptionOnboardingStepPlugin
+import com.duckduckgo.subscriptions.impl.onboarding.SubscriptionOnboardingEvent.BackPressed
 import com.duckduckgo.subscriptions.impl.onboarding.SubscriptionOnboardingEvent.StepFinished
 import com.duckduckgo.subscriptions.impl.onboarding.SubscriptionOnboardingPlanProvider.Companion.SUBSCRIPTION_ONBOARDING_PLAN_ID
 import com.duckduckgo.subscriptions.impl.store.SubscriptionOnboardingStepStore
@@ -52,9 +55,16 @@ class SubscriptionOnboardingPlanProviderTest {
     fun whenStepFinishedForCurrentStepThenAdvancesOtherwiseStays() = runTest {
         val step = providerWith(stubPlugin("welcome")).buildPlan().steps.single()
 
-        assertEquals(Advance, step.transition(StepFinished("welcome")))
-        assertEquals(Stay, step.transition(StepFinished("vpn")))
+        assertEquals(Advance, step.transition(StepFinished("welcome", COMPLETED)))
+        assertEquals(Stay, step.transition(StepFinished("vpn", COMPLETED)))
         assertEquals(Stay, step.transition(object : LinearOnboardingEvent {}))
+    }
+
+    @Test
+    fun whenBackPressedThenGoesBack() = runTest {
+        val step = providerWith(stubPlugin("welcome")).buildPlan().steps.single()
+
+        assertEquals(GoBack, step.transition(BackPressed))
     }
 
     @Test
@@ -78,6 +88,7 @@ class SubscriptionOnboardingPlanProviderTest {
     private fun stubPlugin(id: String, shouldShow: Boolean = true) =
         object : SubscriptionOnboardingStepPlugin {
             override val stepId: String = id
+            override val titleResId: Int = 0
             override suspend fun shouldShow(): Boolean = shouldShow
             override fun createFragment(): Fragment = Fragment()
         }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/store/SubscriptionOnboardingStepStoreTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/store/SubscriptionOnboardingStepStoreTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.subscriptions.impl.store
+
+import com.duckduckgo.data.store.api.FakeSharedPreferencesProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SubscriptionOnboardingStepStoreTest {
+
+    private val store = SubscriptionOnboardingStepStore(FakeSharedPreferencesProvider())
+
+    @Test
+    fun whenNothingCompletedThenStoreIsEmpty() {
+        assertTrue(store.completedSteps().isEmpty())
+        assertFalse(store.isCompleted("vpn"))
+    }
+
+    @Test
+    fun whenStepMarkedCompletedThenItIsRecorded() {
+        store.setCompleted("vpn")
+
+        assertTrue(store.isCompleted("vpn"))
+        assertFalse(store.isCompleted("welcome"))
+        assertEquals(setOf("vpn"), store.completedSteps())
+    }
+
+    @Test
+    fun whenMultipleStepsCompletedThenAllRecorded() {
+        store.setCompleted("welcome")
+        store.setCompleted("vpn")
+
+        assertEquals(setOf("welcome", "vpn"), store.completedSteps())
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201807753394693/task/1216568953769998?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/481882893211075/task/1215708659914715?focus=true

### Description
This is an MVP with the initial steps of the new subscription onboarding flow. The feature is behind a feature flag that is disabled by default, so the onboarding flow won't be available after this is merged.

### Steps to test this PR

_Pre steps_
- [x] Apply patch on https://app.asana.com/1/137249556945/project/481882893211075/task/1215708659914715?focus=true

_Subscription Onboarding_
- [x] Fresh install
- [x] Purchase a test subscription
- [x] Instead being redirected to Welcome screen, verify you are redirected to the new native onbaording flow
- [x] Go through steps
- [x] Test 'go back' option
- [x] Verify exiting onboarding lands on app Settings

_FF disabled_
- [x] Fresh install
- [x] Disable temporary `onboardingSubscriptionExperiment` feature flag
- [x] Purchase a test subscription
- [x] Verify you are redirected to FE Welcome screen and native onboarding doesn't appear

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes post-purchase navigation and extends the shared linear onboarding orchestrator, but the experiment flag defaults off so production behavior is unchanged until enabled.
> 
> **Overview**
> Adds a **native, plugin-based subscription onboarding flow** (welcome → VPN → Duck.ai placeholder steps) hosted in `SubscriptionOnboardingActivity`, wired through the shared `LinearOnboardingOrchestrator` and a `SubscriptionOnboardingStepPlugin` multibinding contract so feature modules own their steps.
> 
> **Linear onboarding** gains `GoBack` / `canGoBack`, history-based step restoration, and `LinearOnboardingHost.SubscriptionOnboardingActivity`. New-user browser/onboarding VMs now **ignore** steps for hosts they do not own.
> 
> After a successful purchase, when **`onboardingSubscriptionExperiment`** is enabled (default **off**), the app launches native onboarding instead of sending the FE `/welcome` JS event. Step **completion** is persisted in `SubscriptionOnboardingStepStore`; back navigation and exit-to-settings are handled via `SubscriptionOnboardingController`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5ff9107dd70e3bf0e181d0fa6191496339edf76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->