### PR TITLE
Add API Proposal CI check and contribution rules

### DIFF
--- a/.cursor/rules/contributions.mdc
+++ b/.cursor/rules/contributions.mdc
@@ -26,6 +26,22 @@ Fill in the template sections as follows:
 - **Steps to test**: reviewer-facing steps per scenario; specific enough that someone unfamiliar with the code can follow them
 - **UI changes**: before/after screenshots or recordings; write `No UI changes` in both columns for pure logic/backend changes
 
+## Tech Design
+
+Larger or cross-cutting changes — work that spans multiple modules or APIs, introduces a new integration, or otherwise can't be captured by a single self-contained API proposal — should also be backed by a **tech design** document. The tech design covers the overall approach; the API proposals cover each public surface it introduces. A big feature often has one tech design and several API proposals.
+
+**Before opening a PR for a change of this size, ask the user for the tech design link** and add it to the `Tech Design URL` field of the PR body — do not open the PR unless the tech design exists and is linked, or the user explicitly confirms that no tech design is needed. Small, self-contained changes don't need one; leave the field blank.
+
+## API Proposals
+
+Any change to a public API — a `.kt`/`.java` file under a `*-api` module's `src/main` — must be accompanied by an **approved API Proposal**. `-api` modules are the contract other modules depend on, so the team reviews the public surface before it ships.
+
+**Before opening a PR, check whether the changes touch a public API** (any `.kt`/`.java` file under a `*-api` module's `src/main`). If they do, stop and explicitly ask the user for the API Proposal link(s) — do not open the PR until they provide them. The proposal should exist and be linked before the PR goes up. If the user confirms the change does not alter the public surface (e.g. KDoc, comments, tests, dependency bumps), record `None` instead.
+
+An API Proposal is an Asana task in the [Android Proposals project](https://app.asana.com/1/137249556945/project/1212087397361015/task/1216523494440439).
+
+**In the PR:** list the proposal link(s) in the `API Proposals` field of the PR body — one per line; a single PR may carry more than one. Use `None` for the no-public-API-change case described above.
+
 ## Creating PRs
 
 Use Graphite (`gt`) to create and submit pull requests. Prefer the GT MCP when it is available; otherwise run `gt` from the terminal:

--- a/.cursor/rules/contributions.mdc
+++ b/.cursor/rules/contributions.mdc
@@ -30,11 +30,15 @@ Fill in the template sections as follows:
 
 Larger or cross-cutting changes — work that spans multiple modules or APIs, introduces a new integration, or otherwise can't be captured by a single self-contained API proposal — should also be backed by a **tech design** document. The tech design covers the overall approach; the API proposals cover each public surface it introduces. A big feature often has one tech design and several API proposals.
 
+**Surface this early.** When you first scope a change, judge whether it's cross-cutting like this. If it is, tell the user up front that a tech design will be needed, so it can be written and reviewed before implementation — don't wait until PR time to raise it.
+
 **Before opening a PR for a change of this size, ask the user for the tech design link** and add it to the `Tech Design URL` field of the PR body — do not open the PR unless the tech design exists and is linked, or the user explicitly confirms that no tech design is needed. Small, self-contained changes don't need one; leave the field blank.
 
 ## API Proposals
 
 Any change to a public API — a `.kt`/`.java` file under a `*-api` module's `src/main` — must be accompanied by an **approved API Proposal**. `-api` modules are the contract other modules depend on, so the team reviews the public surface before it ships.
+
+**Surface this early.** When you first scope a change, check whether it will touch a `-api` public surface. If it will, tell the user up front that an approved API Proposal is required, so it can be started before implementation — don't wait until PR time to raise it.
 
 **Before opening a PR, check whether the changes touch a public API** (any `.kt`/`.java` file under a `*-api` module's `src/main`). If they do, stop and explicitly ask the user for the API Proposal link(s) — do not open the PR until they provide them. The proposal should exist and be linked before the PR goes up. If the user confirms the change does not alter the public surface (e.g. KDoc, comments, tests, dependency bumps), record `None` instead.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,6 @@
 Task/Issue URL: 
 Tech Design URL (if applicable): 
+API Proposals URL(s) (if applicable):
 
 ### Description
 

--- a/.github/workflows/api-proposal-check.yml
+++ b/.github/workflows/api-proposal-check.yml
@@ -17,6 +17,11 @@ jobs:
     name: API Proposal check
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Verify API Proposal is linked for -api changes
         uses: actions/github-script@v8
         with:
@@ -65,12 +70,18 @@ jobs:
             }
 
             // --- 1. Did any -api source change? -----------------------------
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner, repo, pull_number: prNumber, per_page: 100,
-            });
-            const apiFiles = files
-              .filter(f => API_RE.test(f.filename) || (f.previous_filename && API_RE.test(f.previous_filename)))
-              .map(f => f.filename);
+            const { execFileSync } = require('child_process');
+            const baseSha = context.payload.pull_request.base.sha;
+            const headSha = context.payload.pull_request.head.sha;
+            const diff = execFileSync(
+              'git',
+              ['diff', '--name-only', '--no-renames', `${baseSha}...${headSha}`],
+              { encoding: 'utf8' },
+            );
+            const apiFiles = diff
+              .split('\n')
+              .map(f => f.trim())
+              .filter(f => API_RE.test(f));
 
             if (apiFiles.length === 0) {
               core.info('No -api source changes detected — API Proposal not required.');
@@ -109,15 +120,16 @@ jobs:
 
             const comment = [
               MARKER,
-              '### ❌ API Proposal required',
+              '### ⚠️ API Proposal reminder',
               '',
               'This PR changes the public surface of one or more `-api` modules, but the ' +
-                '**API Proposals** field of the PR description is empty.',
+                '**API Proposals** field of the PR description is empty. This is a ' +
+                'non-blocking reminder — please double-check whether a proposal is needed.',
               '',
               'Changed `-api` source files:',
               fileList,
               '',
-              '**To make this check pass**, edit the PR description and either:',
+              'To clear this reminder, edit the PR description and either:',
               '- add the approved API Proposal link(s) in the `API Proposals` field (one per line), or',
               '- write `None` there if this PR does not change the public API (e.g. KDoc, comments, tests).',
               '',
@@ -125,7 +137,7 @@ jobs:
             ].join('\n');
 
             await upsertSticky(comment);
-            core.setFailed(
+            core.warning(
               'This PR changes an -api module but the "API Proposals" field of the PR ' +
               'description is empty. Add the proposal link(s), or "None" if no public API changed.'
             );

--- a/.github/workflows/api-proposal-check.yml
+++ b/.github/workflows/api-proposal-check.yml
@@ -1,0 +1,131 @@
+name: API Proposal check
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  api_proposal_check:
+    name: API Proposal check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify API Proposal is linked for -api changes
+        uses: actions/github-script@v8
+        with:
+          script: |
+            // Any .kt/.java file under a `*-api` module's src/main is a public
+            // API surface change. Matches nested (tabs/tabs-api/...) and
+            // top-level (browser-api/...) modules; excludes :app, -impl, tests
+            // and build.gradle.
+            const API_RE = /(^|\/)[^/]+-api\/src\/main\/.+\.(kt|java)$/;
+            const MARKER = '<!-- api-proposal-check -->';
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = context.payload.pull_request.number;
+
+            // --- Sticky-comment helpers -------------------------------------
+            async function findSticky() {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner, repo, issue_number: prNumber, per_page: 100,
+              });
+              return comments.find(c => c.user?.type === 'Bot' && c.body?.includes(MARKER)) || null;
+            }
+            async function deleteSticky() {
+              try {
+                const existing = await findSticky();
+                if (existing) {
+                  await github.rest.issues.deleteComment({ owner, repo, comment_id: existing.id });
+                }
+              } catch (e) {
+                core.warning(`Could not remove previous check comment: ${e.message}`);
+              }
+            }
+            async function upsertSticky(body) {
+              try {
+                const existing = await findSticky();
+                if (existing) {
+                  await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+                } else {
+                  await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+                }
+              } catch (e) {
+                // Fork PRs run with a read-only token — commenting fails but the
+                // pass/fail status check below is still authoritative.
+                core.warning(`Could not post check comment: ${e.message}`);
+              }
+            }
+
+            // --- 1. Did any -api source change? -----------------------------
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner, repo, pull_number: prNumber, per_page: 100,
+            });
+            const apiFiles = files
+              .filter(f => API_RE.test(f.filename) || (f.previous_filename && API_RE.test(f.previous_filename)))
+              .map(f => f.filename);
+
+            if (apiFiles.length === 0) {
+              core.info('No -api source changes detected — API Proposal not required.');
+              await deleteSticky();
+              return;
+            }
+            core.info(`Detected ${apiFiles.length} changed -api source file(s).`);
+
+            // --- 2. Is the "API Proposals" field filled in? -----------------
+            // Match the field label up to its colon so it tolerates the
+            // "URL(s) (if applicable)" suffix used in the PR template (and stays
+            // backward-compatible with a bare "API Proposals:").
+            const body = context.payload.pull_request.body || '';
+            const noComments = body.replace(/<!--[\s\S]*?-->/g, '');
+            const label = noComments.match(/API Proposals[^\n:]*:/i);
+            let section = '';
+            if (label) {
+              section = noComments.slice(label.index + label[0].length);
+              const heading = section.search(/\n\s*###/); // stop at the next PR-body heading
+              if (heading !== -1) section = section.slice(0, heading);
+            }
+            const hasLink = /https?:\/\/\S+/i.test(section);
+            const hasNone = /\b(none|n\/?a)\b/i.test(section);
+            const satisfied = hasLink || hasNone;
+
+            // --- 3. Report --------------------------------------------------
+            if (satisfied) {
+              core.info('API Proposals section is filled in — check passed.');
+              await deleteSticky();
+              return;
+            }
+
+            const shown = apiFiles.slice(0, 40);
+            const fileList = shown.map(f => '- `' + f + '`').join('\n')
+              + (apiFiles.length > shown.length ? `\n- …and ${apiFiles.length - shown.length} more` : '');
+
+            const comment = [
+              MARKER,
+              '### ❌ API Proposal required',
+              '',
+              'This PR changes the public surface of one or more `-api` modules, but the ' +
+                '**API Proposals** field of the PR description is empty.',
+              '',
+              'Changed `-api` source files:',
+              fileList,
+              '',
+              '**To make this check pass**, edit the PR description and either:',
+              '- add the approved API Proposal link(s) in the `API Proposals` field (one per line), or',
+              '- write `None` there if this PR does not change the public API (e.g. KDoc, comments, tests).',
+              '',
+              'See the *API Proposals* section in `.cursor/rules/contributions.mdc` for details.',
+            ].join('\n');
+
+            await upsertSticky(comment);
+            core.setFailed(
+              'This PR changes an -api module but the "API Proposals" field of the PR ' +
+              'description is empty. Add the proposal link(s), or "None" if no public API changed.'
+            );

--- a/.github/workflows/api-proposal-check.yml
+++ b/.github/workflows/api-proposal-check.yml
@@ -37,7 +37,6 @@ jobs:
             const repo = context.repo.repo;
             const prNumber = context.payload.pull_request.number;
 
-            // --- Sticky-comment helpers -------------------------------------
             async function findSticky() {
               const comments = await github.paginate(github.rest.issues.listComments, {
                 owner, repo, issue_number: prNumber, per_page: 100,
@@ -63,13 +62,11 @@ jobs:
                   await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
                 }
               } catch (e) {
-                // Fork PRs run with a read-only token — commenting fails but the
-                // pass/fail status check below is still authoritative.
+                // Fork PRs run with a read-only token, so commenting may fail.
                 core.warning(`Could not post check comment: ${e.message}`);
               }
             }
 
-            // --- 1. Did any -api source change? -----------------------------
             const { execFileSync } = require('child_process');
             const baseSha = context.payload.pull_request.base.sha;
             const headSha = context.payload.pull_request.head.sha;
@@ -90,7 +87,6 @@ jobs:
             }
             core.info(`Detected ${apiFiles.length} changed -api source file(s).`);
 
