### PR TITLE
Submit strings for translation

### DIFF
--- a/ad-blocking/ad-blocking-impl/src/main/res/values-bg/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-bg/strings-ad-blocking.xml
@@ -24,9 +24,9 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Отваря видеоклипове в режим на киносалон без разсейване, който предотвратява влиянието на гледаното съдържание върху емисията в YouTube.</string>
     <string name="ad_blocking_settings_title_v2">Блокиране на реклами</string>
-    <string name="ad_blocking_settings_header_description">Блокира инвазивните тракери, преди да се заредят, като ефективно елиминира рекламите, които разчитат на проследяването</string>
+    <string name="ad_blocking_settings_header_description">Блокира инвазивните тракери, преди да се заредят, като ефективно елиминира рекламите, които разчитат на проследяването.</string>
     <string name="contingencyMessageTitle">Блокирането на реклами в YouTube е недостъпно</string>
-    <string name="contingencyMessageContent">Блокирането на реклами е засегнато от скорошни промени в YouTube. Работим за отстраняване на тези проблеми и оценяваме Вашето разбиране</string>
+    <string name="contingencyMessageContent">Блокирането на реклами е засегнато от скорошни промени в YouTube. Работим за отстраняване на тези проблеми и оценяваме Вашето разбиране.</string>
     <string name="contingencyMessagePrimaryButton">Разбрах</string>
     <string name="contingencyMessageCloseContentDescription">Затваряне</string>
     <string name="ad_blocking_menu_disable">Деактивиране на блокирането на реклами в YouTube</string>
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Деактивиране до рестартиране</string>
     <string name="ad_blocking_menu_always_off">Винаги изключено</string>
     <string name="ad_blocking_disabled_popup_title">Блокирането на реклами в YouTube не работи?</string>
-    <string name="ad_blocking_disabled_popup_description">Изпратете анонимен сигнал за повреда до DuckDuckGo. Помогнете за подобряване на блокирането на реклами за всички!</string>
+    <string name="ad_blocking_disabled_popup_description">Изпратете анонимен сигнал до DuckDuckGo и помогнете за подобряване на блокирането на реклами за всички!</string>
     <string name="ad_blocking_disabled_primary_action">Изпращане на сигнал за повреда</string>
     <string name="ad_blocking_disabled_secondary_action">Отмяна</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Деактивирано до рестартиране</string>
-    <string name="ad_blocking_omnibar_badge_text">Блокирането на рекламите в YouTube е включено</string>
-</resources>
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Блокирани реклами</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-cs/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-cs/strings-ad-blocking.xml
@@ -42,4 +42,4 @@
     <string name="ad_blocking_disabled_secondary_action">Zrušit</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Vypnuto do opětovného spuštění</string>
     <!-- smartling.character_limit = 19 -->
-    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Blokování reklam zapnuto</string></resources>
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Blokování reklam</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-cs/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-cs/strings-ad-blocking.xml
@@ -24,7 +24,7 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Otevírá videa v režimu kina, který brání tomu, aby sledovaná videa ovlivňovala tvůj feed na YouTube.</string>
     <string name="ad_blocking_settings_title_v2">Blokování reklam</string>
-    <string name="ad_blocking_settings_header_description">Zablokuje invazivní trackery ještě před jejich načtením, čímž účinně eliminuje reklamy, které spoléhají na sledování.</string>
+    <string name="ad_blocking_settings_header_description">Zablokuje invazivní trackery ještě před jejich načtením, čímž účinně eliminuje reklamy, které tě pronásledují.</string>
     <string name="contingencyMessageTitle">Blokování reklam na YouTube není k dispozici</string>
     <string name="contingencyMessageContent">Blokování reklam bylo ovlivněno nedávnými změnami na YouTube. Problémy se snažíme opravit. Děkujeme za pochopení.</string>
     <string name="contingencyMessagePrimaryButton">Rozumím</string>
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Vypnout až do opětovného spuštění</string>
     <string name="ad_blocking_menu_always_off">Vždycky vypnuté</string>
     <string name="ad_blocking_disabled_popup_title">Nefunguje blokování reklam na YouTube?</string>
-    <string name="ad_blocking_disabled_popup_description">Odeslat anonymní hlášení o chybě službě DuckDuckGo. Pomoz vylepšit blokování reklam pro všechny!</string>
+    <string name="ad_blocking_disabled_popup_description">Odešli anonymní hlášení službě DuckDuckGo a pomoz vylepšit blokování reklam pro všechny!</string>
     <string name="ad_blocking_disabled_primary_action">Poslat zprávu o chybě</string>
     <string name="ad_blocking_disabled_secondary_action">Zrušit</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Vypnuto do opětovného spuštění</string>
-    <string name="ad_blocking_omnibar_badge_text">Blokování reklam na YouTube zapnuto</string>
-</resources>
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Blokování reklam zapnuto</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-da/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-da/strings-ad-blocking.xml
@@ -24,9 +24,9 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Åbner videoer i en distraktionsfri biograftilstand, der forhindrer, at det, du ser, påvirker dit YouTube-feed.</string>
     <string name="ad_blocking_settings_title_v2">Annonceblokering</string>
-    <string name="ad_blocking_settings_header_description">Vi blokerer invasive trackere, før de indlæses, hvilket effektivt eliminerer annoncer, der er afhængige af sporing</string>
+    <string name="ad_blocking_settings_header_description">Vi blokerer invasive trackere, før de indlæses, hvilket på effektiv vis eliminerer annoncer, der er afhængige af sporing.</string>
     <string name="contingencyMessageTitle">Blokering af YouTube-annoncer ikke tilgængelig</string>
-    <string name="contingencyMessageContent">Annonceblokering er påvirket af de seneste ændringer i YouTube. Vi arbejder på at løse disse problemer og sætter pris på din forståelse</string>
+    <string name="contingencyMessageContent">Annonceblokering er påvirket af de seneste ændringer i YouTube. Vi arbejder på at løse disse problemer og sætter pris på din forståelse.</string>
     <string name="contingencyMessagePrimaryButton">Forstået</string>
     <string name="contingencyMessageCloseContentDescription">Luk</string>
     <string name="ad_blocking_menu_disable">Deaktiver blokering af YouTube-annoncer</string>
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Deaktiver indtil genstart</string>
     <string name="ad_blocking_menu_always_off">Altid fra</string>
     <string name="ad_blocking_disabled_popup_title">Virker YouTube annonceblokering ikke?</string>
-    <string name="ad_blocking_disabled_popup_description">Send en anonym rapport om nedbrud til DuckDuckGo. Hjælp med at gøre blokering af annoncer bedre for alle!</string>
+    <string name="ad_blocking_disabled_popup_description">Send en anonym rapport til DuckDuckGo, og hjælp med at gøre blokering af annoncer bedre for alle!</string>
     <string name="ad_blocking_disabled_primary_action">Send rapport om nedbrud</string>
     <string name="ad_blocking_disabled_secondary_action">Annuller</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Deaktiveret indtil genstart</string>
-    <string name="ad_blocking_omnibar_badge_text">YouTube Ad Block er slået til</string>
-</resources>
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Annonceblokering</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-de/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-de/strings-ad-blocking.xml
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Deaktivieren bis zum Neustart</string>
     <string name="ad_blocking_menu_always_off">Immer aus</string>
     <string name="ad_blocking_disabled_popup_title">YouTube-Werbeblockierung funktioniert nicht?</string>
-    <string name="ad_blocking_disabled_popup_description">Sende einen anonymen Störungsbericht an DuckDuckGo. Hilf mit, den Werbeblocker für alle zu verbessern!</string>
+    <string name="ad_blocking_disabled_popup_description">Sende einen anonymen Bericht an DuckDuckGo und hilf mit, den Werbeblocker für alle zu verbessern!</string>
     <string name="ad_blocking_disabled_primary_action">Störungsbericht senden</string>
     <string name="ad_blocking_disabled_secondary_action">Abbrechen</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Deaktiviert bis zum Neustart</string>
