### PR TITLE
Fix the Fire tabs title translation in Hungarian

### DIFF
--- a/ad-blocking/ad-blocking-impl/src/main/res/values-nb/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-nb/strings-ad-blocking.xml
@@ -34,12 +34,12 @@
     <string name="ad_blocking_menu_title">Annonseblokkering på YouTube</string>
     <string name="ad_blocking_menu_close_content_description">Lukk</string>
     <string name="ad_blocking_menu_always_on">Alltid på</string>
-    <string name="ad_blocking_menu_disable_until_relaunch">Deaktiver til relansering</string>
+    <string name="ad_blocking_menu_disable_until_relaunch">Deaktiver til neste oppstart</string>
     <string name="ad_blocking_menu_always_off">Alltid av</string>
-    <string name="ad_blocking_disabled_popup_title">Fungerer ikke annonseblokkering for YouTube?</string>
-    <string name="ad_blocking_disabled_popup_description">Send en anonym funksjonssviktrapport til DuckDuckGo. Bidra til å gjøre annonseblokkering bedre for alle!</string>
-    <string name="ad_blocking_disabled_primary_action">Send funksjonssviktrapport</string>
+    <string name="ad_blocking_disabled_popup_title">Fungerer ikke annonseblokkering på YouTube?</string>
+    <string name="ad_blocking_disabled_popup_description">Send en anonym feilrapport til DuckDuckGo. Bidra til å gjøre annonseblokkering bedre for alle!</string>
+    <string name="ad_blocking_disabled_primary_action">Send feilrapport</string>
     <string name="ad_blocking_disabled_secondary_action">Avbryt</string>
-    <string name="ad_blocking_settings_disabled_until_relaunch">Deaktivert til relansering</string>
+    <string name="ad_blocking_settings_disabled_until_relaunch">Deaktiver til neste oppstart</string>
     <string name="ad_blocking_omnibar_badge_text">Annonseblokkering på YouTube er på</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-nb/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-nb/strings-ad-blocking.xml
@@ -40,6 +40,6 @@
     <string name="ad_blocking_disabled_popup_description">Send en anonym feilrapport til DuckDuckGo. Bidra til å gjøre annonseblokkering bedre for alle!</string>
     <string name="ad_blocking_disabled_primary_action">Send feilrapport</string>
     <string name="ad_blocking_disabled_secondary_action">Avbryt</string>
-    <string name="ad_blocking_settings_disabled_until_relaunch">Deaktiver til neste oppstart</string>
+    <string name="ad_blocking_settings_disabled_until_relaunch">Deaktivert til neste oppstart</string>
     <string name="ad_blocking_omnibar_badge_text">Annonseblokkering på YouTube er på</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-nl/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-nl/strings-ad-blocking.xml
@@ -41,5 +41,5 @@
     <string name="ad_blocking_disabled_primary_action">Functioneringsrapport verzenden</string>
     <string name="ad_blocking_disabled_secondary_action">Annuleren</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Uitgeschakeld tot opnieuw starten</string>
-    <string name="ad_blocking_omnibar_badge_text">Blokkering van YouTube-advertenties aan</string>
+    <string name="ad_blocking_omnibar_badge_text">Blokkering van YouTube-advertenties Aan</string>
 </resources>

--- a/ad-blocking/ad-blocking-impl/src/main/res/values-ro/strings-ad-blocking.xml
+++ b/ad-blocking/ad-blocking-impl/src/main/res/values-ro/strings-ad-blocking.xml
@@ -41,5 +41,5 @@
     <string name="ad_blocking_disabled_primary_action">Trimite raportul de erori</string>
     <string name="ad_blocking_disabled_secondary_action">Anulează</string>
     <string name="ad_blocking_settings_disabled_until_relaunch">Dezactivat până la relansare</string>
