### PR TITLE
UTI: Nav bar polish, first-focus visibility and back arrow

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2879,9 +2879,11 @@ class BrowserTabFragment :
                     // Surface the native input widget so its onEnterComplete focuses the input
                     // and brings up the keyboard via the same path as a manual omnibar tap.
                     // Skip if the widget is already attached — Command.ShowKeyboard can fire
-                    // multiple times per session (e.g. CTA refresh) and showNativeInput()
-                    // tears down and re-animates the widget on each call.
-                    if (binding.rootView.findViewById<View?>(com.duckduckgo.app.browser.R.id.inputModeTopRoot) == null) {
+                    // multiple times per session (e.g. CTA refresh / tab swipe back to NTP) and
+                    // showNativeInput() tears down and re-animates the widget on each call.
+                    // Must cover bottom omnibar too (inputModeBottomRoot); checking only the top
+                    // root re-opened UTI on every swipe and stacked NTP content insets.
+                    if (!nativeInputManager.isNativeInputShown()) {
                         showNativeInput()
                     }
                 } else {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1240,7 +1240,7 @@ class BrowserTabFragment :
         )
 
         nativeInputManager.init(omnibar, binding.rootView, viewLifecycleOwner) {
-            nativeInputManager.hideNativeInput()
+            nativeInputManager.hideNativeInput(animate = false)
         }
 
         webViewContainer = binding.webViewContainer

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -5199,6 +5199,9 @@ class BrowserTabFragment :
     private fun onTabVisible() {
         if (!isAdded) return
         webView?.onResume()
+        // ViewPager2 can keep neighbors STARTED/RESUMED; expand so a bottom omnibar that was scrolled
+        // away on a previous visit isn't left as an icons-only strip.
+        omnibar.setExpanded(true)
         launchDownloadMessagesJob()
         viewModel.onViewVisible()
     }
