### PR TITLE
Fix crash on new-user onboarding when resuming into a browser-hosted step

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/launch/LaunchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/launch/LaunchViewModel.kt
@@ -88,10 +88,8 @@ class LaunchViewModel @Inject constructor(
                     LinearOnboardingHost.OnboardingActivity -> {
                         command.value = Command.Onboarding
                     }
-
-                    else -> {
-                        // extend to support initial hosts in the future
-                        throw IllegalArgumentException("unsupported initial onboarding host transition")
+                    LinearOnboardingHost.BrowserActivity -> {
+                        command.value = Command.Home()
                     }
                 }
             } else {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1216623101802743?focus=true
Tech Design URL (if applicable): 

### Description

Fixes a crash in `LaunchViewModel.showOnboardingOrHome` reported as `IllegalArgumentException: unsupported initial onboarding host transition`.

The custom Duck.ai onboarding plan has a step (the Duck.ai demo) hosted by `BrowserActivity` instead of `OnboardingActivity`. If a new user backs out of the app while on that step and the app process survives (not killed), the singleton `LinearOnboardingOrchestratorImpl` still holds an in-progress run parked on that `BrowserActivity`-hosted step. Reopening the app via `LaunchBridgeActivity` re-enters `LaunchViewModel.showOnboardingOrHome`, which still treats the user as new, asks the bootstrapper to start the plan (a no-op since a run is already in progress), and then hits the `else` branch on the current step's host — which only handled `OnboardingActivity` and threw for anything else.

Fix: route the `BrowserActivity`-hosted case to `Command.Home` instead of throwing. `Command.Home` launches `BrowserActivity`, and `NewUserBrowserOnboardingViewModel` already knows how to resume an in-progress run hosted there (it re-resolves the current step and re-presents the Duck.ai demo) — the same resume path `BrandDesignUpdatePageViewModel` already relies on for `OnboardingActivity`.

**Note:** Apply the following patch to force enable the custom Duck.ai onboarding:

```diff
diff --git a/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt b/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
index fe3752cbb2..edd3bfb4dd 100644
--- a/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
@@ -111,13 +111,15 @@ class CustomAiOnboardingStoreImpl @Inject constructor(
             val resolution = referrerExists && customAiOnboardingEnabled && brandDesignEnabled
             preferences.edit { putBoolean(PREFS_KEY_ENABLED, resolution) }

-            return@withContext resolution
+            // return@withContext resolution
+            return@withContext true
         }
     }

     override suspend fun isEnabled(): Boolean = resolveMutex.withLock {
         withContext(dispatcherProvider.io()) {
-            preferences.getBoolean(PREFS_KEY_ENABLED, false)
+            // preferences.getBoolean(PREFS_KEY_ENABLED, false)
+            true
         }
     }
```

### Steps to test this PR

_Custom Duck.ai onboarding crash repro_
- [ ] Apply the `CustomAiOnboardingStore` patch above locally to force-enable the custom Duck.ai onboarding flow
- [ ] On `develop` (pre-fix), fresh install, go through onboarding until reaching the Duck.ai demo step (now in `BrowserActivity`)
- [ ] Press back to exit the app (do not kill the process)
- [ ] Relaunch the app from the launcher icon → confirm it crashes with `IllegalArgumentException: unsupported initial onboarding host transition`
- [ ] Repeat the same steps on this branch → confirm the app instead resumes onboarding, dropping the user back into the Duck.ai demo step, and no crash occurs

_Regression check_
- [ ] Fresh install, go through the default (non-custom-AI) onboarding flow end-to-end → confirm no change in behavior
- [ ] Returning/existing user launch → confirm still routes straight to `Home`

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 451795af7050486b9c3e5819113c49ab4e7990f3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
