### PR TITLE
Fix bottom sheets UX

### DIFF
--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ContingencyMessageBottomSheetFragment.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ContingencyMessageBottomSheetFragment.kt
@@ -16,11 +16,15 @@
 
 package com.duckduckgo.adblocking.impl
 
+import android.app.Dialog
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import com.duckduckgo.adblocking.impl.databinding.BottomSheetContingencyMessageBinding
+import com.duckduckgo.common.ui.setRoundCorners
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 
 class ContingencyMessageBottomSheetFragment : BottomSheetDialogFragment() {
@@ -34,6 +38,14 @@ class ContingencyMessageBottomSheetFragment : BottomSheetDialogFragment() {
         binding.contingencyMessageCloseButton.setOnClickListener { dismiss() }
         binding.contingencyMessagePrimaryButton.setOnClickListener { dismiss() }
         return binding.root
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialog = super.onCreateDialog(savedInstanceState) as BottomSheetDialog
+        dialog.behavior.skipCollapsed = true
+        dialog.behavior.state = BottomSheetBehavior.STATE_EXPANDED
+        dialog.setOnShowListener { dialog.setRoundCorners() }
+        return dialog
     }
 
     companion object {

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingDisabledBottomSheetDialog.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingDisabledBottomSheetDialog.kt
@@ -19,6 +19,8 @@ package com.duckduckgo.adblocking.impl.menu
 import android.annotation.SuppressLint
 import android.content.Context
 import android.view.LayoutInflater
+import android.view.View
+import androidx.core.view.updateLayoutParams
 import com.duckduckgo.adblocking.impl.databinding.BottomSheetAdBlockingDisabledBinding
 import com.duckduckgo.common.ui.applyBottomSystemBarInsetPadding
 import com.duckduckgo.common.ui.setRoundCorners
@@ -45,6 +47,8 @@ class AdBlockingDisabledBottomSheetDialog(
     private val binding: BottomSheetAdBlockingDisabledBinding =
         BottomSheetAdBlockingDisabledBinding.inflate(LayoutInflater.from(context))
 
+    private var defaultSheetHeight: Int? = null
+
     init {
         setContentView(binding.root)
 
@@ -54,10 +58,14 @@ class AdBlockingDisabledBottomSheetDialog(
 
         behavior.skipCollapsed = true
         behavior.isDraggable = false
-        behavior.maxHeight = context.resources.displayMetrics.heightPixels * MAX_HEIGHT_PERCENT / 100
         behavior.state = BottomSheetBehavior.STATE_EXPANDED
 
-        setOnShowListener { setRoundCorners() }
+        setOnShowListener {
+            setRoundCorners()
+            val bottomSheet = findViewById<View>(com.google.android.material.R.id.design_bottom_sheet) ?: return@setOnShowListener
+            bottomSheet.viewTreeObserver.addOnGlobalLayoutListener { capHeightInLandscape(bottomSheet) }
+            capHeightInLandscape(bottomSheet)
+        }
 
         binding.adBlockingDisabledCloseButton.setOnClickListener { dismiss() }
         binding.adBlockingDisabledPrimaryButton.setOnClickListener {
@@ -67,7 +75,23 @@ class AdBlockingDisabledBottomSheetDialog(
         binding.adBlockingDisabledSecondaryButton.setOnClickListener { dismiss() }
     }
 
+    private fun capHeightInLandscape(bottomSheet: View) {
+        val parent = bottomSheet.parent as? View ?: return
+        if (defaultSheetHeight == null) {
+            defaultSheetHeight = bottomSheet.layoutParams.height
+        }
+        val isLandscape = parent.width > parent.height
+        val targetHeight = if (isLandscape && parent.height > 0) {
+            parent.height * LANDSCAPE_MAX_HEIGHT_PERCENT / 100
+        } else {
+            defaultSheetHeight ?: return
+        }
+        if (bottomSheet.layoutParams.height != targetHeight) {
+            bottomSheet.updateLayoutParams { height = targetHeight }
+        }
+    }
+
     private companion object {
-        private const val MAX_HEIGHT_PERCENT = 90
+        private const val LANDSCAPE_MAX_HEIGHT_PERCENT = 90
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuBottomSheetDialog.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuBottomSheetDialog.kt
@@ -24,17 +24,19 @@ import androidx.core.graphics.drawable.toDrawable
 import com.duckduckgo.adblocking.impl.R
 import com.duckduckgo.adblocking.impl.databinding.BottomSheetAdBlockingMenuBinding
 import com.duckduckgo.common.ui.applyBottomSystemBarInsetPadding
+import com.duckduckgo.common.ui.setRoundCorners
 import com.duckduckgo.common.ui.view.listitem.OneLineListItem
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
+import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.duckduckgo.mobile.android.R as CommonR
 
 @SuppressLint("NoBottomSheetDialog")
 class AdBlockingMenuBottomSheetDialog(
     builderContext: Context,
-    private val selectedChoice: AdBlockingChoice,
-    private val edgeToEdgeProvider: EdgeToEdgeProvider,
+    selectedChoice: AdBlockingChoice,
+    edgeToEdgeProvider: EdgeToEdgeProvider,
 ) : BottomSheetDialog(
     builderContext,
     if (edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BOTTOM_SHEETS)) {
@@ -60,6 +62,12 @@ class AdBlockingMenuBottomSheetDialog(
             binding.root.applyBottomSystemBarInsetPadding()
         }
 
+        behavior.skipCollapsed = true
+        behavior.maxHeight = context.resources.displayMetrics.heightPixels * MAX_HEIGHT_PERCENT / 100
+        behavior.state = BottomSheetBehavior.STATE_EXPANDED
+
+        setOnShowListener { setRoundCorners() }
+
         binding.adBlockingMenuAlwaysOn.setChecked(selectedChoice == AdBlockingChoice.ALWAYS_ON)
         binding.adBlockingMenuDisableUntilRelaunch.setChecked(selectedChoice == AdBlockingChoice.DISABLE_UNTIL_RELAUNCH)
         binding.adBlockingMenuAlwaysOff.setChecked(selectedChoice == AdBlockingChoice.ALWAYS_OFF)
@@ -83,5 +91,9 @@ class AdBlockingMenuBottomSheetDialog(
         } else {
             setLeadingIconDrawable(Color.TRANSPARENT.toDrawable())
         }
+    }
+
+    private companion object {
+        private const val MAX_HEIGHT_PERCENT = 90
     }
 }

--- a/ad-blocking/ad-blocking-impl/src/main/res/layout/bottom_sheet_ad_blocking_menu.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/layout/bottom_sheet_ad_blocking_menu.xml
@@ -14,67 +14,73 @@
   ~ limitations under the License.
   -->
 
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:paddingTop="@dimen/keyline_4"
-    android:paddingBottom="@dimen/keyline_4">
+    android:layout_height="wrap_content">
 
-    <com.duckduckgo.common.ui.view.text.DaxTextView
-        android:id="@+id/adBlockingMenuTitle"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/keyline_5"
-        android:layout_marginTop="@dimen/bottomSheetTitleVerticalPadding"
-        android:text="@string/ad_blocking_menu_title"
-        app:layout_constraintEnd_toStartOf="@id/adBlockingMenuCloseButton"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:typography="h2" />
-
-    <ImageButton
-        android:id="@+id/adBlockingMenuCloseButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/keyline_4"
-        android:background="?attr/actionBarItemBackground"
-        android:contentDescription="@string/ad_blocking_menu_close_content_description"
-        android:src="@drawable/ic_close_24"
-        app:layout_constraintBottom_toBottomOf="@id/adBlockingMenuTitle"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@id/adBlockingMenuTitle" />
-
-    <com.duckduckgo.common.ui.view.divider.HorizontalDivider
-        android:id="@+id/adBlockingMenuDivider"
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/keyline_5"
-        app:defaultPadding="false"
-        app:layout_constraintTop_toBottomOf="@id/adBlockingMenuTitle" />
+        android:paddingTop="@dimen/keyline_4"
+        android:paddingBottom="@dimen/keyline_4">
 
-    <com.duckduckgo.common.ui.view.listitem.OneLineListItem
-        android:id="@+id/adBlockingMenuAlwaysOn"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@id/adBlockingMenuDivider"
-        app:leadingIcon="@drawable/check"
-        app:primaryText="@string/ad_blocking_menu_always_on" />
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/adBlockingMenuTitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/keyline_5"
+            android:layout_marginTop="@dimen/bottomSheetTitleVerticalPadding"
+            android:text="@string/ad_blocking_menu_title"
+            app:layout_constraintEnd_toStartOf="@id/adBlockingMenuCloseButton"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:typography="h2" />
 
-    <com.duckduckgo.common.ui.view.listitem.OneLineListItem
-        android:id="@+id/adBlockingMenuDisableUntilRelaunch"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@id/adBlockingMenuAlwaysOn"
-        app:leadingIcon="@drawable/check"
-        app:primaryText="@string/ad_blocking_menu_disable_until_relaunch" />
+        <ImageButton
+            android:id="@+id/adBlockingMenuCloseButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/keyline_4"
+            android:background="?attr/actionBarItemBackground"
+            android:contentDescription="@string/ad_blocking_menu_close_content_description"
+            android:src="@drawable/ic_close_24"
+            app:layout_constraintBottom_toBottomOf="@id/adBlockingMenuTitle"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@id/adBlockingMenuTitle" />
 
-    <com.duckduckgo.common.ui.view.listitem.OneLineListItem
-        android:id="@+id/adBlockingMenuAlwaysOff"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@id/adBlockingMenuDisableUntilRelaunch"
-        app:leadingIcon="@drawable/check"
-        app:primaryText="@string/ad_blocking_menu_always_off" />
+        <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+            android:id="@+id/adBlockingMenuDivider"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/keyline_5"
+            app:defaultPadding="false"
+            app:layout_constraintTop_toBottomOf="@id/adBlockingMenuTitle" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+            android:id="@+id/adBlockingMenuAlwaysOn"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/adBlockingMenuDivider"
+            app:leadingIcon="@drawable/check"
+            app:primaryText="@string/ad_blocking_menu_always_on" />
+
+        <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+            android:id="@+id/adBlockingMenuDisableUntilRelaunch"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/adBlockingMenuAlwaysOn"
+            app:leadingIcon="@drawable/check"
+            app:primaryText="@string/ad_blocking_menu_disable_until_relaunch" />
+
+        <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+            android:id="@+id/adBlockingMenuAlwaysOff"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toBottomOf="@id/adBlockingMenuDisableUntilRelaunch"
+            app:leadingIcon="@drawable/check"
+            app:primaryText="@string/ad_blocking_menu_always_off" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.core.widget.NestedScrollView>

--- a/ad-blocking/ad-blocking-impl/src/main/res/layout/bottom_sheet_ad_blocking_menu.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/layout/bottom_sheet_ad_blocking_menu.xml
@@ -14,73 +14,83 @@
   ~ limitations under the License.
   -->
 
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <com.google.android.material.bottomsheet.BottomSheetDragHandleView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingTop="@dimen/keyline_4"
-        android:paddingBottom="@dimen/keyline_4">
+        android:layout_height="wrap_content" />
 
-        <com.duckduckgo.common.ui.view.text.DaxTextView
-            android:id="@+id/adBlockingMenuTitle"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/keyline_5"
-            android:layout_marginTop="@dimen/bottomSheetTitleVerticalPadding"
-            android:text="@string/ad_blocking_menu_title"
-            app:layout_constraintEnd_toStartOf="@id/adBlockingMenuCloseButton"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:typography="h2" />
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
 
-        <ImageButton
-            android:id="@+id/adBlockingMenuCloseButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="@dimen/keyline_4"
-            android:background="?attr/actionBarItemBackground"
-            android:contentDescription="@string/ad_blocking_menu_close_content_description"
-            android:src="@drawable/ic_close_24"
-            app:layout_constraintBottom_toBottomOf="@id/adBlockingMenuTitle"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@id/adBlockingMenuTitle" />
-
-        <com.duckduckgo.common.ui.view.divider.HorizontalDivider
-            android:id="@+id/adBlockingMenuDivider"
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="@dimen/keyline_5"
-            app:defaultPadding="false"
-            app:layout_constraintTop_toBottomOf="@id/adBlockingMenuTitle" />
+            android:paddingBottom="@dimen/keyline_4">
 
-        <com.duckduckgo.common.ui.view.listitem.OneLineListItem
-            android:id="@+id/adBlockingMenuAlwaysOn"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:layout_constraintTop_toBottomOf="@id/adBlockingMenuDivider"
-            app:leadingIcon="@drawable/check"
-            app:primaryText="@string/ad_blocking_menu_always_on" />
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/adBlockingMenuTitle"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/keyline_5"
+                android:layout_marginTop="@dimen/bottomSheetTitleVerticalPadding"
+                android:text="@string/ad_blocking_menu_title"
+                app:layout_constraintEnd_toStartOf="@id/adBlockingMenuCloseButton"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:typography="h2" />
 
-        <com.duckduckgo.common.ui.view.listitem.OneLineListItem
-            android:id="@+id/adBlockingMenuDisableUntilRelaunch"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:layout_constraintTop_toBottomOf="@id/adBlockingMenuAlwaysOn"
-            app:leadingIcon="@drawable/check"
-            app:primaryText="@string/ad_blocking_menu_disable_until_relaunch" />
+            <ImageButton
+                android:id="@+id/adBlockingMenuCloseButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/keyline_4"
+                android:background="?attr/actionBarItemBackground"
+                android:contentDescription="@string/ad_blocking_menu_close_content_description"
+                android:src="@drawable/ic_close_24"
+                app:layout_constraintBottom_toBottomOf="@id/adBlockingMenuTitle"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="@id/adBlockingMenuTitle" />
 
-        <com.duckduckgo.common.ui.view.listitem.OneLineListItem
-            android:id="@+id/adBlockingMenuAlwaysOff"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:layout_constraintTop_toBottomOf="@id/adBlockingMenuDisableUntilRelaunch"
-            app:leadingIcon="@drawable/check"
-            app:primaryText="@string/ad_blocking_menu_always_off" />
+            <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+                android:id="@+id/adBlockingMenuDivider"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/keyline_5"
+                app:defaultPadding="false"
+                app:layout_constraintTop_toBottomOf="@id/adBlockingMenuTitle" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+                android:id="@+id/adBlockingMenuAlwaysOn"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintTop_toBottomOf="@id/adBlockingMenuDivider"
+                app:leadingIcon="@drawable/check"
+                app:primaryText="@string/ad_blocking_menu_always_on" />
 
-</androidx.core.widget.NestedScrollView>
+            <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+                android:id="@+id/adBlockingMenuDisableUntilRelaunch"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintTop_toBottomOf="@id/adBlockingMenuAlwaysOn"
+                app:leadingIcon="@drawable/check"
+                app:primaryText="@string/ad_blocking_menu_disable_until_relaunch" />
+
+            <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+                android:id="@+id/adBlockingMenuAlwaysOff"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintTop_toBottomOf="@id/adBlockingMenuDisableUntilRelaunch"
+                app:leadingIcon="@drawable/check"
+                app:primaryText="@string/ad_blocking_menu_always_off" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </androidx.core.widget.NestedScrollView>
+
+</LinearLayout>

--- a/ad-blocking/ad-blocking-impl/src/main/res/layout/bottom_sheet_contingency_message.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/layout/bottom_sheet_contingency_message.xml
@@ -14,74 +14,80 @@
   ~ limitations under the License.
   -->
 
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:paddingTop="@dimen/keyline_6"
-    android:paddingBottom="@dimen/keyline_5">
+    android:layout_height="wrap_content">
 
-    <ImageButton
-        android:id="@+id/contingencyMessageCloseButton"
-        android:layout_width="wrap_content"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/keyline_4"
-        android:background="?actionBarItemBackground"
-        android:contentDescription="@string/contingencyMessageCloseContentDescription"
-        android:src="@drawable/ic_close_24"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:paddingTop="@dimen/keyline_6"
+        android:paddingBottom="@dimen/keyline_5">
 
-    <ImageView
-        android:id="@+id/contingencyMessageIcon"
-        android:layout_width="wrap_content"
-        android:layout_height="96dp"
-        android:adjustViewBounds="true"
-        android:importantForAccessibility="no"
-        android:src="@drawable/youtube_warning_96"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        <ImageButton
+            android:id="@+id/contingencyMessageCloseButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="@dimen/keyline_4"
+            android:background="?actionBarItemBackground"
+            android:contentDescription="@string/contingencyMessageCloseContentDescription"
+            android:src="@drawable/ic_close_24"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
-    <com.duckduckgo.common.ui.view.text.DaxTextView
-        android:id="@+id/contingencyMessageTitle"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="40dp"
-        android:layout_marginTop="@dimen/keyline_4"
-        android:gravity="center"
-        android:text="@string/contingencyMessageTitle"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/contingencyMessageIcon"
-        app:typography="h2" />
+        <ImageView
+            android:id="@+id/contingencyMessageIcon"
+            android:layout_width="wrap_content"
+            android:layout_height="96dp"
+            android:adjustViewBounds="true"
+            android:importantForAccessibility="no"
+            android:src="@drawable/youtube_warning_96"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
-    <com.duckduckgo.common.ui.view.text.DaxTextView
-        android:id="@+id/contingencyMessageContent"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="56dp"
-        android:layout_marginTop="@dimen/keyline_4"
-        android:gravity="center"
-        android:text="@string/contingencyMessageContent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/contingencyMessageTitle"
-        app:textType="secondary"
-        app:typography="body2" />
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/contingencyMessageTitle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="40dp"
+            android:layout_marginTop="@dimen/keyline_4"
+            android:gravity="center"
+            android:text="@string/contingencyMessageTitle"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/contingencyMessageIcon"
+            app:typography="h2" />
 
-    <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
-        android:id="@+id/contingencyMessagePrimaryButton"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="40dp"
-        android:layout_marginTop="@dimen/keyline_5"
-        android:text="@string/contingencyMessagePrimaryButton"
-        app:daxButtonSize="large"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/contingencyMessageContent"
-        tools:text="Got It" />
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/contingencyMessageContent"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="56dp"
+            android:layout_marginTop="@dimen/keyline_4"
+            android:gravity="center"
+            android:text="@string/contingencyMessageContent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/contingencyMessageTitle"
+            app:textType="secondary"
+            app:typography="body2" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+        <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+            android:id="@+id/contingencyMessagePrimaryButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="40dp"
+            android:layout_marginTop="@dimen/keyline_5"
+            android:text="@string/contingencyMessagePrimaryButton"
+            app:daxButtonSize="large"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/contingencyMessageContent"
+            tools:text="Got It" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.core.widget.NestedScrollView>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216567155163128?focus=true 
Tech Design URL (if applicable): 

### Description
* Add handler to ad blocking menu bottom sheet
* Fix landscape for contingency, ad blocking menu, and ad blocking disabled bottom sheets

### Steps to test this PR

_Feature 1_
- [x] Fresh install
- [x] Enable adBlockingUxImprovements, enabledByDefault, and contingencyModeEnabled flags
- [x] Open a YouTube video
- [x] Check contingency bottom sheet correctly displays in both portrait and landscape


_Feature 2_
- [x] From previous scenario, disable contingencyModeEnabled flags
- [x] Open a YouTube video
- [x] Open browser menu
- [x] Click "Disable Ad Blocking"
- [x] Check the bottom sheet is correctly displayed in portrait and landscape
- [x] Select "Disabled until relaunch"
- [x] Check the disabled bottom sheet is displayed correctly in both portrait and landscape 

### UI changes
| Before  | After |
| ------ | ----- |
|<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/0c40c7d0-76f5-4148-b49b-a8af6ffdfa2c" />| <img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/4d7302b6-0b54-4964-a633-40393ba5f5e9" />|
|<img width="2340" height="1080" alt="image" src="https://github.com/user-attachments/assets/37005b79-8765-4c1f-bd32-f5f853e79bd1" />|  <img width="2340" height="1080" alt="image" src="https://github.com/user-attachments/assets/19ad4139-a561-4c69-9242-3df03a1bd1af" />|
|<img width="2340" height="1080" alt="image" src="https://github.com/user-attachments/assets/3197c161-d725-40c2-b3c2-d2416114f943" />| <img width="2340" height="1080" alt="image" src="https://github.com/user-attachments/assets/03bf0e1e-766b-41c3-adac-15f08fddd324" />|
| <img width="2340" height="1080" alt="image" src="https://github.com/user-attachments/assets/1f3d2151-77ab-4330-915f-977f7dfd8742" /> | <img width="2340" height="1080" alt="image" src="https://github.com/user-attachments/assets/cb949896-1b4d-43b6-ad94-9e3c6f85879e" /> |




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to ad-blocking bottom sheets; no changes to blocking logic, persistence, or network.
> 
> **Overview**
> Aligns ad-blocking bottom sheets with Material patterns and fixes layout issues in landscape.
> 
> **Contingency message** (`ContingencyMessageBottomSheetFragment`) now opens **expanded** with **no collapsed peek**, applies **rounded corners** on show, and wraps content in a **`NestedScrollView`** so tall content can scroll.
> 
> **Ad blocking menu** adds a **`BottomSheetDragHandleView`**, **`NestedScrollView`**, and the same **expanded + 90% max height + round corners** behavior as other sheets.
> 
> **Ad blocking disabled** drops a fixed **90% screen `maxHeight`** in favor of **`capHeightInLandscape`**: in landscape the sheet height is capped to **90% of the parent height** via a layout listener; portrait keeps the natural height.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10e4aaf99a55d99f407a0eb274d480d644f943e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->