### PR TITLE
Add simplified sync enabled setting page

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
@@ -16,22 +16,31 @@
 
 package com.duckduckgo.sync.impl.ui.v2
 
+import android.content.res.ColorStateList
 import android.os.Bundle
+import android.view.View
 import androidx.core.view.isGone
+import androidx.core.view.isVisible
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.spans.DuckDuckGoClickableSpan
+import com.duckduckgo.common.ui.view.addClickableSpan
+import com.duckduckgo.common.ui.view.getColorFromAttr
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.databinding.ActivitySyncV2Binding
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.ViewState
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import logcat.logcat
 import javax.inject.Inject
 import com.duckduckgo.mobile.android.R as CommonR
 
@@ -47,6 +56,8 @@ class SyncActivity : DuckDuckGoActivity() {
     @Inject
     lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
 
+    private val syncedDeviceAdapter = SyncedDeviceAdapter()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -60,6 +71,9 @@ class SyncActivity : DuckDuckGoActivity() {
         }
 
         configureToolbar()
+        configureDevicesRecyclerView()
+        configureDataExpirationNotice()
+        configureDataDeletionItem()
 
         observeViewModel()
     }
@@ -76,10 +90,17 @@ class SyncActivity : DuckDuckGoActivity() {
             isSyncEnabled = viewState.showAccount,
             isDuckAiAvailable = viewState.aiChatSyncEnabled,
         )
+
         binding.includeDisabledView.root.isGone = viewState.showAccount
         binding.includeDisabledView.synOnOtherPlatformsItem.setState(
             isNewDesktopBrowserAvailable = viewState.newDesktopBrowserSettingEnabled,
         )
