### PR TITLE
Style disabled sync CTA components

### DIFF
--- a/sync/sync-impl/src/main/res/layout/view_sync_v2_disabled.xml
+++ b/sync/sync-impl/src/main/res/layout/view_sync_v2_disabled.xml
@@ -16,7 +16,6 @@
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">
@@ -25,8 +24,8 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="@dimen/keyline_4"
-        android:background="#f0f"
-        tools:ignore="InvalidColorAttribute">
+        android:background="@drawable/background_large_rounded_surface"
+        android:paddingVertical="@dimen/keyline_2">
 
         <com.duckduckgo.common.ui.view.listitem.OneLineListItem
             android:id="@+id/syncThisDeviceToggle"
@@ -45,7 +44,7 @@
         android:layout_marginBottom="60dp"
         android:text="@string/sync_setup_with_another_device_cta_title"
         app:daxButtonSize="large"
-        app:icon="@drawable/ic_qr_24" />
+        app:icon="@drawable/ic_qr2_24" />
 
     <com.duckduckgo.common.ui.view.divider.HorizontalDivider
         android:layout_width="match_parent"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216103556496795/task/1216556653226032?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1216103556496795/task/1216509582049467?focus=true

### Description

Styles CTA components based on the design feedback.

### Steps to test this PR

_Styled CTAs_
- [ ] Go to the Sync Dev Settings.
- [ ] Tap "Launch Sync Settings V2"
- [ ] Verify that the CTAs are styled.

### UI changes
| Before  | After |
| ------ | ----- |
| <img width="1080" height="2400" alt="before" src="https://github.com/user-attachments/assets/8cbe4d54-7c66-4d89-ba39-f26089d33cb9" /> | <img width="1080" height="2400" alt="after" src="https://github.com/user-attachments/assets/5aab44f3-5094-4c9d-91ce-ad8bfdfe32ea" /> |


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout-only XML changes with no sync logic or behavior changes.
> 
> **Overview**
> Updates **`view_sync_v2_disabled.xml`** so the disabled Sync Settings V2 CTAs match design feedback.
> 
> The **“sync this device”** toggle container drops the temporary magenta debug background and uses **`background_large_rounded_surface`** with vertical padding. The **“sync with another device”** secondary button switches its icon from **`ic_qr_24`** to **`ic_qr2_24`**, consistent with the enabled Sync V2 layout. Unused **`tools`** namespace attributes are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20fc79aa4f6efdae5c56f475974b5ecb32246351. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->