-    <string name="ad_blocking_omnibar_badge_text">Blocarea reclamelor pe YouTube activată</string>
+    <string name="ad_blocking_omnibar_badge_text">Blocarea reclamelor pe YouTube este activată</string>
 </resources>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Нов раздел Fire</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>НОВО!</b> Изпробвайте разделите Fire, в които сърфирате, без да запазвате локална история.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Изтриване на разделите Fire и данните в тях?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Файлът не може да се отвори. Проверете за съвместимо приложение.</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -1048,5 +1048,6 @@
     <string name="fireTabsNewTabButton">Nová karta Fire</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NOVINKA!</b> Vyzkoušej karty Fire pro prohlížení bez ukládání místní historie.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Smazat karty Fire a jejich data?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Soubor nejde otevřít. Zkus vyhledat kompatibilní aplikaci.</string>
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Ny Fire-fane</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NYT!</b> Prøv Fire-faner for at surfe uden at gemme lokal historik.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Slet Fire-faner og deres data?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Kan ikke åbne filen. Kontrollér, om der er en kompatibel app.</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Neues Fire-Tab</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NEU!</b> Fire-Tabs ausprobieren, um zu surfen, ohne den lokalen Verlauf zu speichern.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Fire-Tabs und deren Daten löschen?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Datei kann nicht geöffnet werden. Nach einer kompatiblen App suchen.</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Νέα καρτέλα Fire</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>ΝΕΟ!</b> Δοκιμάστε τις καρτέλες Fire για περιήγηση χωρίς να αποθηκεύετε το τοπικό ιστορικό.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Να διαγραφούν οι καρτέλες Fire και τα δεδομένα τους;</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Δεν ήταν δυνατό το άνοιγμα του αρχείου. Ελέγξτε για μια συμβατή εφαρμογή.</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Nueva Fire tab</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>¡NUEVO!</b> Prueba Fire Tabs para navegar sin guardar el historial local.]]></string>
     <string name="singleTabFireDialogTitleFireMode">¿Eliminar Fire tabs y sus datos?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">No se puede abrir el archivo. Busca una aplicación compatible.</string>
 </resources>

--- a/app/src/main/res/values-et/strings.xml
+++ b/app/src/main/res/values-et/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Uus Fire vahekaart</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>UUS!</b> Proovi Fire vahekaarte, et sirvida ilma kohalikku ajalugu salvestamata.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Kas kustutada Fire vahekaardid ja nende andmed?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Faili ei saa avada. Otsi ühilduvat rakendust.</string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Uusi Fire-välilehti</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>UUTTA!</b> Kokeile Fire-välilehtiä selataksesi ilman paikallisen historian tallentamista.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Poistetaanko Fire-välilehdet ja niiden tiedot?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Tiedoston avaaminen ei onnistu. Tarkista yhteensopiva sovellus.</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Nouvel onglet Fire</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NOUVEAU !</b> Essayez les onglets Fire pour naviguer sans enregistrer l\'historique local.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Supprimer les onglets Fire et leurs données ?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Impossible d\'ouvrir le fichier. Vérifiez la compatibilité de l\'application.</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -1048,5 +1048,6 @@
     <string name="fireTabsNewTabButton">Nova Fire kartica</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NOVO!</b> Isprobaj Fire kartice za pregledavanje bez spremanja lokalne povijesti.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Želiš li izbrisati Fire kartice i njihove podatke?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Datoteka se ne može otvoriti. Provjerite postoji li kompatibilna aplikacija.</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -1000,7 +1000,7 @@
     <string name="browserModeToggleTabCountInfinite">∞</string>
     <string name="fireTabMenuItem">Fire-lap</string>
     <string name="fireTabNewTabPageTitle">Fire-lap</string>