-    <string name="ad_blocking_omnibar_badge_text">YouTube-Werbungsblocker aktiviert</string>
-</resources>
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Werbeblockierung aktiv</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-de/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-de/strings-ad-blocking.xml
@@ -42,4 +42,4 @@
     <string name="ad_blocking_disabled_secondary_action">Abbrechen</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Deaktiviert bis zum Neustart</string>
     <!-- smartling.character_limit = 19 -->
-    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Werbeblockierung aktiv</string></resources>
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Werbeblockierung an</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-el/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-el/strings-ad-blocking.xml
@@ -24,9 +24,9 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Ανοίγει βίντεο σε λειτουργία κινηματογράφου χωρίς περισπάσεις, η οποία εμποδίζει το περιεχόμενο που παρακολουθείς να επηρεάσει τη ροή σου στο YouTube.</string>
     <string name="ad_blocking_settings_title_v2">Αποκλεισμός διαφημίσεων</string>
-    <string name="ad_blocking_settings_header_description">Αποκλείει επεμβατικά προγράμματα παρακολούθησης προτού φορτώσουν, εξαλείφοντας αποτελεσματικά διαφημίσεις που βασίζονται σε παρακολούθηση</string>
+    <string name="ad_blocking_settings_header_description">Αποκλείει επεμβατικά προγράμματα παρακολούθησης προτού φορτώσουν, εξαλείφοντας αποτελεσματικά διαφημίσεις που βασίζονται σε παρακολούθηση.</string>
     <string name="contingencyMessageTitle">Ο αποκλεισμός διαφημίσεων στο YouTube δεν είναι διαθέσιμος</string>
-    <string name="contingencyMessageContent">Ο αποκλεισμός διαφημίσεων έχει επηρεαστεί από τις πρόσφατες αλλαγές στο YouTube. Προσπαθούμε να διορθώσουμε αυτά τα προβλήματα και εκτιμούμε την κατανόησή σου</string>
+    <string name="contingencyMessageContent">Ο αποκλεισμός διαφημίσεων έχει επηρεαστεί από τις πρόσφατες αλλαγές στο YouTube. Προσπαθούμε να διορθώσουμε αυτά τα προβλήματα και εκτιμούμε την κατανόησή σας.</string>
     <string name="contingencyMessagePrimaryButton">Κατάλαβα</string>
     <string name="contingencyMessageCloseContentDescription">Κλείσιμο</string>
     <string name="ad_blocking_menu_disable">Απενεργοποίηση αποκλεισμού διαφημίσεων στο YouTube</string>
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Απενεργοποίηση μέχρι την επανεκκίνηση</string>
     <string name="ad_blocking_menu_always_off">Πάντα ανενεργός</string>
     <string name="ad_blocking_disabled_popup_title">Ο αποκλεισμός διαφημίσεων στο YouTube δεν λειτουργεί;</string>
-    <string name="ad_blocking_disabled_popup_description">Στείλε μια ανώνυμη αναφορά βλάβης στο DuckDuckGo. Βοήθησε να κάνουμε τον αποκλεισμό διαφημίσεων καλύτερο για όλους!</string>
+    <string name="ad_blocking_disabled_popup_description">Στείλτε μια ανώνυμη αναφορά στο DuckDuckGo και βοηθήστε να κάνουμε τον αποκλεισμό διαφημίσεων καλύτερο για όλους!</string>
     <string name="ad_blocking_disabled_primary_action">Αποστολή Αναφοράς βλάβης</string>
     <string name="ad_blocking_disabled_secondary_action">Ακύρωση</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Απενεργοποιήθηκε μέχρι την επανεκκίνηση</string>
-    <string name="ad_blocking_omnibar_badge_text">Αποκλεισμός διαφημίσεων YouTube ενεργός</string>
-</resources>
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Αποκλεισμός διαφημίσεων ενεργός</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-el/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-el/strings-ad-blocking.xml
@@ -42,4 +42,4 @@
     <string name="ad_blocking_disabled_secondary_action">Ακύρωση</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Απενεργοποιήθηκε μέχρι την επανεκκίνηση</string>
     <!-- smartling.character_limit = 19 -->
-    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Αποκλεισμός διαφημίσεων ενεργός</string></resources>
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Αποκλεισμός διαφημίσεων</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-es/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-es/strings-ad-blocking.xml
@@ -24,9 +24,9 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Abre vídeos en modo teatro sin distracciones que impide que lo que ves influya en tu feed de YouTube.</string>
     <string name="ad_blocking_settings_title_v2">Bloqueo de anuncios</string>
-    <string name="ad_blocking_settings_header_description">Bloquea los rastreadores invasivos antes de que se carguen, eliminando de manera efectiva los anuncios que se basan en el rastreo</string>
+    <string name="ad_blocking_settings_header_description">Bloquea los rastreadores invasivos antes de que se carguen, eliminando de manera efectiva los anuncios que se basan en el rastreo.</string>
     <string name="contingencyMessageTitle">El bloqueo de anuncios en YouTube no está disponible</string>
-    <string name="contingencyMessageContent">El bloqueo de anuncios se ha visto afectado por los cambios recientes en YouTube. Estamos trabajando para solucionar estos problemas y agradecemos tu comprensión</string>
+    <string name="contingencyMessageContent">El bloqueo de anuncios se ha visto afectado por los cambios recientes en YouTube. Estamos trabajando para solucionar estos problemas y agradecemos tu comprensión.</string>
     <string name="contingencyMessagePrimaryButton">Entendido</string>
     <string name="contingencyMessageCloseContentDescription">Cerrar</string>
     <string name="ad_blocking_menu_disable">Desactivar el bloqueo de anuncios en YouTube</string>
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Desactivar hasta volver a iniciar</string>
     <string name="ad_blocking_menu_always_off">Siempre desactivado</string>
     <string name="ad_blocking_disabled_popup_title">¿El bloqueo de anuncios de YouTube no funciona?</string>
-    <string name="ad_blocking_disabled_popup_description">Envía un informe anónimo de fallos a DuckDuckGo. ¡Ayuda a que el bloqueo de anuncios sea mejor para todos!</string>
+    <string name="ad_blocking_disabled_popup_description">Envía un informe anónimo a DuckDuckGo y ¡ayuda a que el bloqueo de anuncios sea mejor para todos!</string>
     <string name="ad_blocking_disabled_primary_action">Enviar informe de averías</string>
     <string name="ad_blocking_disabled_secondary_action">Cancelar</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Desactivado hasta volver a iniciar</string>
-    <string name="ad_blocking_omnibar_badge_text">Bloqueo de anuncios en YouTube activado</string>
-</resources>
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Bloqueo de anuncios</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-et/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-et/strings-ad-blocking.xml
@@ -24,9 +24,9 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Avab videod segajatevabas kinorežiimis, mis hoiab ära selle, et vaadatav sisu mõjutaks sinu YouTube’i voogu.</string>
     <string name="ad_blocking_settings_title_v2">Reklaamide blokeerimine</string>
-    <string name="ad_blocking_settings_header_description">Blokeerib invasiivsed jälgijad enne nende laadimist, kõrvaldades tõhusalt reklaamid, mis tuginevad jälgimisele</string>
+    <string name="ad_blocking_settings_header_description">Blokeerib invasiivsed jälgijad enne nende laadimist, kõrvaldades tõhusalt reklaamid, mis tuginevad jälgimisele.</string>
     <string name="contingencyMessageTitle">YouTube\'i reklaamiblokeerija pole saadaval</string>
-    <string name="contingencyMessageContent">YouTube\'i hiljutised muudatused on mõjutanud reklaamide blokeerimist. Töötame nende probleemide lahendamise nimel ja täname sind mõistva suhtumise eest</string>
+    <string name="contingencyMessageContent">YouTube\'i hiljutised muudatused on mõjutanud reklaamide blokeerimist. Töötame nende probleemide lahendamise nimel ja täname sind mõistva suhtumise eest.</string>
     <string name="contingencyMessagePrimaryButton">Sain aru</string>
     <string name="contingencyMessageCloseContentDescription">Sulge</string>
     <string name="ad_blocking_menu_disable">Keela YouTube\'i reklaamide blokeerimine</string>
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Inaktiveeri kuni taaskäivitamiseni</string>
     <string name="ad_blocking_menu_always_off">Alati välja lülitatud</string>
     <string name="ad_blocking_disabled_popup_title">YouTube\'i reklaamiblokeerija ei tööta?</string>
