### PR TITLE
Bump native-github-asana-sync to v2.6.0

### DIFF
--- a/.github/workflows/e2e-duckplayer.yml
+++ b/.github/workflows/e2e-duckplayer.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Create Asana task when workflow failed
         if: ${{ failure() && github.event_name != 'workflow_dispatch' && steps.maestro-cloud-asana.outputs.flow_summary_status != 'failure'}}
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ secrets.DUCK_PLAYER_AOR_PROJECT_ID }}

--- a/.github/workflows/e2e-nightly-full-suite.yml
+++ b/.github/workflows/e2e-nightly-full-suite.yml
@@ -380,7 +380,7 @@ jobs:
       - name: Create Asana task when workflow failed
         if: ${{ failure() && inputs.create_asana_tasks == true && github.event_name != 'workflow_dispatch' }}
         id: create-failure-task
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ secrets.GH_ASANA_AOR_PROJECT_ID }}

--- a/.github/workflows/e2e-nightly-non-blockers-suite.yml
+++ b/.github/workflows/e2e-nightly-non-blockers-suite.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Create Asana task when workflow failed
         if: ${{ failure() && github.event_name != 'workflow_dispatch' }}
         id: create-failure-task
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ secrets.GH_ASANA_AOR_PROJECT_ID }}

--- a/.github/workflows/e2e-nightly-sync-critical-path.yml
+++ b/.github/workflows/e2e-nightly-sync-critical-path.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Add Asana task to Browser Sync & Backup project
         if: ${{ failure() && steps.maestro-cloud-asana.outputs.asana_task_id != '' }}
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ vars.GH_BROWSER_SYNC_BACKUP_PROJECT_ID }}
@@ -71,7 +71,7 @@ jobs:
 
       - name: Create Asana task when workflow failed
         if: ${{ failure() && github.event_name != 'workflow_dispatch' && steps.maestro-cloud-asana.outputs.flow_summary_status != 'failure'}}
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}

--- a/.github/workflows/nightly-metro.yml
+++ b/.github/workflows/nightly-metro.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Create Asana task on failure
         if: ${{ failure() && github.event_name != 'workflow_dispatch' }}
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ secrets.GH_ASANA_AOR_PROJECT_ID }}

--- a/.github/workflows/nightly-orchestrator.yml
+++ b/.github/workflows/nightly-orchestrator.yml
@@ -127,7 +127,7 @@ jobs:
       max-parallel: 1
     steps:
       - name: Add task to project (no-op if already there)
-        uses: duckduckgo/native-github-asana-sync@v2.5.1
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ vars.GH_ANDROID_RELEASE_BOARD_PROJECT_ID }}
@@ -135,7 +135,7 @@ jobs:
           asana-task-id: ${{ matrix.task_id }}
           action: 'add-task-asana-project'
       - name: Tag task as LGC
-        uses: duckduckgo/native-github-asana-sync@v2.5.1
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-task-id: ${{ matrix.task_id }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -223,7 +223,7 @@ jobs:
     steps:
       - name: Create Asana task when workflow failed
         id: create-failure-task
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ secrets.GH_ASANA_AOR_PROJECT_ID }}
@@ -235,7 +235,7 @@ jobs:
       - name: Adding as a release blocker
         # Only block releases for the default Anvil path. Metro is informational.
         if: ${{ env.DDG_DI == 'AnvilDagger' && steps.create-failure-task.outputs.taskId != '' }}
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_ID }}

--- a/.github/workflows/privacy.yml
+++ b/.github/workflows/privacy.yml
@@ -151,7 +151,7 @@ jobs:
       - name: Create Asana task when workflow failed
         if: ${{ failure() && github.event_name != 'workflow_dispatch' }}
         id: create-failure-task
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ secrets.GH_ASANA_AOR_PROJECT_ID }}
@@ -163,7 +163,7 @@ jobs:
       - name: Adding as a release blocker
         # Only block releases for the default Anvil path. Metro is informational.
         if: ${{ failure() && env.DDG_DI == 'AnvilDagger' && steps.create-failure-task.outputs.taskId != '' }}
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_ID }}

--- a/.github/workflows/ps-review-analysis.yml
+++ b/.github/workflows/ps-review-analysis.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.9"
 
@@ -43,18 +43,22 @@ jobs:
       - name: Set Default Inputs for Scheduled Runs
         if: ${{ github.event_name == 'schedule' }}
         run: |
-          echo "package_name=com.duckduckgo.mobile.android" >> $GITHUB_ENV
-          echo "langs=en" >> $GITHUB_ENV
-          echo "countries=us" >> $GITHUB_ENV
-          echo "count=10000" >> $GITHUB_ENV
+          {
+            echo "package_name=com.duckduckgo.mobile.android"
+            echo "langs=en"
+            echo "countries=us"
+            echo "count=10000"
+          } >> "$GITHUB_ENV"
 
       - name: Override Inputs for Manual Trigger
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
-          echo "package_name=${{ github.event.inputs.package_name }}" >> $GITHUB_ENV
-          echo "langs=${{ github.event.inputs.langs }}" >> $GITHUB_ENV
-          echo "countries=${{ github.event.inputs.countries }}" >> $GITHUB_ENV
-          echo "count=${{ github.event.inputs.count }}" >> $GITHUB_ENV
+          {
+            echo "package_name=${{ github.event.inputs.package_name }}"
+            echo "langs=${{ github.event.inputs.langs }}"
+            echo "countries=${{ github.event.inputs.countries }}"
+            echo "count=${{ github.event.inputs.count }}"
+          } >> "$GITHUB_ENV"
 
       - name: Run Review Analysis Script
         id: run-script
