### PR TITLE
Set ad blocking pill to always on

### DIFF
--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingProtectionsSettingsEntryView.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingProtectionsSettingsEntryView.kt
@@ -55,6 +55,7 @@ class AdBlockingProtectionsSettingsEntryView @JvmOverloads constructor(
     private val listItem = SettingsListItem(context).apply {
         setLeadingIconResource(CommonR.drawable.ic_ads_blocked_color_24)
         setPrimaryText(context.getString(R.string.ad_blocking_settings_title_v2))
+        setStatus(true)
     }
 
     init {
@@ -84,7 +85,6 @@ class AdBlockingProtectionsSettingsEntryView @JvmOverloads constructor(
         conflatedStateJob += viewModel.viewState
             .onEach {
                 isGone = !it.isVisible
-                listItem.setStatus(it.isOn)
             }
             .launchIn(coroutineScope!!)
 

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingProtectionsSettingsEntryViewModel.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingProtectionsSettingsEntryViewModel.kt
@@ -21,7 +21,6 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.duckduckgo.adblocking.impl.domain.AdBlockingState
 import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
 import com.duckduckgo.adblocking.impl.domain.SettingsPlacement
 import com.duckduckgo.adblocking.impl.ui.AdBlockingProtectionsSettingsEntryViewModel.Command.OpenSettings
@@ -34,9 +33,9 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -51,7 +50,6 @@ class AdBlockingProtectionsSettingsEntryViewModel @Inject constructor(
 
     data class ViewState(
         val isVisible: Boolean = false,
-        val isOn: Boolean = false,
     )
 
     sealed class Command {
@@ -69,17 +67,12 @@ class AdBlockingProtectionsSettingsEntryViewModel @Inject constructor(
     override fun onStart(owner: LifecycleOwner) {
         super.onStart(owner)
 
-        viewStateJob += combine(
-            statusChecker.settingsPlacementFlow(),
-            statusChecker.observeState(),
-        ) { placement, state ->
-            _viewState.update {
-                it.copy(
-                    isVisible = placement == SettingsPlacement.Protections,
-                    isOn = state is AdBlockingState.Enabled,
-                )
+        viewStateJob += statusChecker.settingsPlacementFlow()
+            .onEach { placement ->
+                _viewState.update {
+                    it.copy(isVisible = placement == SettingsPlacement.Protections)
+                }
             }
-        }
             .flowOn(dispatcherProvider.io())
             .launchIn(viewModelScope)
     }

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsV2Activity.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsV2Activity.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.adblocking.impl.R
 import com.duckduckgo.adblocking.impl.databinding.ActivityAdBlockingSettingsV2Binding
 import com.duckduckgo.anvil.annotations.ContributeToActivityStarter
 import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.common.ui.view.StatusIndicatorView
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.listitem.DaxListItem
 import com.duckduckgo.common.ui.view.listitem.OneLineListItem
@@ -62,12 +63,12 @@ class AdBlockingSettingsV2Activity : BaseAdBlockingSettingsActivity() {
         maybeEnableEdgeToEdge()
         setContentView(binding.root)
         setTitle(R.string.ad_blocking_settings_title_v2)
+        binding.adBlockingStatusIndicator.setStatus(StatusIndicatorView.Status.ALWAYS_ON)
         configure()
     }
 
     override fun render(state: AdBlockingSettingsViewModel.ViewState) {
         super.render(state)
-        binding.adBlockingStatusIndicator.setStatus(state.isStatusIndicatorOn)
         binding.blockAdsToggle.isVisible = !state.disabledUntilRelaunch && !state.isContingencyMode
         binding.blockAdsToggleUntilRelaunch.isVisible = state.disabledUntilRelaunch && !state.isContingencyMode
         if (state.disabledUntilRelaunch) {

--- a/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsViewModel.kt
+++ b/ad-blocking/ad-blocking-impl/src/main/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsViewModel.kt
@@ -69,7 +69,6 @@ class AdBlockingSettingsViewModel @Inject constructor(
         val showConsentDescription: Boolean? = null,
         val duckPlayerMode: PrivatePlayerMode = AlwaysAsk,
         val isContingencyMode: Boolean = false,
-        val isStatusIndicatorOn: Boolean = false,
     )
 
     sealed class Command {
@@ -83,14 +82,11 @@ class AdBlockingSettingsViewModel @Inject constructor(
         feature.adBlockingUXImprovements().enabled(),
         feature.enableContingencyMode().enabled(),
     ) { state, duckPlayerPreferences, uxImprovements, contingencyModeOn ->
-        val isEnabled = state is AdBlockingState.Enabled
-        val isContingencyMode = uxImprovements && contingencyModeOn
         ViewState(
             isEnabled = state is AdBlockingState.Enabled,
             disabledUntilRelaunch = state is AdBlockingState.Disabled.UntilRelaunch,
             showConsentDescription = state !is AdBlockingState.Enabled.Default,
-            isContingencyMode = isContingencyMode,
-            isStatusIndicatorOn = isEnabled && !isContingencyMode,
+            isContingencyMode = uxImprovements && contingencyModeOn,
             duckPlayerMode = duckPlayerPreferences.privatePlayerMode,
         )
     }

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ui/AdBlockingProtectionsSettingsEntryViewModelTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ui/AdBlockingProtectionsSettingsEntryViewModelTest.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.adblocking.impl.ui
 
 import androidx.lifecycle.LifecycleOwner
 import app.cash.turbine.test
-import com.duckduckgo.adblocking.impl.domain.AdBlockingState
 import com.duckduckgo.adblocking.impl.domain.AdBlockingStatusChecker
 import com.duckduckgo.adblocking.impl.domain.SettingsPlacement
 import com.duckduckgo.adblocking.impl.ui.AdBlockingProtectionsSettingsEntryViewModel.Command.OpenSettings
@@ -48,7 +47,6 @@ class AdBlockingProtectionsSettingsEntryViewModelTest {
     @Test
     fun whenPlacementIsProtectionsThenVisible() = runTest {
         whenever(statusChecker.settingsPlacementFlow()).thenReturn(flowOf(SettingsPlacement.Protections))
-        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled.Permanent))
 
         val viewModel = createViewModel()
         viewModel.onStart(lifecycleOwner)
@@ -61,7 +59,6 @@ class AdBlockingProtectionsSettingsEntryViewModelTest {
     @Test
     fun whenPlacementIsOtherThenNotVisible() = runTest {
         whenever(statusChecker.settingsPlacementFlow()).thenReturn(flowOf(SettingsPlacement.Other))
-        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled.Permanent))
 
         val viewModel = createViewModel()
         viewModel.onStart(lifecycleOwner)
@@ -74,52 +71,12 @@ class AdBlockingProtectionsSettingsEntryViewModelTest {
     @Test
     fun whenPlacementIsHiddenThenNotVisible() = runTest {
         whenever(statusChecker.settingsPlacementFlow()).thenReturn(flowOf(SettingsPlacement.Hidden))
-        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled.Permanent))
 
         val viewModel = createViewModel()
         viewModel.onStart(lifecycleOwner)
 
         viewModel.viewState.test {
             assertFalse(awaitItem().isVisible)
-        }
-    }
-
-    @Test
-    fun whenStateIsUserEnabledThenStatusIsOn() = runTest {
-        whenever(statusChecker.settingsPlacementFlow()).thenReturn(flowOf(SettingsPlacement.Protections))
-        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Enabled.UserEnabled))
-
-        val viewModel = createViewModel()
-        viewModel.onStart(lifecycleOwner)
-
-        viewModel.viewState.test {
-            assertTrue(awaitItem().isOn)
-        }
-    }
-
-    @Test
-    fun whenStateIsEnabledByDefaultThenStatusIsOn() = runTest {
-        whenever(statusChecker.settingsPlacementFlow()).thenReturn(flowOf(SettingsPlacement.Protections))
-        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Enabled.Default))
-
-        val viewModel = createViewModel()
-        viewModel.onStart(lifecycleOwner)
-
-        viewModel.viewState.test {
-            assertTrue(awaitItem().isOn)
-        }
-    }
-
-    @Test
-    fun whenStateIsDisabledThenStatusIsOff() = runTest {
-        whenever(statusChecker.settingsPlacementFlow()).thenReturn(flowOf(SettingsPlacement.Protections))
-        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled.Permanent))
-
-        val viewModel = createViewModel()
-        viewModel.onStart(lifecycleOwner)
-
-        viewModel.viewState.test {
-            assertFalse(awaitItem().isOn)
         }
     }
 

--- a/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsViewModelTest.kt
+++ b/ad-blocking/ad-blocking-impl/src/test/java/com/duckduckgo/adblocking/impl/ui/AdBlockingSettingsViewModelTest.kt
@@ -180,38 +180,6 @@ class AdBlockingSettingsViewModelTest {
     }
 
     @Test
-    fun whenEnabledAndNotContingencyModeThenStatusIndicatorOn() = runTest {
-        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Enabled.Default))
-        setToggles(uxImprovements = true, contingency = false)
-
-        createViewModel().viewState.test {
-            assertTrue(expectMostRecentItem().isStatusIndicatorOn)
-        }
-    }
-
-    @Test
-    fun whenContingencyModeOnThenStatusIndicatorOff() = runTest {
-        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Enabled.Default))
-        setToggles(uxImprovements = true, contingency = true)
-
-        createViewModel().viewState.test {
-            val state = expectMostRecentItem()
-            assertTrue(state.isEnabled)
-            assertFalse(state.isStatusIndicatorOn)
-        }
-    }
-
-    @Test
-    fun whenDisabledThenStatusIndicatorOff() = runTest {
-        whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled.Permanent))
-        setToggles(uxImprovements = true, contingency = false)
-
-        createViewModel().viewState.test {
-            assertFalse(expectMostRecentItem().isStatusIndicatorOn)
-        }
-    }
-
-    @Test
     fun whenViewModelCreatedThenFiresSettingsOpenedPixels() = runTest {
         whenever(statusChecker.observeState()).thenReturn(flowOf(AdBlockingState.Disabled.Permanent))
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216696186154997?focus=true
Tech Design URL (if applicable): 

### Description
* Set ad blocking pill to always on, regardless od YouTube ad blocking state (we always block tracking ads)
### Steps to test this PR

_Feature 1_
- [ ] Set version.properties to 5.288.8
- [ ] Open Settinfgs
- [ ] Check Ad Blocking settings shows "On"
- [ ] Toggle the feature on and of and check Ad Blocking settings header always shows "Always On" and settings entry always shows "On"

### UI changes
| Before  | After |
| ------ | ----- |
|<img width="1626" height="3453" alt="image" src="https://github.com/user-attachments/assets/d19abcd7-4fad-425e-933e-a1a6f28fff22" />|<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/15be9dec-c10b-4acc-b231-8aa5d543379d" />|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> UI no longer reflects when ad blocking is disabled or in contingency mode, which can mislead users; blocking behavior and toggles are unchanged.
> 
> **Overview**
> Ad blocking **status pills** no longer follow enable/disable or contingency state; they are always shown as on.
> 
> On the Protections settings row, `setStatus(true)` is applied when the list item is built and `isOn` is removed from the entry view model (visibility still comes from settings placement only). On **Ad Blocking settings V2**, the header `StatusIndicatorView` is set to `Status.ALWAYS_ON` in `onCreate` instead of `isStatusIndicatorOn` from `AdBlockingSettingsViewModel`. Related view-model fields and tests for dynamic status are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46ce7aeb521f9481c6f923756b4abbdd6352f5c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->