### PR TITLE
Update action-maestro-cloud to v3

### DIFF
--- a/.github/actions/maestro-cloud-asana-reporter/action.yml
+++ b/.github/actions/maestro-cloud-asana-reporter/action.yml
@@ -79,7 +79,7 @@ runs:
   steps:
     - name: Run Maestro Cloud
       id: maestro-run
-      uses: mobile-dev-inc/action-maestro-cloud@v1.9.8
+      uses: mobile-dev-inc/action-maestro-cloud@v3.0.1
       with:
         api-key: ${{ inputs.maestro_api_key }}
         project-id: ${{ inputs.maestro_project_id }}
@@ -87,7 +87,7 @@ runs:
         timeout: ${{ inputs.maestro_timeout }}
         app-file: ${{ inputs.maestro_app_binary_id == '' && inputs.maestro_app_file || '' }}
         app-binary-id: ${{ inputs.maestro_app_binary_id != '' && inputs.maestro_app_binary_id || '' }}
-        android-api-level: ${{ inputs.maestro_api_level }}
+        device-os: android-${{ inputs.maestro_api_level }}
         workspace: .maestro
         include-tags: ${{ inputs.maestro_include_tags }}
         env: ${{ inputs.maestro_env }}

--- a/.github/workflows/design-system-composable-pr-test.yml
+++ b/.github/workflows/design-system-composable-pr-test.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Run Design System Maestro Tests
         id: maestro-run
-        uses: mobile-dev-inc/action-maestro-cloud@v1.9.8
+        uses: mobile-dev-inc/action-maestro-cloud@v3.0.1
         timeout-minutes: 30
         with:
           api-key: ${{ secrets.ROBIN_API_KEY }}
@@ -71,7 +71,7 @@ jobs:
           name: design_system_pr_${{ github.event.pull_request.number }}_${{ github.sha }}
           timeout: 15
           app-file: apk/internal.apk
-          android-api-level: 30
+          device-os: android-30
           workspace: .maestro
           include-tags: androidDesignSystemTest
 

--- a/.github/workflows/release_tests.yml
+++ b/.github/workflows/release_tests.yml
@@ -35,14 +35,14 @@ jobs:
 
       - name: Maestro tests flows
         id: release-tests
-        uses: mobile-dev-inc/action-maestro-cloud@v1.9.8
+        uses: mobile-dev-inc/action-maestro-cloud@v3.0.1
         timeout-minutes: 120
         with:
           api-key: ${{ secrets.ROBIN_API_KEY }}
           project-id: ${{ vars.ROBIN_ANDROID_PROJECT_ID }}
           timeout: ${{ vars.ROBIN_TIMEOUT_MINUTES }}
           app-file: ${{ steps.assemble.outputs.play_apk_path }}
-          android-api-level: 30
+          device-os: android-30
           workspace: .maestro
           include-tags: releaseTest
 

--- a/.maestro/config.yaml
+++ b/.maestro/config.yaml
@@ -1,7 +1,3 @@
-appStartup:
-  enabled: false
-appSize:
-  enabled: false
 disableRetries: false
 
 flows:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1216661206348410?focus=true

### Description

Howdy, Ducks! I'm Dan from the Maestro team 👋 

Spotted your Maestro Cloud action was using a deprecated field so wanted to offer an update before some future update broke your flows.

There's a lot of work happened under the hood since v1.9.8, but nothing constituting a breaking change for your usage of it. Rather than being a custom API client, the action is now a wrapper around the Maestro CLI, making it a far more consistent tool to what developers use locally.

### Steps to test this PR

[Manually run the e2e-maestro](https://github.com/duckduckgo/Android/actions/workflows/e2e-maestro.yml) workflow against this branch.

### UI changes

None.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency and config updates for Maestro Cloud; no app runtime or security logic changes, though E2E behavior depends on v3 action parity with the old field mapping.
> 
> **Overview**
> Upgrades **Maestro Cloud** GitHub Action from `v1.9.8` to **`v3.0.1`** everywhere it runs CI E2E (composite `maestro-cloud-asana-reporter`, design-system PR workflow, and release Maestro workflow).
> 
> The deprecated **`android-api-level`** input is replaced with **`device-os`** (e.g. `android-30` or `android-${{ maestro_api_level }}`), matching the v3 action API without changing which Android API level is targeted.
> 
> **`.maestro/config.yaml`** drops the disabled `appStartup` and `appSize` blocks, leaving retries and flow glob configuration only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39d1d5adaf7212af02ccc093cb45b41fe9a4438a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->