### PR TITLE
Run Android Lint with the K1 UAST engine instead of K2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,48 +129,56 @@ jobs:
           path: unit-tests-report-${{ matrix.di }}.zip
 
   lint:
-    name: Lint
+    name: ${{ matrix.di == 'AnvilDagger' && 'Lint' || format('Lint ({0})', matrix.di) }}
     needs: [check_changes]
-    if: needs.check_changes.outputs.should_run == 'true'
     runs-on: android-large-runner
+    strategy:
+      fail-fast: false
+      matrix:
+        di: [AnvilDagger, Metro]
     env:
       DEVELOCITY_ACCESS_KEY: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
 
     steps:
       - name: Checkout repository
+        if: needs.check_changes.outputs.should_run == 'true'
         uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Set up JDK version
+        if: needs.check_changes.outputs.should_run == 'true'
         uses: actions/setup-java@v4
         with:
           java-version-file: .github/.java-version
           distribution: 'adopt'
 
       - name: Set up Go
+        if: needs.check_changes.outputs.should_run == 'true'
         uses: actions/setup-go@v5
         with:
           go-version: '1.18.3'
 
       - name: Setup Gradle
+        if: needs.check_changes.outputs.should_run == 'true'
         uses: gradle/actions/setup-gradle@v5
         with:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Lint
-        run: ./gradlew lint
+        if: needs.check_changes.outputs.should_run == 'true'
+        run: ./gradlew lint -Pddg.di=${{ matrix.di }}
 
       - name: Bundle the lint report
-        if: always()
-        run: find . -name lint-results\* | zip -@ -r lint-report.zip
+        if: always() && needs.check_changes.outputs.should_run == 'true'
+        run: find . -name lint-results\* | zip -@ -r lint-report-${{ matrix.di }}.zip
 
       - name: Upload the JVM lint report
-        if: always()
+        if: always() && needs.check_changes.outputs.should_run == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: lint-report
-          path: lint-report.zip
+          name: lint-report-${{ matrix.di }}
+          path: lint-report-${{ matrix.di }}.zip
 
   android_tests:
     needs: [check_changes]

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,5 +24,8 @@ org.gradle.configuration-cache=true
 android.nonFinalResIds=false
 com.squareup.anvil.trackSourceFiles=true
 
+# Run Android Lint with the K1 UAST engine instead of K2.
+android.lint.useK2Uast=false
+
 # DI framework: AnvilDagger (default) or Metro
 ddg.di=AnvilDagger


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216587119836749?focus=true
Tech Design URL (if applicable): N/A

### Description
Metro 1.3.x enables K2 UAST engine by default, triggering false positives during lint checks. We now default back to K1.

Additionally, lint is now run on Metro build as part of every PR instead of only nightly since we want to release it soon and team is using Metro locally.

### Steps to test this PR
Check that both Anvil and Metro Lint checks pass

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and Gradle lint configuration only; no app runtime, auth, or data-path changes.
> 
> **Overview**
> Sets **`android.lint.useK2Uast=false`** in `gradle.properties` so Android Lint uses the K1 UAST engine instead of K2, avoiding false positives when building with Metro 1.3.x.
> 
> The CI **lint** job now mirrors **unit tests**: a matrix over **`AnvilDagger`** and **`Metro`**, `./gradlew lint -Pddg.di=…` per variant, dynamic check names (**Lint** / **Lint (Metro)**), step-level gating on `should_run` (no job-level skip), and per-DI lint report artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fd5eed9b68b0086dd3aa75e335202289bc83485. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->