-    <string name="fireTabsEmptyStateTitle">Fire-lapoka</string>
+    <string name="fireTabsEmptyStateTitle">Fire-lapok</string>
     <string name="fireTabsFeatureNoHistory">Böngéssz helyi előzmények mentése nélkül</string>
     <string name="fireTabsFeatureDifferentAccount">Jelentkezz be egy webhelyre másik fiókkal</string>
     <string name="fireTabsFeatureTroubleshoot">Oldd meg a webhelyekkel kapcsolatos problémákat</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Új Fire-lap</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>ÚJ! </b> Próbáld ki a Fire-lapokat, és böngéssz helyi előzmények mentése nélkül.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Törlöd a Fire-lapokat és az adataikat?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">A fájl nem nyitható meg. Keress kompatibilis alkalmazást.</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Nuova scheda Fire</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NOVITÀ!</b> Prova le schede Fire per navigare senza salvare la cronologia locale.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Eliminare le schede Fire e i relativi dati?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Impossibile aprire il file. Verifica la disponibilità di un\'app compatibile.</string>
 </resources>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -1048,5 +1048,6 @@
     <string name="fireTabsNewTabButton">Naujas „Fire“ skirtukas</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NAUJIENA!</b> Išbandykite „Fire“ skirtukus naršymui neišsaugant vietinės naršymo istorijos.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Ar trinti „Fire“ skirtukus ir jų duomenis?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Nepavyko atidaryti failo. Patikrinkite, ar yra suderinama programa.</string>
 </resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -1028,5 +1028,6 @@
     <string name="fireTabsNewTabButton">Jauna Fire cilne</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>JAUNUMS!</b> Izmēģini Fire Tabs, lai pārlūkotu, nesaglabājot vietējo vēsturi.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Vai dzēst Fire cilnes un to datus?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Nevar atvērt failu. Pārbaudīt saderīgu lietotni.</string>
 </resources>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Ny Fire-fane</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NYHET!</b> Prøv Fire-faner for å surfe uten å lagre lokal historikk.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Vil du slette Fire-faner og dataene i dem?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Kan ikke åpne filen. Se etter kompatibel app.</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Nieuw Fire-tabblad</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NIEUW!</b> Probeer Fire Tabs om te browsen zonder de lokale geschiedenis op te slaan.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Fire-tabbladen en hun gegevens verwijderen?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Kan bestand niet openen. Kijk of er een compatibele app is.</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1048,5 +1048,6 @@
     <string name="fireTabsNewTabButton">Nowa karta Fire</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NOWOŚĆ!</b> Wypróbuj karty Fire, aby przeglądać bez lokalnego zapisywania historii.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Usunąć karty Fire i ich dane?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Nie można otworzyć pliku. Poszukaj zgodnej aplikacji.</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Novo separador Fire</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NOVO!</b> Experimenta os separadores Fire para navegar sem guardar o histórico local.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Eliminar separadores Fire e respetivos dados?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Não é possível abrir o ficheiro. Verificar se a aplicação é compatível.</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -1028,5 +1028,6 @@
     <string name="fireTabsNewTabButton">Noua filă Fire</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NOU!</b> Încearcă filele Fire pentru a naviga fără a salva istoricul local.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Ștergi filele Fire și datele aferente?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Nu se poate deschide fișierul. Caută o aplicație compatibilă.</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1048,5 +1048,6 @@
     <string name="fireTabsNewTabButton">Новая Fire-вкладка</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>Новинка!</b> Используйте Fire-вкладки, чтобы просматривать веб-страницы без сохранения локальной истории.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Удалить Fire-вкладки и их данные?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Не удается открыть файл. Попробуйте найти совместимое приложение.</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -1048,5 +1048,6 @@
     <string name="fireTabsNewTabButton">Nová karta Fire</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NOVINKA!</b> Vyskúšaj karty Fire na prehliadanie bez ukladania do lokálnej histórie.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Chceš vymazať karty Fire a ich údaje?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Súbor sa nedá otvoriť. Vyhľadajte kompatibilnú aplikáciu.</string>
 </resources>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -1048,5 +1048,6 @@
     <string name="fireTabsNewTabButton">Nov zavihek Fire</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NOVO!</b> Preizkusite zavihke Fire za brskanje brez shranjevanja lokalne zgodovine.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Želite izbrisati zavihke Fire in njihove podatke?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Datoteke ni mogoče odpreti. Poiščite združljivo aplikacijo.</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Ny Fire-flik</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>NYTT!</b> Prova Fire-flikar för att surfa utan att spara lokal historik.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Ta bort Fire Tabs och deras data?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Det går inte att öppna filen. Sök efter en kompatibel app.</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -1008,5 +1008,6 @@
     <string name="fireTabsNewTabButton">Yeni Fire Sekmesi</string>
     <string name="fireTabsPromoTabSwitcherText"><![CDATA[<b>YENİ!</b> Yerel geçmişi kaydetmeden göz atmak için Fire Sekmelerini deneyin.]]></string>
     <string name="singleTabFireDialogTitleFireMode">Fire Sekmeleri ve verileri silinsin mi?</string>
+
     <string name="downloadsCannotOpenFileErrorMessage">Dosya açılamıyor. Uyumlu uygulama arayın.</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-bg/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-bg/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Споделяне с…</string>
     <string name="downloadsStateInProgress">В процес на изпълнение…</string>
     <string name="downloadsUndoActionName">Отмяна</string>
+    <string name="downloadsSearchHint">Търсене</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-cs/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-cs/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Sdílet s...</string>
     <string name="downloadsStateInProgress">Probíhá...</string>
     <string name="downloadsUndoActionName">Vrátit</string>
+    <string name="downloadsSearchHint">Vyhledávání</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-da/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-da/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Del med ...</string>
     <string name="downloadsStateInProgress">I gang ...</string>
     <string name="downloadsUndoActionName">Fortryd</string>
+    <string name="downloadsSearchHint">Søg</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-de/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-de/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Teilen mit …</string>
     <string name="downloadsStateInProgress">In Bearbeitung …</string>
     <string name="downloadsUndoActionName">Rückgängig machen</string>
+    <string name="downloadsSearchHint">Suche</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-el/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-el/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Κοινή χρήση με...</string>
     <string name="downloadsStateInProgress">Σε εξέλιξη...</string>
     <string name="downloadsUndoActionName">Αναίρεση</string>
+    <string name="downloadsSearchHint">Αναζήτηση</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-es/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-es/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Compartir con…</string>
     <string name="downloadsStateInProgress">En curso…</string>
     <string name="downloadsUndoActionName">Deshacer</string>
+    <string name="downloadsSearchHint">Buscar</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-et/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-et/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Jaga…</string>
     <string name="downloadsStateInProgress">Pooleli…</string>
     <string name="downloadsUndoActionName">Võta tagasi</string>
+    <string name="downloadsSearchHint">Otsi</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-fi/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-fi/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Jaa...</string>
     <string name="downloadsStateInProgress">Käynnissä…</string>
     <string name="downloadsUndoActionName">Kumoa</string>
+    <string name="downloadsSearchHint">Hae</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-fr/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-fr/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Partager avec…</string>
     <string name="downloadsStateInProgress">En cours...</string>
     <string name="downloadsUndoActionName">Annuler</string>
+    <string name="downloadsSearchHint">Rechercher</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-hr/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-hr/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Podijeli s...</string>
     <string name="downloadsStateInProgress">U tijeku...</string>
     <string name="downloadsUndoActionName">Poništi</string>
+    <string name="downloadsSearchHint">Pretraživanje</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-hu/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-hu/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Megosztás vele…</string>
     <string name="downloadsStateInProgress">Folyamatban…</string>
     <string name="downloadsUndoActionName">Visszavonás</string>
+    <string name="downloadsSearchHint">Keresés</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-it/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-it/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Condividi con…</string>
     <string name="downloadsStateInProgress">In corso…</string>
     <string name="downloadsUndoActionName">Annulla</string>
+    <string name="downloadsSearchHint">Ricerca</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-lt/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-lt/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Dalintis su...</string>
     <string name="downloadsStateInProgress">Vykdoma...</string>
     <string name="downloadsUndoActionName">Anuliuoti</string>
+    <string name="downloadsSearchHint">Paieška</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-lv/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-lv/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Kopīgot ar…</string>
     <string name="downloadsStateInProgress">Notiek...</string>
     <string name="downloadsUndoActionName">Atsaukt</string>
+    <string name="downloadsSearchHint">Meklēt</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-nb/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-nb/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Del med …</string>
     <string name="downloadsStateInProgress">Pågår…</string>
     <string name="downloadsUndoActionName">Angre</string>
