### PR TITLE
Forward @-mentions in PR conversation comments to Asana

### DIFF
--- a/.github/workflows/pr-review-notifications.yaml
+++ b/.github/workflows/pr-review-notifications.yaml
@@ -5,11 +5,16 @@ on:
     types: [submitted]
   pull_request_review_comment:
     types: [created]
+  issue_comment:
+    types: [created]
 
 jobs:
   sync:
     name: Sync PR review/mentions with Asana
     runs-on: ubuntu-latest
+    # issue_comment fires on both issues and PRs; only run it for PR comments.
+    # The review events always run (github.event.issue is absent for them).
+    if: ${{ github.event_name != 'issue_comment' || github.event.issue.pull_request }}
     steps:
       - name: Checkout native actions repo
         uses: actions/checkout@v4
@@ -19,8 +24,8 @@ jobs:
           path: native-github-asana-sync
           repository: duckduckgo/native-github-asana-sync
 
-      # Posts canned review-event notes, and forwards review summaries and
-      # inline comments @-mentioning a user.
+      # Posts canned review-event notes, and forwards review summaries,
+      # inline comments, and PR conversation comments @-mentioning a user.
       - name: Sync PR review/mentions with Asana
         uses: ./native-github-asana-sync/.github/actions/pr-review-notifications
         with:


### PR DESCRIPTION

Task/Issue URL: https://app.asana.com/1/137249556945/project/1212608036467427/task/1216558962531573?focus=true
Tech Design URL (if applicable): 

### Description
Subscribe the review-notifications workflow to issue_comment (created) so that @-mentions in top-level PR conversation comments are forwarded to the linked Asana task, alongside the existing review summaries and inline review comments. The native action (v2.6.0) already handles issue_comment payloads; this only enables the trigger.

issue_comment fires on both issues and PRs, so the job is guarded to run only for PR comments, leaving the review events unaffected. issue_comment also resolves its workflow from the default branch, so unlike the review events this takes effect on all PRs as soon as it merges.

### Testing
This PR is the test: https://app.asana.com/1/137249556945/project/488551667048375/task/1216558962531573?focus=true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow trigger and conditional only; no app code, secrets, or composite action version change beyond comments.
> 
> **Overview**
> Extends the **Asana sync workflow** so **@-mentions in top-level PR conversation comments** are forwarded to the linked task, in addition to review summaries and inline review comments. The change adds an `issue_comment` (`created`) trigger and reuses the existing `pr-review-notifications` composite at **v2.6.0**, which already supports that event type.
> 
> Because `issue_comment` runs for **issues and PRs**, the sync job is gated with `github.event_name != 'issue_comment' || github.event.issue.pull_request` so only PR threads run the new path; existing `pull_request_review` and `pull_request_review_comment` behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 296e850b70e16102cce35249f85f6a372f30a753. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->