### PR TITLE
Hide Force Dark Theme toggle when Light theme is selected

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/appearance/AppearanceActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/appearance/AppearanceActivity.kt
@@ -195,8 +195,7 @@ class AppearanceActivity : DuckDuckGoActivity() {
                     updateSelectedTheme(it.theme)
                     binding.changeAppIcon.setImageResource(it.appIcon.icon)
                     binding.experimentalNightMode.quietlySetIsChecked(viewState.forceDarkModeEnabled, forceDarkModeToggleListener)
-                    binding.experimentalNightMode.isEnabled = viewState.canForceDarkMode
-                    binding.experimentalNightMode.isVisible = viewState.supportsForceDarkMode
+                    binding.experimentalNightMode.isVisible = viewState.supportsForceDarkMode && viewState.canForceDarkMode
                     binding.showFullUrlSetting.quietlySetIsChecked(viewState.isFullUrlEnabled, showFullUrlToggleListener)
                     binding.showTrackersCountInTabSwitcher.quietlySetIsChecked(
                         viewState.isTrackersCountInTabSwitcherEnabled,

--- a/app/src/main/java/com/duckduckgo/app/appearance/AppearanceViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/appearance/AppearanceViewModel.kt
@@ -119,7 +119,7 @@ class AppearanceViewModel @Inject constructor(
     private val command = Channel<Command>(1, BufferOverflow.DROP_OLDEST)
     fun commands(): Flow<Command> = command.receiveAsFlow()
 
-    private fun canForceDarkMode(): Boolean = themingDataStore.theme != DuckDuckGoTheme.LIGHT
+    private fun canForceDarkMode(theme: DuckDuckGoTheme = themingDataStore.theme): Boolean = theme != DuckDuckGoTheme.LIGHT
 
     fun userRequestedToChangeTheme() {
         viewModelScope.launch { command.send(Command.LaunchThemeSettings(viewState.value.theme)) }
@@ -145,7 +145,7 @@ class AppearanceViewModel @Inject constructor(
         viewModelScope.launch(dispatcherProvider.io()) {
             themingDataStore.theme = selectedTheme
             withContext(dispatcherProvider.main()) {
-                viewState.update { it.copy(theme = selectedTheme, forceDarkModeEnabled = canForceDarkMode()) }
+                viewState.update { it.copy(theme = selectedTheme, canForceDarkMode = canForceDarkMode(selectedTheme)) }
                 command.send(Command.UpdateTheme)
             }
         }

--- a/app/src/test/java/com/duckduckgo/app/appearance/AppearanceViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/appearance/AppearanceViewModelTest.kt
@@ -435,6 +435,66 @@ internal class AppearanceViewModelTest {
         }
 
     @Test
+    fun whenLightThemeThenCanForceDarkModeIsFalse() =
+        runTest {
+            whenever(mockThemeSettingsDataStore.theme).thenReturn(DuckDuckGoTheme.LIGHT)
+            initializeViewModel()
+
+            testee.viewState().test {
+                assertEquals(false, expectMostRecentItem().canForceDarkMode)
+                cancelAndConsumeRemainingEvents()
+            }
+        }
+
+    @Test
+    fun whenDarkThemeThenCanForceDarkModeIsTrue() =
+        runTest {
+            whenever(mockThemeSettingsDataStore.theme).thenReturn(DuckDuckGoTheme.DARK)
+            initializeViewModel()
+
+            testee.viewState().test {
+                assertEquals(true, expectMostRecentItem().canForceDarkMode)
+                cancelAndConsumeRemainingEvents()
+            }
+        }
+
+    @Test
+    fun whenSystemDefaultThemeThenCanForceDarkModeIsTrue() =
+        runTest {
+            whenever(mockThemeSettingsDataStore.theme).thenReturn(DuckDuckGoTheme.SYSTEM_DEFAULT)
+            initializeViewModel()
+
+            testee.viewState().test {
+                assertEquals(true, expectMostRecentItem().canForceDarkMode)
+                cancelAndConsumeRemainingEvents()
+            }
+        }
+
+    @Test
+    fun whenThemeChangedToLightThenCanForceDarkModeIsFalse() =
+        runTest {
+            givenThemeSelected(DuckDuckGoTheme.DARK)
+
+            testee.viewState().test {
+                testee.onThemeSelected(DuckDuckGoTheme.LIGHT)
+                assertEquals(false, expectMostRecentItem().canForceDarkMode)
+                cancelAndConsumeRemainingEvents()
+            }
+        }
+
+    @Test
+    fun whenThemeChangedFromLightToDarkThenCanForceDarkModeIsTrue() =
+        runTest {
+            givenThemeSelected(DuckDuckGoTheme.LIGHT)
+
+            testee.viewState().test {
+                testee.onThemeSelected(DuckDuckGoTheme.DARK)
+                assertEquals(true, expectMostRecentItem().canForceDarkMode)
+                cancelAndConsumeRemainingEvents()
+            }
+        }
+
+    @Test
     fun whenInitialisedAndLightThemeThenViewStateEmittedWithProperValues() =
         runTest {
             whenever(mockThemeSettingsDataStore.theme).thenReturn(DuckDuckGoTheme.LIGHT)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1216509582277307?focus=true 
Tech Design URL (if applicable): 

### Description

The "Force Websites To Use Dark Theme" (Night Mode) sub-option in "Settings → Appearance" was visible even when the **Light** theme was selected, where it can never take effect (dark website rendering only applies while the app is in dark mode). Previously the toggle was only greyed-out/disabled in Light theme.

The toggle is now **hidden entirely** when the selected theme is Light, and shown for Dark and System Default 

### Steps to test this PR

_Force Dark Theme visibility_
- [x] Ensure the current theme is **not** Light (Settings → Appearance → Theme → e.g. Dark or System Default, Set Theme)
- [x] On the Appearance screen, confirm "Force Websites To Use Dark Theme" (Night Mode) is visible
- [x] Open Theme, select **Light**
- [x] Confirm the "Force Websites To Use Dark Theme" option is now **hidden**
- [x] Change the theme back to Dark or System Default and confirm the option reappears

### UI changes
| Before  | After |
| ------ | ----- |
|<img width="540" height="1200" alt="Screenshot_20260713_200047" src="https://github.com/user-attachments/assets/a89f34aa-d16b-453d-92c1-cdfa4d061dd9" />|<img width="540" height="1200" alt="Screenshot_20260713_195112" src="https://github.com/user-attachments/assets/9db843db-b6d2-48ad-8cff-4afe7442b839" />|



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Appearance settings UI and view-state wiring only; no auth, data migration, or WebView behavior changes in this diff.
> 
> **Overview**
> **Hides** the experimental “force dark mode” (night mode for websites) control in Appearance settings when the app theme is **Light**, instead of leaving it visible but disabled.
> 
> `AppearanceActivity` now drives visibility with `supportsForceDarkMode && canForceDarkMode` and drops separate `isEnabled` handling. `AppearanceViewModel` updates `canForceDarkMode` when the user picks a theme (via `canForceDarkMode(selectedTheme)`), and `canForceDarkMode` accepts an optional theme argument.
> 
> Unit tests cover initial `canForceDarkMode` for light/dark/system default and updates when switching to or from light theme.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fcf03e9a65d6f0361d0c9b16954fe5f1318cf204. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->