### PR TITLE
Update content scope scripts to version 15.13.0

### DIFF
--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/autofillImport.js
@@ -8088,7 +8088,7 @@
           message: `could not find element to click with selector '${element.selector}'!`
         });
       }
-      const loopLength = element.multiple && element.multiple === true ? elements2.length : 1;
+      const loopLength = element.multiple == true ? elements2.length : 1;
       for (let i = 0; i < loopLength; i++) {
         const elem = elements2[i];
         if ("disabled" in elem) {

--- a/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
+++ b/node_modules/@duckduckgo/content-scope-scripts/build/android/brokerProtection.js
@@ -8057,7 +8057,7 @@
           message: `could not find element to click with selector '${element.selector}'!`
         });
       }
-      const loopLength = element.multiple && element.multiple === true ? elements2.length : 1;
+      const loopLength = element.multiple == true ? elements2.length : 1;
       for (let i = 0; i < loopLength; i++) {
         const elem = elements2[i];
         if ("disabled" in elem) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "ddg-android",
       "version": "1.0.0",
       "dependencies": {
-        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
         "@duckduckgo/autoconsent": "^16.9.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.12.0",
+        "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.13.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.9.0.tgz",
-      "integrity": "sha512-f0xwshjJpkNKuMTa8lPH4KRrIAkMRUaSbw4PJiDSy3piYi/wvj9U8mvb6inYr/FO1MZ8KpykIDS2MBhY3958Jw==",
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.11.0.tgz",
+      "integrity": "sha512-d6a6TmHAieH9+TVOvsVMuuHXuHeNGOw9RhdlvO77JD8FcCA1AJ3YLOHSDW5pirO0dkvsLnXessJBzKl/oh1GEg==",
       "license": "MPL-2.0",
       "dependencies": {
         "tldts-experimental": "^7.4.3"
@@ -61,7 +61,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#dc9b1280951a22359aac33d07ffd410cbbae2b94",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#780f81202c9a045e41ec264ee3305e2d6c5cbea3",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",
@@ -594,18 +594,18 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.4.8",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.8.tgz",
-      "integrity": "sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==",
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
       "license": "MIT"
     },
     "node_modules/tldts-experimental": {
-      "version": "7.4.8",
-      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.4.8.tgz",
-      "integrity": "sha512-BhnfwjtvAhq2ea0vglBojLEvn2QtZFZenstPQt75O8RtSqf8Xgh2vh7ksD4afpKwqjUNKg9ze2f18C8KbmSy7A==",
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-7.4.9.tgz",
+      "integrity": "sha512-zxh7G+3XL+Rg8CqSzjsqz9GODJY7ZhlwD9azD1ihVpueayTWAyQU5yyf7s34yZ5yDESCo6rr4TL8bHxykdy5hQ==",
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.4.8"
+        "tldts-core": "^7.4.9"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
     "@duckduckgo/autoconsent": "^16.9.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.12.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.13.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1216627683967551

- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches injected privacy/autofill/broker-protection scripts used in the WebView; behavior change is small but affects user-facing automation on pages.
> 
> **Overview**
> Bumps **`@duckduckgo/content-scope-scripts`** from **15.12.0** to **15.13.0** in `package.json` and refreshes **`package-lock.json`**, including updated vendored Android bundles under `node_modules/@duckduckgo/content-scope-scripts/build/android/`.
> 
> The bundled script change adjusts click-action handling: **`loopLength`** for multi-element clicks now uses `element.multiple == true` instead of `element.multiple && element.multiple === true` (in **`autofillImport.js`** and **`brokerProtection.js`**). The lockfile also reflects transitive updates (e.g. **`@duckduckgo/autoconsent`** 16.9.0 → 16.11.0, **`tldts-*`** 7.4.8 → 7.4.9).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f14008a242135e776be7b046ce5ef24027a8f93b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->