### PR TITLE
Make ad blocking animation text more visible

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/BrowserLottieTrackersAnimatorHelper.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/animations/addressbar/BrowserLottieTrackersAnimatorHelper.kt
@@ -244,8 +244,9 @@ class BrowserLottieTrackersAnimatorHelper @Inject constructor(
         adBlockingView.show()
         adBlockingView.alpha = 0F
         adBlockingView.setImageResource(iconRes)
-        // The static player icon has no built-in inset (unlike the cookie Lottie), so pad it off the
-        // badge container's leading edge to line it up with the cookie/tracker icons.
+        // The static player icon has no built-in inset (unlike the cookie/tracker Lottie compositions,
+        // whose artwork fills the badge chip), so pad it to center the glyph in the chip and match their
+        // spacing to the text.
         adBlockingView.setPaddingRelative(AD_BLOCKING_ICON_START_PADDING_DP.toPx(), 0, 0, 0)
 
         val slideInTransition: Transition = createSlideTransition()
@@ -573,7 +574,7 @@ class BrowserLottieTrackersAnimatorHelper @Inject constructor(
         // before starting the cookies animation
         private const val DELAY_BETWEEN_ANIMATIONS_DURATION = 1500L
 
-        private const val AD_BLOCKING_ICON_START_PADDING_DP = 6
+        private const val AD_BLOCKING_ICON_START_PADDING_DP = 9
     }
 }
 

--- a/app/src/main/res/layout/ad_blocking_scene_1.xml
+++ b/app/src/main/res/layout/ad_blocking_scene_1.xml
@@ -21,12 +21,12 @@
 
     <com.duckduckgo.common.ui.view.text.DaxTextView
         android:id="@+id/adBlockingText"
-        app:typography="body1"
+        app:typography="body2"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
         android:layout_marginStart="8dp"
         android:paddingStart="16dp"
-        android:paddingEnd="16dp"
+        android:paddingEnd="12dp"
         android:maxLines="1"
         android:gravity="center"
         android:visibility="invisible"

--- a/app/src/main/res/layout/ad_blocking_scene_2.xml
+++ b/app/src/main/res/layout/ad_blocking_scene_2.xml
@@ -30,9 +30,9 @@
         android:gravity="center"
         android:maxLines="1"
         android:paddingStart="16dp"
-        android:paddingEnd="16dp"
+        android:paddingEnd="12dp"
         android:text="@string/ad_blocking_omnibar_badge_text"
         android:visibility="visible"
-        app:typography="body1"
+        app:typography="body2"
         tools:ignore="RtlCompat" />
 </FrameLayout>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1216661256870311?focus=true
Tech Design URL (if applicable): 

### Description
Center ad blocking icon, reduce font size, and reduce end padding, so the text fits better

### Steps to test this PR
n/a

### UI changes
| Before  | After |
| ------ | ----- |
|<img width="1626" height="3453" alt="image" src="https://github.com/user-attachments/assets/f13f0995-82bd-4684-bf9f-64577ff0ee59" />|<img width="1626" height="3453" alt="image" src="https://github.com/user-attachments/assets/2bb552ca-b58d-46cc-98d1-b3f1eabbc573" />|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Omnibar animation layout and typography only; no logic, data, or security impact.
> 
> **Overview**
> Tweaks the **ad blocking** address-bar badge so the label fits and lines up with cookie/tracker badges.
> 
> The badge text in `ad_blocking_scene_1` and `ad_blocking_scene_2` switches from **body1** to **body2** and **end padding** drops from 16dp to 12dp. In `BrowserLottieTrackersAnimatorHelper`, **start padding** on the static ad-blocking icon increases from **6dp to 9dp** so the glyph sits centered in the chip like the Lottie-based icons; the related comment is updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02b332199704f610b45c6ea47786803e9c10fbd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->