-    <string name="ad_blocking_disabled_popup_description">Saada DuckDuckGo-le anonüümne rikketeade. Aita muuta reklaamide blokeerimine kõigi jaoks paremaks!</string>
+    <string name="ad_blocking_disabled_popup_description">Saada DuckDuckGo-le anonüümne aruanne ja aita muuta reklaamide blokeerimine kõigi jaoks paremaks!</string>
     <string name="ad_blocking_disabled_primary_action">Saada rikketeade</string>
     <string name="ad_blocking_disabled_secondary_action">Tühista</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Inaktiveeritud kuni taaskäivitamiseni</string>
-    <string name="ad_blocking_omnibar_badge_text">YouTube’i reklaamiblokeerija on sees</string>
-</resources>
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Reklaami blokeerimine</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-fi/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-fi/strings-ad-blocking.xml
@@ -24,7 +24,7 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Avaa videot häiriöttömässä teatteritilassa, jolloin katsomasi sisältö ei vaikuta YouTube-syötteeseesi.</string>
     <string name="ad_blocking_settings_title_v2">Mainosten esto</string>
-    <string name="ad_blocking_settings_header_description">Estää tunkeilevat seurantaohjelmat ennen niiden latautumista, mikä eliminoi tehokkaasti seurantaa käyttävät mainokset</string>
+    <string name="ad_blocking_settings_header_description">Estää tunkeilevat seurantatoiminnot ennen niiden latautumista, mikä eliminoi tehokkaasti seurantaa käyttävät mainokset.</string>
     <string name="contingencyMessageTitle">YouTube-mainosten esto ei ole käytettävissä</string>
     <string name="contingencyMessageContent">YouTuben viimeaikaiset muutokset ovat vaikuttaneet mainosten estämiseen. Pyrimme korjaamaan nämä ongelmat. Kiitos ymmärryksestä.</string>
     <string name="contingencyMessagePrimaryButton">Selvä</string>
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Poissa käytöstä uudelleenkäynnistykseen asti</string>
     <string name="ad_blocking_menu_always_off">Aina pois käytöstä</string>
     <string name="ad_blocking_disabled_popup_title">Eikö YouTube-mainosten esto toimi?</string>
-    <string name="ad_blocking_disabled_popup_description">Lähetä anonyymi rikkoutumisraportti DuckDuckGolle. Auta meitä parantamaan mainosten estoa kaikille!</string>
+    <string name="ad_blocking_disabled_popup_description">Lähetä anonyymi raportti DuckDuckGolle ja auta meitä parantamaan mainosten estoa!</string>
     <string name="ad_blocking_disabled_primary_action">Lähetä rikkoutumisraportti</string>
     <string name="ad_blocking_disabled_secondary_action">Peruuta</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Poissa käytöstä uudelleenkäynnistykseen asti</string>
-    <string name="ad_blocking_omnibar_badge_text">YouTube-mainosten esto käytössä</string>
-</resources>
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Mainosesto käytössä</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-fr/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-fr/strings-ad-blocking.xml
@@ -42,4 +42,4 @@
     <string name="ad_blocking_disabled_secondary_action">Annuler</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Désactivé jusqu\'au redémarrage</string>
     <!-- smartling.character_limit = 19 -->
-    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Blocage des publicités activé</string></resources>
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Blocage pubs activé</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-fr/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-fr/strings-ad-blocking.xml
@@ -24,7 +24,7 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Ouvre les vidéos en mode « Salle de projection sans distractions », ce qui empêche ce que vous regardez d\'influencer votre fil d\'actualité YouTube.</string>
     <string name="ad_blocking_settings_title_v2">Blocage des publicités</string>
-    <string name="ad_blocking_settings_header_description">Bloque les traqueurs invasifs avant leur chargement, ce qui permet d\'éliminer efficacement les publicités reposant sur le pistage</string>
+    <string name="ad_blocking_settings_header_description">Bloque les traqueurs invasifs avant leur chargement, ce qui permet d\'éliminer efficacement les publicités reposant sur le pistage.</string>
     <string name="contingencyMessageTitle">Blocage des publicités sur YouTube indisponible</string>
     <string name="contingencyMessageContent">Les récents changements apportés à YouTube ont affecté le blocage des publicités. Nous nous efforçons de résoudre ces problèmes et vous remercions de votre compréhension.</string>
     <string name="contingencyMessagePrimaryButton">J\'ai compris</string>
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Désactiver jusqu\'au redémarrage</string>
     <string name="ad_blocking_menu_always_off">Toujours désactivé</string>
     <string name="ad_blocking_disabled_popup_title">Le blocage des publicités sur YouTube ne fonctionne pas ?</string>
-    <string name="ad_blocking_disabled_popup_description">Envoyez un rapport anonyme de dysfonctionnement à DuckDuckGo. Contribuez à améliorer le blocage des publicités pour tous !</string>
+    <string name="ad_blocking_disabled_popup_description">Envoyez un rapport anonyme à DuckDuckGo et contribuez à améliorer le blocage des publicités pour tous !</string>
     <string name="ad_blocking_disabled_primary_action">Envoyer un rapport de défaillance</string>
     <string name="ad_blocking_disabled_secondary_action">Annuler</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Désactivé jusqu\'au redémarrage</string>
-    <string name="ad_blocking_omnibar_badge_text">Blocage des publicités sur YouTube activé</string>
-</resources>
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Blocage des publicités activé</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-hr/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-hr/strings-ad-blocking.xml
@@ -24,9 +24,9 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Otvara videozapise u kino načinu rada bez ometanja koji sprječava da ono što gledaš utječe na tvoj YouTube feed.</string>
     <string name="ad_blocking_settings_title_v2">Blokiranje oglasa</string>
-    <string name="ad_blocking_settings_header_description">Blokira invazivne alate za praćenje prije nego što se učitaju, učinkovito eliminirajući oglase koji se oslanjaju na praćenje</string>
+    <string name="ad_blocking_settings_header_description">Blokira invazivne alate za praćenje prije nego što se učitaju, učinkovito eliminirajući oglase koji se oslanjaju na praćenje.</string>
     <string name="contingencyMessageTitle">Blokiranje oglasa na YouTubeu nije dostupno</string>
-    <string name="contingencyMessageContent">Blokiranje oglasa pogođeno je nedavnim promjenama na YouTubeu. Radimo na rješavanju tih problema i cijenimo tvoje razumijevanje</string>
+    <string name="contingencyMessageContent">Blokiranje oglasa pogođeno je nedavnim promjenama YouTubea. Radimo na rješavanju ovih problema i cijenimo tvoje razumijevanje.</string>
     <string name="contingencyMessagePrimaryButton">Shvaćam</string>
     <string name="contingencyMessageCloseContentDescription">Zatvori</string>
     <string name="ad_blocking_menu_disable">Onemogući blokiranje oglasa na YouTubeu</string>
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Onemogući do ponovnog pokretanja</string>
     <string name="ad_blocking_menu_always_off">Uvijek isključeno</string>
     <string name="ad_blocking_disabled_popup_title">Blokiranje oglasa na YouTubeu ne funkcionira?</string>
-    <string name="ad_blocking_disabled_popup_description">Pošalji anonimnu prijavu kvara DuckDuckGou. Pomozi nam da poboljšamo blokiranje oglasa za sve!</string>
+    <string name="ad_blocking_disabled_popup_description">Pošalji anonimnu prijavu DuckDuckGou i pomozi nam da poboljšamo blokiranje oglasa za sve!</string>
     <string name="ad_blocking_disabled_primary_action">Pošalji izvješće o problemu</string>
     <string name="ad_blocking_disabled_secondary_action">Otkaži</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Onemogućeno do ponovnog pokretanja</string>
