### PR TITLE
Add simplified sync feature flag

### DIFF
--- a/feature-toggles/feature-toggles-test/src/main/java/com/duckduckgo/feature/toggles/api/FakeToggleStore.kt
+++ b/feature-toggles/feature-toggles-test/src/main/java/com/duckduckgo/feature/toggles/api/FakeToggleStore.kt
@@ -16,6 +16,9 @@
 
 package com.duckduckgo.feature.toggles.api
 
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
 class FakeToggleStore : Toggle.Store {
     private val map = mutableMapOf<String, Toggle.State>()
 
@@ -33,12 +36,14 @@ class FakeFeatureToggleFactory {
         fun <T> create(
             toggles: Class<T>,
             store: Toggle.Store = FakeToggleStore(),
+            ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
             appVersionProvider: () -> Int = { Int.MAX_VALUE },
         ): T {
             return FeatureToggles.Builder()
                 .store(store)
                 .appVersionProvider(appVersionProvider)
                 .featureName("fakeFeature")
+                .ioDispatcher(ioDispatcher)
                 .build()
                 .create(toggles)
         }

--- a/sync/sync-impl/build.gradle
+++ b/sync/sync-impl/build.gradle
@@ -120,6 +120,8 @@ dependencies {
 }
 
 android {
+    namespace "com.duckduckgo.sync.impl"
+
     anvil {
         generateDaggerFactories = true // default is false
     }

--- a/sync/sync-impl/build.gradle
+++ b/sync/sync-impl/build.gradle
@@ -120,8 +120,6 @@ dependencies {
 }
 
 android {
-    namespace "com.duckduckgo.sync.impl"
-
     anvil {
         generateDaggerFactories = true // default is false
     }

--- a/sync/sync-impl/src/main/AndroidManifest.xml
+++ b/sync/sync-impl/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
   ~ limitations under the License.
   -->
 
-<manifest package="com.duckduckgo.sync.impl"
+<manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
@@ -82,5 +82,12 @@
             android:name="com.journeyapps.barcodescanner.CaptureActivity"
             android:screenOrientation="portrait"
             tools:replace="screenOrientation" />
+
+        <activity
+            android:name=".ui.v2.SyncActivity"
+            android:exported="false"
+            android:label="@string/sync_screen_title"
+            android:screenOrientation="portrait"
+            android:parentActivityName="com.duckduckgo.app.settings.SettingsActivity"/>
     </application>
 </manifest>

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
@@ -102,4 +102,7 @@ interface SyncFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun restrictScannedBarcodesToQrTypes(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun useSimplifiedSync(): Toggle
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivity.kt
@@ -22,7 +22,6 @@ import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
-import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.spans.DuckDuckGoClickableSpan
@@ -108,10 +107,6 @@ import logcat.logcat
 import javax.inject.Inject
 
 @InjectWith(ActivityScope::class, delayGeneration = true)
-@ContributeToActivityStarter(SyncActivityWithEmptyParams::class)
-@ContributeToActivityStarter(SyncActivityWithSourceParams::class)
-@ContributeToActivityStarter(SyncActivityFromSetupUrl::class)
-@ContributeToActivityStarter(SyncActivityWithAnotherDevice::class)
 class SyncActivity : DuckDuckGoActivity() {
     private val binding: ActivitySyncBinding by viewBinding()
     private val viewModel: SyncActivityViewModel by bindViewModel()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityParamMapper.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityParamMapper.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui
+
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.LifecycleOwner
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.lifecycle.MainProcessLifecycleObserver
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.navigation.api.GlobalActivityStarter.ActivityParams
+import com.duckduckgo.navigation.api.GlobalActivityStarter.DeeplinkActivityParams
+import com.duckduckgo.navigation.api.GlobalActivityStarter.ParamToActivityMapper
+import com.duckduckgo.sync.api.SyncActivityFromSetupUrl
+import com.duckduckgo.sync.api.SyncActivityWithAnotherDevice
+import com.duckduckgo.sync.api.SyncActivityWithEmptyParams
+import com.duckduckgo.sync.impl.SyncFeature
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.Lazy
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import com.duckduckgo.sync.impl.ui.v2.SyncActivity as SyncActivityV2
+
+@SingleInstanceIn(AppScope::class)
+@ContributesMultibinding(AppScope::class, boundType = ParamToActivityMapper::class)
+@ContributesMultibinding(AppScope::class, boundType = MainProcessLifecycleObserver::class)
+class SyncActivityParamMapper @Inject constructor(
+    // Lazy to break a DI cycle: SyncFeature's generated toggle store transitively depends on
+    // GlobalActivityStarter (via VariantManager → ExperimentFiltersManager → Subscriptions),
+    // and GlobalActivityStarter injects every ParamToActivityMapper, including this one.
+    private val syncFeature: Lazy<SyncFeature>,
+    @AppCoroutineScope private val appScope: CoroutineScope,
+) : ParamToActivityMapper, MainProcessLifecycleObserver {
+
+    @Volatile private var useSimplifiedSync = false
+
+    override fun map(activityParams: ActivityParams): Class<out AppCompatActivity>? {
+        return when (activityParams) {
+            is SyncActivityWithEmptyParams,
+            is SyncActivityWithSourceParams,
+            is SyncActivityFromSetupUrl,
+            is SyncActivityWithAnotherDevice,
+            -> if (useSimplifiedSync) {
+                SyncActivityV2::class.java
+            } else {
+                SyncActivity::class.java
+            }
+
+            else -> null
+        }
+    }
+
+    override fun map(deeplinkActivityParams: DeeplinkActivityParams): ActivityParams? = null
+
+    override fun onCreate(owner: LifecycleOwner) {
+        // We don't read useSimplifiedSync().isEnabled() directly when mapping Activity params
+        // because getting a feature flag value can perform an I/O disk read. This way
+        // we avoid potential ANRs.
+        appScope.launch {
+            syncFeature.get().useSimplifiedSync()
+                .enabled()
+                .collect { useSimplifiedSync = it }
+        }
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityParamMapper.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityParamMapper.kt
@@ -36,6 +36,11 @@ import kotlinx.coroutines.launch
 import javax.inject.Inject
 import com.duckduckgo.sync.impl.ui.v2.SyncActivity as SyncActivityV2
 
+// Typically, ParamToActivityMapper instances are generated in the code via @ContributeToActivityStarter
+// annotations on an Activity. This mapper is handwritten because we need to support two separate Activity
+// paths as long as the useSimplifiedSync feature flag is available.
+//
+// Once the FF is removed we can drop one of the code paths and move mapper contribution back to annotations.
 @SingleInstanceIn(AppScope::class)
 @ContributesMultibinding(AppScope::class, boundType = ParamToActivityMapper::class)
 @ContributesMultibinding(AppScope::class, boundType = MainProcessLifecycleObserver::class)

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui.v2
+
+import android.graphics.Color
+import android.os.Bundle
+import android.view.ViewGroup
+import android.view.ViewGroup.LayoutParams.MATCH_PARENT
+import android.widget.FrameLayout
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.di.scopes.ActivityScope
+
+@InjectWith(ActivityScope::class)
+class SyncActivity : DuckDuckGoActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(
+            FrameLayout(this).apply {
+                setBackgroundColor(Color.MAGENTA)
+                layoutParams = ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT)
+            },
+        )
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncActivityParamMapperTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncActivityParamMapperTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui
+
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.navigation.api.GlobalActivityStarter
+import com.duckduckgo.sync.api.SyncActivityFromSetupUrl
+import com.duckduckgo.sync.api.SyncActivityWithAnotherDevice
+import com.duckduckgo.sync.api.SyncActivityWithEmptyParams
+import com.duckduckgo.sync.impl.SyncFeature
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import com.duckduckgo.sync.impl.ui.v2.SyncActivity as SyncActivityV2
+
+class SyncActivityParamMapperTest {
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val syncFeature = FakeFeatureToggleFactory.create(
+        SyncFeature::class.java,
+        ioDispatcher = coroutineRule.testDispatcher,
+    )
+
+    private val testee = SyncActivityParamMapper(
+        syncFeature = { syncFeature },
+        appScope = coroutineRule.testScope.backgroundScope,
+    )
+
+    @Before
+    fun setup() {
+        testee.onCreate(mock())
+    }
+
+    @After
+    fun tearDown() {
+        testee.onDestroy(mock())
+    }
+
+    @Test
+    fun `map 'with empty params' activity params`() = coroutineRule.testScope.runTest {
+        enableSimplifiedSync(false)
+        assertEquals(SyncActivity::class.java, testee.map(SyncActivityWithEmptyParams))
+
+        enableSimplifiedSync(true)
+        assertEquals(SyncActivityV2::class.java, testee.map(SyncActivityWithEmptyParams))
+    }
+
+    @Test
+    fun `map 'with source params' activity params`() = coroutineRule.testScope.runTest {
+        enableSimplifiedSync(false)
+        assertEquals(SyncActivity::class.java, testee.map(SyncActivityWithSourceParams(source = "source")))
+
+        enableSimplifiedSync(true)
+        assertEquals(SyncActivityV2::class.java, testee.map(SyncActivityWithSourceParams(source = "source")))
+    }
+
+    @Test
+    fun `map 'from setup url' activity params`() = coroutineRule.testScope.runTest {
+        enableSimplifiedSync(false)
+        assertEquals(SyncActivity::class.java, testee.map(SyncActivityFromSetupUrl(url = "url")))
+
+        enableSimplifiedSync(true)
+        assertEquals(SyncActivityV2::class.java, testee.map(SyncActivityFromSetupUrl(url = "url")))
+    }
+
+    @Test
+    fun `map 'with another device' activity params`() = coroutineRule.testScope.runTest {
+        enableSimplifiedSync(false)
+        assertEquals(SyncActivity::class.java, testee.map(SyncActivityWithAnotherDevice(source = "source")))
+
+        enableSimplifiedSync(true)
+        assertEquals(SyncActivityV2::class.java, testee.map(SyncActivityWithAnotherDevice(source = "source")))
+    }
+
+    @Test
+    fun `map unknown activity params to null`() = coroutineRule.testScope.runTest {
+        enableSimplifiedSync(false)
+        assertNull(testee.map(object : GlobalActivityStarter.ActivityParams {}))
+
+        enableSimplifiedSync(true)
+        assertNull(testee.map(object : GlobalActivityStarter.ActivityParams {}))
+    }
+
+    private fun enableSimplifiedSync(enable: Boolean) {
+        syncFeature.useSimplifiedSync().setRawStoredState(State(enable))
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216103556496795/task/1216263241588926?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1215321458176118/task/1216509582049467?focus=true

### Description

Adds simplified sync feature flag. The feature flag is used in a hand-written `ParamToActivityMapper` that dispatches to legacy flow or to new flow depending on the FF value. In order to support the mapper I removed `@ContributeToActivityStarter` annotations from the legacy `SyncActivity`.

New `SyncActivity` is at the moment a dummy activity for testeing purposes.

I also modified `FakeFeatureToggleFactory.create()` function to accept an optional coroutine dispatcher. Without it the created toggles dispatched on real IO thread pool and failed tests due to race conditions.

### Steps to test this PR

_Feature flag navigation_
- [ ] Have `useSimplifiedSync` FF disabled (this is the default state).
- [ ] Go to the Settings.
- [ ] Tap "Sync & Backup".
- [ ] You should see the legacy flow.
- [ ] Enable `useSimplifiedSync` in the FF inventory.
- [ ] Go to the Settings.
- [ ] Tap "Sync & Backup".
- [ ] You should see a magenta filled screen.

### UI changes
N/A


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all Sync & Backup deep links resolve at runtime; default remains legacy, but incorrect mapper or stale cached flag could send users to the wrong activity once the flag is enabled.
> 
> **Overview**
> Introduces **`useSimplifiedSync`** (default off) and wires Sync & Backup navigation through a hand-written **`SyncActivityParamMapper`** instead of `@ContributeToActivityStarter` on the legacy screen.
> 
> When the flag is on, existing sync entry params launch **`ui.v2.SyncActivity`** (currently a magenta placeholder); when off, behavior stays on the legacy **`SyncActivity`**. The mapper caches the flag from a background **`enabled()`** flow so mapping does not trigger disk I/O on the main thread.
> 
> **`FakeFeatureToggleFactory.create()`** now accepts an optional **`ioDispatcher`** so toggle tests can use the test dispatcher and avoid races. **`SyncActivityParamMapperTest`** covers all supported param types and unknown params.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ca49fa72755a8f0f18e2bb5f5255938bcef4054. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->