### PR TITLE
Add daily state-snapshot pixels for after-idle settings

### DIFF
--- a/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
+++ b/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
@@ -309,5 +309,77 @@
         "triggers": ["other"],
         "suffixes": ["first_daily_count", "form_factor"],
         "parameters": ["appVersion"]
+    },
+
+    // Daily state-snapshot pixels: one per active user per day reflecting the current setting
+    "m_ntp_after_idle_return_to_last_tab_enabled_daily": {
+        "description": "(Daily Pixel) The Return To Last Tab shortcut is currently enabled",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_return_to_last_tab_disabled_daily": {
+        "description": "(Daily Pixel) The Return To Last Tab shortcut is currently disabled",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_idle_timeout_always_daily": {
+        "description": "(Daily Pixel) The idle timeout is currently set to Always (0s)",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_idle_timeout_60_daily": {
+        "description": "(Daily Pixel) The idle timeout is currently set to 60 seconds (1 minute)",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_idle_timeout_300_daily": {
+        "description": "(Daily Pixel) The idle timeout is currently set to 300 seconds (5 minutes)",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_idle_timeout_600_daily": {
+        "description": "(Daily Pixel) The idle timeout is currently set to 600 seconds (10 minutes)",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_idle_timeout_1800_daily": {
+        "description": "(Daily Pixel) The idle timeout is currently set to 1800 seconds (30 minutes)",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_idle_timeout_3600_daily": {
+        "description": "(Daily Pixel) The idle timeout is currently set to 3600 seconds (1 hour)",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_idle_timeout_43200_daily": {
+        "description": "(Daily Pixel) The idle timeout is currently set to 43200 seconds (12 hours)",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_idle_timeout_86400_daily": {
+        "description": "(Daily Pixel) The idle timeout is currently set to 86400 seconds (24 hours)",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["form_factor"],
+        "parameters": ["appVersion"]
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandler.kt
@@ -39,7 +39,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import logcat.logcat
-import org.json.JSONObject
 import javax.inject.Inject
 
 @ContributesMultibinding(
@@ -63,6 +62,7 @@ class FirstScreenHandlerImpl @Inject constructor(
     private val browserModeStateHolder: BrowserModeStateHolder,
     private val modeSwitchRecreateSignal: ModeSwitchRecreateSignal,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val idleThresholdResolver: IdleThresholdResolver,
 ) : BrowserLifecycleObserver {
 
     private val tabRepository: TabRepository
@@ -155,26 +155,11 @@ class FirstScreenHandlerImpl @Inject constructor(
         }
     }
 
-    private fun getTimeoutSeconds(): Long {
-        val userPref = settingsDataStore.userSelectedIdleThresholdSeconds
-        if (userPref != null) return userPref
-
-        return parseDefaultIdleThresholdSeconds(androidBrowserConfigFeature.showNTPAfterIdleReturn().getSettings())
-            ?: DEFAULT_IDLE_THRESHOLD_SECONDS
-    }
+    private fun getTimeoutSeconds(): Long =
+        idleThresholdResolver.effectiveThresholdSeconds(settingsDataStore.userSelectedIdleThresholdSeconds)
 
     companion object {
         const val DEFAULT_IDLE_THRESHOLD_SECONDS = 300L
         val DEFAULT_IDLE_THRESHOLD_OPTIONS = listOf(0L, 60L, 300L, 600L, 1800L, 3600L, 43200L, 86400L)
-
-        fun parseDefaultIdleThresholdSeconds(settingsJson: String?): Long? {
-            if (settingsJson == null) return null
-            return try {
-                val json = JSONObject(settingsJson)
-                if (json.has("defaultIdleThresholdSeconds")) json.getLong("defaultIdleThresholdSeconds") else null
-            } catch (e: Exception) {
-                null
-            }
-        }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/IdleThresholdResolver.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/IdleThresholdResolver.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch
+
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import org.json.JSONObject
+import javax.inject.Inject
+
+/**
+ * Single source for the effective after-idle timeout. Resolves, in order: the user's chosen
+ * value, else the remote-config default, else the hardcoded default.
+ */
+interface IdleThresholdResolver {
+    fun effectiveThresholdSeconds(userSelectedSeconds: Long?): Long
+}
+
+@ContributesBinding(AppScope::class)
+class RealIdleThresholdResolver @Inject constructor(
+    private val androidBrowserConfigFeature: AndroidBrowserConfigFeature,
+) : IdleThresholdResolver {
+
+    override fun effectiveThresholdSeconds(userSelectedSeconds: Long?): Long =
+        userSelectedSeconds
+            ?: parseRemoteDefaultSeconds(androidBrowserConfigFeature.showNTPAfterIdleReturn().getSettings())
+            ?: FirstScreenHandlerImpl.DEFAULT_IDLE_THRESHOLD_SECONDS
+
+    private fun parseRemoteDefaultSeconds(settingsJson: String?): Long? {
+        if (settingsJson == null) return null
+        return try {
+            val json = JSONObject(settingsJson)
+            if (json.has("defaultIdleThresholdSeconds")) json.getLong("defaultIdleThresholdSeconds") else null
+        } catch (e: Exception) {
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/NtpAfterIdleStatePixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/NtpAfterIdleStatePixelName.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch
+
+import com.duckduckgo.app.statistics.pixels.Pixel
+
+/**
+ * Daily state  pixels for the NTP-after-idle settings.
+ */
+enum class NtpAfterIdleStatePixelName(override val pixelName: String) : Pixel.PixelName {
+    RETURN_TO_LAST_TAB_ENABLED_DAILY("m_ntp_after_idle_return_to_last_tab_enabled_daily"),
+    RETURN_TO_LAST_TAB_DISABLED_DAILY("m_ntp_after_idle_return_to_last_tab_disabled_daily"),
+    IDLE_TIMEOUT_ALWAYS_DAILY("m_ntp_after_idle_idle_timeout_always_daily"),
+    IDLE_TIMEOUT_60_DAILY("m_ntp_after_idle_idle_timeout_60_daily"),
+    IDLE_TIMEOUT_300_DAILY("m_ntp_after_idle_idle_timeout_300_daily"),
+    IDLE_TIMEOUT_600_DAILY("m_ntp_after_idle_idle_timeout_600_daily"),
+    IDLE_TIMEOUT_1800_DAILY("m_ntp_after_idle_idle_timeout_1800_daily"),
+    IDLE_TIMEOUT_3600_DAILY("m_ntp_after_idle_idle_timeout_3600_daily"),
+    IDLE_TIMEOUT_43200_DAILY("m_ntp_after_idle_idle_timeout_43200_daily"),
+    IDLE_TIMEOUT_86400_DAILY("m_ntp_after_idle_idle_timeout_86400_daily"),
+}

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/NtpAfterIdleStateReporter.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/NtpAfterIdleStateReporter.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch
+
+import com.duckduckgo.app.di.AppCoroutineScope
+import com.duckduckgo.app.settings.db.SettingsDataStore
+import com.duckduckgo.app.statistics.api.AtbLifecyclePlugin
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
+import com.squareup.anvil.annotations.ContributesMultibinding
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+/**
+ * Emits a daily snapshot of the after-idle settings: one return-to-last-tab-enabled/disabled pixel and
+ * one idle-timeout pixel per active user per day, including the defaults for users who never changed
+ * a setting.
+ */
+@ContributesMultibinding(AppScope::class)
+class NtpAfterIdleStateReporter @Inject constructor(
+    private val pixel: Pixel,
+    @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
+    private val dispatcherProvider: DispatcherProvider,
+    private val settingsDataStore: SettingsDataStore,
+    private val ntpAfterIdleManager: NtpAfterIdleManager,
+    private val idleThresholdResolver: IdleThresholdResolver,
+) : AtbLifecyclePlugin {
+
+    override fun onSearchRetentionAtbRefreshed(oldAtb: String, newAtb: String) {
+        report()
+    }
+
+    override fun onAppRetentionAtbRefreshed(oldAtb: String, newAtb: String) {
+        report()
+    }
+
+    private fun report() {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            val returnToLastTabEnabled = ntpAfterIdleManager.returnToLastTabEnabled.firstOrNull() ?: true
+            pixel.fire(
+                if (returnToLastTabEnabled) {
+                    NtpAfterIdleStatePixelName.RETURN_TO_LAST_TAB_ENABLED_DAILY
+                } else {
+                    NtpAfterIdleStatePixelName.RETURN_TO_LAST_TAB_DISABLED_DAILY
+                },
+                type = Daily(),
+            )
+
+            val idleTimeoutSeconds =
+                idleThresholdResolver.effectiveThresholdSeconds(settingsDataStore.userSelectedIdleThresholdSeconds)
+            idleTimeoutSeconds.toIdleTimeoutPixel()?.let { pixel.fire(it, type = Daily()) }
+        }
+    }
+
+    private fun Long.toIdleTimeoutPixel(): NtpAfterIdleStatePixelName? = when (this) {
+        0L -> NtpAfterIdleStatePixelName.IDLE_TIMEOUT_ALWAYS_DAILY
+        60L -> NtpAfterIdleStatePixelName.IDLE_TIMEOUT_60_DAILY
+        300L -> NtpAfterIdleStatePixelName.IDLE_TIMEOUT_300_DAILY
+        600L -> NtpAfterIdleStatePixelName.IDLE_TIMEOUT_600_DAILY
+        1800L -> NtpAfterIdleStatePixelName.IDLE_TIMEOUT_1800_DAILY
+        3600L -> NtpAfterIdleStatePixelName.IDLE_TIMEOUT_3600_DAILY
+        43200L -> NtpAfterIdleStatePixelName.IDLE_TIMEOUT_43200_DAILY
+        86400L -> NtpAfterIdleStatePixelName.IDLE_TIMEOUT_86400_DAILY
+        else -> null
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchActivity.kt
@@ -42,7 +42,7 @@ import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
 @InjectWith(ActivityScope::class)
-@ContributeToActivityStarter(ShowOnAppLaunchScreenNoParams::class)
+@ContributeToActivityStarter(ShowOnAppLaunchScreenNoParams::class, screenName = "settingsAfterInactivity")
 class ShowOnAppLaunchActivity : DuckDuckGoActivity() {
 
     private val viewModel: ShowOnAppLaunchViewModel by bindViewModel()

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchPixelParamRemovalPlugin.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchPixelParamRemovalPlugin.kt
@@ -25,6 +25,7 @@ import javax.inject.Inject
 @ContributesMultibinding(AppScope::class)
 class ShowOnAppLaunchPixelParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin {
     override fun names(): List<Pair<String, Set<PixelParameter>>> {
-        return ShowOnAppLaunchPixelName.entries.map { it.pixelName to PixelParameter.removeAtb() }
+        return ShowOnAppLaunchPixelName.entries.map { it.pixelName to PixelParameter.removeAtb() } +
+            NtpAfterIdleStatePixelName.entries.map { it.pixelName to PixelParameter.removeAtb() }
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModel.kt
@@ -50,6 +50,7 @@ class ShowOnAppLaunchViewModel @Inject constructor(
     private val settingsDataStore: SettingsDataStore,
     private val pixel: Pixel,
     private val ntpAfterIdleManager: NtpAfterIdleManager,
+    private val idleThresholdResolver: IdleThresholdResolver,
 ) : ViewModel() {
 
     data class ViewState(
@@ -85,16 +86,11 @@ class ShowOnAppLaunchViewModel @Inject constructor(
             userSelectedThreshold,
             ntpAfterIdleManager.returnToLastTabEnabled,
         ) { option, specificPageUrl, showNTPAfterIdleReturn, userThreshold, returnToLastTabEnabled ->
-            val effectiveThreshold = userThreshold
-                ?: FirstScreenHandlerImpl.parseDefaultIdleThresholdSeconds(
-                    androidBrowserConfigFeature.showNTPAfterIdleReturn().getSettings(),
-                )
-                ?: FirstScreenHandlerImpl.DEFAULT_IDLE_THRESHOLD_SECONDS
             _viewState.value = ViewState(
                 selectedOption = option,
                 specificPageUrl = specificPageUrl,
                 showNTPAfterIdleReturn = showNTPAfterIdleReturn,
-                selectedIdleThresholdSeconds = effectiveThreshold,
+                selectedIdleThresholdSeconds = idleThresholdResolver.effectiveThresholdSeconds(userThreshold),
                 returnToLastTabEnabled = returnToLastTabEnabled,
             )
         }.flowOn(dispatcherProvider.io())

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/FirstScreenHandlerImplTest.kt
@@ -113,6 +113,7 @@ class FirstScreenHandlerImplTest {
             modeSwitchRecreateSignal = modeSwitchRecreateSignal,
             dispatcherProvider = coroutineTestRule.testDispatcherProvider,
             appCoroutineScope = testScope,
+            idleThresholdResolver = RealIdleThresholdResolver(androidBrowserConfigFeature),
         )
     }
 

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/NtpAfterIdleStateReporterTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/NtpAfterIdleStateReporterTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch
+
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.app.settings.db.SettingsDataStore
+import com.duckduckgo.app.statistics.pixels.Pixel
+import com.duckduckgo.app.statistics.pixels.Pixel.PixelType.Daily
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
+import kotlinx.coroutines.flow.flowOf
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class NtpAfterIdleStateReporterTest {
+
+    @get:Rule val coroutineTestRule = CoroutineTestRule()
+
+    private val pixel: Pixel = mock()
+    private val settingsDataStore: SettingsDataStore = mock()
+    private val ntpAfterIdleManager: NtpAfterIdleManager = mock()
+    private val feature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
+
+    private val testee =
+        NtpAfterIdleStateReporter(
+            pixel,
+            coroutineTestRule.testScope,
+            coroutineTestRule.testDispatcherProvider,
+            settingsDataStore,
+            ntpAfterIdleManager,
+            RealIdleThresholdResolver(feature),
+        )
+
+    @Test
+    fun whenReturnToLastTabEnabledThenFiresEnabledDailyPixel() {
+        stubState(returnToLastTabEnabled = true, idleThresholdSeconds = 300L)
+
+        testee.onSearchRetentionAtbRefreshed("v1", "v2")
+
+        verify(pixel).fire(NtpAfterIdleStatePixelName.RETURN_TO_LAST_TAB_ENABLED_DAILY, type = Daily())
+    }
+
+    @Test
+    fun whenReturnToLastTabDisabledThenFiresDisabledDailyPixel() {
+        stubState(returnToLastTabEnabled = false, idleThresholdSeconds = 300L)
+
+        testee.onSearchRetentionAtbRefreshed("v1", "v2")
+
+        verify(pixel).fire(NtpAfterIdleStatePixelName.RETURN_TO_LAST_TAB_DISABLED_DAILY, type = Daily())
+    }
+
+    @Test
+    fun whenIdleThresholdSetThenFiresMatchingTimeoutDailyPixel() {
+        stubState(returnToLastTabEnabled = true, idleThresholdSeconds = 1800L)
+
+        testee.onSearchRetentionAtbRefreshed("v1", "v2")
+
+        verify(pixel).fire(NtpAfterIdleStatePixelName.IDLE_TIMEOUT_1800_DAILY, type = Daily())
+    }
+
+    @Test
+    fun whenIdleThresholdIsZeroThenFiresAlwaysDailyPixel() {
+        stubState(returnToLastTabEnabled = true, idleThresholdSeconds = 0L)
+
+        testee.onSearchRetentionAtbRefreshed("v1", "v2")
+
+        verify(pixel).fire(NtpAfterIdleStatePixelName.IDLE_TIMEOUT_ALWAYS_DAILY, type = Daily())
+    }
+
+    @Test
+    fun whenIdleThresholdUnsetThenFiresDefaultTimeoutDailyPixel() {
+        stubState(returnToLastTabEnabled = true, idleThresholdSeconds = null)
+
+        testee.onSearchRetentionAtbRefreshed("v1", "v2")
+
+        // FirstScreenHandlerImpl.DEFAULT_IDLE_THRESHOLD_SECONDS = 300L
+        verify(pixel).fire(NtpAfterIdleStatePixelName.IDLE_TIMEOUT_300_DAILY, type = Daily())
+    }
+
+    @Test
+    fun whenIdleThresholdUnsetButRemoteDefaultSetThenFiresRemoteDefaultBucket() {
+        feature.showNTPAfterIdleReturn().setRawStoredState(
+            Toggle.State(enable = true, settings = """{"defaultIdleThresholdSeconds":1800}"""),
+        )
+        stubState(returnToLastTabEnabled = true, idleThresholdSeconds = null)
+
+        testee.onSearchRetentionAtbRefreshed("v1", "v2")
+
+        verify(pixel).fire(NtpAfterIdleStatePixelName.IDLE_TIMEOUT_1800_DAILY, type = Daily())
+    }
+
+    private fun stubState(returnToLastTabEnabled: Boolean, idleThresholdSeconds: Long?) {
+        whenever(ntpAfterIdleManager.returnToLastTabEnabled).thenReturn(flowOf(returnToLastTabEnabled))
+        whenever(settingsDataStore.userSelectedIdleThresholdSeconds).thenReturn(idleThresholdSeconds)
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/RealIdleThresholdResolverTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/RealIdleThresholdResolverTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.generalsettings.showonapplaunch
+
+import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RealIdleThresholdResolverTest {
+
+    private val feature = FakeFeatureToggleFactory.create(AndroidBrowserConfigFeature::class.java)
+    private val testee = RealIdleThresholdResolver(feature)
+
+    @Test
+    fun whenUserSelectedThenReturnsUserSelectedIgnoringRemoteDefault() {
+        setRemoteDefault(1800)
+
+        assertEquals(600L, testee.effectiveThresholdSeconds(600L))
+    }
+
+    @Test
+    fun whenNoUserSelectionThenReturnsRemoteDefault() {
+        setRemoteDefault(1800)
+
+        assertEquals(1800L, testee.effectiveThresholdSeconds(null))
+    }
+
+    @Test
+    fun whenNoUserSelectionAndNoRemoteDefaultThenReturnsHardcodedDefault() {
+        // No settings stored -> getSettings() is null.
+        assertEquals(FirstScreenHandlerImpl.DEFAULT_IDLE_THRESHOLD_SECONDS, testee.effectiveThresholdSeconds(null))
+    }
+
+    @Test
+    fun whenNoUserSelectionAndInvalidRemoteSettingsThenReturnsHardcodedDefault() {
+        feature.showNTPAfterIdleReturn().setRawStoredState(Toggle.State(enable = true, settings = "not-json"))
+
+        assertEquals(FirstScreenHandlerImpl.DEFAULT_IDLE_THRESHOLD_SECONDS, testee.effectiveThresholdSeconds(null))
+    }
+
+    private fun setRemoteDefault(seconds: Long) {
+        feature.showNTPAfterIdleReturn().setRawStoredState(
+            Toggle.State(enable = true, settings = """{"defaultIdleThresholdSeconds":$seconds}"""),
+        )
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModelTest.kt
@@ -70,6 +70,7 @@ class ShowOnAppLaunchViewModelTest {
             settingsDataStore,
             pixel,
             ntpAfterIdleManager,
+            RealIdleThresholdResolver(fakeBrowserConfigFeature),
         )
     }
 
@@ -117,6 +118,7 @@ class ShowOnAppLaunchViewModelTest {
         fakeBrowserConfigFeature.showNTPAfterIdleReturn().setRawStoredState(Toggle.State(false))
         testee = ShowOnAppLaunchViewModel(
             dispatcherProvider, fakeDataStore, FakeUrlConverter(), fakeBrowserConfigFeature, settingsDataStore, pixel, ntpAfterIdleManager,
+            RealIdleThresholdResolver(fakeBrowserConfigFeature),
         )
 
         testee.viewState.test {
@@ -130,6 +132,7 @@ class ShowOnAppLaunchViewModelTest {
         fakeBrowserConfigFeature.showNTPAfterIdleReturn().setRawStoredState(Toggle.State(true))
         testee = ShowOnAppLaunchViewModel(
             dispatcherProvider, fakeDataStore, FakeUrlConverter(), fakeBrowserConfigFeature, settingsDataStore, pixel, ntpAfterIdleManager,
+            RealIdleThresholdResolver(fakeBrowserConfigFeature),
         )
 
         testee.viewState.test {
@@ -145,6 +148,7 @@ class ShowOnAppLaunchViewModelTest {
         fakeBrowserConfigFeature.showNTPAfterIdleReturn().setRawStoredState(Toggle.State(true))
         testee = ShowOnAppLaunchViewModel(
             dispatcherProvider, fakeDataStore, FakeUrlConverter(), fakeBrowserConfigFeature, settingsDataStore, pixel, ntpAfterIdleManager,
+            RealIdleThresholdResolver(fakeBrowserConfigFeature),
         )
 
         testee.viewState.test {
@@ -160,6 +164,7 @@ class ShowOnAppLaunchViewModelTest {
         )
         testee = ShowOnAppLaunchViewModel(
             dispatcherProvider, fakeDataStore, FakeUrlConverter(), fakeBrowserConfigFeature, settingsDataStore, pixel, ntpAfterIdleManager,
+            RealIdleThresholdResolver(fakeBrowserConfigFeature),
         )
 
         testee.viewState.test {
@@ -176,6 +181,7 @@ class ShowOnAppLaunchViewModelTest {
         )
         testee = ShowOnAppLaunchViewModel(
             dispatcherProvider, fakeDataStore, FakeUrlConverter(), fakeBrowserConfigFeature, settingsDataStore, pixel, ntpAfterIdleManager,
+            RealIdleThresholdResolver(fakeBrowserConfigFeature),
         )
 
         testee.viewState.test {
@@ -191,6 +197,7 @@ class ShowOnAppLaunchViewModelTest {
         )
         testee = ShowOnAppLaunchViewModel(
             dispatcherProvider, fakeDataStore, FakeUrlConverter(), fakeBrowserConfigFeature, settingsDataStore, pixel, ntpAfterIdleManager,
+            RealIdleThresholdResolver(fakeBrowserConfigFeature),
         )
 
         testee.viewState.test {
@@ -256,6 +263,7 @@ class ShowOnAppLaunchViewModelTest {
         fakeBrowserConfigFeature.showNTPAfterIdleReturn().setRawStoredState(Toggle.State(true))
         testee = ShowOnAppLaunchViewModel(
             dispatcherProvider, fakeDataStore, FakeUrlConverter(), fakeBrowserConfigFeature, settingsDataStore, pixel, ntpAfterIdleManager,
+            RealIdleThresholdResolver(fakeBrowserConfigFeature),
         )
 
         testee.viewState.test {
@@ -271,6 +279,7 @@ class ShowOnAppLaunchViewModelTest {
         fakeBrowserConfigFeature.showNTPAfterIdleReturn().setRawStoredState(Toggle.State(true))
         testee = ShowOnAppLaunchViewModel(
             dispatcherProvider, fakeDataStore, FakeUrlConverter(), fakeBrowserConfigFeature, settingsDataStore, pixel, ntpAfterIdleManager,
+            RealIdleThresholdResolver(fakeBrowserConfigFeature),
         )
 
         testee.commands.test {

--- a/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchView.kt
+++ b/browser/browser-ui/src/main/java/com/duckduckgo/browser/ui/newtab/hatch/NewTabReturnHatchView.kt
@@ -174,7 +174,7 @@ class NewTabReturnHatchView @JvmOverloads constructor(
         popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.hatchMenuCloseTab)) {
             viewModel.closeTab()
         }
-        popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.hatchMenuDontShowThis)) {
+        popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.hatchMenuHideShortcut)) {
             viewModel.onDontShowThisPressed()
         }
         popupMenu.onMenuItemClicked(popupMenu.contentView.findViewById(R.id.hatchMenuAfterInactivity)) {

--- a/browser/browser-ui/src/main/res/layout/popup_hatch_menu.xml
+++ b/browser/browser-ui/src/main/res/layout/popup_hatch_menu.xml
@@ -48,11 +48,11 @@
         android:layout_height="wrap_content"/>
 
     <com.duckduckgo.common.ui.view.PopupMenuItemView
-        android:id="@+id/hatchMenuDontShowThis"
+        android:id="@+id/hatchMenuHideShortcut"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:leadingIcon="@drawable/ic_eye_closed_24"
-        app:primaryText="@string/hatchMenuDontShowThis" />
+        app:primaryText="@string/hatchMenuHideShortcut" />
 
     <com.duckduckgo.common.ui.view.divider.HorizontalDivider
         app:defaultPadding="false"

--- a/browser/browser-ui/src/main/res/values/donottranslate.xml
+++ b/browser/browser-ui/src/main/res/values/donottranslate.xml
@@ -28,7 +28,7 @@
     <string name="hatchMenuAfterInactivitySettings">After Inactivity</string>
     <string name="hatchMenuCloseTab">Close Tab</string>
     <string name="hatchMenuBurnTab">Delete Tab</string>
-    <string name="hatchMenuDontShowThis">Don\'t Show This</string>
+    <string name="hatchMenuHideShortcut">Hide shortcut</string>
     <string name="newTabReturnHatchTabClosed">Tab closed</string>
     <string name="newTabReturnHatchUndo">Undo</string>
     <string name="browserMenuChats">Chats</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1215861246875407?focus=true 
Tech Design URL (if applicable): 

### Description

This adds daily state-snapshot pixels so we can measure the after-idle settings.

Pixels added:
- `m_ntp_after_idle_return_to_last_tab_enabled_daily` / `…_disabled_daily`
- `m_ntp_after_idle_idle_timeout_{always,60,300,600,1800,3600,43200,86400}_daily`

`NtpAfterIdleStateReporter` (an `AtbLifecyclePlugin`) reads the current settings
on ATB refresh and fires the one matching pixel per dimension with `type =
Daily()`

### Steps to test this PR

- [ ] Filter logcat by “pixel sent” to see the pixels
- [ ] Trigger an ATB refresh (open the app / do a search)
      → exactly one `…return_to_last_tab_{enabled|disabled}_daily` and one
      `…idle_timeout_<value>_daily` fire, matching your current settings, with
      **no `atb` param**.
- [ ] Change the hatch toggle / idle timeout, trigger ATB refresh again → the new values are reported.
- [ ] Confirm each fires at most once per day.

### UI changes
None. Telemetry only.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only changes with a small refactor of idle-threshold resolution; no user-facing behavior or security-sensitive paths.
> 
> **Overview**
> Adds **daily state-snapshot telemetry** for NTP-after-idle settings so analytics can see current configuration (not just toggle events), including users who never changed a setting.
> 
> New pixel definitions cover **Return To Last Tab** enabled/disabled and **idle timeout** buckets (Always through 24h). `NtpAfterIdleStateReporter` hooks **ATB refresh** (`AtbLifecyclePlugin`) and fires one matching pixel per dimension with `Daily()`, using effective timeout from user pref → remote default → hardcoded default. The new daily pixels are registered in `ShowOnAppLaunchPixelParamRemovalPlugin` to strip **`atb`**.
> 
> Idle timeout resolution is **centralized** in new `IdleThresholdResolver` (`RealIdleThresholdResolver`), replacing duplicated JSON parsing in `FirstScreenHandlerImpl` and `ShowOnAppLaunchViewModel`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5aaecf1464dd26fd9d2907366cfd840d1769f36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->