### PR TITLE
Only show after-idle message when a real tab was replaced

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/rmf/AfterIdleMessageTriggerProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/rmf/AfterIdleMessageTriggerProvider.kt
@@ -17,6 +17,7 @@
 package com.duckduckgo.app.generalsettings.showonapplaunch.rmf
 
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.newtabpage.api.EscapeHatchTargetResolver
 import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
 import com.duckduckgo.remote.messaging.api.MessageTrigger
 import kotlinx.coroutines.flow.Flow
@@ -25,11 +26,16 @@ import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 /**
- * Resolves the after-idle NTP context into [MessageTrigger.AFTER_IDLE]
+ * Resolves the after-idle NTP context into [MessageTrigger.AFTER_IDLE].
+ *
+ * Emits the trigger only when the NTP was shown as an after-idle return AND there is a real tab to return
+ * to. Reusing the escape hatch's target resolution ([EscapeHatchTargetResolver.resolve] returns null when
+ * there's nothing to return to).
  */
 class AfterIdleMessageTriggerProvider @Inject constructor(
     private val ntpAfterIdleManager: NtpAfterIdleManager,
     private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
+    private val escapeHatchTargetResolver: EscapeHatchTargetResolver,
 ) {
 
     fun activeTrigger(): Flow<MessageTrigger?> {
@@ -38,7 +44,7 @@ class AfterIdleMessageTriggerProvider @Inject constructor(
         if (!rolloutEnabled) return flowOf(null)
 
         return ntpAfterIdleManager.isAfterIdleReturn.map { afterIdle ->
-            if (afterIdle) MessageTrigger.AFTER_IDLE else null
+            if (afterIdle && escapeHatchTargetResolver.resolve() != null) MessageTrigger.AFTER_IDLE else null
         }
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/rmf/AfterIdleMessageTriggerProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/rmf/AfterIdleMessageTriggerProviderTest.kt
@@ -17,8 +17,11 @@
 package com.duckduckgo.app.generalsettings.showonapplaunch.rmf
 
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.newtabpage.api.EscapeHatchTarget
+import com.duckduckgo.newtabpage.api.EscapeHatchTargetResolver
 import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
 import com.duckduckgo.remote.messaging.api.MessageTrigger
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -33,20 +36,32 @@ import org.mockito.kotlin.whenever
 class AfterIdleMessageTriggerProviderTest {
 
     private val ntpAfterIdleManager: NtpAfterIdleManager = mock()
+    private val escapeHatchTargetResolver: EscapeHatchTargetResolver = mock()
     private val feature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
 
-    private val testee = AfterIdleMessageTriggerProvider(ntpAfterIdleManager, feature)
+    private val testee = AfterIdleMessageTriggerProvider(ntpAfterIdleManager, feature, escapeHatchTargetResolver)
 
     @Test
-    fun whenBothFlagsEnabledAndAfterIdleReturnThenAfterIdleTrigger() = runTest {
+    fun whenBothFlagsEnabledAndAfterIdleReturnWithReturnTargetThenAfterIdleTrigger() = runTest {
         enableBothFlags()
         whenever(ntpAfterIdleManager.isAfterIdleReturn).thenReturn(MutableStateFlow(true))
+        whenever(escapeHatchTargetResolver.resolve()).thenReturn(EscapeHatchTarget("tab1", BrowserMode.REGULAR))
 
         assertEquals(MessageTrigger.AFTER_IDLE, testee.activeTrigger().firstOrNull())
     }
 
     @Test
-    fun whenBothFlagsEnabledAndNotAfterIdleReturnThenNull() = runTest {
+    fun whenAfterIdleReturnButNoReturnTargetThenNull() = runTest {
+        // e.g. cold launch onto an existing NTP: after-idle, but nothing real to return to.
+        enableBothFlags()
+        whenever(ntpAfterIdleManager.isAfterIdleReturn).thenReturn(MutableStateFlow(true))
+        whenever(escapeHatchTargetResolver.resolve()).thenReturn(null)
+
+        assertNull(testee.activeTrigger().firstOrNull())
+    }
+
+    @Test
+    fun whenNotAfterIdleReturnThenNull() = runTest {
         enableBothFlags()
         whenever(ntpAfterIdleManager.isAfterIdleReturn).thenReturn(MutableStateFlow(false))
 
@@ -55,8 +70,8 @@ class AfterIdleMessageTriggerProviderTest {
 
     @Test
     fun whenShowNtpAfterIdleReturnFlagDisabledThenNull() = runTest {
+        feature.showNTPAfterIdleReturn().setRawStoredState(Toggle.State(enable = false))
         feature.ntpAsDefaultAfterIdleReturn().setRawStoredState(Toggle.State(enable = true))
-        // showNTPAfterIdleReturn stays off → gated out before idle state is observed
 
         assertNull(testee.activeTrigger().firstOrNull())
     }
@@ -64,7 +79,7 @@ class AfterIdleMessageTriggerProviderTest {
     @Test
     fun whenNtpAsDefaultFlagDisabledThenNull() = runTest {
         feature.showNTPAfterIdleReturn().setRawStoredState(Toggle.State(enable = true))
-        // ntpAsDefaultAfterIdleReturn stays off → gated out before idle state is observed
+        feature.ntpAsDefaultAfterIdleReturn().setRawStoredState(Toggle.State(enable = false))
 
         assertNull(testee.activeTrigger().firstOrNull())
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1216573975622687?focus=true
Tech Design URL (if applicable): 

### Description
Fixes the after-idle RMF opt-out message appearing when the user is **already on the New Tab Page**, backgrounds, and reopens after inactivity. The case where no real tab was replaced, so there is nothing to return to and the message is out of context.

**Cause:** the message gated on `NtpAfterIdleManager.isAfterIdleReturn`, which is deliberately **preserved across backgrounding** (the return-to-last-tab hatch relies on it surviving a background/resume so the hatch stays available while the user sits on that NTP). So on a background→reopen while already on an NTP, it was still `true` and the message showed again even though no substitution happened this time.

**Fix:** `AfterIdleMessageTriggerProvider` now emits the `AFTER_IDLE` trigger only when the NTP was shown as an after-idle return **and** there's a real tab to return to, reusing the escape hatch's own target resolution: `EscapeHatchTargetResolver.resolve()` returns `null` when there's nothing to return to 

API proposal: 

### Steps to test this PR
- [ ] enable showNTPAfterIdleReturn and ntpAsDefaultAfterIdleReturn FF
- [ ] You will need to hard code a staging environment for the RMF. Use https://staticcdn.duckduckgo.com/remotemessaging/config/staging/376/android-config.json
- [ ] Trigger an after-idle return from an NTP. → the NTP opens and the message is NOT shown.
- [ ] Delete the app then reinstall or clear data. 
- [ ] With message configured, trigger an after-idle return from a real browsing tab → the NTP opens and the message shows.

_Hatch unaffected_
- [ ] Verify the return-to-last-tab hatch still behaves as before across background/resume.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small gating change in RMF trigger logic with unit test coverage; reuses existing escape hatch resolution.
> 
> **Overview**
> Stops the after-idle remote messaging trigger from firing when the user is on the NTP after idle but there is **no real tab** to return to (e.g. already on NTP, background, reopen).
> 
> `AfterIdleMessageTriggerProvider` now requires both `isAfterIdleReturn` and a non-null result from `EscapeHatchTargetResolver.resolve()`—the same logic the return-to-last-tab hatch uses—before emitting `MessageTrigger.AFTER_IDLE`. Tests cover the new “after idle but no target” case and tighten feature-flag setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc2a46a86f91ca6b4fb72a1841a17c66444295dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->