### PR TITLE
 Fix empty browser tab after leaving the subscription webView

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1811,7 +1811,7 @@ class BrowserTabViewModel @Inject constructor(
         onUserDismissedCta(ctaViewState.value?.cta)
     }
 
-    fun closeAndReturnToSourceIfBlankTab() {
+    override fun closeAndReturnToSourceIfBlankTab() {
         if (url == null) {
             closeAndSelectSourceTab()
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserWebViewClient.kt
@@ -256,6 +256,7 @@ class BrowserWebViewClient @Inject constructor(
             return when (val urlType = specialUrlDetector.determineType(initiatingUrl = webView.originalUrl, uri = url)) {
                 is SpecialUrlDetector.UrlType.ShouldLaunchSubscriptionLink -> {
                     subscriptions.launchSubscription(webView.context, url)
+                    webViewClientListener?.closeAndReturnToSourceIfBlankTab()
                     true
                 }
 

--- a/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/WebViewClientListener.kt
@@ -109,6 +109,8 @@ interface WebViewClientListener {
 
     fun closeAndSelectSourceTab()
 
+    fun closeAndReturnToSourceIfBlankTab()
+
     fun upgradedToHttps()
 
     fun surrogateDetected(surrogate: SurrogateResponse)

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserWebViewClientTest.kt
@@ -557,6 +557,14 @@ class BrowserWebViewClientTest {
     }
 
     @Test
+    fun whenSubscriptionLinkDetectedThenCloseTabIfBlank() {
+        val urlType = SpecialUrlDetector.UrlType.ShouldLaunchSubscriptionLink
+        whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)
+        testee.shouldOverrideUrlLoading(webView, webResourceRequest)
+        verify(listener).closeAndReturnToSourceIfBlankTab()
+    }
+
+    @Test
     fun whenDuckChatLinkDetectedThenLaunchDuckChatAndReturnTrue() {
         val urlType = SpecialUrlDetector.UrlType.ShouldLaunchDuckChatLink
         whenever(specialUrlDetector.determineType(initiatingUrl = any(), uri = any())).thenReturn(urlType)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1204912272578138/task/1216614106909360?focus=true
Tech Design URL (if applicable): 

### Description


### Steps to test this PR

_Pre steps_
- [ ] Apply patch in https://app.asana.com/1/137249556945/project/1209991789468715/task/1210448620621729?focus=true

_Go back from landing page_
- [x] Install from branch
- [x] Go to duckduckgo.com
- [x] Open the site menu and select DuckDuckGo Subscription
- [x] Subscriptions webView will be open
- [x] Go back or close the screen 'X'
- [x] Verify it returns to duckduckgo.com instead an empty tab

_Go back after purchase (optional)_
- [x] Install from branch
- [x] Go to duckduckgo.com
- [x] Open the site menu and select DuckDuckGo Subscription
- [x] Subscriptions webView will be open
- [x] Purchase a test subscription
- [x] Verify it returns to app settings
- [x] Go back
- [x] Verify it returns to duckduckgo.com instead an empty tab


### No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small navigation cleanup gated on `url == null`, with no auth or data-path changes; main risk is closing the wrong tab if blank-tab detection is wrong in edge cases.
> 
> **Overview**
> Fixes users landing on an **empty browser tab** after opening DuckDuckGo Subscription from a page and then going back or closing the subscription WebView.
> 
> When `BrowserWebViewClient` intercepts a **subscription URL**, it still launches the subscription flow, but now also calls **`closeAndReturnToSourceIfBlankTab()`** on the WebView listener. That hook is added to **`WebViewClientListener`** and **`BrowserTabViewModel`** is marked **`override`**; behavior is unchanged—if the tab has **no loaded URL**, it **closes the tab and selects the source tab** instead of leaving a blank tab behind.
> 
> A unit test asserts the listener is invoked when a subscription link is detected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3df9cc56f8160f858f8e2aa2b51cd5257b98a8df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->