### PR TITLE
Android/Contextual: Fix auto-attach behavior

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -393,8 +393,8 @@ class DuckChatContextualFragment :
                                             id,
                                             data,
                                             Mode.CONTEXTUAL,
-                                            viewModel.updatedPageContext,
-                                            viewModel.sheetTabId,
+                                            viewModel.currentPageContext,
+                                            viewModel.viewState.value.tabId,
                                             browserMode,
                                         )?.let { response ->
                                             logcat { "JS Helper: response $response" }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -109,9 +109,22 @@ class DuckChatContextualViewModel @Inject constructor(
     }
 
     private var fullModeUrl: String = ""
-    var updatedPageContext: String = ""
-    private var attachedPageContext: String = ""
-    var sheetTabId: String = ""
+
+    private data class PageContextState(
+        // The current page reported by the browser — what a manual attach grabs.
+        val currentPage: String = "",
+        // The frozen snapshot actually submitted for the current attachment, so passive navigation
+        // doesn't change what an existing attachment sends.
+        val attachedPage: String = "",
+    )
+
+    private var pageContextState = PageContextState()
+
+    var currentPageContext: String
+        get() = pageContextState.currentPage
+        set(value) {
+            pageContextState = pageContextState.copy(currentPage = value)
+        }
 
     // Chat id currently shown in the contextual webview, derived from the URL query param.
     // Null when in INPUT mode (composing a new chat) or when the URL has no chatID yet.
@@ -272,7 +285,7 @@ class DuckChatContextualViewModel @Inject constructor(
     fun onSheetReopened() {
         logcat { "Duck.ai: onSheetReopened" }
 
-        contextualNativeInputManager.onContextualReopened(sheetTabId)
+        contextualNativeInputManager.onContextualReopened(_viewState.value.tabId)
 
         viewModelScope.launch(dispatchers.io()) {
             withContext(dispatchers.main()) {
@@ -344,7 +357,6 @@ class DuckChatContextualViewModel @Inject constructor(
                 isPageContextRequested = true
                 commandChannel.trySend(Command.RequestPageContext)
             }
-            sheetTabId = tabId
 
             val existingChatUrl = contextualDataStore.getTabChatUrl(tabId)
             if (existingChatUrl.isNullOrBlank()) {
@@ -498,7 +510,7 @@ class DuckChatContextualViewModel @Inject constructor(
         val viewState = _viewState.value
         val pageContext =
             if (viewState.showContext) {
-                attachedPageContext
+                pageContextState.attachedPage
                     .takeIf { it.isNotBlank() }
                     ?.let { runCatching { JSONObject(it) }.getOrNull() }
                     ?: run {
@@ -557,8 +569,8 @@ class DuckChatContextualViewModel @Inject constructor(
     }
 
     private fun generatePageContextEventData(): SubscriptionEventData {
-        val pageContext = if (isContextValid(updatedPageContext)) {
-            updatedPageContext
+        val pageContext = if (isContextValid(currentPageContext)) {
+            currentPageContext
                 .takeIf { it.isNotBlank() }
                 ?.let { runCatching { JSONObject(it) }.getOrNull() }
                 ?: run {
@@ -566,7 +578,7 @@ class DuckChatContextualViewModel @Inject constructor(
                     null
                 }
 
-            val json = JSONObject(updatedPageContext)
+            val json = JSONObject(currentPageContext)
             val url = json.optString("url")
             logcat { "Duck.ai: generatePageContextEventData for url $url" }
             json
@@ -610,7 +622,7 @@ class DuckChatContextualViewModel @Inject constructor(
         isPageContextRequested = false
         persistTabClosed()
         duckChatPixels.reportContextualSheetDismissed()
-        contextualNativeInputManager.onContextualClosed(sheetTabId)
+        contextualNativeInputManager.onContextualClosed(_viewState.value.tabId)
     }
 
     private fun persistTabClosed() {
@@ -653,13 +665,13 @@ class DuckChatContextualViewModel @Inject constructor(
             duckChatPixels.reportContextualPlaceholderContextTapped()
         }
         viewModelScope.launch {
-            val isContextValid = isContextValid(updatedPageContext, reportInvalidPixels = true)
+            val isContextValid = isContextValid(currentPageContext, reportInvalidPixels = true)
             if (isContextValid) {
-                attachedPageContext = updatedPageContext
-                val json = JSONObject(updatedPageContext)
+                pageContextState = pageContextState.copy(attachedPage = pageContextState.currentPage)
+                val json = JSONObject(currentPageContext)
                 duckChatPixels.reportContextualPageContextManuallyAttachedNative()
                 _viewState.update { current ->
-                    logcat { "Duck.ai Contextual: addPageContext $current context $updatedPageContext" }
+                    logcat { "Duck.ai Contextual: addPageContext $current context $currentPageContext" }
                     current.copy(
                         showContext = true,
                         userRemovedContext = false,
@@ -715,9 +727,9 @@ class DuckChatContextualViewModel @Inject constructor(
             } else {
                 input.plus(" ").plus(prompt)
             }
-            val hasValidContext = isContextValid(updatedPageContext)
+            val hasValidContext = isContextValid(currentPageContext)
             if (hasValidContext) {
-                attachedPageContext = updatedPageContext
+                pageContextState = pageContextState.copy(attachedPage = pageContextState.currentPage)
             }
             _viewState.update { current ->
                 current.copy(
@@ -736,7 +748,7 @@ class DuckChatContextualViewModel @Inject constructor(
             }
 
             QuickActionState.ASK_ABOUT_PAGE -> {
-                if (!isContextValid(updatedPageContext)) {
+                if (!isContextValid(currentPageContext)) {
                     // Page context not ready yet; stay in ASK_ABOUT_PAGE so the user can retry.
                     return
                 }
@@ -763,7 +775,7 @@ class DuckChatContextualViewModel @Inject constructor(
     }
 
     fun onAskAboutTabClicked() {
-        if (!isContextValid(updatedPageContext)) {
+        if (!isContextValid(currentPageContext)) {
             // Page context not ready/valid; do nothing (and don't fire invalid-context pixels).
             return
         }
@@ -830,7 +842,7 @@ class DuckChatContextualViewModel @Inject constructor(
         isStorePageContextEnabled: Boolean = false,
     ) {
         if (isContextValid(pageContext)) {
-            updatedPageContext = pageContext
+            currentPageContext = pageContext
         }
         val inputMode = _viewState.value
         if (inputMode.sheetMode == SheetMode.INPUT &&
@@ -862,7 +874,7 @@ class DuckChatContextualViewModel @Inject constructor(
                 }
                 val newlyAutoAttached = showContext && !inputMode.showContext
                 if (showContext) {
-                    attachedPageContext = pageContext
+                    pageContextState = pageContextState.copy(attachedPage = pageContext)
                 }
                 val updatedState =
                     inputMode.copy(
@@ -985,7 +997,7 @@ class DuckChatContextualViewModel @Inject constructor(
 
                 withContext(dispatchers.main()) {
                     clearSheetUrl()
-                    attachedPageContext = ""
+                    pageContextState = pageContextState.copy(attachedPage = "")
                     val resetQuickActionState = if (isContextualSheetImprovementsEnabled) {
                         QuickActionState.ASK_ABOUT_PAGE
                     } else {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -837,12 +837,14 @@ class DuckChatContextualViewModel @Inject constructor(
             if (inputMode.sheetMode == SheetMode.INPUT) {
                 val allowsAutomaticContextAttachment = duckChatInternal.isAutomaticContextAttachmentEnabled()
 
+                val urlChanged = inputMode.contextUrl.isNotEmpty() && url != inputMode.contextUrl
+                val remainsUserRemoved = inputMode.userRemovedContext && !urlChanged
                 val dropStaleAttachment = !allowsAutomaticContextAttachment &&
                     inputMode.showContext &&
-                    url != inputMode.contextUrl
+                    urlChanged
 
                 val showContext = when {
-                    allowsAutomaticContextAttachment -> !inputMode.userRemovedContext
+                    allowsAutomaticContextAttachment -> !remainsUserRemoved
                     dropStaleAttachment -> false
                     else -> inputMode.showContext
                 }
@@ -854,6 +856,7 @@ class DuckChatContextualViewModel @Inject constructor(
                         tabId = tabId,
                         allowsAutomaticContextAttachment = allowsAutomaticContextAttachment,
                         showContext = showContext,
+                        userRemovedContext = remainsUserRemoved,
                         quickActionState = when {
                             isContextualSheetImprovementsEnabled && newlyAutoAttached -> QuickActionState.SUBMIT_SUMMARIZE
                             isContextualSheetImprovementsEnabled && dropStaleAttachment -> QuickActionState.ASK_ABOUT_PAGE

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -836,10 +836,15 @@ class DuckChatContextualViewModel @Inject constructor(
             val inputMode = _viewState.value
             if (inputMode.sheetMode == SheetMode.INPUT) {
                 val allowsAutomaticContextAttachment = duckChatInternal.isAutomaticContextAttachmentEnabled()
-                val showContext = if (allowsAutomaticContextAttachment) {
-                    !inputMode.userRemovedContext
-                } else {
-                    inputMode.showContext
+
+                val dropStaleAttachment = !allowsAutomaticContextAttachment &&
+                    inputMode.showContext &&
+                    url != inputMode.contextUrl
+
+                val showContext = when {
+                    allowsAutomaticContextAttachment -> !inputMode.userRemovedContext
+                    dropStaleAttachment -> false
+                    else -> inputMode.showContext
                 }
                 val newlyAutoAttached = showContext && !inputMode.showContext
                 val updatedState =
@@ -849,12 +854,10 @@ class DuckChatContextualViewModel @Inject constructor(
                         tabId = tabId,
                         allowsAutomaticContextAttachment = allowsAutomaticContextAttachment,
                         showContext = showContext,
-                        // With the improved sheet, auto-attaching context skips the ASK_ABOUT_PAGE step:
-                        // move the quick action straight to submit-summarize so the pill reads "Summarize".
-                        quickActionState = if (isContextualSheetImprovementsEnabled && newlyAutoAttached) {
-                            QuickActionState.SUBMIT_SUMMARIZE
-                        } else {
-                            inputMode.quickActionState
+                        quickActionState = when {
+                            isContextualSheetImprovementsEnabled && newlyAutoAttached -> QuickActionState.SUBMIT_SUMMARIZE
+                            isContextualSheetImprovementsEnabled && dropStaleAttachment -> QuickActionState.ASK_ABOUT_PAGE
+                            else -> inputMode.quickActionState
                         },
                     )
                 if (newlyAutoAttached) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -836,20 +836,28 @@ class DuckChatContextualViewModel @Inject constructor(
             val inputMode = _viewState.value
             if (inputMode.sheetMode == SheetMode.INPUT) {
                 val allowsAutomaticContextAttachment = duckChatInternal.isAutomaticContextAttachmentEnabled()
+                val showContext = if (allowsAutomaticContextAttachment) {
+                    !inputMode.userRemovedContext
+                } else {
+                    inputMode.showContext
+                }
+                val newlyAutoAttached = showContext && !inputMode.showContext
                 val updatedState =
                     inputMode.copy(
                         contextTitle = title,
                         contextUrl = url,
                         tabId = tabId,
                         allowsAutomaticContextAttachment = allowsAutomaticContextAttachment,
-                        showContext =
-                        if (allowsAutomaticContextAttachment && !isContextualSheetImprovementsEnabled) {
-                            !inputMode.userRemovedContext
+                        showContext = showContext,
+                        // With the improved sheet, auto-attaching context skips the ASK_ABOUT_PAGE step:
+                        // move the quick action straight to submit-summarize so the pill reads "Summarize".
+                        quickActionState = if (isContextualSheetImprovementsEnabled && newlyAutoAttached) {
+                            QuickActionState.SUBMIT_SUMMARIZE
                         } else {
-                            inputMode.showContext
+                            inputMode.quickActionState
                         },
                     )
-                if (updatedState.showContext && !inputMode.showContext) {
+                if (newlyAutoAttached) {
                     duckChatPixels.reportContextualPageContextAutoAttached()
                 }
                 _viewState.update { updatedState }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -351,6 +351,7 @@ class DuckChatContextualViewModel @Inject constructor(
     }
 
     fun onSheetOpened(tabId: String) {
+        _viewState.update { it.copy(tabId = tabId) }
         viewModelScope.launch(dispatchers.io()) {
             logcat { "Duck.ai: onSheetOpened for tab=$tabId" }
             withContext(dispatchers.main()) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -110,6 +110,7 @@ class DuckChatContextualViewModel @Inject constructor(
 
     private var fullModeUrl: String = ""
     var updatedPageContext: String = ""
+    private var attachedPageContext: String = ""
     var sheetTabId: String = ""
 
     // Chat id currently shown in the contextual webview, derived from the URL query param.
@@ -497,7 +498,7 @@ class DuckChatContextualViewModel @Inject constructor(
         val viewState = _viewState.value
         val pageContext =
             if (viewState.showContext) {
-                updatedPageContext
+                attachedPageContext
                     .takeIf { it.isNotBlank() }
                     ?.let { runCatching { JSONObject(it) }.getOrNull() }
                     ?: run {
@@ -654,12 +655,16 @@ class DuckChatContextualViewModel @Inject constructor(
         viewModelScope.launch {
             val isContextValid = isContextValid(updatedPageContext, reportInvalidPixels = true)
             if (isContextValid) {
+                attachedPageContext = updatedPageContext
+                val json = JSONObject(updatedPageContext)
                 duckChatPixels.reportContextualPageContextManuallyAttachedNative()
                 _viewState.update { current ->
                     logcat { "Duck.ai Contextual: addPageContext $current context $updatedPageContext" }
                     current.copy(
-                        showContext = isContextValid(updatedPageContext),
+                        showContext = true,
                         userRemovedContext = false,
+                        contextTitle = json.optString("title"),
+                        contextUrl = json.optString("url"),
                     )
                 }
             }
@@ -710,10 +715,14 @@ class DuckChatContextualViewModel @Inject constructor(
             } else {
                 input.plus(" ").plus(prompt)
             }
+            val hasValidContext = isContextValid(updatedPageContext)
+            if (hasValidContext) {
+                attachedPageContext = updatedPageContext
+            }
             _viewState.update { current ->
                 current.copy(
                     prompt = newPrompt,
-                    showContext = isContextValid(updatedPageContext),
+                    showContext = hasValidContext,
                 )
             }
         }
@@ -820,20 +829,23 @@ class DuckChatContextualViewModel @Inject constructor(
         pageContext: String,
         isStorePageContextEnabled: Boolean = false,
     ) {
-        if (isStorePageContextEnabled && !isPageContextRequested && !duckChatInternal.isAutomaticContextAttachmentEnabled()) {
-            // Only applies when storePageContext is enabled.
-            // We don't process what we receive if the sheet did not specifically request it and automatic context attachment is disabled
+        if (isContextValid(pageContext)) {
+            updatedPageContext = pageContext
+        }
+        val inputMode = _viewState.value
+        if (inputMode.sheetMode == SheetMode.INPUT &&
+            !isPageContextRequested &&
+            !duckChatInternal.isAutomaticContextAttachmentEnabled()
+        ) {
             return
         }
 
         if (isContextValid(pageContext, reportInvalidPixels = true)) {
-            updatedPageContext = pageContext
-            val json = JSONObject(updatedPageContext)
+            val json = JSONObject(pageContext)
             val title = json.optString("title")
             val url = json.optString("url")
 
             logcat { "Duck.ai: onPageContextReceived for url $url" }
-            val inputMode = _viewState.value
             if (inputMode.sheetMode == SheetMode.INPUT) {
                 val allowsAutomaticContextAttachment = duckChatInternal.isAutomaticContextAttachmentEnabled()
 
@@ -849,6 +861,9 @@ class DuckChatContextualViewModel @Inject constructor(
                     else -> inputMode.showContext
                 }
                 val newlyAutoAttached = showContext && !inputMode.showContext
+                if (showContext) {
+                    attachedPageContext = pageContext
+                }
                 val updatedState =
                     inputMode.copy(
                         contextTitle = title,
@@ -883,8 +898,6 @@ class DuckChatContextualViewModel @Inject constructor(
                     }
                 }
             }
-        } else {
-            updatedPageContext = ""
         }
     }
 
@@ -972,6 +985,7 @@ class DuckChatContextualViewModel @Inject constructor(
 
                 withContext(dispatchers.main()) {
                     clearSheetUrl()
+                    attachedPageContext = ""
                     val resetQuickActionState = if (isContextualSheetImprovementsEnabled) {
                         QuickActionState.ASK_ABOUT_PAGE
                     } else {
@@ -1040,11 +1054,10 @@ class DuckChatContextualViewModel @Inject constructor(
         val currentState = _viewState.value
         if (currentState.sheetMode != SheetMode.INPUT) return
 
-        if (duckChatInternal.isAutomaticContextAttachmentEnabled()) {
-            viewModelScope.launch(dispatchers.main()) {
-                logcat { "Duck.ai: requesting page context after main browser page change" }
-                commandChannel.trySend(Command.RequestPageContext)
-            }
+        isPageContextRequested = false
+        viewModelScope.launch(dispatchers.main()) {
+            logcat { "Duck.ai: requesting page context after main browser page change" }
+            commandChannel.trySend(Command.RequestPageContext)
         }
     }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -841,7 +841,7 @@ class DuckChatContextualViewModelTest {
         }
 
     @Test
-    fun `when page context received without request and attachments disabled then context ignored`() =
+    fun `when page context received without request and attachments disabled then attached chip is not updated but latest is tracked`() =
         runTest {
             whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
             whenever(duckChatInternal.areMultipleContentAttachmentsEnabled()).thenReturn(false)
@@ -875,9 +875,11 @@ class DuckChatContextualViewModelTest {
             testee.onPageContextReceived("tab-1", serializedPageData, isStorePageContextEnabled = true)
 
             val state = testee.viewState.value
+            // The attached chip is untouched by an unsolicited push while auto-attach is off...
             assertEquals("", state.contextTitle)
             assertEquals("", state.contextUrl)
-            assertEquals("", testee.updatedPageContext)
+            // ...but the latest page is tracked so a later manual attach can use the current page.
+            assertEquals(serializedPageData, testee.updatedPageContext)
         }
 
     @Test
@@ -1645,13 +1647,16 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
-    fun `when main browser page finished in input mode with auto context disabled then no command emitted`() = runTest {
+    fun `when main browser page finished in input mode with auto context disabled then page context still requested to track latest`() = runTest {
         whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
 
         testee.commands.test {
             testee.onMainBrowserPageFinished()
 
-            expectNoEvents()
+            // Even with auto-attach off we refresh the latest page context on navigation so a manual
+            // attach targets the current page; the attached chip is left untouched (see onPageContextReceived).
+            val command = awaitItem()
+            assertTrue(command is DuckChatContextualViewModel.Command.RequestPageContext)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -1838,6 +1843,49 @@ class DuckChatContextualViewModelTest {
 
         assertFalse(testee.viewState.value.showContext)
         assertTrue(testee.viewState.value.userRemovedContext)
+    }
+
+    @Test
+    fun `when auto-attach off and reattaching after navigating then the current page is attached`() = runTest {
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        testee.onPageContextReceived("tab-1", """{"title":"A","url":"https://a.com","content":"a"}""")
+        testee.addPageContext()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        assertEquals("https://a.com", testee.viewState.value.contextUrl)
+
+        // Navigate to page B (a passive navigation push, not sheet-solicited), then remove and re-attach.
+        testee.onMainBrowserPageFinished()
+        testee.onPageContextReceived("tab-1", """{"title":"B","url":"https://b.com","content":"b"}""")
+        testee.removePageContext()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.addPageContext()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        assertTrue(testee.viewState.value.showContext)
+        assertEquals("https://b.com", testee.viewState.value.contextUrl)
+    }
+
+    @Test
+    fun `when auto-attach off and attached then passive navigation leaves the attached chip unchanged`() = runTest {
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        testee.onPageContextReceived("tab-1", """{"title":"A","url":"https://a.com","content":"a"}""")
+        testee.addPageContext()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        assertTrue(testee.viewState.value.showContext)
+
+        // Passive navigation to page B while the sheet stays open must not change the attached chip.
+        testee.onMainBrowserPageFinished()
+        testee.onPageContextReceived("tab-1", """{"title":"B","url":"https://b.com","content":"b"}""")
+
+        assertTrue(testee.viewState.value.showContext)
+        assertEquals("https://a.com", testee.viewState.value.contextUrl)
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -1801,6 +1801,46 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
+    fun `when auto-attach on and removed context then navigating to a new url re-attaches`() = runTest {
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(true)
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        testee.onPageContextReceived("tab-1", """{"title":"A","url":"https://a.com","content":"a"}""")
+        assertTrue(testee.viewState.value.showContext)
+        // User removes the auto-attached context for page A.
+        testee.removePageContext()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        assertFalse(testee.viewState.value.showContext)
+        assertTrue(testee.viewState.value.userRemovedContext)
+
+        // Navigating to page B auto-attaches again.
+        testee.onPageContextReceived("tab-1", """{"title":"B","url":"https://b.com","content":"b"}""")
+
+        assertTrue(testee.viewState.value.showContext)
+        assertEquals("https://b.com", testee.viewState.value.contextUrl)
+        assertFalse(testee.viewState.value.userRemovedContext)
+    }
+
+    @Test
+    fun `when auto-attach on and removed context then re-receiving the same url stays removed`() = runTest {
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(true)
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        testee.onPageContextReceived("tab-1", """{"title":"A","url":"https://a.com","content":"a"}""")
+        testee.removePageContext()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        assertFalse(testee.viewState.value.showContext)
+
+        // The same page's context arriving again (e.g. a refresh) must respect the removal.
+        testee.onPageContextReceived("tab-1", """{"title":"A","url":"https://a.com","content":"a"}""")
+
+        assertFalse(testee.viewState.value.showContext)
+        assertTrue(testee.viewState.value.userRemovedContext)
+    }
+
+    @Test
     fun `when sheet closed then isPageContextRequested is reset`() = runTest {
         val tabId = "tab-1"
         testee.onSheetOpened(tabId)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -211,7 +211,7 @@ class DuckChatContextualViewModelTest {
 
     @Test
     fun `when prompt sent without updated page context then without-context pixel fired`() = runTest {
-        testee.updatedPageContext = ""
+        testee.currentPageContext = ""
 
         testee.onPromptSent("Hello Duck.ai")
 
@@ -556,7 +556,7 @@ class DuckChatContextualViewModelTest {
     @Test
     fun `when addPageContext with missing content then context stays hidden`() =
         runTest {
-            testee.updatedPageContext =
+            testee.currentPageContext =
                 """
                 {
                     "title": "Ctx Title",
@@ -578,7 +578,7 @@ class DuckChatContextualViewModelTest {
     @Test
     fun `when addPageContext with empty context then invalid empty pixel fired`() =
         runTest {
-            testee.updatedPageContext = ""
+            testee.currentPageContext = ""
 
             testee.addPageContext()
             coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
@@ -589,7 +589,7 @@ class DuckChatContextualViewModelTest {
     @Test
     fun `when addPageContext with missing title then invalid no title pixel fired`() =
         runTest {
-            testee.updatedPageContext =
+            testee.currentPageContext =
                 """
                 {
                     "url": "https://ctx.com",
@@ -606,7 +606,7 @@ class DuckChatContextualViewModelTest {
     @Test
     fun `when addPageContext with both title and content missing then both invalid pixels fired`() =
         runTest {
-            testee.updatedPageContext =
+            testee.currentPageContext =
                 """
                 {
                     "url": "https://ctx.com"
@@ -623,7 +623,7 @@ class DuckChatContextualViewModelTest {
     @Test
     fun `when addPageContext with valid context then context shown`() =
         runTest {
-            testee.updatedPageContext =
+            testee.currentPageContext =
                 """
                 {
                     "title": "Ctx Title",
@@ -660,7 +660,7 @@ class DuckChatContextualViewModelTest {
             assertEquals("", state.contextTitle)
             assertEquals("", state.contextUrl)
             assertEquals("", state.tabId)
-            assertEquals("", testee.updatedPageContext)
+            assertEquals("", testee.currentPageContext)
             verify(duckChatPixels).reportContextualPageContextInvalidNoContent()
             verify(duckChatPixels, never()).reportContextualPageContextCollectionEmpty()
         }
@@ -678,7 +678,7 @@ class DuckChatContextualViewModelTest {
 
             testee.onPageContextReceived("tab-1", serializedPageData)
 
-            assertEquals("", testee.updatedPageContext)
+            assertEquals("", testee.currentPageContext)
             verify(duckChatPixels).reportContextualPageContextInvalidNoTitle()
             verify(duckChatPixels, never()).reportContextualPageContextCollectionEmpty()
         }
@@ -688,7 +688,7 @@ class DuckChatContextualViewModelTest {
         runTest {
             testee.onPageContextReceived("tab-1", "")
 
-            assertEquals("", testee.updatedPageContext)
+            assertEquals("", testee.currentPageContext)
             verify(duckChatPixels).reportContextualPageContextInvalidEmpty()
             verify(duckChatPixels, never()).reportContextualPageContextCollectionEmpty()
         }
@@ -698,7 +698,7 @@ class DuckChatContextualViewModelTest {
         runTest {
             testee.onPageContextReceived("tab-1", "{not valid json")
 
-            assertEquals("", testee.updatedPageContext)
+            assertEquals("", testee.currentPageContext)
             verify(duckChatPixels).reportContextualPageContextCollectionEmpty()
             verify(duckChatPixels, never()).reportContextualPageContextInvalidNoTitle()
             verify(duckChatPixels, never()).reportContextualPageContextInvalidNoContent()
@@ -879,7 +879,7 @@ class DuckChatContextualViewModelTest {
             assertEquals("", state.contextTitle)
             assertEquals("", state.contextUrl)
             // ...but the latest page is tracked so a later manual attach can use the current page.
-            assertEquals(serializedPageData, testee.updatedPageContext)
+            assertEquals(serializedPageData, testee.currentPageContext)
         }
 
     @Test
@@ -921,7 +921,7 @@ class DuckChatContextualViewModelTest {
             val state = testee.viewState.value
             assertEquals("Ctx Title", state.contextTitle)
             assertEquals("https://ctx.com", state.contextUrl)
-            assertEquals(serializedPageData, testee.updatedPageContext)
+            assertEquals(serializedPageData, testee.currentPageContext)
         }
 
     @Test
@@ -943,7 +943,7 @@ class DuckChatContextualViewModelTest {
             val state = testee.viewState.value
             assertEquals("Ctx Title", state.contextTitle)
             assertEquals("https://ctx.com", state.contextUrl)
-            assertEquals(serializedPageData, testee.updatedPageContext)
+            assertEquals(serializedPageData, testee.currentPageContext)
         }
 
     @Test
@@ -973,7 +973,7 @@ class DuckChatContextualViewModelTest {
                 // initial emission
                 awaitItem()
 
-                testee.updatedPageContext =
+                testee.currentPageContext =
                     """
                     {
                         "title": "Ctx Title",
@@ -1178,7 +1178,7 @@ class DuckChatContextualViewModelTest {
     @Test
     fun `when prompt cleared then context state unchanged`() =
         runTest {
-            testee.updatedPageContext =
+            testee.currentPageContext =
                 """
                 {
                     "title": "Ctx Title",
@@ -2662,7 +2662,7 @@ class DuckChatContextualViewModelTest {
     fun `when ask about tab clicked without valid context then showContext stays false`() =
         runTest {
             testee.onSheetOpened("tab-1")
-            testee.updatedPageContext = ""
+            testee.currentPageContext = ""
 
             testee.onAskAboutTabClicked()
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -1700,6 +1700,107 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
+    fun `when auto-attach enabled then a navigation page context push refreshes the attached context`() = runTest {
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(true)
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        // Context for the initial page is auto-attached.
+        testee.onPageContextReceived("tab-1", """{"title":"A","url":"https://a.com","content":"a"}""", isStorePageContextEnabled = true)
+        assertTrue(testee.viewState.value.showContext)
+        assertEquals("https://a.com", testee.viewState.value.contextUrl)
+
+        // URL changes: the browser pushes the new page's context unsolicited.
+        testee.onMainBrowserPageFinished(isStorePageContextEnabled = true)
+        testee.onPageContextReceived("tab-1", """{"title":"B","url":"https://b.com","content":"b"}""", isStorePageContextEnabled = true)
+
+        assertTrue(testee.viewState.value.showContext)
+        assertEquals("https://b.com", testee.viewState.value.contextUrl)
+    }
+
+    @Test
+    fun `when auto-attach disabled then a navigation page context push does not refresh the attached context`() = runTest {
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        // Context for the initial page is available and manually attached.
+        testee.onPageContextReceived("tab-1", """{"title":"A","url":"https://a.com","content":"a"}""", isStorePageContextEnabled = true)
+        testee.addPageContext()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        assertTrue(testee.viewState.value.showContext)
+        assertEquals("https://a.com", testee.viewState.value.contextUrl)
+
+        // URL changes: the unsolicited push must be ignored, leaving the attached context untouched.
+        testee.onMainBrowserPageFinished(isStorePageContextEnabled = true)
+        testee.onPageContextReceived("tab-1", """{"title":"B","url":"https://b.com","content":"b"}""", isStorePageContextEnabled = true)
+
+        assertTrue(testee.viewState.value.showContext)
+        assertEquals("https://a.com", testee.viewState.value.contextUrl)
+    }
+
+    @Test
+    fun `when auto-attach off and sheet reopened on a different url then the stale attached context is dropped`() = runTest {
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        // Manually attach context for page A.
+        testee.onPageContextReceived("tab-1", """{"title":"A","url":"https://a.com","content":"a"}""", isStorePageContextEnabled = true)
+        testee.addPageContext()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        assertTrue(testee.viewState.value.showContext)
+
+        // Close, navigate to page B, and reopen: the page-A attachment is now stale.
+        testee.onSheetClosed()
+        testee.onSheetReopened()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        testee.onPageContextReceived("tab-1", """{"title":"B","url":"https://b.com","content":"b"}""", isStorePageContextEnabled = true)
+
+        assertFalse(testee.viewState.value.showContext)
+    }
+
+    @Test
+    fun `when auto-attach off and sheet reopened on the same url then the attached context is kept`() = runTest {
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        testee.onPageContextReceived("tab-1", """{"title":"A","url":"https://a.com","content":"a"}""", isStorePageContextEnabled = true)
+        testee.addPageContext()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        assertTrue(testee.viewState.value.showContext)
+
+        // Reopen on the same page: the attachment still matches, so keep it.
+        testee.onSheetClosed()
+        testee.onSheetReopened()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        testee.onPageContextReceived("tab-1", """{"title":"A","url":"https://a.com","content":"a"}""", isStorePageContextEnabled = true)
+
+        assertTrue(testee.viewState.value.showContext)
+        assertEquals("https://a.com", testee.viewState.value.contextUrl)
+    }
+
+    @Test
+    fun `when auto-attach on and sheet reopened on a different url then the attached context is refreshed not dropped`() = runTest {
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(true)
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        testee.onPageContextReceived("tab-1", """{"title":"A","url":"https://a.com","content":"a"}""", isStorePageContextEnabled = true)
+        assertTrue(testee.viewState.value.showContext)
+        assertEquals("https://a.com", testee.viewState.value.contextUrl)
+
+        testee.onSheetClosed()
+        testee.onSheetReopened()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        testee.onPageContextReceived("tab-1", """{"title":"B","url":"https://b.com","content":"b"}""", isStorePageContextEnabled = true)
+
+        assertTrue(testee.viewState.value.showContext)
+        assertEquals("https://b.com", testee.viewState.value.contextUrl)
+    }
+
+    @Test
     fun `when sheet closed then isPageContextRequested is reset`() = runTest {
         val tabId = "tab-1"
         testee.onSheetOpened(tabId)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -1745,6 +1745,16 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
+    fun `when sheet opened then tabId is set synchronously before the async open completes`() = runTest {
+        val testee = buildViewModel()
+
+        testee.onSheetOpened("tab-1")
+
+        // No advanceUntilIdle: tabId must already be set so per-tab consumers never read an empty id.
+        assertEquals("tab-1", testee.viewState.value.tabId)
+    }
+
+    @Test
     fun `when auto-attach off and sheet reopened on a different url then the stale attached context is dropped`() = runTest {
         whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -1053,6 +1053,7 @@ class DuckChatContextualViewModelTest {
     @Test
     fun `when summarize quick action clicked in submit mode then summarize prompt selected pixel fired`() = runTest {
         whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
         val pageContext = """{"title":"Page","url":"https://example.com","content":"text"}"""
@@ -1067,6 +1068,7 @@ class DuckChatContextualViewModelTest {
     @Test
     fun `when ask about page quick action clicked then summarize prompt selected pixel not fired`() = runTest {
         whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
         val pageContext = """{"title":"Page","url":"https://example.com","content":"text"}"""
@@ -1080,6 +1082,7 @@ class DuckChatContextualViewModelTest {
     @Test
     fun `when ask about page quick action clicked then focus input command emitted`() = runTest {
         whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
         coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
@@ -1814,6 +1817,7 @@ class DuckChatContextualViewModelTest {
     @Test
     fun `when quick action clicked in ASK_ABOUT_PAGE with valid context then state transitions to SUBMIT_SUMMARIZE`() = runTest {
         whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
         val pageContext = """{"title":"Page","url":"https://example.com","content":"text"}"""
@@ -1838,8 +1842,27 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
-    fun `when contextualSheetImprovements enabled and page context arrives then context is NOT auto-attached`() = runTest {
+    fun `when contextualSheetImprovements enabled and auto-attach enabled then context is auto-attached in SUBMIT_SUMMARIZE`() = runTest {
         whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(true)
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+        val pageContext = """{"title":"Page","url":"https://example.com","content":"text"}"""
+
+        testee.onPageContextReceived("tab-1", pageContext)
+
+        assertTrue(testee.viewState.value.showContext)
+        assertEquals(
+            DuckChatContextualViewModel.QuickActionState.SUBMIT_SUMMARIZE,
+            testee.viewState.value.quickActionState,
+        )
+        verify(duckChatPixels).reportContextualPageContextAutoAttached()
+    }
+
+    @Test
+    fun `when contextualSheetImprovements enabled and auto-attach disabled then page context is NOT auto-attached`() = runTest {
+        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
         val pageContext = """{"title":"Page","url":"https://example.com","content":"text"}"""
@@ -1847,12 +1870,17 @@ class DuckChatContextualViewModelTest {
         testee.onPageContextReceived("tab-1", pageContext)
 
         assertFalse(testee.viewState.value.showContext)
+        assertEquals(
+            DuckChatContextualViewModel.QuickActionState.ASK_ABOUT_PAGE,
+            testee.viewState.value.quickActionState,
+        )
         verify(duckChatPixels, never()).reportContextualPageContextAutoAttached()
     }
 
     @Test
     fun `when contextualSheetImprovements enabled then context only attaches after ASK_ABOUT_PAGE clicked`() = runTest {
         whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
         val pageContext = """{"title":"Page","url":"https://example.com","content":"text"}"""
@@ -1867,6 +1895,7 @@ class DuckChatContextualViewModelTest {
     @Test
     fun `when quick action clicked in ASK_ABOUT_PAGE with valid page context then context is attached`() = runTest {
         whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
         val pageContext = """{"title":"Page","url":"https://example.com","content":"text"}"""
@@ -1880,6 +1909,7 @@ class DuckChatContextualViewModelTest {
     @Test
     fun `when quick action clicked in SUBMIT_SUMMARIZE then summarize prompt is auto-submitted`() = runTest {
         whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
         val pageContext = """{"title":"Page","url":"https://example.com","content":"text"}"""
@@ -1902,6 +1932,7 @@ class DuckChatContextualViewModelTest {
     @Test
     fun `when SUBMIT_SUMMARIZE clicked then context-attach pixel not re-fired`() = runTest {
         whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
         val pageContext = """{"title":"Page","url":"https://example.com","content":"text"}"""
@@ -1919,6 +1950,7 @@ class DuckChatContextualViewModelTest {
     @Test
     fun `when SUBMIT_SUMMARIZE clicked after user removed context then summarize is NOT submitted`() = runTest {
         whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
         val pageContext = """{"title":"Page","url":"https://example.com","content":"text"}"""
@@ -1940,6 +1972,7 @@ class DuckChatContextualViewModelTest {
     @Test
     fun `when new chat triggered with contextualSheetImprovements enabled then quickActionState resets to ASK_ABOUT_PAGE`() = runTest {
         whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
         val pageContext = """{"title":"Page","url":"https://example.com","content":"text"}"""
@@ -1965,6 +1998,7 @@ class DuckChatContextualViewModelTest {
     @Test
     fun `when SUBMIT_SUMMARIZE clicked with typed input then web prefill event emitted after auto-submit`() = runTest {
         whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
         val pageContext = """{"title":"Page","url":"https://example.com","content":"text"}"""
@@ -1996,6 +2030,7 @@ class DuckChatContextualViewModelTest {
     @Test
     fun `when SUBMIT_SUMMARIZE clicked with typed input then ChangeSheetState carries prefill`() = runTest {
         whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
         val pageContext = """{"title":"Page","url":"https://example.com","content":"text"}"""
@@ -2045,6 +2080,7 @@ class DuckChatContextualViewModelTest {
     @Test
     fun `when removePageContext from SUBMIT_SUMMARIZE then quickActionState reverts to ASK_ABOUT_PAGE`() = runTest {
         whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
         val pageContext = """{"title":"Page","url":"https://example.com","content":"text"}"""
@@ -2109,6 +2145,7 @@ class DuckChatContextualViewModelTest {
     @Test
     fun `when removePageContext reverts to ASK_ABOUT_PAGE then placeholder shown pixel is not fired but removed pixel is`() = runTest {
         whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
         val testee = buildViewModel()
         testee.onSheetOpened("tab-1")
         val pageContext = """{"title":"Page","url":"https://example.com","content":"text"}"""


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1216113532784491?focus=true 
Tech Design URL (if applicable): 

### Description
Refines page-context attachment behavior in the Duck.ai contextual sheet, keying off the user's automatic-context-attachment setting.
  - **Auto-attach under `contextualSheetImprovements`:** when the setting is on, page context is attached on receipt and the quick action goes straight to `SUBMIT_SUMMARIZE`, skipping the `ASK_ABOUT_PAGE` step.
  When the setting is off, the manual `ASK_ABOUT_PAGE` flow is unchanged.
  - **Reopen on a different URL (auto-attach off):** if the sheet is closed and reopened on a URL different from the attached one, the stale attachment is dropped instead of silently swapping to the new page; the
  pill reverts to `ASK_ABOUT_PAGE` so the user can re-attach.
  - **Re-attach on navigation (auto-attach on):** a manual removal is now scoped to the URL it was made on — navigating to a different URL re-attaches the new page, while re-receiving the same URL still respects
  the removal.
  - Passive navigation with auto-attach off still leaves the attached context untouched.

### Steps to test this PR
Setup:
 - Run all the tests with contextualNativeInput = FALSE 
 - Run all tests again with contextualNativeInput = TRUE (Manually enable via FF inventory, app restart required)
 
  ### 1. Auto-attach OFF — empty sheet, navigate Page A → Page B (sheet left open)
  - [x] **Automatically Send Page Content** = OFF
  - [x] Open the contextual sheet on Page A 
  - [x] Verify that NO context is attached automatically
  - [x] Without closing the sheet (just unfocus the input), Navigate from Page A → Page B
  - [x] Verify that No context is attached automatically
  - [x] The “Ask About Page” is shown in both cases

  ### 2a. Auto-attach OFF — manually attach Page A, navigate to Page B (sheet left open)
  - [x] **Automatically Send Page Content** = OFF
  - [x] Manually attach Page A (via "Ask about page") — attachment shows Page A
  - [x] Without closing the sheet (just unfocus the input), Navigate from Page A → Page B
  - [x] Page A **stays** attached (chip still shows Page A, not Page B)
  - [x] Remove attachment and select Ask About Page again
  - [x] Verify that the correct url is attached (Page B)

  ### 2b. Auto-attach OFF — manually attach Page A, close, navigate to Page B, reopen on Page B
  - [x] **Automatically Send Page Content** = OFF
  - [x] Manually attach Page A — attachment shows Page A
  - [x] Close the sheet, navigate the browser to Page B, then reopen the sheet on Page B
  - [x] Page A attachment is **cleared** (no attachment shown)
  - [x] The quick-action pill returns to **Ask about page**
  - [x] Tapping **Ask about page** now attaches Page B (current page)

  ### 3. Auto-attach OFF — manually attach Page A, remove, navigate Page A → Page B
  - [x] **Automatically Send Page Content** = OFF
  - [x] Manually attach Page A, then remove it (attachment dismissed) and Close the sheet,
  - [x] Navigate the underlying browser Page A → Page B
  - [x] No context attaches automatically
  - [x] The “Ask About Page” is shown

  ### 4. Auto-attach ON — Page A attached, navigate Page A → Page B
  - [x] **Automatically Send Page Content** = ON
  - [x] Open the sheet on Page A — Page A auto-attaches (attachment shows Page A)
  - [x] Without closing the sheet, Navigate the underlying browser Page A → Page B
  - [x] Chip updates to Page B (Page B attaches)

  ### 5. Auto-attach ON — Page A attached, remove, navigate Page A → Page B
  - [x] **Automatically Send Page Content** = ON
  - [x] Open the sheet on Page A — Page A auto-attaches
  - [x] Remove the attached context (attachment dismissed)
  - [x] Without closing the sheet, Navigate the underlying browser Page A → Page B
  - [x] Page B auto-attaches (chip shows Page B)

  ### 6. Auto-attach ON — submit with Page A context, close/reopen sheet on same Page A
  - [x] **Automatically Send Page Content** = ON
  - [x] On Page A, submit a prompt with Page A context attached — sheet moves to the chat (WEBVIEW)
  - [x] Close the sheet, then reopen it on the same Page A
  - [x] The existing chat/session is restored (no new chat created)
  - [x] Page A context is **not** re-attached as a new chip or re-submitted / duplicated in the conversation



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes prompt submission and page-context attachment logic in the contextual AI sheet across navigation and settings; wrong edge-case handling could send stale or missing page content to Duck.ai, but behavior is heavily covered by new unit tests.
> 
> **Overview**
> **Fixes Duck.ai contextual sheet page-context attachment** so behavior matches the **Automatically Send Page Content** setting and navigation/reopen cases.
> 
> The ViewModel now splits **latest browser page** (`currentPageContext`) from a **frozen attachment snapshot** (`attachedPage`) used when submitting prompts, so passive navigation with auto-attach off no longer swaps what an existing chip sends. **`tabId`** is set synchronously in `onSheetOpened` and used from `viewState` (replacing `sheetTabId`); the fragment passes `currentPageContext` and `tabId` into JS callbacks.
> 
> **`onPageContextReceived`** always tracks valid latest context; unsolicited updates in INPUT with auto-attach off skip UI changes but still update `currentPage` for manual attach. With auto-attach on, context can auto-attach and move quick actions to **`SUBMIT_SUMMARIZE`**; with auto-attach off, a URL change while attached drops a stale chip and returns to **`ASK_ABOUT_PAGE`**. User removal is URL-scoped (new URL can re-attach; same URL respects removal). **`onMainBrowserPageFinished`** always requests fresh context in INPUT (not only when auto-attach is on). New chat clears `attachedPage`.
> 
> Tests are expanded/updated for these navigation, reopen, and auto-attach matrix cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b8d361cd9b5056e58294354d54ebceec1644a3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->