### PR TITLE
Update strings

### DIFF
--- a/ad-blocking/ad-blocking-impl/src/main/res/values-bg/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-bg/strings-ad-blocking.xml
@@ -24,9 +24,9 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Отваря видеоклипове в режим на киносалон без разсейване, който предотвратява влиянието на гледаното съдържание върху емисията в YouTube.</string>
     <string name="ad_blocking_settings_title_v2">Блокиране на реклами</string>
-    <string name="ad_blocking_settings_header_description">Блокира инвазивните тракери, преди да се заредят, като ефективно елиминира рекламите, които разчитат на проследяването</string>
+    <string name="ad_blocking_settings_header_description">Блокира инвазивните тракери, преди да се заредят, като ефективно елиминира рекламите, които разчитат на проследяването.</string>
     <string name="contingencyMessageTitle">Блокирането на реклами в YouTube е недостъпно</string>
-    <string name="contingencyMessageContent">Блокирането на реклами е засегнато от скорошни промени в YouTube. Работим за отстраняване на тези проблеми и оценяваме Вашето разбиране</string>
+    <string name="contingencyMessageContent">Блокирането на реклами е засегнато от скорошни промени в YouTube. Работим за отстраняване на тези проблеми и оценяваме Вашето разбиране.</string>
     <string name="contingencyMessagePrimaryButton">Разбрах</string>
     <string name="contingencyMessageCloseContentDescription">Затваряне</string>
     <string name="ad_blocking_menu_disable">Деактивиране на блокирането на реклами в YouTube</string>
@@ -37,9 +37,11 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Деактивиране до рестартиране</string>
     <string name="ad_blocking_menu_always_off">Винаги изключено</string>
     <string name="ad_blocking_disabled_popup_title">Блокирането на реклами в YouTube не работи?</string>
-    <string name="ad_blocking_disabled_popup_description">Изпратете анонимен сигнал за повреда до DuckDuckGo. Помогнете за подобряване на блокирането на реклами за всички!</string>
+    <string name="ad_blocking_disabled_popup_description">Изпратете анонимен сигнал до DuckDuckGo и помогнете за подобряване на блокирането на реклами за всички!</string>
     <string name="ad_blocking_disabled_primary_action">Изпращане на сигнал за повреда</string>
     <string name="ad_blocking_disabled_secondary_action">Отмяна</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Деактивирано до рестартиране</string>
-    <string name="ad_blocking_omnibar_badge_text">Блокирането на рекламите в YouTube е включено</string>
+
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Блокирани реклами</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-cs/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-cs/strings-ad-blocking.xml
@@ -41,5 +41,7 @@
     <string name="ad_blocking_disabled_primary_action">Poslat zprávu o chybě</string>
     <string name="ad_blocking_disabled_secondary_action">Zrušit</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Vypnuto do opětovného spuštění</string>
-    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. Keep it as short as possible — aim for under ~20 characters or it will be truncated with an ellipsis. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Blokování reklam zapnuto</string>
+
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Blokování reklam zapnuto</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-cs/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-cs/strings-ad-blocking.xml
@@ -24,7 +24,7 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Otevírá videa v režimu kina, který brání tomu, aby sledovaná videa ovlivňovala tvůj feed na YouTube.</string>
     <string name="ad_blocking_settings_title_v2">Blokování reklam</string>
-    <string name="ad_blocking_settings_header_description">Zablokuje invazivní trackery ještě před jejich načtením, čímž účinně eliminuje reklamy, které spoléhají na sledování.</string>
+    <string name="ad_blocking_settings_header_description">Zablokuje invazivní trackery ještě před jejich načtením, čímž účinně eliminuje reklamy, které tě pronásledují.</string>
     <string name="contingencyMessageTitle">Blokování reklam na YouTube není k dispozici</string>
     <string name="contingencyMessageContent">Blokování reklam bylo ovlivněno nedávnými změnami na YouTube. Problémy se snažíme opravit. Děkujeme za pochopení.</string>
     <string name="contingencyMessagePrimaryButton">Rozumím</string>
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Vypnout až do opětovného spuštění</string>
     <string name="ad_blocking_menu_always_off">Vždycky vypnuté</string>
     <string name="ad_blocking_disabled_popup_title">Nefunguje blokování reklam na YouTube?</string>
-    <string name="ad_blocking_disabled_popup_description">Odeslat anonymní hlášení o chybě službě DuckDuckGo. Pomoz vylepšit blokování reklam pro všechny!</string>
+    <string name="ad_blocking_disabled_popup_description">Odešli anonymní hlášení službě DuckDuckGo a pomoz vylepšit blokování reklam pro všechny!</string>
     <string name="ad_blocking_disabled_primary_action">Poslat zprávu o chybě</string>
     <string name="ad_blocking_disabled_secondary_action">Zrušit</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Vypnuto do opětovného spuštění</string>
-    <string name="ad_blocking_omnibar_badge_text">Blokování reklam na YouTube zapnuto</string>
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. Keep it as short as possible — aim for under ~20 characters or it will be truncated with an ellipsis. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Blokování reklam zapnuto</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-de/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-de/strings-ad-blocking.xml
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Deaktivieren bis zum Neustart</string>
     <string name="ad_blocking_menu_always_off">Immer aus</string>
     <string name="ad_blocking_disabled_popup_title">YouTube-Werbeblockierung funktioniert nicht?</string>
-    <string name="ad_blocking_disabled_popup_description">Sende einen anonymen Störungsbericht an DuckDuckGo. Hilf mit, den Werbeblocker für alle zu verbessern!</string>
+    <string name="ad_blocking_disabled_popup_description">Sende einen anonymen Bericht an DuckDuckGo und hilf mit, den Werbeblocker für alle zu verbessern!</string>
     <string name="ad_blocking_disabled_primary_action">Störungsbericht senden</string>
     <string name="ad_blocking_disabled_secondary_action">Abbrechen</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Deaktiviert bis zum Neustart</string>
-    <string name="ad_blocking_omnibar_badge_text">YouTube-Werbungsblocker aktiviert</string>
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. Keep it as short as possible — aim for under ~20 characters or it will be truncated with an ellipsis. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Werbeblockierung aktiv</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-de/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-de/strings-ad-blocking.xml
@@ -41,5 +41,7 @@
     <string name="ad_blocking_disabled_primary_action">Störungsbericht senden</string>
     <string name="ad_blocking_disabled_secondary_action">Abbrechen</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Deaktiviert bis zum Neustart</string>
-    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. Keep it as short as possible — aim for under ~20 characters or it will be truncated with an ellipsis. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Werbeblockierung aktiv</string>
+
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Werbeblockierung aktiv</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-el/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-el/strings-ad-blocking.xml
@@ -24,9 +24,9 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Ανοίγει βίντεο σε λειτουργία κινηματογράφου χωρίς περισπάσεις, η οποία εμποδίζει το περιεχόμενο που παρακολουθείς να επηρεάσει τη ροή σου στο YouTube.</string>
     <string name="ad_blocking_settings_title_v2">Αποκλεισμός διαφημίσεων</string>
-    <string name="ad_blocking_settings_header_description">Αποκλείει επεμβατικά προγράμματα παρακολούθησης προτού φορτώσουν, εξαλείφοντας αποτελεσματικά διαφημίσεις που βασίζονται σε παρακολούθηση</string>
+    <string name="ad_blocking_settings_header_description">Αποκλείει επεμβατικά προγράμματα παρακολούθησης προτού φορτώσουν, εξαλείφοντας αποτελεσματικά διαφημίσεις που βασίζονται σε παρακολούθηση.</string>
     <string name="contingencyMessageTitle">Ο αποκλεισμός διαφημίσεων στο YouTube δεν είναι διαθέσιμος</string>
-    <string name="contingencyMessageContent">Ο αποκλεισμός διαφημίσεων έχει επηρεαστεί από τις πρόσφατες αλλαγές στο YouTube. Προσπαθούμε να διορθώσουμε αυτά τα προβλήματα και εκτιμούμε την κατανόησή σου</string>
+    <string name="contingencyMessageContent">Ο αποκλεισμός διαφημίσεων έχει επηρεαστεί από τις πρόσφατες αλλαγές στο YouTube. Προσπαθούμε να διορθώσουμε αυτά τα προβλήματα και εκτιμούμε την κατανόησή σας.</string>
     <string name="contingencyMessagePrimaryButton">Κατάλαβα</string>
     <string name="contingencyMessageCloseContentDescription">Κλείσιμο</string>
     <string name="ad_blocking_menu_disable">Απενεργοποίηση αποκλεισμού διαφημίσεων στο YouTube</string>
@@ -37,9 +37,11 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Απενεργοποίηση μέχρι την επανεκκίνηση</string>
     <string name="ad_blocking_menu_always_off">Πάντα ανενεργός</string>
     <string name="ad_blocking_disabled_popup_title">Ο αποκλεισμός διαφημίσεων στο YouTube δεν λειτουργεί;</string>
-    <string name="ad_blocking_disabled_popup_description">Στείλε μια ανώνυμη αναφορά βλάβης στο DuckDuckGo. Βοήθησε να κάνουμε τον αποκλεισμό διαφημίσεων καλύτερο για όλους!</string>
+    <string name="ad_blocking_disabled_popup_description">Στείλτε μια ανώνυμη αναφορά στο DuckDuckGo και βοηθήστε να κάνουμε τον αποκλεισμό διαφημίσεων καλύτερο για όλους!</string>
     <string name="ad_blocking_disabled_primary_action">Αποστολή Αναφοράς βλάβης</string>
     <string name="ad_blocking_disabled_secondary_action">Ακύρωση</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Απενεργοποιήθηκε μέχρι την επανεκκίνηση</string>
-    <string name="ad_blocking_omnibar_badge_text">Αποκλεισμός διαφημίσεων YouTube ενεργός</string>
+
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Αποκλεισμός διαφημίσεων ενεργός</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-et/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-et/strings-ad-blocking.xml
@@ -24,9 +24,9 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Avab videod segajatevabas kinorežiimis, mis hoiab ära selle, et vaadatav sisu mõjutaks sinu YouTube’i voogu.</string>
     <string name="ad_blocking_settings_title_v2">Reklaamide blokeerimine</string>
-    <string name="ad_blocking_settings_header_description">Blokeerib invasiivsed jälgijad enne nende laadimist, kõrvaldades tõhusalt reklaamid, mis tuginevad jälgimisele</string>
+    <string name="ad_blocking_settings_header_description">Blokeerib invasiivsed jälgijad enne nende laadimist, kõrvaldades tõhusalt reklaamid, mis tuginevad jälgimisele.</string>
     <string name="contingencyMessageTitle">YouTube\'i reklaamiblokeerija pole saadaval</string>
-    <string name="contingencyMessageContent">YouTube\'i hiljutised muudatused on mõjutanud reklaamide blokeerimist. Töötame nende probleemide lahendamise nimel ja täname sind mõistva suhtumise eest</string>
+    <string name="contingencyMessageContent">YouTube\'i hiljutised muudatused on mõjutanud reklaamide blokeerimist. Töötame nende probleemide lahendamise nimel ja täname sind mõistva suhtumise eest.</string>
     <string name="contingencyMessagePrimaryButton">Sain aru</string>
     <string name="contingencyMessageCloseContentDescription">Sulge</string>
     <string name="ad_blocking_menu_disable">Keela YouTube\'i reklaamide blokeerimine</string>
@@ -37,9 +37,11 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Inaktiveeri kuni taaskäivitamiseni</string>
     <string name="ad_blocking_menu_always_off">Alati välja lülitatud</string>
     <string name="ad_blocking_disabled_popup_title">YouTube\'i reklaamiblokeerija ei tööta?</string>
-    <string name="ad_blocking_disabled_popup_description">Saada DuckDuckGo-le anonüümne rikketeade. Aita muuta reklaamide blokeerimine kõigi jaoks paremaks!</string>
+    <string name="ad_blocking_disabled_popup_description">Saada DuckDuckGo-le anonüümne aruanne ja aita muuta reklaamide blokeerimine kõigi jaoks paremaks!</string>
     <string name="ad_blocking_disabled_primary_action">Saada rikketeade</string>
     <string name="ad_blocking_disabled_secondary_action">Tühista</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Inaktiveeritud kuni taaskäivitamiseni</string>
-    <string name="ad_blocking_omnibar_badge_text">YouTube’i reklaamiblokeerija on sees</string>
+
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Reklaami blokeerimine</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-fi/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-fi/strings-ad-blocking.xml
@@ -41,5 +41,7 @@
     <string name="ad_blocking_disabled_primary_action">Lähetä rikkoutumisraportti</string>
     <string name="ad_blocking_disabled_secondary_action">Peruuta</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Poissa käytöstä uudelleenkäynnistykseen asti</string>
-    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. Keep it as short as possible — aim for under ~20 characters or it will be truncated with an ellipsis. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Mainosesto käytössä</string>
+
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Mainosesto käytössä</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-fi/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-fi/strings-ad-blocking.xml
@@ -24,7 +24,7 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Avaa videot häiriöttömässä teatteritilassa, jolloin katsomasi sisältö ei vaikuta YouTube-syötteeseesi.</string>
     <string name="ad_blocking_settings_title_v2">Mainosten esto</string>
-    <string name="ad_blocking_settings_header_description">Estää tunkeilevat seurantaohjelmat ennen niiden latautumista, mikä eliminoi tehokkaasti seurantaa käyttävät mainokset</string>
+    <string name="ad_blocking_settings_header_description">Estää tunkeilevat seurantatoiminnot ennen niiden latautumista, mikä eliminoi tehokkaasti seurantaa käyttävät mainokset.</string>
     <string name="contingencyMessageTitle">YouTube-mainosten esto ei ole käytettävissä</string>
     <string name="contingencyMessageContent">YouTuben viimeaikaiset muutokset ovat vaikuttaneet mainosten estämiseen. Pyrimme korjaamaan nämä ongelmat. Kiitos ymmärryksestä.</string>
     <string name="contingencyMessagePrimaryButton">Selvä</string>
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Poissa käytöstä uudelleenkäynnistykseen asti</string>
     <string name="ad_blocking_menu_always_off">Aina pois käytöstä</string>
     <string name="ad_blocking_disabled_popup_title">Eikö YouTube-mainosten esto toimi?</string>
-    <string name="ad_blocking_disabled_popup_description">Lähetä anonyymi rikkoutumisraportti DuckDuckGolle. Auta meitä parantamaan mainosten estoa kaikille!</string>
+    <string name="ad_blocking_disabled_popup_description">Lähetä anonyymi raportti DuckDuckGolle ja auta meitä parantamaan mainosten estoa!</string>
     <string name="ad_blocking_disabled_primary_action">Lähetä rikkoutumisraportti</string>
     <string name="ad_blocking_disabled_secondary_action">Peruuta</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Poissa käytöstä uudelleenkäynnistykseen asti</string>
-    <string name="ad_blocking_omnibar_badge_text">YouTube-mainosten esto käytössä</string>
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. Keep it as short as possible — aim for under ~20 characters or it will be truncated with an ellipsis. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Mainosesto käytössä</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-fr/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-fr/strings-ad-blocking.xml
@@ -41,5 +41,7 @@
     <string name="ad_blocking_disabled_primary_action">Envoyer un rapport de défaillance</string>
     <string name="ad_blocking_disabled_secondary_action">Annuler</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Désactivé jusqu\'au redémarrage</string>