-    <string name="ad_blocking_omnibar_badge_text">Blokiranje YouTube oglasa je uključeno</string>
-</resources>
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Oglasi blokirani</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-hu/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-hu/strings-ad-blocking.xml
@@ -24,7 +24,7 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Zavaró elemektől mentes, mozis nézetben nyitja meg a videókat, így a nézett tartalom nem befolyásolja a YouTube-hírfolyamodat.</string>
     <string name="ad_blocking_settings_title_v2">Hirdetésblokkolás</string>
-    <string name="ad_blocking_settings_header_description">Még betöltés előtt blokkolja az invazív nyomkövetőket, így hatékonyan kiküszöböljük a nyomkövetésre épülő hirdetéseket</string>
+    <string name="ad_blocking_settings_header_description">Még betöltés előtt blokkolja az invazív nyomkövetőket, így hatékonyan kiküszöböljük a nyomkövetésre épülő hirdetéseket.</string>
     <string name="contingencyMessageTitle">YouTube-hirdetésblokkolás nem érhető el</string>
     <string name="contingencyMessageContent">A hirdetésblokkolást érintették a YouTube legutóbbi módosításai. Dolgozunk a problémák megoldásán, és köszönjük a megértésedet.</string>
     <string name="contingencyMessagePrimaryButton">Értem</string>
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Letiltás újraindításig</string>
     <string name="ad_blocking_menu_always_off">Mindig ki van kapcsolva</string>
     <string name="ad_blocking_disabled_popup_title">Nem működik a YouTube-hirdetésblokkolás?</string>
-    <string name="ad_blocking_disabled_popup_description">Küldj névtelen hibajelentést a DuckDuckGónak. Segíts, hogy mindenkinek jobb legyen a hirdetésblokkolás.</string>
+    <string name="ad_blocking_disabled_popup_description">Küldj névtelen jelentést a DuckDuckGónak, és segíts, hogy mindenkinek jobb legyen a hirdetésblokkolás.</string>
     <string name="ad_blocking_disabled_primary_action">Hibás működésre vonatkozó jelentés küldése</string>
     <string name="ad_blocking_disabled_secondary_action">Mégsem</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Letiltva az újraindításig</string>
-    <string name="ad_blocking_omnibar_badge_text">A YouTube-hirdetésblokkolás be van kapcsolva</string>
-</resources>
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Hirdetésblokkolás</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-it/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-it/strings-ad-blocking.xml
@@ -42,4 +42,4 @@
     <string name="ad_blocking_disabled_secondary_action">Annulla</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Disattivato fino al rilancio</string>
     <!-- smartling.character_limit = 19 -->
-    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Blocco annunci attivo</string></resources>
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Blocco annunci</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-it/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-it/strings-ad-blocking.xml
@@ -24,9 +24,9 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Apre i video in una modalità cinema senza distrazioni che impedisce a ciò che guardi di influenzare il tuo feed di YouTube.</string>
     <string name="ad_blocking_settings_title_v2">Blocco degli annunci</string>
-    <string name="ad_blocking_settings_header_description">Blocca i sistemi di tracciamento prima che vengano caricati, eliminando di fatto gli annunci che si basano sul tracciamento</string>
+    <string name="ad_blocking_settings_header_description">Blocca i sistemi di tracciamento prima che vengano caricati, eliminando di fatto gli annunci che si basano sul tracciamento.</string>
     <string name="contingencyMessageTitle">Blocco degli annunci su YouTube non disponibile</string>
-    <string name="contingencyMessageContent">Il blocco degli annunci è stato influenzato dalle recenti modifiche a YouTube. Stiamo lavorando per risolvere questi problemi. Grazie per la comprensione</string>
+    <string name="contingencyMessageContent">Il blocco degli annunci è stato influenzato dalle recenti modifiche a YouTube. Stiamo lavorando per risolvere questi problemi. Grazie per la comprensione.</string>
     <string name="contingencyMessagePrimaryButton">Ho capito</string>
     <string name="contingencyMessageCloseContentDescription">Chiudi</string>
     <string name="ad_blocking_menu_disable">Disattiva il blocco annunci su YouTube</string>
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Disattiva fino al rilancio</string>
     <string name="ad_blocking_menu_always_off">Sempre disattivato</string>
     <string name="ad_blocking_disabled_popup_title">Il blocco degli annunci di YouTube non funziona?</string>
-    <string name="ad_blocking_disabled_popup_description">Invia una segnalazione anonima di malfunzionamento a DuckDuckGo. Aiuta a migliorare il blocco degli annunci per tutti!</string>
+    <string name="ad_blocking_disabled_popup_description">Invia una segnalazione anonima a DuckDuckGo e aiuta a migliorare il blocco degli annunci per tutti!</string>
     <string name="ad_blocking_disabled_primary_action">Invia la segnalazione di malfunzionamento</string>
     <string name="ad_blocking_disabled_secondary_action">Annulla</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Disattivato fino al rilancio</string>
-    <string name="ad_blocking_omnibar_badge_text">Blocco degli annunci di YouTube attivato</string>
-</resources>
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Blocco annunci attivo</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-lt/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-lt/strings-ad-blocking.xml
@@ -24,9 +24,9 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Atidaro vaizdo įrašus neblaškančiu kino teatro režimu, kad tai, ką žiūri, nedarytų įtakos tavo „YouTube“ srautui.</string>
     <string name="ad_blocking_settings_title_v2">Reklamų blokavimas</string>
-    <string name="ad_blocking_settings_header_description">Blokuoja įkyrias sekimo priemones dar prieš jas įkeliant, todėl veiksmingai pašalina sekimu pagrįstas reklamas</string>
+    <string name="ad_blocking_settings_header_description">Blokuoja įkyrius sekiklius dar jiems neįsikėlus ir veiksmingai pašalina sekimu paremtus skelbimus.</string>
     <string name="contingencyMessageTitle">„YouTube“ reklamų blokavimas nepasiekiamas</string>
-    <string name="contingencyMessageContent">Naujausi „YouTube“ pakeitimai paveikė reklamų blokavimą. Sprendžiame šias problemas ir dėkojame už supratingumą</string>
+    <string name="contingencyMessageContent">Dėl pastarųjų „YouTube“ pakeitimų sutriko skelbimų blokavimas. Stengiamės išspręsti šiuos nesklandumus ir dėkojame už supratingumą.</string>
     <string name="contingencyMessagePrimaryButton">Supratau</string>
     <string name="contingencyMessageCloseContentDescription">Uždaryti</string>
     <string name="ad_blocking_menu_disable">Išjungti „YouTube“ reklamų blokavimą</string>
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Išjungti iki paleidimo iš naujo</string>
     <string name="ad_blocking_menu_always_off">Visada išjungta</string>
     <string name="ad_blocking_disabled_popup_title">Neveikia „YouTube“ reklamų blokavimas?</string>
-    <string name="ad_blocking_disabled_popup_description">Siųsk anoniminį pranešimą apie triktį „DuckDuckGo“. Padėk patobulinti reklamų blokavimą visiems!</string>
+    <string name="ad_blocking_disabled_popup_description">Siųsk anoniminį pranešimą „DuckDuckGo“ ir padėk tobulinti skelbimų blokavimą visiems!</string>
     <string name="ad_blocking_disabled_primary_action">Siųsti pranešimą apie triktį</string>
     <string name="ad_blocking_disabled_secondary_action">Atšaukti</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Išjungta iki paleidimo iš naujo</string>
-    <string name="ad_blocking_omnibar_badge_text">„YouTube“ reklamų blokavimas įjungtas</string>
-</resources>
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Skelbimų blokavimas įjungtas</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-lt/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-lt/strings-ad-blocking.xml
@@ -42,4 +42,4 @@
     <string name="ad_blocking_disabled_secondary_action">Atšaukti</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Išjungta iki paleidimo iš naujo</string>
     <!-- smartling.character_limit = 19 -->
-    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Skelbimų blokavimas įjungtas</string></resources>
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Skelbimų blokavimas</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-lv/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-lv/strings-ad-blocking.xml
@@ -24,9 +24,9 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Atver videoklipus teātra režīmā bez uzmanības novēršanas, kas neļauj skatītajam ietekmēt tavu YouTube plūsmu.</string>
     <string name="ad_blocking_settings_title_v2">Reklāmu bloķēšana</string>
