### PR TITLE
Android/Target16: Optout of Adaptive layouts

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -49,6 +49,10 @@
         android:requestLegacyExternalStorage="true"
         android:enableOnBackInvokedCallback="false"
         tools:ignore="GoogleAppIndexingWarning,UnusedAttribute">
+        <property
+            android:name="android.window.PROPERTY_COMPAT_ALLOW_RESTRICTED_RESIZABILITY"
+            android:value="true" />
+
         <meta-data
             android:name="android.webkit.WebView.MetricsOptOut"
             android:value="true" />


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1216655615117979?focus=true 
Tech Design URL (if applicable): 

### Description
Temporary opt-out of adaptive layout changes by adding `android.window.PROPERTY_COMPAT_ALLOW_RESTRICTED_RESIZABILITY="true"
`
### Steps to test this PR
QA-optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single manifest flag with no logic or security changes; main impact is how the OS resizes the app on large screens or foldables.
> 
> **Overview**
> Adds an application-level manifest property so the app **opts out of Android’s adaptive-layout / restricted-resizability behavior** when targeting API 16, keeping window sizing closer to today’s phone-focused experience.
> 
> The change sets `android.window.PROPERTY_COMPAT_ALLOW_RESTRICTED_RESIZABILITY` to `true` on the `<application>` element in `AndroidManifest.xml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08615f19d13a0da2ebc97bfca174a3f07cf3e435. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->