+    <string name="downloadsSearchHint">Søk</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-nl/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-nl/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Delen met...</string>
     <string name="downloadsStateInProgress">Bezig...</string>
     <string name="downloadsUndoActionName">Ongedaan maken</string>
+    <string name="downloadsSearchHint">Zoeken</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-pl/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-pl/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Udostępnij…</string>
     <string name="downloadsStateInProgress">W trakcie…</string>
     <string name="downloadsUndoActionName">Cofnij</string>
+    <string name="downloadsSearchHint">Szukaj</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-pt/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-pt/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Partilhar com...</string>
     <string name="downloadsStateInProgress">Em curso…</string>
     <string name="downloadsUndoActionName">Anular</string>
+    <string name="downloadsSearchHint">Pesquisar</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-ro/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-ro/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Distribuie către...</string>
     <string name="downloadsStateInProgress">În curs...</string>
     <string name="downloadsUndoActionName">Anulează</string>
+    <string name="downloadsSearchHint">Căutare</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-ru/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-ru/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Поделиться с…</string>
     <string name="downloadsStateInProgress">Выполняется…</string>
     <string name="downloadsUndoActionName">Отменить</string>
+    <string name="downloadsSearchHint">Поиск</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-sk/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-sk/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Zdieľať s...</string>
     <string name="downloadsStateInProgress">Prebieha…</string>
     <string name="downloadsUndoActionName">Vrátenie späť</string>
+    <string name="downloadsSearchHint">Vyhľadávať</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-sl/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-sl/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Deli s/z …</string>
     <string name="downloadsStateInProgress">Poteka …</string>
     <string name="downloadsUndoActionName">Prekliči spremembe</string>
+    <string name="downloadsSearchHint">Iskanje</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-sv/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-sv/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Dela med …</string>
     <string name="downloadsStateInProgress">Pågår …</string>
     <string name="downloadsUndoActionName">Återställ</string>
+    <string name="downloadsSearchHint">Sök</string>
 </resources>

--- a/downloads/downloads-impl/src/main/res/values-tr/strings-downloads.xml
+++ b/downloads/downloads-impl/src/main/res/values-tr/strings-downloads.xml
@@ -50,4 +50,5 @@
     <string name="downloadsShareTitle">Paylaş…</string>
     <string name="downloadsStateInProgress">Devam ediyor…</string>
     <string name="downloadsUndoActionName">Geri al</string>
+    <string name="downloadsSearchHint">Arama yap</string>
 </resources>

--- a/feedback/feedback-impl/src/main/res/values-bg/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-bg/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-cs/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-cs/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-da/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-da/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-de/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-de/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-el/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-el/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-es/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-es/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-et/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-et/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-fi/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-fi/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-fr/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-fr/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-hr/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-hr/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-hu/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-hu/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-it/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-it/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-lt/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-lt/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-lv/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-lv/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-nb/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-nb/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-nl/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-nl/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-pl/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-pl/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-pt/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-pt/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-ro/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-ro/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-ru/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-ru/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-sk/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-sk/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-sl/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-sl/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-sv/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-sv/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/feedback/feedback-impl/src/main/res/values-tr/strings-feedback.xml
+++ b/feedback/feedback-impl/src/main/res/values-tr/strings-feedback.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- smartling.entity_escaping = false -->
 <!-- smartling.instruction_attributes = instruction -->
 <resources>

--- a/sync/sync-impl/src/main/res/values-el/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-el/strings-sync.xml
@@ -121,7 +121,7 @@
     <string name="sync_permission_required_store_recovery_code">Η αποθήκευση του PDF ανάκτησης απαιτεί άδεια αποθήκευσης</string>
     <string name="sync_share_title">Κοινή χρήση με...</string>
     <string name="sync_pdf_title">Συγχρονισμός κωδικού ανάκτησης</string>
