### PR TITLE
Android/Contextual/UTI: Add separate FF for contextual sheet changes

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -284,6 +284,12 @@ interface DuckChatInternal : DuckChat {
     fun isNativeChatInputEnabled(): Boolean
 
     /**
+     * Returns whether the Duck.ai contextual sheet's INPUT mode should use the native unified input.
+     * True only when [isNativeChatInputEnabled] is true AND the [contextualNativeInput] toggle is on.
+     */
+    fun isContextualNativeInputEnabled(): Boolean
+
+    /**
      * Returns whether Duck.ai in contextual mode should attach more than one content
      */
     fun areMultipleContentAttachmentsEnabled(): Boolean
@@ -449,6 +455,7 @@ class RealDuckChat @Inject constructor(
     private var areMultipleContentAttachmentsEnabled: Boolean = false
     private var isNativeInputFieldEnabled: Boolean = false
     private var isNativeChatInputEnabled: Boolean = false
+    private var isContextualNativeInputEnabled: Boolean = false
 
     init {
         if (isMainProcess) {
@@ -523,6 +530,8 @@ class RealDuckChat @Inject constructor(
     override fun isNativeStorageEnabled(): Boolean = duckAiNativeStorage
 
     override fun isNativeChatInputEnabled(): Boolean = isNativeChatInputEnabled
+
+    override fun isContextualNativeInputEnabled(): Boolean = isContextualNativeInputEnabled
 
     override fun areMultipleContentAttachmentsEnabled(): Boolean = areMultipleContentAttachmentsEnabled
 
@@ -940,6 +949,9 @@ class RealDuckChat @Inject constructor(
             isNativeInputFieldEnabled = _nativeInputFieldEnabled.value
             isNativeChatInputEnabled = isNativeInputFieldEnabled && duckChatFeature.nativeChatInput().isEnabled()
             _nativeChatInputEnabled.value = isNativeChatInputEnabled
+            // Contextual native INPUT mode is gated by nativeChatInput AND the contextualNativeInput flag.
+            // Read synchronously via isContextualNativeInputEnabled() — no flow needed (static per session).
+            isContextualNativeInputEnabled = isNativeChatInputEnabled && duckChatFeature.contextualNativeInput().isEnabled()
             _nativeInputNavBarEnabled.value = duckChatFeature.nativeInputNavBar().isEnabled()
             val inputScreenUserSettingEnabled = duckChatFeatureRepository.isInputScreenUserSettingEnabled()
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
@@ -23,9 +23,9 @@ import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.di.scopes.FragmentScope
-import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
+import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.helper.RealDuckChatJSHelper
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.NativeInputModeWidget
 import com.duckduckgo.js.messaging.api.JsMessaging
@@ -95,11 +95,12 @@ interface ContextualNativeInputManager {
 
 @ContributesBinding(FragmentScope::class)
 class RealContextualNativeInputManager @Inject constructor(
-    private val duckChat: DuckChat,
+    private val duckChatInternal: DuckChatInternal,
     private val nativeInputStatePublisher: NativeInputStatePublisher,
 ) : ContextualNativeInputManager {
 
     private var isNativeInputEnabled = false
+    private var isContextualNativeInputEnabled = false
     private var card: MaterialCardView? = null
     private var jsMessaging: JsMessaging? = null
     private var widget: NativeInputModeWidget? = null
@@ -172,13 +173,13 @@ class RealContextualNativeInputManager @Inject constructor(
 
     override fun onInputMode() {
         lastMode = Mode.INPUT
-        if (isNativeInputEnabled) {
+        if (isContextualNativeInputEnabled) {
             // The unified input widget is the composer for the initial sheet.
             card?.show()
             // INPUT mode is a new chat: restore the picker so the user can pick a model before starting.
             modelPickerEnabled.value = true
         } else {
-            // Flag off: the legacy EditText composer is shown instead, so keep the widget card hidden.
+            // contextualNativeInput off: the legacy EditText composer is shown instead, so keep the card hidden.
             card?.gone()
         }
     }
@@ -248,12 +249,10 @@ class RealContextualNativeInputManager @Inject constructor(
     }
 
     private fun observeNativeInputSetting(lifecycleOwner: LifecycleOwner) {
-        duckChat.observeNativeChatInputEnabled()
+        isContextualNativeInputEnabled = duckChatInternal.isContextualNativeInputEnabled()
+        duckChatInternal.observeNativeChatInputEnabled()
             .onEach { isEnabled ->
                 isNativeInputEnabled = isEnabled
-                // Re-apply the current mode so the card shows/hides immediately when the flag
-                // flips at runtime — otherwise a card left over from WEBVIEW mode would overlap
-                // the web input after the flag turns off.
                 when (lastMode) {
                     Mode.WEBVIEW -> onWebViewMode()
                     Mode.INPUT -> onInputMode()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -235,7 +235,7 @@ class DuckChatContextualFragment :
                 val imeVisible = heightDiff > threshold
                 if (imeVisible != isKeyboardVisible) {
                     isKeyboardVisible = imeVisible
-                    val composerHasFocus = if (viewModel.viewState.value.nativeChatInputEnabled) {
+                    val composerHasFocus = if (viewModel.viewState.value.contextualNativeInputEnabled) {
                         binding.contextualNativeInputWidget.hasFocus()
                     } else {
                         binding.contextualModeNativeContent.hasFocus()
@@ -599,7 +599,7 @@ class DuckChatContextualFragment :
             viewModel.addPageContext(fromPlaceholderTap = true)
         }
         binding.contextualPromptQuickAction.setOnClickListener {
-            val currentInput = if (viewModel.viewState.value.nativeChatInputEnabled) {
+            val currentInput = if (viewModel.viewState.value.contextualNativeInputEnabled) {
                 binding.contextualNativeInputWidget.text
             } else {
                 binding.legacyInputField.text.toString()
@@ -677,7 +677,7 @@ class DuckChatContextualFragment :
                     }
 
                     is DuckChatContextualViewModel.Command.FocusInput -> {
-                        if (viewModel.viewState.value.nativeChatInputEnabled) {
+                        if (viewModel.viewState.value.contextualNativeInputEnabled) {
                             binding.contextualNativeInputWidget.focusInput(activity)
                         } else {
                             binding.legacyInputField.let {
@@ -759,8 +759,8 @@ class DuckChatContextualFragment :
                 }
                 binding.contextualFire.gone()
 
-                if (viewState.nativeChatInputEnabled) {
-                    // The unified input widget is the composer; ContextualNativeInputManager.onInputMode()
+                if (viewState.contextualNativeInputEnabled) {
+                    // The unified input widget is the INPUT composer; ContextualNativeInputManager.onInputMode()
                     // shows its card. Hide the legacy EditText composer and its context chip/placeholder.
                     binding.contextualModeNativeContent.gone()
                 } else {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -160,6 +160,7 @@ class DuckChatContextualViewModel @Inject constructor(
                 prompt = "",
                 isFireButtonEnabled = false,
                 quickActionState = QuickActionState.LEGACY_SUMMARIZE,
+                contextualNativeInputEnabled = duckChatInternal.isContextualNativeInputEnabled(),
             ),
         )
     val viewState: StateFlow<ViewState> = _viewState.asStateFlow()
@@ -263,9 +264,8 @@ class DuckChatContextualViewModel @Inject constructor(
         // When true, the legacy "+" icon is replaced by the chats icon and shown regardless of sheet mode.
         val showChatsIcon: Boolean = false,
         val recentChats: List<ChatHistoryItem> = emptyList(),
-        // When true, the initial (INPUT) sheet uses the unified input widget as its composer instead
-        // of the legacy EditText. Mirrors duckChat.observeNativeChatInputEnabled().
         val nativeChatInputEnabled: Boolean = false,
+        val contextualNativeInputEnabled: Boolean = false,
     )
 
     fun onSheetReopened() {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -319,4 +319,14 @@ interface DuckChatFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun removeChatHistory(): Toggle
+
+    /**
+     * @return `true` when the Duck.ai contextual sheet's initial INPUT state should use the native
+     * unified input widget as its composer. Gated together with [nativeChatInput] (and
+     * [nativeInputField]): when this is off but native chat input is on, the contextual sheet uses
+     * the legacy input for INPUT mode while still using the native widget in WEBVIEW (in-chat) mode.
+     * When native chat input is off, this has no effect (everything falls back to legacy/web input).
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun contextualNativeInput(): Toggle
 }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -380,6 +380,42 @@ class RealDuckChatTest {
     }
 
     @Test
+    fun whenNativeChatInputAndContextualNativeInputEnabledThenObserveContextualNativeInputEmitsTrue() = runTest {
+        duckChatFeature.nativeInputField().setRawStoredState(State(enable = true))
+        duckChatFeature.nativeChatInput().setRawStoredState(State(enable = true))
+        duckChatFeature.contextualNativeInput().setRawStoredState(State(enable = true))
+
+        testee.onPrivacyConfigDownloaded()
+        advanceUntilIdle()
+
+        assertTrue(testee.isContextualNativeInputEnabled())
+    }
+
+    @Test
+    fun whenNativeChatInputEnabledButContextualNativeInputDisabledThenObserveContextualNativeInputEmitsFalse() = runTest {
+        duckChatFeature.nativeInputField().setRawStoredState(State(enable = true))
+        duckChatFeature.nativeChatInput().setRawStoredState(State(enable = true))
+        duckChatFeature.contextualNativeInput().setRawStoredState(State(enable = false))
+
+        testee.onPrivacyConfigDownloaded()
+        advanceUntilIdle()
+
+        assertFalse(testee.isContextualNativeInputEnabled())
+    }
+
+    @Test
+    fun whenContextualNativeInputEnabledButNativeChatInputDisabledThenObserveContextualNativeInputEmitsFalse() = runTest {
+        duckChatFeature.nativeInputField().setRawStoredState(State(enable = true))
+        duckChatFeature.nativeChatInput().setRawStoredState(State(enable = false))
+        duckChatFeature.contextualNativeInput().setRawStoredState(State(enable = true))
+
+        testee.onPrivacyConfigDownloaded()
+        advanceUntilIdle()
+
+        assertFalse(testee.isContextualNativeInputEnabled())
+    }
+
+    @Test
     fun whenSetChatSuggestionsUserSettingThenRepositorySetCalled() = runTest {
         testee.setChatSuggestionsUserSetting(true)
         verify(mockDuckChatFeatureRepository).setChatSuggestionsUserSetting(true)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealContextualNativeInputManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealContextualNativeInputManagerTest.kt
@@ -23,9 +23,9 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
-import com.duckduckgo.duckchat.api.DuckChat
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
+import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.NativeInputModeWidget
 import com.duckduckgo.js.messaging.api.JsMessaging
 import com.google.android.material.card.MaterialCardView
@@ -54,9 +54,9 @@ class RealContextualNativeInputManagerTest {
     @get:Rule
     val coroutineRule = CoroutineTestRule()
 
-    private val duckChat: DuckChat = mock()
+    private val duckChatInternal: DuckChatInternal = mock()
     private val publisher: NativeInputStatePublisher = mock()
-    private val testee = RealContextualNativeInputManager(duckChat, publisher)
+    private val testee = RealContextualNativeInputManager(duckChatInternal, publisher)
 
     @Test
     fun `when onContextualClosed called with blank tabId then publisher is not touched`() {
@@ -106,7 +106,8 @@ class RealContextualNativeInputManagerTest {
     @Test
     fun `when webview mode then input mode modelPickerEnabled emits false then true`() = runTest {
         val enabled = MutableStateFlow(true)
-        whenever(duckChat.observeNativeChatInputEnabled()).thenReturn(enabled)
+        whenever(duckChatInternal.observeNativeChatInputEnabled()).thenReturn(enabled)
+        whenever(duckChatInternal.isContextualNativeInputEnabled()).thenReturn(true)
         val widget = mock<NativeInputModeWidget>()
         val pickerFlowCaptor = argumentCaptor<Flow<Boolean>>()
         testee.init(
@@ -137,7 +138,7 @@ class RealContextualNativeInputManagerTest {
     @Test
     fun `when native chat input flips off in web view mode then card is hidden`() {
         val enabled = MutableStateFlow(true)
-        whenever(duckChat.observeNativeChatInputEnabled()).thenReturn(enabled)
+        whenever(duckChatInternal.observeNativeChatInputEnabled()).thenReturn(enabled)
         val card = mockCard()
         val widget = mock<NativeInputModeWidget>()
         testee.init(
@@ -157,9 +158,10 @@ class RealContextualNativeInputManagerTest {
     }
 
     @Test
-    fun `when native chat input enabled and onInputMode then card shown`() {
+    fun `when contextual native input enabled and onInputMode then card shown`() {
         val enabled = MutableStateFlow(true)
-        whenever(duckChat.observeNativeChatInputEnabled()).thenReturn(enabled)
+        whenever(duckChatInternal.observeNativeChatInputEnabled()).thenReturn(enabled)
+        whenever(duckChatInternal.isContextualNativeInputEnabled()).thenReturn(true)
         val card = mockCard()
         // View.show() only writes visibility when it isn't already VISIBLE; a mock defaults to 0
         // (VISIBLE), so start it GONE to observe the transition.
@@ -185,7 +187,7 @@ class RealContextualNativeInputManagerTest {
     @Test
     fun `when native chat input disabled and onInputMode then card hidden`() {
         val enabled = MutableStateFlow(false)
-        whenever(duckChat.observeNativeChatInputEnabled()).thenReturn(enabled)
+        whenever(duckChatInternal.observeNativeChatInputEnabled()).thenReturn(enabled)
         val card = mockCard()
         val widget = mock<NativeInputModeWidget>()
         testee.init(
@@ -206,7 +208,7 @@ class RealContextualNativeInputManagerTest {
     @Test
     fun `when input mode and chat submitted then routes to new chat callback with widget selections`() {
         val enabled = MutableStateFlow(true)
-        whenever(duckChat.observeNativeChatInputEnabled()).thenReturn(enabled)
+        whenever(duckChatInternal.observeNativeChatInputEnabled()).thenReturn(enabled)
         val widget = mock<NativeInputModeWidget>()
         whenever(widget.getSelectedModelId()).thenReturn("model-1")
         whenever(widget.getResolvedReasoningEffort()).thenReturn("high")
@@ -237,7 +239,7 @@ class RealContextualNativeInputManagerTest {
     @Test
     fun `when web view mode and chat submitted then routes to prompt callback and does not send event directly`() {
         val enabled = MutableStateFlow(true)
-        whenever(duckChat.observeNativeChatInputEnabled()).thenReturn(enabled)
+        whenever(duckChatInternal.observeNativeChatInputEnabled()).thenReturn(enabled)
         val widget = mock<NativeInputModeWidget>()
         whenever(widget.getSelectedModelId()).thenReturn("model-1")
         val jsMessaging = mock<JsMessaging>()
@@ -268,7 +270,7 @@ class RealContextualNativeInputManagerTest {
     @Test
     fun `when chat submitted before any mode set then routes to new chat callback`() {
         val enabled = MutableStateFlow(true)
-        whenever(duckChat.observeNativeChatInputEnabled()).thenReturn(enabled)
+        whenever(duckChatInternal.observeNativeChatInputEnabled()).thenReturn(enabled)
         val widget = mock<NativeInputModeWidget>()
         val jsMessaging = mock<JsMessaging>()
         var submitted: NativeInputPrompt? = null

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/messaging/fakes/FakeDuckChatInternal.kt
@@ -181,6 +181,8 @@ class FakeDuckChatInternal(
     override fun isNativeStorageEnabled(): Boolean = false
     override fun isNativeChatInputEnabled(): Boolean = false
 
+    override fun isContextualNativeInputEnabled(): Boolean = false
+
     override fun keepSessionIntervalInMinutes(): Int = 30
 
     override fun isInputScreenFeatureAvailable(): Boolean = false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1216619502028207?focus=true
Tech Design URL (if applicable): 

### Description
 - Brings the native unified input (UTI) to the Duck.ai contextual sheet, replacing the legacy EditText composer in the the initial INPUT state.
 - Gates INPUT vs WEBVIEW composers with two flags under aiChat: nativeChatInput (in-chat/WEBVIEW native composer) and the new contextualNativeInput (initial INPUT native composer). With both on → native
everywhere; nativeChatInput only → legacy INPUT + native WEBVIEW; neither → legacy INPUT + web WEBVIEW.

### Steps to test this PR
Setup
 - [x] Internal build installed `nativeChatInput`, `contextualNativeInput` default to INTERNAL/on)
 - [x] Open a web page, then open the Duck.ai contextual sheet from the omnibar
 - [x] For per-flag cases, override the flags via the dev feature-flag screen and relaunch

  1. `nativeChatInput` ON, `contextualNativeInput` ON
 - [x] INPUT mode shows the native unified input (rounded floating card), not the legacy EditText
 - [x] The native input's left controls (attach / model picker / tools) ARE visible
 - [x] Close and re-open sheet, verify input remains native with all controls visible.
 - [x] Sending a prompt switches to WEBVIEW and the in-chat composer is the native card
 - [x] Follow-up prompts in WEBVIEW submit through the native card

  2. `nativeChatInput` ON, `contextualNativeInput` OFF
 - [x] INPUT mode shows the legacy input composer (not the native card) and only shows send icon + placeholder  when Ask about page is selected.
 - [x] Close and re-open sheet, verify input remains legacy.
 - [x] After sending, WEBVIEW mode's in-chat composer IS the native card
 - [x] Legacy INPUT clear-text button clears the field; send button submits

  3. `nativeChatInput` OFF (with contextualNativeInput either value)
 - [x] INPUT mode shows the legacy input composer
 - [x]  Close and re-open sheet, verify input remains legacy.
 - [x] After sending, WEBVIEW mode uses the web page's input (native card is NOT shown)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes contextual-sheet input UX behind new feature flags with a dual-composer matrix; risk is moderate rollout/complexity in Duck.ai, not security or data handling.
> 
> **Overview**
> Adds a new **`contextualNativeInput`** remote flag under `aiChat` so the Duck.ai contextual sheet can roll out the native unified input (UTI) for the **initial INPUT state** independently of in-chat composition.
> 
> **`isContextualNativeInputEnabled()`** is true only when **`nativeChatInput`** (and the native input field) are already on **and** **`contextualNativeInput`** is on. **`nativeChatInput`** alone still drives the native card in **WEBVIEW** (active chat); when **`contextualNativeInput`** is off, INPUT keeps the legacy EditText while WEBVIEW can still use the native widget.
> 
> The contextual fragment and **`ContextualNativeInputManager`** now branch on **`contextualNativeInputEnabled`** for INPUT-mode UI (composer visibility, keyboard focus, quick actions, legacy vs native layout). Unit tests cover the combined flag matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16a87c6374598cff932cbecce415d3f874b31ebe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->