### PR TITLE
Improve AdBlockingMenuController KDoc

### DIFF
--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuController.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/menu/AdBlockingMenuController.kt
@@ -53,13 +53,12 @@ interface AdBlockingMenuController {
     fun onChoiceSelected(choice: AdBlockingChoice)
 
     /**
-     * Handles a tap on the "Enable" browsing-menu row, enabling ad blocking directly without
-     * showing the choice sheet.
+     * Handles a tap on the "Enable" browsing-menu row, enabling ad blocking.
      */
     fun onEnableTapped()
 
     /**
-     * Handles a tap on the "Disable" browsing-menu row, which opens the disable-mode picker.
+     * Handles a tap on the "Disable" browsing-menu row.
      */
     fun onDisableTapped()
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212227266948491/task/1216622332001863?focus=true
Tech Design URL (if applicable): 

### Description

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only changes with no logic, security, or data-handling impact.
> 
> **Overview**
> Updates **KDoc** on `AdBlockingMenuController` only—no runtime or API behavior changes.
> 
> For `onEnableTapped()`, the comment no longer says enabling happens *without* showing the choice sheet. For `onDisableTapped()`, it no longer states that the row *opens the disable-mode picker*. The descriptions are shortened to match the current menu flow without baking in UI navigation details in the interface docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c71c0ef3f8278c36298c77d785427f66594931f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->