+
+        binding.includeEnabledView.root.isVisible = viewState.showAccount
+        binding.includeEnabledView.synOnOtherPlatformsItem.setState(
+            isNewDesktopBrowserAvailable = viewState.newDesktopBrowserSettingEnabled,
+        )
+        syncedDeviceAdapter.submitList(viewState.syncedDevices)
     }
 
     private fun configureEdgeToEdgeInsets() {
@@ -92,5 +113,33 @@ class SyncActivity : DuckDuckGoActivity() {
         setSupportActionBar(binding.includeToolbar.toolbar)
         binding.includeToolbar.toolbar.setNavigationIcon(CommonR.drawable.ic_arrow_left_24)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
+    }
+
+    private fun configureDevicesRecyclerView() {
+        binding.includeEnabledView.devicesRecycler.apply {
+            layoutManager = LinearLayoutManager(this@SyncActivity)
+            adapter = syncedDeviceAdapter
+        }
+    }
+
+    private fun configureDataExpirationNotice() {
+        binding.includeEnabledView.expirationNoticeLabel.addClickableSpan(
+            textSequence = getText(R.string.sync_settings_data_expiration),
+            spans = listOf(
+                "learn_more_link" to object : DuckDuckGoClickableSpan() {
+                    override fun onClick(widget: View) {
+                        logcat { "Learn more clicked" }
+                    }
+                },
+            ),
+        )
+    }
+
+    private fun configureDataDeletionItem() {
+        val color = ColorStateList.valueOf(getColorFromAttr(CommonR.attr.daxColorDestructive))
+        binding.includeEnabledView.deleteAccountItem.apply {
+            leadingIcon().imageTintList = color
+            setPrimaryTextColorStateList(color)
+        }
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
@@ -92,15 +92,24 @@ class SyncActivity : DuckDuckGoActivity() {
         )
 
         binding.includeDisabledView.root.isGone = viewState.showAccount
-        binding.includeDisabledView.synOnOtherPlatformsItem.setState(
+        binding.includeDisabledView.syncOnOtherPlatformsItem.setState(
             isNewDesktopBrowserAvailable = viewState.newDesktopBrowserSettingEnabled,
         )
 
         binding.includeEnabledView.root.isVisible = viewState.showAccount
-        binding.includeEnabledView.synOnOtherPlatformsItem.setState(
+        syncedDeviceAdapter.submitList(viewState.syncedDevices)
+
+        binding.includeEnabledView.syncOnOtherPlatformsItem.setState(
             isNewDesktopBrowserAvailable = viewState.newDesktopBrowserSettingEnabled,
         )
-        syncedDeviceAdapter.submitList(viewState.syncedDevices)
+
+        binding.includeEnabledView.restoreOnReinstallItem.isVisible = viewState.showAutoRestoreToggle
+        if (viewState.showAutoRestoreToggle) {
+            binding.includeEnabledView.restoreOnReinstallItem.quietlySetIsChecked(viewState.autoRestoreEnabled, changeListener = null)
+            binding.includeEnabledView.restoreOnReinstallItem.setLeadingIconResource(
+                if (viewState.autoRestoreEnabled) R.drawable.device_default_24 else R.drawable.device_soft_alert_24,
+            )
+        }
     }
 
     private fun configureEdgeToEdgeInsets() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncedDeviceAdapter.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncedDeviceAdapter.kt
@@ -70,7 +70,6 @@ class SyncedDeviceAdapter : ListAdapter<SyncDeviceListItem, ViewHolder>(ItemCall
         when (holder) {
             is LocalDeviceViewHolder -> holder.bind((getItem(position) as SyncedDevice).device)
             is RemoteDeviceViewHolder -> holder.bind((getItem(position) as SyncedDevice).device)
-            is LoadingDeviceViewHolder -> Unit
         }
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncedDeviceAdapter.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncedDeviceAdapter.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui.v2
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView.ViewHolder
+import com.duckduckgo.sync.impl.ConnectedDevice
+import com.duckduckgo.sync.impl.R
+import com.duckduckgo.sync.impl.asDrawableRes
+import com.duckduckgo.sync.impl.databinding.ItemSyncDeviceLoadingBinding
+import com.duckduckgo.sync.impl.databinding.ItemSyncV2DeviceLocalBinding
+import com.duckduckgo.sync.impl.databinding.ItemSyncV2DeviceRemoteBinding
+import com.duckduckgo.sync.impl.ui.SyncDeviceListItem
+import com.duckduckgo.sync.impl.ui.SyncDeviceListItem.LoadingItem
+import com.duckduckgo.sync.impl.ui.SyncDeviceListItem.SyncedDevice
+
+class SyncedDeviceAdapter : ListAdapter<SyncDeviceListItem, ViewHolder>(ItemCallback) {
+    override fun getItemViewType(position: Int): Int = when (val item = getItem(position)) {
+        is LoadingItem -> R.layout.item_sync_device_loading
+        is SyncedDevice -> when {
+            item.loading -> R.layout.item_sync_device_loading
+            item.device.thisDevice -> R.layout.item_sync_v2_device_local
+            else -> R.layout.item_sync_v2_device_remote
+        }
+    }
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): ViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        return when (viewType) {
+            R.layout.item_sync_v2_device_local -> {
+                LocalDeviceViewHolder(ItemSyncV2DeviceLocalBinding.inflate(inflater, parent, false))
+            }
+
+            R.layout.item_sync_v2_device_remote -> {
+                RemoteDeviceViewHolder(ItemSyncV2DeviceRemoteBinding.inflate(inflater, parent, false))
+            }
+
+            R.layout.item_sync_device_loading -> {
+                LoadingDeviceViewHolder(ItemSyncDeviceLoadingBinding.inflate(inflater, parent, false))
+            }
+
+            else -> error("Unknown view type: ${parent.context.resources.getResourceName(viewType)}")
+        }
+    }
+
+    override fun onBindViewHolder(
+        holder: ViewHolder,
+        position: Int,
+    ) {
+        when (holder) {
+            is LocalDeviceViewHolder -> holder.bind((getItem(position) as SyncedDevice).device)
+            is RemoteDeviceViewHolder -> holder.bind((getItem(position) as SyncedDevice).device)
+            is LoadingDeviceViewHolder -> Unit
+        }
+    }
+}
+
+private object ItemCallback : DiffUtil.ItemCallback<SyncDeviceListItem>() {
+    override fun areItemsTheSame(
+        oldItem: SyncDeviceListItem,
+        newItem: SyncDeviceListItem,
+    ): Boolean {
+        return if (oldItem is SyncedDevice && newItem is SyncedDevice) {
+            oldItem.device.deviceId == newItem.device.deviceId
+        } else {
+            oldItem == newItem
+        }
+    }
+
+    override fun areContentsTheSame(
+        oldItem: SyncDeviceListItem,
+        newItem: SyncDeviceListItem,
+    ): Boolean {
+        return oldItem == newItem
+    }
+}
+
+private class LocalDeviceViewHolder(
+    private val binding: ItemSyncV2DeviceLocalBinding,
+) : ViewHolder(binding.root) {
+    init {
+        binding.root.setSecondaryText(itemView.context.getString(R.string.sync_device_this_device_hint))
+    }
+
+    fun bind(device: ConnectedDevice) {
+        binding.root.setLeadingIconResource(device.deviceType.type().asDrawableRes())
+        binding.root.setPrimaryText(device.deviceName)
+    }
+}
+
+private class RemoteDeviceViewHolder(
+    private val binding: ItemSyncV2DeviceRemoteBinding,
+) : ViewHolder(binding.root) {
+    fun bind(device: ConnectedDevice) {
+        binding.root.setPrimaryText(device.deviceName)
+        binding.root.setLeadingIconResource(device.deviceType.type().asDrawableRes())
+    }
+}
+
+private class LoadingDeviceViewHolder(
+    binding: ItemSyncDeviceLoadingBinding,
+) : ViewHolder(binding.root)

--- a/sync/sync-impl/src/main/res/drawable/ic_qr2_24.xml
+++ b/sync/sync-impl/src/main/res/drawable/ic_qr2_24.xml
@@ -1,0 +1,61 @@
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M2.75,15.25C3.164,15.25 3.5,15.586 3.5,16V17C3.5,18.933 5.067,20.5 7,20.5H8C8.414,20.5 8.75,20.836 8.75,21.25C8.75,21.664 8.414,22 8,22H7C4.239,22 2,19.761 2,17V16C2,15.586 2.336,15.25 2.75,15.25Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"/>
+  <path
+      android:pathData="M21.25,15.25C21.664,15.25 22,15.586 22,16V17C22,19.761 19.761,22 17,22H16C15.586,22 15.25,21.664 15.25,21.25C15.25,20.836 15.586,20.5 16,20.5H17C18.933,20.5 20.5,18.933 20.5,17V16C20.5,15.586 20.836,15.25 21.25,15.25Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"/>
+  <path
+      android:pathData="M9,12.5C10.243,12.5 11.25,13.507 11.25,14.75V16.25C11.25,17.493 10.243,18.5 9,18.5H7.5C6.257,18.5 5.25,17.493 5.25,16.25V14.75C5.25,13.507 6.257,12.5 7.5,12.5H9ZM7.5,14C7.086,14 6.75,14.336 6.75,14.75V16.25C6.75,16.664 7.086,17 7.5,17H9C9.414,17 9.75,16.664 9.75,16.25V14.75C9.75,14.336 9.414,14 9,14H7.5Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M13.5,16.125C13.914,16.125 14.25,16.461 14.25,16.875V17H14.5C14.914,17 15.25,17.336 15.25,17.75C15.25,18.164 14.914,18.5 14.5,18.5H14C13.31,18.5 12.75,17.94 12.75,17.25V16.875C12.75,16.461 13.086,16.125 13.5,16.125Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"/>
+  <path
+      android:pathData="M18,15.875C18.414,15.875 18.75,16.211 18.75,16.625V17.25C18.75,17.94 18.19,18.5 17.5,18.5H17C16.586,18.5 16.25,18.164 16.25,17.75C16.25,17.336 16.586,17 17,17H17.25V16.625C17.25,16.211 17.586,15.875 18,15.875Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"/>
+  <path
+      android:pathData="M16,14.5C16.414,14.5 16.75,14.836 16.75,15.25V15.75C16.75,16.164 16.414,16.5 16,16.5H15.5C15.086,16.5 14.75,16.164 14.75,15.75V15.25C14.75,14.836 15.086,14.5 15.5,14.5H16Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"/>
+  <path
+      android:pathData="M17.5,12.5C18.19,12.5 18.75,13.06 18.75,13.75V14.375C18.75,14.789 18.414,15.125 18,15.125C17.586,15.125 17.25,14.789 17.25,14.375V14H17C16.586,14 16.25,13.664 16.25,13.25C16.25,12.836 16.586,12.5 17,12.5H17.5Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"/>
+  <path
+      android:pathData="M14.5,12.5C14.914,12.5 15.25,12.836 15.25,13.25C15.25,13.664 14.914,14 14.5,14H14.25V14.25C14.25,14.664 13.914,15 13.5,15C13.086,15 12.75,14.664 12.75,14.25V13.75C12.75,13.06 13.31,12.5 14,12.5H14.5Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"/>
+  <path
+      android:pathData="M9,5.25C10.243,5.25 11.25,6.257 11.25,7.5V9C11.25,10.243 10.243,11.25 9,11.25H7.5C6.257,11.25 5.25,10.243 5.25,9V7.5C5.25,6.257 6.257,5.25 7.5,5.25H9ZM7.5,6.75C7.086,6.75 6.75,7.086 6.75,7.5V9C6.75,9.414 7.086,9.75 7.5,9.75H9C9.414,9.75 9.75,9.414 9.75,9V7.5C9.75,7.086 9.414,6.75 9,6.75H7.5Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M16.5,5.25C17.743,5.25 18.75,6.257 18.75,7.5V9C18.75,10.243 17.743,11.25 16.5,11.25H15C13.757,11.25 12.75,10.243 12.75,9V7.5C12.75,6.257 13.757,5.25 15,5.25H16.5ZM15,6.75C14.586,6.75 14.25,7.086 14.25,7.5V9C14.25,9.414 14.586,9.75 15,9.75H16.5C16.914,9.75 17.25,9.414 17.25,9V7.5C17.25,7.086 16.914,6.75 16.5,6.75H15Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M8,2C8.414,2 8.75,2.336 8.75,2.75C8.75,3.164 8.414,3.5 8,3.5H7C5.067,3.5 3.5,5.067 3.5,7V8C3.5,8.414 3.164,8.75 2.75,8.75C2.336,8.75 2,8.414 2,8V7C2,4.239 4.239,2 7,2H8Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"/>
+  <path
+      android:pathData="M17,2C19.761,2 22,4.239 22,7V8C22,8.414 21.664,8.75 21.25,8.75C20.836,8.75 20.5,8.414 20.5,8V7C20.5,5.067 18.933,3.5 17,3.5H16C15.586,3.5 15.25,3.164 15.25,2.75C15.25,2.336 15.586,2 16,2H17Z"
+      android:fillColor="?attr/daxColorPrimaryIcon"/>
+</vector>

--- a/sync/sync-impl/src/main/res/layout/activity_sync_v2.xml
+++ b/sync/sync-impl/src/main/res/layout/activity_sync_v2.xml
@@ -48,7 +48,15 @@
                 android:id="@+id/include_disabled_view"
                 layout="@layout/view_sync_v2_disabled"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
+                android:layout_height="wrap_content"
+                android:visibility="gone" />
+
+            <include
+                android:id="@+id/include_enabled_view"
+                layout="@layout/view_sync_v2_enabled"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone" />
 
         </LinearLayout>
     </ScrollView>

--- a/sync/sync-impl/src/main/res/layout/item_sync_v2_device_local.xml
+++ b/sync/sync-impl/src/main/res/layout/item_sync_v2_device_local.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2023 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<com.duckduckgo.common.ui.view.listitem.TwoLineListItem xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    app:leadingIconBackground="circular" />

--- a/sync/sync-impl/src/main/res/layout/item_sync_v2_device_remote.xml
+++ b/sync/sync-impl/src/main/res/layout/item_sync_v2_device_remote.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2023 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<com.duckduckgo.common.ui.view.listitem.OneLineListItem xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    app:leadingIconBackground="circular" />

--- a/sync/sync-impl/src/main/res/layout/view_sync_v2_disabled.xml
+++ b/sync/sync-impl/src/main/res/layout/view_sync_v2_disabled.xml
@@ -65,7 +65,7 @@
         android:layout_marginVertical="@dimen/keyline_4" />
 
     <com.duckduckgo.sync.impl.ui.v2.SyncOnOtherPlatformsListItem
-        android:id="@+id/synOnOtherPlatformsItem"
+        android:id="@+id/sync_on_other_platforms_item"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 

--- a/sync/sync-impl/src/main/res/layout/view_sync_v2_enabled.xml
+++ b/sync/sync-impl/src/main/res/layout/view_sync_v2_enabled.xml
@@ -56,7 +56,7 @@
         app:primaryText="@string/sync_settings_v2_download_section_header" />
 
     <com.duckduckgo.sync.impl.ui.v2.SyncOnOtherPlatformsListItem
-        android:id="@+id/synOnOtherPlatformsItem"
+        android:id="@+id/sync_on_other_platforms_item"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 
@@ -76,10 +76,12 @@
         android:id="@+id/restoreOnReinstallItem"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:visibility="gone"
         app:leadingIcon="@drawable/device_default_24"
         app:leadingIconBackground="circular"
         app:primaryText="@string/sync_restore_on_reinstall_title"
-        app:secondaryText="@string/sync_restore_on_reinstall_description" />
+        app:secondaryText="@string/sync_restore_on_reinstall_description"
+        app:showSwitch="true" />
 
     <com.duckduckgo.common.ui.view.listitem.OneLineListItem
         android:id="@+id/copyRecoveryCodeItem"

--- a/sync/sync-impl/src/main/res/layout/view_sync_v2_enabled.xml
+++ b/sync/sync-impl/src/main/res/layout/view_sync_v2_enabled.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2023 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/keyline_2" />
+
+    <!-- TODO Warnings container -->
+
+    <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:primaryText="@string/sync_settings_v2_devices_section_header" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/devicesRecycler"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+        android:id="@+id/syncWithAnotherDeviceItem"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:leadingIcon="@drawable/ic_qr2_24"
+        app:leadingIconBackground="circular"
+        app:primaryText="@string/sync_setup_with_another_device_cta_title" />
+
+    <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginVertical="@dimen/keyline_2" />
+
+    <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:primaryText="@string/sync_settings_v2_download_section_header" />
+
+    <com.duckduckgo.sync.impl.ui.v2.SyncOnOtherPlatformsListItem
+        android:id="@+id/synOnOtherPlatformsItem"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginVertical="@dimen/keyline_2" />
+
+    <!-- TODO Options container -->
+
+    <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:primaryText="@string/sync_settings_recovery_section_header" />
+
+    <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+        android:id="@+id/restoreOnReinstallItem"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:leadingIcon="@drawable/device_default_24"
+        app:leadingIconBackground="circular"
+        app:primaryText="@string/sync_restore_on_reinstall_title"
+        app:secondaryText="@string/sync_restore_on_reinstall_description" />
+
+    <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+        android:id="@+id/copyRecoveryCodeItem"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:leadingIcon="@drawable/ic_copy_24"
+        app:leadingIconBackground="circular"
+        app:primaryText="@string/sync_settings_v2_copy_recovery_code_item" />
+
+    <com.duckduckgo.common.ui.view.listitem.TwoLineListItem
+        android:id="@+id/downloadRecoveryCodeItem"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:leadingIcon="@drawable/ic_downloads_24"
+        app:leadingIconBackground="circular"
+        app:primaryText="@string/sync_settings_v2_download_recovery_code_item"
+        app:secondaryText="@string/sync_settings_download_recovery_code_item_hint" />
+
+    <com.duckduckgo.common.ui.view.text.DaxTextView
+        android:id="@+id/expirationNoticeLabel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/keyline_4"
+        android:layout_marginVertical="@dimen/keyline_2"
+        android:text="@string/sync_settings_data_expiration"
+        app:textType="secondary"
+        app:typography="caption" />
+
+    <com.duckduckgo.common.ui.view.divider.HorizontalDivider
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginVertical="@dimen/keyline_2" />
+
+    <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+        android:id="@+id/deleteAccountItem"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/keyline_4"
+        app:leadingIcon="@drawable/ic_trash_24"
+        app:leadingIconBackground="circular"
+        app:primaryText="@string/sync_settings_v2_delete_account_item" />
+
+</LinearLayout>

--- a/sync/sync-impl/src/main/res/values/donottranslate.xml
+++ b/sync/sync-impl/src/main/res/values/donottranslate.xml
@@ -23,4 +23,9 @@
     <string name="sync_settings_v2_header_body_enabled">Your autofill data and bookmarks are being synced with end-to-end encryption.</string>
     <string name="sync_settings_v2_header_body_enabled_with_duck_ai">Your autofill data, bookmarks, and Duck.ai chats, are being synced with end-to-end encryption.</string>
     <string name="sync_settings_v2_this_device_cta_title">Sync &amp; Backup this device</string>
+    <string name="sync_settings_v2_devices_section_header">My Devices</string>
+    <string name="sync_settings_v2_download_section_header">Download</string>
+    <string name="sync_settings_v2_download_recovery_code_item">Download Your Recovery Code</string>
+    <string name="sync_settings_v2_copy_recovery_code_item">Copy Your Recovery Code</string>
+    <string name="sync_settings_v2_delete_account_item">Turn Off and Delete Server Data</string>
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216103556496795/task/1216585846803582?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1216103556496795/task/1216509582049467?focus=true

### Description
Adds enabled sync UI:
- My Devices section
- Download section
- Recovery section
- Deletion section

Bookmarks section isn't implemented here as it is driven by plugins. I want to do it in a separate PR as I'm not 100% sure how the current plugin design applies to the new UI, so I'd rather isolate it.

There is an animation issue when devices are being synced. If your data is backed up but there is no other device synced, or if you have more than one other device, opening the screen causes the devices section to jump. This issue already exists in the legacy UI. This happens because only devices are part of the `RecyclerView`, so the view changes height depending on the number of devices. Probably the best way to solve it would be to migrate the whole screen to a single `RecyclerView` with a `ConcatAdapter`. But in the current state it doesn't play nicely with the plugins, etc. I'll leave it for now and mention it as a known issue during the ship review. If you think we should address it beforehand, let me know. You can see the issue in the video below:

| Old | New |
| - | - |
| <video src="https://github.com/user-attachments/assets/0eb1f614-fb2f-45c9-a28d-270e04c9a0df" /> | <video src="https://github.com/user-attachments/assets/6107743a-da1e-4349-a4a7-47a600092362" /> |

### Steps to test this PR
_Enabled state_
- [ ] Go to the Sync Dev Settings.
- [ ] Tap "Launch Sync Settings".
- [ ] Sync your device with another device.
- [ ] Go back to the Sync Dev Settings.
- [ ] Tap "Launch Sync Settings V2".
- [ ] Verify that you don't see the enabled UI state.

### UI changes
<img width="540" alt="image" src="https://github.com/user-attachments/assets/ba4bc472-5802-47f4-ad9c-24a68766adfd" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sync account settings and surfaces delete-server-data and recovery UI, but largely reuses existing `SyncActivityViewModel` state without new sync logic or click handlers wired yet.
> 
> **Overview**
> **Adds the signed-in (“enabled”) layout for Sync Settings V2**, shown when `showAccount` is true alongside the existing disabled view. `activity_sync_v2.xml` now includes `view_sync_v2_enabled`, and `SyncActivity` toggles visibility, feeds `viewState.syncedDevices` into a new **`SyncedDeviceAdapter`**, and mirrors enabled-state bits already on the legacy screen (other-platforms item, restore-on-reinstall visibility/icon/check state).
> 
> The enabled screen is structured into **My Devices** (RecyclerView + “sync with another device” row), **Download** (`SyncOnOtherPlatformsListItem`), **Recovery** (restore toggle, copy/download recovery code rows, data-expiration caption with a learn-more span), and **deletion** (destructive-styled “turn off and delete server data” row). New layouts (`item_sync_v2_device_local` / `remote`), `ic_qr2_24`, and v2 string resources support the design; the disabled layout ID typo `synOnOtherPlatformsItem` is fixed to `sync_on_other_platforms_item`.
> 
> Most list actions and the learn-more link are **presentation-only in this PR** (e.g. learn-more logs to logcat; restore toggle is updated from state without a change listener). Bookmarks/plugin sections and several TODO containers are intentionally left out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f1720aac4b7018633103b348cd565e415eb75b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->