### PR TITLE
Fix PIR condition step to align to other platforms

### DIFF
--- a/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/PirEndToEndTest.kt
+++ b/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/PirEndToEndTest.kt
@@ -809,7 +809,7 @@ class PirEndToEndTest {
             StartedEventHandler(),
             LoadUrlCompleteEventHandler(),
             LoadUrlFailedEventHandler(),
-            ErrorReceivedHandler(pirRunStateHandler),
+            ErrorReceivedHandler(pirRunStateHandler, fakeTimeProvider),
             RetryGetCaptchaSolutionEventHandler(),
             RetryAwaitCaptchaSolutionEventHandler(),
             JsActionSuccessEventHandler(pirRunStateHandler, fakeTimeProvider),

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/ErrorReceivedHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/ErrorReceivedHandler.kt
@@ -16,16 +16,22 @@
 
 package com.duckduckgo.pir.impl.common.actions
 
+import com.duckduckgo.common.utils.CurrentTimeProvider
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.OptOutStep
 import com.duckduckgo.pir.impl.common.PirRunStateHandler
+import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerOptOutConditionNotFound
 import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerStepInvalidEvent
 import com.duckduckgo.pir.impl.common.actions.EventHandler.Next
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.BrokerActionFailed
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.ErrorReceived
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.ExecuteBrokerStepAction
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.State
 import com.duckduckgo.pir.impl.models.Broker
+import com.duckduckgo.pir.impl.scripts.models.BrokerAction
 import com.duckduckgo.pir.impl.scripts.models.PirError
+import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData.UserProfile
 import com.squareup.anvil.annotations.ContributesMultibinding
 import javax.inject.Inject
 import kotlin.reflect.KClass
@@ -36,6 +42,7 @@ import kotlin.reflect.KClass
 )
 class ErrorReceivedHandler @Inject constructor(
     private val pirRunStateHandler: PirRunStateHandler,
+    private val currentTimeProvider: CurrentTimeProvider,
 ) : EventHandler {
     override val event: KClass<out Event> = ErrorReceived::class
 
@@ -69,11 +76,46 @@ class ErrorReceivedHandler @Inject constructor(
             return Next(nextState = state)
         }
 
+        // A condition action reports a JS error when its expectation is not met. That is expected rather than
+        // fatal: treat it as "condition not met" and skip to the next action instead of failing the whole
+        // broker step. Mirrors SubJobWebRunner.onError on Apple.
+        val currentAction = state.brokerStepsToExecute[state.currentBrokerStepIndex].step.actions[state.currentActionIndex]
+        if (currentAction is BrokerAction.Condition) {
+            return handleConditionNotMet(state)
+        }
+
         return Next(
             nextState = state,
             nextEvent = BrokerActionFailed(
                 error = (event as ErrorReceived).error,
                 allowRetry = false,
+            ),
+        )
+    }
+
+    private suspend fun handleConditionNotMet(state: State): Next {
+        val currentBrokerStep = state.brokerStepsToExecute[state.currentBrokerStepIndex]
+        if (currentBrokerStep is OptOutStep) {
+            pirRunStateHandler.handleState(
+                BrokerOptOutConditionNotFound(
+                    broker = currentBrokerStep.broker,
+                    actionID = currentBrokerStep.step.actions[state.currentActionIndex].id,
+                    attemptId = state.attemptId,
+                    durationMs = currentTimeProvider.currentTimeMillis() - state.stageStatus.stageStartMs,
+                    currentActionAttemptCount = state.actionRetryCount + 1,
+                ),
+            )
+        }
+
+        return Next(
+            nextState = state.copy(
+                currentActionIndex = state.currentActionIndex + 1,
+                actionRetryCount = 0,
+            ),
+            nextEvent = ExecuteBrokerStepAction(
+                UserProfile(
+                    userProfile = state.profileQuery,
+                ),
             ),
         )
     }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/ErrorReceivedHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/ErrorReceivedHandlerTest.kt
@@ -17,32 +17,41 @@
 package com.duckduckgo.pir.impl.common.actions
 
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.common.utils.CurrentTimeProvider
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.OptOutStep
 import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.ScanStep
+import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.OptOutStepActions
 import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.ScanStepActions
 import com.duckduckgo.pir.impl.common.PirJob.RunType
 import com.duckduckgo.pir.impl.common.PirRunStateHandler
+import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerOptOutConditionNotFound
 import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerStepInvalidEvent
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.BrokerActionFailed
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.ErrorReceived
+import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.Event.ExecuteBrokerStepAction
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.PirStageStatus
 import com.duckduckgo.pir.impl.common.actions.PirActionsRunnerStateEngine.State
 import com.duckduckgo.pir.impl.models.Broker
+import com.duckduckgo.pir.impl.models.ExtractedProfile
 import com.duckduckgo.pir.impl.models.ProfileQuery
 import com.duckduckgo.pir.impl.pixels.PirStage
 import com.duckduckgo.pir.impl.scripts.models.BrokerAction
 import com.duckduckgo.pir.impl.scripts.models.PirError
 import com.duckduckgo.pir.impl.scripts.models.PirError.ActionError.CaptchaServiceError
 import com.duckduckgo.pir.impl.scripts.models.PirError.ActionError.EmailError