@@ -6779,6 +6782,12 @@ class BrowserTabFragment :
     }
 
     fun onTabSwipedAway() {
+        // Dismiss browser UTI when leaving the tab so the omnibar is restored and we don't leave a
+        // half-hidden address field / leftover nav chrome for the next visit. Skip Duck.ai: the
+        // widget is the persistent chat input there.
+        if (omnibar.viewMode != ViewMode.DuckAI) {
+            nativeInputManager.hideNativeInput(animate = false)
+        }
         viewModel.onTabSwipedAway()
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2094,6 +2094,10 @@ class BrowserTabFragment :
 
     private fun launchTabSwitcher() {
         val activity = activity ?: return
+        // Dismiss the native input first (no-op when it isn't shown). Reachable from the input nav bar's
+        // tabs button while the widget is open; leaving it attached breaks the "UTI open ⟺ omnibar hidden"
+        // invariant, so on return the re-rendered omnibar and the lingering widget would both be visible.
+        nativeInputManager.hideNativeInput(animate = false)
         val intent = TabSwitcherActivity.intent(activity)
         tabSwitcherActivityResult.launch(intent)
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -2094,10 +2094,13 @@ class BrowserTabFragment :
 
     private fun launchTabSwitcher() {
         val activity = activity ?: return
-        // Dismiss the native input first (no-op when it isn't shown). Reachable from the input nav bar's
-        // tabs button while the widget is open; leaving it attached breaks the "UTI open ⟺ omnibar hidden"
-        // invariant, so on return the re-rendered omnibar and the lingering widget would both be visible.
-        nativeInputManager.hideNativeInput(animate = false)
+        // Dismiss the native input first (no-op when it isn't shown) so a browser-input widget doesn't
+        // linger behind the switcher and leave the omnibar and widget both visible on return. Skip Duck.ai:
+        // there the widget is the persistent chat input, and hideNativeInput would restore the default
+        // omnibar and tear it down.
+        if (omnibar.viewMode != ViewMode.DuckAI) {
+            nativeInputManager.hideNativeInput(animate = false)
+        }
         val intent = TabSwitcherActivity.intent(activity)
         tabSwitcherActivityResult.launch(intent)
     }

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
@@ -72,6 +72,8 @@ interface NativeInputAnimator {
         onComplete: () -> Unit = {},
     )
     fun cancelAnimation()
+    /** Cancels only the enter/exit morph; leaves an in-flight nav-bar slide running. */
+    fun cancelMorphAnimation()
     fun applyLayoutTransitions(widgetView: View)
     fun applyLayoutTransitions(widgetView: View, isBottom: Boolean)
     fun clearLayoutTransitions(widgetView: View)
@@ -131,7 +133,8 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         onCancel: () -> Unit,
         onComplete: () -> Unit,
     ) {
-        cancelAnimation()
+        // Morph only — a concurrent nav-bar slide (open/close) must keep running.
+        cancelMorphAnimation()
 
         val startWidth = (widgetCard.layoutParams as ViewGroup.MarginLayoutParams).width
         val startHeight = (widgetCard.layoutParams as ViewGroup.MarginLayoutParams).height
@@ -166,7 +169,8 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         onCancel: () -> Unit,
         onComplete: () -> Unit,
     ) {
-        cancelAnimation()
+        // Morph only — hideNativeInput may already be sliding the nav bar out in parallel.
+        cancelMorphAnimation()
         clearLayoutTransitions(widgetView)
         (widgetView as? ViewGroup)?.clipChildren = false
         (widgetView.parent as? ViewGroup)?.clipChildren = false
@@ -208,9 +212,19 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         }
 
         navBarView.visibility = View.VISIBLE
-        val startBar = navBarView.translationY
-        val startWidget = if (ridesWidget) widgetView.translationY else 0f
         val endWidget = if (ridesWidget) endBar else 0f
+        // Fresh show often lands with translationY already at the end (0) — e.g. a re-show after a
+        // cancelled slide. Start from off-screen whenever there's no travel so the slide-in is visible.
+        var startBar = navBarView.translationY
+        if (show && startBar == endBar) {
+            startBar = hiddenY
+            navBarView.translationY = hiddenY
+        }
+        if (ridesWidget && show && widgetView.translationY == endWidget && startBar == hiddenY) {
+            // Keep the widget locked to the bar when the bar is forced (or pre-positioned) off-screen.
+            widgetView.translationY = hiddenY
+        }
+        val startWidget = if (ridesWidget) widgetView.translationY else 0f
 
         navBarAnimator = ValueAnimator.ofFloat(0f, 1f).apply {
             duration = ANIMATION_DURATION_MS
@@ -314,14 +328,18 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
     }
 
     override fun cancelAnimation() {
+        cancelMorphAnimation()
+        navBarAnimator?.cancel()
+        navBarAnimator = null
+    }
+
+    override fun cancelMorphAnimation() {
         pendingPreDraw?.let { (view, listener) -> view.viewTreeObserver.removeOnPreDrawListener(listener) }
         pendingPreDraw = null
         animationCleanup?.invoke()
         animationCleanup = null
         transitionAnimator?.cancel()
         transitionAnimator = null
-        navBarAnimator?.cancel()
-        navBarAnimator = null
     }
 
     override fun applyLayoutTransitions(widgetView: View) {
@@ -561,7 +579,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         onCancel: () -> Unit = {},
         onEnd: () -> Unit,
     ) {
-        cancelAnimation()
+        cancelMorphAnimation()
         animationCleanup = cleanup
         transitionAnimator = ValueAnimator.ofFloat(0f, 1f).apply {
             duration = ANIMATION_DURATION_MS

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
@@ -61,6 +61,7 @@ interface NativeInputAnimator {
         onCancel: () -> Unit = {},
         onComplete: () -> Unit,
     )
+
     /**
      * @param moveWidgetWithBar top mode only: when true, [widgetView] tracks the bar's translation
      * (mid-session latch). Pass false while an enter/exit morph is running so the card can morph
@@ -79,6 +80,7 @@ interface NativeInputAnimator {
         onComplete: () -> Unit = {},
     )
     fun cancelAnimation()
+
     /** Cancels only the enter/exit morph; leaves an in-flight nav-bar slide running. */
     fun cancelMorphAnimation()
     fun applyLayoutTransitions(widgetView: View)

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
@@ -43,6 +43,12 @@ interface NativeInputAnimator {
         widgetView: View,
         margins: Margins,
         onUpdate: (fraction: Float) -> Unit = {},
+        /**
+         * Invoked after the omnibar's on-screen position has been captured and before the morph
+         * starts. Use to hide the omnibar when a nav bar is replacing it, so it doesn't cover the
+         * bar for the duration of the enter.
+         */
+        onStart: () -> Unit = {},
         onCancel: () -> Unit = {},
         onComplete: () -> Unit = {},
     )
@@ -121,6 +127,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         widgetView: View,
         margins: Margins,
         onUpdate: (fraction: Float) -> Unit,
+        onStart: () -> Unit,
         onCancel: () -> Unit,
         onComplete: () -> Unit,
     ) {
@@ -132,6 +139,9 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
 
         waitForLayout(widgetCard) {
             val omnibarPosition = visibleSurfacePosition(omnibarCard)
+            // Position is captured — safe to tear down the omnibar (e.g. reveal the nav bar) before
+            // the morph runs.
+            onStart()
             performEnterAnimation(
                 widgetCard,
                 omnibarCard,
@@ -429,7 +439,8 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
             onCancel = onCancel,
             onEnd = {
                 widgetContent?.alpha = 1f
-                omnibarCard.alpha = 1f
+                // Leave omnibarCard at 0 — [onComplete] hides the omnibar. Restoring alpha here
+                // flashes the card for a frame before hide().
                 animateCornerRadius(card, widgetCornerRadius)
                 restoreLayout(card, params, margins)
                 card.post { applyLayoutTransitions(widgetView) }

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
@@ -61,6 +61,12 @@ interface NativeInputAnimator {
         onCancel: () -> Unit = {},
         onComplete: () -> Unit,
     )
+    /**
+     * @param moveWidgetWithBar top mode only: when true, [widgetView] tracks the bar's translation
+     * (mid-session latch). Pass false while an enter/exit morph is running so the card can morph
+     * from/to the omnibar while the bar (buttons) slides alone. Ignored in bottom mode — the widget
+     * never rides the bar there.
+     */
     fun animateNavBarVisibility(
         navBarView: View,
         widgetView: View,
@@ -68,6 +74,7 @@ interface NativeInputAnimator {
         heightPx: Int,
         show: Boolean,
         animate: Boolean,
+        moveWidgetWithBar: Boolean = !isBottom,
         onFrame: (onScreenHeightPx: Int) -> Unit = {},
         onComplete: () -> Unit = {},
     )
@@ -189,6 +196,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         heightPx: Int,
         show: Boolean,
         animate: Boolean,
+        moveWidgetWithBar: Boolean,
         onFrame: (onScreenHeightPx: Int) -> Unit,
         onComplete: () -> Unit,
     ) {
@@ -196,7 +204,8 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         navBarAnimator = null
 
         val hiddenY = -heightPx.toFloat()
-        val ridesWidget = !isBottom
+        // Bottom mode never couples the widget to the bar; top mode only when the caller asks.
+        val ridesWidget = !isBottom && moveWidgetWithBar
         val endBar = if (show) 0f else hiddenY
 
         // How much of the bar is currently on screen given its slide translation, used to keep the

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
@@ -62,6 +62,7 @@ interface NativeInputAnimator {
         heightPx: Int,
         show: Boolean,
         animate: Boolean,
+        onFrame: (onScreenHeightPx: Int) -> Unit = {},
         onComplete: () -> Unit = {},
     )
     fun cancelAnimation()
@@ -174,6 +175,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         heightPx: Int,
         show: Boolean,
         animate: Boolean,
+        onFrame: (onScreenHeightPx: Int) -> Unit,
         onComplete: () -> Unit,
     ) {
         navBarAnimator?.cancel()
@@ -182,6 +184,10 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         val hiddenY = -heightPx.toFloat()
         val ridesWidget = !isBottom
         val endBar = if (show) 0f else hiddenY
+
+        // How much of the bar is currently on screen given its slide translation, used to keep the
+        // content offset in lock-step with the bar every frame.
+        fun onScreenHeight(barTranslationY: Float): Int = (heightPx + barTranslationY).toInt().coerceIn(0, heightPx)
 
         if (!animate) {
             navBarView.translationY = endBar
@@ -201,8 +207,10 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
             interpolator = FastOutSlowInInterpolator()
             addUpdateListener { anim ->
                 val f = anim.animatedFraction
-                navBarView.translationY = lerpF(startBar, endBar, f)
+                val bar = lerpF(startBar, endBar, f)
+                navBarView.translationY = bar
                 if (ridesWidget) widgetView.translationY = lerpF(startWidget, endWidget, f)
+                onFrame(onScreenHeight(bar))
             }
             addListener(object : AnimatorListenerAdapter() {
                 private var cancelled = false
@@ -215,6 +223,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
                     navBarView.translationY = endBar
                     if (ridesWidget) widgetView.translationY = endWidget
                     if (!show) navBarView.visibility = View.GONE
+                    onFrame(onScreenHeight(endBar))
                     onComplete()
                 }
             })

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -50,6 +50,7 @@ class NativeInputLayoutCoordinator(
 
     private var navBarInsetPx: Int = 0
     private var reapplyContentOffset: (() -> Unit)? = null
+
     /** Restores content targets to the padding snapshotted in [configureContentOffset]. */
     private var resetContentOffset: (() -> Unit)? = null
     private var reapplyAutocompleteOffset: (() -> Unit)? = null

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -197,9 +197,20 @@ class NativeInputLayoutCoordinator(
         this.navBarInsetPx = navBarInsetPx
         data class Target(val view: View, val basePadding: Padding)
 
+        // Drop any prior session's applied inset before snapshotting. Otherwise a leftover top/bottom
+        // padding (incomplete close, or ShowKeyboard → showNativeInput after a tab swipe) becomes the
+        // new baseline and stacks on every reopen.
+        resetContentOffset?.invoke()
+        clearNtpScrollArtifacts()
+
         val newTabContent =
             rootView.findViewById<View?>(R.id.newTabPage)
                 ?: rootView.findViewById(R.id.includeNewBrowserTab)
+        // newTabPage has no XML padding — any top/bottom here is from a prior offset session. Zero it
+        // so the snapshot can't inherit a dirty baseline. Leave browserLayout alone: its bottom padding
+        // is owned by BottomOmnibarBrowserContainerLayoutBehavior.
+        newTabContent?.setPadding(newTabContent.paddingLeft, 0, newTabContent.paddingRight, 0)
+
         val targets =
             listOfNotNull(
                 rootView.findViewById(R.id.browserLayout),
@@ -298,6 +309,7 @@ class NativeInputLayoutCoordinator(
         fun applyOffset() {
             if (!widgetView.isShown) {
                 targets.forEach { applyPadding(it.view, it.basePadding, deltaTop = 0, deltaBottom = 0) }
+                clearNtpScrollArtifacts()
                 return
             }
             val anchorLocation = IntArray(2).also { anchor.getLocationInWindow(it) }
@@ -327,6 +339,7 @@ class NativeInputLayoutCoordinator(
         reapplyContentOffset = { applyOffset() }
         resetContentOffset = {
             targets.forEach { applyPadding(it.view, it.basePadding, deltaTop = 0, deltaBottom = 0) }
+            clearNtpScrollArtifacts()
         }
         widgetView.post { applyOffset() }
         val layoutListener =
@@ -366,6 +379,7 @@ class NativeInputLayoutCoordinator(
                     targets.forEach { target ->
                         applyPadding(target.view, target.basePadding, deltaTop = 0, deltaBottom = 0)
                     }
+                    clearNtpScrollArtifacts()
                     v.removeOnLayoutChangeListener(layoutListener)
                     rootView.removeOnLayoutChangeListener(layoutListener)
                     ntpContentView?.viewTreeObserver?.takeIf { it.isAlive }?.removeOnGlobalLayoutListener(globalLayoutListener)
@@ -373,6 +387,22 @@ class NativeInputLayoutCoordinator(
                 }
             },
         )
+    }
+
+    /**
+     * LayoutTransition CHANGING (Search ↔ Duck.ai reflow) can leave temporary margins/translations on
+     * [R.id.newTabContainerScrollView]. Clear them whenever we restore the content baseline so tab-swipe
+     * reopen cycles can't accumulate a growing gap above the NTP content.
+     */
+    private fun clearNtpScrollArtifacts() {
+        val scrollView = rootView.findViewById<View?>(R.id.newTabContainerScrollView) ?: return
+        val lp = scrollView.layoutParams as? ViewGroup.MarginLayoutParams
+        if (lp != null && (lp.topMargin != 0 || lp.bottomMargin != 0 || lp.leftMargin != 0 || lp.rightMargin != 0)) {
+            lp.setMargins(0, 0, 0, 0)
+            scrollView.layoutParams = lp
+        }
+        if (scrollView.translationX != 0f) scrollView.translationX = 0f
+        if (scrollView.translationY != 0f) scrollView.translationY = 0f
     }
 
     /**

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -386,8 +386,12 @@ class NativeInputLayoutCoordinator(
         suspendContentReflow()
     }
 
+    /**
+     * Ends a [beginNavBarSlide] session. Resumes content reflow but leaves [isWidgetAnimating] alone —
+     * the slide may run alongside enter/exit, which owns that flag until its own complete/cancel.
+     * Callers that solely own the session (mid-session show/hide) should clear it after this returns.
+     */
     fun endNavBarSlide() {
-        isWidgetAnimating = false
         resumeContentReflow()
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -50,6 +50,8 @@ class NativeInputLayoutCoordinator(
 
     private var navBarInsetPx: Int = 0
     private var reapplyContentOffset: (() -> Unit)? = null
+    /** Restores content targets to the padding snapshotted in [configureContentOffset]. */
+    private var resetContentOffset: (() -> Unit)? = null
     private var reapplyAutocompleteOffset: (() -> Unit)? = null
 
     // The content-reflow LayoutTransition is suspended while a per-frame content-offset drive is running
@@ -323,6 +325,9 @@ class NativeInputLayoutCoordinator(
         }
 
         reapplyContentOffset = { applyOffset() }
+        resetContentOffset = {
+            targets.forEach { applyPadding(it.view, it.basePadding, deltaTop = 0, deltaBottom = 0) }
+        }
         widgetView.post { applyOffset() }
         val layoutListener =
             View.OnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
@@ -353,6 +358,7 @@ class NativeInputLayoutCoordinator(
                     pendingContentLayoutTransition = null
                     widgetAnimationFrameHandler = null
                     reapplyContentOffset = null
+                    resetContentOffset = null
                     isWidgetAnimating = false
                     contentTransitionGroup = null
                     suspendedContentTransition = null
@@ -369,10 +375,6 @@ class NativeInputLayoutCoordinator(
         )
     }
 
-    /**
-     * Updates the nav bar top-inset used by the (already-registered) content-offset listeners and
-     * re-applies immediately. Cheap: no new listeners — unlike re-calling [configureContentOffset].
-     */
     /**
      * Around a nav bar show/hide slide (widget stays open): silence the layout listeners and suspend the
      * content-reflow transition so the per-frame [updateNavBarInset] drive moves the content in lock-step
@@ -407,6 +409,15 @@ class NativeInputLayoutCoordinator(
         isContentReflowSuspended = false
         contentTransitionGroup?.layoutTransition = suspendedContentTransition
         suspendedContentTransition = null
+    }
+
+    /**
+     * Instantly restores content padding to the [configureContentOffset] baseline. Call while the
+     * content-reflow transition is suspended (e.g. exit teardown) so a [LayoutTransition] can't race
+     * the reset and leave stale top padding after the omnibar returns.
+     */
+    fun resetContentOffsetToBase() {
+        resetContentOffset?.invoke()
     }
 
     fun updateNavBarInset(px: Int) {

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -409,15 +409,6 @@ class NativeInputLayoutCoordinator(
         suspendedContentTransition = null
     }
 
-    /**
-     * Sets the nav bar inset used by the content-offset math WITHOUT re-applying — the caller's own
-     * per-frame drive (e.g. the exit's [onWidgetAnimationFrame]) applies it. Use [updateNavBarInset] when
-     * an immediate re-apply is wanted instead.
-     */
-    fun setNavBarInset(px: Int) {
-        navBarInsetPx = px
-    }
-
     fun updateNavBarInset(px: Int) {
         navBarInsetPx = px
         reapplyContentOffset?.invoke()

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputLayoutCoordinator.kt
@@ -52,6 +52,12 @@ class NativeInputLayoutCoordinator(
     private var reapplyContentOffset: (() -> Unit)? = null
     private var reapplyAutocompleteOffset: (() -> Unit)? = null
 
+    // The content-reflow LayoutTransition is suspended while a per-frame content-offset drive is running
+    // (nav bar slide or widget exit) so that drive is the only thing moving the content. Captured on suspend.
+    private var contentTransitionGroup: ViewGroup? = null
+    private var suspendedContentTransition: LayoutTransition? = null
+    private var isContentReflowSuspended: Boolean = false
+
     fun buildWidgetLayoutParams(isBottom: Boolean, topInsetPx: Int = 0): ViewGroup.LayoutParams {
         return CoordinatorLayout.LayoutParams(
             ViewGroup.LayoutParams.MATCH_PARENT,
@@ -223,6 +229,11 @@ class NativeInputLayoutCoordinator(
         // setPadding during the enter would spawn CHANGING animators and the content would lag the widget.
         val ntpGroup = newTabContent as? ViewGroup
         val previousNtpTransition = ntpGroup?.layoutTransition
+        // Fresh session: reset any stale nav bar slide bookkeeping and track this NTP group as the reflow
+        // transition owner so begin/endNavBarSlide can suspend it.
+        contentTransitionGroup = ntpGroup
+        isContentReflowSuspended = false
+        suspendedContentTransition = null
         if (ntpGroup != null) {
             pendingContentLayoutTransition =
                 ntpGroup to
@@ -343,6 +354,9 @@ class NativeInputLayoutCoordinator(
                     widgetAnimationFrameHandler = null
                     reapplyContentOffset = null
                     isWidgetAnimating = false
+                    contentTransitionGroup = null
+                    suspendedContentTransition = null
+                    isContentReflowSuspended = false
                     targets.forEach { target ->
                         applyPadding(target.view, target.basePadding, deltaTop = 0, deltaBottom = 0)
                     }
@@ -359,6 +373,51 @@ class NativeInputLayoutCoordinator(
      * Updates the nav bar top-inset used by the (already-registered) content-offset listeners and
      * re-applies immediately. Cheap: no new listeners — unlike re-calling [configureContentOffset].
      */
+    /**
+     * Around a nav bar show/hide slide (widget stays open): silence the layout listeners and suspend the
+     * content-reflow transition so the per-frame [updateNavBarInset] drive moves the content in lock-step
+     * with the bar. Paired with [endNavBarSlide]; both idempotent, so a rapid re-toggle that cancels the
+     * previous slide stays suspended until the last slide ends. [configureContentOffset]/detach reset it.
+     */
+    fun beginNavBarSlide() {
+        isWidgetAnimating = true
+        suspendContentReflow()
+    }
+
+    fun endNavBarSlide() {
+        isWidgetAnimating = false
+        resumeContentReflow()
+    }
+
+    /**
+     * Suspends the content-reflow [LayoutTransition] so a per-frame content-offset drive (nav bar slide or
+     * widget exit) moves the content instantly, instead of the transition animating each change on its own
+     * clock and lagging the driver. Idempotent; paired with [resumeContentReflow].
+     */
+    fun suspendContentReflow() {
+        if (isContentReflowSuspended) return
+        val group = contentTransitionGroup ?: return
+        isContentReflowSuspended = true
+        suspendedContentTransition = group.layoutTransition
+        group.layoutTransition = null
+    }
+
+    fun resumeContentReflow() {
+        if (!isContentReflowSuspended) return
+        isContentReflowSuspended = false
+        contentTransitionGroup?.layoutTransition = suspendedContentTransition
+        suspendedContentTransition = null
+    }
+
+    /**
+     * Sets the nav bar inset used by the content-offset math WITHOUT re-applying — the caller's own
+     * per-frame drive (e.g. the exit's [onWidgetAnimationFrame]) applies it. Use [updateNavBarInset] when
+     * an immediate re-apply is wanted instead.
+     */
+    fun setNavBarInset(px: Int) {
+        navBarInsetPx = px
+    }
+
     fun updateNavBarInset(px: Int) {
         navBarInsetPx = px
         reapplyContentOffset?.invoke()

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -28,6 +28,7 @@ import android.view.ViewOutlineProvider
 import android.webkit.ValueCallback
 import android.widget.FrameLayout
 import androidx.core.net.toUri
+import androidx.core.view.doOnAttach
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
@@ -1097,10 +1098,24 @@ class RealNativeInputManager @Inject constructor(
     private fun onEnterComplete(widgetView: View) {
         layoutCoordinator.enableContentLayoutTransition()
         if (omnibarController.isDuckAiMode()) return
-        // Skip the IME-raising work if the widget has been detached before the animation
-        // finished (e.g. fragment-manager transient detach during a tab switch). Otherwise
-        // focusInput would raise the keyboard on whatever tab is now in front.
-        if (!widgetView.isAttachedToWindow) return
+        if (widgetView.isAttachedToWindow) {
+            completeEnter(widgetView)
+            return
+        }
+        // The enter finished while the widget was transiently detached — e.g. the ViewPager re-attaches
+        // fragments when a new tab is created. Raising the IME now could target whatever tab is in front,
+        // so defer the focus until this widget re-attaches. Hide the omnibar immediately so the tab can't
+        // settle with both the omnibar and the widget visible, and finish focus on re-attach (guarded so a
+        // since-replaced widget is a no-op).
+        omnibarController.hide()
+        widgetView.doOnAttach {
+            if (widgetRoot === widgetView && !omnibarController.isDuckAiMode()) {
+                completeEnter(widgetView)
+            }
+        }
+    }
+
+    private fun completeEnter(widgetView: View) {
         omnibarController.hide()
         widgetFrom(widgetView)?.apply {
             focusInput(rootView.context as? Activity)

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -232,7 +232,14 @@ class RealNativeInputManager @Inject constructor(
         this.layoutCoordinator = NativeInputLayoutCoordinator(rootView, this.omnibarController)
         duckChat.observeNativeInputFieldUserSettingEnabled()
             .onEach { isEnabled ->
-                if (isNativeInputFieldEnabled && !isEnabled) onDisabled()
+                if (isNativeInputFieldEnabled && !isEnabled) {
+                    // Instant teardown before clearing the flag. Settings toggles often fire while the
+                    // tab is paused, so an animated exit's waitForLayout may never run; and once the
+                    // flag is false, hideNativeInput used to no-op and leave UTI chrome / a missing
+                    // address field on return to NTP.
+                    hideNativeInput(animate = false)
+                    onDisabled()
+                }
                 isNativeInputFieldEnabled = isEnabled
             }
             .launchIn(lifecycleOwner.lifecycleScope)
@@ -334,11 +341,14 @@ class RealNativeInputManager @Inject constructor(
     }
 
     override fun hideNativeInput(animate: Boolean, isNavigation: Boolean): Boolean {
-        if (!isNativeInputFieldEnabled) return false
+        if (!::rootView.isInitialized) return false
 
         val widgetView = rootView.findViewById<View?>(R.id.inputModeTopRoot)
             ?: rootView.findViewById(R.id.inputModeBottomRoot)
             ?: return false
+
+        // Do not require isNativeInputFieldEnabled: teardown must still run after the setting flips
+        // off (and after a paused animated hide left the widget attached).
 
         if (isNavigation) {
             widgetFrom(widgetView)?.let { widget ->
@@ -373,6 +383,12 @@ class RealNativeInputManager @Inject constructor(
         if (!animate) {
             animator.cancelAnimation()
             isExiting = false
+            // Match animated exit: suspend LayoutTransition before resetting offsets so CHANGING
+            // can't leave a leftover NTP gap (e.g. live switch to Search-only while UTI is open on
+            // bottom omnibar with a nav-bar top inset).
+            layoutCoordinator.suspendContentReflow()
+            layoutCoordinator.updateNavBarInset(0)
+            layoutCoordinator.resetContentOffsetToBase()
             omnibarController.restore()
             omnibarController.show()
             removeWidget()
@@ -1033,7 +1049,9 @@ class RealNativeInputManager @Inject constructor(
      * [NativeInputLayoutCoordinator.endNavBarSlide] here would resume reflow mid-exit.
      *
      * Never moves the widget with the bar: exit morph needs the card planted so it can morph back to
-     * the omnibar while the buttons slide away alone (top and bottom).
+     * the omnibar while the buttons slide away alone. Still drives [NativeInputLayoutCoordinator.updateNavBarInset]
+     * each frame so NTP/browser content tracks the sliding bar instead of keeping the full inset until
+     * exit's reset-to-base.
      */
     private fun slideNavBarOutWithClose(animate: Boolean) {
         val navBar = navBarRoot ?: return
@@ -1048,8 +1066,8 @@ class RealNativeInputManager @Inject constructor(
             show = false,
             animate = animate,
             moveWidgetWithBar = false,
-            onFrame = {},
-            onComplete = {},
+            onFrame = { onScreenPx -> layoutCoordinator.updateNavBarInset(onScreenPx) },
+            onComplete = { layoutCoordinator.updateNavBarInset(0) },
         )
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -200,6 +200,10 @@ class RealNativeInputManager @Inject constructor(
     private var navBarTabCountObserver: Observer<Int>? = null
     private var lastCallbacks: NativeInputCallbacks? = null
 
+    // The NTP top stroke is driven by hasFavorites, so we save its visibility on attach and restore it
+    // on detach rather than re-showing unconditionally (which would show it with no favorites present).
+    private var savedTopNtpStrokeVisibility: Int? = null
+
     private val interactionLockSource = MutableStateFlow(InteractionLock.Unlocked)
     private val duckAiFireButtonHighlightSource = MutableStateFlow(false)
 
@@ -690,6 +694,10 @@ class RealNativeInputManager @Inject constructor(
             floatingSubmitContainer = null
         }
         if (removed) widgetRoot = null
+        savedTopNtpStrokeVisibility?.let { vis ->
+            rootView.findViewById<View?>(R.id.topNtpOutlineStroke)?.visibility = vis
+            savedTopNtpStrokeVisibility = null
+        }
         duckAiToolbarHidden = false
         // Drop Fragment-scoped callback closures so they don't outlive the widget.
         lastCallbacks = null
@@ -978,6 +986,13 @@ class RealNativeInputManager @Inject constructor(
         if (isBottom) {
             rootView.findViewById<View?>(R.id.navigationBar)?.gone()
             rootView.findViewById<View?>(R.id.bottomBrowserOutlineStroke)?.gone()
+            // The top outline strokes separate a top omnibar from content; with the input's nav bar at
+            // the top they just draw a hairline under the bar. Hide them, restored on close.
+            rootView.findViewById<View?>(R.id.topBrowserOutlineStroke)?.gone()
+            rootView.findViewById<View?>(R.id.topNtpOutlineStroke)?.let {
+                if (savedTopNtpStrokeVisibility == null) savedTopNtpStrokeVisibility = it.visibility
+                it.gone()
+            }
             if (omnibarController.isBrowserMode()) {
                 widgetView.setBackgroundColor(
                     widgetView.context.getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorBackground),

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -366,37 +366,23 @@ class RealNativeInputManager @Inject constructor(
         isExiting = true
         if (!omnibarController.isDuckAiMode() && card != null && omnibarCard != null && omnibarCard.width > 0) {
             layoutCoordinator.setWidgetAnimating(true)
-            // A visible nav bar rides the same exit: its slide is keyed off the exit's fraction (one
-            // animator, one timeline) and the content offset is driven per-frame by onWidgetAnimationFrame,
-            // so bar, widget and content collapse together instead of the bar sitting still and popping at
-            // the end. Suspend the reflow transition so the per-frame content padding is instant.
-            val exitingNavBar = navBarRoot?.takeIf { navBarShown == true }
-            val navStartY = exitingNavBar?.translationY ?: 0f
-            val navEndY = -navBarHeightPx.toFloat()
-            if (exitingNavBar != null) {
-                layoutCoordinator.suspendContentReflow()
-                navBarShown = false
-            }
+            // The nav bar stays in place during the exit — only the input card morphs back to the omnibar
+            // (removed with the widget in removeWidget). Suspend the content-reflow transition so the
+            // per-frame content offset driven by onWidgetAnimationFrame is instant; otherwise it animates
+            // on the transition's own clock and the reset-to-base races, leaving stale top padding.
+            layoutCoordinator.suspendContentReflow()
             animator.animateExit(
                 widgetCard = card,
                 widgetView = widgetView,
                 omnibarCard = omnibarCard,
                 isBottom = isBottom,
-                onUpdate = { fraction ->
-                    if (exitingNavBar != null) {
-                        val navY = navStartY + (navEndY - navStartY) * fraction
-                        exitingNavBar.translationY = navY
-                        layoutCoordinator.setNavBarInset((navBarHeightPx + navY).toInt().coerceIn(0, navBarHeightPx))
-                    }
-                    layoutCoordinator.onWidgetAnimationFrame(card)
-                },
+                onUpdate = { layoutCoordinator.onWidgetAnimationFrame(card) },
                 onCancel = {
                     layoutCoordinator.setWidgetAnimating(false)
                     layoutCoordinator.resumeContentReflow()
                 },
                 onComplete = {
                     layoutCoordinator.setWidgetAnimating(false)
-                    layoutCoordinator.resumeContentReflow()
                     isExiting = false
                     onHide()
                 },
@@ -602,7 +588,6 @@ class RealNativeInputManager @Inject constructor(
     ) {
         val widget = widgetFrom(widgetView) ?: return
         val onSearchTextChanged: (String) -> Unit = { text ->
-            if (text.isNotEmpty()) onNavBarInputInteraction()
             if (omnibarController.isDuckAiMode() && text.isBlank()) {
                 callbacks.onClearAutocomplete()
             } else {
@@ -611,6 +596,10 @@ class RealNativeInputManager @Inject constructor(
         }
         widget.bindInputEvents(
             onSearchTextChanged = onSearchTextChanged,
+            // Fires on every keystroke regardless of the selected tab (search text routes to
+            // onSearchTextChanged, chat text to onChatTextChanged), so this is the tab-agnostic signal
+            // that latches the nav bar off on the user's first input.
+            onInputTextEmptyChanged = { isEmpty -> if (!isEmpty) onNavBarInputInteraction() },
             onSearchSubmitted = { query ->
                 nativeInputEventListener.onSearchSubmitted(query)
                 hideNativeInput(isNavigation = true)

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -194,6 +194,7 @@ class RealNativeInputManager @Inject constructor(
     private var widgetRoot: View? = null
     private var navBarRoot: View? = null
     private var navBarShown: Boolean? = null
+    private var isKeyboardVisible: Boolean = false
     private var navBarHeightPx: Int = 0
     private var navBarIsBottom: Boolean = false
     private var navBarTabCountLiveData: LiveData<Int>? = null
@@ -361,15 +362,37 @@ class RealNativeInputManager @Inject constructor(
         isExiting = true
         if (!omnibarController.isDuckAiMode() && card != null && omnibarCard != null && omnibarCard.width > 0) {
             layoutCoordinator.setWidgetAnimating(true)
+            // A visible nav bar rides the same exit: its slide is keyed off the exit's fraction (one
+            // animator, one timeline) and the content offset is driven per-frame by onWidgetAnimationFrame,
+            // so bar, widget and content collapse together instead of the bar sitting still and popping at
+            // the end. Suspend the reflow transition so the per-frame content padding is instant.
+            val exitingNavBar = navBarRoot?.takeIf { navBarShown == true }
+            val navStartY = exitingNavBar?.translationY ?: 0f
+            val navEndY = -navBarHeightPx.toFloat()
+            if (exitingNavBar != null) {
+                layoutCoordinator.suspendContentReflow()
+                navBarShown = false
+            }
             animator.animateExit(
                 widgetCard = card,
                 widgetView = widgetView,
                 omnibarCard = omnibarCard,
                 isBottom = isBottom,
-                onUpdate = { layoutCoordinator.onWidgetAnimationFrame(card) },
-                onCancel = { layoutCoordinator.setWidgetAnimating(false) },
+                onUpdate = { fraction ->
+                    if (exitingNavBar != null) {
+                        val navY = navStartY + (navEndY - navStartY) * fraction
+                        exitingNavBar.translationY = navY
+                        layoutCoordinator.setNavBarInset((navBarHeightPx + navY).toInt().coerceIn(0, navBarHeightPx))
+                    }
+                    layoutCoordinator.onWidgetAnimationFrame(card)
+                },
+                onCancel = {
+                    layoutCoordinator.setWidgetAnimating(false)
+                    layoutCoordinator.resumeContentReflow()
+                },
                 onComplete = {
                     layoutCoordinator.setWidgetAnimating(false)
+                    layoutCoordinator.resumeContentReflow()
                     isExiting = false
                     onHide()
                 },
@@ -421,6 +444,10 @@ class RealNativeInputManager @Inject constructor(
         } else {
             onKeyboardHidden(widget)
         }
+
+        // The nav bar is shown while the keyboard is up (both placements) and hidden when it's dismissed.
+        isKeyboardVisible = isVisible
+        refreshNavBarVisibility()
     }
 
     private fun onKeyboardShown(widgetRoot: View?) {
@@ -548,6 +575,10 @@ class RealNativeInputManager @Inject constructor(
             }
         }
         attachWidget(widgetView, navBarView, isBottom, tabId)
+        // The widget opens focused, so the soft keyboard rises immediately. Seed the keyboard state to
+        // match (unless a hardware keyboard means no soft IME) so the bar snaps to its resting state
+        // instead of sliding in once the real keyboard callback lands.
+        isKeyboardVisible = !isExternalKeyboardConnected()
         applyNavBarVisibility(
             show = navBarShouldBeVisible(),
             animate = false,
@@ -891,7 +922,7 @@ class RealNativeInputManager @Inject constructor(
      *  browser-context rule so a live mode/flag change (e.g. Search & Duck.ai → Search-only) hides it. */
     private fun navBarShouldBeVisible(): Boolean =
         shouldCreateNavBar(isNavBarFeatureEnabled, omnibarController.isDuckAiMode(), inputModeCapability) &&
-            shouldShowNavBar(isBrowserContext = navBarRoot != null)
+            shouldShowNavBar(isBrowserContext = navBarRoot != null, isKeyboardVisible = isKeyboardVisible)
 
     /** Re-applies the nav bar visibility for the current input state; no-op when no bar is attached. */
     private fun refreshNavBarVisibility() {
@@ -910,19 +941,35 @@ class RealNativeInputManager @Inject constructor(
         if (!shouldAnimateNavBar(navBarShown, show)) return
         navBarShown = show
         val navBarInset = if (show) navBarHeightPx else 0
+        if (!animate) {
+            animator.animateNavBarVisibility(
+                navBarView = navBar,
+                widgetView = widget,
+                isBottom = navBarIsBottom,
+                heightPx = navBarHeightPx,
+                show = show,
+                animate = false,
+                onComplete = { layoutCoordinator.updateNavBarInset(navBarInset) },
+            )
+            return
+        }
+        // Drive the content offset from the bar's on-screen height every frame, under a suspended reflow
+        // transition, so the NTP/browser content moves in lock-step with the sliding bar/widget instead
+        // of lagging it (top mode) or animating on the LayoutTransition's own clock (bottom mode).
+        layoutCoordinator.beginNavBarSlide()
         animator.animateNavBarVisibility(
             navBarView = navBar,
             widgetView = widget,
             isBottom = navBarIsBottom,
             heightPx = navBarHeightPx,
             show = show,
-            animate = animate,
-            // Re-apply after the slide settles so the top-mode "show" case (widget rides down to its
-            // final position) recomputes the offset from where the widget actually lands.
-            onComplete = { layoutCoordinator.updateNavBarInset(navBarInset) },
+            animate = true,
+            onFrame = { onScreenPx -> layoutCoordinator.updateNavBarInset(onScreenPx) },
+            onComplete = {
+                layoutCoordinator.updateNavBarInset(navBarInset)
+                layoutCoordinator.endNavBarSlide()
+            },
         )
-        // Apply immediately too, so the inset tracks the toggle without waiting for the animation.
-        layoutCoordinator.updateNavBarInset(navBarInset)
     }
 
     private fun attachWidget(widgetView: View, navBarView: View?, isBottom: Boolean, tabId: String) {
@@ -1242,10 +1289,12 @@ internal fun shouldCreateNavBar(featureEnabled: Boolean, isDuckAiMode: Boolean, 
     featureEnabled && !isDuckAiMode && inputMode == NativeInputState.InputMode.SEARCH_AND_DUCK_AI
 
 /**
- * The persistent input-mode nav bar is shown for the whole browser-input session, regardless of
- * whether the field has text. Duck.ai and contextual input never show it.
+ * Whether the input-mode nav bar should currently be on screen. It's tied to the keyboard: shown while
+ * the browser-input session has the keyboard up (both top and bottom placements), hidden once it's
+ * dismissed. Duck.ai and contextual input never show it.
  */
-internal fun shouldShowNavBar(isBrowserContext: Boolean): Boolean = isBrowserContext
+internal fun shouldShowNavBar(isBrowserContext: Boolean, isKeyboardVisible: Boolean): Boolean =
+    isBrowserContext && isKeyboardVisible
 
 /**
  * Whether a visibility change is needed. [currentShown] is null before the first apply, which always

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -125,6 +125,9 @@ interface NativeInputManager {
      */
     fun isNativeInputActive(): Boolean
 
+    /** True when the native input widget is currently attached (top or bottom omnibar). */
+    fun isNativeInputShown(): Boolean
+
     /** True when the widget is shown with the chat tab selected. */
     fun isChatTabSelected(): Boolean
 
@@ -275,6 +278,13 @@ class RealNativeInputManager @Inject constructor(
         // Duck.ai always uses the native input; the browser omnibar only does so outside search-only.
         val inDuckAi = ::omnibarController.isInitialized && omnibarController.isDuckAiMode()
         return inDuckAi || inputModeCapability != NativeInputState.InputMode.SEARCH_ONLY
+    }
+
+    override fun isNativeInputShown(): Boolean {
+        if (!::rootView.isInitialized) return false
+        return widgetRoot != null ||
+            rootView.findViewById<View?>(R.id.inputModeTopRoot) != null ||
+            rootView.findViewById<View?>(R.id.inputModeBottomRoot) != null
     }
 
     override fun isChatTabSelected(): Boolean {

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -545,7 +545,7 @@ class RealNativeInputManager @Inject constructor(
         }
         attachWidget(widgetView, navBarView, isBottom, tabId)
         applyNavBarVisibility(
-            show = navBarShouldBeVisible(isInputEmpty = prefillText.isEmpty()),
+            show = navBarShouldBeVisible(),
             animate = false,
         )
         lifecycleOwner.lifecycleScope.launch {
@@ -629,12 +629,6 @@ class RealNativeInputManager @Inject constructor(
                     nativeInputEventListener.onChatPromptSubmitted()
                     callbacks.onDuckAiQuerySubmitted(query)
                 }
-            },
-            onInputTextEmptyChanged = { isEmpty ->
-                applyNavBarVisibility(
-                    show = navBarShouldBeVisible(isInputEmpty = isEmpty),
-                    animate = true,
-                )
             },
         )
         widget.onChangeModelSubmitted = { modelId -> callbacks.onChangeModelSubmitted(modelId) }
@@ -887,20 +881,15 @@ class RealNativeInputManager @Inject constructor(
     }
 
     /** Current on-screen visibility the nav bar should have, combining the create-time gate with the
-     *  empty-field rule so a live mode/flag change (e.g. Search & Duck.ai → Search-only) hides it. */
-    private fun navBarShouldBeVisible(isInputEmpty: Boolean): Boolean =
+     *  browser-context rule so a live mode/flag change (e.g. Search & Duck.ai → Search-only) hides it. */
+    private fun navBarShouldBeVisible(): Boolean =
         shouldCreateNavBar(isNavBarFeatureEnabled, omnibarController.isDuckAiMode(), inputModeCapability) &&
-            shouldShowNavBar(isBrowserContext = navBarRoot != null, isInputEmpty = isInputEmpty)
+            shouldShowNavBar(isBrowserContext = navBarRoot != null)
 
     /** Re-applies the nav bar visibility for the current input state; no-op when no bar is attached. */
     private fun refreshNavBarVisibility() {
         if (navBarRoot == null) return
-        applyNavBarVisibility(show = navBarShouldBeVisible(isInputEmpty = currentInputEmpty()), animate = true)
-    }
-
-    private fun currentInputEmpty(): Boolean {
-        val widget = widgetRoot?.let { widgetFrom(it) } ?: return true
-        return widget.text.isNullOrEmpty()
+        applyNavBarVisibility(show = navBarShouldBeVisible(), animate = true)
     }
 
     /**
@@ -1236,11 +1225,10 @@ internal fun shouldCreateNavBar(featureEnabled: Boolean, isDuckAiMode: Boolean, 
     featureEnabled && !isDuckAiMode && inputMode == NativeInputState.InputMode.SEARCH_AND_DUCK_AI
 
 /**
- * The persistent input-mode nav bar is shown only for browser input and only while the input field
- * is empty (whitespace counts as text). Duck.ai and contextual input never show it.
+ * The persistent input-mode nav bar is shown for the whole browser-input session, regardless of
+ * whether the field has text. Duck.ai and contextual input never show it.
  */
-internal fun shouldShowNavBar(isBrowserContext: Boolean, isInputEmpty: Boolean): Boolean =
-    isBrowserContext && isInputEmpty
+internal fun shouldShowNavBar(isBrowserContext: Boolean): Boolean = isBrowserContext
 
 /**
  * Whether a visibility change is needed. [currentShown] is null before the first apply, which always

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -926,10 +926,13 @@ class RealNativeInputManager @Inject constructor(
         if (navBarView != null) {
             rootView.addView(navBarView, layoutCoordinator.buildNavBarLayoutParams(navBarHeightPx))
             // Bottom omnibar only: the autocomplete list overlaps the top strip and would draw over the
-            // bar (e.g. the Duck.ai tab's suggestions), so float it above. Top omnibar has no such overlap,
-            // and the elevation shadow there would tint the bar's background so it no longer matches the
-            // content — leave it flat.
-            if (isBottom) navBarView.translationZ = WIDGET_ELEVATION_DP.toPx()
+            // bar (e.g. the Duck.ai tab's suggestions), so float it above via translationZ. Suppress the
+            // shadow the raised Z would otherwise cast, we only want the draw order, not the elevation.
+            // Top omnibar has no such overlap, leave it flat.
+            if (isBottom) {
+                navBarView.translationZ = WIDGET_ELEVATION_DP.toPx()
+                suppressShadow(navBarView)
+            }
         }
         // Top mode offsets the widget below the nav bar so it isn't overlapped; bottom mode is unaffected.
         rootView.addView(widgetView, layoutCoordinator.buildWidgetLayoutParams(isBottom, topInsetPx = navBarHeightPx))

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -195,7 +195,10 @@ class RealNativeInputManager @Inject constructor(
     private var widgetRoot: View? = null
     private var navBarRoot: View? = null
     private var navBarShown: Boolean? = null
-    private var isKeyboardVisible: Boolean = false
+
+    // The nav bar is shown once when the browser input opens empty, then latched off the first time the
+    // user types. Latched stays off for the session — clearing text or toggling the keyboard won't bring it back.
+    private var navBarInteractionLatched: Boolean = false
     private var navBarHeightPx: Int = 0
     private var navBarIsBottom: Boolean = false
     private var navBarTabCountLiveData: LiveData<Int>? = null
@@ -445,10 +448,8 @@ class RealNativeInputManager @Inject constructor(
         } else {
             onKeyboardHidden(widget)
         }
-
-        // The nav bar is shown while the keyboard is up (both placements) and hidden when it's dismissed.
-        isKeyboardVisible = isVisible
-        refreshNavBarVisibility()
+        // Nav bar visibility is decoupled from the keyboard: it's decided at open (empty → shown) and only
+        // hidden on the first keystroke. Toggling the keyboard neither shows nor hides it.
     }
 
     private fun onKeyboardShown(widgetRoot: View?) {
@@ -543,15 +544,15 @@ class RealNativeInputManager @Inject constructor(
         }
         val isBottom = omnibarController.isDuckAiMode() || omnibarController.isOmnibarBottom()
         val widgetView = createWidgetView(layoutInflater, isBottom)
-        // The nav bar belongs to browser input only. Duck.ai (and, via a separate manager, contextual)
-        // never show it. Gated behind the nativeInputNavBar flag and Search & Duck.ai mode — search-only
-        // users, or users without the flag, never get it.
-        val navBarView = if (shouldCreateNavBar(isNavBarFeatureEnabled, omnibarController.isDuckAiMode(), inputModeCapability)) {
-            createNavBarView(layoutInflater)
-        } else {
-            null
-        }
         val prefillText = query.ifEmpty { omnibarController.getText() }
+        // The nav bar is a first-focus affordance for the empty browser input. It belongs to browser input
+        // only (Duck.ai / contextual never show it), is gated behind the nativeInputNavBar flag and the
+        // Search & Duck.ai mode, and is only created when the field opens empty — focusing a site (URL
+        // prefilled) never gets one. Fresh session, so the interaction latch resets.
+        navBarInteractionLatched = false
+        val createNavBar = shouldCreateNavBar(isNavBarFeatureEnabled, omnibarController.isDuckAiMode(), inputModeCapability) &&
+            prefillText.isEmpty()
+        val navBarView = if (createNavBar) createNavBarView(layoutInflater) else null
         bindWidget(widgetView, lifecycleOwner, tabs, currentTabUrl, callbacks, isBottom)
         if (navBarView != null) bindNavBar(navBarView, widgetView, lifecycleOwner, tabs, callbacks)
         if (!omnibarController.isDuckAiMode() && prefillText.isNotEmpty()) {
@@ -576,14 +577,11 @@ class RealNativeInputManager @Inject constructor(
             }
         }
         attachWidget(widgetView, navBarView, isBottom, tabId)
-        // The widget opens focused, so the soft keyboard rises immediately. Seed the keyboard state to
-        // match (unless a hardware keyboard means no soft IME) so the bar snaps to its resting state
-        // instead of sliding in once the real keyboard callback lands.
-        isKeyboardVisible = !isExternalKeyboardConnected()
         applyNavBarVisibility(
             show = navBarShouldBeVisible(),
             animate = false,
         )
+        syncBackArrowToNavBar()
         lifecycleOwner.lifecycleScope.launch {
             if (isDuckAiSettingsUrl(currentTabUrl.firstOrNull())) widgetView.gone()
         }
@@ -604,6 +602,7 @@ class RealNativeInputManager @Inject constructor(
     ) {
         val widget = widgetFrom(widgetView) ?: return
         val onSearchTextChanged: (String) -> Unit = { text ->
+            if (text.isNotEmpty()) onNavBarInputInteraction()
             if (omnibarController.isDuckAiMode() && text.isBlank()) {
                 callbacks.onClearAutocomplete()
             } else {
@@ -919,16 +918,30 @@ class RealNativeInputManager @Inject constructor(
         }
     }
 
-    /** Current on-screen visibility the nav bar should have, combining the create-time gate with the
-     *  browser-context rule so a live mode/flag change (e.g. Search & Duck.ai → Search-only) hides it. */
+    /** Current on-screen visibility the nav bar should have: still browser + flag + Search & Duck.ai (so a
+     *  live mode/flag change hides it) and not yet latched off by the user's first keystroke. */
     private fun navBarShouldBeVisible(): Boolean =
         shouldCreateNavBar(isNavBarFeatureEnabled, omnibarController.isDuckAiMode(), inputModeCapability) &&
-            shouldShowNavBar(isBrowserContext = navBarRoot != null, isKeyboardVisible = isKeyboardVisible)
+            shouldShowNavBar(isBrowserContext = navBarRoot != null, interactionLatched = navBarInteractionLatched)
 
     /** Re-applies the nav bar visibility for the current input state; no-op when no bar is attached. */
     private fun refreshNavBarVisibility() {
         if (navBarRoot == null) return
         applyNavBarVisibility(show = navBarShouldBeVisible(), animate = true)
+        syncBackArrowToNavBar()
+    }
+
+    /** The toggle-row back arrow is the inverse of the nav bar: it fills in as the back affordance only
+     *  while the nav bar is hidden, so exactly one back arrow shows at a time. */
+    private fun syncBackArrowToNavBar() {
+        widgetFrom(rootView)?.setNavBarVisible(navBarShown == true)
+    }
+
+    /** The user typed: latch the nav bar off for the rest of this input session and slide it out. */
+    private fun onNavBarInputInteraction() {
+        if (navBarInteractionLatched || navBarRoot == null) return
+        navBarInteractionLatched = true
+        refreshNavBarVisibility()
     }
 
     /**
@@ -1298,18 +1311,19 @@ internal fun computeVoiceButtonAvailability(
  * Whether to create the nav bar for this input session. It's a browser-input affordance gated behind the
  * [nativeInputNavBar][com.duckduckgo.duckchat.impl.feature.DuckChatFeature.nativeInputNavBar] flag and the
  * Search & Duck.ai input mode: search-only users, Duck.ai/contextual input, or a disabled flag never get it.
- * Once created, per-state visibility is decided by [shouldShowNavBar].
+ * The caller additionally only creates it when the field opens empty (a first-focus affordance), so focusing
+ * a site with a prefilled URL never gets one. Once created, on-screen visibility is decided by [shouldShowNavBar].
  */
 internal fun shouldCreateNavBar(featureEnabled: Boolean, isDuckAiMode: Boolean, inputMode: NativeInputState.InputMode): Boolean =
     featureEnabled && !isDuckAiMode && inputMode == NativeInputState.InputMode.SEARCH_AND_DUCK_AI
 
 /**
- * Whether the input-mode nav bar should currently be on screen. It's tied to the keyboard: shown while
- * the browser-input session has the keyboard up (both top and bottom placements), hidden once it's
- * dismissed. Duck.ai and contextual input never show it.
+ * Whether the input-mode nav bar should currently be on screen. It's shown for a browser-input session that
+ * opened empty and stays shown until the user's first keystroke latches it off — the keyboard state does not
+ * affect it, and once latched clearing the text won't bring it back. Duck.ai and contextual input never show it.
  */
-internal fun shouldShowNavBar(isBrowserContext: Boolean, isKeyboardVisible: Boolean): Boolean =
-    isBrowserContext && isKeyboardVisible
+internal fun shouldShowNavBar(isBrowserContext: Boolean, interactionLatched: Boolean): Boolean =
+    isBrowserContext && !interactionLatched
 
 /**
  * Whether a visibility change is needed. [currentShown] is null before the first apply, which always

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -382,7 +382,11 @@ class RealNativeInputManager @Inject constructor(
                     layoutCoordinator.resumeContentReflow()
                 },
                 onComplete = {
-                    layoutCoordinator.setWidgetAnimating(false)
+                    // Reset content under the still-suspended reflow and keep isWidgetAnimating true
+                    // until removeWidget's detach: clearing the animating flag here lets layout
+                    // listeners re-apply the exit-end inset during the fade and race the detach reset,
+                    // which is what left intermittent leftover space under the omnibar.
+                    layoutCoordinator.resetContentOffsetToBase()
                     isExiting = false
                     onHide()
                 },
@@ -1080,6 +1084,14 @@ class RealNativeInputManager @Inject constructor(
             widgetView = widgetView,
             margins = margins,
             onUpdate = { layoutCoordinator.onWidgetAnimationFrame(widgetCard) },
+            // Once the morph has the omnibar's screen position, hide it immediately when a nav bar
+            // is replacing the chrome — otherwise the omnibar sits on top of the bar for the whole
+            // enter and pops away at the end (the flicker).
+            onStart = {
+                if (navBarRoot != null) {
+                    omnibarController.hide()
+                }
+            },
             onCancel = {
                 layoutCoordinator.setWidgetAnimating(false)
                 widgetFrom(widgetView)?.let { widget ->

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -207,6 +207,7 @@ class RealNativeInputManager @Inject constructor(
     private var navBarTabCountLiveData: LiveData<Int>? = null
     private var navBarTabCountObserver: Observer<Int>? = null
     private var lastCallbacks: NativeInputCallbacks? = null
+
     /** True while an enter morph from [attachWidget] still owns [NativeInputLayoutCoordinator]'s animating flag. */
     private var pendingEnterOwnsAnimating = false
 

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -362,10 +362,11 @@ class RealNativeInputManager @Inject constructor(
             lastCallbacks?.restoreOmnibarAutocomplete?.invoke(omnibarController.getText())
         }
 
-        // Slide the nav bar out with the close instead of leaving it up until removeWidget pops it.
-        // Visual-only: exit owns content reflow / isWidgetAnimating until removeWidget, so we must not
-        // run begin/endNavBarSlide (that would resume reflow mid-exit and reintroduce the padding race).
-        if (navBarShown == true) {
+        // Bottom omnibar: slide the nav bar out with the close (visual-only — exit owns reflow /
+        // isWidgetAnimating, so no begin/endNavBarSlide). Top omnibar: leave the bar in place for
+        // the exit morph so the card morphs back to the omnibar while the buttons stay put
+        // (removed with the widget in removeWidget) — sliding it would steal that animation.
+        if (navBarShown == true && navBarIsBottom) {
             slideNavBarOutWithClose(animate = animate)
         }
 
@@ -385,11 +386,11 @@ class RealNativeInputManager @Inject constructor(
         isExiting = true
         if (!omnibarController.isDuckAiMode() && card != null && omnibarCard != null && omnibarCard.width > 0) {
             layoutCoordinator.setWidgetAnimating(true)
-            // The nav bar slides out on its own timeline (started in hideNativeInput); this exit
-            // only morphs the input card back to the omnibar. Suspend the content-reflow transition
-            // so the per-frame content offset driven by onWidgetAnimationFrame is instant; otherwise
-            // it animates on the transition's own clock and the reset-to-base races, leaving stale
-            // top padding.
+            // Bottom: nav bar may already be sliding out on its own timeline. Top: bar stays put —
+            // this exit only morphs the input card back to the omnibar. Suspend the content-reflow
+            // transition so the per-frame content offset driven by onWidgetAnimationFrame is instant;
+            // otherwise it animates on the transition's own clock and the reset-to-base races, leaving
+            // stale top padding.
             layoutCoordinator.suspendContentReflow()
             animator.animateExit(
                 widgetCard = card,
@@ -587,12 +588,17 @@ class RealNativeInputManager @Inject constructor(
             }
         }
         attachWidget(widgetView, navBarView, isBottom, tabId)
+        // Bottom omnibar: slide the nav bar in with open. Top omnibar: snap the bar so the enter
+        // morph can run from the omnibar while the buttons appear without animating — a concurrent
+        // top slide fights that morph (and was only needed for bottom chrome).
         applyNavBarVisibility(
             show = navBarShouldBeVisible(),
-            animate = true,
+            animate = isBottom,
             // Enter morph (when started) owns isWidgetAnimating until it completes; clearing it when
-            // the open slide finishes first would re-enable layout listeners mid-enter.
+            // an open slide finishes first would re-enable layout listeners mid-enter.
             clearAnimatingOnComplete = !pendingEnterOwnsAnimating,
+            // Never ride the widget during open — bottom never does; top must stay planted for morph.
+            moveWidgetWithBar = false,
         )
         syncBackArrowToNavBar()
         lifecycleOwner.lifecycleScope.launch {
@@ -963,17 +969,20 @@ class RealNativeInputManager @Inject constructor(
 
     /**
      * Shows/hides the persistent nav bar. No-op when there is no bar (non-browser context) or the bar
-     * is already in the target state. On change it slides the bar (and, in top mode, the widget) and
-     * reflows content to clear or reclaim the bar strip.
+     * is already in the target state. On change it slides the bar and reflows content to clear or
+     * reclaim the bar strip. In top mode, mid-session toggles also translate the widget with the bar
+     * unless [moveWidgetWithBar] is false (enter/exit morph — card must stay put relative to omnibar).
      *
      * @param clearAnimatingOnComplete when true (default), clears [NativeInputLayoutCoordinator]'s
      * animating flag after the slide — correct for mid-session toggles. Pass false when the slide
      * runs alongside enter/exit, which already owns that flag.
+     * @param moveWidgetWithBar top mid-session only. Bottom mode never moves the widget with the bar.
      */
     private fun applyNavBarVisibility(
         show: Boolean,
         animate: Boolean,
         clearAnimatingOnComplete: Boolean = true,
+        moveWidgetWithBar: Boolean = !navBarIsBottom,
     ) {
         val navBar = navBarRoot ?: return
         val widget = widgetRoot ?: return
@@ -988,6 +997,7 @@ class RealNativeInputManager @Inject constructor(
                 heightPx = navBarHeightPx,
                 show = show,
                 animate = false,
+                moveWidgetWithBar = moveWidgetWithBar,
                 onComplete = { layoutCoordinator.updateNavBarInset(navBarInset) },
             )
             return
@@ -1005,6 +1015,7 @@ class RealNativeInputManager @Inject constructor(
             heightPx = navBarHeightPx,
             show = show,
             animate = true,
+            moveWidgetWithBar = moveWidgetWithBar,
             onFrame = { onScreenPx -> layoutCoordinator.updateNavBarInset(onScreenPx) },
             onComplete = {
                 layoutCoordinator.updateNavBarInset(navBarInset)
@@ -1020,6 +1031,9 @@ class RealNativeInputManager @Inject constructor(
      * Hides the nav bar as UTI closes. Unlike [applyNavBarVisibility], this does not take ownership of
      * content reflow — the exit morph already suspends it and resets padding on complete. Calling
      * [NativeInputLayoutCoordinator.endNavBarSlide] here would resume reflow mid-exit.
+     *
+     * Never moves the widget with the bar: exit morph needs the card planted so it can morph back to
+     * the omnibar while the buttons slide away alone (top and bottom).
      */
     private fun slideNavBarOutWithClose(animate: Boolean) {
         val navBar = navBarRoot ?: return
@@ -1033,6 +1047,7 @@ class RealNativeInputManager @Inject constructor(
             heightPx = navBarHeightPx,
             show = false,
             animate = animate,
+            moveWidgetWithBar = false,
             onFrame = {},
             onComplete = {},
         )
@@ -1058,12 +1073,9 @@ class RealNativeInputManager @Inject constructor(
             }
         }
         // Top mode offsets the widget below the nav bar so it isn't overlapped; bottom mode is unaffected.
+        // Do not translate the widget off-screen with the bar: enter morph needs it planted so the card
+        // can grow from the omnibar while only the bar (buttons) slides in.
         rootView.addView(widgetView, layoutCoordinator.buildWidgetLayoutParams(isBottom, topInsetPx = navBarHeightPx))
-        // Top mode: the widget rides the bar. Start it off-screen with the bar so the open slide is
-        // unified (bottom mode leaves the widget alone — it only morphs from the omnibar).
-        if (navBarView != null && !isBottom) {
-            widgetView.translationY = -navBarHeightPx.toFloat()
-        }
         widgetRoot = widgetView
         navBarRoot = navBarView
 

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -204,6 +204,8 @@ class RealNativeInputManager @Inject constructor(
     private var navBarTabCountLiveData: LiveData<Int>? = null
     private var navBarTabCountObserver: Observer<Int>? = null
     private var lastCallbacks: NativeInputCallbacks? = null
+    /** True while an enter morph from [attachWidget] still owns [NativeInputLayoutCoordinator]'s animating flag. */
+    private var pendingEnterOwnsAnimating = false
 
     // The NTP top stroke is driven by hasFavorites, so we save its visibility on attach and restore it
     // on detach rather than re-showing unconditionally (which would show it with no favorites present).
@@ -350,6 +352,13 @@ class RealNativeInputManager @Inject constructor(
             lastCallbacks?.restoreOmnibarAutocomplete?.invoke(omnibarController.getText())
         }
 
+        // Slide the nav bar out with the close instead of leaving it up until removeWidget pops it.
+        // Visual-only: exit owns content reflow / isWidgetAnimating until removeWidget, so we must not
+        // run begin/endNavBarSlide (that would resume reflow mid-exit and reintroduce the padding race).
+        if (navBarShown == true) {
+            slideNavBarOutWithClose(animate = animate)
+        }
+
         if (!animate) {
             animator.cancelAnimation()
             isExiting = false
@@ -366,10 +375,11 @@ class RealNativeInputManager @Inject constructor(
         isExiting = true
         if (!omnibarController.isDuckAiMode() && card != null && omnibarCard != null && omnibarCard.width > 0) {
             layoutCoordinator.setWidgetAnimating(true)
-            // The nav bar stays in place during the exit — only the input card morphs back to the omnibar
-            // (removed with the widget in removeWidget). Suspend the content-reflow transition so the
-            // per-frame content offset driven by onWidgetAnimationFrame is instant; otherwise it animates
-            // on the transition's own clock and the reset-to-base races, leaving stale top padding.
+            // The nav bar slides out on its own timeline (started in hideNativeInput); this exit
+            // only morphs the input card back to the omnibar. Suspend the content-reflow transition
+            // so the per-frame content offset driven by onWidgetAnimationFrame is instant; otherwise
+            // it animates on the transition's own clock and the reset-to-base races, leaving stale
+            // top padding.
             layoutCoordinator.suspendContentReflow()
             animator.animateExit(
                 widgetCard = card,
@@ -569,7 +579,10 @@ class RealNativeInputManager @Inject constructor(
         attachWidget(widgetView, navBarView, isBottom, tabId)
         applyNavBarVisibility(
             show = navBarShouldBeVisible(),
-            animate = false,
+            animate = true,
+            // Enter morph (when started) owns isWidgetAnimating until it completes; clearing it when
+            // the open slide finishes first would re-enable layout listeners mid-enter.
+            clearAnimatingOnComplete = !pendingEnterOwnsAnimating,
         )
         syncBackArrowToNavBar()
         lifecycleOwner.lifecycleScope.launch {
@@ -709,6 +722,7 @@ class RealNativeInputManager @Inject constructor(
             navBarRoot = null
         }
         navBarShown = null
+        pendingEnterOwnsAnimating = false
         navBarTabCountObserver?.let { existing -> navBarTabCountLiveData?.removeObserver(existing) }
         navBarTabCountObserver = null
         navBarTabCountLiveData = null
@@ -941,8 +955,16 @@ class RealNativeInputManager @Inject constructor(
      * Shows/hides the persistent nav bar. No-op when there is no bar (non-browser context) or the bar
      * is already in the target state. On change it slides the bar (and, in top mode, the widget) and
      * reflows content to clear or reclaim the bar strip.
+     *
+     * @param clearAnimatingOnComplete when true (default), clears [NativeInputLayoutCoordinator]'s
+     * animating flag after the slide — correct for mid-session toggles. Pass false when the slide
+     * runs alongside enter/exit, which already owns that flag.
      */
-    private fun applyNavBarVisibility(show: Boolean, animate: Boolean) {
+    private fun applyNavBarVisibility(
+        show: Boolean,
+        animate: Boolean,
+        clearAnimatingOnComplete: Boolean = true,
+    ) {
         val navBar = navBarRoot ?: return
         val widget = widgetRoot ?: return
         if (!shouldAnimateNavBar(navBarShown, show)) return
@@ -960,10 +982,12 @@ class RealNativeInputManager @Inject constructor(
             )
             return
         }
-        // Drive the content offset from the bar's on-screen height every frame, under a suspended reflow
-        // transition, so the NTP/browser content moves in lock-step with the sliding bar/widget instead
-        // of lagging it (top mode) or animating on the LayoutTransition's own clock (bottom mode).
-        layoutCoordinator.beginNavBarSlide()
+        // When the open slide shares the session with enter, skip begin/endNavBarSlide: enter already
+        // owns isWidgetAnimating, and endNavBarSlide's resume would clear the LayoutTransition that
+        // onEnterComplete just assigned. Mid-session toggles (default) take full ownership.
+        if (clearAnimatingOnComplete) {
+            layoutCoordinator.beginNavBarSlide()
+        }
         animator.animateNavBarVisibility(
             navBarView = navBar,
             widgetView = widget,
@@ -974,8 +998,33 @@ class RealNativeInputManager @Inject constructor(
             onFrame = { onScreenPx -> layoutCoordinator.updateNavBarInset(onScreenPx) },
             onComplete = {
                 layoutCoordinator.updateNavBarInset(navBarInset)
-                layoutCoordinator.endNavBarSlide()
+                if (clearAnimatingOnComplete) {
+                    layoutCoordinator.endNavBarSlide()
+                    layoutCoordinator.setWidgetAnimating(false)
+                }
             },
+        )
+    }
+
+    /**
+     * Hides the nav bar as UTI closes. Unlike [applyNavBarVisibility], this does not take ownership of
+     * content reflow — the exit morph already suspends it and resets padding on complete. Calling
+     * [NativeInputLayoutCoordinator.endNavBarSlide] here would resume reflow mid-exit.
+     */
+    private fun slideNavBarOutWithClose(animate: Boolean) {
+        val navBar = navBarRoot ?: return
+        val widget = widgetRoot ?: return
+        if (!shouldAnimateNavBar(navBarShown, targetShown = false)) return
+        navBarShown = false
+        animator.animateNavBarVisibility(
+            navBarView = navBar,
+            widgetView = widget,
+            isBottom = navBarIsBottom,
+            heightPx = navBarHeightPx,
+            show = false,
+            animate = animate,
+            onFrame = {},
+            onComplete = {},
         )
     }
 
@@ -986,6 +1035,9 @@ class RealNativeInputManager @Inject constructor(
         this.navBarIsBottom = isBottom
         if (navBarView != null) {
             rootView.addView(navBarView, layoutCoordinator.buildNavBarLayoutParams(navBarHeightPx))
+            // Start off-screen so the first apply can slide the bar in (or snap it) instead of
+            // flashing it at rest for a frame. -height matches animateNavBarVisibility's hiddenY.
+            navBarView.translationY = -navBarHeightPx.toFloat()
             // Bottom omnibar only: the autocomplete list overlaps the top strip and would draw over the
             // bar (e.g. the Duck.ai tab's suggestions), so float it above via translationZ. Suppress the
             // shadow the raised Z would otherwise cast, we only want the draw order, not the elevation.
@@ -997,6 +1049,11 @@ class RealNativeInputManager @Inject constructor(
         }
         // Top mode offsets the widget below the nav bar so it isn't overlapped; bottom mode is unaffected.
         rootView.addView(widgetView, layoutCoordinator.buildWidgetLayoutParams(isBottom, topInsetPx = navBarHeightPx))
+        // Top mode: the widget rides the bar. Start it off-screen with the bar so the open slide is
+        // unified (bottom mode leaves the widget alone — it only morphs from the omnibar).
+        if (navBarView != null && !isBottom) {
+            widgetView.translationY = -navBarHeightPx.toFloat()
+        }
         widgetRoot = widgetView
         navBarRoot = navBarView
 
@@ -1007,10 +1064,14 @@ class RealNativeInputManager @Inject constructor(
 
         applyWindowChrome(widgetView, isBottom)
 
-        if (!startEnterAnimation(widgetView, isBottom)) {
+        val enterStarted = startEnterAnimation(widgetView, isBottom)
+        if (!enterStarted) {
             animator.applyLayoutTransitions(widgetView, isBottom)
             onEnterComplete(widgetView)
         }
+        // Stash so showNativeInput can avoid clearing isWidgetAnimating when the open slide
+        // finishes before the enter morph.
+        pendingEnterOwnsAnimating = enterStarted
     }
 
     override fun setInteractionLock(lock: InteractionLock) {
@@ -1093,6 +1154,7 @@ class RealNativeInputManager @Inject constructor(
                 }
             },
             onCancel = {
+                pendingEnterOwnsAnimating = false
                 layoutCoordinator.setWidgetAnimating(false)
                 widgetFrom(widgetView)?.let { widget ->
                     widget.endEnterAnimationPreview()
@@ -1102,6 +1164,7 @@ class RealNativeInputManager @Inject constructor(
                 }
             },
             onComplete = {
+                pendingEnterOwnsAnimating = false
                 layoutCoordinator.setWidgetAnimating(false)
                 onEnterComplete(widgetView)
             },
@@ -1328,8 +1391,8 @@ internal fun shouldShowNavBar(isBrowserContext: Boolean, interactionLatched: Boo
 
 /**
  * Whether a visibility change is needed. [currentShown] is null before the first apply, which always
- * applies (snaps to the resting state); otherwise apply only when the target differs — this makes
- * repeated same-state callbacks (e.g. the prefill-driven emptiness callback) no-ops.
+ * applies; otherwise apply only when the target differs — this makes repeated same-state callbacks
+ * (e.g. the prefill-driven emptiness callback) no-ops.
  */
 internal fun shouldAnimateNavBar(currentShown: Boolean?, targetShown: Boolean): Boolean =
     currentShown != targetShown

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -650,11 +650,10 @@ class RealNativeInputManager @Inject constructor(
             callbacks.onClearAutocomplete()
             previousOnChatSelected?.invoke(animate)
         }
-        widget.onClearTextTapped = {
-            if (!widget.isChatTabSelected()) {
-                callbacks.onClearAutocomplete()
-            }
-        }
+        // Clearing the field must not dismiss the focused view: onClearAutocomplete re-triggers
+        // autocomplete with hasFocus=false and hides the focused view, so on a browser tab it would
+        // wipe the favourites the empty+focused state should show. The clear's own text change already
+        // re-renders the correct empty state (favourites), so no extra handling is needed here.
     }
 
     private fun showNtp() {

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
@@ -264,8 +264,17 @@ class RealNativeInputOmnibarController(
 
     private fun restoreOmnibarContent() {
         val omnibarView = omnibar.omnibarView as? View ?: return
-        omnibarView.findViewById<View?>(R.id.omniBarContainerShadow)?.show()
-        omnibarView.findViewById<View?>(R.id.omniBarContainer)?.show()
+        // Enter morph fades the address card to 0 and intentionally leaves it there before hide().
+        // Restore must put alpha back — otherwise show() reveals an invisible field with only the
+        // trailing fire/tabs/menu icons visible (common after Search-only / Duck.ai-off teardown).
+        omnibarView.findViewById<View?>(R.id.omniBarContainerShadow)?.apply {
+            alpha = 1f
+            show()
+        }
+        omnibarView.findViewById<View?>(R.id.omniBarContainer)?.apply {
+            alpha = 1f
+            show()
+        }
         omnibarView.findViewById<View?>(R.id.endIconsContainer)?.show()
         omnibarView.findViewById<View?>(R.id.omnibarIconContainer)?.show()
         omnibarView.findViewById<View?>(R.id.omnibarTextInput)?.show()

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
@@ -264,6 +264,8 @@ class RealNativeInputOmnibarController(
 
     private fun restoreOmnibarContent() {
         val omnibarView = omnibar.omnibarView as? View ?: return
+        omnibarView.findViewById<View?>(R.id.omniBarContainerShadow)?.show()
+        omnibarView.findViewById<View?>(R.id.omniBarContainer)?.show()
         omnibarView.findViewById<View?>(R.id.endIconsContainer)?.show()
         omnibarView.findViewById<View?>(R.id.omnibarIconContainer)?.show()
         omnibarView.findViewById<View?>(R.id.omnibarTextInput)?.show()

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputOmnibarController.kt
@@ -258,6 +258,7 @@ class RealNativeInputOmnibarController(
         } else {
             rootView.findViewById<View?>(R.id.bottomBrowserOutlineStroke)?.show()
         }
+        rootView.findViewById<View?>(R.id.topBrowserOutlineStroke)?.show()
         omnibar.isScrollingEnabled = true
     }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabPageView.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/newtab/NewTabPageView.kt
@@ -67,6 +67,7 @@ import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.DuckChatInputModeState
 import com.duckduckgo.duckchat.api.InputMode
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.mobile.android.app.tracking.ui.AppTrackingProtectionScreens.AppTrackerOnboardingActivityWithEmptyParamsParams
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.navigation.api.GlobalActivityStarter.DeeplinkActivityParams
@@ -74,6 +75,7 @@ import com.duckduckgo.newtabpage.api.interactions.HatchInteractionsPlugin
 import com.duckduckgo.remote.messaging.api.RemoteMessage
 import com.duckduckgo.remote.messaging.api.SharePromoLinkIntentFactory
 import dagger.android.support.AndroidSupportInjection
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -174,8 +176,15 @@ class NewTabPageView @JvmOverloads constructor(
             .onEach { processCommands(it) }
             .launchIn(findViewTreeLifecycleOwner()?.lifecycleScope!!)
 
-        conflatedNativeInputJob += duckChat.observeNativeInputFieldUserSettingEnabled()
-            .onEach { enabled -> updateLogoMargin(enabled) }
+        conflatedNativeInputJob += combine(
+            duckChat.observeNativeInputFieldUserSettingEnabled(),
+            inputModeState.inputModeCapability,
+        ) { enabled, capability ->
+            // Search-only still has the native-input field setting on, but the browser uses the
+            // legacy omnibar — drop the UTI chrome margin so the logo isn't left too low.
+            enabled && capability != NativeInputState.InputMode.SEARCH_ONLY
+        }
+            .onEach { updateLogoMargin(it) }
             .launchIn(findViewTreeLifecycleOwner()?.lifecycleScope!!)
 
         conflatedChatModeJob += inputModeState.displayedMode

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/BottomAppBarBehavior.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/BottomAppBarBehavior.kt
@@ -56,6 +56,8 @@ class BottomAppBarBehavior<V : View>(
         R.id.browserLayout,
         R.id.includeNewBrowserTab,
         R.id.inputModeBottomRoot,
+        R.id.inputModeTopRoot,
+        R.id.inputModeWidgetNavLayout,
     )
 
     @SuppressLint("RestrictedApi")

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -950,6 +950,11 @@ class OmnibarLayout @JvmOverloads constructor(
     }
 
     private fun renderBrowserMode(viewState: ViewState) {
+        // Custom Tab / find-in-page hide the address field. Browser mode must put it back — otherwise
+        // a prior hide leaves an empty toolbar strip with only the trailing icons (especially noticeable
+        // with a bottom omnibar after tab swipe).
+        ensureBrowserAddressFieldVisible()
+
         renderOutline(viewState.hasFocus)
         renderOmnibarText(viewState)
         if (viewState.expanded) {
@@ -984,6 +989,12 @@ class OmnibarLayout @JvmOverloads constructor(
         renderPulseAnimation(viewState)
 
         renderLeadingIconState(viewState)
+    }
+
+    private fun ensureBrowserAddressFieldVisible() {
+        if (omniBarContainer.isVisible) return
+        omniBarContainer.show()
+        omnibarCardShadow.show()
     }
 
     private fun renderDuckAiMode(viewState: ViewState) {

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayout.kt
@@ -992,9 +992,14 @@ class OmnibarLayout @JvmOverloads constructor(
     }
 
     private fun ensureBrowserAddressFieldVisible() {
-        if (omniBarContainer.isVisible) return
-        omniBarContainer.show()
-        omnibarCardShadow.show()
+        if (!omniBarContainer.isVisible || omniBarContainer.alpha < 1f) {
+            omniBarContainer.alpha = 1f
+            omniBarContainer.show()
+        }
+        if (!omnibarCardShadow.isVisible || omnibarCardShadow.alpha < 1f) {
+            omnibarCardShadow.alpha = 1f
+            omnibarCardShadow.show()
+        }
     }
 
     private fun renderDuckAiMode(viewState: ViewState) {

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/NavBarVisibilityDecisionTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/NavBarVisibilityDecisionTest.kt
@@ -44,19 +44,19 @@ class NavBarVisibilityDecisionTest {
     }
 
     @Test
-    fun `nav bar shows in browser context while the keyboard is visible`() {
-        assertTrue(shouldShowNavBar(isBrowserContext = true, isKeyboardVisible = true))
+    fun `nav bar shows in browser context until the user interacts`() {
+        assertTrue(shouldShowNavBar(isBrowserContext = true, interactionLatched = false))
     }
 
     @Test
-    fun `nav bar hides when the keyboard is dismissed`() {
-        assertFalse(shouldShowNavBar(isBrowserContext = true, isKeyboardVisible = false))
+    fun `nav bar hides once the interaction latch is set`() {
+        assertFalse(shouldShowNavBar(isBrowserContext = true, interactionLatched = true))
     }
 
     @Test
     fun `nav bar never shows outside the browser context`() {
-        assertFalse(shouldShowNavBar(isBrowserContext = false, isKeyboardVisible = false))
-        assertFalse(shouldShowNavBar(isBrowserContext = false, isKeyboardVisible = true))
+        assertFalse(shouldShowNavBar(isBrowserContext = false, interactionLatched = false))
+        assertFalse(shouldShowNavBar(isBrowserContext = false, interactionLatched = true))
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/NavBarVisibilityDecisionTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/NavBarVisibilityDecisionTest.kt
@@ -44,11 +44,9 @@ class NavBarVisibilityDecisionTest {
     }
 
     @Test
-    fun `nav bar shows only in browser context with an empty field`() {
-        assertTrue(shouldShowNavBar(isBrowserContext = true, isInputEmpty = true))
-        assertFalse(shouldShowNavBar(isBrowserContext = true, isInputEmpty = false))
-        assertFalse(shouldShowNavBar(isBrowserContext = false, isInputEmpty = true))
-        assertFalse(shouldShowNavBar(isBrowserContext = false, isInputEmpty = false))
+    fun `nav bar shows for the whole browser-input session regardless of field content`() {
+        assertTrue(shouldShowNavBar(isBrowserContext = true))
+        assertFalse(shouldShowNavBar(isBrowserContext = false))
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/NavBarVisibilityDecisionTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/NavBarVisibilityDecisionTest.kt
@@ -44,9 +44,19 @@ class NavBarVisibilityDecisionTest {
     }
 
     @Test
-    fun `nav bar shows for the whole browser-input session regardless of field content`() {
-        assertTrue(shouldShowNavBar(isBrowserContext = true))
-        assertFalse(shouldShowNavBar(isBrowserContext = false))
+    fun `nav bar shows in browser context while the keyboard is visible`() {
+        assertTrue(shouldShowNavBar(isBrowserContext = true, isKeyboardVisible = true))
+    }
+
+    @Test
+    fun `nav bar hides when the keyboard is dismissed`() {
+        assertFalse(shouldShowNavBar(isBrowserContext = true, isKeyboardVisible = false))
+    }
+
+    @Test
+    fun `nav bar never shows outside the browser context`() {
+        assertFalse(shouldShowNavBar(isBrowserContext = false, isKeyboardVisible = false))
+        assertFalse(shouldShowNavBar(isBrowserContext = false, isKeyboardVisible = true))
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputAnimatorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputAnimatorTest.kt
@@ -174,4 +174,63 @@ class RealNativeInputAnimatorTest {
         assertEquals(-56f, navBar.translationY, 0f)
         assertEquals(-56f, widget.translationY, 0f)
     }
+
+    @Test
+    fun whenAnimateShowInTopModeWithoutMovingWidgetThenWidgetStaysPlanted() {
+        val navBar = FrameLayout(context).apply { translationY = 0f }
+        val widget = FrameLayout(context).apply { translationY = 0f }
+
+        testee.animateNavBarVisibility(
+            navBarView = navBar,
+            widgetView = widget,
+            isBottom = false,
+            heightPx = 56,
+            show = true,
+            animate = true,
+            moveWidgetWithBar = false,
+        )
+
+        assertEquals(-56f, navBar.translationY, 0f)
+        assertEquals(0f, widget.translationY, 0f)
+    }
+
+    @Test
+    fun whenSnapHideInTopModeWithoutMovingWidgetThenWidgetStaysPlanted() {
+        val navBar = FrameLayout(context)
+        val widget = FrameLayout(context).apply { translationY = 12f }
+
+        testee.animateNavBarVisibility(
+            navBarView = navBar,
+            widgetView = widget,
+            isBottom = false,
+            heightPx = 56,
+            show = false,
+            animate = false,
+            moveWidgetWithBar = false,
+        )
+
+        assertEquals(View.GONE, navBar.visibility)
+        assertEquals(-56f, navBar.translationY, 0f)
+        assertEquals(12f, widget.translationY, 0f)
+    }
+
+    @Test
+    fun whenMoveWidgetWithBarTrueInBottomModeThenWidgetStillUntouched() {
+        val navBar = FrameLayout(context)
+        val widget = FrameLayout(context).apply { translationY = 99f }
+
+        testee.animateNavBarVisibility(
+            navBarView = navBar,
+            widgetView = widget,
+            isBottom = true,
+            heightPx = 56,
+            show = false,
+            animate = false,
+            moveWidgetWithBar = true,
+        )
+
+        assertEquals(View.GONE, navBar.visibility)
+        assertEquals(-56f, navBar.translationY, 0f)
+        assertEquals(99f, widget.translationY, 0f)
+    }
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputAnimatorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputAnimatorTest.kt
@@ -150,4 +150,28 @@ class RealNativeInputAnimatorTest {
         assertEquals(0f, navBar.translationY, 0f)
         assertEquals(99f, widget.translationY, 0f)
     }
+
+    @Test
+    fun whenAnimateShowFromRestThenBarStartsOffScreen() {
+        val navBar = FrameLayout(context).apply { translationY = 0f }
+        val widget = FrameLayout(context).apply { translationY = 0f }
+
+        testee.animateNavBarVisibility(navBar, widget, isBottom = true, heightPx = 56, show = true, animate = true)
+
+        // Animator starts from hiddenY so the slide-in has travel; first frame may not have run yet
+        // under Robolectric, but the view must be positioned off-screen before the ValueAnimator ticks.
+        assertEquals(View.VISIBLE, navBar.visibility)
+        assertEquals(-56f, navBar.translationY, 0f)
+    }
+
+    @Test
+    fun whenAnimateShowInTopModeFromRestThenWidgetRidesOffScreenWithBar() {
+        val navBar = FrameLayout(context).apply { translationY = 0f }
+        val widget = FrameLayout(context).apply { translationY = 0f }
+
+        testee.animateNavBarVisibility(navBar, widget, isBottom = false, heightPx = 56, show = true, animate = true)
+
+        assertEquals(-56f, navBar.translationY, 0f)
+        assertEquals(-56f, widget.translationY, 0f)
+    }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -124,6 +124,10 @@ interface NativeInputWidget {
     fun setVoiceChatAvailable(available: Boolean)
     fun submitMessage(message: String?)
     fun setToggleVisible(visible: Boolean)
+
+    /** Whether the input nav bar is currently on screen. The toggle-row back arrow fills in as the back
+     *  affordance only while the nav bar (which carries its own back arrow) is hidden. */
+    fun setNavBarVisible(visible: Boolean)
     fun setFloatingSubmitContainer(container: ViewGroup)
     fun getSelectedModelId(): String?
     fun getResolvedReasoningEffort(): String?
@@ -260,6 +264,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private var isStreaming: Boolean = false
     private var attachmentLimitExceeded: Boolean = false
     private var hasAttachments: Boolean = false
+
+    // Set by the manager; the toggle-row back arrow is the inverse of this (fills in while the nav bar is hidden).
+    private var navBarVisible: Boolean = false
     private var nativeInputState: NativeInputState? = null
     private var chatSuggestionsBinding: NativeInputChatSuggestionsBinder.Binding? = null
 
@@ -740,7 +747,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     private fun updateBackButtons(state: NativeInputState) {
         findViewById<View?>(R.id.inputModeWidgetBack)?.visibility =
-            if (state.shouldShowToggleRowBack(duckChatFeature.nativeInputNavBar().isEnabled())) VISIBLE else GONE
+            if (state.shouldShowToggleRowBack(navBarVisible)) VISIBLE else GONE
         findViewById<View?>(R.id.inputModeUnifiedBack)?.visibility =
             if (state.shouldShowCardRowBack()) VISIBLE else GONE
         findViewById<View?>(R.id.inputModeWidgetBack)?.setBackgroundResource(
@@ -1069,6 +1076,12 @@ class NativeInputModeWidget @JvmOverloads constructor(
         suspendLayoutTransitions {
             applyToggleVisibility(isVisible)
         }
+    }
+
+    override fun setNavBarVisible(visible: Boolean) {
+        if (navBarVisible == visible) return
+        navBarVisible = visible
+        nativeInputState?.let { updateBackButtons(it) }
     }
 
     private inline fun suspendLayoutTransitions(block: () -> Unit) {
@@ -1623,10 +1636,11 @@ class NativeInputModeWidget @JvmOverloads constructor(
 internal fun NativeInputState.chatHintRes(): Int =
     if (chatId != null) R.string.native_input_chat_duck_mode_hint else R.string.native_input_chat_hint
 
-// The nav bar carries its own back arrow, so this one only fills in when the nav bar feature is off
-// (browser only; this arrow never renders in Duck.ai / contextual, where toggleVisible is false).
-internal fun NativeInputState.shouldShowToggleRowBack(isNavBarFeatureEnabled: Boolean): Boolean =
-    toggleVisible && inputContext == NativeInputState.InputContext.BROWSER && !isNavBarFeatureEnabled
+// The nav bar carries its own back arrow, so this one fills in as the back affordance only while the nav
+// bar is hidden — the two are never visible at once (browser only; this arrow never renders in Duck.ai /
+// contextual, where toggleVisible is false).
+internal fun NativeInputState.shouldShowToggleRowBack(isNavBarVisible: Boolean): Boolean =
+    toggleVisible && inputContext == NativeInputState.InputContext.BROWSER && !isNavBarVisible
 
 internal fun NativeInputState.shouldShowCardRowBack(): Boolean =
     !toggleVisible && inputContext == NativeInputState.InputContext.BROWSER

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -527,8 +527,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
             updateSendButtonVisibility()
             updateVoiceButtonVisibility()
             updateNewLineButtonVisibility()
-            // The toggle-row back arrow flips with text presence (inverse of the nav bar).
-            nativeInputState?.let { updateBackButtons(it) }
         }
     }
 
@@ -741,9 +739,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     private fun updateBackButtons(state: NativeInputState) {
-        val hasText = !inputField.text.isNullOrEmpty()
         findViewById<View?>(R.id.inputModeWidgetBack)?.visibility =
-            if (state.shouldShowToggleRowBack(hasText)) VISIBLE else GONE
+            if (state.shouldShowToggleRowBack(duckChatFeature.nativeInputNavBar().isEnabled())) VISIBLE else GONE
         findViewById<View?>(R.id.inputModeUnifiedBack)?.visibility =
             if (state.shouldShowCardRowBack()) VISIBLE else GONE
         findViewById<View?>(R.id.inputModeWidgetBack)?.setBackgroundResource(
@@ -1626,11 +1623,10 @@ class NativeInputModeWidget @JvmOverloads constructor(
 internal fun NativeInputState.chatHintRes(): Int =
     if (chatId != null) R.string.native_input_chat_duck_mode_hint else R.string.native_input_chat_hint
 
-// Inverse of the top nav bar: the nav bar shows its own back arrow while the field is empty, so this
-// one shows only once there is text — the two are never visible at the same time (browser only; this
-// arrow never renders in Duck.ai / contextual, where toggleVisible is false).
-internal fun NativeInputState.shouldShowToggleRowBack(hasText: Boolean): Boolean =
-    toggleVisible && inputContext == NativeInputState.InputContext.BROWSER && hasText
+// The nav bar carries its own back arrow, so this one only fills in when the nav bar feature is off
+// (browser only; this arrow never renders in Duck.ai / contextual, where toggleVisible is false).
+internal fun NativeInputState.shouldShowToggleRowBack(isNavBarFeatureEnabled: Boolean): Boolean =
+    toggleVisible && inputContext == NativeInputState.InputContext.BROWSER && !isNavBarFeatureEnabled
 
 internal fun NativeInputState.shouldShowCardRowBack(): Boolean =
     !toggleVisible && inputContext == NativeInputState.InputContext.BROWSER

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetBackButtonsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetBackButtonsTest.kt
@@ -29,27 +29,27 @@ import org.junit.Test
 class NativeInputModeWidgetBackButtonsTest {
 
     @Test
-    fun `toggle row back is shown when toggle visible, context is browser and nav bar is disabled`() {
+    fun `toggle row back is shown when toggle visible, context is browser and nav bar is hidden`() {
         val state = stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.BROWSER)
 
-        assertTrue(state.shouldShowToggleRowBack(isNavBarFeatureEnabled = false))
+        assertTrue(state.shouldShowToggleRowBack(isNavBarVisible = false))
         assertFalse(state.shouldShowCardRowBack())
     }
 
     @Test
-    fun `toggle row back is hidden when toggle visible and context is browser but the nav bar is enabled`() {
+    fun `toggle row back is hidden when toggle visible and context is browser but the nav bar is visible`() {
         // The nav bar carries its own back arrow, so this one hides to avoid two at once.
         val state = stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.BROWSER)
 
-        assertFalse(state.shouldShowToggleRowBack(isNavBarFeatureEnabled = true))
+        assertFalse(state.shouldShowToggleRowBack(isNavBarVisible = true))
     }
 
     @Test
     fun `toggle row back is hidden when toggle visible and context is duck ai`() {
         val state = stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.DUCK_AI)
 
-        assertFalse(state.shouldShowToggleRowBack(isNavBarFeatureEnabled = false))
-        assertFalse(state.shouldShowToggleRowBack(isNavBarFeatureEnabled = true))
+        assertFalse(state.shouldShowToggleRowBack(isNavBarVisible = false))
+        assertFalse(state.shouldShowToggleRowBack(isNavBarVisible = true))
         assertFalse(state.shouldShowCardRowBack())
     }
 
@@ -57,14 +57,14 @@ class NativeInputModeWidgetBackButtonsTest {
     fun `toggle row back is hidden when toggle hidden and context is browser`() {
         val state = stateOf(InputMode.SEARCH_ONLY, InputContext.BROWSER)
 
-        assertFalse(state.shouldShowToggleRowBack(isNavBarFeatureEnabled = false))
+        assertFalse(state.shouldShowToggleRowBack(isNavBarVisible = false))
     }
 
     @Test
     fun `toggle row back is hidden when toggle hidden and context is duck ai`() {
         val state = stateOf(InputMode.SEARCH_ONLY, InputContext.DUCK_AI)
 
-        assertFalse(state.shouldShowToggleRowBack(isNavBarFeatureEnabled = false))
+        assertFalse(state.shouldShowToggleRowBack(isNavBarVisible = false))
     }
 
     @Test
@@ -90,9 +90,9 @@ class NativeInputModeWidgetBackButtonsTest {
     @Test
     fun `toggle row back is hidden in duck ai contextual context`() {
         assertFalse(
-            stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.DUCK_AI_CONTEXTUAL).shouldShowToggleRowBack(isNavBarFeatureEnabled = false),
+            stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.DUCK_AI_CONTEXTUAL).shouldShowToggleRowBack(isNavBarVisible = false),
         )
-        assertFalse(stateOf(InputMode.SEARCH_ONLY, InputContext.DUCK_AI_CONTEXTUAL).shouldShowToggleRowBack(isNavBarFeatureEnabled = false))
+        assertFalse(stateOf(InputMode.SEARCH_ONLY, InputContext.DUCK_AI_CONTEXTUAL).shouldShowToggleRowBack(isNavBarVisible = false))
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetBackButtonsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetBackButtonsTest.kt
@@ -29,28 +29,27 @@ import org.junit.Test
 class NativeInputModeWidgetBackButtonsTest {
 
     @Test
-    fun `toggle row back is shown when toggle visible, context is browser and there is text`() {
+    fun `toggle row back is shown when toggle visible, context is browser and nav bar is disabled`() {
         val state = stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.BROWSER)
 
-        assertTrue(state.shouldShowToggleRowBack(hasText = true))
+        assertTrue(state.shouldShowToggleRowBack(isNavBarFeatureEnabled = false))
         assertFalse(state.shouldShowCardRowBack())
     }
 
     @Test
-    fun `toggle row back is hidden when toggle visible and context is browser but the field is empty`() {
-        // Inverse of the nav bar: when empty, the nav bar shows its own back arrow, so this one hides
-        // to avoid two back arrows at once.
+    fun `toggle row back is hidden when toggle visible and context is browser but the nav bar is enabled`() {
+        // The nav bar carries its own back arrow, so this one hides to avoid two at once.
         val state = stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.BROWSER)
 
-        assertFalse(state.shouldShowToggleRowBack(hasText = false))
+        assertFalse(state.shouldShowToggleRowBack(isNavBarFeatureEnabled = true))
     }
 
     @Test
     fun `toggle row back is hidden when toggle visible and context is duck ai`() {
         val state = stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.DUCK_AI)
 
-        assertFalse(state.shouldShowToggleRowBack(hasText = true))
-        assertFalse(state.shouldShowToggleRowBack(hasText = false))
+        assertFalse(state.shouldShowToggleRowBack(isNavBarFeatureEnabled = false))
+        assertFalse(state.shouldShowToggleRowBack(isNavBarFeatureEnabled = true))
         assertFalse(state.shouldShowCardRowBack())
     }
 
@@ -58,14 +57,14 @@ class NativeInputModeWidgetBackButtonsTest {
     fun `toggle row back is hidden when toggle hidden and context is browser`() {
         val state = stateOf(InputMode.SEARCH_ONLY, InputContext.BROWSER)
 
-        assertFalse(state.shouldShowToggleRowBack(hasText = true))
+        assertFalse(state.shouldShowToggleRowBack(isNavBarFeatureEnabled = false))
     }
 
     @Test
     fun `toggle row back is hidden when toggle hidden and context is duck ai`() {
         val state = stateOf(InputMode.SEARCH_ONLY, InputContext.DUCK_AI)
 
-        assertFalse(state.shouldShowToggleRowBack(hasText = true))
+        assertFalse(state.shouldShowToggleRowBack(isNavBarFeatureEnabled = false))
     }
 
     @Test
@@ -90,8 +89,10 @@ class NativeInputModeWidgetBackButtonsTest {
 
     @Test
     fun `toggle row back is hidden in duck ai contextual context`() {
-        assertFalse(stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.DUCK_AI_CONTEXTUAL).shouldShowToggleRowBack(hasText = true))
-        assertFalse(stateOf(InputMode.SEARCH_ONLY, InputContext.DUCK_AI_CONTEXTUAL).shouldShowToggleRowBack(hasText = true))
+        assertFalse(
+            stateOf(InputMode.SEARCH_AND_DUCK_AI, InputContext.DUCK_AI_CONTEXTUAL).shouldShowToggleRowBack(isNavBarFeatureEnabled = false),
+        )
+        assertFalse(stateOf(InputMode.SEARCH_ONLY, InputContext.DUCK_AI_CONTEXTUAL).shouldShowToggleRowBack(isNavBarFeatureEnabled = false))
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1174433894299346/task/1216620431661077?focus=true
Tech Design URL (if applicable):

### Description

Nav bar polish for the unified input, plus a first-focus visibility model and its back-arrow / lifecycle follow-ups.

Nav bar improvements:
- Improve the input-mode nav bar (back / fire / tabs / menu), suppress its shadow in bottom-bar mode, hide the top outline strokes below it, keep favourites visible when clearing the input.

Visibility model:
- The nav bar is created only when the browser input opens **empty** (focusing a site with a prefilled URL never gets one), shown with the widget, and **latched off on the first keystroke**. Once latched it stays hidden for the session — clearing the text or toggling the keyboard won't bring it back. Keyboard visibility does not drive it.
- Show/hide slide and the UTI-close exit are synced with the content offset (per-frame under a suspended reflow transition) so bar, widget and content move together.

Back arrow:
- The toggle-row back arrow mirrors the nav bar — it fills in as the back affordance only while the nav bar is hidden, so exactly one back arrow shows at a time.

Tab / lifecycle fixes:
- Dismiss the browser input when opening the tab switcher (skipped in Duck.ai, where the widget is the persistent chat input).
- Finish the input enter when the widget re-attaches (new-tab ViewPager re-attach could otherwise leave the omnibar and widget both visible with no keyboard).

Settings / capability teardown:
- Switching to **Search only** or turning **Duck.ai** off while UTI was open (or returning to NTP afterward) must fully restore the legacy omnibar — including address-field alpha and NTP content insets — so the bottom bar is not left with only fire/tabs/menu icons.

### Steps to test this PR

_Visibility_
- [ ] Internal build, `nativeInputNavBar` on. Focus the input on an NTP (empty) → nav bar visible; close the keyboard → still visible; type → slides out; clear text / reopen keyboard → stays gone
- [ ] Focus a loaded site (URL prefilled) → no nav bar, in-field back arrow shown instead
- [ ] Launch the app on an NTP → nav bar visible
- [ ] Long-press tabs to open a new tab → empty NTP → nav bar visible, omnibar hidden, keyboard up

_Back arrow_
- [ ] Nav bar visible → no in-field back arrow; after typing → in-field back arrow appears; both paths close the UTI

_Tab / lifecycle_
- [ ] Open the tab switcher from a Duck.ai chat and return → chat input + tier pill intact
- [ ] Open the tab switcher from a browser NTP with the input open → returns to a clean omnibar
- [ ] Bottom omnibar: swipe NTP ↔ other tab and back → no stacked NTP gap; address field still visible

_Settings teardown (bottom omnibar)_
- [ ] On NTP with UTI open (or after using UTI), go to **Settings → AI Features → Search only**, return to NTP → full bottom omnibar restored (address field + icons), no leftover UTI chrome / empty icon-only strip, logo not left too low
- [ ] On NTP with UTI open (or after using UTI), go to **Settings → AI Features** and **disable Duck.ai**, return to NTP → same clean legacy omnibar (address field visible and usable with keyboard), not fire/tabs/menu only

_Top vs bottom animation_
- [ ] Top omnibar: open/close UTI → card morphs from/to the omnibar; main buttons stay put (no slide stealing the morph)
- [ ] Bottom omnibar: open/close UTI → nav bar slides with content inset in sync

### UI changes

Animation-timing / visibility change (no static UI diff). Before/after screen recording to be attached in the browser.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches omnibar/native-input animation, NTP padding, and tab lifecycle across top and bottom layouts; regressions would show as visual glitches rather than data loss, but the surface area is broad.
> 
> **Overview**
> Polishes the **unified browser input (UTI)** nav bar and fixes lifecycle/animation races that left broken omnibar chrome, stacked NTP gaps, or duplicate back affordances.
> 
> **Nav bar behavior:** The bar is created only when browser input opens **empty**, shown on open, and **latched off on the first keystroke** (keyboard and clearing text no longer bring it back). The in-field toggle-row back arrow mirrors the bar—visible only while the bar is hidden. Top vs bottom omnibar diverge: bottom slides the bar with content insets; top keeps the widget planted during enter/exit morph while the bar slides alone (`moveWidgetWithBar`, `cancelMorphAnimation`).
> 
> **Content & animation:** `NativeInputLayoutCoordinator` resets/snapshots padding before reopen, suspends NTP `LayoutTransition` during per-frame inset drives, clears scroll-view margin artifacts, and syncs nav-bar slide height via `onFrame`. Enter hides the omnibar early when a nav bar replaces it; exit restores omnibar alpha and avoids flashing the faded card.
> 
> **Lifecycle:** `BrowserTabFragment` dismisses browser UTI (not Duck.ai) before the tab switcher and on tab swipe; `ShowKeyboard` uses `isNativeInputShown()` for top and bottom roots; tab visible forces omnibar expanded. Settings/mode teardown (`hideNativeInput` without requiring the feature flag) and Search-only NTP logo margin restore a full legacy omnibar after UTI was open.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5cf75f5d769029d0fe0dc85485a3ef60842159a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->