### PR TITLE
Disable ad blocking animation

### DIFF
--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/RealAdBlockingOmnibarAnimation.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/RealAdBlockingOmnibarAnimation.kt
@@ -20,6 +20,7 @@ import androidx.core.net.toUri
 import com.duckduckgo.adblocking.api.AdBlockingAnimation
 import com.duckduckgo.adblocking.api.AdBlockingOmnibarAnimationProvider
 import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
 import com.duckduckgo.di.scopes.FragmentScope
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
@@ -30,17 +31,18 @@ import javax.inject.Inject
 class RealAdBlockingOmnibarAnimation @Inject constructor(
     private val statusChecker: AdBlockingStatusChecker,
     private val domainMatcher: AdBlockingExtensionDomainMatcher,
+    private val adBlockingFeature: AdBlockingExtensionFeature,
 ) : AdBlockingOmnibarAnimationProvider {
 
     private var lastAnimatedVideoId: String? = null
 
     override suspend fun getAnimation(url: String, pageChanged: Boolean): AdBlockingAnimation {
-        // TODO (cbarreiro) Remove after fixing https://app.asana.com/1/137249556945/task/1216628472297441?focus=true
-        return AdBlockingAnimation.Skip
-
         val videoId = videoIdOrNull(url)
         if (videoId == null) {
             lastAnimatedVideoId = null
+            return AdBlockingAnimation.Skip
+        }
+        if (!adBlockingFeature.showAdBlockingOmnibarAnimation().isEnabled() || !adBlockingFeature.adBlockingUXImprovements().isEnabled()) {
             return AdBlockingAnimation.Skip
         }
         if (!statusChecker.canInject()) return AdBlockingAnimation.Skip

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/RealAdBlockingOmnibarAnimation.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/RealAdBlockingOmnibarAnimation.kt
@@ -35,6 +35,9 @@ class RealAdBlockingOmnibarAnimation @Inject constructor(
     private var lastAnimatedVideoId: String? = null
 
     override suspend fun getAnimation(url: String, pageChanged: Boolean): AdBlockingAnimation {
+        // TODO (cbarreiro) Remove after fixing https://app.asana.com/1/137249556945/task/1216628472297441?focus=true
+        return AdBlockingAnimation.Skip
+
         val videoId = videoIdOrNull(url)
         if (videoId == null) {
             lastAnimatedVideoId = null

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionFeature.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/remoteconfig/AdBlockingExtensionFeature.kt
@@ -48,4 +48,10 @@ interface AdBlockingExtensionFeature {
      */
     @Toggle.DefaultValue(Toggle.DefaultFeatureValue.FALSE)
     fun adBlockingUXImprovements(): Toggle
+
+    /**
+     * When enabled, ad blocking animation will show on the omnibar if all other conditions met
+     */
+    @Toggle.DefaultValue(Toggle.DefaultFeatureValue.FALSE)
+    fun showAdBlockingOmnibarAnimation(): Toggle
 }

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/RealAdBlockingOmnibarAnimationTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/RealAdBlockingOmnibarAnimationTest.kt
@@ -21,8 +21,10 @@ import com.duckduckgo.adblocking.api.AdBlockingAnimation
 import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
 import com.duckduckgo.common.test.CoroutineTestRule
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -48,17 +50,22 @@ class RealAdBlockingOmnibarAnimationTest {
     }
 
     @Test
+    fun whenPageLoadedOnWatchVideoThenDoNotShow() = runTest {
+        assertFalse(testee.getAnimation("https://www.youtube.com/watch?v=abc123", pageChanged = true) is AdBlockingAnimation.Show)
+    }
+
+    @Test @Ignore("Add back after fixing https://app.asana.com/1/137249556945/task/1216628472297441?focus=true")
     fun whenPageLoadedOnWatchVideoThenShow() = runTest {
         assertTrue(testee.getAnimation("https://www.youtube.com/watch?v=abc123", pageChanged = true) is AdBlockingAnimation.Show)
     }
 
-    @Test
+    @Test @Ignore("Add back after fixing https://app.asana.com/1/137249556945/task/1216628472297441?focus=true")
     fun whenUrlChangedToSameVideoIdThenRetain() = runTest {
         assertTrue(testee.getAnimation("https://www.youtube.com/watch?v=abc123", pageChanged = true) is AdBlockingAnimation.Show)
         assertTrue(testee.getAnimation("https://www.youtube.com/watch?v=abc123", pageChanged = false) is AdBlockingAnimation.Retain)
     }
 
-    @Test
+    @Test @Ignore("Add back after fixing https://app.asana.com/1/137249556945/task/1216628472297441?focus=true")
     fun whenPageReloadedOnSameVideoThenShowAgain() = runTest {
         assertTrue(testee.getAnimation("https://www.youtube.com/watch?v=abc123", pageChanged = true) is AdBlockingAnimation.Show)
 
@@ -66,42 +73,42 @@ class RealAdBlockingOmnibarAnimationTest {
         assertTrue(testee.getAnimation("https://www.youtube.com/watch?v=abc123", pageChanged = true) is AdBlockingAnimation.Show)
     }
 
-    @Test
+    @Test @Ignore("Add back after fixing https://app.asana.com/1/137249556945/task/1216628472297441?focus=true")
     fun whenUrlChangedAToBToAThenShowOnReturn() = runTest {
         assertTrue(testee.getAnimation("https://www.youtube.com/watch?v=aaa", pageChanged = false) is AdBlockingAnimation.Show)
         assertTrue(testee.getAnimation("https://www.youtube.com/watch?v=bbb", pageChanged = false) is AdBlockingAnimation.Show)
         assertTrue(testee.getAnimation("https://www.youtube.com/watch?v=aaa", pageChanged = false) is AdBlockingAnimation.Show)
     }
 
-    @Test
+    @Test @Ignore("Add back after fixing https://app.asana.com/1/137249556945/task/1216628472297441?focus=true")
     fun whenShortsLiveClipVideosThenShow() = runTest {
         assertTrue(testee.getAnimation("https://www.youtube.com/shorts/short1", pageChanged = false) is AdBlockingAnimation.Show)
         assertTrue(testee.getAnimation("https://www.youtube.com/live/live1", pageChanged = false) is AdBlockingAnimation.Show)
         assertTrue(testee.getAnimation("https://www.youtube.com/clip/clip1", pageChanged = false) is AdBlockingAnimation.Show)
     }
 
-    @Test
+    @Test @Ignore("Add back after fixing https://app.asana.com/1/137249556945/task/1216628472297441?focus=true")
     fun whenWatchUrlHasEmptyVideoIdThenSkip() = runTest {
         assertTrue(testee.getAnimation("https://www.youtube.com/watch?v=", pageChanged = true) is AdBlockingAnimation.Skip)
     }
 
-    @Test
+    @Test @Ignore("Add back after fixing https://app.asana.com/1/137249556945/task/1216628472297441?focus=true")
     fun whenNonVideoUrlThenSkip() = runTest {
         assertTrue(testee.getAnimation("https://www.youtube.com/results?search_query=cats", pageChanged = true) is AdBlockingAnimation.Skip)
     }
 
-    @Test
+    @Test @Ignore("Add back after fixing https://app.asana.com/1/137249556945/task/1216628472297441?focus=true")
     fun whenNonYoutubeUrlThenSkip() = runTest {
         assertTrue(testee.getAnimation("https://www.example.com/watch?v=abc123", pageChanged = true) is AdBlockingAnimation.Skip)
     }
 
-    @Test
+    @Test @Ignore("Add back after fixing https://app.asana.com/1/137249556945/task/1216628472297441?focus=true")
     fun whenFeatureToggleOffThenAlwaysSkip() = runTest {
         whenever(statusChecker.canInject()).thenReturn(false)
         assertTrue(testee.getAnimation("https://www.youtube.com/watch?v=abc123", pageChanged = true) is AdBlockingAnimation.Skip)
     }
 
-    @Test
+    @Test @Ignore("Add back after fixing https://app.asana.com/1/137249556945/task/1216628472297441?focus=true")
     fun whenNonVideoAfterVideoThenReturningToVideoShows() = runTest {
         assertTrue(testee.getAnimation("https://www.youtube.com/watch?v=abc123", pageChanged = false) is AdBlockingAnimation.Show)
 

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/RealAdBlockingOmnibarAnimationTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/RealAdBlockingOmnibarAnimationTest.kt
@@ -16,15 +16,17 @@
 
 package com.duckduckgo.adblocking.impl
 
+import android.annotation.SuppressLint
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.adblocking.api.AdBlockingAnimation
 import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
+import com.duckduckgo.adblocking.impl.remoteconfig.AdBlockingExtensionFeature
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -33,6 +35,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
+@SuppressLint("DenyListedApi") // setRawStoredState
 @RunWith(AndroidJUnit4::class)
 class RealAdBlockingOmnibarAnimationTest {
 
@@ -40,32 +43,42 @@ class RealAdBlockingOmnibarAnimationTest {
     val coroutineRule = CoroutineTestRule()
 
     private val statusChecker: AdBlockingStatusChecker = mock()
+    private val feature = FakeFeatureToggleFactory.create(AdBlockingExtensionFeature::class.java)
 
     private lateinit var testee: RealAdBlockingOmnibarAnimation
 
     @Before
     fun setup() {
         whenever(statusChecker.canInject()).thenReturn(true)
-        testee = RealAdBlockingOmnibarAnimation(statusChecker, RealAdBlockingExtensionDomainMatcher())
+        feature.showAdBlockingOmnibarAnimation().setRawStoredState(Toggle.State(enable = true))
+        feature.adBlockingUXImprovements().setRawStoredState(Toggle.State(enable = true))
+        testee = RealAdBlockingOmnibarAnimation(statusChecker, RealAdBlockingExtensionDomainMatcher(), feature)
     }
 
     @Test
-    fun whenPageLoadedOnWatchVideoThenDoNotShow() = runTest {
-        assertFalse(testee.getAnimation("https://www.youtube.com/watch?v=abc123", pageChanged = true) is AdBlockingAnimation.Show)
-    }
-
-    @Test @Ignore("Add back after fixing https://app.asana.com/1/137249556945/task/1216628472297441?focus=true")
     fun whenPageLoadedOnWatchVideoThenShow() = runTest {
         assertTrue(testee.getAnimation("https://www.youtube.com/watch?v=abc123", pageChanged = true) is AdBlockingAnimation.Show)
     }
 
-    @Test @Ignore("Add back after fixing https://app.asana.com/1/137249556945/task/1216628472297441?focus=true")
+    @Test
+    fun whenShowAdBlockingOmnibarAnimationDisabledThenSkip() = runTest {
+        feature.showAdBlockingOmnibarAnimation().setRawStoredState(Toggle.State(enable = false))
+        assertTrue(testee.getAnimation("https://www.youtube.com/watch?v=abc123", pageChanged = true) is AdBlockingAnimation.Skip)
+    }
+
+    @Test
+    fun whenAdBlockingUXImprovementsDisabledThenSkip() = runTest {
+        feature.adBlockingUXImprovements().setRawStoredState(Toggle.State(enable = false))
+        assertTrue(testee.getAnimation("https://www.youtube.com/watch?v=abc123", pageChanged = true) is AdBlockingAnimation.Skip)
+    }
+
+    @Test
     fun whenUrlChangedToSameVideoIdThenRetain() = runTest {
         assertTrue(testee.getAnimation("https://www.youtube.com/watch?v=abc123", pageChanged = true) is AdBlockingAnimation.Show)
         assertTrue(testee.getAnimation("https://www.youtube.com/watch?v=abc123", pageChanged = false) is AdBlockingAnimation.Retain)
     }
 
-    @Test @Ignore("Add back after fixing https://app.asana.com/1/137249556945/task/1216628472297441?focus=true")
+    @Test
     fun whenPageReloadedOnSameVideoThenShowAgain() = runTest {
         assertTrue(testee.getAnimation("https://www.youtube.com/watch?v=abc123", pageChanged = true) is AdBlockingAnimation.Show)
 
@@ -73,42 +86,42 @@ class RealAdBlockingOmnibarAnimationTest {
         assertTrue(testee.getAnimation("https://www.youtube.com/watch?v=abc123", pageChanged = true) is AdBlockingAnimation.Show)
     }
 
-    @Test @Ignore("Add back after fixing https://app.asana.com/1/137249556945/task/1216628472297441?focus=true")
+    @Test
     fun whenUrlChangedAToBToAThenShowOnReturn() = runTest {
         assertTrue(testee.getAnimation("https://www.youtube.com/watch?v=aaa", pageChanged = false) is AdBlockingAnimation.Show)
         assertTrue(testee.getAnimation("https://www.youtube.com/watch?v=bbb", pageChanged = false) is AdBlockingAnimation.Show)
         assertTrue(testee.getAnimation("https://www.youtube.com/watch?v=aaa", pageChanged = false) is AdBlockingAnimation.Show)
     }
 
-    @Test @Ignore("Add back after fixing https://app.asana.com/1/137249556945/task/1216628472297441?focus=true")
+    @Test
     fun whenShortsLiveClipVideosThenShow() = runTest {
         assertTrue(testee.getAnimation("https://www.youtube.com/shorts/short1", pageChanged = false) is AdBlockingAnimation.Show)
         assertTrue(testee.getAnimation("https://www.youtube.com/live/live1", pageChanged = false) is AdBlockingAnimation.Show)
         assertTrue(testee.getAnimation("https://www.youtube.com/clip/clip1", pageChanged = false) is AdBlockingAnimation.Show)
     }
 
-    @Test @Ignore("Add back after fixing https://app.asana.com/1/137249556945/task/1216628472297441?focus=true")
+    @Test
     fun whenWatchUrlHasEmptyVideoIdThenSkip() = runTest {
         assertTrue(testee.getAnimation("https://www.youtube.com/watch?v=", pageChanged = true) is AdBlockingAnimation.Skip)
     }
 
-    @Test @Ignore("Add back after fixing https://app.asana.com/1/137249556945/task/1216628472297441?focus=true")
+    @Test
     fun whenNonVideoUrlThenSkip() = runTest {
         assertTrue(testee.getAnimation("https://www.youtube.com/results?search_query=cats", pageChanged = true) is AdBlockingAnimation.Skip)
     }
 
-    @Test @Ignore("Add back after fixing https://app.asana.com/1/137249556945/task/1216628472297441?focus=true")
+    @Test
     fun whenNonYoutubeUrlThenSkip() = runTest {
         assertTrue(testee.getAnimation("https://www.example.com/watch?v=abc123", pageChanged = true) is AdBlockingAnimation.Skip)
     }
 
-    @Test @Ignore("Add back after fixing https://app.asana.com/1/137249556945/task/1216628472297441?focus=true")
-    fun whenFeatureToggleOffThenAlwaysSkip() = runTest {
+    @Test
+    fun whenCannotInjectThenAlwaysSkip() = runTest {
         whenever(statusChecker.canInject()).thenReturn(false)
         assertTrue(testee.getAnimation("https://www.youtube.com/watch?v=abc123", pageChanged = true) is AdBlockingAnimation.Skip)
     }
 
-    @Test @Ignore("Add back after fixing https://app.asana.com/1/137249556945/task/1216628472297441?focus=true")
+    @Test
     fun whenNonVideoAfterVideoThenReturningToVideoShows() = runTest {
         assertTrue(testee.getAnimation("https://www.youtube.com/watch?v=abc123", pageChanged = false) is AdBlockingAnimation.Show)
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216621209513277?focus=true
Tech Design URL (if applicable): 

### Description

### Steps to test this PR

_Feature 1_
- [ ] Set app version to 5.288.3 in version.properties
- [ ] Fresh install
- [ ] Make sure `adBlockingUxImprovements`, `adBlockingExtension`, and `enabledByDefault` are enabled, and `showAdBlockingOmnibarAnimation` is disabled
- [ ] Open a YouTube video
- [ ] Check the ad blocking animation isn't shown

_Feature 2_
- [ ] From previous scenario
- [ ] Make sure `adBlockingUxImprovements`, `adBlockingExtension`, `enabledByDefault` and `showAdBlockingOmnibarAnimation` are enabled
- [ ] Open a YouTube video
- [ ] Check the ad blocking animation is shown

_Feature 3_
- [ ] From previous scenario
- [ ] Make sure `adBlockingExtension`, `enabledByDefault` and `showAdBlockingOmnibarAnimation` are enabled, and `adBlockingUxImprovements` is disabled
- [ ] Open a YouTube video
- [ ] Check the ad blocking animation isn't shown

### UI changes
n/a


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only behavior behind feature flags with defaults disabling the animation; no auth, data, or injection logic changes beyond an early Skip.
> 
> **Overview**
> **Ad blocking omnibar animation is now off by default** and only runs when remote config enables it.
> 
> A new `showAdBlockingOmnibarAnimation()` toggle is added on `AdBlockingExtensionFeature` (default **false**). `RealAdBlockingOmnibarAnimation.getAnimation` returns `Skip` unless **both** `showAdBlockingOmnibarAnimation()` and `adBlockingUXImprovements()` are enabled, in addition to existing video URL and inject checks.
> 
> Unit tests wire in `FakeFeatureToggleFactory`, enable both toggles in setup for happy-path cases, and add coverage when either toggle is disabled; the inject-failure test is renamed to `whenCannotInjectThenAlwaysSkip`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c195a540feb1bc6e396cbc3365cdd0248c20185. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->