### PR TITLE
Update hatch menu copy and idle settings screen name

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
@@ -42,7 +42,7 @@ import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
 @InjectWith(ActivityScope::class)
-@ContributeToActivityStarter(ShowOnAppLaunchScreenNoParams::class)
+@ContributeToActivityStarter(ShowOnAppLaunchScreenNoParams::class, screenName = "settingsAfterInactivity")
 class ShowOnAppLaunchActivity : DuckDuckGoActivity() {
 
     private val viewModel: ShowOnAppLaunchViewModel by bindViewModel()

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchView.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchView.kt
@@ -174,7 +174,7 @@ class NewTabReturnHatchView @JvmOverloads constructor(
         popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.hatchMenuCloseTab)) {
             viewModel.closeTab()
         }
-        popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.hatchMenuDontShowThis)) {
+        popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.hatchMenuHideShortcut)) {
             viewModel.onDontShowThisPressed()
         }
         popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.hatchMenuAfterInactivity)) {

--- a/browser/browser-ui/src/main/res/layout/popup_hatch_menu.xml
+++ b/browser/browser-ui/src/main/res/layout/popup_hatch_menu.xml
@@ -48,11 +48,11 @@
         android:layout_height="wrap_content"/>
 
     <com.duckduckgo.common.ui.view.PopupMenuItemView
-        android:id="@+id/hatchMenuDontShowThis"
+        android:id="@+id/hatchMenuHideShortcut"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:leadingIcon="@drawable/ic_eye_closed_24"
-        app:primaryText="@string/hatchMenuDontShowThis" />
+        app:primaryText="@string/hatchMenuHideShortcut" />
 
     <com.duckduckgo.common.ui.view.divider.HorizontalDivider
         app:defaultPadding="false"

--- a/browser/browser-ui/src/main/res/values/donottranslate.xml
+++ b/browser/browser-ui/src/main/res/values/donottranslate.xml
@@ -28,7 +28,7 @@
     <string name="hatchMenuAfterInactivitySettings">After Inactivity</string>
     <string name="hatchMenuCloseTab">Close Tab</string>
     <string name="hatchMenuBurnTab">Delete Tab</string>
-    <string name="hatchMenuDontShowThis">Don\'t Show This</string>
+    <string name="hatchMenuHideShortcut">Hide shortcut</string>
     <string name="newTabReturnHatchTabClosed">Tab closed</string>
     <string name="newTabReturnHatchUndo">Undo</string>
     <string name="browserMenuChats">Chats</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1216620810416993?focus=true 
Tech Design URL (if applicable): N/A

### Description

- Registered ShowOnAppLaunchActivity with screenName = "settingsAfterInactivity" so the RMF navigation action can target it directly.
- Renamed the hatch menu item "Don't Show This" → "Hide shortcut",

### Steps to test this PR

- [ ] Open the return-to-last-tab hatch overflow → item reads "Hide shortcut"; tapping it hides the hatch as before.


### UI changes
| Before  | After |
| ------ | ----- |
| <img width="1080" height="2410" alt="image" src="https://github.com/user-attachments/assets/95511c3f-1674-4d6f-9b19-9a3c9cdc29fc" />|<img width="540" height="1200" alt="image" src="https://github.com/user-attachments/assets/9664aeca-371b-4d31-b550-38ce942cf824" />|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and navigation registration only; no changes to hide-shortcut or settings business logic.
> 
> **Overview**
> Adds **`screenName = "settingsAfterInactivity"`** on `ShowOnAppLaunchActivity` so RMF navigation can open the after-inactivity settings screen directly.
> 
> Renames the new-tab return hatch overflow action from **"Don't Show This"** to **"Hide shortcut"** (`hatchMenuHideShortcut` in layout, strings, and `NewTabReturnHatchView`); behavior still goes through `onDontShowThisPressed()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d7cf5fd44ab0a6547d7b795ced1f3393c246994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->