-            // --- 2. Is the "API Proposals" field filled in? -----------------
             // Match the field label up to its colon so it tolerates the
             // "URL(s) (if applicable)" suffix used in the PR template (and stays
             // backward-compatible with a bare "API Proposals:").
@@ -107,7 +103,6 @@ jobs:
             const hasNone = /\b(none|n\/?a)\b/i.test(section);
             const satisfied = hasLink || hasNone;
 
-            // --- 3. Report --------------------------------------------------
             if (satisfied) {
               core.info('API Proposals section is filled in — check passed.');
               await deleteSticky();

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,12 @@ and the Gradle version in `gradle/wrapper/gradle-wrapper.properties`.
 
 ---
 
+## Before you implement
+
+Before writing code, assess whether the change will touch a public `-api` surface or is cross-cutting (spans multiple modules / adds a new integration). If so, tell the user at planning time that it will need an approved **API Proposal** and/or **Tech Design** — start these before implementation, don't surface them for the first time at PR time. See the *API Proposals* and *Tech Design* sections of `.cursor/rules/contributions.mdc`.
+
+---
+
 ## Build System
 
 ### Module Discovery

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,9 @@ Thank you for taking the time to contribute to DuckDuckGo! :sparkles:
 
 We are pleased to open up the project to you - our community. How can you contribute?
 
+## Internal contributors
+If you're an internal contributor please read the [contributions.mdc](.cursor/rules/contributions.mdc) "API Proposals" and "Tech Design" sections. Any change in the `api` should be accompanied by an API Proposal. Any change that is more complex and involves multiple components should be accompanied by a Tech Design.
+
 ## Improve translations
 We are introducing support for additional languages and would like your help in improving the translations. Please see [improving translations](TRANSLATIONS.md) for how you can help us.
 

--- a/modal-coordinator/modal-coordinator-api/src/main/java/com/duckduckgo/modalcoordinator/api/ModalEvaluator.kt
+++ b/modal-coordinator/modal-coordinator-api/src/main/java/com/duckduckgo/modalcoordinator/api/ModalEvaluator.kt
@@ -28,6 +28,8 @@ interface ModalEvaluator {
      */
     val priority: Int
 
+    val test: String
+
     /**
      * Unique identifier for this evaluator, used for tracking completion timestamps.
      */

--- a/modal-coordinator/modal-coordinator-api/src/main/java/com/duckduckgo/modalcoordinator/api/ModalEvaluator.kt
+++ b/modal-coordinator/modal-coordinator-api/src/main/java/com/duckduckgo/modalcoordinator/api/ModalEvaluator.kt
@@ -28,8 +28,6 @@ interface ModalEvaluator {
      */
     val priority: Int
 
-    val test: String
-
     /**
      * Unique identifier for this evaluator, used for tracking completion timestamps.
      */


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214901934989258/task/1216567840454275?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description

Enforces the existing (but previously undocumented) rule that any change to a public API must come with an API Proposal, and documents it for contributors and LLM agents.

- **New workflow `.github/workflows/api-proposal-check.yml`** — on every PR, detects changes to `.kt`/`.java` files under a `*-api` module's `src/main`. If any are found, it requires the PR body's `API Proposals` field to contain a link (or `None`); otherwise it posts a sticky comment explaining how to fix it. When no `-api` source changed it passes immediately.
- **PR template** — new `API Proposals URL(s) (if applicable):` field.
- **`.cursor/rules/contributions.mdc`** — new **Tech Design** and **API Proposals** sections instructing agents to ask the user for the tech design / API Proposal link(s) *before* opening a PR (the CI check is the safety net, not the discovery mechanism).

### Steps to test this PR

_API Proposal check_
- [ ] Open a test PR that edits a `.kt`/`.java` file under any `*-api/src/main` with the `API Proposals` field left empty → the `API Proposal check` fails and a sticky comment appears listing the changed `-api` files.
- [ ] Edit the PR body to put a link (or `None`) in the `API Proposals` field → re-run passes and the sticky comment is removed.
- [ ] Open a PR that touches only `:app`/`-impl`/test files → the check passes with no comment.

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to PR templates, contributor docs, and a read-only GitHub Actions check with PR comments—no app runtime or build logic.
> 
> **Overview**
> Documents and automates the rule that **public `-api` surface changes** need an approved API Proposal (and that larger work may need a **Tech Design**), so contributors and agents surface links before PRs instead of only at review time.
> 
> Adds a **GitHub Actions** workflow that diffs PRs for `.kt`/`.java` under `*-api/src/main`; when matches exist, it expects the PR body’s **API Proposals** field to include a URL or `None`, otherwise it posts/updates a **sticky bot comment** listing changed files (non-blocking warning). The **PR template** gains `API Proposals URL(s)`, and **contributions.mdc**, **AGENTS.md**, and **CONTRIBUTING.md** spell out early planning, field usage, and when to use `None`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91001987261f4a99260b8942e7d1dd85ec01591d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->