### PR TITLE
Update Duck Player e2e tests

### DIFF
--- a/.maestro/duckplayer/ask_serp_organic_duckplayer.yaml
+++ b/.maestro/duckplayer/ask_serp_organic_duckplayer.yaml
@@ -10,6 +10,7 @@ tags:
           clearState: true
 
       - runFlow: ../shared/skip_all_onboarding.yaml
+      - runFlow: common/enable_duck_player_ask.yaml
       - runFlow: common/load_serp_videos_organic.yaml
       - runFlow: common/serp_dialog_duckplayer.yaml
       - runFlow: common/assert_duckplayer_visible.yaml

--- a/.maestro/duckplayer/ask_serp_organic_youtube.yaml
+++ b/.maestro/duckplayer/ask_serp_organic_youtube.yaml
@@ -11,6 +11,7 @@ tags:
           clearState: true
 
       - runFlow: ../shared/skip_all_onboarding.yaml
+      - runFlow: common/enable_duck_player_ask.yaml
       - runFlow: common/load_serp_videos_organic.yaml
       - runFlow: common/serp_dialog_youtube.yaml
       - runFlow: common/handle_youtube_cookies.yaml

--- a/.maestro/duckplayer/ask_serp_videos_duckplayer.yaml
+++ b/.maestro/duckplayer/ask_serp_videos_duckplayer.yaml
@@ -10,6 +10,7 @@ tags:
           clearState: true
 
       - runFlow: ../shared/skip_all_onboarding.yaml
+      - runFlow: common/enable_duck_player_ask.yaml
       - runFlow: common/load_serp_videos_vertical.yaml
       - runFlow: common/serp_dialog_duckplayer.yaml
       - runFlow: common/assert_duckplayer_visible.yaml

--- a/.maestro/duckplayer/ask_serp_videos_youtube.yaml
+++ b/.maestro/duckplayer/ask_serp_videos_youtube.yaml
@@ -11,6 +11,7 @@ tags:
           clearState: true
 
       - runFlow: ../shared/skip_all_onboarding.yaml
+      - runFlow: common/enable_duck_player_ask.yaml
       - runFlow: common/load_serp_videos_vertical.yaml
       - runFlow: common/serp_dialog_youtube.yaml
       - runFlow: common/handle_youtube_cookies.yaml

--- a/.maestro/duckplayer/common/enable_duck_player_ask.yaml
+++ b/.maestro/duckplayer/common/enable_duck_player_ask.yaml
@@ -1,0 +1,14 @@
+appId: com.duckduckgo.mobile.android
+---
+# Open settings and set Duck Player to ask every time
+- runFlow: open_duck_player_settings.yaml
+
+- tapOn:
+    text: "Ask Every Time"
+
+- tapOn:
+    text: "Save"
+
+- pressKey: Back
+- launchApp:
+      stopApp: true

--- a/.maestro/duckplayer/direct_duckplayer.yaml
+++ b/.maestro/duckplayer/direct_duckplayer.yaml
@@ -10,6 +10,7 @@ tags:
           clearState: true
 
       - runFlow: ../shared/skip_all_onboarding.yaml
+      - runFlow: common/enable_duck_player_ask.yaml
 
       - runFlow: ../shared/dismiss_native_input.yaml
       - tapOn:

--- a/.maestro/duckplayer/direct_duckplayer_youtube.yaml
+++ b/.maestro/duckplayer/direct_duckplayer_youtube.yaml
@@ -11,6 +11,7 @@ tags:
           clearState: true
 
       - runFlow: ../shared/skip_all_onboarding.yaml
+      - runFlow: common/enable_duck_player_ask.yaml
 
       - runFlow: ../shared/dismiss_native_input.yaml
       - tapOn:

--- a/.maestro/duckplayer/duckplayer_settings.yaml
+++ b/.maestro/duckplayer/duckplayer_settings.yaml
@@ -23,11 +23,11 @@ tags:
 
       - scrollUntilVisible:
           element:
-            text: "YouTube Ad Blocking"
+            text: "Ad Blocking"
           direction: DOWN
 
       - tapOn:
-          text: "YouTube Ad Blocking"
+          text: "Ad Blocking"
 
       - tapOn:
           text: "Duck Player"

--- a/.maestro/duckplayer/patches/ad_blocking_enabled_patch.json
+++ b/.maestro/duckplayer/patches/ad_blocking_enabled_patch.json
@@ -8,5 +8,21 @@
     "op": "replace",
     "path": "/features/adBlockingExtension/minSupportedVersion",
     "value": 0
+  },
+  {
+    "op": "add",
+    "path": "/features/adBlockingExtension/features/enabledByDefault",
+    "value": {
+      "state": "enabled",
+      "minSupportedVersion": 0
+    }
+  },
+  {
+    "op": "add",
+    "path": "/features/adBlockingExtension/features/adBlockingUXImprovements",
+    "value": {
+      "state": "enabled",
+      "minSupportedVersion": 0
+    }
   }
 ]


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212227266948491/task/1216624321528486?focus=true
Tech Design URL (if applicable): 

### Description
* Update Duck Player tests to use new settings entry point

### Steps to test this PR

_Feature 1_
- [ ] Check [workflow](https://github.com/duckduckgo/Android/actions/runs/29583689738) passes

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Maestro e2e YAML and a test feature patch; no production app code is modified.
> 
> **Overview**
> Updates Maestro Duck Player flows so e2e setup matches the **Ad Blocking** settings entry point and the **Ask Every Time** Duck Player mode.
> 
> Adds shared flow `common/enable_duck_player_ask.yaml` and runs it after onboarding in SERP, direct `duck://player`, and related scenarios so tests consistently configure Duck Player before assertions. The Duck Player settings smoke test now scrolls to and taps **Ad Blocking** instead of **YouTube Ad Blocking**.
> 
> The `ad_blocking_enabled_patch.json` test patch also enables `enabledByDefault` and `adBlockingUXImprovements` under `adBlockingExtension` so the patched feature config matches the new UX in CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6da0e331a6b4529cbd850656ac5ac57bca685546. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->