### PR TITLE
fix an issue where skipping Custom AI onboarding via quick setup wouldn't apply input setting

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingActivityDialog.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingActivityDialog.kt
@@ -36,6 +36,7 @@ sealed interface NewUserOnboardingActivityDialog {
         val showSplitOption: Boolean,
         val hideSetDefaultBrowserRow: Boolean,
         val hideAddWidgetRow: Boolean,
+        val hideAddressBarRow: Boolean,
         val isReinstallUser: Boolean,
     ) : NewUserOnboardingActivityDialog
 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProvider.kt
@@ -160,7 +160,7 @@ class NewUserOnboardingPlanProvider @Inject constructor(
         val firstDialog = SuspendMemo { resolveFirstDialog(ctx) }
 
         val skipPlan = skipPlan()
-        val quickSetupPlan = quickSetupPlan(ctx)
+        val quickSetupPlan = quickSetupPlan(ctx, forceWithAiInput = true)
 
         val dismissDuckAiFireCta = suspend {
             // End-of-plan dismissal for Duck AI Fire CTA — deferred to here (vs. on user interaction)
@@ -220,8 +220,8 @@ class NewUserOnboardingPlanProvider @Inject constructor(
     private fun skipPlan(): LinearOnboardingPlan =
         LinearOnboardingPlan(id = SKIP_PLAN_ID, steps = listOf(skipOnboardingOptionStep()).firingShownPixels().abortingOnDevSkip())
 
-    private fun quickSetupPlan(ctx: NewUserOnboardingPlanContext): LinearOnboardingPlan =
-        LinearOnboardingPlan(id = QUICK_SETUP_PLAN_ID, steps = listOf(quickSetupStep(ctx)).firingShownPixels().abortingOnDevSkip())
+    private fun quickSetupPlan(ctx: NewUserOnboardingPlanContext, forceWithAiInput: Boolean = false): LinearOnboardingPlan =
+        LinearOnboardingPlan(id = QUICK_SETUP_PLAN_ID, steps = listOf(quickSetupStep(ctx, forceWithAiInput)).firingShownPixels().abortingOnDevSkip())
 
     /**
      * Wraps each step so the internal dev "skip all onboarding" shortcut aborts the run from wherever
@@ -647,7 +647,7 @@ class NewUserOnboardingPlanProvider @Inject constructor(
         )
     }
 
-    private fun quickSetupStep(ctx: NewUserOnboardingPlanContext): NewUserOnboardingActivityStep {
+    private fun quickSetupStep(ctx: NewUserOnboardingPlanContext, forceWithAiInput: Boolean): NewUserOnboardingActivityStep {
         val pixelName = OnboardingPixelName.ONBOARDING_QUICK_SETUP
         return NewUserOnboardingActivityStep(
             id = NewUserOnboardingStepIds.QUICK_SETUP,
@@ -660,6 +660,7 @@ class NewUserOnboardingPlanProvider @Inject constructor(
                     showSplitOption = isSplitOmnibarEnabled(),
                     hideSetDefaultBrowserRow = isDefault,
                     hideAddWidgetRow = hasWidget,
+                    hideAddressBarRow = forceWithAiInput,
                     isReinstallUser = ctx.isReinstall,
                 )
             },
@@ -669,6 +670,9 @@ class NewUserOnboardingPlanProvider @Inject constructor(
                         val resolved = resolveOmnibarType(event.type)
                         settingsDataStore.omnibarType = resolved
                         applyInputModeSelection(ctx, event.withAi, fireTelemetry = false)
+                        if (forceWithAiInput) {
+                            duckChat.setInputScreenUserSetting(true)
+                        }
                         onboardingPixelSender.fire(
                             pixelName,
                             OnboardingPixelAction.QuickSetupClicked(

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModel.kt
@@ -113,6 +113,7 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
         val inputScreenPreviewIsSearchSelected: Boolean = false,
         val hideSetDefaultBrowserRow: Boolean = false,
         val hideAddWidgetRow: Boolean = false,
+        val hideAddressBarRow: Boolean = false,
         val isCustomAiOnboardingFlow: Boolean = false,
         val stepIndicator: StepProgress? = null,
         val onboardingImprovementsV2Enabled: Boolean = true,
@@ -521,6 +522,7 @@ class BrandDesignUpdatePageViewModel @Inject constructor(
                         showSplitOption = dialog.showSplitOption,
                         hideSetDefaultBrowserRow = dialog.hideSetDefaultBrowserRow,
                         hideAddWidgetRow = dialog.hideAddWidgetRow,
+                        hideAddressBarRow = dialog.hideAddressBarRow,
                         isReinstallUser = dialog.isReinstallUser,
                     )
                 }

--- a/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdateWelcomePage.kt
@@ -2064,8 +2064,8 @@ class BrandDesignUpdateWelcomePage : OnboardingPageFragment(R.layout.content_onb
             setDefaultBrowserDivider.isVisible = !state.hideSetDefaultBrowserRow
             addWidgetItem.isVisible = !state.hideAddWidgetRow
             addWidgetDivider.isVisible = !state.hideAddWidgetRow
-            addressBarSearchOptionsItem.isVisible = !state.isCustomAiOnboardingFlow
-            addressBarSearchOptionsDivider.isVisible = !state.isCustomAiOnboardingFlow
+            addressBarSearchOptionsItem.isVisible = !state.hideAddressBarRow
+            addressBarSearchOptionsDivider.isVisible = !state.hideAddressBarRow
         }
     }
 

--- a/app/src/test/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProviderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProviderTest.kt
@@ -232,6 +232,31 @@ class NewUserOnboardingPlanProviderTest {
                 inputScreenSelected = true,
             ),
         )
+        verify(duckChat, never()).setInputScreenUserSetting(true)
+        assertEquals(Skipped(rootPlanId = NewUserOnboardingPlanProvider.ROOT_PLAN_ID), orchestrator.state.value)
+    }
+
+    @Test
+    fun `when custom ai path and quick setup confirmed with ai then forces input screen user setting on`() = runTest {
+        whenever(customAiOnboardingResolver.resolve()).thenReturn(true)
+        whenever(appBuildConfig.isAppReinstall()).thenReturn(true)
+        whenever(quickSetupExperiment.enroll()).thenReturn(QuickSetupExperimentVariant.TREATMENT)
+        start()
+        orchestrator.onEvent(NewUserOnboardingEvent.IntroAnimationFinished)
+        orchestrator.onEvent(NewUserOnboardingEvent.NotificationPermissionFinished(granted = null))
+        assertStep(NewUserOnboardingStepIds.INITIAL_REINSTALL_USER)
+        orchestrator.onEvent(NewUserOnboardingEvent.SkipRequested)
+        assertStep(NewUserOnboardingStepIds.QUICK_SETUP)
+        orchestrator.onEvent(NewUserOnboardingEvent.QuickSetupConfirmed(OmnibarType.SINGLE_TOP, withAi = true))
+        // Skipping Custom AI onboarding via quick setup must force the input screen user setting on.
+        verify(duckChat).setInputScreenUserSetting(true)
+        verify(onboardingPixelSender).fire(
+            ONBOARDING_QUICK_SETUP,
+            OnboardingPixelAction.QuickSetupClicked(
+                addressBarPosition = OmnibarType.SINGLE_TOP,
+                inputScreenSelected = true,
+            ),
+        )
         assertEquals(Skipped(rootPlanId = NewUserOnboardingPlanProvider.ROOT_PLAN_ID), orchestrator.state.value)
     }
 

--- a/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/onboarding/ui/page/BrandDesignUpdatePageViewModelTest.kt
@@ -168,7 +168,7 @@ class BrandDesignUpdatePageViewModelTest {
     }
 
     // Starts the real orchestrator on a single QUICK_SETUP step so the view model actually renders QUICK_SETUP.
-    private suspend fun createViewModelAtQuickSetup(): BrandDesignUpdatePageViewModel {
+    private suspend fun createViewModelAtQuickSetup(hideAddressBarRow: Boolean = false): BrandDesignUpdatePageViewModel {
         val plan = LinearOnboardingPlan(
             id = NewUserOnboardingPlanProvider.ROOT_PLAN_ID,
             steps = listOf(
@@ -181,6 +181,7 @@ class BrandDesignUpdatePageViewModelTest {
                             showSplitOption = false,
                             hideSetDefaultBrowserRow = false,
                             hideAddWidgetRow = false,
+                            hideAddressBarRow = hideAddressBarRow,
                             isReinstallUser = false,
                         )
                     },
@@ -575,6 +576,24 @@ class BrandDesignUpdatePageViewModelTest {
             assertFalse((command as Command.SyncAddWidgetSwitch).isChecked)
             cancelAndConsumeRemainingEvents()
         }
+    }
+
+    // endregion
+
+    // region Quick setup address bar row visibility
+
+    @Test
+    fun whenQuickSetupDialogHidesAddressBarRowThenViewStateHideAddressBarRowIsTrue() = runTest {
+        val testee = createViewModelAtQuickSetup(hideAddressBarRow = true)
+        advanceUntilIdle()
+        assertTrue(testee.viewState.value.hideAddressBarRow)
+    }
+
+    @Test
+    fun whenQuickSetupDialogShowsAddressBarRowThenViewStateHideAddressBarRowIsFalse() = runTest {
+        val testee = createViewModelAtQuickSetup(hideAddressBarRow = false)
+        advanceUntilIdle()
+        assertFalse(testee.viewState.value.hideAddressBarRow)
     }
 
     // endregion


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1216703983172646?focus=true
Tech Design URL (if applicable): 

### Description
Fixes an issue where Custom AI onboarding plan didn't apply input setting if skipped via quick-setup path. 

### Steps to test this PR

- [x] Apply below diff:
```diff
diff --git a/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProvider.kt b/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProvider.kt
index 7229dfc48b..c45afe26e3 100644
--- a/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProvider.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/orchestrator/NewUserOnboardingPlanProvider.kt
@@ -692,7 +692,7 @@ class NewUserOnboardingPlanProvider @Inject constructor(
         skipPlan: LinearOnboardingPlan,
         quickSetupPlan: LinearOnboardingPlan,
     ): LinearOnboardingTransition =
-        if (onboardingQuickSetupExperimentManager.enroll() == QuickSetupExperimentVariant.TREATMENT) {
+        if (true) {
             SwitchTo(quickSetupPlan)
         } else {
             SwitchTo(skipPlan)
```

- [x] Fresh install
- [x] Click "I've been here before"
- [x] Verify input toggle option is visible
- [x] Click "Start Browsing"
- [x] Verify new tab opens with focused native input on a search tab

- [x] Additionally apply below diff:
```diff
diff --git a/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt b/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
index fe3752cbb2..af220bb09d 100644
--- a/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
@@ -100,6 +100,7 @@ class CustomAiOnboardingStoreImpl @Inject constructor(
     }
 
     override suspend fun resolve() = resolveMutex.withLock {
+        return@withLock true
         withContext(dispatcherProvider.io()) {
             // Ensure the install referrer (and therefore the processing function) has resolved before reading.
             withTimeoutOrNull(MAX_REFERRER_WAIT_TIME_MS) { referrerStateListener.get().waitForReferrerCode() }
@@ -116,6 +117,7 @@ class CustomAiOnboardingStoreImpl @Inject constructor(
     }
 
     override suspend fun isEnabled(): Boolean = resolveMutex.withLock {
+        return@withLock true
         withContext(dispatcherProvider.io()) {
             preferences.getBoolean(PREFS_KEY_ENABLED, false)
         }
```

- [x] Fresh install
- [x] Click "I've been here before"
- [x] Verify input toggle option **is not** visible
- [x] Click "Start AI Chat"
- [x] Verify new tab opens with focused native input on a **chat tab**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to new-user onboarding and Duck Chat input preferences; no auth or data-layer changes, with regression coverage for the Custom AI quick-setup path.
> 
> **Overview**
> **Fixes Custom AI onboarding** when users bail out through **quick setup** instead of the full skip dialog: confirming quick setup now calls `duckChat.setInputScreenUserSetting(true)`, matching the behavior of the dedicated skip-onboarding path.
> 
> The Custom AI plan wires quick setup with `forceWithAiInput = true`, which sets `hideAddressBarRow` on the quick-setup dialog and hides the address-bar / search-options row in the UI (via `hideAddressBarRow` in view state rather than inferring from `isCustomAiOnboardingFlow`). Default onboarding quick setup is unchanged and still does not force that user setting.
> 
> Tests cover the orchestrator (Custom AI vs default quick-setup confirm) and view-model mapping for `hideAddressBarRow`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39e97f8e7d59a1af455dfab07816b2aa875b5a86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->