-    <string name="ad_blocking_settings_header_description">Bloķē uzmācīgus izsekotājus, pirms tie tiek ielādēti, tādējādi efektīvi novēršot izsekošanā balstītās reklāmas.</string>
+    <string name="ad_blocking_settings_header_description">Bloķē uzmācīgus izsekotājus, pirms tie tiek ielādēti, tādējādi efektīvi novēršot reklāmas, kas balstās uz izsekošanu.</string>
     <string name="contingencyMessageTitle">YouTube reklāmu bloķēšana nav pieejama</string>
-    <string name="contingencyMessageContent">Reklāmu bloķēšanu ir ietekmējušas nesenās izmaiņas pakalpojumā YouTube. Mēs jau strādājam pie šo problēmu novēršanas un novērtējam tavu sapratni.</string>
+    <string name="contingencyMessageContent">Reklāmu bloķēšanu ir ietekmējušas nesenās izmaiņas pakalpojumā YouTube. Mēs strādājam, lai novērstu šīs problēmas, un novērtējam tavu sapratni.</string>
     <string name="contingencyMessagePrimaryButton">Sapratu</string>
     <string name="contingencyMessageCloseContentDescription">Aizvērt</string>
     <string name="ad_blocking_menu_disable">Atspējot YouTube reklāmu bloķēšanu</string>
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Atspējot līdz atkārtotai palaišanai</string>
     <string name="ad_blocking_menu_always_off">Vienmēr izslēgts</string>
     <string name="ad_blocking_disabled_popup_title">YouTube reklāmu bloķēšana nedarbojas?</string>
-    <string name="ad_blocking_disabled_popup_description">Nosūti DuckDuckGo anonīmu ziņojumu par traucējumiem. Palīdzi uzlabot reklāmu bloķēšanu visiem!</string>
+    <string name="ad_blocking_disabled_popup_description">Nosūti DuckDuckGo anonīmu ziņojumu un palīdzi uzlabot reklāmu bloķēšanu visiem!</string>
     <string name="ad_blocking_disabled_primary_action">Nosūtīt ziņojumu par traucējumiem</string>
     <string name="ad_blocking_disabled_secondary_action">Atcelt</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Atspējots līdz atkārtotai palaišanai</string>
-    <string name="ad_blocking_omnibar_badge_text">YouTube reklāmu bloķēšana ieslēgta</string>
-</resources>
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Reklāmu bloķēšana</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-nb/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-nb/strings-ad-blocking.xml
@@ -24,9 +24,9 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Åpner videoer i en distraksjonsfri kinomodus som hindrer at det du ser på påvirker YouTube-feeden din.</string>
     <string name="ad_blocking_settings_title_v2">Annonseblokkering</string>
-    <string name="ad_blocking_settings_header_description">Blokkerer invaderende sporere før de blir lastet inn, og dette eliminerer også annonser som er basert på sporing</string>
+    <string name="ad_blocking_settings_header_description">Blokkerer invaderende sporere før de blir lastet inn, og dette eliminerer også annonser som er basert på sporing.</string>
     <string name="contingencyMessageTitle">Annonseblokkering på YouTube er ikke tilgjengelig</string>
-    <string name="contingencyMessageContent">Annonseblokkering har blitt påvirket av nylige endringer på YouTube. Vi jobber med å løse disse problemene og takker for tålmodigheten</string>
+    <string name="contingencyMessageContent">Annonseblokkering har blitt påvirket av nylige endringer på YouTube. Vi jobber med å løse disse problemene og takker for tålmodigheten.</string>
     <string name="contingencyMessagePrimaryButton">Den er grei</string>
     <string name="contingencyMessageCloseContentDescription">Lukk</string>
     <string name="ad_blocking_menu_disable">Deaktiver annonseblokkering på YouTube</string>
@@ -37,9 +37,10 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Deaktiver til neste oppstart</string>
     <string name="ad_blocking_menu_always_off">Alltid av</string>
     <string name="ad_blocking_disabled_popup_title">Fungerer ikke annonseblokkering på YouTube?</string>
-    <string name="ad_blocking_disabled_popup_description">Send en anonym feilrapport til DuckDuckGo. Bidra til å gjøre annonseblokkering bedre for alle!</string>
+    <string name="ad_blocking_disabled_popup_description">Send en anonym rapport til DuckDuckGo og bidra til å gjøre annonseblokkering bedre for alle!</string>
     <string name="ad_blocking_disabled_primary_action">Send feilrapport</string>
     <string name="ad_blocking_disabled_secondary_action">Avbryt</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Deaktivert til neste oppstart</string>
-    <string name="ad_blocking_omnibar_badge_text">Annonseblokkering på YouTube er på</string>
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Annonseblokkering på</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-nb/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-nb/strings-ad-blocking.xml
@@ -42,5 +42,4 @@
     <string name="ad_blocking_disabled_secondary_action">Avbryt</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Deaktivert til neste oppstart</string>
     <!-- smartling.character_limit = 19 -->
-    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Annonseblokkering på</string>
-</resources>
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Annonseblokkering</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-nl/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-nl/strings-ad-blocking.xml
@@ -24,9 +24,9 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Opent video\'s in een afleidingsvrije theatermodus die voorkomt dat wat je bekijkt je YouTube-feed beïnvloedt.</string>
     <string name="ad_blocking_settings_title_v2">Advertentieblokkering</string>
-    <string name="ad_blocking_settings_header_description">Blokkeert invasieve trackers voordat ze worden geladen, waardoor advertenties die afhankelijk zijn van tracking effectief worden geëlimineerd</string>
+    <string name="ad_blocking_settings_header_description">We blokkeren invasieve trackers voordat ze worden geladen. Zo elimineren we effectief advertenties die afhankelijk zijn van tracking.</string>
     <string name="contingencyMessageTitle">YouTube-advertentieblokkering niet beschikbaar</string>
-    <string name="contingencyMessageContent">Door recente wijzigingen in YouTube werkt advertentieblokkering niet meer naar behoren. We werken aan een oplossing voor deze problemen. Bedankt voor je begrip.</string>
+    <string name="contingencyMessageContent">De blokkering van advertenties is beïnvloed door recente wijzigingen aan YouTube. We werken aan een oplossing voor deze problemen. Bedankt voor je begrip.</string>
     <string name="contingencyMessagePrimaryButton">Ik snap het</string>
     <string name="contingencyMessageCloseContentDescription">Sluiten</string>
     <string name="ad_blocking_menu_disable">YouTube-advertentieblokkering uitschakelen</string>
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Uitschakelen tot opnieuw opstarten</string>
     <string name="ad_blocking_menu_always_off">Altijd uit</string>
     <string name="ad_blocking_disabled_popup_title">Werkt de blokkering van YouTube-advertenties niet?</string>
-    <string name="ad_blocking_disabled_popup_description">Stuur een anoniem functioneringsrapport naar DuckDuckGo. Help mee om advertentieblokkering voor iedereen te verbeteren!</string>
+    <string name="ad_blocking_disabled_popup_description">Stuur een anoniem rapport naar DuckDuckGo en help mee om advertentieblokkering voor iedereen te verbeteren!</string>
     <string name="ad_blocking_disabled_primary_action">Functioneringsrapport verzenden</string>
     <string name="ad_blocking_disabled_secondary_action">Annuleren</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Uitgeschakeld tot opnieuw starten</string>
-    <string name="ad_blocking_omnibar_badge_text">Blokkering van YouTube-advertenties Aan</string>
-</resources>
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Ad-blokkering aan</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-pl/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-pl/strings-ad-blocking.xml
@@ -24,9 +24,9 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Otwiera filmy w trybie kinowym bez rozpraszania uwagi, który zapobiega wpływowi oglądania na Twój kanał YouTube.</string>
     <string name="ad_blocking_settings_title_v2">Blokowanie reklam</string>
