### PR TITLE
UTI: Improve nav bar

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -200,6 +200,10 @@ class RealNativeInputManager @Inject constructor(
     private var navBarTabCountObserver: Observer<Int>? = null
     private var lastCallbacks: NativeInputCallbacks? = null
 
+    // The NTP top stroke is driven by hasFavorites, so we save its visibility on attach and restore it
+    // on detach rather than re-showing unconditionally (which would show it with no favorites present).
+    private var savedTopNtpStrokeVisibility: Int? = null
+
     private val interactionLockSource = MutableStateFlow(InteractionLock.Unlocked)
     private val duckAiFireButtonHighlightSource = MutableStateFlow(false)
 
@@ -690,6 +694,10 @@ class RealNativeInputManager @Inject constructor(
             floatingSubmitContainer = null
         }
         if (removed) widgetRoot = null
+        savedTopNtpStrokeVisibility?.let { vis ->
+            rootView.findViewById<View?>(R.id.topNtpOutlineStroke)?.visibility = vis
+            savedTopNtpStrokeVisibility = null
+        }
         duckAiToolbarHidden = false
         // Drop Fragment-scoped callback closures so they don't outlive the widget.
         lastCallbacks = null
@@ -978,6 +986,13 @@ class RealNativeInputManager @Inject constructor(
         if (isBottom) {
             rootView.findViewById<View?>(R.id.navigationBar)?.gone()
             rootView.findViewById<View?>(R.id.bottomBrowserOutlineStroke)?.gone()
+            // The top outline strokes separate a top omnibar from content; with the input's nav bar at
+            // the top they just draw a hairline under the bar. Hide them, restored on close.
+            rootView.findViewById<View?>(R.id.topBrowserOutlineStroke)?.gone()
+            rootView.findViewById<View?>(R.id.topNtpOutlineStroke)?.let {
+                if (savedTopNtpStrokeVisibility == null) savedTopNtpStrokeVisibility = it.visibility
+                it.gone()
+            }
             if (omnibarController.isBrowserMode()) {
                 widgetView.setBackgroundColor(
                     widgetView.context.getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorBackground),

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -545,7 +545,7 @@ class RealNativeInputManager @Inject constructor(
         }
         attachWidget(widgetView, navBarView, isBottom, tabId)
         applyNavBarVisibility(
-            show = navBarShouldBeVisible(isInputEmpty = prefillText.isEmpty()),
+            show = navBarShouldBeVisible(),
             animate = false,
         )
         lifecycleOwner.lifecycleScope.launch {
@@ -629,12 +629,6 @@ class RealNativeInputManager @Inject constructor(
                     nativeInputEventListener.onChatPromptSubmitted()
                     callbacks.onDuckAiQuerySubmitted(query)
                 }
-            },
-            onInputTextEmptyChanged = { isEmpty ->
-                applyNavBarVisibility(
-                    show = navBarShouldBeVisible(isInputEmpty = isEmpty),
-                    animate = true,
-                )
             },
         )
         widget.onChangeModelSubmitted = { modelId -> callbacks.onChangeModelSubmitted(modelId) }
@@ -887,20 +881,15 @@ class RealNativeInputManager @Inject constructor(
     }
 
     /** Current on-screen visibility the nav bar should have, combining the create-time gate with the
-     *  empty-field rule so a live mode/flag change (e.g. Search & Duck.ai → Search-only) hides it. */
-    private fun navBarShouldBeVisible(isInputEmpty: Boolean): Boolean =
+     *  browser-context rule so a live mode/flag change (e.g. Search & Duck.ai → Search-only) hides it. */
+    private fun navBarShouldBeVisible(): Boolean =
         shouldCreateNavBar(isNavBarFeatureEnabled, omnibarController.isDuckAiMode(), inputModeCapability) &&
-            shouldShowNavBar(isBrowserContext = navBarRoot != null, isInputEmpty = isInputEmpty)
+            shouldShowNavBar(isBrowserContext = navBarRoot != null)
 
     /** Re-applies the nav bar visibility for the current input state; no-op when no bar is attached. */
     private fun refreshNavBarVisibility() {
         if (navBarRoot == null) return
-        applyNavBarVisibility(show = navBarShouldBeVisible(isInputEmpty = currentInputEmpty()), animate = true)
-    }
-
-    private fun currentInputEmpty(): Boolean {
-        val widget = widgetRoot?.let { widgetFrom(it) } ?: return true
-        return widget.text.isNullOrEmpty()
+        applyNavBarVisibility(show = navBarShouldBeVisible(), animate = true)
     }
 
     /**
@@ -1236,11 +1225,10 @@ internal fun shouldCreateNavBar(featureEnabled: Boolean, isDuckAiMode: Boolean, 
     featureEnabled && !isDuckAiMode && inputMode == NativeInputState.InputMode.SEARCH_AND_DUCK_AI
 
 /**
- * The persistent input-mode nav bar is shown only for browser input and only while the input field
- * is empty (whitespace counts as text). Duck.ai and contextual input never show it.
+ * The persistent input-mode nav bar is shown for the whole browser-input session, regardless of
+ * whether the field has text. Duck.ai and contextual input never show it.
  */
-internal fun shouldShowNavBar(isBrowserContext: Boolean, isInputEmpty: Boolean): Boolean =
-    isBrowserContext && isInputEmpty
+internal fun shouldShowNavBar(isBrowserContext: Boolean): Boolean = isBrowserContext
 
 /**
  * Whether a visibility change is needed. [currentShown] is null before the first apply, which always

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -926,10 +926,13 @@ class RealNativeInputManager @Inject constructor(
         if (navBarView != null) {
             rootView.addView(navBarView, layoutCoordinator.buildNavBarLayoutParams(navBarHeightPx))
             // Bottom omnibar only: the autocomplete list overlaps the top strip and would draw over the
-            // bar (e.g. the Duck.ai tab's suggestions), so float it above. Top omnibar has no such overlap,
-            // and the elevation shadow there would tint the bar's background so it no longer matches the
-            // content — leave it flat.
-            if (isBottom) navBarView.translationZ = WIDGET_ELEVATION_DP.toPx()
+            // bar (e.g. the Duck.ai tab's suggestions), so float it above via translationZ. Suppress the
+            // shadow the raised Z would otherwise cast, we only want the draw order, not the elevation.
+            // Top omnibar has no such overlap, leave it flat.
+            if (isBottom) {
+                navBarView.translationZ = WIDGET_ELEVATION_DP.toPx()
+                suppressShadow(navBarView)
+            }
         }
         // Top mode offsets the widget below the nav bar so it isn't overlapped; bottom mode is unaffected.
         rootView.addView(widgetView, layoutCoordinator.buildWidgetLayoutParams(isBottom, topInsetPx = navBarHeightPx))

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -650,11 +650,10 @@ class RealNativeInputManager @Inject constructor(
             callbacks.onClearAutocomplete()
             previousOnChatSelected?.invoke(animate)
         }
-        widget.onClearTextTapped = {
-            if (!widget.isChatTabSelected()) {
-                callbacks.onClearAutocomplete()
-            }
-        }
+        // Clearing the field must not dismiss the focused view: onClearAutocomplete re-triggers
+        // autocomplete with hasFocus=false and hides the focused view, so on a browser tab it would
+        // wipe the favourites the empty+focused state should show. The clear's own text change already
+        // re-renders the correct empty state (favourites), so no extra handling is needed here.
     }
 
     private fun showNtp() {

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
@@ -258,6 +258,7 @@ class RealNativeInputOmnibarController(
         } else {
             rootView.findViewById<View?>(R.id.bottomBrowserOutlineStroke)?.show()
         }
+        rootView.findViewById<View?>(R.id.topBrowserOutlineStroke)?.show()
         omnibar.isScrollingEnabled = true
     }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/NavBarVisibilityDecisionTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/NavBarVisibilityDecisionTest.kt
@@ -44,11 +44,9 @@ class NavBarVisibilityDecisionTest {
     }
 
     @Test
-    fun `nav bar shows only in browser context with an empty field`() {
-        assertTrue(shouldShowNavBar(isBrowserContext = true, isInputEmpty = true))
-        assertFalse(shouldShowNavBar(isBrowserContext = true, isInputEmpty = false))
-        assertFalse(shouldShowNavBar(isBrowserContext = false, isInputEmpty = true))
-        assertFalse(shouldShowNavBar(isBrowserContext = false, isInputEmpty = false))
+    fun `nav bar shows for the whole browser-input session regardless of field content`() {
+        assertTrue(shouldShowNavBar(isBrowserContext = true))
+        assertFalse(shouldShowNavBar(isBrowserContext = false))
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -527,8 +527,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
             updateSendButtonVisibility()
             updateVoiceButtonVisibility()
             updateNewLineButtonVisibility()
-            // The toggle-row back arrow flips with text presence (inverse of the nav bar).
-            nativeInputState?.let { updateBackButtons(it) }
         }
     }
 
@@ -741,9 +739,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     private fun updateBackButtons(state: NativeInputState) {
-        val hasText = !inputField.text.isNullOrEmpty()
         findViewById<View?>(R.id.inputModeWidgetBack)?.visibility =
-            if (state.shouldShowToggleRowBack(hasText)) VISIBLE else GONE
+            if (state.shouldShowToggleRowBack(duckChatFeature.nativeInputNavBar().isEnabled())) VISIBLE else GONE
         findViewById<View?>(R.id.inputModeUnifiedBack)?.visibility =
             if (state.shouldShowCardRowBack()) VISIBLE else GONE
         findViewById<View?>(R.id.inputModeWidgetBack)?.setBackgroundResource(
@@ -1626,11 +1623,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
 internal fun NativeInputState.chatHintRes(): Int =
     if (chatId != null) R.string.native_input_chat_duck_mode_hint else R.string.native_input_chat_hint
 
-// Inverse of the top nav bar: the nav bar shows its own back arrow while the field is empty, so this
-// one shows only once there is text — the two are never visible at the same time (browser only; this
-// arrow never renders in Duck.ai / contextual, where toggleVisible is false).
-internal fun NativeInputState.shouldShowToggleRowBack(hasText: Boolean): Boolean =
-    toggleVisible && inputContext == NativeInputState.InputContext.BROWSER && hasText
+// The nav bar carries its own back arrow, so this one only fills in when the nav bar feature is off
+// (browser only; this arrow never renders in Duck.ai / contextual, where toggleVisible is false).
+internal fun NativeInputState.shouldShowToggleRowBack(isNavBarFeatureEnabled: Boolean): Boolean =
+    toggleVisible && inputContext == NativeInputState.InputContext.BROWSER && !isNavBarFeatureEnabled
 
 internal fun NativeInputState.shouldShowCardRowBack(): Boolean =
     !toggleVisible && inputContext == NativeInputState.InputContext.BROWSER

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetBackButtonsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetBackButtonsTest.kt
@@ -29,28 +29,27 @@ import org.junit.Test
 class NativeInputModeWidgetBackButtonsTest {
 
     @Test
-    fun `toggle row back is shown when toggle visible, context is browser and there is text`() {
+    fun `toggle row back is shown when toggle visible, context is browser and nav bar is disabled`() {
         val state = stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.BROWSER)
 
-        assertTrue(state.shouldShowToggleRowBack(hasText = true))
+        assertTrue(state.shouldShowToggleRowBack(isNavBarFeatureEnabled = false))
         assertFalse(state.shouldShowCardRowBack())
     }
 
     @Test
-    fun `toggle row back is hidden when toggle visible and context is browser but the field is empty`() {
-        // Inverse of the nav bar: when empty, the nav bar shows its own back arrow, so this one hides
-        // to avoid two back arrows at once.
+    fun `toggle row back is hidden when toggle visible and context is browser but the nav bar is enabled`() {
+        // The nav bar carries its own back arrow, so this one hides to avoid two at once.
         val state = stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.BROWSER)
 
-        assertFalse(state.shouldShowToggleRowBack(hasText = false))
+        assertFalse(state.shouldShowToggleRowBack(isNavBarFeatureEnabled = true))
     }
 
     @Test
     fun `toggle row back is hidden when toggle visible and context is duck ai`() {
         val state = stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.DUCK_AI)
 
-        assertFalse(state.shouldShowToggleRowBack(hasText = true))
-        assertFalse(state.shouldShowToggleRowBack(hasText = false))
+        assertFalse(state.shouldShowToggleRowBack(isNavBarFeatureEnabled = false))
+        assertFalse(state.shouldShowToggleRowBack(isNavBarFeatureEnabled = true))
         assertFalse(state.shouldShowCardRowBack())
     }
 
@@ -58,14 +57,14 @@ class NativeInputModeWidgetBackButtonsTest {
     fun `toggle row back is hidden when toggle hidden and context is browser`() {
         val state = stateOf(InputMode.SEARCH_ONLY, InputContext.BROWSER)
 
-        assertFalse(state.shouldShowToggleRowBack(hasText = true))
+        assertFalse(state.shouldShowToggleRowBack(isNavBarFeatureEnabled = false))
     }
 
     @Test
     fun `toggle row back is hidden when toggle hidden and context is duck ai`() {
         val state = stateOf(InputMode.SEARCH_ONLY, InputContext.DUCK_AI)
 
-        assertFalse(state.shouldShowToggleRowBack(hasText = true))
+        assertFalse(state.shouldShowToggleRowBack(isNavBarFeatureEnabled = false))
     }
 
     @Test
@@ -90,8 +89,10 @@ class NativeInputModeWidgetBackButtonsTest {
 
     @Test
     fun `toggle row back is hidden in duck ai contextual context`() {
-        assertFalse(stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.DUCK_AI_CONTEXTUAL).shouldShowToggleRowBack(hasText = true))
-        assertFalse(stateOf(InputMode.SEARCH_ONLY, InputContext.DUCK_AI_CONTEXTUAL).shouldShowToggleRowBack(hasText = true))
+        assertFalse(
+            stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.DUCK_AI_CONTEXTUAL).shouldShowToggleRowBack(isNavBarFeatureEnabled = false),
+        )
+        assertFalse(stateOf(InputMode.SEARCH_ONLY, InputContext.DUCK_AI_CONTEXTUAL).shouldShowToggleRowBack(isNavBarFeatureEnabled = false))
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1216594519254115
Tech Design URL (if applicable):

### Description

Improvements to the Unified Text Input (UTI) browser nav bar (the back / fire / tabs / menu strip shown above the input while focused from browser input).

- **Nav bar visible for the whole browser-input session.** Previously the nav bar only showed while the input field was empty; it now stays for the entire browser-input session regardless of text.
- **Toggle-row back arrow gated on the nav bar feature.** With the nav bar always present, the toggle-row back arrow can no longer key off text presence (that would show two back arrows once the field has text). It now shows only when the nav bar feature is off, so the nav bar's own back arrow is the single source when the feature is on.
- **Suppressed the nav bar elevation shadow (bottom-omnibar mode).** The bottom-mode nav bar is floated above the autocomplete list via `translationZ` so suggestions draw under it; the raised Z also cast a drop shadow that read as unwanted elevation. The draw order is kept but the shadow is suppressed.
- **Hid the top outline strokes below the nav bar.** The top browser and NTP outline strokes (0.5dp `daxColorShade` separators meant to divide a top omnibar from content) drew a hairline directly under the nav bar in both light and dark themes. They are hidden while the input is showing and restored on close.
- **Fixed favourites disappearing when clearing the input.** Focusing the input from a site and then clearing all text hid the favourites: the clear both re-triggered autocomplete correctly (focused view with favourites) and then called `onClearAutocomplete`, which re-triggered with `hasFocus=false` and hid the focused view, overwriting the correct state. The redundant call on text-clear was dropped; `onClearAutocomplete`'s dismiss behaviour is unchanged for its other callers (chat-tab switch, Duck.ai mode).

### Steps to test this PR

_Nav bar visibility & back arrow_
- [ ] Enable the native input nav bar (internal build). Focus the omnibar from a web page.
- [ ] Confirm the nav bar (back / fire / tabs / menu) is shown and stays visible while typing (not only when empty).
- [ ] Confirm there is a single back arrow at a time (no duplicate in the toggle row).

_Appearance_
- [ ] Bottom-omnibar mode: confirm there is no shadow/elevation under the nav bar.
- [ ] Confirm there is no thin separator line between the nav bar and the content, in both light and dark themes.

_Favourites on clear_
- [ ] Focus the input from a site (URL prefilled), clear all text.
- [ ] Confirm the favourites remain visible.
- [ ] Switch between Search and Duck.ai tabs and confirm favourites/autocomplete still behave correctly.

### UI changes
| Before  | After |
| ------ | ----- |
| (Upload before screenshot) | (Upload after screenshot) |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-facing native input and omnibar chrome behavior changes across focus, typing, and clear; logic is covered by updated unit tests but regression risk is in integrated browser/NTP UI.
> 
> **Overview**
> **Unified Text Input (UTI)** browser nav bar and chrome are tightened so the strip behaves like a full-session control bar instead of an empty-field-only affordance.
> 
> The **nav bar stays visible for the whole browser-input session** (not only when the field is empty). Visibility no longer tracks text via `onInputTextEmptyChanged` / `isInputEmpty`; `shouldShowNavBar` is browser-context only.
> 
> **Back affordances** are deduped: the toggle-row back shows only when the **nav bar feature is off** (`shouldShowToggleRowBack(isNavBarFeatureEnabled)`), since the nav bar always provides back when the feature is on.
> 
> **Visual polish** while native input is open: bottom-mode nav bar keeps `translationZ` draw order over autocomplete but **suppresses elevation shadow**; **top browser/NTP outline strokes** are hidden under the top nav bar, with **saved/restored** `topNtpOutlineStroke` visibility on detach. Omnibar **restore** re-shows `topBrowserOutlineStroke`.
> 
> **Clear-text fix**: dropping the clear handler’s `onClearAutocomplete` call stops favourites from disappearing when clearing a prefilled field (empty+focused state no longer gets overwritten).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99f398e66a5c0e06d90d036bf050d6d27bde972f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->