### PR TITLE
Bump Develocity Artifact Cache CLI to 1.4.0

### DIFF
--- a/.github/actions/develocity-artifact-cache/action.yml
+++ b/.github/actions/develocity-artifact-cache/action.yml
@@ -25,7 +25,7 @@ inputs:
   cli-version:
     description: 'Artifact Cache CLI version'
     required: false
-    default: '1.3.0'
+    default: '1.4.0'
   cli-filename:
     description: 'Artifact Cache CLI artifact id / filename (without extension)'
     required: false


### PR DESCRIPTION
Task/Issue URL: 
Tech Design URL (if applicable): 

### Description

Bumps the Develocity Artifact Cache CLI default version from `1.3.0` to `1.4.0` in the `develocity-artifact-cache` composite action.

1.4.0 fixes the negative restore-size values the CLI recorded in build scan custom values on 1.3.0. Those bad values distort Artifact Cache savings analysis on Develocity (DRV), where restore sizes currently read as misleadingly net-negative.

No change to build behaviour — only the CLI jar version the action downloads and invokes.

> ⚠️ **Prerequisite — the 1.4.0 jar must be published first.**
> The action does not fetch the CLI from Gradle; it downloads it from **this org's GitHub Packages Maven registry**: `maven.pkg.github.com/duckduckgo/android-cache-tools`, at `com/gradle/develocity-artifact-cache-cli/1.4.0/develocity-artifact-cache-cli-1.4.0.jar` (authenticated as `daxmobile`).
> This PR will fail at the "Downloading Artifact Cache CLI v1.4.0" step unless `develocity-artifact-cache-cli-1.4.0.jar` has been published to that registry. **Please publish 1.4.0 there before (or together with) merging.** I couldn't verify its presence — no `read:packages` access to the private repo.

### Steps to test this PR

_Artifact Cache CLI 1.4.0_
- [ ] Ensure `develocity-artifact-cache-cli-1.4.0.jar` is published to `maven.pkg.github.com/duckduckgo/android-cache-tools` (see prerequisite above).
- [ ] Trigger the `Build debug apk` workflow (open/push a PR against `develop`).
- [ ] In the "Restore Develocity Setup + Artifact Cache" step logs, confirm `Downloading Artifact Cache CLI v1.4.0...` (or a tool-cache hit for the 1.4.0 jar).
- [ ] Open the resulting build scan on https://duckduckgo.develocity.cloud and confirm the Artifact Cache restore-size custom values are non-negative.

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |