### PR TITLE
Edit devices in simplifed sync flow

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivity.kt
@@ -36,12 +36,16 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
-import com.duckduckgo.di.*
-import com.duckduckgo.di.scopes.*
+import com.duckduckgo.di.DaggerMap
+import com.duckduckgo.di.DaggerSet
+import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.navigation.api.getActivityParams
 import com.duckduckgo.settings.api.SettingsWebViewScreenWithParams
-import com.duckduckgo.sync.api.*
+import com.duckduckgo.sync.api.SyncActivityFromSetupUrl
+import com.duckduckgo.sync.api.SyncActivityWithAnotherDevice
+import com.duckduckgo.sync.api.SyncMessagePlugin
+import com.duckduckgo.sync.api.SyncSettingsPlugin
 import com.duckduckgo.sync.impl.ConnectedDevice
 import com.duckduckgo.sync.impl.PermissionRequest
 import com.duckduckgo.sync.impl.R
@@ -70,7 +74,6 @@ import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.LaunchOriginalF
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.LaunchSyncGetOnOtherPlatforms
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.RecoveryCodePDFSuccess
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.RequestSetupAuthentication
-import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.SetSyncThisDeviceToggle
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowDeviceConnected
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowDeviceUnsupported
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowError
@@ -457,8 +460,6 @@ class SyncActivity : DuckDuckGoActivity() {
                     deepLinkIntoSetup(command.barcodeSyncUrl.asUrl())
                 }
             }
-            // This is a no-op in this flow. Simplified sync flow uses a toggle that needs to be checked off.
-            is SetSyncThisDeviceToggle -> Unit
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivity.kt
@@ -70,12 +70,12 @@ import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.LaunchOriginalF
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.LaunchSyncGetOnOtherPlatforms
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.RecoveryCodePDFSuccess
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.RequestSetupAuthentication
+import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.SetSyncThisDeviceToggle
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowDeviceConnected
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowDeviceUnsupported
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowError
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowPreviousSessionReady
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowRecoveryCode
-import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.SyncThisDeviceCanceled
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.SyncWithAnotherDevice
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.OriginalFlow
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.SetupFlows
@@ -458,7 +458,7 @@ class SyncActivity : DuckDuckGoActivity() {
                 }
             }
             // This is a no-op in this flow. Simplified sync flow uses a toggle that needs to be checked off.
-            is SyncThisDeviceCanceled -> Unit
+            is SetSyncThisDeviceToggle -> Unit
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
@@ -185,6 +185,7 @@ class SyncActivityViewModel @Inject constructor(
             newDesktopBrowserSettingEnabled = settingsPageFeature.newDesktopBrowserSettingEnabled().isEnabled(),
             showAutoRestoreToggle = autoRestoreState.showToggle,
             autoRestoreEnabled = autoRestoreState.enabled,
+            isThisDeviceSyncing = currentState.isThisDeviceSyncing,
         )
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
@@ -66,7 +66,6 @@ import com.duckduckgo.sync.impl.ui.SyncDeviceListItem.SyncedDevice
 import com.duckduckgo.sync.impl.ui.qrcode.SyncBarcodeUrl
 import com.duckduckgo.sync.impl.wideevents.SyncSetupWideEvent
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -111,7 +110,7 @@ class SyncActivityViewModel @Inject constructor(
     // null until the first load from preference; used by onScreenExit() to detect changes.
     @Volatile private var initialAutoRestoreEnabled: Boolean? = null
 
-    private val command = Channel<Command>(1, DROP_OLDEST)
+    private val command = Channel<Command>(Channel.BUFFERED)
     private val viewState = MutableStateFlow(ViewState())
     fun commands(): Flow<Command> = command.receiveAsFlow().onStart {
         checkIfDeviceSupported()
@@ -254,7 +253,7 @@ class SyncActivityViewModel @Inject constructor(
         data class LaunchLearnMore(val url: String) : Command()
         data class ShowPreviousSessionReady(val originalFlow: OriginalFlow) : Command()
         data class LaunchOriginalFlow(val originalFlow: OriginalFlow) : Command()
-        data object SyncThisDeviceCanceled : Command()
+        data class SetSyncThisDeviceToggle(val isOn: Boolean) : Command()
     }
 
     enum class OriginalFlow {
@@ -372,9 +371,11 @@ class SyncActivityViewModel @Inject constructor(
             syncPixels.fireUserConfirmedToTurnOffSync()
 
             viewState.value = viewState.value.hideAccount()
+            command.send(Command.SetSyncThisDeviceToggle(isOn = false))
             when (val result = syncAccountRepository.logout(connectedDevice.deviceId)) {
                 is Error -> {
                     viewState.value = viewState.value.showAccount()
+                    command.send(Command.SetSyncThisDeviceToggle(isOn = true))
                     command.send(ShowError(R.string.sync_turn_off_error, result.reason))
                 }
 
@@ -568,7 +569,7 @@ class SyncActivityViewModel @Inject constructor(
 
     fun onSyncThisDeviceCanceled() {
         viewModelScope.launch {
-            command.send(Command.SyncThisDeviceCanceled)
+            command.send(Command.SetSyncThisDeviceToggle(isOn = false))
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
@@ -66,6 +66,7 @@ import com.duckduckgo.sync.impl.ui.SyncDeviceListItem.SyncedDevice
 import com.duckduckgo.sync.impl.ui.qrcode.SyncBarcodeUrl
 import com.duckduckgo.sync.impl.wideevents.SyncSetupWideEvent
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -110,7 +111,7 @@ class SyncActivityViewModel @Inject constructor(
     // null until the first load from preference; used by onScreenExit() to detect changes.
     @Volatile private var initialAutoRestoreEnabled: Boolean? = null
 
-    private val command = Channel<Command>(Channel.BUFFERED)
+    private val command = Channel<Command>(1, DROP_OLDEST)
     private val viewState = MutableStateFlow(ViewState())
     fun commands(): Flow<Command> = command.receiveAsFlow().onStart {
         checkIfDeviceSupported()
@@ -220,6 +221,7 @@ class SyncActivityViewModel @Inject constructor(
         val newDesktopBrowserSettingEnabled: Boolean = false,
         val showAutoRestoreToggle: Boolean = false,
         val autoRestoreEnabled: Boolean = false,
+        val isThisDeviceSyncing: Boolean = false,
     )
 
     sealed class SetupFlows {
@@ -253,7 +255,6 @@ class SyncActivityViewModel @Inject constructor(
         data class LaunchLearnMore(val url: String) : Command()
         data class ShowPreviousSessionReady(val originalFlow: OriginalFlow) : Command()
         data class LaunchOriginalFlow(val originalFlow: OriginalFlow) : Command()
-        data class SetSyncThisDeviceToggle(val isOn: Boolean) : Command()
     }
 
     enum class OriginalFlow {
@@ -283,6 +284,7 @@ class SyncActivityViewModel @Inject constructor(
     }
 
     fun onSyncThisDevice(source: String? = null) {
+        viewState.value = viewState.value.setThisDeviceSyncInProgress()
         viewModelScope.launch(dispatchers.io()) {
             syncSetupWideEvent.onFlowStarted(source)
             requiresSetupAuthentication(
@@ -370,12 +372,10 @@ class SyncActivityViewModel @Inject constructor(
         viewModelScope.launch(dispatchers.io()) {
             syncPixels.fireUserConfirmedToTurnOffSync()
 
-            viewState.value = viewState.value.hideAccount()
-            command.send(Command.SetSyncThisDeviceToggle(isOn = false))
+            viewState.value = viewState.value.hideAccount().setThisDeviceSyncIdle()
             when (val result = syncAccountRepository.logout(connectedDevice.deviceId)) {
                 is Error -> {
                     viewState.value = viewState.value.showAccount()
-                    command.send(Command.SetSyncThisDeviceToggle(isOn = true))
                     command.send(ShowError(R.string.sync_turn_off_error, result.reason))
                 }
 
@@ -538,6 +538,7 @@ class SyncActivityViewModel @Inject constructor(
     }
 
     fun onDeviceConnected() {
+        viewState.value = viewState.value.setThisDeviceSyncIdle()
         viewModelScope.launch {
             fetchRemoteDevices()
         }
@@ -568,9 +569,7 @@ class SyncActivityViewModel @Inject constructor(
     }
 
     fun onSyncThisDeviceCanceled() {
-        viewModelScope.launch {
-            command.send(Command.SetSyncThisDeviceToggle(isOn = false))
-        }
+        viewState.value = viewState.value.setThisDeviceSyncIdle()
     }
 
     private fun showAccountDetailsIfNeeded() {
@@ -626,6 +625,8 @@ class SyncActivityViewModel @Inject constructor(
 
     private fun ViewState.showAccount() = copy(showAccount = true)
     private fun ViewState.hideAccount() = copy(showAccount = false)
+    private fun ViewState.setThisDeviceSyncInProgress() = copy(isThisDeviceSyncing = true)
+    private fun ViewState.setThisDeviceSyncIdle() = copy(isThisDeviceSyncing = false)
 
     fun processSetupDeepLink(setupUrl: String) {
         logcat { "Sync-setup: got setup deep link $setupUrl" }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
@@ -69,6 +69,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.BufferOverflow.DROP_OLDEST
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOn
@@ -101,8 +102,9 @@ class SyncActivityViewModel @Inject constructor(
     private val syncSetupWideEvent: SyncSetupWideEvent,
 ) : ViewModel() {
 
-    private var syncStateObserverJob = ConflatedJob()
-    private var backgroundRefreshJob = ConflatedJob()
+    private val syncStateObserverJob = ConflatedJob()
+    private val backgroundRefreshJob = ConflatedJob()
+    private val fetchDevicesJob = ConflatedJob()
 
     // @Volatile because loadAutoRestoreState() writes these on the IO dispatcher while
     // onScreenExit() reads them from a different coroutine launched on the IO dispatcher.
@@ -353,19 +355,19 @@ class SyncActivityViewModel @Inject constructor(
         }
     }
 
-    private suspend fun fetchRemoteDevices(showLoadingState: Boolean = true) {
-        if (showLoadingState) {
-            viewState.value = viewState.value.showDeviceListItemLoading()
-        }
+    private fun fetchRemoteDevices(showLoadingState: Boolean = true) {
+        fetchDevicesJob += viewModelScope.launch(dispatchers.io()) {
+            if (showLoadingState) {
+                viewState.value = viewState.value.showDeviceListItemLoading()
+            }
 
-        val result = withContext(dispatchers.io()) {
-            syncAccountRepository.getConnectedDevices()
-        }
-        if (result is Success) {
-            val newState = viewState.value.hideDeviceListItemLoading().setDevices(result.data.map { SyncedDevice(it) })
-            viewState.value = newState
-        } else {
-            viewState.value = viewState.value.hideDeviceListItemLoading()
+            val result = syncAccountRepository.getConnectedDevices()
+            ensureActive() // don't apply a result that was superseded while in flight
+            viewState.value = if (result is Success) {
+                viewState.value.hideDeviceListItemLoading().setDevices(result.data.map { SyncedDevice(it) })
+            } else {
+                viewState.value.hideDeviceListItemLoading()
+            }
         }
     }
 
@@ -510,26 +512,32 @@ class SyncActivityViewModel @Inject constructor(
 
     fun onRemoveDeviceConfirmed(device: ConnectedDevice) {
         viewModelScope.launch(dispatchers.io()) {
-            val oldList = viewState.value.syncedDevices
             viewState.value = viewState.value.showDeviceListItemLoading(device)
             when (val result = syncAccountRepository.logout(device.deviceId)) {
                 is Error -> {
-                    viewState.value = viewState.value.setDevices(oldList)
+                    viewState.value = viewState.value.hideDeviceListItemLoading(device)
                     command.send(ShowError(R.string.sync_remove_device_error, result.reason))
                 }
 
-                is Success -> fetchRemoteDevices()
+                is Success -> {
+                    // Remove the device optimistically instead of refetching: a fetch that read the
+                    // server before the logout could otherwise land afterwards and re-insert the
+                    // device until the next periodic refresh corrects it.
+                    fetchDevicesJob.cancel()
+                    viewState.value = viewState.value.setDevices(
+                        viewState.value.syncedDevices.filterNot { it is SyncedDevice && it.device.deviceId == device.deviceId },
+                    )
+                }
             }
         }
     }
 
     fun onDeviceEdited(editedConnectedDevice: ConnectedDevice) {
         viewModelScope.launch(dispatchers.io()) {
-            val oldList = viewState.value.syncedDevices
             viewState.value = viewState.value.showDeviceListItemLoading(editedConnectedDevice)
             when (val result = syncAccountRepository.renameDevice(editedConnectedDevice)) {
                 is Error -> {
-                    viewState.value = viewState.value.setDevices(oldList)
+                    viewState.value = viewState.value.hideDeviceListItemLoading(editedConnectedDevice)
                     command.send(ShowError(R.string.sync_edit_device_error, result.reason))
                 }
 
@@ -540,15 +548,11 @@ class SyncActivityViewModel @Inject constructor(
 
     fun onDeviceConnected() {
         viewState.value = viewState.value.setThisDeviceSyncIdle()
-        viewModelScope.launch {
-            fetchRemoteDevices()
-        }
+        fetchRemoteDevices()
     }
 
     fun onDevicesUpdated() {
-        viewModelScope.launch {
-            fetchRemoteDevices(showLoadingState = false)
-        }
+        fetchRemoteDevices(showLoadingState = false)
     }
 
     fun onGetOnOtherPlatformsClickedWhenSyncDisabled() {
@@ -611,6 +615,17 @@ class SyncActivityViewModel @Inject constructor(
 
     private fun ViewState.setDevices(devices: List<SyncDeviceListItem>) = copy(syncedDevices = devices)
     private fun ViewState.hideDeviceListItemLoading() = copy(syncedDevices = syncedDevices.filterNot { it is LoadingItem })
+    private fun ViewState.hideDeviceListItemLoading(updatedDevice: ConnectedDevice): ViewState {
+        return copy(
+            syncedDevices = syncedDevices.map {
+                if (it is SyncedDevice && it.device.deviceId == updatedDevice.deviceId) {
+                    it.copy(loading = false)
+                } else {
+                    it
+                }
+            },
+        )
+    }
     private fun ViewState.showDeviceListItemLoading() = copy(syncedDevices = syncedDevices + LoadingItem)
     private fun ViewState.showDeviceListItemLoading(updatingDevice: ConnectedDevice): ViewState {
         return copy(

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
@@ -542,6 +542,13 @@ class SyncActivityViewModel @Inject constructor(
         }
     }
 
+    fun onDeviceUpdated(device: ConnectedDevice) {
+        viewModelScope.launch {
+            viewState.value = viewState.value.showDeviceListItemLoading(device)
+            fetchRemoteDevices(showLoadingState = false)
+        }
+    }
+
     fun onGetOnOtherPlatformsClickedWhenSyncDisabled() {
         viewModelScope.launch(dispatchers.main()) {
             command.send(LaunchSyncGetOnOtherPlatforms(source = SOURCE_SYNC_DISABLED))

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
@@ -542,9 +542,8 @@ class SyncActivityViewModel @Inject constructor(
         }
     }
 
-    fun onDeviceUpdated(device: ConnectedDevice) {
+    fun onDevicesUpdated() {
         viewModelScope.launch {
-            viewState.value = viewState.value.showDeviceListItemLoading(device)
             fetchRemoteDevices(showLoadingState = false)
         }
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceActivity.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.res.ColorStateList
 import android.os.Bundle
+import android.widget.CompoundButton.OnCheckedChangeListener
 import androidx.activity.viewModels
 import androidx.core.content.IntentCompat
 import androidx.core.view.isGone
@@ -29,6 +30,8 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.view.dialog.CustomAlertDialogBuilder
+import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.getColorFromAttr
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
@@ -37,9 +40,21 @@ import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.databinding.ActivitySyncV2EditDeviceBinding
+import com.duckduckgo.sync.impl.databinding.DialogEditDeviceBinding
 import com.duckduckgo.sync.impl.ui.v2.EditDeviceContract.Companion.DEVICE_KEY
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceContract.Companion.RESULT_DEVICE_EDITED
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceContract.Companion.RESULT_DEVICE_REMOVED
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceContract.Companion.RESULT_SYNC_TURNED_OFF
 import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.AskEditDevice
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.AskRemoveDevice
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.AskTurnOffSync
 import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.Close
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.ResetTurnOffSyncToggle
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.SetEditDeviceResult
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.SetRemoveDeviceResult
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.SetTurnOffSyncResult
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.ShowError
 import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Factory
 import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Factory.Provider
 import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.ViewState
@@ -50,11 +65,6 @@ import com.duckduckgo.mobile.android.R as CommonR
 
 @InjectWith(ActivityScope::class)
 class EditDeviceActivity : DuckDuckGoActivity() {
-    private val device
-        get() = requireNotNull(IntentCompat.getParcelableExtra(intent, DEVICE_KEY, ParcelableDevice::class.java)) {
-            "Missing intent extra: '$DEVICE_KEY'"
-        }.toConnectedDevice()
-
     private val binding by viewBinding<ActivitySyncV2EditDeviceBinding>()
 
     @Inject
@@ -67,7 +77,17 @@ class EditDeviceActivity : DuckDuckGoActivity() {
     lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
 
     private val viewModel by viewModels<EditDeviceViewModel> {
-        Provider(vmFactory, device)
+        val device = requireNotNull(IntentCompat.getParcelableExtra(intent, DEVICE_KEY, ParcelableDevice::class.java)) {
+            "Missing intent extra: '$DEVICE_KEY'"
+        }
+
+        Provider(vmFactory, device.toConnectedDevice())
+    }
+
+    private val currentDevice get() = viewModel.viewState.value.device
+
+    private val turnOffSyncListener = OnCheckedChangeListener { _, isChecked ->
+        if (!isChecked) viewModel.onTurnOffSync()
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -83,7 +103,9 @@ class EditDeviceActivity : DuckDuckGoActivity() {
         }
 
         configureToolbar()
+        configureEditDeviceNameItem()
         configureRemoveAnotherDeviceItem()
+        configureTurnOffSyncToggle()
 
         observeViewModel()
     }
@@ -129,8 +151,109 @@ class EditDeviceActivity : DuckDuckGoActivity() {
 
     private fun processCommand(command: Command) {
         when (command) {
-            Close -> finish()
+            is AskEditDevice -> {
+                askEditDevice()
+            }
+
+            is SetEditDeviceResult -> {
+                setResult(RESULT_DEVICE_EDITED, EditDeviceContract.resultIntent(currentDevice))
+            }
+
+            is AskRemoveDevice -> {
+                askRemoveDevice()
+            }
+
+            is SetRemoveDeviceResult -> {
+                setResult(RESULT_DEVICE_REMOVED, EditDeviceContract.resultIntent(currentDevice))
+            }
+
+            is AskTurnOffSync -> {
+                askTurnOffSync()
+            }
+
+            is SetTurnOffSyncResult -> {
+                setResult(RESULT_SYNC_TURNED_OFF, EditDeviceContract.resultIntent(currentDevice))
+            }
+
+            is ResetTurnOffSyncToggle -> {
+                binding.syncThisDeviceToggle.quietlySetIsChecked(true, turnOffSyncListener)
+            }
+
+            is ShowError -> {
+                showError(command)
+            }
+
+            is Close -> {
+                finish()
+            }
         }
+    }
+
+    private fun askEditDevice() {
+        val inputBinding = DialogEditDeviceBinding.inflate(layoutInflater).apply {
+            customDialogTextInput.text = currentDevice.deviceName
+        }
+        CustomAlertDialogBuilder(this)
+            .setTitle(R.string.sync_device_v2_edit_device_dialog_title)
+            .setPositiveButton(R.string.sync_device_v2_edit_device_dialog_primary_button)
+            .setNegativeButton(R.string.sync_device_v2_edit_device_dialog_secondary_button)
+            .setView(inputBinding)
+            .addEventListener(
+                object : CustomAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() {
+                        viewModel.confirmNewDeviceName(inputBinding.customDialogTextInput.text)
+                    }
+                },
+            )
+            .show()
+    }
+
+    private fun askRemoveDevice() {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_device_v2_remove_device_dialog_title)
+            .setMessage(getString(R.string.sync_device_v2_remove_device_dialog_body, currentDevice.deviceName))
+            .setPositiveButton(R.string.sync_device_v2_remove_device_dialog_primary_button)
+            .setNegativeButton(R.string.sync_device_v2_remove_device_dialog_secondary_button)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() {
+                        viewModel.onRemoveDeviceConfirmed()
+                    }
+                },
+            )
+            .show()
+    }
+
+    private fun askTurnOffSync() {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_device_v2_turn_off_sync_dialog_title)
+            .setMessage(getString(R.string.sync_device_v2_turn_off_sync_dialog_body))
+            .setPositiveButton(R.string.sync_device_v2_turn_off_sync_dialog_primary_button)
+            .setNegativeButton(R.string.sync_device_v2_turn_off_sync_dialog_secondary_button)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() {
+                        viewModel.onTurnOffSyncConfirmed()
+                    }
+
+                    override fun onNegativeButtonClicked() {
+                        viewModel.onTurnOffSyncCanceled()
+                    }
+
+                    override fun onDialogCancelled() {
+                        viewModel.onTurnOffSyncCanceled()
+                    }
+                },
+            )
+            .show()
+    }
+
+    private fun showError(command: ShowError) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_dialog_error_title)
+            .setMessage(getString(command.message) + "\n" + command.reason)
+            .setPositiveButton(R.string.sync_dialog_error_ok)
+            .show()
     }
 
     private fun configureToolbar() {
@@ -139,11 +262,25 @@ class EditDeviceActivity : DuckDuckGoActivity() {
         }
     }
 
+    private fun configureEditDeviceNameItem() {
+        binding.editThisDeviceNameItem.setOnClickListener {
+            viewModel.onEditDeviceName()
+        }
+    }
+
+    private fun configureTurnOffSyncToggle() {
+        binding.syncThisDeviceToggle.apply {
+            setIsChecked(true)
+            setOnCheckedChangeListener(turnOffSyncListener)
+        }
+    }
+
     private fun configureRemoveAnotherDeviceItem() {
         val color = ColorStateList.valueOf(getColorFromAttr(CommonR.attr.daxColorDestructive))
         binding.removeAnotherDeviceItem.apply {
             leadingIcon().imageTintList = color
             setPrimaryTextColorStateList(color)
+            setOnClickListener { viewModel.onRemoveDevice() }
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceActivity.kt
@@ -137,7 +137,11 @@ class EditDeviceActivity : DuckDuckGoActivity() {
 
         binding.editThisDeviceNameItem.isVisible = viewState.device.thisDevice && !viewState.isEditingName
         binding.editThisDeviceNameItem.setSecondaryText(viewState.device.deviceName)
-        binding.editThisDeviceNameShimmer.isVisible = viewState.device.thisDevice && viewState.isEditingName
+        binding.editThisDeviceNameShimmer.apply {
+            val showShimmer = viewState.device.thisDevice && viewState.isEditingName
+            isVisible = showShimmer
+            if (showShimmer) startShimmer() else stopShimmer()
+        }
         binding.editThisDeviceNameDivider.isVisible = viewState.device.thisDevice
         binding.syncThisDeviceToggleContainer.isVisible = viewState.device.thisDevice
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceActivity.kt
@@ -226,6 +226,7 @@ class EditDeviceActivity : DuckDuckGoActivity() {
                     }
                 },
             )
+            .setCancellable(true)
             .show()
     }
 
@@ -250,6 +251,7 @@ class EditDeviceActivity : DuckDuckGoActivity() {
                     }
                 },
             )
+            .setCancellable(true)
             .show()
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceActivity.kt
@@ -135,8 +135,9 @@ class EditDeviceActivity : DuckDuckGoActivity() {
 
         binding.removeAnotherDeviceItem.isGone = viewState.device.thisDevice
 
-        binding.editThisDeviceNameItem.isVisible = viewState.device.thisDevice
+        binding.editThisDeviceNameItem.isVisible = viewState.device.thisDevice && !viewState.isEditingName
         binding.editThisDeviceNameItem.setSecondaryText(viewState.device.deviceName)
+        binding.editThisDeviceNameShimmer.isVisible = viewState.device.thisDevice && viewState.isEditingName
         binding.editThisDeviceNameDivider.isVisible = viewState.device.thisDevice
         binding.syncThisDeviceToggleContainer.isVisible = viewState.device.thisDevice
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceActivity.kt
@@ -51,9 +51,9 @@ import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.AskRemoveDevic
 import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.AskTurnOffSync
 import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.Close
 import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.ResetTurnOffSyncToggle
-import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.SetEditDeviceResult
-import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.SetRemoveDeviceResult
-import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.SetTurnOffSyncResult
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.SetDeviceEditedResult
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.SetDeviceRemovedResult
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.SetSyncTurnedOffResult
 import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.ShowError
 import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Factory
 import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Factory.Provider
@@ -156,7 +156,7 @@ class EditDeviceActivity : DuckDuckGoActivity() {
                 askEditDevice()
             }
 
-            is SetEditDeviceResult -> {
+            is SetDeviceEditedResult -> {
                 setResult(RESULT_DEVICE_EDITED, EditDeviceContract.resultIntent(currentDevice))
             }
 
@@ -164,7 +164,7 @@ class EditDeviceActivity : DuckDuckGoActivity() {
                 askRemoveDevice()
             }
 
-            is SetRemoveDeviceResult -> {
+            is SetDeviceRemovedResult -> {
                 setResult(RESULT_DEVICE_REMOVED, EditDeviceContract.resultIntent(currentDevice))
             }
 
@@ -172,7 +172,7 @@ class EditDeviceActivity : DuckDuckGoActivity() {
                 askTurnOffSync()
             }
 
-            is SetTurnOffSyncResult -> {
+            is SetSyncTurnedOffResult -> {
                 setResult(RESULT_SYNC_TURNED_OFF, EditDeviceContract.resultIntent(currentDevice))
             }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceContract.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceContract.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
+import androidx.core.content.IntentCompat
 import com.duckduckgo.sync.impl.ConnectedDevice
 import com.duckduckgo.sync.impl.DeviceType
 import kotlinx.parcelize.Parcelize
@@ -36,14 +37,38 @@ class EditDeviceContract : ActivityResultContract<EditDeviceContract.Input, Edit
         resultCode: Int,
         intent: Intent?,
     ): Output {
-        return Output
+        val device = intent
+            ?.let { IntentCompat.getParcelableExtra(it, DEVICE_KEY, ParcelableDevice::class.java) }
+            ?.toConnectedDevice()
+            ?: return Output.NoOp
+
+        return when (resultCode) {
+            RESULT_DEVICE_EDITED -> Output.EditDevice(device)
+            RESULT_DEVICE_REMOVED -> Output.RemoveDevice(device)
+            RESULT_SYNC_TURNED_OFF -> Output.TurnOffSync(device)
+            else -> Output.NoOp
+        }
     }
 
     data class Input(
         val device: ConnectedDevice,
     )
 
-    data object Output
+    sealed interface Output {
+        data class EditDevice(
+            val device: ConnectedDevice,
+        ) : Output
+
+        data class TurnOffSync(
+            val device: ConnectedDevice,
+        ) : Output
+
+        data class RemoveDevice(
+            val device: ConnectedDevice,
+        ) : Output
+
+        data object NoOp : Output
+    }
 
     companion object {
         const val DEVICE_KEY = "device"

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceContract.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceContract.kt
@@ -47,6 +47,11 @@ class EditDeviceContract : ActivityResultContract<EditDeviceContract.Input, Edit
 
     companion object {
         const val DEVICE_KEY = "device"
+        const val RESULT_DEVICE_EDITED = 200
+        const val RESULT_DEVICE_REMOVED = 201
+        const val RESULT_SYNC_TURNED_OFF = 202
+
+        fun resultIntent(device: ConnectedDevice) = Intent().putExtra(DEVICE_KEY, ParcelableDevice.fromConnectedDevice(device))
     }
 }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceContract.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceContract.kt
@@ -43,9 +43,9 @@ class EditDeviceContract : ActivityResultContract<EditDeviceContract.Input, Edit
             ?: return Output.NoOp
 
         return when (resultCode) {
-            RESULT_DEVICE_EDITED -> Output.EditDevice(device)
-            RESULT_DEVICE_REMOVED -> Output.RemoveDevice(device)
-            RESULT_SYNC_TURNED_OFF -> Output.TurnOffSync(device)
+            RESULT_DEVICE_EDITED -> Output.DeviceEdited(device)
+            RESULT_DEVICE_REMOVED -> Output.RemoveDeviceConfirmed(device)
+            RESULT_SYNC_TURNED_OFF -> Output.TurnOffSyncConfirmed(device)
             else -> Output.NoOp
         }
     }
@@ -55,15 +55,15 @@ class EditDeviceContract : ActivityResultContract<EditDeviceContract.Input, Edit
     )
 
     sealed interface Output {
-        data class EditDevice(
+        data class DeviceEdited(
             val device: ConnectedDevice,
         ) : Output
 
-        data class TurnOffSync(
+        data class TurnOffSyncConfirmed(
             val device: ConnectedDevice,
         ) : Output
 
-        data class RemoveDevice(
+        data class RemoveDeviceConfirmed(
             val device: ConnectedDevice,
         ) : Output
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceViewModel.kt
@@ -16,32 +16,99 @@
 
 package com.duckduckgo.sync.impl.ui.v2
 
+import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.sync.impl.ConnectedDevice
+import com.duckduckgo.sync.impl.R
+import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.impl.SyncAccountRepository
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class EditDeviceViewModel @AssistedInject constructor(
     @Assisted device: ConnectedDevice,
+    private val syncAccountRepository: SyncAccountRepository,
+    private val dispatchers: DispatcherProvider,
 ) : ViewModel() {
     private val _viewState = MutableStateFlow(
-        ViewState(device = device),
+        ViewState(
+            device = device,
+            isEditingName = false,
+        ),
     )
     val viewState: StateFlow<ViewState> = _viewState.asStateFlow()
 
-    private val _commands = Channel<Command>(1, BufferOverflow.DROP_OLDEST)
+    private val _commands = Channel<Command>(Channel.BUFFERED)
     val commands: Flow<Command> = _commands.receiveAsFlow()
+
+    fun onEditDeviceName() {
+        viewModelScope.launch {
+            _commands.send(Command.AskEditDevice)
+        }
+    }
+
+    fun confirmNewDeviceName(newName: String) {
+        viewModelScope.launch(dispatchers.io()) {
+            _viewState.update { it.copy(isEditingName = true) }
+            val editedDevice = viewState.value.device.copy(deviceName = newName)
+            when (val result = syncAccountRepository.renameDevice(editedDevice)) {
+                is Success -> {
+                    _viewState.update { it.copy(device = editedDevice) }
+                }
+
+                is Error -> {
+                    _commands.send(Command.ResetTurnOffSyncToggle)
+                    _commands.send(Command.ShowError(R.string.sync_edit_device_error, result.reason))
+                }
+            }
+            _viewState.update { it.copy(isEditingName = false) }
+        }
+    }
+
+    fun onTurnOffSync() {
+        viewModelScope.launch {
+            _commands.send(Command.AskTurnOffSync)
+        }
+    }
+
+    fun onTurnOffSyncConfirmed() {
+        viewModelScope.launch {
+            _commands.send(Command.SetTurnOffSyncResult)
+            _commands.send(Command.Close)
+        }
+    }
+
+    fun onTurnOffSyncCanceled() {
+        viewModelScope.launch {
+            _commands.send(Command.ResetTurnOffSyncToggle)
+        }
+    }
+
+    fun onRemoveDevice() {
+        viewModelScope.launch {
+            _commands.send(Command.AskRemoveDevice)
+        }
+    }
+
+    fun onRemoveDeviceConfirmed() {
+        viewModelScope.launch {
+            _commands.send(Command.SetRemoveDeviceResult)
+            _commands.send(Command.Close)
+        }
+    }
 
     fun onCloseClicked() {
         viewModelScope.launch {
@@ -51,10 +118,30 @@ class EditDeviceViewModel @AssistedInject constructor(
 
     data class ViewState(
         val device: ConnectedDevice,
+        val isEditingName: Boolean,
     )
 
-    sealed class Command {
-        data object Close : Command()
+    sealed interface Command {
+        data object AskEditDevice : Command
+
+        data object SetEditDeviceResult : Command
+
+        data object AskRemoveDevice : Command
+
+        data object SetRemoveDeviceResult : Command
+
+        data object AskTurnOffSync : Command
+
+        data object ResetTurnOffSyncToggle : Command
+
+        data object SetTurnOffSyncResult : Command
+
+        data class ShowError(
+            @StringRes val message: Int,
+            val reason: String = "",
+        ) : Command
+
+        data object Close : Command
     }
 
     @AssistedFactory

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceViewModel.kt
@@ -70,7 +70,6 @@ class EditDeviceViewModel @AssistedInject constructor(
                 }
 
                 is Error -> {
-                    _commands.send(Command.ResetTurnOffSyncToggle)
                     _commands.send(Command.ShowError(R.string.sync_edit_device_error, result.reason))
                 }
             }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceViewModel.kt
@@ -67,6 +67,7 @@ class EditDeviceViewModel @AssistedInject constructor(
             when (val result = syncAccountRepository.renameDevice(editedDevice)) {
                 is Success -> {
                     _viewState.update { it.copy(device = editedDevice) }
+                    _commands.send(Command.SetDeviceEditedResult)
                 }
 
                 is Error -> {
@@ -85,7 +86,7 @@ class EditDeviceViewModel @AssistedInject constructor(
 
     fun onTurnOffSyncConfirmed() {
         viewModelScope.launch {
-            _commands.send(Command.SetTurnOffSyncResult)
+            _commands.send(Command.SetSyncTurnedOffResult)
             _commands.send(Command.Close)
         }
     }
@@ -104,7 +105,7 @@ class EditDeviceViewModel @AssistedInject constructor(
 
     fun onRemoveDeviceConfirmed() {
         viewModelScope.launch {
-            _commands.send(Command.SetRemoveDeviceResult)
+            _commands.send(Command.SetDeviceRemovedResult)
             _commands.send(Command.Close)
         }
     }
@@ -123,17 +124,17 @@ class EditDeviceViewModel @AssistedInject constructor(
     sealed interface Command {
         data object AskEditDevice : Command
 
-        data object SetEditDeviceResult : Command
+        data object SetDeviceEditedResult : Command
 
         data object AskRemoveDevice : Command
 
-        data object SetRemoveDeviceResult : Command
+        data object SetDeviceRemovedResult : Command
 
         data object AskTurnOffSync : Command
 
         data object ResetTurnOffSyncToggle : Command
 
-        data object SetTurnOffSyncResult : Command
+        data object SetSyncTurnedOffResult : Command
 
         data class ShowError(
             @StringRes val message: Int,

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
@@ -142,7 +142,7 @@ class SyncActivity : DuckDuckGoActivity() {
         EditDeviceContract(),
     ) { result ->
         when (result) {
-            is DeviceEdited -> viewModel.onDeviceUpdated(result.device)
+            is DeviceEdited -> viewModel.onDevicesUpdated()
             is RemoveDeviceConfirmed -> viewModel.onRemoveDeviceConfirmed(result.device)
             is TurnOffSyncConfirmed -> viewModel.onTurnOffSyncConfirmed(result.device)
             is NoOp -> Unit

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
@@ -80,6 +80,10 @@ import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.SetupFlows.CreateAccoun
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.SetupFlows.SignInFlow
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.ViewState
 import com.duckduckgo.sync.impl.ui.SyncActivityWithSourceParams
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceContract.Output.EditDevice
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceContract.Output.NoOp
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceContract.Output.RemoveDevice
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceContract.Output.TurnOffSync
 import com.duckduckgo.sync.impl.wideevents.SyncSetupWideEvent
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -137,7 +141,13 @@ class SyncActivity : DuckDuckGoActivity() {
     private val editDeviceLauncher = registerForActivityResult(
         EditDeviceContract(),
     ) { result ->
-        logcat { "Edit device result: $result" }
+        when (result) {
+            is RemoveDevice -> viewModel.onRemoveDeviceConfirmed(result.device)
+            is TurnOffSync -> viewModel.onTurnOffSyncConfirmed(result.device)
+            // We don't have to refresh the device after editing it because it will be reloaded when a user returns here.
+            is EditDevice -> Unit
+            is NoOp -> Unit
+        }
     }
 
     private val syncedDeviceAdapter = SyncedDeviceAdapter(

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
@@ -69,12 +69,12 @@ import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.LaunchOriginalF
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.LaunchSyncGetOnOtherPlatforms
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.RecoveryCodePDFSuccess
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.RequestSetupAuthentication
+import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.SetSyncThisDeviceToggle
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowDeviceConnected
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowDeviceUnsupported
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowError
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowPreviousSessionReady
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowRecoveryCode
-import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.SyncThisDeviceCanceled
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.SyncWithAnotherDevice
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.SetupFlows.CreateAccountFlow
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.SetupFlows.SignInFlow
@@ -336,8 +336,8 @@ class SyncActivity : DuckDuckGoActivity() {
                 logcat { "TODO: Handle ${command.javaClass.simpleName} command" }
             }
 
-            is SyncThisDeviceCanceled -> {
-                binding.includeDisabledView.syncThisDeviceToggle.quietlySetIsChecked(false, syncThisDeviceListener)
+            is SetSyncThisDeviceToggle -> {
+                binding.includeDisabledView.syncThisDeviceToggle.quietlySetIsChecked(command.isOn, syncThisDeviceListener)
             }
 
             is SyncWithAnotherDevice -> {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
@@ -79,10 +79,6 @@ import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.SetupFlows.CreateAccoun
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.SetupFlows.SignInFlow
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.ViewState
 import com.duckduckgo.sync.impl.ui.SyncActivityWithSourceParams
-import com.duckduckgo.sync.impl.ui.v2.EditDeviceContract.Output.DeviceEdited
-import com.duckduckgo.sync.impl.ui.v2.EditDeviceContract.Output.NoOp
-import com.duckduckgo.sync.impl.ui.v2.EditDeviceContract.Output.RemoveDeviceConfirmed
-import com.duckduckgo.sync.impl.ui.v2.EditDeviceContract.Output.TurnOffSyncConfirmed
 import com.duckduckgo.sync.impl.wideevents.SyncSetupWideEvent
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -141,10 +137,19 @@ class SyncActivity : DuckDuckGoActivity() {
         EditDeviceContract(),
     ) { result ->
         when (result) {
-            is DeviceEdited -> viewModel.onDevicesUpdated()
-            is RemoveDeviceConfirmed -> viewModel.onRemoveDeviceConfirmed(result.device)
-            is TurnOffSyncConfirmed -> viewModel.onTurnOffSyncConfirmed(result.device)
-            is NoOp -> Unit
+            is EditDeviceContract.Output.DeviceEdited -> {
+                viewModel.onDevicesUpdated()
+            }
+
+            is EditDeviceContract.Output.RemoveDeviceConfirmed -> {
+                viewModel.onRemoveDeviceConfirmed(result.device)
+            }
+
+            is EditDeviceContract.Output.TurnOffSyncConfirmed -> {
+                viewModel.onTurnOffSyncConfirmed(result.device)
+            }
+
+            is EditDeviceContract.Output.NoOp -> Unit
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
@@ -421,12 +421,8 @@ class SyncActivity : DuckDuckGoActivity() {
                         deviceAuthenticator.launchDeviceAuthEnrollment(this@SyncActivity)
                     }
 
-                    override fun onNegativeButtonClicked() {
+                    override fun onDialogDismissed() {
                         // Only the Sync This Device flow uses a toggle that must be reset; other flows must not touch it.
-                        if (forSyncThisDevice) viewModel.onSyncThisDeviceCanceled()
-                    }
-
-                    override fun onDialogCancelled() {
                         if (forSyncThisDevice) viewModel.onSyncThisDeviceCanceled()
                     }
                 },

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
@@ -69,7 +69,6 @@ import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.LaunchOriginalF
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.LaunchSyncGetOnOtherPlatforms
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.RecoveryCodePDFSuccess
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.RequestSetupAuthentication
-import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.SetSyncThisDeviceToggle
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowDeviceConnected
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowDeviceUnsupported
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowError
@@ -224,6 +223,7 @@ class SyncActivity : DuckDuckGoActivity() {
     private fun renderDisabledState(viewState: ViewState) {
         binding.includeDisabledView.apply {
             root.isGone = viewState.showAccount
+            syncThisDeviceToggle.quietlySetIsChecked(viewState.isThisDeviceSyncing, syncThisDeviceListener)
             syncOnOtherPlatformsItem.setState(
                 isNewDesktopBrowserAvailable = viewState.newDesktopBrowserSettingEnabled,
             )
@@ -334,10 +334,6 @@ class SyncActivity : DuckDuckGoActivity() {
 
             is ShowRecoveryCode -> {
                 logcat { "TODO: Handle ${command.javaClass.simpleName} command" }
-            }
-
-            is SetSyncThisDeviceToggle -> {
-                binding.includeDisabledView.syncThisDeviceToggle.quietlySetIsChecked(command.isOn, syncThisDeviceListener)
             }
 
             is SyncWithAnotherDevice -> {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
@@ -80,10 +80,10 @@ import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.SetupFlows.CreateAccoun
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.SetupFlows.SignInFlow
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.ViewState
 import com.duckduckgo.sync.impl.ui.SyncActivityWithSourceParams
-import com.duckduckgo.sync.impl.ui.v2.EditDeviceContract.Output.EditDevice
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceContract.Output.DeviceEdited
 import com.duckduckgo.sync.impl.ui.v2.EditDeviceContract.Output.NoOp
-import com.duckduckgo.sync.impl.ui.v2.EditDeviceContract.Output.RemoveDevice
-import com.duckduckgo.sync.impl.ui.v2.EditDeviceContract.Output.TurnOffSync
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceContract.Output.RemoveDeviceConfirmed
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceContract.Output.TurnOffSyncConfirmed
 import com.duckduckgo.sync.impl.wideevents.SyncSetupWideEvent
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -142,10 +142,9 @@ class SyncActivity : DuckDuckGoActivity() {
         EditDeviceContract(),
     ) { result ->
         when (result) {
-            is RemoveDevice -> viewModel.onRemoveDeviceConfirmed(result.device)
-            is TurnOffSync -> viewModel.onTurnOffSyncConfirmed(result.device)
-            // We don't have to refresh the device after editing it because it will be reloaded when a user returns here.
-            is EditDevice -> Unit
+            is DeviceEdited -> viewModel.onDeviceUpdated(result.device)
+            is RemoveDeviceConfirmed -> viewModel.onRemoveDeviceConfirmed(result.device)
+            is TurnOffSyncConfirmed -> viewModel.onTurnOffSyncConfirmed(result.device)
             is NoOp -> Unit
         }
     }

--- a/sync/sync-impl/src/main/res/layout/activity_sync_v2_edit_device.xml
+++ b/sync/sync-impl/src/main/res/layout/activity_sync_v2_edit_device.xml
@@ -80,6 +80,34 @@
                 app:leadingIconBackground="circular"
                 app:primaryText="@string/sync_setup_v2_edit_device_name_item" />
 
+            <com.facebook.shimmer.ShimmerFrameLayout
+                android:id="@+id/editThisDeviceNameShimmer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:minHeight="@dimen/twoLineItemHeight"
+                    android:orientation="horizontal">
+
+                    <com.duckduckgo.common.ui.view.SkeletonView
+                        android:layout_width="@dimen/listItemImageContainerSize"
+                        android:layout_height="@dimen/listItemImageContainerSize"
+                        android:layout_gravity="center_vertical"
+                        android:layout_marginStart="@dimen/keyline_4" />
+
+                    <com.duckduckgo.common.ui.view.SkeletonView
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:layout_marginStart="@dimen/keyline_4"
+                        android:layout_marginEnd="64dp" />
+                </LinearLayout>
+
+            </com.facebook.shimmer.ShimmerFrameLayout>
+
             <com.duckduckgo.common.ui.view.divider.HorizontalDivider
                 android:id="@+id/editThisDeviceNameDivider"
                 android:layout_width="match_parent"

--- a/sync/sync-impl/src/main/res/values/donottranslate.xml
+++ b/sync/sync-impl/src/main/res/values/donottranslate.xml
@@ -37,4 +37,15 @@
     <string name="sync_setup_v2_edit_device_name_item">Edit Name</string>
     <string name="sync_setup_v2_remove_this_device_notice">This device will no longer be able to access your synced data if you remove it.</string>
     <string name="sync_setup_v2_remove_another_device_notice">This device will no longer be able to access your synced data if this is turned off.</string>
+    <string name="sync_device_v2_edit_device_dialog_title">Edit Name</string>
+    <string name="sync_device_v2_edit_device_dialog_primary_button">Done</string>
+    <string name="sync_device_v2_edit_device_dialog_secondary_button">Cancel</string>
+    <string name="sync_device_v2_remove_device_dialog_title">Remove Device?</string>
+    <string name="sync_device_v2_remove_device_dialog_body" instruction="Placeholder is a device name">\"%1$s\" will no longer be able to access your synced data.</string>
+    <string name="sync_device_v2_remove_device_dialog_primary_button">Remove</string>
+    <string name="sync_device_v2_remove_device_dialog_secondary_button">Cancel</string>
+    <string name="sync_device_v2_turn_off_sync_dialog_title">Turn Off Sync &amp; Backup?</string>
+    <string name="sync_device_v2_turn_off_sync_dialog_body">This device will no longer be able to access your synced data on other devices.</string>
+    <string name="sync_device_v2_turn_off_sync_dialog_primary_button">Turn Off</string>
+    <string name="sync_device_v2_turn_off_sync_dialog_secondary_button">Cancel</string>
 </resources>

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModelTest.kt
@@ -696,6 +696,32 @@ class SyncActivityViewModelTest {
     }
 
     @Test
+    fun whenOnDeviceUpdatedThenFetchRemoteDevices() = runTest {
+        givenAuthenticatedUser()
+
+        testee.onDeviceUpdated(connectedDevice)
+
+        verify(syncAccountRepository).getConnectedDevices()
+    }
+
+    @Test
+    fun whenOnDeviceUpdatedThenViewStateReflectsRefreshedDevices() = runTest {
+        givenAuthenticatedUser()
+
+        testee.viewState().test {
+            expectMostRecentItem()
+
+            val updatedDevice = connectedDevice.copy(deviceName = "updatedDevice")
+            whenever(syncAccountRepository.getConnectedDevices()).thenReturn(Success(listOf(updatedDevice)))
+            testee.onDeviceUpdated(connectedDevice)
+            val refreshedItem = expectMostRecentItem()
+            assertNotNull(refreshedItem.syncedDevices.filterIsInstance<SyncedDevice>().first { it.device.deviceName == updatedDevice.deviceName })
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun whenSyncStateIsDisabledThenViewStateChanges() = runTest {
         givenAuthenticatedUser()
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModelTest.kt
@@ -696,16 +696,7 @@ class SyncActivityViewModelTest {
     }
 
     @Test
-    fun whenOnDeviceUpdatedThenFetchRemoteDevices() = runTest {
-        givenAuthenticatedUser()
-
-        testee.onDeviceUpdated(connectedDevice)
-
-        verify(syncAccountRepository).getConnectedDevices()
-    }
-
-    @Test
-    fun whenOnDeviceUpdatedThenViewStateReflectsRefreshedDevices() = runTest {
+    fun whenOnDevicesUpdatedThenViewStateReflectsRefreshedDevices() = runTest {
         givenAuthenticatedUser()
 
         testee.viewState().test {
@@ -713,7 +704,7 @@ class SyncActivityViewModelTest {
 
             val updatedDevice = connectedDevice.copy(deviceName = "updatedDevice")
             whenever(syncAccountRepository.getConnectedDevices()).thenReturn(Success(listOf(updatedDevice)))
-            testee.onDeviceUpdated(connectedDevice)
+            testee.onDevicesUpdated()
             val refreshedItem = expectMostRecentItem()
             assertNotNull(refreshedItem.syncedDevices.filterIsInstance<SyncedDevice>().first { it.device.deviceName == updatedDevice.deviceName })
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModelTest.kt
@@ -55,8 +55,8 @@ import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.LaunchLearnMore
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.LaunchSyncGetOnOtherPlatforms
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.RecoveryCodePDFSuccess
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.RequestSetupAuthentication
+import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.SetSyncThisDeviceToggle
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowPreviousSessionReady
-import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.SyncThisDeviceCanceled
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.OriginalFlow
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.SetupFlows.CreateAccountFlow
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.SetupFlows.SignInFlow
@@ -322,10 +322,12 @@ class SyncActivityViewModelTest {
     }
 
     @Test
-    fun whenSyncThisDeviceCanceledThenEmitCommandSyncThisDeviceCanceled() = runTest {
+    fun whenSyncThisDeviceCanceledThenSyncThisDeviceToggleSetOff() = runTest {
         testee.commands().test {
             testee.onSyncThisDeviceCanceled()
-            awaitItem().assertCommandType(SyncThisDeviceCanceled::class)
+            val command = awaitItem()
+            command.assertCommandType(SetSyncThisDeviceToggle::class)
+            assertFalse((command as SetSyncThisDeviceToggle).isOn)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -396,6 +398,39 @@ class SyncActivityViewModelTest {
         testee.onTurnOffSyncConfirmed(connectedDevice)
 
         verify(syncPixels).fireUserConfirmedToTurnOffSync()
+    }
+
+    @Test
+    fun whenTurnOffSyncConfirmedThenSyncThisDeviceToggleSetOff() = runTest {
+        whenever(syncAccountRepository.logout(deviceId)).thenReturn(Result.Success(true))
+
+        testee.commands().test {
+            testee.onTurnOffSyncConfirmed(connectedDevice)
+            val command = awaitItem()
+            command.assertCommandType(SetSyncThisDeviceToggle::class)
+            assertFalse((command as SetSyncThisDeviceToggle).isOn)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenTurnOffSyncConfirmedFailsThenSyncThisDeviceToggleSetOnAndErrorShown() = runTest {
+        whenever(syncAccountRepository.logout(deviceId)).thenReturn(Result.Error(reason = "error"))
+
+        testee.commands().test {
+            testee.onTurnOffSyncConfirmed(connectedDevice)
+
+            val toggleOff = awaitItem()
+            toggleOff.assertCommandType(SetSyncThisDeviceToggle::class)
+            assertFalse((toggleOff as SetSyncThisDeviceToggle).isOn)
+
+            val toggleOn = awaitItem()
+            toggleOn.assertCommandType(SetSyncThisDeviceToggle::class)
+            assertTrue((toggleOn as SetSyncThisDeviceToggle).isOn)
+
+            awaitItem().assertCommandType(Command.ShowError::class)
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     @Test

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModelTest.kt
@@ -605,14 +605,14 @@ class SyncActivityViewModelTest {
     }
 
     @Test
-    fun whenOnRemoveDeviceSucceedsThenFetchRemoteDevices() = runTest {
+    fun whenOnRemoveDeviceSucceedsThenDeviceIsRemovedWithoutRefetch() = runTest {
         givenAuthenticatedUser()
 
         whenever(syncAccountRepository.logout(deviceId)).thenReturn(Result.Success(true))
 
         testee.onRemoveDeviceConfirmed(connectedDevice)
 
-        verify(syncAccountRepository).getConnectedDevices()
+        verify(syncAccountRepository, never()).getConnectedDevices()
     }
 
     @Test
@@ -624,16 +624,43 @@ class SyncActivityViewModelTest {
         testee.viewState().test {
             var awaitItem = expectMostRecentItem()
             assertEquals(1, awaitItem.syncedDevices.size)
-            whenever(syncAccountRepository.getConnectedDevices()).thenReturn(Result.Success(listOf()))
             testee.onRemoveDeviceConfirmed(connectedDevice)
-            awaitItem = awaitItem()
+            awaitItem = expectMostRecentItem()
             assertEquals(0, awaitItem.syncedDevices.size)
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun whenOnRemoveDeviceFailsThenRestorePreviousList() = runTest {
+    fun whenStaleDeviceFetchCompletesAfterRemovalThenRemovedDeviceDoesNotReappear() = runTest {
+        givenAuthenticatedUser()
+
+        val otherDevice = connectedDevice.copy(thisDevice = false, deviceId = "otherDeviceId")
+        whenever(syncAccountRepository.logout(otherDevice.deviceId)).thenReturn(Result.Success(true))
+        var fetchCount = 0
+        whenever(syncAccountRepository.getConnectedDevices()).thenAnswer {
+            fetchCount++
+            if (fetchCount == 2) {
+                // this fetch read the server before the removal: the user confirms the removal
+                // while it is in flight, so its stale result lands afterwards
+                testee.onRemoveDeviceConfirmed(otherDevice)
+            }
+            Result.Success(listOf(connectedDevice, otherDevice))
+        }
+
+        testee.viewState().test {
+            assertEquals(2, expectMostRecentItem().syncedDevices.size)
+
+            testee.onDevicesUpdated()
+
+            val devices = expectMostRecentItem().syncedDevices.filterIsInstance<SyncedDevice>()
+            assertEquals(listOf(deviceId), devices.map { it.device.deviceId })
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenOnRemoveDeviceFailsThenDeviceRemainsInList() = runTest {
         givenAuthenticatedUser()
 
         whenever(syncAccountRepository.logout(deviceId)).thenReturn(Result.Error(reason = "error"))
@@ -642,6 +669,7 @@ class SyncActivityViewModelTest {
             testee.onRemoveDeviceConfirmed(connectedDevice)
             val awaitItem = expectMostRecentItem()
             assertEquals(1, awaitItem.syncedDevices.size)
+            assertFalse((awaitItem.syncedDevices.first() as SyncedDevice).loading)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -657,8 +685,23 @@ class SyncActivityViewModelTest {
             val newDevice = connectedDevice.copy(deviceName = "newDevice")
             whenever(syncAccountRepository.getConnectedDevices()).thenReturn(Result.Success(listOf(newDevice)))
             testee.onDeviceEdited(newDevice)
-            awaitItem = awaitItem()
+            awaitItem = expectMostRecentItem()
             assertNotNull(awaitItem.syncedDevices.filterIsInstance<SyncedDevice>().first { it.device.deviceName == newDevice.deviceName })
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenOnDeviceEditedFailsThenDeviceRemainsInList() = runTest {
+        givenAuthenticatedUser()
+
+        whenever(syncAccountRepository.renameDevice(any())).thenReturn(Result.Error(reason = "error"))
+
+        testee.viewState().test {
+            testee.onDeviceEdited(connectedDevice.copy(deviceName = "newDevice"))
+            val awaitItem = expectMostRecentItem()
+            assertEquals(1, awaitItem.syncedDevices.size)
+            assertFalse((awaitItem.syncedDevices.first() as SyncedDevice).loading)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModelTest.kt
@@ -55,7 +55,6 @@ import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.LaunchLearnMore
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.LaunchSyncGetOnOtherPlatforms
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.RecoveryCodePDFSuccess
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.RequestSetupAuthentication
-import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.SetSyncThisDeviceToggle
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowPreviousSessionReady
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.OriginalFlow
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.SetupFlows.CreateAccountFlow
@@ -322,12 +321,23 @@ class SyncActivityViewModelTest {
     }
 
     @Test
-    fun whenSyncThisDeviceCanceledThenSyncThisDeviceToggleSetOff() = runTest {
-        testee.commands().test {
+    fun whenSyncThisDeviceThenThisDeviceSyncInProgress() = runTest {
+        testee.viewState().test {
+            testee.onSyncThisDevice()
+            assertTrue(expectMostRecentItem().isThisDeviceSyncing)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenSyncThisDeviceCanceledThenThisDeviceSyncIdle() = runTest {
+        testee.viewState().test {
+            testee.onSyncThisDevice()
+            assertTrue(expectMostRecentItem().isThisDeviceSyncing)
+
             testee.onSyncThisDeviceCanceled()
-            val command = awaitItem()
-            command.assertCommandType(SetSyncThisDeviceToggle::class)
-            assertFalse((command as SetSyncThisDeviceToggle).isOn)
+            assertFalse(expectMostRecentItem().isThisDeviceSyncing)
+
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -401,32 +411,11 @@ class SyncActivityViewModelTest {
     }
 
     @Test
-    fun whenTurnOffSyncConfirmedThenSyncThisDeviceToggleSetOff() = runTest {
-        whenever(syncAccountRepository.logout(deviceId)).thenReturn(Result.Success(true))
-
-        testee.commands().test {
-            testee.onTurnOffSyncConfirmed(connectedDevice)
-            val command = awaitItem()
-            command.assertCommandType(SetSyncThisDeviceToggle::class)
-            assertFalse((command as SetSyncThisDeviceToggle).isOn)
-            cancelAndIgnoreRemainingEvents()
-        }
-    }
-
-    @Test
-    fun whenTurnOffSyncConfirmedFailsThenSyncThisDeviceToggleSetOnAndErrorShown() = runTest {
+    fun whenTurnOffSyncConfirmedFailsThenErrorShown() = runTest {
         whenever(syncAccountRepository.logout(deviceId)).thenReturn(Result.Error(reason = "error"))
 
         testee.commands().test {
             testee.onTurnOffSyncConfirmed(connectedDevice)
-
-            val toggleOff = awaitItem()
-            toggleOff.assertCommandType(SetSyncThisDeviceToggle::class)
-            assertFalse((toggleOff as SetSyncThisDeviceToggle).isOn)
-
-            val toggleOn = awaitItem()
-            toggleOn.assertCommandType(SetSyncThisDeviceToggle::class)
-            assertTrue((toggleOn as SetSyncThisDeviceToggle).isOn)
 
             awaitItem().assertCommandType(Command.ShowError::class)
             cancelAndIgnoreRemainingEvents()
@@ -722,10 +711,14 @@ class SyncActivityViewModelTest {
         whenever(syncAccountRepository.getConnectedDevices()).thenReturn(Result.Success(connectedDevices))
 
         testee.viewState().test {
+            testee.onSyncThisDevice()
+            assertTrue(expectMostRecentItem().isThisDeviceSyncing)
+
             testee.onDeviceConnected()
 
             val initialState = expectMostRecentItem()
             assertEquals(connectedDevices.size, initialState.syncedDevices.size)
+            assertFalse(initialState.isThisDeviceSyncing)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceViewModelTest.kt
@@ -106,13 +106,10 @@ class EditDeviceViewModelTest {
         testee.commands.test {
             testee.confirmNewDeviceName("New Device Name")
 
-            val resetToggleCommand = awaitItem()
-            assertIs<ResetTurnOffSyncToggle>(resetToggleCommand)
-
-            val showErrorCommand = awaitItem()
-            assertIs<ShowError>(showErrorCommand)
-            assertEquals(R.string.sync_edit_device_error, showErrorCommand.message)
-            assertEquals("boom", showErrorCommand.reason)
+            val command = awaitItem()
+            assertIs<ShowError>(command)
+            assertEquals(R.string.sync_edit_device_error, command.message)
+            assertEquals("boom", command.reason)
 
             cancel()
         }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceViewModelTest.kt
@@ -28,8 +28,9 @@ import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.AskRemoveDevic
 import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.AskTurnOffSync
 import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.Close
 import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.ResetTurnOffSyncToggle
-import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.SetRemoveDeviceResult
-import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.SetTurnOffSyncResult
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.SetDeviceEditedResult
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.SetDeviceRemovedResult
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.SetSyncTurnedOffResult
 import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.ShowError
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -100,6 +101,18 @@ class EditDeviceViewModelTest {
     }
 
     @Test
+    fun `when renaming the device succeeds then the edited result is set`() = runTest {
+        whenever(syncAccountRepository.renameDevice(any())).thenReturn(Result.Success(true))
+
+        testee.commands.test {
+            testee.confirmNewDeviceName("New Device Name")
+            assertIs<SetDeviceEditedResult>(awaitItem())
+
+            cancel()
+        }
+    }
+
+    @Test
     fun `when renaming the device fails then the toggle is reset and an error is shown`() = runTest {
         whenever(syncAccountRepository.renameDevice(any())).thenReturn(Result.Error(reason = "boom"))
 
@@ -138,7 +151,7 @@ class EditDeviceViewModelTest {
     fun `when turning off sync is confirmed then the result is set and the screen closes`() = runTest {
         testee.commands.test {
             testee.onTurnOffSyncConfirmed()
-            assertIs<SetTurnOffSyncResult>(awaitItem())
+            assertIs<SetSyncTurnedOffResult>(awaitItem())
             assertIs<Close>(awaitItem())
 
             cancel()
@@ -169,7 +182,7 @@ class EditDeviceViewModelTest {
     fun `when removing the device is confirmed then the result is set and the screen closes`() = runTest {
         testee.commands.test {
             testee.onRemoveDeviceConfirmed()
-            assertIs<SetRemoveDeviceResult>(awaitItem())
+            assertIs<SetDeviceRemovedResult>(awaitItem())
             assertIs<Close>(awaitItem())
 
             cancel()

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceViewModelTest.kt
@@ -20,12 +20,28 @@ import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.sync.impl.ConnectedDevice
 import com.duckduckgo.sync.impl.DeviceType
+import com.duckduckgo.sync.impl.R
+import com.duckduckgo.sync.impl.Result
+import com.duckduckgo.sync.impl.SyncAccountRepository
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.AskEditDevice
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.AskRemoveDevice
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.AskTurnOffSync
 import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.Close
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.ResetTurnOffSyncToggle
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.SetRemoveDeviceResult
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.SetTurnOffSyncResult
+import com.duckduckgo.sync.impl.ui.v2.EditDeviceViewModel.Command.ShowError
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
 
 class EditDeviceViewModelTest {
     @get:Rule
@@ -38,12 +54,126 @@ class EditDeviceViewModelTest {
         deviceType = DeviceType(deviceFactor = "phone"),
     )
 
-    private val testee = EditDeviceViewModel(device)
+    private val syncAccountRepository = mock<SyncAccountRepository>()
+
+    private val testee = EditDeviceViewModel(
+        device = device,
+        syncAccountRepository = syncAccountRepository,
+        dispatchers = coroutineTestRule.testDispatcherProvider,
+    )
 
     @Test
     fun `when the view state is observed then it emits the device it was created with`() = runTest {
         testee.viewState.test {
             assertEquals(device, awaitItem().device)
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when the user edits the device name then the edit dialog is requested`() = runTest {
+        testee.commands.test {
+            testee.onEditDeviceName()
+            assertIs<AskEditDevice>(awaitItem())
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when a new device name is confirmed then the device is renamed in the repository`() = runTest {
+        whenever(syncAccountRepository.renameDevice(any())).thenReturn(Result.Success(true))
+
+        testee.confirmNewDeviceName("New Device Name")
+
+        verify(syncAccountRepository).renameDevice(device.copy(deviceName = "New Device Name"))
+    }
+
+    @Test
+    fun `when renaming the device succeeds then the view state reflects the new name`() = runTest {
+        whenever(syncAccountRepository.renameDevice(any())).thenReturn(Result.Success(true))
+
+        testee.confirmNewDeviceName("New Device Name")
+
+        assertEquals("New Device Name", testee.viewState.value.device.deviceName)
+    }
+
+    @Test
+    fun `when renaming the device fails then the toggle is reset and an error is shown`() = runTest {
+        whenever(syncAccountRepository.renameDevice(any())).thenReturn(Result.Error(reason = "boom"))
+
+        testee.commands.test {
+            testee.confirmNewDeviceName("New Device Name")
+
+            val resetToggleCommand = awaitItem()
+            assertIs<ResetTurnOffSyncToggle>(resetToggleCommand)
+
+            val showErrorCommand = awaitItem()
+            assertIs<ShowError>(showErrorCommand)
+            assertEquals(R.string.sync_edit_device_error, showErrorCommand.message)
+            assertEquals("boom", showErrorCommand.reason)
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when renaming the device fails then the device name is not updated`() = runTest {
+        whenever(syncAccountRepository.renameDevice(any())).thenReturn(Result.Error(reason = "boom"))
+
+        testee.confirmNewDeviceName("New Device Name")
+
+        assertEquals(device, testee.viewState.value.device)
+    }
+
+    @Test
+    fun `when the user turns off sync then confirmation is requested`() = runTest {
+        testee.commands.test {
+            testee.onTurnOffSync()
+            assertIs<AskTurnOffSync>(awaitItem())
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when turning off sync is confirmed then the result is set and the screen closes`() = runTest {
+        testee.commands.test {
+            testee.onTurnOffSyncConfirmed()
+            assertIs<SetTurnOffSyncResult>(awaitItem())
+            assertIs<Close>(awaitItem())
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when turning off sync is canceled then the toggle is reset`() = runTest {
+        testee.commands.test {
+            testee.onTurnOffSyncCanceled()
+            assertIs<ResetTurnOffSyncToggle>(awaitItem())
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when the user removes the device then confirmation is requested`() = runTest {
+        testee.commands.test {
+            testee.onRemoveDevice()
+            assertIs<AskRemoveDevice>(awaitItem())
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when removing the device is confirmed then the result is set and the screen closes`() = runTest {
+        testee.commands.test {
+            testee.onRemoveDeviceConfirmed()
+            assertIs<SetRemoveDeviceResult>(awaitItem())
+            assertIs<Close>(awaitItem())
 
             cancel()
         }
@@ -60,6 +190,10 @@ class EditDeviceViewModelTest {
     }
 }
 
+@OptIn(ExperimentalContracts::class)
 private inline fun <reified T> assertIs(value: Any?) {
+    contract {
+        returns() implies (value is T)
+    }
     assertTrue("Expected ${T::class.simpleName} but was ${value?.let { it::class.simpleName }}", value is T)
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216649201495933?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1216103556496795/task/1216509582049467?focus=true

### Description

Wires up the behavior for the simplified Sync Edit Device screen. This PR makes its three actions functional and reports their outcomes back to the v2 Sync settings screen.

This device:
- Edit Name — tapping opens an input dialog; confirming renames the device. A shimmer placeholder is shown on the name item while the request is in flight, and a failure surfaces an error dialog and leaves the name unchanged.
- Sync This Device toggle — switching it off shows a "Turn Off Sync & Backup?" confirmation. Confirming closes the screen and reports the result to `SyncActivity`; cancelling (button, back, or tap-outside) resets the toggle back on.

Another device:
- Remove Device — shows a "Remove Device?" confirmation naming the device. Confirming closes the screen and reports the removal to `SyncActivity`.

Result plumbing:
- `EditDeviceContract.Output` becomes a sealed interface (`DeviceEdited`, `TurnOffSyncConfirmed`, `RemoveDeviceConfirmed`, `NoOp`), parsed from the activity result code and the returned device.
- `SyncActivity` handles the results by delegating to VM functions.
- The `EditDeviceViewModel` command channel switched from `DROP_OLDEST` (capacity 1) to `BUFFERED`, so the `SetResult` + `Close` command pairs both reach the Activity.

> [!note]
> This PR changes how the "Sync This Device" toggle state is managed. Previously it was done via commands; now it is part of ViewState. This change was made to accommodate turning the toggle off after disabling sync in the edit screen. Handling it via commands was problematic because the commands Channel in the VM drops the latest commands, and I didn't want to switch it to buffering in order to avoid regressions in the legacy UI.

### Steps to test this PR

_Rename this device_
- [ ] Set up Sync on the device.
- [ ] Open Sync Dev Settings → Launch Sync Settings V2.
- [ ] Tap this device under My Devices, then tap Edit Name.
- [ ] Change the name and tap Done — the name item briefly shimmers, then shows the new name.
- [x] Reopen the screen and confirm the new name persisted.

_Turn off sync on this device_
- [ ] Open Sync Dev Settings → Launch Sync Settings V2.
- [ ] Open this device and toggle Sync This Device off.
- [ ] Cancel the dialog (button / back / tap outside) — the toggle returns to on.
- [x] Toggle off again and confirm — the screen closes and sync is turned off.

_Remove another device_
- [ ] Sync the device with another device.
- [ ] Open Sync Dev Settings → Launch Sync Settings V2.
- [ ] From the first device, open the second device and tap Remove Device.
- [x] Confirm — the screen closes and the device is removed from the list.

### UI changes
| Edit name | Shimmer | Turn off sync | Remove device|
| ------ | ----- | - | - |
| <img width="540" alt="Screenshot_20260720_155556" src="https://github.com/user-attachments/assets/05985695-68b6-44de-b851-355ff8b7f6c4" /> | <img width="540"  alt="Screenshot_20260720_155647" src="https://github.com/user-attachments/assets/bcc653a9-40b7-4ecd-bb03-5ceacae17b55" /> | <img width="540" alt="Screenshot_20260720_155719" src="https://github.com/user-attachments/assets/babc0d23-b403-4309-a8c7-cb9750ac4fe4" /> | <img width="540" alt="Screenshot_20260720_155705" src="https://github.com/user-attachments/assets/bd3260b5-a918-405b-8d2d-f6287196357f" /> |




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sync account logout, device list consistency, and turn-off-sync UX across v2 and shared VM; rename/remove race fixes are important but scoped to sync settings with added tests.
> 
> **Overview**
> Wires the **simplified Sync v2 Edit Device** screen so rename, turn-off-sync, and remove-device are real flows with confirmation dialogs, shimmer while renaming, and structured **activity results** back to v2 `SyncActivity`.
> 
> **Edit device (v2):** `EditDeviceContract.Output` is now a sealed type (`DeviceEdited`, `TurnOffSyncConfirmed`, `RemoveDeviceConfirmed`, `NoOp`). Rename runs in `EditDeviceViewModel` via `SyncAccountRepository.renameDevice`; turn-off and remove confirm in the edit screen then delegate **logout / list updates** to shared `SyncActivityViewModel` from the settings activity result handler. The edit VM command channel uses **BUFFERED** so paired commands (set result + close) are not dropped.
> 
> **Shared `SyncActivityViewModel`:** Adds **`isThisDeviceSyncing`** in view state (replacing `SyncThisDeviceCanceled` commands). Device fetches run in a cancellable job with **`ensureActive`**; successful removal **optimistically** drops the device and cancels in-flight fetches to avoid stale lists. New **`onDevicesUpdated()`** refreshes after a rename from edit device. v2 settings binds the disabled-state toggle to `isThisDeviceSyncing` and resets it on auth enrollment dismiss via **`onDialogDismissed`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22a9d66770ecfb51a4a2c7470811507aeb4f5289. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->