### PR TITLE
Android/ Contextual/UTI: Add favicon for attachment

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -808,7 +808,6 @@ class DuckChatContextualFragment :
             binding.contextualNativeInputWidget.setPageContext(
                 title = viewState.contextTitle,
                 url = viewState.contextUrl,
-                faviconUrl = null,
             )
         } else {
             binding.contextualNativeInputWidget.clearPageContext()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/attachment/PageContextAttachment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/attachment/PageContextAttachment.kt
@@ -18,10 +18,11 @@ package com.duckduckgo.duckchat.impl.ui.nativeinput.attachment
 
 /**
  * Display-only token representing the current page attached to the unified input as a chip.
- * The page content itself is held by the contextual layer; this carries only what the chip needs.
+ * The page content itself is held by the contextual layer; this carries only what the chip needs,
+ * including the [tabId] and [url] used to resolve the page favicon from the local favicon store.
  */
 data class PageContextAttachment(
     val title: String,
     val url: String,
-    val faviconUrl: String?,
+    val tabId: String?,
 )

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/AttachmentView.kt
@@ -34,6 +34,8 @@ import android.widget.TextView
 import androidx.core.view.isVisible
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.findViewTreeViewModelStoreOwner
+import androidx.lifecycle.viewModelScope
+import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.common.ui.view.text.DaxTextView
 import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.utils.ViewViewModelFactory
@@ -67,6 +69,7 @@ class AttachmentView(
     var onPageContextRemoved: (() -> Unit)? = null
 
     private var viewModel: AttachmentViewModel? = null
+    private var faviconManager: FaviconManager? = null
     private var supportsUpload: Boolean = false
     private var nativeInputStateJob: Job? = null
     private var lastNativeInputState: NativeInputState? = null
@@ -82,10 +85,16 @@ class AttachmentView(
         setOnClickListener { showPopupMenu() }
     }
 
-    fun bind(scope: CoroutineScope, factory: ViewViewModelFactory, nativeInputStateProvider: NativeInputStateProvider) {
+    fun bind(
+        scope: CoroutineScope,
+        factory: ViewViewModelFactory,
+        nativeInputStateProvider: NativeInputStateProvider,
+        faviconManager: FaviconManager,
+    ) {
         val owner = findViewTreeViewModelStoreOwner() ?: return
         val vm = ViewModelProvider(owner, factory)[AttachmentViewModel::class.java]
         viewModel = vm
+        this.faviconManager = faviconManager
         val container = rootView?.findViewById<FrameLayout>(R.id.attachmentsContainer) ?: return
         setupContainerViews(container, vm)
         scope.launch {
@@ -244,6 +253,11 @@ class AttachmentView(
             view.show(next) {
                 viewModel?.removePageContext()
                 onPageContextRemoved?.invoke()
+            }
+            view.faviconView()?.let { faviconView ->
+                viewModel?.viewModelScope?.launch {
+                    faviconManager?.loadToViewFromLocalWithRetry(tabId = next.tabId, url = next.url, view = faviconView)
+                }
             }
         }
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -48,6 +48,7 @@ import androidx.lifecycle.findViewTreeViewModelStoreOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView
 import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.app.browser.favicon.FaviconManager
 import com.duckduckgo.browser.api.autocomplete.AutoComplete.AutoCompleteSuggestion
 import com.duckduckgo.browser.ui.PulseAnimation
 import com.duckduckgo.browsermode.api.BrowserMode
@@ -147,7 +148,7 @@ interface NativeInputWidget {
     fun getImageAttachmentsJson(): JSONArray?
     fun getFileAttachmentsJson(): JSONArray?
     fun clearAttachments()
-    fun setPageContext(title: String, url: String, faviconUrl: String?)
+    fun setPageContext(title: String, url: String)
     fun clearPageContext()
     fun getPageContext(): PageContextAttachment?
     fun setContextualAttachmentActions(
@@ -245,6 +246,9 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     @Inject
     lateinit var browserMode: BrowserMode
+
+    @Inject
+    lateinit var faviconManager: FaviconManager
 
     private var activeTabId: String? = null
 
@@ -454,7 +458,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
             pluginView.onAskAboutTab = pendingAskAboutTab
             pluginView.onAskAboutPage = pendingAskAboutPage
             pluginView.onPageContextRemoved = pendingOnPageContextRemoved
-            pluginView.bind(scope, viewModelFactory, nativeInputStateProvider)
+            pluginView.bind(scope, viewModelFactory, nativeInputStateProvider, faviconManager)
             pendingPageContext?.let { pluginView.setPageContext(it) }
         }
         (pluginView as? ModelPicker)?.let { picker ->
@@ -1227,8 +1231,8 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     override fun getFileAttachmentsJson(): JSONArray? = attachmentView?.getFileAttachmentsJson()
 
-    override fun setPageContext(title: String, url: String, faviconUrl: String?) {
-        val attachment = PageContextAttachment(title = title, url = url, faviconUrl = faviconUrl)
+    override fun setPageContext(title: String, url: String) {
+        val attachment = PageContextAttachment(title = title, url = url, tabId = activeTabId)
         pendingPageContext = attachment
         attachmentView?.setPageContext(attachment)
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/PageContextAttachmentView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/PageContextAttachmentView.kt
@@ -45,10 +45,6 @@ class PageContextAttachmentView @JvmOverloads constructor(
 
     fun current(): PageContextAttachment? = attachment
 
-    /**
-     * The favicon [ImageView] for the currently shown chip, or null when nothing is shown. The host
-     * loads the page favicon into it; until then it keeps its default placeholder icon.
-     */
     fun faviconView(): ImageView? = faviconView
 
     fun show(attachment: PageContextAttachment, onRemoved: () -> Unit) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/PageContextAttachmentView.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/PageContextAttachmentView.kt
@@ -34,6 +34,7 @@ class PageContextAttachmentView @JvmOverloads constructor(
 ) : LinearLayout(context, attrs, defStyleAttr) {
 
     private var attachment: PageContextAttachment? = null
+    private var faviconView: ImageView? = null
 
     init {
         orientation = HORIZONTAL
@@ -44,18 +45,26 @@ class PageContextAttachmentView @JvmOverloads constructor(
 
     fun current(): PageContextAttachment? = attachment
 
+    /**
+     * The favicon [ImageView] for the currently shown chip, or null when nothing is shown. The host
+     * loads the page favicon into it; until then it keeps its default placeholder icon.
+     */
+    fun faviconView(): ImageView? = faviconView
+
     fun show(attachment: PageContextAttachment, onRemoved: () -> Unit) {
         this.attachment = attachment
         removeAllViews()
         val itemView = LayoutInflater.from(context).inflate(R.layout.view_page_context_attachment_item, this, false)
         itemView.findViewById<DaxTextView>(R.id.pageContextTitle).text = attachment.title
         itemView.findViewById<ImageView>(R.id.pageContextRemove).setOnClickListener { onRemoved() }
+        faviconView = itemView.findViewById(R.id.pageContextFavicon)
         addView(itemView)
         show()
     }
 
     fun hide() {
         attachment = null
+        faviconView = null
         removeAllViews()
         gone()
     }

--- a/duckchat/duckchat-impl/src/main/res/layout/view_page_context_attachment_item.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_page_context_attachment_item.xml
@@ -27,13 +27,13 @@
     android:orientation="horizontal"
     android:paddingStart="@dimen/keyline_2"
     android:paddingEnd="@dimen/keyline_3"
-    android:paddingTop="@dimen/keyline_1"
-    android:paddingBottom="@dimen/keyline_1">
+    android:paddingTop="@dimen/keyline_2"
+    android:paddingBottom="@dimen/keyline_2">
 
     <ImageView
         android:id="@+id/pageContextFavicon"
-        android:layout_width="@dimen/keyline_6"
-        android:layout_height="@dimen/keyline_6"
+        android:layout_width="@dimen/keyline_5"
+        android:layout_height="@dimen/keyline_5"
         android:importantForAccessibility="no"
         app:srcCompat="@drawable/ic_page_content_attach_24" />
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/AttachmentViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/AttachmentViewModelTest.kt
@@ -973,7 +973,7 @@ class AttachmentViewModelTest {
 
     @Test
     fun whenSetPageContextThenAttachmentStateAndGetterReflectIt() = runTest {
-        val pageContext = PageContextAttachment(title = "Example", url = "https://example.com", faviconUrl = null)
+        val pageContext = PageContextAttachment(title = "Example", url = "https://example.com", tabId = "tab-1")
 
         viewModel.setPageContext(pageContext)
 
@@ -983,8 +983,8 @@ class AttachmentViewModelTest {
 
     @Test
     fun whenSetPageContextTwiceThenLatestReplaces() = runTest {
-        viewModel.setPageContext(PageContextAttachment("First", "https://first.com", null))
-        val latest = PageContextAttachment("Second", "https://second.com", "https://second.com/fav.ico")
+        viewModel.setPageContext(PageContextAttachment("First", "https://first.com", "tab-1"))
+        val latest = PageContextAttachment("Second", "https://second.com", "tab-2")
 
         viewModel.setPageContext(latest)
 
@@ -993,7 +993,7 @@ class AttachmentViewModelTest {
 
     @Test
     fun whenRemovePageContextThenStateIsNull() = runTest {
-        viewModel.setPageContext(PageContextAttachment("Example", "https://example.com", null))
+        viewModel.setPageContext(PageContextAttachment("Example", "https://example.com", "tab-1"))
 
         viewModel.removePageContext()
 
@@ -1003,14 +1003,14 @@ class AttachmentViewModelTest {
 
     @Test
     fun whenOnlyPageContextPresentThenHasAttachmentsIsTrue() = runTest {
-        viewModel.setPageContext(PageContextAttachment("Example", "https://example.com", null))
+        viewModel.setPageContext(PageContextAttachment("Example", "https://example.com", "tab-1"))
 
         assertTrue(viewModel.attachmentState.value.hasAttachments)
     }
 
     @Test
     fun whenClearAttachmentsThenPageContextCleared() = runTest {
-        viewModel.setPageContext(PageContextAttachment("Example", "https://example.com", null))
+        viewModel.setPageContext(PageContextAttachment("Example", "https://example.com", "tab-1"))
 
         viewModel.clearAttachments()
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1216652646920727?focus=true 
Tech Design URL (if applicable): 

### Description
  - The page-context attachment chip in the contextual sheet's native input (contextualNativeInput) now shows the page favicon instead of a generic placeholder icon.

### Steps to test this PR
Setup
  - [x] Use an internal build, manually enable `contextualNativeInput`

  1. nativeChatInput enabled, contextualNativeInput enabled (native input path)
  - [x] The page-context chip renders inside the unified native input composer
  - [x] The chip shows the actual page favicon (not the generic placeholder icon)
  - [x] Favicon is correctly sized/padded within the chip
  - [x] Tapping the remove ✕ removes the page-context chip
  - [x] Favicon matches the site currently open in the tab

  2. nativeChatInput enabled, contextualNativeInput disabled (legacy path)
  - [x] The legacy context chip renders (not the native composer)
  - [x] The chip shows the actual page favicon (unchanged legacy behavior)
  - [x] Tapping remove/close behaves as before

  3. nativeChatInput disabled (legacy path)
  - [x] The legacy input + legacy context chip render
  - [x] The chip shows the actual page favicon (unchanged legacy behavior)

  4. Native input path, page with no cached favicon
  - [x] Open the contextual sheet from a page whose favicon is not available locally
  - [x] The chip shows the default placeholder icon (no crash, no empty/broken image)

  5. Native input path, favicon persistence
  - [x] Open contextual sheet on Site A → correct favicon shown
  - [x] Dismiss, navigate to Site B, open contextual sheet → chip shows Site B's favicon (not stale Site A favicon)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only Duck Chat attachment chip changes with no auth, data, or API contract impact beyond dropping unused faviconUrl from the model.
> 
> **Overview**
> The **page-context attachment chip** in the contextual native input now shows the **tab’s real favicon** from the local favicon store instead of relying on a passed-in URL or only the generic placeholder.
> 
> `PageContextAttachment` drops `faviconUrl` and carries **`tabId`** (with `url`) so favicons resolve the same way as elsewhere in the browser. Callers only pass **title and URL** into `setPageContext`; the widget attaches **`activeTabId`** when building the chip model. **`AttachmentView`** takes **`FaviconManager`** and, when the chip is shown, loads into the favicon `ImageView` via **`loadToViewFromLocalWithRetry`**. **`PageContextAttachmentView`** holds a reference to that image view; the chip layout gets minor **padding/size** tweaks for the icon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e7c242c7fb2beb244cb670fc9c2b2fa1a6b123d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->