### PR TITLE
Add unit test for resuming new-user onboarding on a browser-hosted step

### DIFF
--- a/app/src/test/java/com/duckduckgo/app/launch/LaunchViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/launch/LaunchViewModelTest.kt
@@ -172,6 +172,33 @@ class LaunchViewModelTest {
     }
 
     @Test
+    fun whenOrchestratorEngagedWithBrowserActivityHostThenCommandIsHome() = runTest {
+        // Simulates resuming a new-user onboarding run left in progress on a BrowserActivity-hosted
+        // step (e.g. the Duck.ai demo) after the app process survived being backed out of.
+        whenever(userStageStore.getUserAppStage()).thenReturn(AppStage.NEW)
+        val inProgress = LinearOnboardingState.InProgress(
+            rootPlanId = "test_plan",
+            currentPlan = LinearOnboardingPlan(id = "test_plan", steps = listOf(stepHostedIn(LinearOnboardingHost.BrowserActivity))),
+            currentStepIndex = 0,
+        )
+        whenever(newUserOnboardingPlanBootstrapper.startNewUserOnboardingPlan()).thenReturn(inProgress)
+        testee = LaunchViewModel(
+            userStageStore,
+            StubAppReferrerFoundStateListener("xx"),
+            pixel = pixel,
+            testScenarioSeeder = testScenarioSeeder,
+            newUserOnboardingPlanBootstrapper = newUserOnboardingPlanBootstrapper,
+            brandDesignUpdateToggles = brandDesignUpdateToggles,
+        )
+        testee.command.observeForever(mockCommandObserver)
+
+        testee.start(mock<Intent>())
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        verify(mockCommandObserver).onChanged(any<Home>())
+    }
+
+    @Test
     fun whenNewUserAndBrandDesignUpdateDisabledThenOnboardingCommandAndPlanNotStarted() = runTest {
         whenever(userStageStore.getUserAppStage()).thenReturn(AppStage.NEW)
         whenever(brandDesignUpdateToggles.brandDesignUpdate()).thenReturn(disabledToggle)


### PR DESCRIPTION
### Description
Covers the fix in https://github.com/duckduckgo/Android/pull/9213: when the orchestrator's in-progress run is parked on a BrowserActivity-hosted step (e.g. the Duck.ai demo), LaunchViewModel.showOnboardingOrHome must route to Command.Home instead of throwing.

### Steps to test this PR
CI passes

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code modifications.
> 
> **Overview**
> Adds a **`LaunchViewModelTest`** case that mirrors the existing OnboardingActivity-host routing test, but with the orchestrator’s in-progress step hosted in **`LinearOnboardingHost.BrowserActivity`**.
> 
> For a **new user** with brand design update enabled, it stubs **`startNewUserOnboardingPlan()`** to return that state and asserts **`Command.Home`** is emitted on **`start()`**—covering resume after the process survives backing out of a browser-hosted onboarding step (e.g. Duck.ai demo), per the fix in #9213.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b997fe6beea6aed0ba3d696e768efea94cd15c5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->