### PR TITLE
Quick Win: Android: Hide Disable Privacy Protection menu option when on SERP

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/menu/BrowserMenuViewStateFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/menu/BrowserMenuViewStateFactory.kt
@@ -139,7 +139,7 @@ class RealBrowserMenuViewStateFactory @Inject constructor(
         serpLogoUrl: String? = null,
         siteUrl: String? = null,
     ): BrowserMenuViewState.Browser {
-        val isDuckDuckGoSerp = siteUrl?.let { duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(it) } ?: false
+        val isDuckDuckGoPage = siteUrl?.let { duckDuckGoUrlDetector.isDuckDuckGoUrl(it) } ?: false
         return BrowserMenuViewState.Browser(
             canGoBack = browserViewState.canGoBack,
             canGoForward = browserViewState.canGoForward,
@@ -163,9 +163,9 @@ class RealBrowserMenuViewStateFactory @Inject constructor(
             canFindInPage = browserViewState.canFindInPage && browserViewState.currentPdfCachedUri == null,
             addToHomeVisible = browserViewState.addToHomeVisible,
             addToHomeEnabled = browserViewState.addToHomeEnabled,
-            canChangePrivacyProtection = browserViewState.canChangePrivacyProtection && !isDuckDuckGoSerp,
+            canChangePrivacyProtection = browserViewState.canChangePrivacyProtection && !isDuckDuckGoPage,
             isPrivacyProtectionDisabled = browserViewState.isPrivacyProtectionDisabled,
-            canReportSite = browserViewState.canReportSite && !isDuckDuckGoSerp,
+            canReportSite = browserViewState.canReportSite && !isDuckDuckGoPage,
             showAutofill = browserViewState.showAutofill,
             isSSLError = browserViewState.sslError != NONE,
             canPrintPage = browserViewState.canPrintPage,

--- a/app/src/main/java/com/duckduckgo/app/browser/menu/BrowserMenuViewStateFactory.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/menu/BrowserMenuViewStateFactory.kt
@@ -139,6 +139,7 @@ class RealBrowserMenuViewStateFactory @Inject constructor(
         serpLogoUrl: String? = null,
         siteUrl: String? = null,
     ): BrowserMenuViewState.Browser {
+        val isDuckDuckGoSerp = siteUrl?.let { duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(it) } ?: false
         return BrowserMenuViewState.Browser(
             canGoBack = browserViewState.canGoBack,
             canGoForward = browserViewState.canGoForward,
@@ -162,9 +163,9 @@ class RealBrowserMenuViewStateFactory @Inject constructor(
             canFindInPage = browserViewState.canFindInPage && browserViewState.currentPdfCachedUri == null,
             addToHomeVisible = browserViewState.addToHomeVisible,
             addToHomeEnabled = browserViewState.addToHomeEnabled,
-            canChangePrivacyProtection = browserViewState.canChangePrivacyProtection,
+            canChangePrivacyProtection = browserViewState.canChangePrivacyProtection && !isDuckDuckGoSerp,
             isPrivacyProtectionDisabled = browserViewState.isPrivacyProtectionDisabled,
-            canReportSite = browserViewState.canReportSite,
+            canReportSite = browserViewState.canReportSite && !isDuckDuckGoSerp,
             showAutofill = browserViewState.showAutofill,
             isSSLError = browserViewState.sslError != NONE,
             canPrintPage = browserViewState.canPrintPage,

--- a/app/src/test/java/com/duckduckgo/app/browser/menu/RealBrowserMenuViewStateFactoryTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/menu/RealBrowserMenuViewStateFactoryTest.kt
@@ -598,6 +598,58 @@ class RealBrowserMenuViewStateFactoryTest {
     }
 
     @Test
+    fun `when browser page is a duckduckgo search results page then privacy protection and report site items are hidden`() = runTest {
+        val serpUrl = "https://duckduckgo.com/?q=cats"
+        whenever(duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(serpUrl)).thenReturn(true)
+        val browserViewState = BrowserViewState(
+            canChangePrivacyProtection = true,
+            isPrivacyProtectionDisabled = false,
+            canReportSite = true,
+        )
+
+        val result = testee.create(
+            omnibarViewMode = ViewMode.Browser(serpUrl),
+            viewState = browserViewState,
+            customTabsMode = false,
+            tabId = "",
+            title = null,
+            shortUrl = null,
+            omnibarText = null,
+            siteUrl = serpUrl,
+        )
+        val viewState = result as BrowserMenuViewState.Browser
+
+        assertFalse(viewState.canChangePrivacyProtection)
+        assertFalse(viewState.canReportSite)
+    }
+
+    @Test
+    fun `when browser page is not a duckduckgo search results page then privacy protection and report site items propagate`() = runTest {
+        val siteUrl = "https://example.com/page"
+        whenever(duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(siteUrl)).thenReturn(false)
+        val browserViewState = BrowserViewState(
+            canChangePrivacyProtection = true,
+            isPrivacyProtectionDisabled = false,
+            canReportSite = true,
+        )
+
+        val result = testee.create(
+            omnibarViewMode = ViewMode.Browser(siteUrl),
+            viewState = browserViewState,
+            customTabsMode = false,
+            tabId = "",
+            title = null,
+            shortUrl = null,
+            omnibarText = null,
+            siteUrl = siteUrl,
+        )
+        val viewState = result as BrowserMenuViewState.Browser
+
+        assertTrue(viewState.canChangePrivacyProtection)
+        assertTrue(viewState.canReportSite)
+    }
+
+    @Test
     fun `when error with no site but omnibarText then page context header is Error with omnibarText`() = runTest {
         val result = testee.create(
             omnibarViewMode = ViewMode.Browser("https://broken-site.com/"),

--- a/app/src/test/java/com/duckduckgo/app/browser/menu/RealBrowserMenuViewStateFactoryTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/menu/RealBrowserMenuViewStateFactoryTest.kt
@@ -600,7 +600,7 @@ class RealBrowserMenuViewStateFactoryTest {
     @Test
     fun `when browser page is a duckduckgo search results page then privacy protection and report site items are hidden`() = runTest {
         val serpUrl = "https://duckduckgo.com/?q=cats"
-        whenever(duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(serpUrl)).thenReturn(true)
+        whenever(duckDuckGoUrlDetector.isDuckDuckGoUrl(serpUrl)).thenReturn(true)
         val browserViewState = BrowserViewState(
             canChangePrivacyProtection = true,
             isPrivacyProtectionDisabled = false,
@@ -624,9 +624,35 @@ class RealBrowserMenuViewStateFactoryTest {
     }
 
     @Test
-    fun `when browser page is not a duckduckgo search results page then privacy protection and report site items propagate`() = runTest {
+    fun `when browser page is a non-search duckduckgo page then privacy protection and report site items are hidden`() = runTest {
+        val ddgUrl = "https://duckduckgo.com/about"
+        whenever(duckDuckGoUrlDetector.isDuckDuckGoUrl(ddgUrl)).thenReturn(true)
+        val browserViewState = BrowserViewState(
+            canChangePrivacyProtection = true,
+            isPrivacyProtectionDisabled = false,
+            canReportSite = true,
+        )
+
+        val result = testee.create(
+            omnibarViewMode = ViewMode.Browser(ddgUrl),
+            viewState = browserViewState,
+            customTabsMode = false,
+            tabId = "",
+            title = null,
+            shortUrl = null,
+            omnibarText = null,
+            siteUrl = ddgUrl,
+        )
+        val viewState = result as BrowserMenuViewState.Browser
+
+        assertFalse(viewState.canChangePrivacyProtection)
+        assertFalse(viewState.canReportSite)
+    }
+
+    @Test
+    fun `when browser page is not a duckduckgo page then privacy protection and report site items propagate`() = runTest {
         val siteUrl = "https://example.com/page"
-        whenever(duckDuckGoUrlDetector.isDuckDuckGoQueryUrl(siteUrl)).thenReturn(false)
+        whenever(duckDuckGoUrlDetector.isDuckDuckGoUrl(siteUrl)).thenReturn(false)
         val browserViewState = BrowserViewState(
             canChangePrivacyProtection = true,
             isPrivacyProtectionDisabled = false,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200581511062568/task/1215963476579104?focus=true
Tech Design URL (if applicable):

### Description

When viewing any duckduckgo.com page (including SERP), the browser overflow menu now hides the "Disable/Enable Privacy Protection" and "Report Broken Site" items. These actions don't apply to DuckDuckGo's own pages, so they shouldn't be offered there.

The gating lives in RealBrowserMenuViewStateFactory (the browser-menu state mapping layer), which already receives the current page URL and injects DuckDuckGoUrlDetector. We use isDuckDuckGoUrl() to force canChangePrivacyProtection and canReportSite to false on any DDG page

  Scope notes:
  - Applies to all duckduckgo.com pages — search results, homepage, and other DDG pages.
  - Applies to the standard browser menu (not custom tabs or the Duck.ai menu).
  - The source flags in BrowserTabViewModel are intentionally left untouched, so other consumers (omnibar privacy shield, broken-site flows elsewhere) are unchanged.

  Added unit tests in RealBrowserMenuViewStateFactoryTest covering a DDG search results page, a non-search DDG page, and a non-DDG page (items propagate).


### Steps to test this PR

- [x]  Install the build and open the app.
- [x]  Perform a search on DuckDuckGo (e.g. type cats and search) so the results page loads, then open the overflow menu.
- [x] Verify "Disable Privacy Protection" and "Report Broken Site" are not shown.
- [x] Navigate to the DuckDuckGo homepage (https://duckduckgo.com, no search query) and open the overflow menu.
- [x] Verify both items are not shown.
- [x] Navigate to any regular website (e.g. https://example.com) and open the overflow menu.
- [x] Verify "Disable Privacy Protection" and "Report Broken Site" are shown as usual.

### UI changes

| Before | After |
| --- | --- |
|<img width="1080" height="2424" alt="Screenshot_20260716_120128" src="https://github.com/user-attachments/assets/b38492d5-7bd4-471e-af0c-89e3d0333d74" />|<img width="1080" height="2424" alt="Screenshot_20260716_120328" src="https://github.com/user-attachments/assets/a9b306ce-b9b9-4812-96c4-718d37bdc7bd" />|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only gating in the browser menu factory; underlying privacy and broken-site state in the tab view model is unchanged.
> 
> **Overview**
> The standard browser overflow menu no longer offers **Disable/Enable Privacy Protection** or **Report Broken Site** when the current tab URL is detected as a DuckDuckGo page.
> 
> `RealBrowserMenuViewStateFactory` now derives `isDuckDuckGoPage` from `siteUrl` via `DuckDuckGoUrlDetector.isDuckDuckGoUrl` and ANDs that with the existing `canChangePrivacyProtection` and `canReportSite` flags from `BrowserViewState`, so only the menu mapping layer changes—custom tabs and other menu modes are untouched.
> 
> Unit tests cover DuckDuckGo SERP URLs, other DuckDuckGo paths (e.g. `/about`), and third-party sites to assert the two menu flags are hidden or preserved accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1475f66e150549d9f3d13ad98486b96ec72386af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->