### PR TITLE
Revert "Fix crash on new-user onboarding when resuming into a browser-hosted step"

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/launch/LaunchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/launch/LaunchViewModel.kt
@@ -88,8 +88,10 @@ class LaunchViewModel @Inject constructor(
                     LinearOnboardingHost.OnboardingActivity -> {
                         command.value = Command.Onboarding
                     }
-                    LinearOnboardingHost.BrowserActivity -> {
-                        command.value = Command.Home()
+
+                    else -> {
+                        // extend to support initial hosts in the future
+                        throw IllegalArgumentException("unsupported initial onboarding host transition")
                     }
                 }
             } else {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1216624305771573?focus=true
Tech Design URL (if applicable): 

### Description
Reverts duckduckgo/Android#9213, as it fixes the crash but can create several chat tabs instead

### Steps to test this PR
```diff
diff --git a/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt b/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
index fe3752cbb2..edd3bfb4dd 100644
--- a/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
@@ -111,13 +111,15 @@ class CustomAiOnboardingStoreImpl @Inject constructor(
             val resolution = referrerExists && customAiOnboardingEnabled && brandDesignEnabled
             preferences.edit { putBoolean(PREFS_KEY_ENABLED, resolution) }

-            return@withContext resolution
+            // return@withContext resolution
+            return@withContext true
         }
     }

     override suspend fun isEnabled(): Boolean = resolveMutex.withLock {
         withContext(dispatcherProvider.io()) {
-            preferences.getBoolean(PREFS_KEY_ENABLED, false)
+            // preferences.getBoolean(PREFS_KEY_ENABLED, false)
+            true
         }
     }
```
- [x] Apply the `CustomAiOnboardingStore` patch above locally to force-enable the custom Duck.ai onboarding flow
- [x] Fresh install, go through onboarding until reaching the Duck.ai demo step (now in `BrowserActivity`)
- [x] Press back to exit the app (do not kill the process)
- [x] Relaunch the app from the launcher icon → confirm it crashes with `IllegalArgumentException: unsupported initial onboarding host transition`



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes first-launch routing for new users on brand-design onboarding; browser-hosted resume paths crash again instead of reaching Home, which affects onboarding reliability but not auth or data handling.
> 
> **Overview**
> Reverts the launch-path fix that sent new users with a **browser-hosted** linear onboarding step straight to **Home** instead of crashing.
> 
> In `LaunchViewModel.showOnboardingOrHome()`, when brand-design onboarding is enabled, only `LinearOnboardingHost.OnboardingActivity` still routes to `Command.Onboarding`. **`BrowserActivity` (and any other host) no longer maps to `Command.Home()`** — the `else` branch again throws `IllegalArgumentException("unsupported initial onboarding host transition")`.
> 
> **Trade-off:** restores the prior crash when onboarding resumes on a browser-hosted step, but avoids the regression where that Home routing opened **multiple Duck.ai/chat tabs**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17c824ce5f7f1c1e9ee37a42e367036b29618b39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->