### PR TITLE
Ensure all Maestro test suites run even if earlier one failed for release-blocking tests

### DIFF
--- a/.github/workflows/e2e-nightly-full-suite.yml
+++ b/.github/workflows/e2e-nightly-full-suite.yml
@@ -112,6 +112,8 @@ jobs:
 
       - name: Autofill Critical Path
         id: maestro-autofill-critical
+        # Run regardless of earlier suite failures, but only if the release binary uploaded.
+        if: ${{ !cancelled() && steps.maestro-upload-release-binary.outcome == 'success' }}
         uses: ./.github/actions/maestro-cloud-asana-reporter
         timeout-minutes: 120
         with:
@@ -134,6 +136,8 @@ jobs:
 
       - name: Custom tabs flows
         id: maestro-custom-tabs
+        # Run regardless of earlier suite failures, but only if the internal binary uploaded.
+        if: ${{ !cancelled() && steps.maestro-upload-internal-binary.outcome == 'success' }}
         uses: ./.github/actions/maestro-cloud-asana-reporter
         timeout-minutes: 120
         with:
@@ -156,6 +160,8 @@ jobs:
 
       - name: Internal Privacy Tests
         id: maestro-internal-privacy
+        # Run regardless of earlier suite failures, but only if the internal binary uploaded.
+        if: ${{ !cancelled() && steps.maestro-upload-internal-binary.outcome == 'success' }}
         uses: ./.github/actions/maestro-cloud-asana-reporter
         timeout-minutes: 120
         with:
@@ -178,6 +184,8 @@ jobs:
 
       - name: Onboarding flows
         id: maestro-onboarding
+        # Run regardless of earlier suite failures, but only if the release binary uploaded.
+        if: ${{ !cancelled() && steps.maestro-upload-release-binary.outcome == 'success' }}
         uses: ./.github/actions/maestro-cloud-asana-reporter
         timeout-minutes: 120
         with:
@@ -200,6 +208,8 @@ jobs:
 
       - name: Internal Onboarding Flows
         id: maestro-internal-onboarding
+        # Run regardless of earlier suite failures, but only if the internal binary uploaded.
+        if: ${{ !cancelled() && steps.maestro-upload-internal-binary.outcome == 'success' }}
         uses: ./.github/actions/maestro-cloud-asana-reporter
         timeout-minutes: 120
         with:
@@ -222,6 +232,8 @@ jobs:
 
       - name: Deeplink tests
         id: maestro-deeplink
+        # Run regardless of earlier suite failures, but only if the release binary uploaded.
+        if: ${{ !cancelled() && steps.maestro-upload-release-binary.outcome == 'success' }}
         uses: ./.github/actions/maestro-cloud-asana-reporter
         timeout-minutes: 120
         with:
@@ -244,6 +256,8 @@ jobs:
 
       - name: Ad click detection flows
         id: maestro-ad-click
+        # Run regardless of earlier suite failures, but only if the release binary uploaded.
+        if: ${{ !cancelled() && steps.maestro-upload-release-binary.outcome == 'success' }}
         uses: ./.github/actions/maestro-cloud-asana-reporter
         timeout-minutes: 120
         with:
@@ -266,6 +280,8 @@ jobs:
 
       - name: Privacy Tests
         id: maestro-privacy
+        # Run regardless of earlier suite failures, but only if the release binary uploaded.
+        if: ${{ !cancelled() && steps.maestro-upload-release-binary.outcome == 'success' }}
         uses: ./.github/actions/maestro-cloud-asana-reporter
         timeout-minutes: 120
         with:
@@ -288,6 +304,8 @@ jobs:
 
       - name: Security Tests
         id: maestro-security
+        # Run regardless of earlier suite failures, but only if the release binary uploaded.
+        if: ${{ !cancelled() && steps.maestro-upload-release-binary.outcome == 'success' }}
         uses: ./.github/actions/maestro-cloud-asana-reporter
         timeout-minutes: 120
         with:
@@ -310,6 +328,8 @@ jobs:
 
       - name: Release Tests
         id: maestro-release
+        # Run regardless of earlier suite failures, but only if the release binary uploaded.
+        if: ${{ !cancelled() && steps.maestro-upload-release-binary.outcome == 'success' }}
         uses: ./.github/actions/maestro-cloud-asana-reporter
         timeout-minutes: 120
         with:
@@ -332,6 +352,8 @@ jobs:
 
       - name: Unified Input Field
         id: maestro-unified-input
+        # Run regardless of earlier suite failures, but only if the internal binary uploaded.
+        if: ${{ !cancelled() && steps.maestro-upload-internal-binary.outcome == 'success' }}
         uses: ./.github/actions/maestro-cloud-asana-reporter
         timeout-minutes: 120
         with:
@@ -354,6 +376,8 @@ jobs:
 
       - name: Notifications permissions Android 13+
         id: maestro-notification-permissions
+        # Run regardless of earlier suite failures, but only if the release binary uploaded.
+        if: ${{ !cancelled() && steps.maestro-upload-release-binary.outcome == 'success' }}
         uses: ./.github/actions/maestro-cloud-asana-reporter
         timeout-minutes: 120
         with:


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211760946270935/task/1216563765664300?focus=true
Tech Design URL (if applicable): 

### Description

We have two main maestro test runs 
- a release-blocking one ([GHA](https://github.com/duckduckgo/Android/actions/workflows/e2e-nightly-full-suite.yml))
- a non-release-blocking one ([GHA](https://github.com/duckduckgo/Android/actions/workflows/e2e-nightly-non-blockers-suite.yml))

Each test run is made up of multiple test suites (e.g., adClick tests, autofill tests etc...). For release-blocking, when a test suite fails we prematurely end the test run. 
- This leads to quicker failure feedback but at a cost of masking future errors; we can end up fixing one problem only to later discover there were always more to fix, and had we known them all could have fixed them all sooner.
- This differs from non-release-blocking, which is already running them all thanks to [✓ Update non-release blocking tests to run independently](https://app.asana.com/1/137249556945/project/1211724162604201/task/1215827024665943?focus=true)

This PR makes the two GHA consistent, in that all Maestro test suites are executed even if earlier test suite failed

> [!NOTE]
> Every step in a job implicitly has `if: success()` unless you write something else. `success()` means "all previous steps in this job succeeded." so by providing the `if` in this PR we are overriding that default behaviour.


### Steps to test this PR
- QA optional
- There is test run here: https://github.com/duckduckgo/Android/actions/runs/29825428179/job/88617571319

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow orchestration only; no app or test logic changes. Slightly longer nightly runs when early suites fail, but improves release signal coverage.
> 
> **Overview**
> Nightly full-suite E2E workflow steps no longer stop when an earlier Maestro suite fails. Each downstream Maestro job now has an explicit **`if`** so it still runs unless the workflow was cancelled or the required binary upload did not succeed.
> 
> Release-APK suites (autofill critical path, onboarding, deeplinks, ad click, privacy, security, release, notification permissions) gate on **`steps.maestro-upload-release-binary.outcome == 'success'`**. Internal-APK suites (custom tabs, internal privacy, internal onboarding, unified input) gate on **`steps.maestro-upload-internal-binary.outcome == 'success'`**. Both use **`!cancelled()`** so cancelled runs do not keep executing tests.
> 
> This should surface failures across all release-blocking nightly suites in one run instead of hiding later suites behind the first failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 043bc5dc5baf34d0ca37d97c8bd4a847c9c1b37c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->