### PR TITLE
Preserve certificate for same-origin navigations

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1249,7 +1249,15 @@ class BrowserTabViewModel @Inject constructor(
             buildingSiteFactoryJob?.cancel()
         }
         val externalLaunch = stillExternal ?: false
+        val previousUrl = site?.uri
+        val previousCertificate = site?.certificate
         site = siteFactory.buildSite(url, tabId, title, httpsUpgraded, externalLaunch)
+        if (androidBrowserConfig.preserveCertificateOnSameOrigin().isEnabled() &&
+            previousUrl != null &&
+            sameOrigin(previousUrl, url)
+        ) {
+            site?.certificate = previousCertificate
+        }
         if (updateMaliciousSiteStatus) {
             site?.maliciousSiteStatus = maliciousSiteStatus
         }
@@ -4344,9 +4352,17 @@ class BrowserTabViewModel @Inject constructor(
         firstUrl: String,
         secondUrl: String,
     ): Boolean {
+        return runCatching {
+            sameOrigin(Uri.parse(firstUrl), secondUrl)
+        }.getOrNull() ?: return false
+    }
+
+    private fun sameOrigin(
+        firstUri: Uri,
+        secondUrl: String,
+    ): Boolean {
         return kotlin
             .runCatching {
-                val firstUri = Uri.parse(firstUrl)
                 val secondUri = Uri.parse(secondUrl)
 
                 firstUri.host == secondUri.host && firstUri.scheme == secondUri.scheme && firstUri.port == secondUri.port

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1256,6 +1256,11 @@ class BrowserTabViewModel @Inject constructor(
             previousUrl != null &&
             sameOrigin(previousUrl, url)
         ) {
+            /* An in-page (same-origin) navigation can be reported by WebView as a new page, rebuilding the
+            Site with a null certificate. Unlike a real load, no progress callback follows to re-capture it,
+            so the Privacy Dashboard would wrongly report an invalid certificate. Seed the new Site with the
+            previous certificate as a fallback; if a certificate callback does arrive it overwrites this value.
+             */
             site?.certificate = previousCertificate
         }
         if (updateMaliciousSiteStatus) {

--- a/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/pixels/remoteconfig/AndroidBrowserConfigFeature.kt
@@ -443,4 +443,14 @@ interface AndroidBrowserConfigFeature {
      */
     @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun customTabEndlessLoopFix(): Toggle
+
+    /**
+     * Controls whether a Site rebuilt for the same origin (e.g. an in-page/SPA navigation that
+     * WebView reports as a new page) inherits the previous Site's TLS certificate.
+     * @return `true` when the remote config has the global "preserveCertificateOnSameOrigin" androidBrowserConfig
+     * sub-feature flag enabled
+     * If the remote feature is not present defaults to `internal`
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
+    fun preserveCertificateOnSameOrigin(): Toggle
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -7484,6 +7484,49 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenNewPageForSameOriginThenCertificateIsPreserved() = runTest {
+        fakeAndroidConfigBrowserFeature.preserveCertificateOnSameOrigin().setRawStoredState(State(enable = true))
+        val certificate = aRSASslCertificate()
+        loadUrl("https://m.youtube.com/gaming")
+        testee.onCertificateReceived(certificate)
+
+        // In-page navigation that WebView reports as a new page (originalUrl changed) on the same origin
+        testee.navigationStateChanged(
+            buildWebNavigation(originalUrl = "https://m.youtube.com/", currentUrl = "https://m.youtube.com/"),
+        )
+
+        assertEquals(certificate, testee.siteLiveData.value?.certificate)
+    }
+
+    @Test
+    fun whenNewPageForDifferentOriginThenCertificateIsNotPreserved() = runTest {
+        fakeAndroidConfigBrowserFeature.preserveCertificateOnSameOrigin().setRawStoredState(State(enable = true))
+        val certificate = aRSASslCertificate()
+        loadUrl("https://m.youtube.com/gaming")
+        testee.onCertificateReceived(certificate)
+
+        testee.navigationStateChanged(
+            buildWebNavigation(originalUrl = "https://www.example.com/", currentUrl = "https://www.example.com/"),
+        )
+
+        assertNull(testee.siteLiveData.value?.certificate)
+    }
+
+    @Test
+    fun whenNewPageForSameOriginAndFeatureDisabledThenCertificateIsNotPreserved() = runTest {
+        fakeAndroidConfigBrowserFeature.preserveCertificateOnSameOrigin().setRawStoredState(State(enable = false))
+        val certificate = aRSASslCertificate()
+        loadUrl("https://m.youtube.com/gaming")
+        testee.onCertificateReceived(certificate)
+
+        testee.navigationStateChanged(
+            buildWebNavigation(originalUrl = "https://m.youtube.com/", currentUrl = "https://m.youtube.com/"),
+        )
+
+        assertNull(testee.siteLiveData.value?.certificate)
+    }
+
+    @Test
     fun whenResetSSLErrorThenBrowserErrorStateIsLoading() {
         whenever(mockEnabledToggle.isEnabled()).thenReturn(true)
         val url = exampleUrl


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1216652703312150?focus=true
Tech Design URL (if applicable): 

### Description
On SPA sites like YouTube/Yahoo, an in-page navigation can be reported by WebView as a new page, which rebuilds the tab’s Site object with a null certificate. On a real page load the certificate is repopulated by the subsequent progress events, but those are never received in SPA navigations, so the new Site keeps a null certificate and the Privacy Dashboard reports the connection as having an invalid certificate. 

Fix: when a Site is rebuilt for the same origin, it inherits the previous Site's certificate, since the connection — and therefore the certificate — is unchanged. Guarded behind the `preserveCertificateOnSameOrigin` remote flag

### Steps to test this PR

_Feature 1_
- [ ] Open yahoo.com, check connection shows as encrypted on the privacy dashboard
- [ ] Click on an article, check connection shows as encrypted on the privacy dashboard

_Feature 2_
- [ ] Open badssl.com, check connection shows as encrypted on the privacy dashboard
- [ ] Click on untrusted-root, accept risk and visit the site
- [ ] Check connection shows as unencrypted on the privacy dashboard

_Feature 3_
- [ ] Open youtube.com
- [ ] Open Privacy dashboard and click on the privacy line. Check certificate is for m.youtube.com
- [ ] Click on the YouTube settings icon
- [ ] Click History & privacy
- [ ] Click My Ad Center, will open accounts.google.com
- [ ] Open Privacy dashboard and click on the privacy line. Check certificate is for accounts.google.com

_Feature 4_
- [ ] Smoke test privacy dashboard

### UI changes
n/a


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how connection/certificate is shown in the Privacy Dashboard for same-origin navigations; scope is narrow and gated by remote config, with real certificate callbacks still taking precedence.
> 
> **Overview**
> Fixes false **invalid certificate** states in the Privacy Dashboard when WebView treats SPA in-page navigations (e.g. YouTube/Yahoo) as a new page and rebuilds `Site` without the usual progress/certificate callbacks.
> 
> When `preserveCertificateOnSameOrigin` is enabled, a rebuilt `Site` on the **same origin** copies the previous tab’s TLS certificate as a fallback; a later `onCertificateReceived` still overwrites it. Cross-origin navigations and the flag-off path behave as before. Adds the `preserveCertificateOnSameOrigin` androidBrowserConfig toggle (default on) and unit tests for same-origin, different-origin, and disabled-flag cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34e556f94a97364d171d7a29fc0635574f0c4cac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->