### PR TITLE
Update content scope scripts to version 15.19.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@duckduckgo/autoconsent": "^16.9.0",
         "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
-        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.18.0",
+        "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.19.0",
         "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
         "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@duckduckgo/autoconsent": {
-      "version": "16.12.0",
-      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.12.0.tgz",
-      "integrity": "sha512-vnMf56yESKE0MIX5PHxrTqjXjij/dO8ddgvI5yz64jbbbAIzkBiYiNu2vaM83urtgBuggfVUc5cZ5aC+XDW6kA==",
+      "version": "16.13.0",
+      "resolved": "https://registry.npmjs.org/@duckduckgo/autoconsent/-/autoconsent-16.13.0.tgz",
+      "integrity": "sha512-6IoNy3Ii/B4MarBy5ekRs4ZZUOMqLChELKmQ/BYFyiARAXSyno39ORHHVIoGKUHNsHt398d3jKJHE2gDgxWTxw==",
       "license": "MPL-2.0",
       "dependencies": {
         "tldts-experimental": "^7.4.3"
@@ -61,7 +61,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/@duckduckgo/content-scope-scripts": {
-      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#c757cf8afc2c89aedeb7cd8eeb84044239b088b3",
+      "resolved": "git+ssh://git@github.com/duckduckgo/content-scope-scripts.git#3011e9e06cc68d3f9c2cd7b00aadabcd34d2869a",
       "license": "Apache-2.0",
       "workspaces": [
         "injected",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@duckduckgo/autofill": "github:duckduckgo/duckduckgo-autofill#19.2.0",
     "@duckduckgo/autoconsent": "^16.9.0",
-    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.18.0",
+    "@duckduckgo/content-scope-scripts": "github:duckduckgo/content-scope-scripts#15.19.0",
     "@duckduckgo/privacy-dashboard": "github:duckduckgo/privacy-dashboard#9.0.0",
     "@duckduckgo/privacy-reference-tests": "github:duckduckgo/privacy-reference-tests#1766162897"
   }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1216777305773439

- Automated content scope scripts dependency update

This PR updates the content scope scripts dependency to the latest available version and copies the necessary files.

Tests will only run if something has changed in the `node_modules/@duckduckgo/content-scope-scripts` folder.

If only the package version has changed, there is no need to run the tests.

If tests have failed, see https://app.asana.com/0/1202561462274611/1203986899650836/f for further information on what to do next.

_`content-scope-scripts` folder update_
- [ ] All tests must pass
- [ ] Privacy tests must pass

_Only `content-scope-scripts` package update_
- [ ] All tests must pass
- [ ] Privacy tests do not need to run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency version pin only; privacy test scope depends on whether bundled `content-scope-scripts` assets changed, per the PR checklist.
> 
> **Overview**
> Bumps **`@duckduckgo/content-scope-scripts`** from **15.18.0** to **15.19.0** in `package.json` and refreshes `package-lock.json` to the new git ref.
> 
> The lockfile also resolves **`@duckduckgo/autoconsent`** to **16.13.0** (from 16.12.0), likely from a full lock refresh rather than an explicit dependency change in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72fa9f5a73bdc94bdcea3bde5e49d1c981e978b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->