-    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. Keep it as short as possible — aim for under ~20 characters or it will be truncated with an ellipsis. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Blocage des publicités activé</string>
+
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Blocage des publicités activé</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-fr/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-fr/strings-ad-blocking.xml
@@ -24,7 +24,7 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Ouvre les vidéos en mode « Salle de projection sans distractions », ce qui empêche ce que vous regardez d\'influencer votre fil d\'actualité YouTube.</string>
     <string name="ad_blocking_settings_title_v2">Blocage des publicités</string>
-    <string name="ad_blocking_settings_header_description">Bloque les traqueurs invasifs avant leur chargement, ce qui permet d\'éliminer efficacement les publicités reposant sur le pistage</string>
+    <string name="ad_blocking_settings_header_description">Bloque les traqueurs invasifs avant leur chargement, ce qui permet d\'éliminer efficacement les publicités reposant sur le pistage.</string>
     <string name="contingencyMessageTitle">Blocage des publicités sur YouTube indisponible</string>
     <string name="contingencyMessageContent">Les récents changements apportés à YouTube ont affecté le blocage des publicités. Nous nous efforçons de résoudre ces problèmes et vous remercions de votre compréhension.</string>
     <string name="contingencyMessagePrimaryButton">J\'ai compris</string>
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Désactiver jusqu\'au redémarrage</string>
     <string name="ad_blocking_menu_always_off">Toujours désactivé</string>
     <string name="ad_blocking_disabled_popup_title">Le blocage des publicités sur YouTube ne fonctionne pas ?</string>
-    <string name="ad_blocking_disabled_popup_description">Envoyez un rapport anonyme de dysfonctionnement à DuckDuckGo. Contribuez à améliorer le blocage des publicités pour tous !</string>
+    <string name="ad_blocking_disabled_popup_description">Envoyez un rapport anonyme à DuckDuckGo et contribuez à améliorer le blocage des publicités pour tous !</string>
     <string name="ad_blocking_disabled_primary_action">Envoyer un rapport de défaillance</string>
     <string name="ad_blocking_disabled_secondary_action">Annuler</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Désactivé jusqu\'au redémarrage</string>
-    <string name="ad_blocking_omnibar_badge_text">Blocage des publicités sur YouTube activé</string>
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. Keep it as short as possible — aim for under ~20 characters or it will be truncated with an ellipsis. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Blocage des publicités activé</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-hr/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-hr/strings-ad-blocking.xml
@@ -24,9 +24,9 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Otvara videozapise u kino načinu rada bez ometanja koji sprječava da ono što gledaš utječe na tvoj YouTube feed.</string>
     <string name="ad_blocking_settings_title_v2">Blokiranje oglasa</string>
-    <string name="ad_blocking_settings_header_description">Blokira invazivne alate za praćenje prije nego što se učitaju, učinkovito eliminirajući oglase koji se oslanjaju na praćenje</string>
+    <string name="ad_blocking_settings_header_description">Blokira invazivne alate za praćenje prije nego što se učitaju, učinkovito eliminirajući oglase koji se oslanjaju na praćenje.</string>
     <string name="contingencyMessageTitle">Blokiranje oglasa na YouTubeu nije dostupno</string>
-    <string name="contingencyMessageContent">Blokiranje oglasa pogođeno je nedavnim promjenama na YouTubeu. Radimo na rješavanju tih problema i cijenimo tvoje razumijevanje</string>
+    <string name="contingencyMessageContent">Blokiranje oglasa pogođeno je nedavnim promjenama YouTubea. Radimo na rješavanju ovih problema i cijenimo tvoje razumijevanje.</string>
     <string name="contingencyMessagePrimaryButton">Shvaćam</string>
     <string name="contingencyMessageCloseContentDescription">Zatvori</string>
     <string name="ad_blocking_menu_disable">Onemogući blokiranje oglasa na YouTubeu</string>
@@ -37,9 +37,11 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Onemogući do ponovnog pokretanja</string>
     <string name="ad_blocking_menu_always_off">Uvijek isključeno</string>
     <string name="ad_blocking_disabled_popup_title">Blokiranje oglasa na YouTubeu ne funkcionira?</string>
-    <string name="ad_blocking_disabled_popup_description">Pošalji anonimnu prijavu kvara DuckDuckGou. Pomozi nam da poboljšamo blokiranje oglasa za sve!</string>
+    <string name="ad_blocking_disabled_popup_description">Pošalji anonimnu prijavu DuckDuckGou i pomozi nam da poboljšamo blokiranje oglasa za sve!</string>
     <string name="ad_blocking_disabled_primary_action">Pošalji izvješće o problemu</string>
     <string name="ad_blocking_disabled_secondary_action">Otkaži</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Onemogućeno do ponovnog pokretanja</string>
-    <string name="ad_blocking_omnibar_badge_text">Blokiranje YouTube oglasa je uključeno</string>
+
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Oglasi blokirani</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-hu/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-hu/strings-ad-blocking.xml
@@ -24,7 +24,7 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Zavaró elemektől mentes, mozis nézetben nyitja meg a videókat, így a nézett tartalom nem befolyásolja a YouTube-hírfolyamodat.</string>
     <string name="ad_blocking_settings_title_v2">Hirdetésblokkolás</string>
-    <string name="ad_blocking_settings_header_description">Még betöltés előtt blokkolja az invazív nyomkövetőket, így hatékonyan kiküszöböljük a nyomkövetésre épülő hirdetéseket</string>
+    <string name="ad_blocking_settings_header_description">Még betöltés előtt blokkolja az invazív nyomkövetőket, így hatékonyan kiküszöböljük a nyomkövetésre épülő hirdetéseket.</string>
     <string name="contingencyMessageTitle">YouTube-hirdetésblokkolás nem érhető el</string>
     <string name="contingencyMessageContent">A hirdetésblokkolást érintették a YouTube legutóbbi módosításai. Dolgozunk a problémák megoldásán, és köszönjük a megértésedet.</string>
     <string name="contingencyMessagePrimaryButton">Értem</string>
@@ -37,9 +37,11 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Letiltás újraindításig</string>
     <string name="ad_blocking_menu_always_off">Mindig ki van kapcsolva</string>
     <string name="ad_blocking_disabled_popup_title">Nem működik a YouTube-hirdetésblokkolás?</string>
-    <string name="ad_blocking_disabled_popup_description">Küldj névtelen hibajelentést a DuckDuckGónak. Segíts, hogy mindenkinek jobb legyen a hirdetésblokkolás.</string>
+    <string name="ad_blocking_disabled_popup_description">Küldj névtelen jelentést a DuckDuckGónak, és segíts, hogy mindenkinek jobb legyen a hirdetésblokkolás.</string>
     <string name="ad_blocking_disabled_primary_action">Hibás működésre vonatkozó jelentés küldése</string>
     <string name="ad_blocking_disabled_secondary_action">Mégsem</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Letiltva az újraindításig</string>
-    <string name="ad_blocking_omnibar_badge_text">A YouTube-hirdetésblokkolás be van kapcsolva</string>
+
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Hirdetésblokkolás</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-it/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-it/strings-ad-blocking.xml
@@ -24,9 +24,9 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Apre i video in una modalità cinema senza distrazioni che impedisce a ciò che guardi di influenzare il tuo feed di YouTube.</string>
     <string name="ad_blocking_settings_title_v2">Blocco degli annunci</string>
-    <string name="ad_blocking_settings_header_description">Blocca i sistemi di tracciamento prima che vengano caricati, eliminando di fatto gli annunci che si basano sul tracciamento</string>
+    <string name="ad_blocking_settings_header_description">Blocca i sistemi di tracciamento prima che vengano caricati, eliminando di fatto gli annunci che si basano sul tracciamento.</string>
     <string name="contingencyMessageTitle">Blocco degli annunci su YouTube non disponibile</string>
-    <string name="contingencyMessageContent">Il blocco degli annunci è stato influenzato dalle recenti modifiche a YouTube. Stiamo lavorando per risolvere questi problemi. Grazie per la comprensione</string>
+    <string name="contingencyMessageContent">Il blocco degli annunci è stato influenzato dalle recenti modifiche a YouTube. Stiamo lavorando per risolvere questi problemi. Grazie per la comprensione.</string>
     <string name="contingencyMessagePrimaryButton">Ho capito</string>
     <string name="contingencyMessageCloseContentDescription">Chiudi</string>
     <string name="ad_blocking_menu_disable">Disattiva il blocco annunci su YouTube</string>
@@ -37,9 +37,11 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Disattiva fino al rilancio</string>
     <string name="ad_blocking_menu_always_off">Sempre disattivato</string>
     <string name="ad_blocking_disabled_popup_title">Il blocco degli annunci di YouTube non funziona?</string>
-    <string name="ad_blocking_disabled_popup_description">Invia una segnalazione anonima di malfunzionamento a DuckDuckGo. Aiuta a migliorare il blocco degli annunci per tutti!</string>
+    <string name="ad_blocking_disabled_popup_description">Invia una segnalazione anonima a DuckDuckGo e aiuta a migliorare il blocco degli annunci per tutti!</string>
     <string name="ad_blocking_disabled_primary_action">Invia la segnalazione di malfunzionamento</string>
     <string name="ad_blocking_disabled_secondary_action">Annulla</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Disattivato fino al rilancio</string>
-    <string name="ad_blocking_omnibar_badge_text">Blocco degli annunci di YouTube attivato</string>
+
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Blocco annunci attivo</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-lt/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-lt/strings-ad-blocking.xml
@@ -24,9 +24,9 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Atidaro vaizdo įrašus neblaškančiu kino teatro režimu, kad tai, ką žiūri, nedarytų įtakos tavo „YouTube“ srautui.</string>
     <string name="ad_blocking_settings_title_v2">Reklamų blokavimas</string>
-    <string name="ad_blocking_settings_header_description">Blokuoja įkyrias sekimo priemones dar prieš jas įkeliant, todėl veiksmingai pašalina sekimu pagrįstas reklamas</string>
+    <string name="ad_blocking_settings_header_description">Blokuoja įkyrius sekiklius dar jiems neįsikėlus ir veiksmingai pašalina sekimu paremtus skelbimus.</string>
     <string name="contingencyMessageTitle">„YouTube“ reklamų blokavimas nepasiekiamas</string>
-    <string name="contingencyMessageContent">Naujausi „YouTube“ pakeitimai paveikė reklamų blokavimą. Sprendžiame šias problemas ir dėkojame už supratingumą</string>
+    <string name="contingencyMessageContent">Dėl pastarųjų „YouTube“ pakeitimų sutriko skelbimų blokavimas. Stengiamės išspręsti šiuos nesklandumus ir dėkojame už supratingumą.</string>
     <string name="contingencyMessagePrimaryButton">Supratau</string>
     <string name="contingencyMessageCloseContentDescription">Uždaryti</string>
     <string name="ad_blocking_menu_disable">Išjungti „YouTube“ reklamų blokavimą</string>
@@ -37,9 +37,11 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Išjungti iki paleidimo iš naujo</string>
     <string name="ad_blocking_menu_always_off">Visada išjungta</string>
     <string name="ad_blocking_disabled_popup_title">Neveikia „YouTube“ reklamų blokavimas?</string>
-    <string name="ad_blocking_disabled_popup_description">Siųsk anoniminį pranešimą apie triktį „DuckDuckGo“. Padėk patobulinti reklamų blokavimą visiems!</string>
+    <string name="ad_blocking_disabled_popup_description">Siųsk anoniminį pranešimą „DuckDuckGo“ ir padėk tobulinti skelbimų blokavimą visiems!</string>
     <string name="ad_blocking_disabled_primary_action">Siųsti pranešimą apie triktį</string>
     <string name="ad_blocking_disabled_secondary_action">Atšaukti</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Išjungta iki paleidimo iš naujo</string>
-    <string name="ad_blocking_omnibar_badge_text">„YouTube“ reklamų blokavimas įjungtas</string>
+
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Skelbimų blokavimas įjungtas</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-lv/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-lv/strings-ad-blocking.xml
@@ -24,9 +24,9 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Atver videoklipus teātra režīmā bez uzmanības novēršanas, kas neļauj skatītajam ietekmēt tavu YouTube plūsmu.</string>
     <string name="ad_blocking_settings_title_v2">Reklāmu bloķēšana</string>
-    <string name="ad_blocking_settings_header_description">Bloķē uzmācīgus izsekotājus, pirms tie tiek ielādēti, tādējādi efektīvi novēršot izsekošanā balstītās reklāmas.</string>
+    <string name="ad_blocking_settings_header_description">Bloķē uzmācīgus izsekotājus, pirms tie tiek ielādēti, tādējādi efektīvi novēršot reklāmas, kas balstās uz izsekošanu.</string>
     <string name="contingencyMessageTitle">YouTube reklāmu bloķēšana nav pieejama</string>
-    <string name="contingencyMessageContent">Reklāmu bloķēšanu ir ietekmējušas nesenās izmaiņas pakalpojumā YouTube. Mēs jau strādājam pie šo problēmu novēršanas un novērtējam tavu sapratni.</string>
+    <string name="contingencyMessageContent">Reklāmu bloķēšanu ir ietekmējušas nesenās izmaiņas pakalpojumā YouTube. Mēs strādājam, lai novērstu šīs problēmas, un novērtējam tavu sapratni.</string>
     <string name="contingencyMessagePrimaryButton">Sapratu</string>
     <string name="contingencyMessageCloseContentDescription">Aizvērt</string>
     <string name="ad_blocking_menu_disable">Atspējot YouTube reklāmu bloķēšanu</string>
@@ -37,9 +37,11 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Atspējot līdz atkārtotai palaišanai</string>
     <string name="ad_blocking_menu_always_off">Vienmēr izslēgts</string>
     <string name="ad_blocking_disabled_popup_title">YouTube reklāmu bloķēšana nedarbojas?</string>
-    <string name="ad_blocking_disabled_popup_description">Nosūti DuckDuckGo anonīmu ziņojumu par traucējumiem. Palīdzi uzlabot reklāmu bloķēšanu visiem!</string>
+    <string name="ad_blocking_disabled_popup_description">Nosūti DuckDuckGo anonīmu ziņojumu un palīdzi uzlabot reklāmu bloķēšanu visiem!</string>
     <string name="ad_blocking_disabled_primary_action">Nosūtīt ziņojumu par traucējumiem</string>
     <string name="ad_blocking_disabled_secondary_action">Atcelt</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Atspējots līdz atkārtotai palaišanai</string>
-    <string name="ad_blocking_omnibar_badge_text">YouTube reklāmu bloķēšana ieslēgta</string>
+
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Reklāmu bloķēšana</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-nb/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-nb/strings-ad-blocking.xml
@@ -24,9 +24,9 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Åpner videoer i en distraksjonsfri kinomodus som hindrer at det du ser på påvirker YouTube-feeden din.</string>
     <string name="ad_blocking_settings_title_v2">Annonseblokkering</string>
-    <string name="ad_blocking_settings_header_description">Blokkerer invaderende sporere før de blir lastet inn, og dette eliminerer også annonser som er basert på sporing</string>
+    <string name="ad_blocking_settings_header_description">Blokkerer invaderende sporere før de blir lastet inn, og dette eliminerer også annonser som er basert på sporing.</string>
     <string name="contingencyMessageTitle">Annonseblokkering på YouTube er ikke tilgjengelig</string>
-    <string name="contingencyMessageContent">Annonseblokkering har blitt påvirket av nylige endringer på YouTube. Vi jobber med å løse disse problemene og takker for tålmodigheten</string>
+    <string name="contingencyMessageContent">Annonseblokkering har blitt påvirket av nylige endringer på YouTube. Vi jobber med å løse disse problemene og takker for tålmodigheten.</string>
     <string name="contingencyMessagePrimaryButton">Den er grei</string>
     <string name="contingencyMessageCloseContentDescription">Lukk</string>
     <string name="ad_blocking_menu_disable">Deaktiver annonseblokkering på YouTube</string>
@@ -34,12 +34,14 @@
     <string name="ad_blocking_menu_title">Annonseblokkering på YouTube</string>
     <string name="ad_blocking_menu_close_content_description">Lukk</string>
     <string name="ad_blocking_menu_always_on">Alltid på</string>
-    <string name="ad_blocking_menu_disable_until_relaunch">Deaktiver til relansering</string>
+    <string name="ad_blocking_menu_disable_until_relaunch">Deaktiver til neste oppstart</string>
     <string name="ad_blocking_menu_always_off">Alltid av</string>
-    <string name="ad_blocking_disabled_popup_title">Fungerer ikke annonseblokkering for YouTube?</string>
-    <string name="ad_blocking_disabled_popup_description">Send en anonym funksjonssviktrapport til DuckDuckGo. Bidra til å gjøre annonseblokkering bedre for alle!</string>
-    <string name="ad_blocking_disabled_primary_action">Send funksjonssviktrapport</string>
+    <string name="ad_blocking_disabled_popup_title">Fungerer ikke annonseblokkering på YouTube?</string>
+    <string name="ad_blocking_disabled_popup_description">Send en anonym rapport til DuckDuckGo og bidra til å gjøre annonseblokkering bedre for alle!</string>
+    <string name="ad_blocking_disabled_primary_action">Send feilrapport</string>
     <string name="ad_blocking_disabled_secondary_action">Avbryt</string>
-    <string name="ad_blocking_settings_disabled_until_relaunch">Deaktivert til relansering</string>
-    <string name="ad_blocking_omnibar_badge_text">Annonseblokkering på YouTube er på</string>
+    <string name="ad_blocking_settings_disabled_until_relaunch">Deaktiver til neste oppstart</string>
+
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Annonseblokkering på</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-ro/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-ro/strings-ad-blocking.xml
@@ -41,5 +41,7 @@
     <string name="ad_blocking_disabled_primary_action">Trimite raportul de erori</string>
     <string name="ad_blocking_disabled_secondary_action">Anulează</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Dezactivat până la relansare</string>
-    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. Keep it as short as possible — aim for under ~20 characters or it will be truncated with an ellipsis. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Blocarea reclamelor a fost activată</string>
+
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Blocarea reclamelor a fost activată</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-ro/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-ro/strings-ad-blocking.xml
@@ -24,9 +24,9 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Deschide videoclipurile într-un mod cinematografic fără distrageri, care te împiedică să influențezi fluxul de YouTube prin ceea ce vizionezi.</string>
     <string name="ad_blocking_settings_title_v2">Blocarea reclamelor</string>
-    <string name="ad_blocking_settings_header_description">Blochează tehnologiile de urmărire invazive înainte de a se încărca, eliminând eficient reclamele care se bazează pe urmărire</string>
+    <string name="ad_blocking_settings_header_description">Blochează tehnologiile de urmărire invazive înainte de a se încărca, eliminând eficient reclamele care se bazează pe urmărire.</string>
     <string name="contingencyMessageTitle">Blocarea reclamelor pe YouTube este indisponibilă</string>
-    <string name="contingencyMessageContent">Blocarea reclamelor a fost afectată de modificările recente aduse YouTube. Lucrăm pentru a remedia aceste probleme și apreciem înțelegerea ta</string>
+    <string name="contingencyMessageContent">Blocarea reclamelor a fost afectată de modificările recente aduse YouTube. Lucrăm pentru a remedia aceste probleme și apreciem înțelegerea ta.</string>
     <string name="contingencyMessagePrimaryButton">Am înțeles</string>
     <string name="contingencyMessageCloseContentDescription">Închide</string>
     <string name="ad_blocking_menu_disable">Dezactivează blocarea reclamelor pe YouTube</string>
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Dezactivează până la relansare</string>
     <string name="ad_blocking_menu_always_off">Întotdeauna dezactivat</string>
     <string name="ad_blocking_disabled_popup_title">Blocarea reclamelor YouTube nu funcționează?</string>
-    <string name="ad_blocking_disabled_popup_description">Trimite un raport anonim despre erori către DuckDuckGo. Ajută la îmbunătățirea blocării reclamelor pentru toată lumea!</string>
+    <string name="ad_blocking_disabled_popup_description">Trimite un raport anonim către DuckDuckGo și ajută la îmbunătățirea blocării reclamelor pentru toată lumea!</string>
     <string name="ad_blocking_disabled_primary_action">Trimite raportul de erori</string>
     <string name="ad_blocking_disabled_secondary_action">Anulează</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Dezactivat până la relansare</string>
-    <string name="ad_blocking_omnibar_badge_text">Blocarea reclamelor pe YouTube activată</string>
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. Keep it as short as possible — aim for under ~20 characters or it will be truncated with an ellipsis. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Blocarea reclamelor a fost activată</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-ru/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-ru/strings-ad-blocking.xml
@@ -24,7 +24,7 @@
     <string name="ad_blocking_settings_duck_player_header">Проигрыватель Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Открывает видео в режиме кинотеатра без отвлекающих элементов, чтобы просмотренные видео не влияли на вашу ленту YouTube.</string>
     <string name="ad_blocking_settings_title_v2">Блокировка рекламы</string>
-    <string name="ad_blocking_settings_header_description">Блокирует навязчивые трекеры до их загрузки, устраняя рекламу с отслеживанием</string>
+    <string name="ad_blocking_settings_header_description">Блокирует трекеры, следящие за вашей активностью, еще до их загрузки, фактически устраняя рекламу на основе отслеживания.</string>
     <string name="contingencyMessageTitle">Блокировка рекламы на YouTube недоступна</string>
     <string name="contingencyMessageContent">Недавние изменения на YouTube повлияли на работу блокировки рекламы. Мы занимаемся решением этой проблемы и благодарим вас за понимание.</string>
     <string name="contingencyMessagePrimaryButton">Понятно</string>
@@ -37,9 +37,11 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Отключить до перезапуска</string>
     <string name="ad_blocking_menu_always_off">Всегда выключено</string>
     <string name="ad_blocking_disabled_popup_title">Блокировка рекламы на YouTube не работает?</string>
-    <string name="ad_blocking_disabled_popup_description">Отправьте анонимное сообщение о проблеме в DuckDuckGo. Помогите улучшить блокировку рекламы для всех!</string>
+    <string name="ad_blocking_disabled_popup_description">Отправьте анонимные сведения в DuckDuckGo и помогите улучшить блокировку рекламы для всех!</string>
     <string name="ad_blocking_disabled_primary_action">Сообщить о проблеме</string>
     <string name="ad_blocking_disabled_secondary_action">Отменить</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Отключено до перезапуска</string>
-    <string name="ad_blocking_omnibar_badge_text">Блокировка рекламы на YouTube включена</string>
+
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Блокировка рекламы</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-sk/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-sk/strings-ad-blocking.xml
@@ -37,9 +37,11 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Vypnúť do opätovného spustenia</string>
     <string name="ad_blocking_menu_always_off">Vždy vypnuté</string>
     <string name="ad_blocking_disabled_popup_title">Nefunguje blokovanie reklám na YouTube?</string>
-    <string name="ad_blocking_disabled_popup_description">Odošli anonymnú správu o poruche na DuckDuckGo. Pomôž zlepšiť blokovanie reklám pre všetkých!</string>
+    <string name="ad_blocking_disabled_popup_description">Odošli anonymné hlásenie na DuckDuckGo a pomôž zlepšiť blokovanie reklám pre všetkých!</string>
     <string name="ad_blocking_disabled_primary_action">Odoslať správu o poruche</string>
     <string name="ad_blocking_disabled_secondary_action">Zrušiť</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Zakázané až do opätovného spustenia</string>
-    <string name="ad_blocking_omnibar_badge_text">Blokovanie reklám na YouTube je zapnuté</string>
+
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Blokovanie reklám je zapnuté</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-sv/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-sv/strings-ad-blocking.xml
@@ -41,5 +41,7 @@
     <string name="ad_blocking_disabled_primary_action">Skicka felrapport</string>
     <string name="ad_blocking_disabled_secondary_action">Avbryt</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Inaktiverad till omstart</string>
-    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. Keep it as short as possible — aim for under ~20 characters or it will be truncated with an ellipsis. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Annonsblockering på</string>
+
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Annonsblockering på</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-sv/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-sv/strings-ad-blocking.xml
@@ -24,7 +24,7 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Öppnar videor i ett störningsfritt visningsläge som förhindrar att det du tittar på påverkar ditt YouTube-flöde.</string>
     <string name="ad_blocking_settings_title_v2">Annonsblockering</string>
-    <string name="ad_blocking_settings_header_description">Blockerar invasiva spårare innan de läses in, vilket i stort sett eliminerar annonser som bygger på spårning</string>
+    <string name="ad_blocking_settings_header_description">Blockerar invasiva spårare innan de läses in, vilket effektivt eliminerar annonser som bygger på spårning.</string>
     <string name="contingencyMessageTitle">Annonsblockering på YouTube är inte tillgänglig</string>
     <string name="contingencyMessageContent">De senaste ändringarna på YouTube har påverkat annonsblockeringen. Vi jobbar på att lösa problemen och tackar för din förståelse.</string>
     <string name="contingencyMessagePrimaryButton">Jag förstår</string>
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Inaktivera till omstart</string>
     <string name="ad_blocking_menu_always_off">Alltid av</string>
     <string name="ad_blocking_disabled_popup_title">Fungerar inte annonsblockering på YouTube?</string>
-    <string name="ad_blocking_disabled_popup_description">Skicka en anonym felrapport till DuckDuckGo. Hjälp till att göra annonsblockeringen bättre för alla!</string>
+    <string name="ad_blocking_disabled_popup_description">Skicka en anonym rapport till DuckDuckGo och hjälp till att göra annonsblockeringen bättre för alla!</string>
     <string name="ad_blocking_disabled_primary_action">Skicka felrapport</string>
     <string name="ad_blocking_disabled_secondary_action">Avbryt</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Inaktiverad till omstart</string>
-    <string name="ad_blocking_omnibar_badge_text">YouTube-annonsblockering på</string>
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. Keep it as short as possible — aim for under ~20 characters or it will be truncated with an ellipsis. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Annonsblockering på</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values/strings-ad-blocking.xml
@@ -40,5 +40,7 @@
     <string name="ad_blocking_disabled_primary_action">Send Breakage Report</string>
     <string name="ad_blocking_disabled_secondary_action">Cancel</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Disabled until relaunch</string>
-    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. Keep it as short as possible — aim for under ~20 characters or it will be truncated with an ellipsis. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Ad Blocking On</string>
+
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Ad Blocking On</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values/strings-ad-blocking.xml
@@ -23,9 +23,9 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Opens videos in a distraction-free theater mode that prevents what you watch from influencing your YouTube feed.</string>
     <string name="ad_blocking_settings_title_v2">Ad Blocking</string>
-    <string name="ad_blocking_settings_header_description">Blocks invasive trackers before they load, effectively eliminating ads that rely on tracking</string>
+    <string name="ad_blocking_settings_header_description">Blocks invasive trackers before they load, effectively eliminating ads that rely on tracking.</string>
     <string name="contingencyMessageTitle">YouTube Ad Blocking Unavailable</string>
-    <string name="contingencyMessageContent">Ad Blocking has been affected by recent changes to YouTube. We\'re working to fix these issues and appreciate your understanding</string>
+    <string name="contingencyMessageContent">Ad Blocking has been affected by recent changes to YouTube. We\'re working to fix these issues and appreciate your understanding.</string>
     <string name="contingencyMessagePrimaryButton">Got It</string>
     <string name="contingencyMessageCloseContentDescription">Close</string>
     <string name="ad_blocking_menu_disable">Disable YouTube Ad Blocking</string>
@@ -36,9 +36,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Disable Until Relaunch</string>
     <string name="ad_blocking_menu_always_off">Always Off</string>
     <string name="ad_blocking_disabled_popup_title">YouTube Ad Blocking not working?</string>
-    <string name="ad_blocking_disabled_popup_description">Send an anonymous breakage report to DuckDuckGo. Help make ad blocking better for everyone!</string>
+    <string name="ad_blocking_disabled_popup_description">Send an anonymous report to DuckDuckGo and help make ad blocking better for everyone!</string>
     <string name="ad_blocking_disabled_primary_action">Send Breakage Report</string>
     <string name="ad_blocking_disabled_secondary_action">Cancel</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Disabled until relaunch</string>
