### PR TITLE
Move release workflow failures to Android Releases

### DIFF
--- a/.github/workflows/release_create_tag.yml
+++ b/.github/workflows/release_create_tag.yml
@@ -115,8 +115,8 @@ jobs:
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
-          asana-section: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
+          asana-project: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_ID }}
+          asana-section: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_BLOCKER_SECTION_ID }}
           asana-task-name: GH Workflow Failure - Tag Android Release
           asana-task-description: Tag Android Release has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
           action: 'create-asana-task'

--- a/.github/workflows/release_create_task.yml
+++ b/.github/workflows/release_create_task.yml
@@ -88,8 +88,8 @@ jobs:
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
-          asana-section: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
+          asana-project: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_ID }}
+          asana-section: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_BLOCKER_SECTION_ID }}
           asana-task-name: GH Workflow Failure - Create Android App Release Task
           asana-task-description: The Create Android App Release Task workflow has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
           action: 'create-asana-task'

--- a/.github/workflows/release_update_release_notes.yml
+++ b/.github/workflows/release_update_release_notes.yml
@@ -57,8 +57,8 @@ jobs:
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
-          asana-section: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
+          asana-project: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_ID }}
+          asana-section: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_BLOCKER_SECTION_ID }}
           asana-task-name: GH Workflow Failure - Update Release Notes
           asana-task-description: Update Release Notes in Play Store and Github has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
           action: 'create-asana-task'

--- a/.github/workflows/release_upload_play_store.yml
+++ b/.github/workflows/release_upload_play_store.yml
@@ -154,8 +154,8 @@ jobs:
         uses: duckduckgo/native-github-asana-sync@v2.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
-          asana-project: ${{ vars.GH_ANDROID_APP_PROJECT_ID }}
-          asana-section: ${{ vars.GH_ANDROID_APP_INCOMING_SECTION_ID }}
+          asana-project: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_ID }}
+          asana-section: ${{ vars.GH_ANDROID_APP_RELEASES_PROJECT_BLOCKER_SECTION_ID }}
           asana-task-name: GH Workflow Failure - Production Release
           asana-task-description: The Production Release to Play Store and Github workflow has failed. See https://github.com/duckduckgo/Android/actions/runs/${{ github.run_id }}
           action: 'create-asana-task'


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216513310447906?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/414730916066338/task/1216144994462267?focus=true

### Description
Route GitHub workflow-failure tasks for the four release workflows (create tag, create release task, update release notes, upload to Play Store) into the Releases project instead of the general Android App project.
- Each failure task now lands in the Releases project's blocker section, using the GH_ANDROID_APP_RELEASES_PROJECT_ID and GH_ANDROID_APP_RELEASES_PROJECT_BLOCKER_SECTION_ID repo variables (replacing
  GH_ANDROID_APP_PROJECT_ID / GH_ANDROID_APP_INCOMING_SECTION_ID).

### Steps to test this PR
qa-optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to Asana routing on workflow failure; no app or release build logic affected, assuming repo vars for the releases project are configured.
> 
> **Overview**
> **Release GitHub Actions failures** now open Asana tasks in the **Android Releases** project’s **blocker** section instead of the general Android app project **incoming** section.
> 
> The same `asana-project` / `asana-section` swap is applied to the failure-handler step in `release_create_tag.yml`, `release_create_task.yml`, `release_update_release_notes.yml`, and `release_upload_play_store.yml`. Task names and descriptions are unchanged; only where failures are filed moves to match release-focused triage (consistent with release-blocker vars used elsewhere in CI).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a04f4fc8e7b618a65ef9a66840813acbf84064a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->