### PR TITLE
Add browser menu ad blocking pixels

### DIFF
--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingBrokenSiteReportTrigger.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingBrokenSiteReportTrigger.kt
@@ -16,6 +16,9 @@
 
 package com.duckduckgo.adblocking.impl.menu
 
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_BREAKAGE_REPORT_ENTERED_COUNT
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_BREAKAGE_REPORT_ENTERED_DAILY
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.browser.api.brokensite.BrokenSiteData
 import com.duckduckgo.browser.api.brokensite.BrokenSiteReportTriggerPlugin
 import com.duckduckgo.di.scopes.AppScope
@@ -33,8 +36,9 @@ interface BrokenSiteReportRequester {
 @ContributesBinding(AppScope::class, boundType = BrokenSiteReportRequester::class)
 @ContributesMultibinding(AppScope::class, boundType = BrokenSiteReportTriggerPlugin::class)
 @SingleInstanceIn(AppScope::class)
-class AdBlockingBrokenSiteReportTrigger @Inject constructor() :
-    BrokenSiteReportTriggerPlugin,
+class AdBlockingBrokenSiteReportTrigger @Inject constructor(
+    private val pixel: Pixel,
+) : BrokenSiteReportTriggerPlugin,
     BrokenSiteReportRequester {
 
     private val reportRequests = MutableSharedFlow<BrokenSiteData.ReportFlow>(extraBufferCapacity = 1)
@@ -42,6 +46,8 @@ class AdBlockingBrokenSiteReportTrigger @Inject constructor() :
     override fun observeReportRequests(): Flow<BrokenSiteData.ReportFlow> = reportRequests
 
     override fun requestReport() {
+        pixel.fire(AD_BLOCKING_BREAKAGE_REPORT_ENTERED_DAILY, type = Pixel.PixelType.Daily())
+        pixel.fire(AD_BLOCKING_BREAKAGE_REPORT_ENTERED_COUNT)
         reportRequests.tryEmit(BrokenSiteData.ReportFlow.AD_BLOCKING)
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuController.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuController.kt
@@ -16,11 +16,22 @@
 
 package com.duckduckgo.adblocking.impl.menu
 
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_MENU_DISABLE_TAPPED_COUNT
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_MENU_DISABLE_TAPPED_DAILY
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_MENU_ENABLE_TAPPED_COUNT
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_MENU_ENABLE_TAPPED_DAILY
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_PICKER_ALWAYS_OFF_COUNT
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_PICKER_ALWAYS_OFF_DAILY
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_PICKER_ALWAYS_ON_COUNT
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_PICKER_ALWAYS_ON_DAILY
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_PICKER_DISABLE_UNTIL_RELAUNCH_COUNT
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_PICKER_DISABLE_UNTIL_RELAUNCH_DAILY
 import com.duckduckgo.adblocking.impl.AdBlockingSettingsRepository
 import com.duckduckgo.adblocking.impl.domain.AdBlockingState
 import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
 import com.duckduckgo.adblocking.impl.store.AdBlockingSessionStore
 import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesBinding
@@ -36,14 +47,21 @@ interface AdBlockingMenuController {
     fun currentChoice(): AdBlockingChoice
 
     /**
-     * Applies the user's selection to the persisted setting and/or the session override.
+     * Applies a selection made in the disable-mode picker to the persisted setting and/or the
+     * session override.
      */
     fun onChoiceSelected(choice: AdBlockingChoice)
 
     /**
-     * Enables ad blocking directly, without showing the choice sheet.
+     * Handles a tap on the "Enable" browsing-menu row, enabling ad blocking directly without
+     * showing the choice sheet.
      */
-    fun enable()
+    fun onEnableTapped()
+
+    /**
+     * Handles a tap on the "Disable" browsing-menu row, which opens the disable-mode picker.
+     */
+    fun onDisableTapped()
 }
 
 @ContributesBinding(AppScope::class)
@@ -53,6 +71,7 @@ class RealAdBlockingMenuController @Inject constructor(
     private val statusChecker: AdBlockingStatusChecker,
     @AppCoroutineScope private val appScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
+    private val pixel: Pixel,
 ) : AdBlockingMenuController {
 
     override fun currentChoice(): AdBlockingChoice = when (statusChecker.currentState()) {
@@ -62,6 +81,35 @@ class RealAdBlockingMenuController @Inject constructor(
     }
 
     override fun onChoiceSelected(choice: AdBlockingChoice) {
+        when (choice) {
+            AdBlockingChoice.ALWAYS_ON -> {
+                pixel.fire(AD_BLOCKING_PICKER_ALWAYS_ON_DAILY, type = Pixel.PixelType.Daily())
+                pixel.fire(AD_BLOCKING_PICKER_ALWAYS_ON_COUNT)
+            }
+            AdBlockingChoice.DISABLE_UNTIL_RELAUNCH -> {
+                pixel.fire(AD_BLOCKING_PICKER_DISABLE_UNTIL_RELAUNCH_DAILY, type = Pixel.PixelType.Daily())
+                pixel.fire(AD_BLOCKING_PICKER_DISABLE_UNTIL_RELAUNCH_COUNT)
+            }
+            AdBlockingChoice.ALWAYS_OFF -> {
+                pixel.fire(AD_BLOCKING_PICKER_ALWAYS_OFF_DAILY, type = Pixel.PixelType.Daily())
+                pixel.fire(AD_BLOCKING_PICKER_ALWAYS_OFF_COUNT)
+            }
+        }
+        apply(choice)
+    }
+
+    override fun onEnableTapped() {
+        pixel.fire(AD_BLOCKING_MENU_ENABLE_TAPPED_DAILY, type = Pixel.PixelType.Daily())
+        pixel.fire(AD_BLOCKING_MENU_ENABLE_TAPPED_COUNT)
+        apply(AdBlockingChoice.ALWAYS_ON)
+    }
+
+    override fun onDisableTapped() {
+        pixel.fire(AD_BLOCKING_MENU_DISABLE_TAPPED_DAILY, type = Pixel.PixelType.Daily())
+        pixel.fire(AD_BLOCKING_MENU_DISABLE_TAPPED_COUNT)
+    }
+
+    private fun apply(choice: AdBlockingChoice) {
         appScope.launch(dispatcherProvider.io()) {
             when (choice) {
                 AdBlockingChoice.ALWAYS_ON -> {
@@ -76,6 +124,4 @@ class RealAdBlockingMenuController @Inject constructor(
             }
         }
     }
-
-    override fun enable() = onChoiceSelected(AdBlockingChoice.ALWAYS_ON)
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuItemView.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuItemView.kt
@@ -91,8 +91,11 @@ class AdBlockingMenuItemView @JvmOverloads constructor(
         val url = this.url ?: return
         menuItem.setOnClickListener {
             when (menuState) {
-                AdBlockingMenuState.Disabled -> menuController.enable()
-                else -> showMenuBottomSheet()
+                AdBlockingMenuState.Disabled -> menuController.onEnableTapped()
+                else -> {
+                    menuController.onDisableTapped()
+                    showMenuBottomSheet()
+                }
             }
             onHostClick?.invoke()
         }

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/menu/AdBlockingBrokenSiteReportTriggerTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/menu/AdBlockingBrokenSiteReportTriggerTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.adblocking.impl.menu
+
+import app.cash.turbine.test
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_BREAKAGE_REPORT_ENTERED_COUNT
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_BREAKAGE_REPORT_ENTERED_DAILY
+import com.duckduckgo.app.statistics.pixels.Pixel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AdBlockingBrokenSiteReportTriggerTest {
+
+    private val pixel: Pixel = mock()
+
+    private val trigger = AdBlockingBrokenSiteReportTrigger(pixel)
+
+    @Test
+    fun whenReportRequestedThenFiresBreakageReportEnteredPixels() {
+        trigger.requestReport()
+
+        verify(pixel).fire(AD_BLOCKING_BREAKAGE_REPORT_ENTERED_DAILY, type = Pixel.PixelType.Daily())
+        verify(pixel).fire(AD_BLOCKING_BREAKAGE_REPORT_ENTERED_COUNT)
+    }
+
+    @Test
+    fun whenReportRequestedThenEmitsReportRequest() = runTest {
+        trigger.observeReportRequests().test {
+            trigger.requestReport()
+
+            awaitItem()
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+}

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/menu/RealAdBlockingMenuControllerTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/menu/RealAdBlockingMenuControllerTest.kt
@@ -16,10 +16,21 @@
 
 package com.duckduckgo.adblocking.impl.menu
 
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_MENU_DISABLE_TAPPED_COUNT
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_MENU_DISABLE_TAPPED_DAILY
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_MENU_ENABLE_TAPPED_COUNT
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_MENU_ENABLE_TAPPED_DAILY
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_PICKER_ALWAYS_OFF_COUNT
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_PICKER_ALWAYS_OFF_DAILY
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_PICKER_ALWAYS_ON_COUNT
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_PICKER_ALWAYS_ON_DAILY
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_PICKER_DISABLE_UNTIL_RELAUNCH_COUNT
+import com.duckduckgo.adblocking.impl.AdBlockingPixelNames.AD_BLOCKING_PICKER_DISABLE_UNTIL_RELAUNCH_DAILY
 import com.duckduckgo.adblocking.impl.AdBlockingSettingsRepository
 import com.duckduckgo.adblocking.impl.domain.AdBlockingState
 import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
 import com.duckduckgo.adblocking.impl.store.RealAdBlockingSessionStore
+import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.common.test.CoroutineTestRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -32,6 +43,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -51,6 +63,7 @@ class RealAdBlockingMenuControllerTest {
     private val statusChecker: AdBlockingStatusChecker = mock {
         on { currentState() } doReturn AdBlockingState.Enabled.UserEnabled
     }
+    private val pixel: Pixel = mock()
 
     private val controller = RealAdBlockingMenuController(
         settingsRepository,
@@ -58,6 +71,7 @@ class RealAdBlockingMenuControllerTest {
         statusChecker,
         coroutineRule.testScope,
         coroutineRule.testDispatcherProvider,
+        pixel,
     )
 
     @Test
@@ -99,6 +113,14 @@ class RealAdBlockingMenuControllerTest {
     }
 
     @Test
+    fun whenAlwaysOnSelectedThenFiresPickerAlwaysOnPixels() {
+        controller.onChoiceSelected(AdBlockingChoice.ALWAYS_ON)
+
+        verify(pixel).fire(AD_BLOCKING_PICKER_ALWAYS_ON_DAILY, type = Pixel.PixelType.Daily())
+        verify(pixel).fire(AD_BLOCKING_PICKER_ALWAYS_ON_COUNT)
+    }
+
+    @Test
     fun whenDisableUntilRelaunchSelectedThenSetsSessionAndLeavesPersistedUntouched() = runTest {
         userEnabledFlow.value = true
 
@@ -106,6 +128,14 @@ class RealAdBlockingMenuControllerTest {
 
         assertTrue(sessionStore.isDisabledUntilRelaunch())
         assertEquals(true, userEnabledFlow.value)
+    }
+
+    @Test
+    fun whenDisableUntilRelaunchSelectedThenFiresPickerDisableUntilRelaunchPixels() {
+        controller.onChoiceSelected(AdBlockingChoice.DISABLE_UNTIL_RELAUNCH)
+
+        verify(pixel).fire(AD_BLOCKING_PICKER_DISABLE_UNTIL_RELAUNCH_DAILY, type = Pixel.PixelType.Daily())
+        verify(pixel).fire(AD_BLOCKING_PICKER_DISABLE_UNTIL_RELAUNCH_COUNT)
     }
 
     @Test
@@ -119,10 +149,44 @@ class RealAdBlockingMenuControllerTest {
     }
 
     @Test
-    fun whenEnableThenPersistsEnabledAndClearsSession() = runTest {
+    fun whenAlwaysOffSelectedThenFiresPickerAlwaysOffPixels() {
+        controller.onChoiceSelected(AdBlockingChoice.ALWAYS_OFF)
+
+        verify(pixel).fire(AD_BLOCKING_PICKER_ALWAYS_OFF_DAILY, type = Pixel.PixelType.Daily())
+        verify(pixel).fire(AD_BLOCKING_PICKER_ALWAYS_OFF_COUNT)
+    }
+
+    @Test
+    fun whenEnableTappedThenPersistsEnabledAndClearsSession() = runTest {
         sessionStore.setDisabledUntilRelaunch()
 
-        controller.enable()
+        controller.onEnableTapped()
+
+        assertEquals(true, userEnabledFlow.value)
+        assertFalse(sessionStore.isDisabledUntilRelaunch())
+    }
+
+    @Test
+    fun whenEnableTappedThenFiresMenuEnableTappedPixels() {
+        controller.onEnableTapped()
+
+        verify(pixel).fire(AD_BLOCKING_MENU_ENABLE_TAPPED_DAILY, type = Pixel.PixelType.Daily())
+        verify(pixel).fire(AD_BLOCKING_MENU_ENABLE_TAPPED_COUNT)
+    }
+
+    @Test
+    fun whenDisableTappedThenFiresMenuDisableTappedPixels() {
+        controller.onDisableTapped()
+
+        verify(pixel).fire(AD_BLOCKING_MENU_DISABLE_TAPPED_DAILY, type = Pixel.PixelType.Daily())
+        verify(pixel).fire(AD_BLOCKING_MENU_DISABLE_TAPPED_COUNT)
+    }
+
+    @Test
+    fun whenDisableTappedThenDoesNotChangeState() = runTest {
+        userEnabledFlow.value = true
+
+        controller.onDisableTapped()
 
         assertEquals(true, userEnabledFlow.value)
         assertFalse(sessionStore.isDisabledUntilRelaunch())


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1214566871879496?focus=true
Tech Design URL (if applicable): 

### Description
* Fire new ad-blocking menu pixels

### Steps to test this PR

Feel free to run these tests top of the stack, for more efficient test runs

_Feature 1_
- [x] Enable `adBlockingUxImprovements` RC flag
- [x] Open a YouTube video
- [x] Open browser menu
- [x] Click "Enable ad blocking"
- [x] Check `adBlocking_menu_enable_tapped_daily` and `adBlocking_menu_enable_tapped_count` are fired
- [x] Open the menu again and tap "Disable ad blocking"
- [x] Check `adBlocking_menu_disable_tapped_daily` and `adBlocking_menu_disable_tapped_count` are fired
- [x] Click "Disable until relaunch"
- [x] Check `adBlocking_picker_disable_until_relaunch_daily` and `adBlocking_picker_disable_until_relaunch_count` are fired
- [x] Close and reopen the app
- [x] Open browser menu
- [x] Click "Disable ad blocking"
- [x] Check `adBlocking_menu_disable_tapped_count` is fired
- [x] Check "Always off"
- [x] Check `adBlocking_picker_always_off_daily` and `adBlocking_picker_always_off_count` are fired
- [x] Open browser menu
- [x] Click "Enable ad blocking"
- [x] Check `adBlocking_menu_enable_tapped_count` is fired
- [x] Open browser menu
- [x] Click "Disable ad blocking"
- [x] Check `adBlocking_menu_disable_tapped_count` is fired
- [x] Check "Always On"
- [x] Check `adBlocking_picker_always_on_count` and `adBlocking_picker_always_on_daily` are fired

### UI changes
n/a



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to telemetry and a small controller API rename; ad-blocking settings behavior is unchanged aside from explicit disable-tap handling that only records pixels.
> 
> **Overview**
> Adds **analytics pixels** for ad-blocking browser menu flows: enable/disable row taps, each disable-picker choice (always on, until relaunch, always off), and entering the ad-blocking breakage report flow.
> 
> `RealAdBlockingMenuController` now takes `Pixel` and splits behavior into **`onEnableTapped()`** (pixels + enable), **`onDisableTapped()`** (pixels only, before the sheet), and **`onChoiceSelected()`** (pixels + existing `apply` logic). **`AdBlockingMenuItemView`** calls those entry points instead of `enable()` when the row is tapped.
> 
> **`AdBlockingBrokenSiteReportTrigger`** fires breakage-report entered daily/count pixels when `requestReport()` runs. Unit tests cover pixel firing and that disable tap does not change persisted/session state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba9724c9b8632d68979e9b2cccc62cf57517ca6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->