### PR TITLE
Auto-capture GH runner hardware and region as build scan custom values

### DIFF
--- a/.github/actions/develocity-runner-info/action.yml
+++ b/.github/actions/develocity-runner-info/action.yml
@@ -1,0 +1,59 @@
+name: 'Develocity Runner Info'
+description: 'Capture GitHub Actions runner hardware and region as Develocity build scan custom values'
+
+inputs:
+  runner-type:
+    description: >-
+      Optional human-readable label for the runner (e.g. "ubuntu-latest-4-core").
+      Only needed if you want a friendly name alongside the auto-detected VM size,
+      CPU count and region below. Leave unset to rely purely on runtime detection,
+      which needs no maintenance as runner sizes change.
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Capture runner info
+      shell: bash
+      run: |
+        # Every value below is exposed to the Gradle build as an env var; settings.gradle
+        # reads them and publishes them as build scan custom values.
+
+        # Optional human label — only emitted if the caller passed one.
+        if [ -n "${{ inputs.runner-type }}" ]; then
+          echo "DDG_RUNNER_TYPE=${{ inputs.runner-type }}" >> "$GITHUB_ENV"
+        fi
+
+        # From the runner context: the runner name and hosted/self-hosted environment.
+        # environment also tells us whether the Azure IMDS lookups below are expected to
+        # succeed (github-hosted) or not. os/arch are omitted on purpose — the build scan
+        # already records them natively.
+        echo "DDG_RUNNER_NAME=${{ runner.name }}" >> "$GITHUB_ENV"
+        echo "DDG_RUNNER_ENVIRONMENT=${{ runner.environment }}" >> "$GITHUB_ENV"
+
+        # CPU count is available on every runner (hosted or self-hosted) and needs no
+        # maintenance — it reflects the actual hardware the job was given.
+        CPU_COUNT="$(nproc 2>/dev/null || echo '')"
+        if [ -n "$CPU_COUNT" ]; then
+          echo "DDG_RUNNER_CPU_COUNT=$CPU_COUNT" >> "$GITHUB_ENV"
+        fi
+
+        # GitHub-hosted runners are Azure VMs. Query the Azure Instance Metadata Service
+        # (IMDS) for the authoritative VM size and region — no hardcoding, self-updating
+        # as GitHub changes runner SKUs. Best-effort: a self-hosted/restricted runner has
+        # no IMDS, and this must never fail the build.
+        IMDS='http://169.254.169.254/metadata/instance/compute'
+        VM_SIZE="$(curl --silent --fail --max-time 5 -H 'Metadata: true' "$IMDS/vmSize?api-version=2021-02-01&format=text" || true)"
+        REGION="$(curl --silent --fail --max-time 5 -H 'Metadata: true' "$IMDS/location?api-version=2021-02-01&format=text" || true)"
+        if [ -n "$VM_SIZE" ]; then
+          echo "DDG_RUNNER_VM_SIZE=$VM_SIZE" >> "$GITHUB_ENV"
+        fi
+        if [ -n "$REGION" ]; then
+          echo "DDG_RUNNER_REGION=$REGION" >> "$GITHUB_ENV"
+        fi
+
+        echo "Runner: name='${{ runner.name }}' env='${{ runner.environment }}' type='${{ inputs.runner-type }}' vmSize='${VM_SIZE:-?}' cpus='${CPU_COUNT:-?}' region='${REGION:-?}'"
+        if [ -z "$VM_SIZE$REGION" ]; then
+          echo "::notice::Azure IMDS unavailable (self-hosted or restricted runner); only CPU count captured."
+        fi

--- a/.github/workflows/build-debug-apk.yaml
+++ b/.github/workflows/build-debug-apk.yaml
@@ -62,6 +62,11 @@ jobs:
           cache-disabled: true # Develocity Artifact Cache supersedes setup-gradle's Gradle Home caching
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
+      - name: Capture runner info for build scans
+        uses: ./.github/actions/develocity-runner-info
+        # Runner VM size, CPU count and region are auto-detected at runtime; no need to
+        # hardcode a type. Pass runner-type only if you want an extra human-readable label.
+
       - name: Restore Develocity Setup + Artifact Cache
         uses: ./.github/actions/develocity-artifact-cache
         with:

