### PR TITLE
Quick Win: Android: Reenabling Microphone permissions in Settings doesn’t grant permissions to DDG app 

### DIFF
--- a/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/PermissionRequest.kt
+++ b/voice-search/voice-search-impl/src/main/java/com/duckduckgo/voice/impl/PermissionRequest.kt
@@ -18,11 +18,10 @@ package com.duckduckgo.voice.impl
 
 import android.app.Activity
 import android.content.Context
-import android.content.Intent
-import android.net.Uri
-import android.provider.Settings
 import androidx.activity.result.ActivityResultCaller
+import androidx.appcompat.app.AppCompatActivity
 import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.common.utils.extensions.launchApplicationInfoSettings
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.voice.impl.ActivityResultLauncherWrapper.Action.LaunchPermissionRequest
 import com.duckduckgo.voice.impl.ActivityResultLauncherWrapper.Request
@@ -49,10 +48,6 @@ class MicrophonePermissionRequest @Inject constructor(
     private val activityResultLauncherWrapper: ActivityResultLauncherWrapper,
     private val permissionRationale: PermissionRationale,
 ) : PermissionRequest {
-    companion object {
-        private const val SCHEME_PACKAGE = "package"
-    }
-
     private lateinit var voiceSearchDisabled: () -> Unit
 
     override fun registerResultsCallback(
@@ -63,13 +58,11 @@ class MicrophonePermissionRequest @Inject constructor(
     ) {
         activityResultLauncherWrapper.register(
             caller,
-            Request.Permission { result ->
-                if (result) {
+            Request.Permission { granted ->
+                if (granted) {
                     onPermissionsGranted()
-                } else {
-                    if (!permissionRationale.shouldShow(activity)) {
-                        voiceSearchRepository.declinePermissionForever()
-                    }
+                } else if (!permissionRationale.shouldShow(activity)) {
+                    showNoMicAccessDialog(activity)
                 }
             },
         )
@@ -77,30 +70,24 @@ class MicrophonePermissionRequest @Inject constructor(
     }
 
     override fun launch(activity: Activity) {
-        if (voiceSearchRepository.getHasPermissionDeclinedForever()) {
-            voiceSearchPermissionDialogsLauncher.showNoMicAccessDialog(
-                activity,
-                { activity.launchDuckDuckGoSettings() },
-                { showRemoveVoiceSearchDialog(activity) },
-            )
+        if (voiceSearchRepository.getHasAcceptedRationaleDialog()) {
+            activityResultLauncherWrapper.launch(LaunchPermissionRequest)
         } else {
-            if (voiceSearchRepository.getHasAcceptedRationaleDialog()) {
-                activityResultLauncherWrapper.launch(LaunchPermissionRequest)
-            } else {
-                voiceSearchPermissionDialogsLauncher.showPermissionRationale(
-                    activity,
-                    { handleRationaleAccepted() },
-                    { handleRationaleCancelled(activity) },
-                )
-            }
+            voiceSearchPermissionDialogsLauncher.showPermissionRationale(
+                activity,
+                { handleRationaleAccepted() },
+                { handleRationaleCancelled(activity) },
+            )
         }
     }
 
-    private fun Context.launchDuckDuckGoSettings() {
-        val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
-            data = Uri.fromParts(SCHEME_PACKAGE, packageName, null)
-        }
-        startActivity(intent)
+    private fun showNoMicAccessDialog(activity: Activity) {
+        if (activity.isFinishing || activity.isDestroyed) return
+        voiceSearchPermissionDialogsLauncher.showNoMicAccessDialog(
+            activity,
+            { (activity as? AppCompatActivity)?.launchApplicationInfoSettings() },
+            { showRemoveVoiceSearchDialog(activity) },
+        )
     }
 
     private fun handleRationaleAccepted() {

--- a/voice-search/voice-search-impl/src/test/java/com/duckduckgo/voice/impl/MicrophonePermissionRequestTest.kt
+++ b/voice-search/voice-search-impl/src/test/java/com/duckduckgo/voice/impl/MicrophonePermissionRequestTest.kt
@@ -16,6 +16,7 @@
 
 package com.duckduckgo.voice.impl
 
+import android.app.Activity
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.voice.impl.ActivityResultLauncherWrapper.Action.LaunchPermissionRequest
 import com.duckduckgo.voice.impl.fakes.FakeActivityResultLauncherWrapper
@@ -84,7 +85,7 @@ class MicrophonePermissionRequestTest {
     }
 
     @Test
-    fun whenPermissionRequestResultIsFalseThenOnPermissionsGrantedNotInvokedAndDeclinePermissionForever() {
+    fun whenPermissionRequestResultIsFalseAndRationaleShouldNotShowThenShowNoMicAccessDialog() {
         whenever(permissionRationale.shouldShow(any())).thenReturn(false)
         var permissionGranted = false
         testee.registerResultsCallback(mock(), mock(), mock()) {
@@ -95,7 +96,23 @@ class MicrophonePermissionRequestTest {
         lastKnownRequest.onResult(false)
 
         assertFalse(permissionGranted)
-        verify(voiceSearchRepository).declinePermissionForever()
+        assertTrue(voiceSearchPermissionDialogsLauncher.noMicAccessDialogShown)
+    }
+
+    @Test
+    fun whenPermissionResultIsFalseAndRationaleShouldNotShowButActivityIsGoneThenDoNotShowNoMicAccessDialog() {
+        // The permission result callback can be delivered after the host Activity window is gone
+        // (fast auto-denial racing a finish/recreation). Showing a dialog on a dead Activity would
+        // throw WindowManager.BadTokenException, so we must skip it. The next launch() re-derives state.
+        whenever(permissionRationale.shouldShow(any())).thenReturn(false)
+        val goneActivity = mock<Activity>()
+        whenever(goneActivity.isDestroyed).thenReturn(true)
+        testee.registerResultsCallback(mock(), goneActivity, mock()) { }
+
+        val lastKnownRequest = activityResultLauncherWrapper.lastKnownRequest as ActivityResultLauncherWrapper.Request.Permission
+        lastKnownRequest.onResult(false)
+
+        assertFalse(voiceSearchPermissionDialogsLauncher.noMicAccessDialogShown)
     }
 
     @Test
@@ -114,22 +131,27 @@ class MicrophonePermissionRequestTest {
     }
 
     @Test
-    fun whenPermissionDeclinedForeverThenLaunchNoMicAccessDialog() {
-        whenever(voiceSearchRepository.getHasPermissionDeclinedForever()).thenReturn(true)
+    fun whenLaunchAndRationaleAlreadyAcceptedThenRequestPermissionRatherThanShowNoMicAccessDialog() {
+        // Regression test: previously a persisted "declined forever" flag could trap the user on the
+        // no-mic-access dialog forever, even after they re-granted the permission from system settings.
+        // launch() must now always re-request so the OS can surface its prompt (or auto-deny), and the
+        // no-mic-access dialog is driven solely from the permission-result callback.
+        whenever(voiceSearchRepository.getHasAcceptedRationaleDialog()).thenReturn(true)
 
         testee.registerResultsCallback(mock(), mock(), mock()) { }
         testee.launch(mock())
 
-        assertFalse(voiceSearchPermissionDialogsLauncher.rationaleDialogShown)
-        assertTrue(voiceSearchPermissionDialogsLauncher.noMicAccessDialogShown)
+        assertFalse(voiceSearchPermissionDialogsLauncher.noMicAccessDialogShown)
+        assertEquals(LaunchPermissionRequest, activityResultLauncherWrapper.lastKnownAction)
     }
 
     @Test
-    fun whenLaunchNoMicAccessDialogDeclinedThenShowRemoveVoiceSearchDialog() {
-        whenever(voiceSearchRepository.getHasPermissionDeclinedForever()).thenReturn(true)
+    fun whenNoMicAccessDialogDeclinedThenShowRemoveVoiceSearchDialog() {
+        whenever(permissionRationale.shouldShow(any())).thenReturn(false)
 
         testee.registerResultsCallback(mock(), mock(), mock()) { }
-        testee.launch(mock())
+        val lastKnownRequest = activityResultLauncherWrapper.lastKnownRequest as ActivityResultLauncherWrapper.Request.Permission
+        lastKnownRequest.onResult(false)
         voiceSearchPermissionDialogsLauncher.boundNoMicAccessDialogDeclined.invoke()
 
         assertTrue(voiceSearchPermissionDialogsLauncher.removeVoiceSearchDialogShown)
@@ -137,7 +159,6 @@ class MicrophonePermissionRequestTest {
 
     @Test
     fun whenRationalDialogNotYetAcceptedThenLaunchRationalDialog() {
-        whenever(voiceSearchRepository.getHasPermissionDeclinedForever()).thenReturn(false)
         whenever(voiceSearchRepository.getHasAcceptedRationaleDialog()).thenReturn(false)
 
         testee.registerResultsCallback(mock(), mock(), mock()) { }
@@ -149,7 +170,6 @@ class MicrophonePermissionRequestTest {
 
     @Test
     fun whenRationalDialogAcceptedThenLaunchPermisionRequestFlow() {
-        whenever(voiceSearchRepository.getHasPermissionDeclinedForever()).thenReturn(false)
         whenever(voiceSearchRepository.getHasAcceptedRationaleDialog()).thenReturn(true)
 
         testee.registerResultsCallback(mock(), mock(), mock()) { }
@@ -162,7 +182,6 @@ class MicrophonePermissionRequestTest {
 
     @Test
     fun whenRationalDialogShownThenRationalAcceptedInvokedThenFilePixelAndLaunchPermission() {
-        whenever(voiceSearchRepository.getHasPermissionDeclinedForever()).thenReturn(false)
         whenever(voiceSearchRepository.getHasAcceptedRationaleDialog()).thenReturn(false)
         testee.registerResultsCallback(mock(), mock(), mock()) { }
         testee.launch(mock())
@@ -176,7 +195,6 @@ class MicrophonePermissionRequestTest {
 
     @Test
     fun whenRationalDialogShownThenRationalCancelledInvokedThenFilePixelAndLaunchPermission() {
-        whenever(voiceSearchRepository.getHasPermissionDeclinedForever()).thenReturn(false)
         whenever(voiceSearchRepository.getHasAcceptedRationaleDialog()).thenReturn(false)
         testee.registerResultsCallback(mock(), mock(), mock()) { }
         testee.launch(mock())
@@ -188,7 +206,6 @@ class MicrophonePermissionRequestTest {
 
     @Test
     fun whenRationalDialogShownThenRationalCancelledThenShowRemoveVoiceSearchDialog() {
-        whenever(voiceSearchRepository.getHasPermissionDeclinedForever()).thenReturn(false)
         whenever(voiceSearchRepository.getHasAcceptedRationaleDialog()).thenReturn(false)
         testee.registerResultsCallback(mock(), mock(), mock()) { }
         testee.launch(mock())
@@ -201,7 +218,6 @@ class MicrophonePermissionRequestTest {
     @Test
     fun whenNoMicAccessDialogAcceptedThenDisableVoiceSearch() {
         var disableVoiceSearch = false
-        whenever(voiceSearchRepository.getHasPermissionDeclinedForever()).thenReturn(false)
         whenever(voiceSearchRepository.getHasAcceptedRationaleDialog()).thenReturn(false)
         testee.registerResultsCallback(mock(), mock(), mock()) {
             disableVoiceSearch = true

--- a/voice-search/voice-search-store/src/main/java/com/duckduckgo/voice/store/VoiceSearchDataStore.kt
+++ b/voice-search/voice-search-store/src/main/java/com/duckduckgo/voice/store/VoiceSearchDataStore.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 
 interface VoiceSearchDataStore {
-    var permissionDeclinedForever: Boolean
     var userAcceptedRationaleDialog: Boolean
     var availabilityLogged: Boolean
     var countVoiceSearchDismissed: Int
@@ -43,7 +42,6 @@ class SharedPreferencesVoiceSearchDataStore constructor(
 ) : VoiceSearchDataStore {
     companion object {
         const val FILENAME = "com.duckduckgo.app.voice"
-        const val KEY_DECLINED_PERMISSION_FOREVER = "KEY_DECLINED_PERMISSION_FOREVER"
         const val KEY_RATIONALE_DIALOG_ACCEPTED = "KEY_RATIONALE_DIALOG_ACCEPTED"
         const val KEY_VOICE_SEARCH_AVAILABILITY_LOGGED = "KEY_VOICE_SEARCH_AVAILABILITY_LOGGED"
         const val KEY_VOICE_SEARCH_ENABLED = "KEY_VOICE_SEARCH_ENABLED"
@@ -52,12 +50,6 @@ class SharedPreferencesVoiceSearchDataStore constructor(
     }
 
     private val preferences: SharedPreferences by lazy { context.getSharedPreferences(FILENAME, Context.MODE_PRIVATE) }
-
-    override var permissionDeclinedForever: Boolean
-        get() = preferences.getBoolean(KEY_DECLINED_PERMISSION_FOREVER, false)
-        set(declined) {
-            updateValue(KEY_DECLINED_PERMISSION_FOREVER, declined)
-        }
 
     override var userAcceptedRationaleDialog: Boolean
         get() = preferences.getBoolean(KEY_RATIONALE_DIALOG_ACCEPTED, false)

--- a/voice-search/voice-search-store/src/main/java/com/duckduckgo/voice/store/VoiceSearchRepository.kt
+++ b/voice-search/voice-search-store/src/main/java/com/duckduckgo/voice/store/VoiceSearchRepository.kt
@@ -21,10 +21,8 @@ import com.duckduckgo.voice.api.VoiceSearchStatusListener
 import kotlinx.coroutines.flow.Flow
 
 interface VoiceSearchRepository {
-    fun declinePermissionForever()
     fun acceptRationaleDialog()
     fun saveLoggedAvailability()
-    fun getHasPermissionDeclinedForever(): Boolean
     fun getHasAcceptedRationaleDialog(): Boolean
     fun getHasLoggedAvailability(): Boolean
     fun isVoiceSearchUserEnabled(default: Boolean): Boolean
@@ -41,10 +39,6 @@ class RealVoiceSearchRepository constructor(
     private val dataStore: VoiceSearchDataStore,
     private val voiceSearchStatusListener: VoiceSearchStatusListener,
 ) : VoiceSearchRepository {
-    override fun declinePermissionForever() {
-        dataStore.permissionDeclinedForever = true
-    }
-
     override fun acceptRationaleDialog() {
         dataStore.userAcceptedRationaleDialog = true
     }
@@ -52,8 +46,6 @@ class RealVoiceSearchRepository constructor(
     override fun saveLoggedAvailability() {
         dataStore.availabilityLogged = true
     }
-
-    override fun getHasPermissionDeclinedForever(): Boolean = dataStore.permissionDeclinedForever
 
     override fun getHasAcceptedRationaleDialog(): Boolean = dataStore.userAcceptedRationaleDialog
 

--- a/voice-search/voice-search-store/src/test/java/com/duckduckgo/voice/store/RealVoiceSearchRepositoryTest.kt
+++ b/voice-search/voice-search-store/src/test/java/com/duckduckgo/voice/store/RealVoiceSearchRepositoryTest.kt
@@ -47,15 +47,6 @@ class RealVoiceSearchRepositoryTest {
     }
 
     @Test
-    fun whenPermissionDeclinedForeverThenGetHasPermissionDeclinedForeverShouldBeTrue() {
-        assertFalse(testee.getHasPermissionDeclinedForever())
-
-        testee.declinePermissionForever()
-
-        assertTrue(testee.getHasPermissionDeclinedForever())
-    }
-
-    @Test
     fun whenAvailabilityIsLoggedThengetHasLoggedAvailabilityShouldBeTrue() {
         assertFalse(testee.getHasLoggedAvailability())
 
@@ -100,7 +91,6 @@ class RealVoiceSearchRepositoryTest {
 }
 
 class FakeVoiceSearchDataStore : VoiceSearchDataStore {
-    override var permissionDeclinedForever: Boolean = false
     override var userAcceptedRationaleDialog: Boolean = false
     override var availabilityLogged: Boolean = false
     override var countVoiceSearchDismissed: Int = 0


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200581511062568/task/1216071378153650?focus=true
Tech Design URL (if applicable):

### Description

Fixes a bug where voice search kept showing the "enable microphone access in Settings" dialog even after the user had re-granted the permission from system settings.

**Root cause:** The decision to show the "go to Settings" dialog was gated by a persisted `permissionDeclinedForever` flag. That flag was written `true` when a permission request was denied while `shouldShowRequestPermissionRationale` was false, and was **never reset**. When the permission was later re-enabled as "Ask every time", the OS still reports it as _not_ _currently granted_, so the app fell into the flag-gated path and trusted its stale cache instead of re-checking the OS. Only "Allow every time" appeared to fix it, because a granted permission short-circuits before the flag is ever read.

**Fix:** Removed the sticky `permissionDeclinedForever` flag entirely and now decide from live OS state:

- `launch()` always re-requests the permission when the rationale was previously accepted, so the OS can surface its prompt (or auto-deny). It no longer consults any persisted decline flag.
- The "no mic access" dialog is now driven solely by the permission-result callback: shown only when a request comes back denied **and** `shouldShowRequestPermissionRationale` is now false (the live "permanently denied" signal). This self-heals when the user changes the permission from system settings.
- The settings deep-link now uses the shared `launchApplicationInfoSettings()` util, and the dialog is skipped if the host Activity is finishing/destroyed (avoids a `BadTokenException`).

### Steps to test this PR

- [ ]  Install from this branch.
- [ ]  Enable voice search and grant the microphone permission when prompted.
- [ ]  Go to system Settings → App permissions and **disable** the microphone permission for DDG.
- [ ]  Re-enable the permission, choosing **"Ask every time"**.
- [ ]  Return to the app and tap the voice search icon.
- [ ]  **Expected:** the system permission prompt appears
- [ ]  Regression check: permanently denied still works: deny the mic permission twice (until "Ask every time"/"Allow" no longer prompts), tap the voice icon, and confirm the "enable microphone access in Settings" dialog appears and its button opens app settings.

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches microphone permission UX and persistence; behavior changes for users who previously hit the sticky decline path, but logic is narrower and OS-driven with added crash guard.
> 
> **Overview**
> Fixes voice search staying on the “enable microphone in Settings” flow after the user re-grants mic access (e.g. **Ask every time**) from system settings.
> 
> **`permissionDeclinedForever` is removed** from the datastore/repository and is no longer written on deny. **`launch()`** no longer branches on that flag: after the privacy rationale was accepted it always fires the system permission request again. The **no-mic-access** dialog is shown only from the permission result when the request is denied and **`shouldShowRequestPermissionRationale`** is false (live “don’t ask again” signal).
> 
> **`showNoMicAccessDialog`** skips showing if the activity is finishing/destroyed, and app settings opens via **`launchApplicationInfoSettings()`** instead of a hand-rolled intent. Tests are updated for the new flow, including regression coverage for re-request after settings changes and the destroyed-activity case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebbfd1b9a8ea2534f8bde35f4b45469b1c75bb89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->