### PR TITLE
Add value param to all onboarding clicked events

### DIFF
--- a/PixelDefinitions/pixels/definitions/onboarding.json5
+++ b/PixelDefinitions/pixels/definitions/onboarding.json5
@@ -144,7 +144,7 @@
         ]
     },
     "onboarding_set-default": {
-        "description": "Set-as-default-browser step. shown when the comparison/set-default screen is displayed; clicked (no value) when the user taps 'Choose your browser'; confirmed ddg/other after the OS default-browser chooser returns. Unique once per user per (event, value).",
+        "description": "Set-as-default-browser step. shown when the comparison/set-default screen is displayed; clicked engage when the user taps 'Choose your browser'; confirmed ddg/other after the OS default-browser chooser returns. Unique once per user per (event, value).",
         "owners": ["catalinradoiu"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
@@ -167,8 +167,8 @@
             {
                 "key": "value",
                 "type": "string",
-                "description": "Only set when e=confirmed: the resulting default browser. Absent for shown and clicked.",
-                "enum": ["ddg", "other"]
+                "description": "Set to engage when e=clicked. When e=confirmed, the resulting default browser. Absent for shown.",
+                "enum": ["engage", "ddg", "other"]
             }
         ]
     },
@@ -319,7 +319,7 @@
         ]
     },
     "onboarding_ai-intro": {
-        "description": "AI intro step. shown when the AI comparison chart is displayed; clicked (no value) when the user taps the primary CTA. Unique once per user per event.",
+        "description": "AI intro step. shown when the AI comparison chart is displayed; clicked engage when the user taps the primary CTA. Unique once per user per event.",
         "owners": ["catalinradoiu"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
@@ -338,11 +338,12 @@
                 "description": "Days since install (0-28). Omitted when more than 28 days have passed since install."
             },
             { "key": "flow", "type": "string", "description": "Onboarding flow type", "enum": ["default", "duckai"] },
-            { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] }
+            { "key": "pixelSource", "type": "string", "description": "Device form factor", "enum": ["phone", "tablet"] },
+            { "key": "value", "type": "string", "description": "Only set when e=clicked.", "enum": ["engage"] }
         ]
     },
     "onboarding_fire-button": {
-        "description": "Fire-button demo step. shown when the in-browser fire-button demo is presented; clicked (no value) when the demo completes. Displayed both in the Duck.ai flow, on the chat tab, and in the regular flow in the browser tab.",
+        "description": "Fire-button demo step. shown when the in-browser fire-button demo is presented; clicked engage when the demo completes. Displayed both in the Duck.ai flow, on the chat tab, and in the regular flow in the browser tab.",
         "owners": ["catalinradoiu"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
@@ -367,7 +368,8 @@
                 "type": "string",
                 "description": "Duck.ai search/chat branch. Set only in the custom Duck.ai flow.",
                 "enum": ["search_plus_duckai-search", "search_plus_duckai-chat"]
-            }
+            },
+            { "key": "value", "type": "string", "description": "Only set when e=clicked.", "enum": ["engage"] }
         ]
     },
     "onboarding_search": {

--- a/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProvider.kt
@@ -434,7 +434,7 @@ class NewUserOnboardingPlanProvider @Inject constructor(
                             PREONBOARDING_CHOOSE_BROWSER_PRESSED,
                             mapOf(PixelParameter.DEFAULT_BROWSER to (!showDefaultBrowserDialog).toString()),
                         )
-                        onboardingPixelSender.fire(pixelName, OnboardingPixelAction.Clicked())
+                        onboardingPixelSender.fire(pixelName, OnboardingPixelAction.Clicked(engaged = true))
                         Advance
                     }
                     else -> Stay
@@ -557,7 +557,7 @@ class NewUserOnboardingPlanProvider @Inject constructor(
             transition = { event ->
                 when {
                     event is NewUserOnboardingEvent.ContinueClicked -> {
-                        onboardingPixelSender.fire(pixelName, OnboardingPixelAction.Clicked())
+                        onboardingPixelSender.fire(pixelName, OnboardingPixelAction.Clicked(engaged = true))
                         Advance
                     }
                     else -> Stay
@@ -611,7 +611,7 @@ class NewUserOnboardingPlanProvider @Inject constructor(
             transition = { event ->
                 when {
                     event is NewUserOnboardingEvent.DuckAiFireCompleted -> {
-                        onboardingPixelSender.fire(pixelName, OnboardingPixelAction.Clicked())
+                        onboardingPixelSender.fire(pixelName, OnboardingPixelAction.Clicked(engaged = true))
                         Advance
                     }
                     else -> Stay

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/OnboardingPixelSender.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/OnboardingPixelSender.kt
@@ -48,8 +48,7 @@ import javax.inject.Inject
 sealed interface OnboardingPixelAction {
     data object Shown : OnboardingPixelAction
 
-    /** A click/tap. [engaged] null = no value param; true/false = engage/dismiss. */
-    data class Clicked(val engaged: Boolean? = null) : OnboardingPixelAction
+    data class Clicked(val engaged: Boolean) : OnboardingPixelAction
 
     data class SetDefaultConfirmed(val isDdgDefault: Boolean) : OnboardingPixelAction
     data class NotificationsConfirmed(val granted: Boolean) : OnboardingPixelAction
@@ -129,7 +128,7 @@ class RealOnboardingPixelSender @Inject constructor(
                 fireStep(pixelName, PIXEL_EVENT_SHOWN)
 
             is OnboardingPixelAction.Clicked ->
-                fireStep(pixelName, PIXEL_EVENT_CLICKED, action.engaged?.let(::engageOrDismiss))
+                fireStep(pixelName, PIXEL_EVENT_CLICKED, engageOrDismiss(action.engaged))
 
             is OnboardingPixelAction.SetDefaultConfirmed ->
                 fireStep(pixelName, PIXEL_EVENT_CONFIRMED, if (action.isDdgDefault) VALUE_DDG else VALUE_OTHER)
@@ -160,7 +159,7 @@ class RealOnboardingPixelSender @Inject constructor(
                 fireStep(pixelName, PIXEL_EVENT_SHOWN, includeValueInTag = false)
 
             is OnboardingPixelAction.Clicked ->
-                fireStep(pixelName, PIXEL_EVENT_CLICKED, action.engaged?.let(::engageOrDismiss), includeValueInTag = false)
+                fireStep(pixelName, PIXEL_EVENT_CLICKED, engageOrDismiss(action.engaged), includeValueInTag = false)
 
             is OnboardingPixelAction.SuggestionClicked ->
                 fireStep(pixelName, PIXEL_EVENT_CLICKED, if (action.fromSuggestion) VALUE_SUGGESTED else VALUE_CUSTOM, includeValueInTag = false)

--- a/app/src/test/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProviderTest.kt
@@ -814,7 +814,7 @@ class NewUserOnboardingPlanProviderTest {
         orchestrator.onEvent(NewUserOnboardingEvent.NotificationPermissionFinished(granted = null))
         orchestrator.onEvent(NewUserOnboardingEvent.ContinueClicked) // initial
         orchestrator.onEvent(NewUserOnboardingEvent.ContinueClicked) // comparison_chart
-        verify(onboardingPixelSender).fire(ONBOARDING_SET_DEFAULT, OnboardingPixelAction.Clicked())
+        verify(onboardingPixelSender).fire(ONBOARDING_SET_DEFAULT, OnboardingPixelAction.Clicked(engaged = true))
     }
 
     @Test
@@ -933,7 +933,7 @@ class NewUserOnboardingPlanProviderTest {
         orchestrator.onEvent(NewUserOnboardingEvent.ContinueClicked) // initial
         assertStep(NewUserOnboardingStepIds.AI_COMPARISON_CHART)
         orchestrator.onEvent(NewUserOnboardingEvent.ContinueClicked)
-        verify(onboardingPixelSender).fire(ONBOARDING_AI_INTRO, OnboardingPixelAction.Clicked())
+        verify(onboardingPixelSender).fire(ONBOARDING_AI_INTRO, OnboardingPixelAction.Clicked(engaged = true))
     }
 
     @Test
@@ -965,7 +965,7 @@ class NewUserOnboardingPlanProviderTest {
         orchestrator.onEvent(NewUserOnboardingEvent.InputDemoQuerySubmitted(query = "hello", isChat = true, fromSuggestion = false))
         assertStep(NewUserOnboardingStepIds.DUCK_AI_DEMO)
         orchestrator.onEvent(NewUserOnboardingEvent.DuckAiFireCompleted)
-        verify(onboardingPixelSender).fire(ONBOARDING_FIRE_BUTTON, OnboardingPixelAction.Clicked())
+        verify(onboardingPixelSender).fire(ONBOARDING_FIRE_BUTTON, OnboardingPixelAction.Clicked(engaged = true))
     }
 
     // endregion

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/RealOnboardingPixelSenderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/RealOnboardingPixelSenderTest.kt
@@ -264,15 +264,22 @@ class RealOnboardingPixelSenderTest {
     }
 
     @Test
-    fun whenFireSetDefaultClickedThenNoValueAndTagWithoutValue() = runTest {
+    fun whenFireSetDefaultClickedEngagedThenValueEngage() = runTest {
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis())
 
-        testee.fire(ONBOARDING_SET_DEFAULT, OnboardingPixelAction.Clicked())
+        testee.fire(ONBOARDING_SET_DEFAULT, OnboardingPixelAction.Clicked(engaged = true))
 
         verify(mockPixel).fire(
             ONBOARDING_SET_DEFAULT,
-            mapOf("it" to "new", "flow" to "default", "pixelSource" to "phone", "d" to "0", "e" to "clicked"),
-            type = Unique(tag = "onboarding_set-default_clicked"),
+            mapOf(
+                "it" to "new",
+                "flow" to "default",
+                "pixelSource" to "phone",
+                "d" to "0",
+                "e" to "clicked",
+                "value" to "engage",
+            ),
+            type = Unique(tag = "onboarding_set-default_clicked_engage"),
         )
     }
 
@@ -664,15 +671,22 @@ class RealOnboardingPixelSenderTest {
     }
 
     @Test
-    fun whenFireAiComparisonClickedThenNoValueAndTagWithoutValue() = runTest {
+    fun whenFireAiComparisonClickedEngagedThenValueEngage() = runTest {
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis())
 
-        testee.fire(ONBOARDING_AI_INTRO, OnboardingPixelAction.Clicked())
+        testee.fire(ONBOARDING_AI_INTRO, OnboardingPixelAction.Clicked(engaged = true))
 
         verify(mockPixel).fire(
             ONBOARDING_AI_INTRO,
-            mapOf("it" to "new", "flow" to "default", "pixelSource" to "phone", "d" to "0", "e" to "clicked"),
-            type = Unique(tag = "onboarding_ai-intro_clicked"),
+            mapOf(
+                "it" to "new",
+                "flow" to "default",
+                "pixelSource" to "phone",
+                "d" to "0",
+                "e" to "clicked",
+                "value" to "engage",
+            ),
+            type = Unique(tag = "onboarding_ai-intro_clicked_engage"),
         )
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216620680801261?focus=true
Tech Design URL (if applicable): 

### Description

Makes `OnboardingPixelAction.Clicked.engaged` a mandatory `Boolean` (it was previously nullable with a `null` default).

A `null` `engaged` meant the `clicked` pixel fired without a `value` param. The three call sites that relied on this were all primary-action clicks, so they now pass `engaged = true` and emit `value=engage`. As a result, every onboarding `clicked` pixel now carries a `value` param.

The three pixels that were previously firing `clicked` with no `value` (now `value=engage`):
- `onboarding_set-default` — comparison-chart "Continue" clicked
- `onboarding_ai-intro` — AI comparison-chart "Continue" clicked
- `onboarding_fire-button` — Duck.ai demo fire completed

All other `Clicked` call sites already passed an explicit `engaged`, so they are unaffected. 

### Steps to test this PR

_Onboarding clicked pixels always include a value param_
- [ ] Install an internal/debug build, clear app data, and start a fresh onboarding flow with pixel logging enabled (logcat / pixel debugger).
- [ ] Tap "Continue" on the comparison chart and confirm `onboarding_set-default` fires with `e=clicked` and `value=engage`

**Note:** Apply the following patch to force enable the custom Duck.ai onboarding:

```diff
diff --git a/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt b/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
index fe3752cbb2..edd3bfb4dd 100644
--- a/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
@@ -111,13 +111,15 @@ class CustomAiOnboardingStoreImpl @Inject constructor(
             val resolution = referrerExists && customAiOnboardingEnabled && brandDesignEnabled
             preferences.edit { putBoolean(PREFS_KEY_ENABLED, resolution) }

-            return@withContext resolution
+            // return@withContext resolution
+            return@withContext true
         }
     }

     override suspend fun isEnabled(): Boolean = resolveMutex.withLock {
         withContext(dispatcherProvider.io()) {
-            preferences.getBoolean(PREFS_KEY_ENABLED, false)
+            // preferences.getBoolean(PREFS_KEY_ENABLED, false)
+            true
         }
     }
```

- [ ] Clean install with the patch
- [ ] Tap "Continue" on the AI intro comparison chart and confirm `onboarding_ai-intro` fires with `e=clicked` and `value=engage`.
- [ ] Complete the Duck.ai fire demo and confirm `onboarding_fire-button` fires with `e=clicked` and `value=engage`.
- [ ] Confirm no onboarding `clicked` pixel fires without a `value` param.

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only instrumentation changes; no user-facing behavior, though downstream dashboards must treat new `value` and unique-tag shapes for three events.
> 
> **Overview**
> Standardizes onboarding **clicked** analytics so every event includes a **`value`** parameter (`engage` or `dismiss`), instead of allowing some clicks to fire with no `value`.
> 
> **`OnboardingPixelAction.Clicked`** now requires a non-null **`engaged`** flag; **`OnboardingPixelSender`** always maps that to **`value`** via **`engageOrDismiss`**. Three primary-action flows that previously used parameterless **`Clicked()`** now pass **`engaged = true`**: comparison chart continue (**`onboarding_set-default`**), AI intro continue (**`onboarding_ai-intro`**), and Duck.ai fire demo completion (**`onboarding_fire-button`**).
> 
> **`onboarding.json5`** is updated to document **`engage`** on those pixels (and **`engage`** on **`onboarding_set-default`** **`clicked`** alongside existing **`confirmed`** values). Unit tests assert the new payloads and unique tags (e.g. **`…_clicked_engage`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22b6b73867dbc5fdf116fcaa6777d43d7b9efdc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->