+import com.duckduckgo.pir.impl.scripts.models.PirScriptRequestData.UserProfile
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
 
 class ErrorReceivedHandlerTest {
     @get:Rule
@@ -50,6 +59,7 @@ class ErrorReceivedHandlerTest {
 
     private lateinit var testee: ErrorReceivedHandler
     private var mockPirRunStateHandler: PirRunStateHandler = mock()
+    private var mockCurrentTimeProvider: CurrentTimeProvider = mock()
 
     private val testBroker = Broker(
         name = "test-broker",
@@ -66,6 +76,13 @@ class ErrorReceivedHandlerTest {
         url = "https://example.com",
     )
 
+    private val testConditionAction = BrokerAction.Condition(
+        id = "condition-1",
+        comment = "Optional prompt that only sometimes appears",
+        expectations = emptyList(),
+        actions = emptyList(),
+    )
+
     private val testProfileQuery =
         ProfileQuery(
             id = 123L,
@@ -80,9 +97,16 @@ class ErrorReceivedHandlerTest {
             deprecated = false,
         )
 
+    private val testExtractedProfile =
+        ExtractedProfile(
+            profileQueryId = 123L,
+            brokerName = "test-broker",
+            name = "John Doe",
+        )
+
     @Before
     fun setUp() {
-        testee = ErrorReceivedHandler(mockPirRunStateHandler)
+        testee = ErrorReceivedHandler(mockPirRunStateHandler, mockCurrentTimeProvider)
     }
 
     @Test
@@ -468,5 +492,82 @@ class ErrorReceivedHandlerTest {
         assertEquals(testError, nextEvent.error)
         assertFalse(nextEvent.allowRetry)
         verifyNoInteractions(mockPirRunStateHandler)
+    }
+
+    @Test
+    fun whenErrorReceivedForConditionActionInScanThenSkipsToNextActionInsteadOfFailing() = runTest {
+        // A condition whose expectation is not met reports a JS error. For a condition this is not fatal:
+        // the scan must skip to the next action rather than failing the broker step.
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testConditionAction),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = ErrorReceived(error = PirError.JsError.ActionError("element with selector #x not found."))
+
+        val result = testee.invoke(state, event)
+
+        // Continues to the next action (index advances, ExecuteBrokerStepAction) instead of BrokerActionFailed.
+        assertEquals(1, result.nextState.currentActionIndex)
+        assertEquals(ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery)), result.nextEvent)
+        assertTrue(result.nextEvent !is BrokerActionFailed)
+        // Scan step: no opt-out condition pixel fired.
+        verifyNoInteractions(mockPirRunStateHandler)
+    }
+
+    @Test
+    fun whenErrorReceivedForConditionActionInOptOutThenFiresConditionNotFoundAndContinues() = runTest {
+        whenever(mockCurrentTimeProvider.currentTimeMillis()).thenReturn(5000L)
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(testConditionAction),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            attemptId = "attempt-1",
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 1000L,
+            ),
+        )
+        val event = ErrorReceived(error = PirError.JsError.ActionError("element with selector #x not found."))
+
+        val result = testee.invoke(state, event)
+
+        verify(mockPirRunStateHandler).handleState(
+            BrokerOptOutConditionNotFound(
+                broker = testBroker,
+                actionID = testConditionAction.id,
+                attemptId = "attempt-1",
+                durationMs = 4000L,
+                currentActionAttemptCount = 1,
+            ),
+        )
+        assertEquals(1, result.nextState.currentActionIndex)
+        assertEquals(ExecuteBrokerStepAction(UserProfile(userProfile = testProfileQuery)), result.nextEvent)
+        assertTrue(result.nextEvent !is BrokerActionFailed)
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1206873150423133/task/1216590673986919?focus=true
Tech Design URL (if applicable): 

### Description

Fixes the treatment of the Condition action to behave as expected. Namely, to fail silently if the expectation is not met.

### Steps to test this PR

* Before checking out the branch, run the PIR debug mode against propertyrecord.com.json (this is the broker failing on Windows/Android but succeeding on macOS) due to the [presence of a condition](https://dub.duckduckgo.com/duckduckgo/dbp-api/blob/main/dbp-json/data/json/propertyrecord.com.json#L73C1-L95C11).
* Run the scan against some made up details. The condition step covers the fact that this broker will sometimes try to correct search details after the search is executed with a "Did you mean…" box. When this happens, the current execution succeeds, so we're looking for a search where this box does not pop-up, and therefore the scan/opt out fails.
* Check out this branch and run the same search, this time PIR should be able to continue execution whether the box is present or not.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PIR scan/opt-out error handling in the state engine; scoped to condition actions but affects real broker automation outcomes.
> 
> **Overview**
> **PIR broker runs no longer abort when an optional `condition` action’s DOM expectation is missing.** Previously, a JS error on a `BrokerAction.Condition` (e.g. a “Did you mean…” prompt that isn’t on the page) was handled like any other fatal error and emitted `BrokerActionFailed`, which could fail scans/opt-outs on brokers such as propertyrecord.com while other platforms continued.
> 
> `ErrorReceivedHandler` now detects when the failing action is a **condition**, treats that as “condition not met,” advances `currentActionIndex`, resets retries, and queues **`ExecuteBrokerStepAction`** so the step keeps going. On **opt-out** steps it also reports **`BrokerOptOutConditionNotFound`** (with duration from injected **`CurrentTimeProvider`**); scan steps skip without that pixel. Wiring and unit tests cover scan vs opt-out behavior; the integration test passes **`fakeTimeProvider`** into the handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11e1ea9176ba9b1542f3c8d5909655f231038782. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->