### PR TITLE
Add graceful handling of condition action failure

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/BrokerActionFailedEventHandler.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/actions/BrokerActionFailedEventHandler.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.EmailConfirma
 import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.OptOutStep
 import com.duckduckgo.pir.impl.common.PirJob.RunType
 import com.duckduckgo.pir.impl.common.PirRunStateHandler
+import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerOptOutConditionNotFound
 import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerStepActionFailed
 import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerStepInvalidEvent
 import com.duckduckgo.pir.impl.common.actions.EventHandler.Next
@@ -80,6 +81,13 @@ class BrokerActionFailedEventHandler @Inject constructor(
         val currentAction = currentBrokerStep.step.actions[state.currentActionIndex]
         val error = (event as BrokerActionFailed).error
 
+        // A condition action reports a failure (JsActionFailed, or a local timeout) when its expectation
+        // is not met. For a condition that is expected rather than fatal: treat it as "condition not met"
+        // and skip to the next action, instead of retrying and then failing the whole broker step.
+        if (currentAction is BrokerAction.Condition) {
+            return handleConditionNotMet(state)
+        }
+
         // If failure is on Any captcha action, we proceed to next action
         return if (shouldRetryFailedAction(state, event, currentAction)) {
             Next(
@@ -108,6 +116,33 @@ class BrokerActionFailedEventHandler @Inject constructor(
                 ),
             )
         }
+    }
+
+    private suspend fun handleConditionNotMet(state: State): Next {
+        val currentBrokerStep = state.brokerStepsToExecute[state.currentBrokerStepIndex]
+        if (currentBrokerStep is OptOutStep) {
+            pirRunStateHandler.handleState(
+                BrokerOptOutConditionNotFound(
+                    broker = currentBrokerStep.broker,
+                    actionID = currentBrokerStep.step.actions[state.currentActionIndex].id,
+                    attemptId = state.attemptId,
+                    durationMs = currentTimeProvider.currentTimeMillis() - state.stageStatus.stageStartMs,
+                    currentActionAttemptCount = state.actionRetryCount + 1,
+                ),
+            )
+        }
+
+        return Next(
+            nextState = state.copy(
+                currentActionIndex = state.currentActionIndex + 1,
+                actionRetryCount = 0,
+            ),
+            nextEvent = ExecuteBrokerStepAction(
+                UserProfile(
+                    userProfile = state.profileQuery,
+                ),
+            ),
+        )
     }
 
     private fun isEventValid(state: State): Boolean {

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/BrokerActionFailedEventHandlerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/actions/BrokerActionFailedEventHandlerTest.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.OptOut
 import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.ScanStepActions
 import com.duckduckgo.pir.impl.common.PirJob.RunType
 import com.duckduckgo.pir.impl.common.PirRunStateHandler
+import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerOptOutConditionNotFound
 import com.duckduckgo.pir.impl.common.PirRunStateHandler.PirRunState.BrokerStepInvalidEvent
 import com.duckduckgo.pir.impl.common.actions.BrokerActionFailedEventHandler.Companion.MAX_RETRY_COUNT_OPTOUT
 import com.duckduckgo.pir.impl.common.actions.BrokerActionFailedEventHandler.Companion.MAX_RETRY_COUNT_SCAN
@@ -49,6 +50,7 @@ import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 
 class BrokerActionFailedEventHandlerTest {
@@ -105,7 +107,20 @@ class BrokerActionFailedEventHandlerTest {
         expectations = emptyList(),
     )
 
+    private val testConditionAction = BrokerAction.Condition(
+        id = "condition-action-1",
+        comment = "Optional prompt that only sometimes appears",
+        expectations = emptyList(),
+        actions = emptyList(),
+    )
+
     private val testError = PirError.JsError.ActionError("Test error")
+
+    // The real error a condition produces when its expectation is not met (also "Local timeout").
+    private val testConditionError = PirError.ActionError.JsActionFailed(
+        actionID = "condition-action-1",
+        message = "element with selector #spellcheck-original not found.",
+    )
 
     @Before
     fun setUp() {
@@ -423,6 +438,86 @@ class BrokerActionFailedEventHandlerTest {
                 runType = RunType.MANUAL,
             ),
         )
+    }
+
+    @Test
+    fun whenConditionActionFailedInScanThenSkipsToNextActionInsteadOfRetryingOrFailing() = runTest {
+        // A condition whose expectation is not met reports a JsActionFailed (or "Local timeout").
+        // For a condition this is not fatal: skip to the next action instead of retrying then failing
+        // the whole broker step. Uses allowRetry = true to prove the condition bypasses the retry path.
+        val scanStep = ScanStep(
+            broker = testBroker,
+            step = ScanStepActions(
+                stepType = "scan",
+                actions = listOf(testConditionAction, testClickAction),
+                scanType = "initial",
+            ),
+        )
+        val state = State(
+            runType = RunType.MANUAL,
+            brokerStepsToExecute = listOf(scanStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            actionRetryCount = 0,
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 0,
+            ),
+        )
+        val event = BrokerActionFailed(error = testConditionError, allowRetry = true)
+
+        val result = testee.invoke(state, event)
+
+        // Advances to the next action and resets the retry count.
+        assertEquals(1, result.nextState.currentActionIndex)
+        assertEquals(0, result.nextState.actionRetryCount)
+        val nextEvent = result.nextEvent as ExecuteBrokerStepAction
+        assertEquals(testProfileQuery, (nextEvent.actionRequestData as PirScriptRequestData.UserProfile).userProfile)
+        // Scan step: no opt-out condition pixel fired.
+        verifyNoInteractions(mockPirRunStateHandler)
+    }
+
+    @Test
+    fun whenConditionActionFailedInOptOutThenFiresConditionNotFoundAndSkipsToNextAction() = runTest {
+        val optOutStep = OptOutStep(
+            broker = testBroker,
+            step = OptOutStepActions(
+                stepType = "optout",
+                actions = listOf(testConditionAction, testClickAction),
+                optOutType = "form",
+            ),
+            profileToOptOut = testExtractedProfile,
+        )
+        val state = State(
+            runType = RunType.OPTOUT,
+            brokerStepsToExecute = listOf(optOutStep),
+            profileQuery = testProfileQuery,
+            currentBrokerStepIndex = 0,
+            currentActionIndex = 0,
+            actionRetryCount = 0,
+            attemptId = "attempt-1",
+            stageStatus = PirStageStatus(
+                currentStage = PirStage.OTHER,
+                stageStartMs = 1000L,
+            ),
+        )
+        val event = BrokerActionFailed(error = testConditionError, allowRetry = true)
+
+        val result = testee.invoke(state, event)
+
+        verify(mockPirRunStateHandler).handleState(
+            BrokerOptOutConditionNotFound(
+                broker = testBroker,
+                actionID = testConditionAction.id,
+                attemptId = "attempt-1",
+                durationMs = testCurrentTimeInMillis - 1000L,
+                currentActionAttemptCount = 1,
+            ),
+        )
+        assertEquals(1, result.nextState.currentActionIndex)
+        val nextEvent = result.nextEvent as ExecuteBrokerStepAction
+        assertEquals(testProfileQuery, (nextEvent.actionRequestData as PirScriptRequestData.UserProfile).userProfile)
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216659177399664?focus=true
Tech Design URL (if applicable): N/A

### Description
The Condition action can return errors when an expected element is not present on the screen which means the whole scan / opt-out step is cancelled. This adds graceful handling as Condition actions are meant to be optional.

### Steps to test this PR
QA-optional 

- [ ] Run a debug scan on PropertyRecord on develop branch and verify it fails on the Condition action
- [x] Run a debug scan on PropertyRecord on this branch and verify it completes successfully

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PIR broker automation failure semantics for condition actions, which can alter scan/opt-out success vs failure outcomes for brokers like PropertyRecord; scope is localized to one event handler with new tests.
> 
> **Overview**
> **`BrokerActionFailed`** handling now treats failures on **`BrokerAction.Condition`** as “condition not met” instead of a fatal step error. When a condition’s expectation fails (e.g. `JsActionFailed` or local timeout), the runner **advances to the next action** and resets the retry count, bypassing the normal retry-then-**`BrokerStepCompleted(Failure)`** path.
> 
> On **opt-out** steps only, it emits **`BrokerOptOutConditionNotFound`** via **`PirRunStateHandler`** (analytics for optional UI not present); **scan** steps skip without that pixel. Tests cover scan skip behavior and opt-out pixel + continuation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 982a3188b32f0db6efbeb706072951556e268341. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->