-    <string name="ad_blocking_omnibar_badge_text">YouTube Ad Block On</string>
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. Keep it as short as possible — aim for under ~20 characters or it will be truncated with an ellipsis. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active.">Ad Blocking On</string>
 </resources>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Нов раздел Fire</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>НОВО!</b> Изпробвайте разделите Fire, в които сърфирате, без да запазвате локална история.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Изтриване на разделите Fire и данните в тях?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Файлът не може да се отвори. Проверете за съвместимо приложение.</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1048,5 +1048,6 @@
     <string name="fireTabsNewTabButton">Nová karta Fire</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NOVINKA!</b> Vyzkoušej karty Fire pro prohlížení bez ukládání místní historie.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Smazat karty Fire a jejich data?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Soubor nejde otevřít. Zkus vyhledat kompatibilní aplikaci.</string>
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Ny Fire-fane</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NYT!</b> Prøv Fire-faner for at surfe uden at gemme lokal historik.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Slet Fire-faner og deres data?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Kan ikke åbne filen. Kontrollér, om der er en kompatibel app.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Neues Fire-Tab</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NEU!</b> Fire-Tabs ausprobieren, um zu surfen, ohne den lokalen Verlauf zu speichern.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Fire-Tabs und deren Daten löschen?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Datei kann nicht geöffnet werden. Nach einer kompatiblen App suchen.</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Νέα καρτέλα Fire</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>ΝΕΟ!</b> Δοκιμάστε τις καρτέλες Fire για περιήγηση χωρίς να αποθηκεύετε το τοπικό ιστορικό.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Να διαγραφούν οι καρτέλες Fire και τα δεδομένα τους;</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Δεν ήταν δυνατό το άνοιγμα του αρχείου. Ελέγξτε για μια συμβατή εφαρμογή.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Nueva Fire tab</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>¡NUEVO!</b> Prueba Fire Tabs para navegar sin guardar el historial local.]]></string>
     <string name="singleTabFireDialogTitleFireMode">¿Eliminar Fire tabs y sus datos?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">No se puede abrir el archivo. Busca una aplicación compatible.</string>
 </resources>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Uus Fire vahekaart</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>UUS!</b> Proovi Fire vahekaarte, et sirvida ilma kohalikku ajalugu salvestamata.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Kas kustutada Fire vahekaardid ja nende andmed?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Faili ei saa avada. Otsi ühilduvat rakendust.</string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Uusi Fire-välilehti</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>UUTTA!</b> Kokeile Fire-välilehtiä selataksesi ilman paikallisen historian tallentamista.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Poistetaanko Fire-välilehdet ja niiden tiedot?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Tiedoston avaaminen ei onnistu. Tarkista yhteensopiva sovellus.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Nouvel onglet Fire</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NOUVEAU !</b> Essayez les onglets Fire pour naviguer sans enregistrer l\'historique local.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Supprimer les onglets Fire et leurs données ?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Impossible d\'ouvrir le fichier. Vérifiez la compatibilité de l\'application.</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1048,5 +1048,6 @@
     <string name="fireTabsNewTabButton">Nova Fire kartica</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NOVO!</b> Isprobaj Fire kartice za pregledavanje bez spremanja lokalne povijesti.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Želiš li izbrisati Fire kartice i njihove podatke?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Datoteka se ne može otvoriti. Provjerite postoji li kompatibilna aplikacija.</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Új Fire-lap</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>ÚJ! </b> Próbáld ki a Fire-lapokat, és böngéssz helyi előzmények mentése nélkül.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Törlöd a Fire-lapokat és az adataikat?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">A fájl nem nyitható meg. Keress kompatibilis alkalmazást.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Nuova scheda Fire</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NOVITÀ!</b> Prova le schede Fire per navigare senza salvare la cronologia locale.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Eliminare le schede Fire e i relativi dati?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Impossibile aprire il file. Verifica la disponibilità di un\'app compatibile.</string>
 </resources>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -1048,5 +1048,6 @@
     <string name="fireTabsNewTabButton">Naujas „Fire“ skirtukas</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NAUJIENA!</b> Išbandykite „Fire“ skirtukus naršymui neišsaugant vietinės naršymo istorijos.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Ar trinti „Fire“ skirtukus ir jų duomenis?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Nepavyko atidaryti failo. Patikrinkite, ar yra suderinama programa.</string>
 </resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -1028,5 +1028,6 @@
     <string name="fireTabsNewTabButton">Jauna Fire cilne</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>JAUNUMS!</b> Izmēģini Fire Tabs, lai pārlūkotu, nesaglabājot vietējo vēsturi.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Vai dzēst Fire cilnes un to datus?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Nevar atvērt failu. Pārbaudīt saderīgu lietotni.</string>
 </resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Ny Fire-fane</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NYHET!</b> Prøv Fire-faner for å surfe uten å lagre lokal historikk.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Vil du slette Fire-faner og dataene i dem?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Kan ikke åpne filen. Se etter kompatibel app.</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Nieuw Fire-tabblad</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NIEUW!</b> Probeer Fire Tabs om te browsen zonder de lokale geschiedenis op te slaan.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Fire-tabbladen en hun gegevens verwijderen?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Kan bestand niet openen. Kijk of er een compatibele app is.</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1048,5 +1048,6 @@
     <string name="fireTabsNewTabButton">Nowa karta Fire</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NOWOŚĆ!</b> Wypróbuj karty Fire, aby przeglądać bez lokalnego zapisywania historii.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Usunąć karty Fire i ich dane?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Nie można otworzyć pliku. Poszukaj zgodnej aplikacji.</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Novo separador Fire</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NOVO!</b> Experimenta os separadores Fire para navegar sem guardar o histórico local.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Eliminar separadores Fire e respetivos dados?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Não é possível abrir o ficheiro. Verificar se a aplicação é compatível.</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1028,5 +1028,6 @@
     <string name="fireTabsNewTabButton">Noua filă Fire</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NOU!</b> Încearcă filele Fire pentru a naviga fără a salva istoricul local.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Ștergi filele Fire și datele aferente?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Nu se poate deschide fișierul. Caută o aplicație compatibilă.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1048,5 +1048,6 @@
     <string name="fireTabsNewTabButton">Новая Fire-вкладка</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>Новинка!</b> Используйте Fire-вкладки, чтобы просматривать веб-страницы без сохранения локальной истории.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Удалить Fire-вкладки и их данные?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Не удается открыть файл. Попробуйте найти совместимое приложение.</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1048,5 +1048,6 @@
     <string name="fireTabsNewTabButton">Nová karta Fire</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NOVINKA!</b> Vyskúšaj karty Fire na prehliadanie bez ukladania do lokálnej histórie.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Chceš vymazať karty Fire a ich údaje?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Súbor sa nedá otvoriť. Vyhľadajte kompatibilnú aplikáciu.</string>
 </resources>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -1048,5 +1048,6 @@
     <string name="fireTabsNewTabButton">Nov zavihek Fire</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NOVO!</b> Preizkusite zavihke Fire za brskanje brez shranjevanja lokalne zgodovine.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Želite izbrisati zavihke Fire in njihove podatke?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Datoteke ni mogoče odpreti. Poiščite združljivo aplikacijo.</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Ny Fire-flik</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NYTT!</b> Prova Fire-flikar för att surfa utan att spara lokal historik.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Ta bort Fire Tabs och deras data?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Det går inte att öppna filen. Sök efter en kompatibel app.</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Yeni Fire Sekmesi</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>YENİ!</b> Yerel geçmişi kaydetmeden göz atmak için Fire Sekmelerini deneyin.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Fire Sekmeleri ve verileri silinsin mi?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Dosya açılamıyor. Uyumlu uygulama arayın.</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-bg/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-bg/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Споделяне с…</string>
     <string name="downloadsStateInProgress">В процес на изпълнение…</string>
     <string name="downloadsUndoActionName">Отмяна</string>
+    <string name="downloadsSearchHint">Търсене</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-cs/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-cs/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Sdílet s...</string>
     <string name="downloadsStateInProgress">Probíhá...</string>
     <string name="downloadsUndoActionName">Vrátit</string>
+    <string name="downloadsSearchHint">Vyhledávání</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-da/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-da/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Del med ...</string>
     <string name="downloadsStateInProgress">I gang ...</string>
     <string name="downloadsUndoActionName">Fortryd</string>
+    <string name="downloadsSearchHint">Søg</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-de/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-de/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Teilen mit …</string>
     <string name="downloadsStateInProgress">In Bearbeitung …</string>
     <string name="downloadsUndoActionName">Rückgängig machen</string>
+    <string name="downloadsSearchHint">Suche</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-el/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-el/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Κοινή χρήση με...</string>
     <string name="downloadsStateInProgress">Σε εξέλιξη...</string>
     <string name="downloadsUndoActionName">Αναίρεση</string>
+    <string name="downloadsSearchHint">Αναζήτηση</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-es/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-es/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Compartir con…</string>
     <string name="downloadsStateInProgress">En curso…</string>
     <string name="downloadsUndoActionName">Deshacer</string>
+    <string name="downloadsSearchHint">Buscar</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-et/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-et/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Jaga…</string>
     <string name="downloadsStateInProgress">Pooleli…</string>
     <string name="downloadsUndoActionName">Võta tagasi</string>