@@ -64,13 +68,15 @@ jobs:
             --langs "${{ env.langs }}" \
             --countries "${{ env.countries }}" \
             --count "${{ env.count }}" > output.txt
-          echo "script_output<<EOF" >> $GITHUB_ENV
-          cat output.txt >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
+          {
+            echo "script_output<<EOF"
+            cat output.txt
+            echo "EOF"
+          } >> "$GITHUB_ENV"
 
       - name: Get Current Date
         id: date
-        run: echo "current_date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+        run: echo "current_date=$(date +'%Y-%m-%d')" >> "$GITHUB_ENV"
 
       - name: Sync Output to Asana
         uses: duckduckgo/native-github-asana-sync@v2.6.0

--- a/.github/workflows/ps-review-analysis.yml
+++ b/.github/workflows/ps-review-analysis.yml
@@ -73,7 +73,7 @@ jobs:
         run: echo "current_date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
       - name: Sync Output to Asana
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}

--- a/.github/workflows/release_create_tag.yml
+++ b/.github/workflows/release_create_tag.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Notify Mattermost of Release starting
         id: send-mm-release-starting
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           mattermost-token: ${{ secrets.MM_AUTH_TOKEN }}
           mattermost-team-id: ${{ secrets.MM_TEAM_ID }}
@@ -101,7 +101,7 @@ jobs:
 
       - name: Notify Mattermost
         id: send-mm-message
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           mattermost-token: ${{ secrets.MM_AUTH_TOKEN }}
           mattermost-team-id: ${{ secrets.MM_TEAM_ID }}
@@ -112,7 +112,7 @@ jobs:
       - name: Create Asana task when workflow failed
         if: ${{ failure() }}
         id: create-failure-task
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -124,7 +124,7 @@ jobs:
       - name: Notify Mattermost when workflow failed
         if: ${{ failure() }}
         id: send-mm-message-error
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           mattermost-token: ${{ secrets.MM_AUTH_TOKEN }}
           mattermost-team-id: ${{ secrets.MM_TEAM_ID }}

--- a/.github/workflows/release_create_task.yml
+++ b/.github/workflows/release_create_task.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Get Asana Task Permalink
         id: get-task-permalink
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-task-id: ${{ steps.assign-release-task.outputs.task_id }}
@@ -75,7 +75,7 @@ jobs:
 
       - name: Notify Mattermost of Task created
         id: send-mm-task-created
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           mattermost-token: ${{ secrets.MM_AUTH_TOKEN }}
           mattermost-team-id: ${{ secrets.MM_TEAM_ID }}
@@ -85,7 +85,7 @@ jobs:
 
       - name: Create Asana task when workflow failed
         if: ${{ failure() }}
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -97,7 +97,7 @@ jobs:
       - name: Notify Mattermost when workflow failed
         if: ${{ failure() }}
         id: send-mm-message-error
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           mattermost-token: ${{ secrets.MM_AUTH_TOKEN }}
           mattermost-team-id: ${{ secrets.MM_TEAM_ID }}

--- a/.github/workflows/release_update_release_notes.yml
+++ b/.github/workflows/release_update_release_notes.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Create Asana task when workflow failed
         if: ${{ failure() }}
         id: create-failure-task
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}

--- a/.github/workflows/release_upload_internal.yml
+++ b/.github/workflows/release_upload_internal.yml
@@ -205,7 +205,7 @@ jobs:
 
       - name: Create Asana task when workflow failed
         if: ${{ failure() }}
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}

--- a/.github/workflows/release_upload_play_store.yml
+++ b/.github/workflows/release_upload_play_store.yml
@@ -81,7 +81,7 @@ jobs:
           destination-path: $HOME/jenkins_static/com.duckduckgo.mobile.android/
 
       - name: Notify Mattermost that Play Store build is starting
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           mattermost-token: ${{ secrets.MM_AUTH_TOKEN }}
           mattermost-team-id: ${{ secrets.MM_TEAM_ID }}
@@ -116,7 +116,7 @@ jobs:
 
       - name: Notify Mattermost of Play Store upload
         id: send-mm-message-ps-upload
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           mattermost-token: ${{ secrets.MM_AUTH_TOKEN }}
           mattermost-team-id: ${{ secrets.MM_TEAM_ID }}
@@ -131,7 +131,7 @@ jobs:
 
       - name: Notify Mattermost of GH upload
         id: send-mm-message-gh-upload
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           mattermost-token: ${{ secrets.MM_AUTH_TOKEN }}
           mattermost-team-id: ${{ secrets.MM_TEAM_ID }}