-    <string name="sync_pdf_description">Ο κωδικός ανάκτησης σας επιτρέπει να συγχρονίζετε τους κωδικούς πρόσβασής σας, τα δεδομένα αυτόματης συμπλήρωσης και τις συνομιλίες του Duck.ai σε πολλές συσκευές και να ανακτάτε τα συγχρονισμένα δεδομένα σας εάν χάσετε την πρόσβαση σε μια συσκευή.</string>
+    <string name="sync_pdf_description">Ο κωδικός ανάκτησης σας επιτρέπει να συγχρονίζετε τους κωδικούς πρόσβασής σας, τα δεδομένα αυτόματης συμπλήρωσης και τις συνομιλίες του Duck.ai σε πολλές συσκευές και να ανακτάτε τα συγχρονισμένα δεδομένα σας εάν χάσετε την πρόσβαση σε μια συσκευή.\n\n</string>
     <string name="sync_code_box_title">Διατηρήστε αυτές τις πληροφορίες ασφαλείς.</string>
     <string name="sync_instructions_title">Πώς λειτουργεί αυτός ο κώδικας;</string>
     <string name="sync_instructions_step1">Ανοίξτε το DuckDuckGo στη συσκευή που θέλετε να συγχρονίσετε και μεταβείτε στο Sync &amp; Backup στις Ρυθμίσεις.</string>

--- a/sync/sync-impl/src/main/res/values-el/strings-sync.xml
+++ b/sync/sync-impl/src/main/res/values-el/strings-sync.xml
@@ -121,7 +121,7 @@
     <string name="sync_permission_required_store_recovery_code">Η αποθήκευση του PDF ανάκτησης απαιτεί άδεια αποθήκευσης</string>
     <string name="sync_share_title">Κοινή χρήση με...</string>
     <string name="sync_pdf_title">Συγχρονισμός κωδικού ανάκτησης</string>
-    <string name="sync_pdf_description">Ο κωδικός ανάκτησης σας επιτρέπει να συγχρονίζετε τους κωδικούς πρόσβασής σας, τα δεδομένα αυτόματης συμπλήρωσης και τις συνομιλίες του Duck.ai σε πολλές συσκευές και να ανακτάτε τα συγχρονισμένα δεδομένα σας εάν χάσετε την πρόσβαση σε μια συσκευή.\n\n</string>
+    <string name="sync_pdf_description">Ο κωδικός ανάκτησης σας επιτρέπει να συγχρονίζετε τους κωδικούς πρόσβασής σας, τα δεδομένα αυτόματης συμπλήρωσης και τις συνομιλίες του Duck.ai σε πολλές συσκευές και να ανακτάτε τα συγχρονισμένα δεδομένα σας εάν χάσετε την πρόσβαση σε μια συσκευή.</string>
     <string name="sync_code_box_title">Διατηρήστε αυτές τις πληροφορίες ασφαλείς.</string>
     <string name="sync_instructions_title">Πώς λειτουργεί αυτός ο κώδικας;</string>
     <string name="sync_instructions_step1">Ανοίξτε το DuckDuckGo στη συσκευή που θέλετε να συγχρονίσετε και μεταβείτε στο Sync &amp; Backup στις Ρυθμίσεις.</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1207418217763355/task/1216734979853308?focus=true

### Description

Also fixed in Smartling.

### Steps to test this PR

QA-optional


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only localization and formatting changes with no logic or behavior changes in code.
> 
> **Overview**
> This PR syncs **Smartling** translation updates across several Android string resources, with the highlighted fix for the Hungarian **Fire tabs** empty-state title (`fireTabsEmptyStateTitle`: *Fire-lapoka* → *Fire-lapok*).
> 
> **Ad-blocking (YouTube)** copy is refined in Norwegian Bokmål (e.g. “until relaunch” → “until next startup”, popup wording for *on YouTube* and “error report” vs “malfunction report”). Dutch and Romanian omnibar badge strings get small grammar/capitalization tweaks.
> 
> The **downloads** module adds localized `downloadsSearchHint` across many locales. The main **app** `strings.xml` files gain a formatting blank line before `downloadsCannotOpenFileErrorMessage` (no text change). **Feedback** locale files only change the XML declaration encoding from `utf-8` to `UTF-8`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8619db11e5f426192673e6cda5e76c2f1c846af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->