### PR TITLE
Fix internal settings page layouts

### DIFF
--- a/anrs/anrs-internal/src/main/res/layout/activity_crash_anr_internal_settings.xml
+++ b/anrs/anrs-internal/src/main/res/layout/activity_crash_anr_internal_settings.xml
@@ -45,8 +45,9 @@
     <ScrollView
             android:id="@+id/contentScrollView"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="0dp"
             app:layout_constraintTop_toBottomOf="@id/appBar"
+            app:layout_constraintBottom_toBottomOf="parent"
             tools:ignore="Overdraw">
 
         <LinearLayout

--- a/remote-messaging/remote-messaging-internal/src/main/res/layout/activity_rmf_internal_settings.xml
+++ b/remote-messaging/remote-messaging-internal/src/main/res/layout/activity_rmf_internal_settings.xml
@@ -45,8 +45,9 @@
     <ScrollView
             android:id="@+id/contentScrollView"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="0dp"
             app:layout_constraintTop_toBottomOf="@id/appBar"
+            app:layout_constraintBottom_toBottomOf="parent"
             tools:ignore="Overdraw">
 
         <LinearLayout


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1216557981843088?focus=true 
Tech Design URL (if applicable): 

### Description

Root cause is a layout regression from #9131: in `activity_rmf_internal_settings.xml`, the content ScrollView's `android:layout_marginTop="64dp"` was replaced with `app:layout_constraintTop_toBottomOf="@id/appBar"`, but its `android:layout_height` stayed `match_parent`. In a `ConstraintLayout`, `match_parent` is resolved as `0dp` pinned to the parent's top and bottom, which ignores the top constraint so the `ScrollView` renders behind the toolbar and its content (the single settings row) is hidden.

Fix: set the height to `0dp` and add `app:layout_constraintBottom_toBottomOf="parent"` so the content fills the space between the app bar and the parent bottom.

Screens fixed:
- Remote messaging Settings (`activity_rmf_internal_settings.xml`)
- Crash / ANRs internal settings (`activity_crash_anr_internal_settings.xml`)

There might be others that I am not aware of.

### Steps to test this PR
- [ ] Open Settings → Dev Settings → **Remote messaging Settings**.
- [ ] Verify the **"Use RMF staging endpoint"** toggle is visible (previously the page was empty).
- [ ] Confirm the toolbar/back navigation still behaves and content scrolls if it grows.

### UI changes
| Before  | After |
| ------ | ----- |
|<img width="540" height="1200" alt="Screenshot_20260714_131851" src="https://github.com/user-attachments/assets/fbf46b72-4a1b-489e-90b4-17da847400dc" />|<img width="540" height="1200" alt="Screenshot_20260714_131710" src="https://github.com/user-attachments/assets/bacadd9b-7115-4b0d-8661-d13adb2b8eb5" />)|
|<img width="540" height="1200" alt="Screenshot_20260714_133749" src="https://github.com/user-attachments/assets/1771b426-2683-427f-b9e4-c370c9e2d475" />|<img width="540" height="1200" alt="Screenshot_20260714_133406" src="https://github.com/user-attachments/assets/88e746e4-348b-43e2-962c-26eabdd5a31c" />|




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only change on internal dev settings screens with no security, data, or production user-flow impact.
> 
> **Overview**
> Fixes **empty or hidden content** on internal dev settings screens caused by a **ConstraintLayout regression**: the main `ScrollView` used `match_parent` height while being top-constrained to the app bar, so it drew **behind the toolbar** instead of in the area below it.
> 
> The fix is the same in **Remote Messaging** and **Crash/ANR** internal settings layouts: set the `ScrollView` height to **`0dp`** and pin **`layout_constraintBottom_toBottomOf="parent"`**, so the scrollable content fills only the space between the app bar and the bottom of the screen.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da29c1127cc10e309e3dcbde7716a00fefaf40d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->