--- a/settings.gradle
+++ b/settings.gradle
@@ -33,6 +33,25 @@ develocity {
         def diFrameworkTag = providers.gradleProperty('ddg.di').getOrElse('AnvilDagger')
         tag(diFrameworkTag)
         value('ddg.di', diFrameworkTag)
+
+        // Runner metadata, populated on CI by the develocity-runner-info action.
+        // Captured as custom values (not tags) so each dimension stays named and
+        // independently queryable when correlating Artifact Cache overhead with the
+        // runner hardware/region. Each is guarded so local builds emit nothing and so
+        // a runner without Azure IMDS (self-hosted) simply omits what it can't detect.
+        [
+            'Runner Type'       : 'DDG_RUNNER_TYPE',        // optional human label, if the CI step set one
+            'Runner Name'       : 'DDG_RUNNER_NAME',        // runner name from the runner context
+            'Runner Environment': 'DDG_RUNNER_ENVIRONMENT', // github-hosted vs self-hosted (runner context)
+            'Runner VM Size'    : 'DDG_RUNNER_VM_SIZE',     // authoritative Azure SKU from IMDS
+            'Runner CPU Count'  : 'DDG_RUNNER_CPU_COUNT',   // from nproc; works everywhere
+            'Runner Region'     : 'DDG_RUNNER_REGION',      // Azure region from IMDS
+        ].each { name, envVar ->
+            def v = System.getenv(envVar)
+            if (v) {
+                value(name, v)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: 
Tech Design URL (if applicable): 

### Description

Adds runner metadata to Develocity build scans so Artifact Cache restore overhead can be correlated with the runner hardware and region.

- New `develocity-runner-info` composite action, **auto-detecting at runtime** (no hardcoding to maintain):
  - `Runner VM Size` — the authoritative Azure VM SKU, read from the Azure Instance Metadata Service (IMDS). Self-updates as GitHub changes runner sizes.
  - `Runner CPU Count` — from `nproc`; works on every runner, including self-hosted.
  - `Runner Region` — the Azure region, from IMDS.
  - `Runner Environment` — `github-hosted` vs `self-hosted`, from the `runner` context.
  - `Runner Name` — the runner name, from the `runner` context.
  - `Runner Type` — *optional* human-readable label via the `runner-type` input, only if a team wants a friendly name in addition to the detected hardware. Not required.
  - All IMDS calls are best-effort: they never fail the build and simply omit what a self-hosted/restricted runner can't provide.
- `settings.gradle` publishes each as a build scan custom value, guarded so local builds emit nothing.
- Wired into `build-debug-apk` (currently the only workflow using the Artifact Cache) with **no inputs** — it detects everything itself. Add the same step to other workflows as needed.

**Why auto-detect instead of hardcoding the type:** GitHub exposes no runtime API for the `runs-on` label, but the runner is an Azure VM, so IMDS `compute/vmSize` gives the exact SKU and `nproc` gives the core count. That identifies the hardware precisely without anyone maintaining a per-workflow label.

**On the built-in `runner` context / `RUNNER_*` env vars:** they're the same data, and I evaluated all of them. `runner.name` and `runner.environment` are captured (name is non-unique on hosted runners but useful for identifying self-hosted machines; environment also signals whether IMDS is expected to resolve). `runner.os` / `runner.arch` are omitted because the build scan's Infrastructure section already records OS and architecture natively; `runner.debug` is unrelated. None of them provide VM size, region, or CPU count — hence IMDS + `nproc`.

**Tag vs custom value — implemented as custom values, not tags:**
- Several distinct dimensions (vm size, cpu count, region, optional label) stay named and independently queryable. As tags they'd be an unnamed flat set — e.g. `Standard_D4ads_v5` + `eastus` loses which-is-which and pollutes the tag space.
- The DRV export/API exposes custom values by name, so restore overhead can be grouped by VM size / region directly — the analysis driving this request.
- VM size / region are moderate-cardinality; tags are best kept low-cardinality and categorical.
- Consistent with the existing `value('ddg.di', ...)`.
- If at-a-glance filtering in the scan list is wanted later, add one coarse tag for the runner class (e.g. `runner:large` / `runner:default`) alongside these values — the same dual pattern already used for `ddg.di` (tag + value).

### Steps to test this PR

_Runner info custom values_
- [ ] Trigger the `Build debug apk` workflow.
- [ ] Confirm the "Capture runner info for build scans" step logs a line like `Runner: name='GitHub Actions 3' env='github-hosted' type='' vmSize='Standard_...' cpus='4' region='eastus'`.
- [ ] Open the build scan on https://duckduckgo.develocity.cloud → Custom values, and confirm `Runner VM Size`, `Runner CPU Count`, `Runner Region`, `Runner Environment` and `Runner Name` are present with correct values.
- [ ] Run a local build (e.g. `./gradlew help`) and confirm none of the `Runner *` values appear on the local scan.

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |