### PR TITLE
Mitigate issues related to aborted Custom AI Onboarding Flow and re-enable the feature flag

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/launch/LaunchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/launch/LaunchViewModel.kt
@@ -88,7 +88,9 @@ class LaunchViewModel @Inject constructor(
                     LinearOnboardingHost.OnboardingActivity -> {
                         command.value = Command.Onboarding
                     }
-
+                    LinearOnboardingHost.BrowserActivity -> {
+                        command.value = Command.Home()
+                    }
                     else -> {
                         // extend to support initial hosts in the future
                         throw IllegalArgumentException("unsupported initial onboarding host transition")

--- a/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingFeature.kt
@@ -27,6 +27,6 @@ import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 )
 interface CustomAiOnboardingFeature {
 
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/OnboardingActivity.kt
@@ -84,7 +84,7 @@ class OnboardingActivity : DuckDuckGoActivity() {
 
     fun onSkipClicked() {
         viewModel.onOnboardingSkipped()
-        startActivity(BrowserActivity.intent(this@OnboardingActivity, launchSource = Onboarding))
+        startActivity(BrowserActivity.intent(this@OnboardingActivity, launchSource = Onboarding, newSearch = true))
         finish()
     }
 
@@ -97,7 +97,7 @@ class OnboardingActivity : DuckDuckGoActivity() {
     }
 
     fun handOffToBrowserActivity() {
-        startActivity(BrowserActivity.intent(this@OnboardingActivity, launchSource = Onboarding))
+        startActivity(BrowserActivity.intent(this@OnboardingActivity, launchSource = Onboarding, newSearch = true))
         finish()
     }
 
@@ -113,7 +113,7 @@ class OnboardingActivity : DuckDuckGoActivity() {
     private fun onOnboardingDone() {
         lifecycleScope.launch {
             viewModel.onOnboardingDone()
-            startActivity(BrowserActivity.intent(this@OnboardingActivity, launchSource = Onboarding))
+            startActivity(BrowserActivity.intent(this@OnboardingActivity, launchSource = Onboarding, newSearch = true))
             finish()
         }
     }

--- a/app/src/test/java/com/duckduckgo/app/launch/LaunchViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/launch/LaunchViewModelTest.kt
@@ -40,6 +40,7 @@ import com.duckduckgo.onboarding.api.LinearOnboardingTransition
 import com.duckduckgo.testseeder.api.TestScenarioSeeder
 import kotlinx.coroutines.test.runTest
 import org.junit.After
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -169,6 +170,75 @@ class LaunchViewModelTest {
         coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
 
         verify(mockCommandObserver).onChanged(any<Onboarding>())
+    }
+
+    @Test
+    fun whenShowOnboardingOrHomeAndOrchestratorStartsWithBrowserActivityHostThenCommandIsHome() = runTest {
+        whenever(userStageStore.getUserAppStage()).thenReturn(AppStage.NEW)
+        val inProgress = LinearOnboardingState.InProgress(
+            rootPlanId = "test_plan",
+            currentPlan = LinearOnboardingPlan(id = "test_plan", steps = listOf(stepHostedIn(LinearOnboardingHost.BrowserActivity))),
+            currentStepIndex = 0,
+        )
+        whenever(newUserOnboardingPlanBootstrapper.startNewUserOnboardingPlan()).thenReturn(inProgress)
+        testee = LaunchViewModel(
+            userStageStore,
+            StubAppReferrerFoundStateListener("xx"),
+            pixel = pixel,
+            testScenarioSeeder = testScenarioSeeder,
+            newUserOnboardingPlanBootstrapper = newUserOnboardingPlanBootstrapper,
+            brandDesignUpdateToggles = brandDesignUpdateToggles,
+        )
+        testee.command.observeForever(mockCommandObserver)
+
+        testee.showOnboardingOrHome()
+
+        verify(mockCommandObserver).onChanged(any<Home>())
+    }
+
+    @Test
+    fun whenShowOnboardingOrHomeAndOrchestratorStartsWithUnsupportedHostThenThrows() = runTest {
+        whenever(userStageStore.getUserAppStage()).thenReturn(AppStage.NEW)
+        val inProgress = LinearOnboardingState.InProgress(
+            rootPlanId = "test_plan",
+            currentPlan = LinearOnboardingPlan(
+                id = "test_plan",
+                steps = listOf(stepHostedIn(LinearOnboardingHost.SubscriptionOnboardingActivity)),
+            ),
+            currentStepIndex = 0,
+        )
+        whenever(newUserOnboardingPlanBootstrapper.startNewUserOnboardingPlan()).thenReturn(inProgress)
+        testee = LaunchViewModel(
+            userStageStore,
+            StubAppReferrerFoundStateListener("xx"),
+            pixel = pixel,
+            testScenarioSeeder = testScenarioSeeder,
+            newUserOnboardingPlanBootstrapper = newUserOnboardingPlanBootstrapper,
+            brandDesignUpdateToggles = brandDesignUpdateToggles,
+        )
+
+        val exception = runCatching { testee.showOnboardingOrHome() }.exceptionOrNull()
+
+        assertTrue(exception is IllegalArgumentException)
+    }
+
+    @Test
+    fun whenShowOnboardingOrHomeAndNotNewUserThenCommandIsHome() = runTest {
+        whenever(userStageStore.getUserAppStage()).thenReturn(AppStage.DAX_ONBOARDING)
+        testee = LaunchViewModel(
+            userStageStore,
+            StubAppReferrerFoundStateListener("xx"),
+            pixel = pixel,
+            testScenarioSeeder = testScenarioSeeder,
+            newUserOnboardingPlanBootstrapper = newUserOnboardingPlanBootstrapper,
+            brandDesignUpdateToggles = brandDesignUpdateToggles,
+        )
+        testee.command.observeForever(mockCommandObserver)
+
+        testee.showOnboardingOrHome()
+
+        verify(mockCommandObserver).onChanged(any<Home>())
+        verify(newUserOnboardingPlanBootstrapper, never()).startNewUserOnboardingPlan()
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1216624305771569?focus=true
Tech Design URL (if applicable): 

### Description
Mitigates issues related to aborted Custom AI Onboarding Flow and re-enables the feature flag.

This re-applies https://github.com/duckduckgo/Android/pull/9213 and includes addition of always launching `BrowserActivity` in a brand new tab when finishing onboarding.

### Steps to test this PR

_Regression check_
- [x] Fresh install, go through the default (non-custom-AI) onboarding flow end-to-end → confirm no change in behavior
- [x] Returning/existing user launch → confirm still routes straight to `Home`

_Custom Duck.ai onboarding crash repro_
- [x] Apply below patch:
```diff
diff --git a/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt b/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
index fe3752cbb2..af220bb09d 100644
--- a/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
@@ -100,6 +100,7 @@ class CustomAiOnboardingStoreImpl @Inject constructor(
     }
 
     override suspend fun resolve() = resolveMutex.withLock {
+        return@withLock true
         withContext(dispatcherProvider.io()) {
             // Ensure the install referrer (and therefore the processing function) has resolved before reading.
             withTimeoutOrNull(MAX_REFERRER_WAIT_TIME_MS) { referrerStateListener.get().waitForReferrerCode() }
@@ -116,6 +117,7 @@ class CustomAiOnboardingStoreImpl @Inject constructor(
     }
 
     override suspend fun isEnabled(): Boolean = resolveMutex.withLock {
+        return@withLock true
         withContext(dispatcherProvider.io()) {
             preferences.getBoolean(PREFS_KEY_ENABLED, false)
         }
```
- [x] Fresh install, go through onboarding until reaching the Duck.ai demo step (now in `BrowserActivity`)
- [x] Press back to exit the app (do not kill the process)
- [x] Relaunch the app from the launcher icon → confirm the app instead resumes onboarding, dropping the user back into the Duck.ai demo step, and no crash occurs
- [x] Finish the flow and verify you land on a focused new tab with toggle in `Duck.ai` position.
- [x] Dropping focus will reveal the final CTA from behind chat suggestions -- accepted limitation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes first-launch and resume routing for new users and defaults a remote feature flag on; scope is onboarding-only but affects entry paths into BrowserActivity.
> 
> **Overview**
> Fixes crashes and bad routing when users **abort and relaunch** during custom Duck.ai onboarding, and turns **`customAiOnboarding`** back on by default.
> 
> **Launch routing:** If the linear onboarding orchestrator reports the current step is hosted in **`BrowserActivity`** (e.g. user left mid Duck.ai demo), **`LaunchViewModel`** now emits **`Home`** instead of treating that host as unsupported.
> 
> **Handoff to browser:** When **`OnboardingActivity`** finishes via skip, normal completion, or handoff, it starts **`BrowserActivity`** with **`newSearch = true`** so the user lands on a fresh tab (Duck Chat–specific exits are unchanged).
> 
> **Tests:** **`LaunchViewModelTest`** adds coverage for BrowserActivity host → Home, unsupported host → exception, and non–new users → Home without starting the plan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cade74d589c849504df49dd721162c6494a6cb2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->