-    <string name="ad_blocking_settings_header_description">Blokuje inwazyjne mechanizmy śledzące przed ich załadowaniem, skutecznie eliminując reklamy, które opierają się na śledzeniu</string>
+    <string name="ad_blocking_settings_header_description">Blokuje inwazyjne mechanizmy śledzące przed ich załadowaniem, skutecznie eliminując reklamy, które opierają się na śledzeniu.</string>
     <string name="contingencyMessageTitle">Blokowanie reklam na YouTube jest niedostępne</string>
-    <string name="contingencyMessageContent">Niedawne zmiany na YouTube wpłynęły na blokowanie reklam. Pracujemy nad rozwiązaniem tych problemów i dziękujemy za zrozumienie.</string>
+    <string name="contingencyMessageContent">Ostatnie zmiany w YouTube wpłynęły na blokowanie reklam. Pracujemy nad rozwiązaniem tych problemów i dziękujemy za zrozumienie.</string>
     <string name="contingencyMessagePrimaryButton">Rozumiem</string>
     <string name="contingencyMessageCloseContentDescription">Zamknij</string>
     <string name="ad_blocking_menu_disable">Wyłącz blokowanie reklam na YouTube</string>
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Wyłącz do czasu ponownego uruchomienia</string>
     <string name="ad_blocking_menu_always_off">Zawsze wyłączone</string>
     <string name="ad_blocking_disabled_popup_title">Blokowanie reklam w serwisie YouTube nie działa?</string>
-    <string name="ad_blocking_disabled_popup_description">Wyślij anonimowy raport o awarii do DuckDuckGo. Pomóż usprawnić blokowanie reklam u wszystkich użytkowników!</string>
+    <string name="ad_blocking_disabled_popup_description">Wyślij anonimowy raport do DuckDuckGo i pomóż usprawnić blokowanie reklam dla wszystkich!</string>
     <string name="ad_blocking_disabled_primary_action">Wyślij raport o awarii</string>
     <string name="ad_blocking_disabled_secondary_action">Anuluj</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Wyłączono do czasu ponownego uruchomienia</string>
-    <string name="ad_blocking_omnibar_badge_text">Blokowanie reklam YouTube włączone</string>
-</resources>
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Blokowanie reklam</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-pt/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-pt/strings-ad-blocking.xml
@@ -24,7 +24,7 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Abre vídeos num modo de cinema sem distrações que impede que os vídeos que vês influenciem o teu feed do YouTube.</string>
     <string name="ad_blocking_settings_title_v2">Bloqueio de anúncios</string>
-    <string name="ad_blocking_settings_header_description">Bloqueia os rastreadores invasivos antes de serem carregados, eliminando eficazmente os anúncios que usam rastreio</string>
+    <string name="ad_blocking_settings_header_description">Bloqueia os rastreadores invasivos antes de serem carregados, eliminando eficazmente os anúncios que usam o rastreio.</string>
     <string name="contingencyMessageTitle">Bloqueio de anúncios do YouTube indisponível</string>
     <string name="contingencyMessageContent">O bloqueio de anúncios foi afetado por alterações recentes ao YouTube. Estamos a trabalhar para resolver estes problemas e agradecemos a tua compreensão.</string>
     <string name="contingencyMessagePrimaryButton">Entendido</string>
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Desativar até ao relançamento</string>
     <string name="ad_blocking_menu_always_off">Sempre desativado</string>
     <string name="ad_blocking_disabled_popup_title">O bloqueio de anúncios do YouTube não funciona?</string>
-    <string name="ad_blocking_disabled_popup_description">Envia um relatório de falhas anónimo à DuckDuckGo. Ajuda a melhorar o bloqueio de anúncios para toda a gente!</string>
+    <string name="ad_blocking_disabled_popup_description">Envia um relatório anónimo à DuckDuckGo e ajuda a melhorar o bloqueio de anúncios para toda a gente!</string>
     <string name="ad_blocking_disabled_primary_action">Enviar relatório de falhas</string>
     <string name="ad_blocking_disabled_secondary_action">Cancelar</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Desativado até ao relançamento</string>
-    <string name="ad_blocking_omnibar_badge_text">Bloqueio de anúncios do YouTube ativo</string>
-</resources>
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Bloqueio de anúncio</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-ro/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-ro/strings-ad-blocking.xml
@@ -24,9 +24,9 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Deschide videoclipurile într-un mod cinematografic fără distrageri, care te împiedică să influențezi fluxul de YouTube prin ceea ce vizionezi.</string>
     <string name="ad_blocking_settings_title_v2">Blocarea reclamelor</string>
-    <string name="ad_blocking_settings_header_description">Blochează tehnologiile de urmărire invazive înainte de a se încărca, eliminând eficient reclamele care se bazează pe urmărire</string>
+    <string name="ad_blocking_settings_header_description">Blochează tehnologiile de urmărire invazive înainte de a se încărca, eliminând eficient reclamele care se bazează pe urmărire.</string>
     <string name="contingencyMessageTitle">Blocarea reclamelor pe YouTube este indisponibilă</string>
-    <string name="contingencyMessageContent">Blocarea reclamelor a fost afectată de modificările recente aduse YouTube. Lucrăm pentru a remedia aceste probleme și apreciem înțelegerea ta</string>
+    <string name="contingencyMessageContent">Blocarea reclamelor a fost afectată de modificările recente aduse YouTube. Lucrăm pentru a remedia aceste probleme și apreciem înțelegerea ta.</string>
     <string name="contingencyMessagePrimaryButton">Am înțeles</string>
     <string name="contingencyMessageCloseContentDescription">Închide</string>
     <string name="ad_blocking_menu_disable">Dezactivează blocarea reclamelor pe YouTube</string>
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Dezactivează până la relansare</string>
     <string name="ad_blocking_menu_always_off">Întotdeauna dezactivat</string>
     <string name="ad_blocking_disabled_popup_title">Blocarea reclamelor YouTube nu funcționează?</string>
-    <string name="ad_blocking_disabled_popup_description">Trimite un raport anonim despre erori către DuckDuckGo. Ajută la îmbunătățirea blocării reclamelor pentru toată lumea!</string>
+    <string name="ad_blocking_disabled_popup_description">Trimite un raport anonim către DuckDuckGo și ajută la îmbunătățirea blocării reclamelor pentru toată lumea!</string>
     <string name="ad_blocking_disabled_primary_action">Trimite raportul de erori</string>
     <string name="ad_blocking_disabled_secondary_action">Anulează</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Dezactivat până la relansare</string>
-    <string name="ad_blocking_omnibar_badge_text">Blocarea reclamelor pe YouTube este activată</string>
-</resources>
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Blocarea reclamelor a fost activată</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-ro/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-ro/strings-ad-blocking.xml
@@ -42,4 +42,4 @@
     <string name="ad_blocking_disabled_secondary_action">Anulează</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Dezactivat până la relansare</string>
     <!-- smartling.character_limit = 19 -->
-    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Blocarea reclamelor a fost activată</string></resources>
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Blocarea reclamelor</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-ru/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-ru/strings-ad-blocking.xml
@@ -24,7 +24,7 @@
     <string name="ad_blocking_settings_duck_player_header">Проигрыватель Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Открывает видео в режиме кинотеатра без отвлекающих элементов, чтобы просмотренные видео не влияли на вашу ленту YouTube.</string>
     <string name="ad_blocking_settings_title_v2">Блокировка рекламы</string>
-    <string name="ad_blocking_settings_header_description">Блокирует навязчивые трекеры до их загрузки, устраняя рекламу с отслеживанием</string>
+    <string name="ad_blocking_settings_header_description">Блокирует трекеры, следящие за вашей активностью, еще до их загрузки, фактически устраняя рекламу на основе отслеживания.</string>
     <string name="contingencyMessageTitle">Блокировка рекламы на YouTube недоступна</string>
     <string name="contingencyMessageContent">Недавние изменения на YouTube повлияли на работу блокировки рекламы. Мы занимаемся решением этой проблемы и благодарим вас за понимание.</string>
     <string name="contingencyMessagePrimaryButton">Понятно</string>
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Отключить до перезапуска</string>
     <string name="ad_blocking_menu_always_off">Всегда выключено</string>
     <string name="ad_blocking_disabled_popup_title">Блокировка рекламы на YouTube не работает?</string>
