### PR TITLE
Search & Favorites widget configs in landscape is not scrollable

### DIFF
--- a/app/src/main/res/layout/activity_widget_configuration.xml
+++ b/app/src/main/res/layout/activity_widget_configuration.xml
@@ -18,72 +18,78 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="match_parent">
 
-    <LinearLayout
-        android:id="@+id/widgetConfigPanel"
+    <ScrollView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
-        android:background="?attr/daxColorSurface"
-        android:orientation="vertical"
-        android:padding="16dp">
+        android:clipToPadding="false">
 
-        <com.duckduckgo.common.ui.view.text.DaxTextView
+        <LinearLayout
+            android:id="@+id/widgetConfigPanel"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="@string/widgetConfigurationTitleText"
-            app:typography="h2" />
+            android:background="?attr/daxColorSurface"
+            android:orientation="vertical"
+            android:padding="16dp">
 
-        <ImageView
-            android:id="@+id/widgetConfigPreview"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_horizontal"
-            android:layout_marginTop="@dimen/keyline_4"
-            android:src="@drawable/image_preview_search_favorites_widget_light" />
-
-        <RadioGroup
-            android:id="@+id/widgetConfigThemeRadioGroup"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="16dp">
-
-            <RadioButton
-                android:id="@+id/widgetConfigThemeSystem"
+            <com.duckduckgo.common.ui.view.text.DaxTextView
                 android:layout_width="match_parent"
-                android:layout_height="48dp"
-                android:fontFamily="sans-serif-medium"
-                android:text="@string/widgetConfigurationSystemThemeOption"
-                android:textColor="?attr/daxColorPrimaryText"
-                android:visibility="gone"
-                tools:visibility="visible" />
+                android:layout_height="wrap_content"
+                android:text="@string/widgetConfigurationTitleText"
+                app:typography="h2" />
 
-            <RadioButton
-                android:id="@+id/widgetConfigThemeLight"
+            <ImageView
+                android:id="@+id/widgetConfigPreview"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginTop="@dimen/keyline_4"
+                android:src="@drawable/image_preview_search_favorites_widget_light" />
+
+            <RadioGroup
+                android:id="@+id/widgetConfigThemeRadioGroup"
                 android:layout_width="match_parent"
-                android:layout_height="48dp"
-                android:checked="true"
-                android:fontFamily="sans-serif-medium"
-                android:text="@string/widgetConfigurationLightThemeOption"
-                android:textColor="?attr/daxColorPrimaryText" />
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp">
 
-            <RadioButton
-                android:id="@+id/widgetConfigThemeDark"
-                android:layout_width="match_parent"
-                android:layout_height="48dp"
-                android:fontFamily="sans-serif-medium"
-                android:text="@string/widgetConfigurationDarkThemeOption"
-                android:textColor="?attr/daxColorPrimaryText" />
-        </RadioGroup>
+                <RadioButton
+                    android:id="@+id/widgetConfigThemeSystem"
+                    android:layout_width="match_parent"
+                    android:layout_height="48dp"
+                    android:fontFamily="sans-serif-medium"
+                    android:text="@string/widgetConfigurationSystemThemeOption"
+                    android:textColor="?attr/daxColorPrimaryText"
+                    android:visibility="gone"
+                    tools:visibility="visible" />
 
-        <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
-            android:id="@+id/widgetConfigAddWidgetButton"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="end"
-            android:layout_marginTop="16dp"
-            android:layout_marginEnd="8dp"
-            android:text="@string/widgetConfigurationAddWidgetOption" />
-    </LinearLayout>
+                <RadioButton
+                    android:id="@+id/widgetConfigThemeLight"
+                    android:layout_width="match_parent"
+                    android:layout_height="48dp"
+                    android:checked="true"
+                    android:fontFamily="sans-serif-medium"
+                    android:text="@string/widgetConfigurationLightThemeOption"
+                    android:textColor="?attr/daxColorPrimaryText" />
+
+                <RadioButton
+                    android:id="@+id/widgetConfigThemeDark"
+                    android:layout_width="match_parent"
+                    android:layout_height="48dp"
+                    android:fontFamily="sans-serif-medium"
+                    android:text="@string/widgetConfigurationDarkThemeOption"
+                    android:textColor="?attr/daxColorPrimaryText" />
+            </RadioGroup>
+
+            <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+                android:id="@+id/widgetConfigAddWidgetButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="end"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="8dp"
+                android:text="@string/widgetConfigurationAddWidgetOption" />
+        </LinearLayout>
+    </ScrollView>
 </FrameLayout>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200581511062568/task/1216068045011474?focus=true
Tech Design URL (if applicable):

### Description

The widget theme configuration screen (WidgetThemeConfiguration) uses a bottom-anchored panel containing the title, a preview image, three theme radio buttons, and the "Add widget" button. In landscape orientation the panel's content is taller than the available screen height, and because nothing was scrollable, the top of the panel overflowed off-screen and the theme options / Add button became unreachable.

This PR wraps the panel content in a ScrollView so it can scroll when it exceeds the available height, while keeping the bottom-anchored bottom-sheet look in portrait.

Changes to app/src/main/res/layout/activity_widget_configuration.xml:

- Wrapped the widgetConfigPanel LinearLayout in a ScrollView (this is the fix).
- Changed the root FrameLayout height from wrap_content to match_parent so layout_gravity="bottom" resolves against the full screen and the ScrollView can cap at the screen height.
- Added android:clipToPadding="false" so the edge-to-edge nav-bar inset padding on widgetConfigPanel isn't clipped when scrolled to the bottom.

### Steps to test this PR

1. Add the DuckDuckGo Search & Favorites widget to your home screen to trigger the widget configuration screen. (Long press on the app icon -> Widgets)
2. Rotate the device to landscape.
3. Verify you can now scroll the panel and reach all theme options (System/Light/Dark) and the Add widget button.
4. Select each theme and confirm the preview image updates accordingly.
5. Tap Add widget and confirm the widget is added with the selected theme.
6. Rotate back to portrait and confirm the panel still appears anchored to the bottom and behaves as before.
7. (Optional) Verify on both a gesture-nav and 3-button-nav device that the Add button sits above the navigation bar.

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only change to the widget configuration screen with no logic, data, or security impact.
> 
> **Overview**
> Fixes the **Search & Favorites** widget theme configuration screen so the bottom panel stays usable in **landscape** when the title, preview, theme radios, and **Add widget** button exceed the viewport.
> 
> In `activity_widget_configuration.xml`, the config panel is wrapped in a **bottom-anchored** `ScrollView`, the root `FrameLayout` height is **`match_parent`** (was `wrap_content`) so bottom gravity and height limits work against the full screen, and **`clipToPadding="false"`** keeps nav-bar inset padding visible when scrolled. Portrait bottom-sheet behavior is unchanged; no activity or widget logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfeeb956fa041e25fd498c736b4588f547c04ed3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->