### PR TITLE
PIR: Fix PIR debug broker redownload

### DIFF
--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/PirRepository.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/store/PirRepository.kt
@@ -85,7 +85,11 @@ interface PirRepository {
 
     suspend fun updateBrokerJsons(brokers: List<BrokerJson>)
 
-    suspend fun clearAllBrokerJsons()
+    /**
+     * Clears all broker configuration: both the download etags and the parsed broker details
+     * (details, scan/optOut steps, scheduling config, mirror sites).
+     */
+    suspend fun clearAllBrokerData()
 
     suspend fun getAllLocalBrokerJsons(): List<BrokerJson>
 
@@ -348,9 +352,10 @@ class RealPirRepository(
         }
     }
 
-    override suspend fun clearAllBrokerJsons() {
+    override suspend fun clearAllBrokerData() {
         withContext(dispatcherProvider.io()) {
             brokerJsonDao()?.deleteAll()
+            brokerDao()?.deleteAll()
         }
     }
 

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/store/RealPirRepositoryTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/store/RealPirRepositoryTest.kt
@@ -903,4 +903,18 @@ class RealPirRepositoryTest {
         verify(mockBrokerJsonDao, never()).deleteAll()
         verify(mockPirDataStore, never()).reset()
     }
+
+    @Test
+    fun whenClearAllBrokerDataThenClearsEtagsAndBrokerDetailsButKeepsUserData() = runTest {
+        testee.clearAllBrokerData()
+
+        // Both the etag table AND the parsed broker-details tables must be cleared, otherwise a
+        // re-download is version-gated against the stale broker row and silently skipped.
+        verify(mockBrokerJsonDao).deleteAll()
+        verify(mockBrokerDao).deleteAll()
+        // User/profile data must be preserved (this is a broker-config reset, not a full wipe).
+        verify(mockExtractedProfileDao, never()).deleteAllExtractedProfiles()
+        verify(mockUserProfileDao, never()).deleteAllProfiles()
+        verify(mockPirDataStore, never()).reset()
+    }
 }

--- a/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirDevBrokerConfigActivity.kt
+++ b/pir/pir-internal/src/main/java/com/duckduckgo/pir/internal/settings/PirDevBrokerConfigActivity.kt
@@ -192,9 +192,9 @@ class PirDevBrokerConfigActivity : DuckDuckGoActivity() {
 
             try {
                 withContext(dispatcherProvider.io()) {
-                    // Clear etags to force re-download
+                    // Clear etags AND parsed broker details to force a real re-download
                     repository.updateMainEtag(null)
-                    repository.clearAllBrokerJsons()
+                    repository.clearAllBrokerData()
                     repository.setHasBrokerConfigBeenManuallyUpdated(false)
                 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203581873609357/task/1216664324190643?focus=true
Tech Design URL (if applicable): N/A

### Description
Check task description

### Steps to test this PR
QA-optional as it only affects debug tooling

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Debug-only broker config reset path with narrow storage changes and new unit test coverage; no production user-data wipe.
> 
> **Overview**
> Fixes PIR **debug broker “reset all configs”** so it actually forces a fresh broker download instead of silently skipping updates.
> 
> `clearAllBrokerJsons` is renamed to **`clearAllBrokerData`** and now wipes **both** broker JSON etags and **parsed broker detail tables** (via `brokerDao().deleteAll()`), while still leaving user/profile data untouched. `PirDevBrokerConfigActivity` calls the new API when resetting configs, and a repository test locks in that behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dedb0f9d05af9db659c6bdb0e74c7a4e1ae968ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->