### PR TITLE
Fix pixel definition for VPN entry points

### DIFF
--- a/PixelDefinitions/pixels/definitions/network_protection.json5
+++ b/PixelDefinitions/pixels/definitions/network_protection.json5
@@ -4,20 +4,41 @@
         "owners": ["nalcalag"],
         "triggers": ["other"],
         "suffixes": ["daily_count_short", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": [
+            "appVersion",
+            {
+                "key": "ts",
+                "type": "string",
+                "description": "Eastern Time (America/New_York) timestamp of when the event occurred, in yyyy-MM-dd'T'HH:mm:ss format. Added automatically to enqueued pixels."
+            }
+        ]
     },
     "m_netp_ev_vpn_access_revoked_dialog_subscribe_clicked": {
         "description": "Fired when the user taps the 'Subscribe' button on the VPN access revoked dialog",
         "owners": ["nalcalag"],
         "triggers": ["other"],
         "suffixes": ["daily_count_short", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": [
+            "appVersion",
+            {
+                "key": "ts",
+                "type": "string",
+                "description": "Eastern Time (America/New_York) timestamp of when the event occurred, in yyyy-MM-dd'T'HH:mm:ss format. Added automatically to enqueued pixels."
+            }
+        ]
     },
     "m_netp_ev_vpn_access_revoked_dialog_dismiss_clicked": {
         "description": "Fired when the user taps the 'Dismiss' button on the VPN access revoked dialog",
         "owners": ["nalcalag"],
         "triggers": ["other"],
         "suffixes": ["daily_count_short", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": [
+            "appVersion",
+            {
+                "key": "ts",
+                "type": "string",
+                "description": "Eastern Time (America/New_York) timestamp of when the event occurred, in yyyy-MM-dd'T'HH:mm:ss format. Added automatically to enqueued pixels."
+            }
+        ]
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216277453308957?focus=true
Tech Design URL (if applicable): 

### Description
Add missing param to pixel definition

### Steps to test this PR
- [ ] CI passes

### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics pixel schema metadata only; no runtime app or security behavior changes.
> 
> **Overview**
> Adds the missing **`ts`** string parameter to all three VPN access revoked dialog pixels in `network_protection.json5` (`m_netp_ev_vpn_access_revoked_dialog_shown`, `_subscribe_clicked`, and `_dismiss_clicked`). Each event previously listed only **`appVersion`**; the definition now documents the Eastern Time timestamp that the enqueue pipeline attaches automatically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 912fcd244017331f18f1d55b97eff17a901a8c7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->