### PR TITLE
Add ad-blocking disabled breakage-report bottom sheet

### DIFF
--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingBrokenSiteReportTrigger.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingBrokenSiteReportTrigger.kt
@@ -42,6 +42,6 @@ class AdBlockingBrokenSiteReportTrigger @Inject constructor() :
     override fun observeReportRequests(): Flow<BrokenSiteData.ReportFlow> = reportRequests
 
     override fun requestReport() {
-        reportRequests.tryEmit(BrokenSiteData.ReportFlow.MENU)
+        reportRequests.tryEmit(BrokenSiteData.ReportFlow.AD_BLOCKING)
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingBrokenSiteReportTrigger.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingBrokenSiteReportTrigger.kt
@@ -16,7 +16,8 @@
 
 package com.duckduckgo.adblocking.impl.menu
 
-import com.duckduckgo.browser.api.BrokenSiteReportTriggerPlugin
+import com.duckduckgo.browser.api.brokensite.BrokenSiteData
+import com.duckduckgo.browser.api.brokensite.BrokenSiteReportTriggerPlugin
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
@@ -36,11 +37,11 @@ class AdBlockingBrokenSiteReportTrigger @Inject constructor() :
     BrokenSiteReportTriggerPlugin,
     BrokenSiteReportRequester {
 
-    private val reportRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    private val reportRequests = MutableSharedFlow<BrokenSiteData.ReportFlow>(extraBufferCapacity = 1)
 
-    override fun observeReportRequests(): Flow<Unit> = reportRequests
+    override fun observeReportRequests(): Flow<BrokenSiteData.ReportFlow> = reportRequests
 
     override fun requestReport() {
-        reportRequests.tryEmit(Unit)
+        reportRequests.tryEmit(BrokenSiteData.ReportFlow.MENU)
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingBrokenSiteReportTrigger.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingBrokenSiteReportTrigger.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.menu
+
+import com.duckduckgo.browser.api.BrokenSiteReportTriggerPlugin
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import javax.inject.Inject
+
+interface BrokenSiteReportRequester {
+    fun requestReport()
+}
+
+@ContributesBinding(AppScope::class, boundType = BrokenSiteReportRequester::class)
+@ContributesMultibinding(AppScope::class, boundType = BrokenSiteReportTriggerPlugin::class)
+@SingleInstanceIn(AppScope::class)
+class AdBlockingBrokenSiteReportTrigger @Inject constructor() :
+    BrokenSiteReportTriggerPlugin,
+    BrokenSiteReportRequester {
+
+    private val reportRequests = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+
+    override fun observeReportRequests(): Flow<Unit> = reportRequests
+
+    override fun requestReport() {
+        reportRequests.tryEmit(Unit)
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingDisabledBottomSheetDialog.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingDisabledBottomSheetDialog.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.menu
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.view.LayoutInflater
+import com.duckduckgo.adblocking.impl.databinding.BottomSheetAdBlockingDisabledBinding
+import com.duckduckgo.common.ui.applyBottomSystemBarInsetPadding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.duckduckgo.mobile.android.R as CommonR
+
+@SuppressLint("NoBottomSheetDialog")
+class AdBlockingDisabledBottomSheetDialog(
+    builderContext: Context,
+    private val edgeToEdgeProvider: EdgeToEdgeProvider,
+) : BottomSheetDialog(
+    builderContext,
+    if (edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BOTTOM_SHEETS)) {
+        CommonR.style.Widget_DuckDuckGo_BottomSheetDialog_EdgeToEdge
+    } else {
+        0
+    },
+) {
+
+    private val binding: BottomSheetAdBlockingDisabledBinding =
+        BottomSheetAdBlockingDisabledBinding.inflate(LayoutInflater.from(context))
+
+    init {
+        setContentView(binding.root)
+
+        if (edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BOTTOM_SHEETS)) {
+            binding.root.applyBottomSystemBarInsetPadding()
+        }
+
+        binding.adBlockingDisabledCloseButton.setOnClickListener { dismiss() }
+        binding.adBlockingDisabledPrimaryButton.setOnClickListener { dismiss() }
+        binding.adBlockingDisabledSecondaryButton.setOnClickListener { dismiss() }
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingDisabledBottomSheetDialog.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingDisabledBottomSheetDialog.kt
@@ -53,12 +53,10 @@ class AdBlockingDisabledBottomSheetDialog(
         }
 
         behavior.skipCollapsed = true
-        // Wrap to content when it fits, but cap the height so the sheet can never grow into the
-        // status bar in landscape; the NestedScrollView content scrolls once it hits this ceiling.
+        behavior.isDraggable = false
         behavior.maxHeight = context.resources.displayMetrics.heightPixels * MAX_HEIGHT_PERCENT / 100
         behavior.state = BottomSheetBehavior.STATE_EXPANDED
 
-        // Expanding the sheet squares its top corners by default; restore the rounded corners.
         setOnShowListener { setRoundCorners() }
 
         binding.adBlockingDisabledCloseButton.setOnClickListener { dismiss() }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingDisabledBottomSheetDialog.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingDisabledBottomSheetDialog.kt
@@ -21,8 +21,10 @@ import android.content.Context
 import android.view.LayoutInflater
 import com.duckduckgo.adblocking.impl.databinding.BottomSheetAdBlockingDisabledBinding
 import com.duckduckgo.common.ui.applyBottomSystemBarInsetPadding
+import com.duckduckgo.common.ui.setRoundCorners
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.duckduckgo.mobile.android.R as CommonR
 
@@ -50,11 +52,24 @@ class AdBlockingDisabledBottomSheetDialog(
             binding.root.applyBottomSystemBarInsetPadding()
         }
 
+        behavior.skipCollapsed = true
+        // Wrap to content when it fits, but cap the height so the sheet can never grow into the
+        // status bar in landscape; the NestedScrollView content scrolls once it hits this ceiling.
+        behavior.maxHeight = context.resources.displayMetrics.heightPixels * MAX_HEIGHT_PERCENT / 100
+        behavior.state = BottomSheetBehavior.STATE_EXPANDED
+
+        // Expanding the sheet squares its top corners by default; restore the rounded corners.
+        setOnShowListener { setRoundCorners() }
+
         binding.adBlockingDisabledCloseButton.setOnClickListener { dismiss() }
         binding.adBlockingDisabledPrimaryButton.setOnClickListener {
             brokenSiteReportRequester.requestReport()
             dismiss()
         }
         binding.adBlockingDisabledSecondaryButton.setOnClickListener { dismiss() }
+    }
+
+    private companion object {
+        private const val MAX_HEIGHT_PERCENT = 90
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingDisabledBottomSheetDialog.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingDisabledBottomSheetDialog.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.mobile.android.R as CommonR
 class AdBlockingDisabledBottomSheetDialog(
     builderContext: Context,
     private val edgeToEdgeProvider: EdgeToEdgeProvider,
+    private val brokenSiteReportRequester: BrokenSiteReportRequester,
 ) : BottomSheetDialog(
     builderContext,
     if (edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BOTTOM_SHEETS)) {
@@ -50,7 +51,10 @@ class AdBlockingDisabledBottomSheetDialog(
         }
 
         binding.adBlockingDisabledCloseButton.setOnClickListener { dismiss() }
-        binding.adBlockingDisabledPrimaryButton.setOnClickListener { dismiss() }
+        binding.adBlockingDisabledPrimaryButton.setOnClickListener {
+            brokenSiteReportRequester.requestReport()
+            dismiss()
+        }
         binding.adBlockingDisabledSecondaryButton.setOnClickListener { dismiss() }
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuItemView.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuItemView.kt
@@ -114,9 +114,17 @@ class AdBlockingMenuItemView @JvmOverloads constructor(
             eventListener = object : AdBlockingMenuBottomSheetDialog.EventListener {
                 override fun onChoiceSelected(choice: AdBlockingChoice) {
                     menuController.onChoiceSelected(choice)
+                    when (choice) {
+                        AdBlockingChoice.DISABLE_UNTIL_RELAUNCH, AdBlockingChoice.ALWAYS_OFF -> showDisabledBottomSheet()
+                        AdBlockingChoice.ALWAYS_ON -> {}
+                    }
                 }
             }
         }.show()
+    }
+
+    private fun showDisabledBottomSheet() {
+        AdBlockingDisabledBottomSheetDialog(context, edgeToEdgeProvider).show()
     }
 
     private fun render(state: AdBlockingMenuState) {

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuItemView.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuItemView.kt
@@ -58,6 +58,9 @@ class AdBlockingMenuItemView @JvmOverloads constructor(
     @Inject
     lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
 
+    @Inject
+    lateinit var brokenSiteReportRequester: BrokenSiteReportRequester
+
     private val menuItem: MenuItemView by lazy {
         MenuItemView(context).apply {
             setSize(MenuItemViewSize.MEDIUM)
@@ -124,7 +127,7 @@ class AdBlockingMenuItemView @JvmOverloads constructor(
     }
 
     private fun showDisabledBottomSheet() {
-        AdBlockingDisabledBottomSheetDialog(context, edgeToEdgeProvider).show()
+        AdBlockingDisabledBottomSheetDialog(context, edgeToEdgeProvider, brokenSiteReportRequester).show()
     }
 
     private fun render(state: AdBlockingMenuState) {

--- a/ad-blocking/ad-blocking-impl/src/main/res/layout/bottom_sheet_ad_blocking_disabled.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/layout/bottom_sheet_ad_blocking_disabled.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingTop="@dimen/keyline_6"
+    android:paddingBottom="@dimen/keyline_5">
+
+    <ImageButton
+        android:id="@+id/adBlockingDisabledCloseButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/keyline_4"
+        android:background="?actionBarItemBackground"
+        android:contentDescription="@string/ad_blocking_menu_close_content_description"
+        android:src="@drawable/ic_close_24"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/adBlockingDisabledIcon"
+        android:layout_width="wrap_content"
+        android:layout_height="96dp"
+        android:adjustViewBounds="true"
+        android:importantForAccessibility="no"
+        android:src="@drawable/youtube_warning_96"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <com.duckduckgo.common.ui.view.text.DaxTextView
+        android:id="@+id/adBlockingDisabledTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="40dp"
+        android:layout_marginTop="@dimen/keyline_4"
+        android:gravity="center"
+        android:text="@string/ad_blocking_disabled_popup_title"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/adBlockingDisabledIcon"
+        app:typography="h2" />
+
+    <com.duckduckgo.common.ui.view.text.DaxTextView
+        android:id="@+id/adBlockingDisabledContent"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="56dp"
+        android:layout_marginTop="@dimen/keyline_4"
+        android:gravity="center"
+        android:text="@string/ad_blocking_disabled_popup_description"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/adBlockingDisabledTitle"
+        app:textType="secondary"
+        app:typography="body2" />
+
+    <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+        android:id="@+id/adBlockingDisabledPrimaryButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="40dp"
+        android:layout_marginTop="@dimen/keyline_5"
+        android:text="@string/ad_blocking_disabled_primary_action"
+        app:daxButtonSize="large"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/adBlockingDisabledContent"
+        tools:text="Send Breakage Report" />
+
+    <com.duckduckgo.common.ui.view.button.DaxButtonGhost
+        android:id="@+id/adBlockingDisabledSecondaryButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="40dp"
+        android:layout_marginTop="@dimen/keyline_2"
+        android:text="@string/ad_blocking_disabled_secondary_action"
+        app:daxButtonSize="large"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/adBlockingDisabledPrimaryButton"
+        tools:text="Cancel" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/ad-blocking/ad-blocking-impl/src/main/res/layout/bottom_sheet_ad_blocking_disabled.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/layout/bottom_sheet_ad_blocking_disabled.xml
@@ -14,87 +14,93 @@
   ~ limitations under the License.
   -->
 
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:paddingTop="@dimen/keyline_6"
-    android:paddingBottom="@dimen/keyline_5">
+    android:layout_height="wrap_content">
 
-    <ImageButton
-        android:id="@+id/adBlockingDisabledCloseButton"
-        android:layout_width="wrap_content"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/keyline_4"
-        android:background="?actionBarItemBackground"
-        android:contentDescription="@string/ad_blocking_menu_close_content_description"
-        android:src="@drawable/ic_close_24"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:paddingTop="@dimen/keyline_6"
+        android:paddingBottom="@dimen/keyline_5">
 
-    <ImageView
-        android:id="@+id/adBlockingDisabledIcon"
-        android:layout_width="wrap_content"
-        android:layout_height="96dp"
-        android:adjustViewBounds="true"
-        android:importantForAccessibility="no"
-        android:src="@drawable/youtube_warning_96"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        <ImageButton
+            android:id="@+id/adBlockingDisabledCloseButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/keyline_4"
+            android:background="?actionBarItemBackground"
+            android:contentDescription="@string/ad_blocking_menu_close_content_description"
+            android:src="@drawable/ic_close_24"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
-    <com.duckduckgo.common.ui.view.text.DaxTextView
-        android:id="@+id/adBlockingDisabledTitle"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="40dp"
-        android:layout_marginTop="@dimen/keyline_4"
-        android:gravity="center"
-        android:text="@string/ad_blocking_disabled_popup_title"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/adBlockingDisabledIcon"
-        app:typography="h2" />
+        <ImageView
+            android:id="@+id/adBlockingDisabledIcon"
+            android:layout_width="wrap_content"
+            android:layout_height="96dp"
+            android:adjustViewBounds="true"
+            android:importantForAccessibility="no"
+            android:src="@drawable/youtube_warning_96"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
-    <com.duckduckgo.common.ui.view.text.DaxTextView
-        android:id="@+id/adBlockingDisabledContent"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="56dp"
-        android:layout_marginTop="@dimen/keyline_4"
-        android:gravity="center"
-        android:text="@string/ad_blocking_disabled_popup_description"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/adBlockingDisabledTitle"
-        app:textType="secondary"
-        app:typography="body2" />
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/adBlockingDisabledTitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="40dp"
+            android:layout_marginTop="@dimen/keyline_4"
+            android:gravity="center"
+            android:text="@string/ad_blocking_disabled_popup_title"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/adBlockingDisabledIcon"
+            app:typography="h2" />
 
-    <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
-        android:id="@+id/adBlockingDisabledPrimaryButton"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="40dp"
-        android:layout_marginTop="@dimen/keyline_5"
-        android:text="@string/ad_blocking_disabled_primary_action"
-        app:daxButtonSize="large"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/adBlockingDisabledContent"
-        tools:text="Send Breakage Report" />
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/adBlockingDisabledContent"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="56dp"
+            android:layout_marginTop="@dimen/keyline_4"
+            android:gravity="center"
+            android:text="@string/ad_blocking_disabled_popup_description"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/adBlockingDisabledTitle"
+            app:textType="secondary"
+            app:typography="body2" />
 
-    <com.duckduckgo.common.ui.view.button.DaxButtonGhost
-        android:id="@+id/adBlockingDisabledSecondaryButton"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="40dp"
-        android:layout_marginTop="@dimen/keyline_2"
-        android:text="@string/ad_blocking_disabled_secondary_action"
-        app:daxButtonSize="large"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/adBlockingDisabledPrimaryButton"
-        tools:text="Cancel" />
+        <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+            android:id="@+id/adBlockingDisabledPrimaryButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="40dp"
+            android:layout_marginTop="@dimen/keyline_5"
+            android:text="@string/ad_blocking_disabled_primary_action"
+            app:daxButtonSize="large"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/adBlockingDisabledContent"
+            tools:text="Send Breakage Report" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <com.duckduckgo.common.ui.view.button.DaxButtonGhost
+            android:id="@+id/adBlockingDisabledSecondaryButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="40dp"
+            android:layout_marginTop="@dimen/keyline_2"
+            android:text="@string/ad_blocking_disabled_secondary_action"
+            app:daxButtonSize="large"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/adBlockingDisabledPrimaryButton"
+            tools:text="Cancel" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -322,7 +322,6 @@ import com.duckduckgo.autofill.api.passwordgeneration.AutomaticSavedLoginsMonito
 import com.duckduckgo.autofill.impl.AutofillFireproofDialogSuppressor
 import com.duckduckgo.brokensite.api.BrokenSitePrompt
 import com.duckduckgo.brokensite.api.RefreshPattern
-import com.duckduckgo.browser.api.BrokenSiteReportTriggerPlugin
 import com.duckduckgo.browser.api.BrowserRefreshTriggerPlugin
 import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.browser.api.autocomplete.AutoComplete
@@ -338,6 +337,7 @@ import com.duckduckgo.browser.api.autocomplete.AutoCompleteSettings
 import com.duckduckgo.browser.api.brokensite.BrokenSiteData
 import com.duckduckgo.browser.api.brokensite.BrokenSiteData.ReportFlow.MENU
 import com.duckduckgo.browser.api.brokensite.BrokenSiteData.ReportFlow.RELOAD_THREE_TIMES_WITHIN_20_SECONDS
+import com.duckduckgo.browser.api.brokensite.BrokenSiteReportTriggerPlugin
 import com.duckduckgo.browser.api.webviewcompat.WebViewCompatWrapper
 import com.duckduckgo.browser.api.wideevents.BrowserInteractionsPlugin
 import com.duckduckgo.browser.ui.autocomplete.AutocompleteHistoryDeleteFeature

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -322,6 +322,7 @@ import com.duckduckgo.autofill.api.passwordgeneration.AutomaticSavedLoginsMonito
 import com.duckduckgo.autofill.impl.AutofillFireproofDialogSuppressor
 import com.duckduckgo.brokensite.api.BrokenSitePrompt
 import com.duckduckgo.brokensite.api.RefreshPattern
+import com.duckduckgo.browser.api.BrokenSiteReportTriggerPlugin
 import com.duckduckgo.browser.api.BrowserRefreshTriggerPlugin
 import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.browser.api.autocomplete.AutoComplete
@@ -573,6 +574,7 @@ class BrowserTabViewModel @Inject constructor(
     private val ntpAfterIdleManager: NtpAfterIdleManager,
     private val browserInteractionsPlugins: PluginPoint<BrowserInteractionsPlugin>,
     private val browserRefreshTriggerPlugins: PluginPoint<BrowserRefreshTriggerPlugin>,
+    private val brokenSiteReportTriggerPlugins: PluginPoint<BrokenSiteReportTriggerPlugin>,
     private val inlinePdfHandler: InlinePdfHandler,
     private val pdfDownloadTooltipDataStore: PdfDownloadTooltipDataStore,
     private val cachedFileDownloader: CachedFileDownloader,
@@ -764,6 +766,7 @@ class BrowserTabViewModel @Inject constructor(
 
     private var allowlistRefreshTriggerJob: Job? = null
     private var refreshTriggerJob: Job? = null
+    private var brokenSiteReportTriggerJob: Job? = null
 
     /** Non-null while this tab is displayed inside a Custom Tab. Captures the verified
      * calling package (when known) used by [handleAppLink]'s trusted-caller carve-out. */
@@ -888,6 +891,7 @@ class BrowserTabViewModel @Inject constructor(
 
         observeAccessibilitySettings()
         observeRefreshTriggers()
+        observeBrokenSiteReportTriggers()
 
         savedSitesRepository
             .getFavorites()
@@ -1046,6 +1050,7 @@ class BrowserTabViewModel @Inject constructor(
     fun onViewRecreated() {
         observeAccessibilitySettings()
         observeRefreshTriggers()
+        observeBrokenSiteReportTriggers()
     }
 
     fun observeSelectedTab(isRestored: Boolean) {
@@ -1121,6 +1126,20 @@ class BrowserTabViewModel @Inject constructor(
             .debounce(REFRESH_TRIGGER_DEBOUNCE_MILLIS)
             .flatMapLatest { refreshOnViewVisible.asStateFlow().filter { it }.take(1) }
             .onEach { command.value = NavigationCommand.Refresh }
+            .launchIn(viewModelScope)
+    }
+
+    fun observeBrokenSiteReportTriggers() {
+        brokenSiteReportTriggerJob?.cancel()
+        brokenSiteReportTriggerJob = brokenSiteReportTriggerPlugins.getPlugins()
+            .map { plugin ->
+                plugin.observeReportRequests()
+                    .catch { logcat(WARN) { "Broken site report trigger failed: ${it.asLog()}" } }
+            }
+            .merge()
+            // The trigger flow fires in every tab's ViewModel; only the visible tab should report.
+            .filter { refreshOnViewVisible.value }
+            .onEach { onBrokenSiteSelected() }
             .launchIn(viewModelScope)
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1139,7 +1139,7 @@ class BrowserTabViewModel @Inject constructor(
             .merge()
             // The trigger flow fires in every tab's ViewModel; only the visible tab should report.
             .filter { refreshOnViewVisible.value }
-            .onEach { onBrokenSiteSelected() }
+            .onEach { reportFlow -> onBrokenSiteSelected(reportFlow) }
             .launchIn(viewModelScope)
     }
 
@@ -3301,8 +3301,8 @@ class BrowserTabViewModel @Inject constructor(
         }
     }
 
-    fun onBrokenSiteSelected() {
-        command.value = BrokenSiteFeedback(BrokenSiteData.fromSite(site, reportFlow = MENU))
+    fun onBrokenSiteSelected(reportFlow: BrokenSiteData.ReportFlow = MENU) {
+        command.value = BrokenSiteFeedback(BrokenSiteData.fromSite(site, reportFlow = reportFlow))
     }
 
     fun onPrivacyProtectionMenuClicked(clickedFromCustomTab: Boolean = false) {

--- a/app/src/main/java/com/duckduckgo/app/plugins/BrokenSiteReportTriggerPluginPoint.kt
+++ b/app/src/main/java/com/duckduckgo/app/plugins/BrokenSiteReportTriggerPluginPoint.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.plugins
+
+import com.duckduckgo.anvil.annotations.ContributesPluginPoint
+import com.duckduckgo.browser.api.BrokenSiteReportTriggerPlugin
+import com.duckduckgo.di.scopes.AppScope
+
+@ContributesPluginPoint(
+    scope = AppScope::class,
+    boundType = BrokenSiteReportTriggerPlugin::class,
+)
+@Suppress("unused")
+interface UnusedBrokenSiteReportTriggerPluginPoint

--- a/app/src/main/java/com/duckduckgo/app/plugins/BrokenSiteReportTriggerPluginPoint.kt
+++ b/app/src/main/java/com/duckduckgo/app/plugins/BrokenSiteReportTriggerPluginPoint.kt
@@ -17,7 +17,7 @@
 package com.duckduckgo.app.plugins
 
 import com.duckduckgo.anvil.annotations.ContributesPluginPoint
-import com.duckduckgo.browser.api.BrokenSiteReportTriggerPlugin
+import com.duckduckgo.browser.api.brokensite.BrokenSiteReportTriggerPlugin
 import com.duckduckgo.di.scopes.AppScope
 
 @ContributesPluginPoint(

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -266,7 +266,6 @@ import com.duckduckgo.autofill.api.passwordgeneration.AutomaticSavedLoginsMonito
 import com.duckduckgo.autofill.impl.AutofillFireproofDialogSuppressor
 import com.duckduckgo.brokensite.api.BrokenSitePrompt
 import com.duckduckgo.brokensite.api.RefreshPattern
-import com.duckduckgo.browser.api.BrokenSiteReportTriggerPlugin
 import com.duckduckgo.browser.api.BrowserRefreshTriggerPlugin
 import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.browser.api.autocomplete.AutoComplete
@@ -277,6 +276,8 @@ import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggesti
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion.AutoCompleteUrlSuggestion.AutoCompleteSwitchToTabSuggestion
 import com.duckduckgo.browser.api.autocomplete.AutoCompleteSettings
 import com.duckduckgo.browser.api.brokensite.BrokenSiteContext
+import com.duckduckgo.browser.api.brokensite.BrokenSiteData
+import com.duckduckgo.browser.api.brokensite.BrokenSiteReportTriggerPlugin
 import com.duckduckgo.browser.api.webviewcompat.WebViewCompatWrapper
 import com.duckduckgo.browser.api.wideevents.BrowserInteractionsPlugin
 import com.duckduckgo.browser.ui.autocomplete.AutocompleteHistoryDeleteFeature
@@ -650,7 +651,7 @@ class BrowserTabViewModelTest {
     private val mockAdBlockingOmnibarAnimationProvider: AdBlockingOmnibarAnimationProvider = mock {
         onBlocking { getAnimation(any(), any()) } doReturn AdBlockingAnimation.Skip
     }
-    private val brokenSiteReportTriggerFlow = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    private val brokenSiteReportTriggerFlow = MutableSharedFlow<BrokenSiteData.ReportFlow>(extraBufferCapacity = 1)
     private val brokenSiteReportTriggerPlugin: BrokenSiteReportTriggerPlugin = mock {
         on { observeReportRequests() } doReturn brokenSiteReportTriggerFlow
     }
@@ -3086,7 +3087,7 @@ class BrowserTabViewModelTest {
     fun whenBrokenSiteReportTriggerPluginEmitsThenBrokenSiteFeedbackCommandIssued() = runTest {
         loadUrl("foo.com", isBrowserShowing = true)
 
-        brokenSiteReportTriggerFlow.emit(Unit)
+        brokenSiteReportTriggerFlow.emit(BrokenSiteData.ReportFlow.MENU)
         advanceUntilIdle()
 
         val command = captureCommands().lastValue as Command.BrokenSiteFeedback
@@ -3099,7 +3100,7 @@ class BrowserTabViewModelTest {
         testee.onViewHidden()
         advanceUntilIdle()
 
-        brokenSiteReportTriggerFlow.emit(Unit)
+        brokenSiteReportTriggerFlow.emit(BrokenSiteData.ReportFlow.MENU)
         advanceUntilIdle()
 
         assertCommandNotIssued<Command.BrokenSiteFeedback>()

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -266,6 +266,7 @@ import com.duckduckgo.autofill.api.passwordgeneration.AutomaticSavedLoginsMonito
 import com.duckduckgo.autofill.impl.AutofillFireproofDialogSuppressor
 import com.duckduckgo.brokensite.api.BrokenSitePrompt
 import com.duckduckgo.brokensite.api.RefreshPattern
+import com.duckduckgo.browser.api.BrokenSiteReportTriggerPlugin
 import com.duckduckgo.browser.api.BrowserRefreshTriggerPlugin
 import com.duckduckgo.browser.api.UserBrowserProperties
 import com.duckduckgo.browser.api.autocomplete.AutoComplete
@@ -648,6 +649,13 @@ class BrowserTabViewModelTest {
     }
     private val mockAdBlockingOmnibarAnimationProvider: AdBlockingOmnibarAnimationProvider = mock {
         onBlocking { getAnimation(any(), any()) } doReturn AdBlockingAnimation.Skip
+    }
+    private val brokenSiteReportTriggerFlow = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    private val brokenSiteReportTriggerPlugin: BrokenSiteReportTriggerPlugin = mock {
+        on { observeReportRequests() } doReturn brokenSiteReportTriggerFlow
+    }
+    private val mockBrokenSiteReportTriggerPlugins: PluginPoint<BrokenSiteReportTriggerPlugin> = mock {
+        on { getPlugins() } doReturn listOf(brokenSiteReportTriggerPlugin)
     }
     private val mockDuckChatJSHelper: DuckChatJSHelper = mock()
     private val swipingTabsFeature = FakeFeatureToggleFactory.create(SwipingTabsFeature::class.java)
@@ -1046,6 +1054,7 @@ class BrowserTabViewModelTest {
                 ntpAfterIdleManager = mockNtpAfterIdleManager,
                 browserInteractionsPlugins = mockBrowserInteractionsPlugins,
                 browserRefreshTriggerPlugins = mockBrowserRefreshTriggerPlugins,
+                brokenSiteReportTriggerPlugins = mockBrokenSiteReportTriggerPlugins,
                 inlinePdfHandler = mockInlinePdfHandler,
                 pdfDownloadTooltipDataStore = mockPdfDownloadTooltipDataStore,
                 cachedFileDownloader = mockCachedFileDownloader,
@@ -3071,6 +3080,29 @@ class BrowserTabViewModelTest {
         testee.onBrokenSiteSelected()
         val command = captureCommands().lastValue as Command.BrokenSiteFeedback
         assertEquals("", command.data.url)
+    }
+
+    @Test
+    fun whenBrokenSiteReportTriggerPluginEmitsThenBrokenSiteFeedbackCommandIssued() = runTest {
+        loadUrl("foo.com", isBrowserShowing = true)
+
+        brokenSiteReportTriggerFlow.emit(Unit)
+        advanceUntilIdle()
+
+        val command = captureCommands().lastValue as Command.BrokenSiteFeedback
+        assertEquals("foo.com", command.data.url)
+    }
+
+    @Test
+    fun whenBrokenSiteReportTriggerPluginEmitsWhileTabHiddenThenNoReport() = runTest {
+        loadUrl("foo.com", isBrowserShowing = true)
+        testee.onViewHidden()
+        advanceUntilIdle()
+
+        brokenSiteReportTriggerFlow.emit(Unit)
+        advanceUntilIdle()
+
+        assertCommandNotIssued<Command.BrokenSiteFeedback>()
     }
 
     @Test

--- a/browser-api/src/main/java/com/duckduckgo/browser/api/BrokenSiteReportTriggerPlugin.kt
+++ b/browser-api/src/main/java/com/duckduckgo/browser/api/BrokenSiteReportTriggerPlugin.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.browser.api
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Plugin contributed by features that need to request a broken-site report for the active tab.
+ */
+interface BrokenSiteReportTriggerPlugin {
+    /**
+     * Emits when the user requested a broken-site report.
+     */
+    fun observeReportRequests(): Flow<Unit>
+}

--- a/browser-api/src/main/java/com/duckduckgo/browser/api/brokensite/BrokenSiteNav.kt
+++ b/browser-api/src/main/java/com/duckduckgo/browser/api/brokensite/BrokenSiteNav.kt
@@ -41,7 +41,14 @@ data class BrokenSiteData(
     val jsPerformance: DoubleArray?,
     val breakageData: String?,
 ) {
-    enum class ReportFlow { MENU, DASHBOARD, TOGGLE_DASHBOARD, TOGGLE_MENU, RELOAD_THREE_TIMES_WITHIN_20_SECONDS }
+    enum class ReportFlow {
+        MENU,
+        DASHBOARD,
+        TOGGLE_DASHBOARD,
+        TOGGLE_MENU,
+        RELOAD_THREE_TIMES_WITHIN_20_SECONDS,
+        AD_BLOCKING,
+    }
 
     companion object {
         fun fromSite(site: Site?, reportFlow: ReportFlow): BrokenSiteData {

--- a/browser-api/src/main/java/com/duckduckgo/browser/api/brokensite/BrokenSiteReportTriggerPlugin.kt
+++ b/browser-api/src/main/java/com/duckduckgo/browser/api/brokensite/BrokenSiteReportTriggerPlugin.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.duckduckgo.browser.api
+package com.duckduckgo.browser.api.brokensite
 
 import kotlinx.coroutines.flow.Flow
 
@@ -23,7 +23,7 @@ import kotlinx.coroutines.flow.Flow
  */
 interface BrokenSiteReportTriggerPlugin {
     /**
-     * Emits when the user requested a broken-site report.
+     * Emits the report flow to use when the user requested a broken-site report.
      */
-    fun observeReportRequests(): Flow<Unit>
+    fun observeReportRequests(): Flow<BrokenSiteData.ReportFlow>
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1214567099387208
Tech Design URL (if applicable): 

### Description

### Steps to test this PR

Feel free to run these tests top of the stack, for more efficient test runs

_Feature 1_
- [x] Enable `adBlockingUxImprovements` under feature flag inventory
- [x] Enable ad blocking under "Ad Blocking" settings
- [x] Load a YouTube video
- [x] Open the browser menu and select "Disable Ad Blocking"
- [x] Select either "Always Off" or "Disabled until relaunch"
- [x] Check a new bottom sheet is shown and allows you to submit a breakage report

### UI changes
| Before  | After |
| ------ | ----- |
|(Upload before screenshot)|<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/80e931bd-fcba-423b-865f-93283fbcb5d9" />|



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and telemetry-path changes around optional breakage reports; behavior is gated to the visible tab and reuses existing broken-site feedback.
> 
> **Overview**
> After users turn ad blocking off (**Always Off** or **until relaunch**), a new bottom sheet explains the change and offers **Send Breakage Report** or dismiss.
> 
> Reporting is wired through a new **`BrokenSiteReportTriggerPlugin`** multibinding (with an app plugin point). Ad blocking contributes **`AdBlockingBrokenSiteReportTrigger`**, which emits **`ReportFlow.AD_BLOCKING`** when the sheet’s primary action is tapped. **`BrowserTabViewModel`** merges all trigger plugins, opens broken-site feedback with the emitted flow (only on the **visible** tab), and **`onBrokenSiteSelected`** now accepts an optional **`ReportFlow`** instead of always using the menu flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f80076e845fcae962653e312e7d5eddfef9c922c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->