+    <string name="downloadsSearchHint">Otsi</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-fi/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-fi/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Jaa...</string>
     <string name="downloadsStateInProgress">Käynnissä…</string>
     <string name="downloadsUndoActionName">Kumoa</string>
+    <string name="downloadsSearchHint">Hae</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-fr/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-fr/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Partager avec…</string>
     <string name="downloadsStateInProgress">En cours...</string>
     <string name="downloadsUndoActionName">Annuler</string>
+    <string name="downloadsSearchHint">Rechercher</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-hr/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-hr/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Podijeli s...</string>
     <string name="downloadsStateInProgress">U tijeku...</string>
     <string name="downloadsUndoActionName">Poništi</string>
+    <string name="downloadsSearchHint">Pretraživanje</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-hu/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-hu/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Megosztás vele…</string>
     <string name="downloadsStateInProgress">Folyamatban…</string>
     <string name="downloadsUndoActionName">Visszavonás</string>
+    <string name="downloadsSearchHint">Keresés</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-it/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-it/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Condividi con…</string>
     <string name="downloadsStateInProgress">In corso…</string>
     <string name="downloadsUndoActionName">Annulla</string>
+    <string name="downloadsSearchHint">Ricerca</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-lt/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-lt/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Dalintis su...</string>
     <string name="downloadsStateInProgress">Vykdoma...</string>
     <string name="downloadsUndoActionName">Anuliuoti</string>
+    <string name="downloadsSearchHint">Paieška</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-lv/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-lv/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Kopīgot ar…</string>
     <string name="downloadsStateInProgress">Notiek...</string>
     <string name="downloadsUndoActionName">Atsaukt</string>
+    <string name="downloadsSearchHint">Meklēt</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-nb/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-nb/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Del med …</string>
     <string name="downloadsStateInProgress">Pågår…</string>
     <string name="downloadsUndoActionName">Angre</string>
+    <string name="downloadsSearchHint">Søk</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-nl/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-nl/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Delen met...</string>
     <string name="downloadsStateInProgress">Bezig...</string>
     <string name="downloadsUndoActionName">Ongedaan maken</string>
+    <string name="downloadsSearchHint">Zoeken</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-pl/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-pl/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Udostępnij…</string>
     <string name="downloadsStateInProgress">W trakcie…</string>
     <string name="downloadsUndoActionName">Cofnij</string>
+    <string name="downloadsSearchHint">Szukaj</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-pt/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-pt/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Partilhar com...</string>
     <string name="downloadsStateInProgress">Em curso…</string>
     <string name="downloadsUndoActionName">Anular</string>
+    <string name="downloadsSearchHint">Pesquisar</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-ro/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-ro/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Distribuie către...</string>
     <string name="downloadsStateInProgress">În curs...</string>
     <string name="downloadsUndoActionName">Anulează</string>
+    <string name="downloadsSearchHint">Căutare</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-ru/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-ru/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Поделиться с…</string>
     <string name="downloadsStateInProgress">Выполняется…</string>
     <string name="downloadsUndoActionName">Отменить</string>
+    <string name="downloadsSearchHint">Поиск</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-sk/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-sk/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Zdieľať s...</string>
     <string name="downloadsStateInProgress">Prebieha…</string>
     <string name="downloadsUndoActionName">Vrátenie späť</string>
+    <string name="downloadsSearchHint">Vyhľadávať</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-sl/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-sl/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Deli s/z …</string>
     <string name="downloadsStateInProgress">Poteka …</string>
     <string name="downloadsUndoActionName">Prekliči spremembe</string>
+    <string name="downloadsSearchHint">Iskanje</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-sv/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-sv/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Dela med …</string>
     <string name="downloadsStateInProgress">Pågår …</string>
     <string name="downloadsUndoActionName">Återställ</string>
+    <string name="downloadsSearchHint">Sök</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-tr/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-tr/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Paylaş…</string>
     <string name="downloadsStateInProgress">Devam ediyor…</string>
     <string name="downloadsUndoActionName">Geri al</string>
+    <string name="downloadsSearchHint">Arama yap</string>
 </resources>

--- a/feedback/feedback-impl/src/main/res/values-bg/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-bg/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-cs/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-cs/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-da/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-da/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-de/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-de/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-el/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-el/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-es/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-es/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-et/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-et/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-fi/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-fi/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-fr/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-fr/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-hr/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-hr/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-hu/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-hu/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-it/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-it/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-lt/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-lt/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-lv/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-lv/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-nb/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-nb/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-nl/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-nl/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-pl/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-pl/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-pt/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-pt/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-ro/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-ro/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-ru/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-ru/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-sk/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-sk/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-sl/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-sl/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-sv/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-sv/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-tr/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-tr/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/sync/sync-impl/src/main/res/values-el/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-el/strings-sync.xml
@@ -121,7 +121,7 @@
     <string name="sync_permission_required_store_recovery_code">Η αποθήκευση του PDF ανάκτησης απαιτεί άδεια αποθήκευσης</string>
     <string name="sync_share_title">Κοινή χρήση με...</string>
     <string name="sync_pdf_title">Συγχρονισμός κωδικού ανάκτησης</string>
-    <string name="sync_pdf_description">Ο κωδικός ανάκτησης σας επιτρέπει να συγχρονίζετε τους κωδικούς πρόσβασής σας, τα δεδομένα αυτόματης συμπλήρωσης και τις συνομιλίες του Duck.ai σε πολλές συσκευές και να ανακτάτε τα συγχρονισμένα δεδομένα σας εάν χάσετε την πρόσβαση σε μια συσκευή.</string>
+    <string name="sync_pdf_description">Ο κωδικός ανάκτησης σας επιτρέπει να συγχρονίζετε τους κωδικούς πρόσβασής σας, τα δεδομένα αυτόματης συμπλήρωσης και τις συνομιλίες του Duck.ai σε πολλές συσκευές και να ανακτάτε τα συγχρονισμένα δεδομένα σας εάν χάσετε την πρόσβαση σε μια συσκευή.\n\n</string>
     <string name="sync_code_box_title">Διατηρήστε αυτές τις πληροφορίες ασφαλείς.</string>
     <string name="sync_instructions_title">Πώς λειτουργεί αυτός ο κώδικας;</string>
     <string name="sync_instructions_step1">Ανοίξτε το DuckDuckGo στη συσκευή που θέλετε να συγχρονίσετε και μεταβείτε στο Sync &amp; Backup στις Ρυθμίσεις.</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1142021229838617/task/1216704740705275?focus=true
Tech Design URL (if applicable): 

### Description

### Steps to test this PR

_Feature 1_
- [ ] Wait for [job](https://dashboard.smartling.com/app/projects/b01b53ede/account-jobs/b01b53ede:skhjp2ckrn1h) to finish
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Resource-only translation sync; user-visible text may change slightly but no application logic is modified.
> 
> **Overview**
> This PR pulls in **Smartling** updates across ad-blocking, app, downloads, feedback, and sync string resources—no Kotlin or behavior changes.
> 
> **Ad blocking:** `ad_blocking_omnibar_badge_text` is retitled for a **19-character** address-bar pill (often dropping YouTube-specific wording), with new `instruction` / character-limit comments. Several locales also get punctuation, contingency copy, and “anonymous report” wording tweaks on the disabled popup.
> 
> **Downloads & app:** Locales gain **`downloadsSearchHint`** in `downloads-impl`, and **`downloadsCannotOpenFileErrorMessage`** is added under `app` `strings.xml` for each locale (used when opening a downloaded file fails).
> 
> **Misc:** Feedback XML declarations switch to `UTF-8`; Greek **`sync_pdf_description`** gains a trailing newline in the translated string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 174afffee3f32af970bac76ffeb68ae28e5dbaee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->