-    <string name="ad_blocking_disabled_popup_description">Отправьте анонимное сообщение о проблеме в DuckDuckGo. Помогите улучшить блокировку рекламы для всех!</string>
+    <string name="ad_blocking_disabled_popup_description">Отправьте анонимные сведения в DuckDuckGo и помогите улучшить блокировку рекламы для всех!</string>
     <string name="ad_blocking_disabled_primary_action">Сообщить о проблеме</string>
     <string name="ad_blocking_disabled_secondary_action">Отменить</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Отключено до перезапуска</string>
-    <string name="ad_blocking_omnibar_badge_text">Блокировка рекламы на YouTube включена</string>
-</resources>
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Блокировка рекламы</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-sk/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-sk/strings-ad-blocking.xml
@@ -42,4 +42,4 @@
     <string name="ad_blocking_disabled_secondary_action">Zrušiť</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Zakázané až do opätovného spustenia</string>
     <!-- smartling.character_limit = 19 -->
-    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Blokovanie reklám je zapnuté</string></resources>
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Blok. reklám zap.</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-sk/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-sk/strings-ad-blocking.xml
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Vypnúť do opätovného spustenia</string>
     <string name="ad_blocking_menu_always_off">Vždy vypnuté</string>
     <string name="ad_blocking_disabled_popup_title">Nefunguje blokovanie reklám na YouTube?</string>
-    <string name="ad_blocking_disabled_popup_description">Odošli anonymnú správu o poruche na DuckDuckGo. Pomôž zlepšiť blokovanie reklám pre všetkých!</string>
+    <string name="ad_blocking_disabled_popup_description">Odošli anonymné hlásenie na DuckDuckGo a pomôž zlepšiť blokovanie reklám pre všetkých!</string>
     <string name="ad_blocking_disabled_primary_action">Odoslať správu o poruche</string>
     <string name="ad_blocking_disabled_secondary_action">Zrušiť</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Zakázané až do opätovného spustenia</string>
-    <string name="ad_blocking_omnibar_badge_text">Blokovanie reklám na YouTube je zapnuté</string>
-</resources>
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Blokovanie reklám je zapnuté</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-sl/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-sl/strings-ad-blocking.xml
@@ -24,7 +24,7 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Videoposnetke odpre v načinu zasebnega kina, ki preprečuje, da bi vsebina, ki jo gledate, vplivala na vaša priporočila v YouTubu.</string>
     <string name="ad_blocking_settings_title_v2">Blokiranje oglasov</string>
-    <string name="ad_blocking_settings_header_description">Blokira invazivne sledilnike, še preden se naložijo, s čimer učinkovito odstrani oglase, ki temeljijo na sledenju</string>
+    <string name="ad_blocking_settings_header_description">Blokira invazivne sledilnike, še preden se naložijo, s čimer učinkovito odstrani oglase, ki temeljijo na sledenju.</string>
     <string name="contingencyMessageTitle">Blokiranje oglasov na YouTubu ni na voljo</string>
     <string name="contingencyMessageContent">Nedavne spremembe na YouTubu so vplivale na delovanje funkcije blokiranja oglasov. Prizadevamo si za odpravljanje teh težav in cenimo vaše razumevanje.</string>
     <string name="contingencyMessagePrimaryButton">Razumem</string>
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Onemogoči do vnovičnega zagona</string>
     <string name="ad_blocking_menu_always_off">Vedno izklopljeno</string>
     <string name="ad_blocking_disabled_popup_title">Ali blokiranje oglasov na YouTubu ne deluje?</string>
-    <string name="ad_blocking_disabled_popup_description">DuckDuckGo pošljite anonimno poročilo o prekinitvi delovanja. Pomagajte izboljšati blokiranje oglasov za vse uporabnike.</string>
+    <string name="ad_blocking_disabled_popup_description">Pošljite anonimno poročilo v DuckDuckGo in pomagajte izboljšati blokiranje oglasov za vse uporabnike.</string>
     <string name="ad_blocking_disabled_primary_action">Pošlji poročilo o prekinitvi delovanja</string>
     <string name="ad_blocking_disabled_secondary_action">Prekliči</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Onemogočeno do vnovičnega zagona</string>
-    <string name="ad_blocking_omnibar_badge_text">Blokiranje oglasov na YouTubu je omogočeno</string>
-</resources>
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Blokiranje oglasov</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-sv/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-sv/strings-ad-blocking.xml
@@ -24,7 +24,7 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Öppnar videor i ett störningsfritt visningsläge som förhindrar att det du tittar på påverkar ditt YouTube-flöde.</string>
     <string name="ad_blocking_settings_title_v2">Annonsblockering</string>
-    <string name="ad_blocking_settings_header_description">Blockerar invasiva spårare innan de läses in, vilket i stort sett eliminerar annonser som bygger på spårning</string>
+    <string name="ad_blocking_settings_header_description">Blockerar invasiva spårare innan de läses in, vilket effektivt eliminerar annonser som bygger på spårning.</string>
     <string name="contingencyMessageTitle">Annonsblockering på YouTube är inte tillgänglig</string>
     <string name="contingencyMessageContent">De senaste ändringarna på YouTube har påverkat annonsblockeringen. Vi jobbar på att lösa problemen och tackar för din förståelse.</string>
     <string name="contingencyMessagePrimaryButton">Jag förstår</string>
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Inaktivera till omstart</string>
     <string name="ad_blocking_menu_always_off">Alltid av</string>
     <string name="ad_blocking_disabled_popup_title">Fungerar inte annonsblockering på YouTube?</string>
-    <string name="ad_blocking_disabled_popup_description">Skicka en anonym felrapport till DuckDuckGo. Hjälp till att göra annonsblockeringen bättre för alla!</string>
+    <string name="ad_blocking_disabled_popup_description">Skicka en anonym rapport till DuckDuckGo och hjälp till att göra annonsblockeringen bättre för alla!</string>
     <string name="ad_blocking_disabled_primary_action">Skicka felrapport</string>
     <string name="ad_blocking_disabled_secondary_action">Avbryt</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Inaktiverad till omstart</string>
-    <string name="ad_blocking_omnibar_badge_text">YouTube-annonsblockering på</string>
-</resources>
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Annonsblockering på</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-tr/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-tr/strings-ad-blocking.xml
@@ -24,9 +24,9 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Videoları, izlediğiniz içeriğin YouTube akışınızı etkilemesini engelleyen, dikkat dağıtıcı unsurlardan arındırılmış bir sinema moduyla açar.</string>
     <string name="ad_blocking_settings_title_v2">Reklam Engelleme</string>
-    <string name="ad_blocking_settings_header_description">İstilacı izleyicileri yüklenmeden önce engelleyerek, izlemeye dayalı reklamları etkili bir şekilde ortadan kaldırır</string>
+    <string name="ad_blocking_settings_header_description">İstilacı izleyicileri yüklenmeden önce engelleyerek, izlemeye dayalı reklamları etkili bir şekilde ortadan kaldırır.</string>
     <string name="contingencyMessageTitle">YouTube\'da Reklam Engelleme Kullanılamıyor</string>
-    <string name="contingencyMessageContent">YouTube\'da yapılan son değişiklikler reklam engelleme özelliğini etkiledi. Bu sorunları çözmeye çalışıyoruz. Anlayışınız için teşekkür ederiz</string>
+    <string name="contingencyMessageContent">YouTube\'da yapılan son değişiklikler Reklam Engelleme özelliğini etkiledi. Bu sorunları çözmeye çalışıyoruz. Anlayışınız için teşekkür ederiz.</string>
     <string name="contingencyMessagePrimaryButton">Anladım</string>
     <string name="contingencyMessageCloseContentDescription">Kapat</string>
     <string name="ad_blocking_menu_disable">YouTube\'da Reklam Engellemeyi Devre Dışı Bırak</string>