@@ -141,7 +141,7 @@ jobs:
 
       - name: Notify Mattermost of Release completed
         id: send-mm-message-release-complete
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           mattermost-token: ${{ secrets.MM_AUTH_TOKEN }}
           mattermost-team-id: ${{ secrets.MM_TEAM_ID }}
@@ -151,7 +151,7 @@ jobs:
 
       - name: Create Asana task when workflow failed
         if: ${{ failure() }}
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -163,7 +163,7 @@ jobs:
       - name: Notify Mattermost when workflow failed
         if: ${{ failure() }}
         id: send-mm-message-error
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           mattermost-token: ${{ secrets.MM_AUTH_TOKEN }}
           mattermost-team-id: ${{ secrets.MM_TEAM_ID }}

--- a/.github/workflows/update-content-scope.yml
+++ b/.github/workflows/update-content-scope.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Create Asana task in Android App project
         if: ${{ steps.update-check.outcome == 'failure' }}
         id: create-task
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -84,7 +84,7 @@ jobs:
       - name: Get Asana task permalink
         if: ${{ steps.update-check.outcome == 'failure' }}
         id: get-task-permalink
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-task-id: ${{ steps.create-task.outputs.taskId }}
@@ -127,7 +127,7 @@ jobs:
 
       - name: Add Asana task to Release Board project
         if: ${{ steps.create-task.outputs.duplicate == 'false' }}
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ vars.GH_ANDROID_RELEASE_BOARD_PROJECT_ID }}
@@ -138,7 +138,7 @@ jobs:
       - name: Create Asana task when workflow failed
         if: ${{ failure() && github.event_name != 'workflow_dispatch' }}
         id: create-failure-task
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -149,7 +149,7 @@ jobs:
 
       - name: Adding as a release blocker
         if: ${{ failure() && steps.create-failure-task.outputs.taskId != '' }}
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_ID }}

--- a/.github/workflows/update-pir-broker-bundle.yml
+++ b/.github/workflows/update-pir-broker-bundle.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Create Asana task
         if: ${{ steps.broker-check.outputs.has_changes == 'true' }}
         id: create-task
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -65,7 +65,7 @@ jobs:
       - name: Get Asana task permalink
         if: ${{ steps.broker-check.outputs.has_changes == 'true' }}
         id: get-task-permalink
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-task-id: ${{ steps.create-task.outputs.taskId }}
@@ -111,7 +111,7 @@ jobs:
 
       - name: Create Asana task when workflow failed
         if: ${{ failure() && github.event_name != 'workflow_dispatch' }}
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}

--- a/.github/workflows/update-ref-tests.yml
+++ b/.github/workflows/update-ref-tests.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Create Asana task in Android App project
         if: ${{ steps.update-check.outcome == 'failure' }}
         id: create-task
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -87,7 +87,7 @@ jobs:
       - name: Get Asana task permalink
         if: ${{ steps.update-check.outcome == 'failure' }}
         id: get-task-permalink
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-task-id: ${{ steps.create-task.outputs.taskId }}
@@ -119,7 +119,7 @@ jobs:
 
       - name: Add Asana task to Release Board project
         if: ${{ steps.create-task.outputs.duplicate == 'false' }}
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ vars.GH_ANDROID_RELEASE_BOARD_PROJECT_ID }}
@@ -130,7 +130,7 @@ jobs:
       - name: Create Asana task when workflow failed
         if: ${{ failure() && github.event_name != 'workflow_dispatch' }}
         id: create-failure-task
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
@@ -141,7 +141,7 @@ jobs:
 
       - name: Adding as a release blocker
         if: ${{ failure() && steps.create-failure-task.outputs.taskId != '' }}
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_ID }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1216542927950821?focus=true
Tech Design URL (if applicable): 

### Description

Update all GitHub workflow references to `duckduckgo/native-github-asana-sync` from `v2.0` / `v2.5.1` to `v2.6.0`.

v2.6.0 adds @-mention forwarding for PR reviews and comments, better error handling on task creation, and notify-release hardening.

## Steps to test

CI workflows should continue to function as before with the updated action version.

## UI changes

None.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only version pin and shell refactors; no app runtime or auth logic changes, with behavior expected to stay the same aside from the updated action release.
> 
> **Overview**
> **Standardizes CI on `duckduckgo/native-github-asana-sync@v2.6.0`**, replacing prior `v2.0` and `v2.5.1` pins across nightly, E2E, privacy, release, and dependency-update workflows. Step inputs and failure/notification behavior are unchanged; workflows pick up v2.6.0 behavior (e.g. @-mention forwarding, task-creation error handling, notify-release hardening per the PR description).
> 
> In **`ps-review-analysis.yml`**, the same Asana action bump is paired with **`actions/checkout@v4`**, **`actions/setup-python@v5`**, and shell steps that write to **`$GITHUB_ENV`** via grouped `{ ... }` blocks instead of multiple separate `echo` appends.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca596568cf5c80e1325f97f8ba0c14e0b9db20ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->