@@ -37,9 +37,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Yeniden başlatılana kadar devre dışı bırak</string>
     <string name="ad_blocking_menu_always_off">Her Zaman Kapalı</string>
     <string name="ad_blocking_disabled_popup_title">YouTube\'da reklam engelleme çalışmıyor mu?</string>
-    <string name="ad_blocking_disabled_popup_description">DuckDuckGo\'ya anonim bir hata raporu gönderin. Reklam engellemeyi herkes için daha iyi hale getirmemize yardımcı olun!</string>
+    <string name="ad_blocking_disabled_popup_description">DuckDuckGo\'ya anonim bir rapor göndererek reklam engellemeyi herkes için daha iyi hale getirmemize yardımcı olun!</string>
     <string name="ad_blocking_disabled_primary_action">Hata Raporu Gönder</string>
     <string name="ad_blocking_disabled_secondary_action">İptal</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Yeniden başlatılana kadar devre dışı bırakıldı</string>
-    <string name="ad_blocking_omnibar_badge_text">YouTube\'da Reklam Engelleme Açık</string>
-</resources>
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Reklam Engelleme</string></resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values/strings-ad-blocking.xml
@@ -23,9 +23,9 @@
     <string name="ad_blocking_settings_duck_player_header">Duck Player</string>
     <string name="ad_blocking_settings_duck_player_description">Opens videos in a distraction-free theater mode that prevents what you watch from influencing your YouTube feed.</string>
     <string name="ad_blocking_settings_title_v2">Ad Blocking</string>
-    <string name="ad_blocking_settings_header_description">Blocks invasive trackers before they load, effectively eliminating ads that rely on tracking</string>
+    <string name="ad_blocking_settings_header_description">Blocks invasive trackers before they load, effectively eliminating ads that rely on tracking.</string>
     <string name="contingencyMessageTitle">YouTube Ad Blocking Unavailable</string>
-    <string name="contingencyMessageContent">Ad Blocking has been affected by recent changes to YouTube. We\'re working to fix these issues and appreciate your understanding</string>
+    <string name="contingencyMessageContent">Ad Blocking has been affected by recent changes to YouTube. We\'re working to fix these issues and appreciate your understanding.</string>
     <string name="contingencyMessagePrimaryButton">Got It</string>
     <string name="contingencyMessageCloseContentDescription">Close</string>
     <string name="ad_blocking_menu_disable">Disable YouTube Ad Blocking</string>
@@ -36,9 +36,9 @@
     <string name="ad_blocking_menu_disable_until_relaunch">Disable Until Relaunch</string>
     <string name="ad_blocking_menu_always_off">Always Off</string>
     <string name="ad_blocking_disabled_popup_title">YouTube Ad Blocking not working?</string>
-    <string name="ad_blocking_disabled_popup_description">Send an anonymous breakage report to DuckDuckGo. Help make ad blocking better for everyone!</string>
+    <string name="ad_blocking_disabled_popup_description">Send an anonymous report to DuckDuckGo and help make ad blocking better for everyone!</string>
     <string name="ad_blocking_disabled_primary_action">Send Breakage Report</string>
     <string name="ad_blocking_disabled_secondary_action">Cancel</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Disabled until relaunch</string>
-    <string name="ad_blocking_omnibar_badge_text">YouTube Ad Block On</string>
-</resources>
+    <!-- smartling.character_limit = 19 -->
+    <string name="ad_blocking_omnibar_badge_text" instruction="Short status pill shown in the address bar while ad blocking is active on a page. The status word (&quot;On&quot;) can be dropped if needed, since the pill only appears when blocking is active. Translation should refer to the feature, not imply ads blocked">Ad Blocking On</string></resources>

--- a/sync/sync-impl/src/main/res/values-el/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-el/strings-sync.xml
@@ -121,7 +121,7 @@
     <string name="sync_permission_required_store_recovery_code">Η αποθήκευση του PDF ανάκτησης απαιτεί άδεια αποθήκευσης</string>
     <string name="sync_share_title">Κοινή χρήση με...</string>
     <string name="sync_pdf_title">Συγχρονισμός κωδικού ανάκτησης</string>
-    <string name="sync_pdf_description">Ο κωδικός ανάκτησης σας επιτρέπει να συγχρονίζετε τους κωδικούς πρόσβασής σας, τα δεδομένα αυτόματης συμπλήρωσης και τις συνομιλίες του Duck.ai σε πολλές συσκευές και να ανακτάτε τα συγχρονισμένα δεδομένα σας εάν χάσετε την πρόσβαση σε μια συσκευή.</string>
+    <string name="sync_pdf_description">Ο κωδικός ανάκτησης σας επιτρέπει να συγχρονίζετε τους κωδικούς πρόσβασής σας, τα δεδομένα αυτόματης συμπλήρωσης και τις συνομιλίες του Duck.ai σε πολλές συσκευές και να ανακτάτε τα συγχρονισμένα δεδομένα σας εάν χάσετε την πρόσβαση σε μια συσκευή.\n\n</string>
     <string name="sync_code_box_title">Διατηρήστε αυτές τις πληροφορίες ασφαλείς.</string>
     <string name="sync_instructions_title">Πώς λειτουργεί αυτός ο κώδικας;</string>
     <string name="sync_instructions_step1">Ανοίξτε το DuckDuckGo στη συσκευή που θέλετε να συγχρονίσετε και μεταβείτε στο Sync &amp; Backup στις Ρυθμίσεις.</string>

--- a/sync/sync-impl/src/main/res/values-el/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-el/strings-sync.xml
@@ -121,7 +121,7 @@
     <string name="sync_permission_required_store_recovery_code">Η αποθήκευση του PDF ανάκτησης απαιτεί άδεια αποθήκευσης</string>
     <string name="sync_share_title">Κοινή χρήση με...</string>
     <string name="sync_pdf_title">Συγχρονισμός κωδικού ανάκτησης</string>
-    <string name="sync_pdf_description">Ο κωδικός ανάκτησης σας επιτρέπει να συγχρονίζετε τους κωδικούς πρόσβασής σας, τα δεδομένα αυτόματης συμπλήρωσης και τις συνομιλίες του Duck.ai σε πολλές συσκευές και να ανακτάτε τα συγχρονισμένα δεδομένα σας εάν χάσετε την πρόσβαση σε μια συσκευή.\n\n</string>
+    <string name="sync_pdf_description">Ο κωδικός ανάκτησης σας επιτρέπει να συγχρονίζετε τους κωδικούς πρόσβασής σας, τα δεδομένα αυτόματης συμπλήρωσης και τις συνομιλίες του Duck.ai σε πολλές συσκευές και να ανακτάτε τα συγχρονισμένα δεδομένα σας εάν χάσετε την πρόσβαση σε μια συσκευή.</string>
     <string name="sync_code_box_title">Διατηρήστε αυτές τις πληροφορίες ασφαλείς.</string>
     <string name="sync_instructions_title">Πώς λειτουργεί αυτός ο κώδικας;</string>
     <string name="sync_instructions_step1">Ανοίξτε το DuckDuckGo στη συσκευή που θέλετε να συγχρονίσετε και μεταβείτε στο Sync &amp; Backup στις Ρυθμίσεις.</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1216704740705275?focus=true
Tech Design URL (if applicable): 

### Description

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-resource-only changes with no logic updates; main review focus is UI fit for the 19-character omnibar pill and translation accuracy.
> 
> **Overview**
> Updates **returned Smartling translations** for ad-blocking copy across the default `values` bundle and many locale `strings-ad-blocking.xml` files.
> 
> The main user-visible shift is **`ad_blocking_omnibar_badge_text`**: wording moves from YouTube-specific “on” labels to shorter, generic **ad blocking** status text (e.g. English **“Ad Blocking On”**), with a **19-character** Smartling limit and an `instruction` attribute so translators treat it as an address-bar pill for the feature, not a count of blocked ads.
> 
> Several other strings get small copy edits—mostly **terminal punctuation**, **`ad_blocking_disabled_popup_description`** reframed as an anonymous **report** (not explicitly a “breakage” report), and minor locale tweaks to settings headers and YouTube contingency messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8822956480979d88780f7c2e3c2fe178bc383c1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->