### PR TITLE
Return device fron SyncThisDeviceContract

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceContract.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceContract.kt
@@ -18,12 +18,9 @@ package com.duckduckgo.sync.impl.ui.v2
 
 import android.content.Context
 import android.content.Intent
-import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.core.content.IntentCompat
 import com.duckduckgo.sync.impl.ConnectedDevice
-import com.duckduckgo.sync.impl.DeviceType
-import kotlinx.parcelize.Parcelize
 
 class EditDeviceContract : ActivityResultContract<EditDeviceContract.Input, EditDeviceContract.Output>() {
     override fun createIntent(
@@ -77,29 +74,5 @@ class EditDeviceContract : ActivityResultContract<EditDeviceContract.Input, Edit
         const val RESULT_SYNC_TURNED_OFF = 202
 
         fun resultIntent(device: ConnectedDevice) = Intent().putExtra(DEVICE_KEY, ParcelableDevice.fromConnectedDevice(device))
-    }
-}
-
-@Parcelize
-data class ParcelableDevice(
-    val id: String,
-    val name: String,
-    val factor: String,
-    val isThisDevice: Boolean,
-) : Parcelable {
-    fun toConnectedDevice() = ConnectedDevice(
-        deviceId = id,
-        deviceName = name,
-        deviceType = DeviceType(factor),
-        thisDevice = isThisDevice,
-    )
-
-    companion object {
-        fun fromConnectedDevice(device: ConnectedDevice) = ParcelableDevice(
-            id = device.deviceId,
-            name = device.deviceName,
-            factor = device.deviceType.deviceFactor,
-            isThisDevice = device.thisDevice,
-        )
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ParcelableDevice.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/ParcelableDevice.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui.v2
+
+import android.os.Parcelable
+import com.duckduckgo.sync.impl.ConnectedDevice
+import com.duckduckgo.sync.impl.DeviceType
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class ParcelableDevice(
+    val id: String,
+    val name: String,
+    val factor: String,
+    val isThisDevice: Boolean,
+) : Parcelable {
+    fun toConnectedDevice() = ConnectedDevice(
+        deviceId = id,
+        deviceName = name,
+        deviceType = DeviceType(factor),
+        thisDevice = isThisDevice,
+    )
+
+    companion object {
+        fun fromConnectedDevice(device: ConnectedDevice) = ParcelableDevice(
+            id = device.deviceId,
+            name = device.deviceName,
+            factor = device.deviceType.deviceFactor,
+            isThisDevice = device.thisDevice,
+        )
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/RecoveryCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/RecoveryCodeActivity.kt
@@ -49,7 +49,7 @@ class RecoveryCodeActivity : DuckDuckGoActivity() {
                         updateMargins(top = 60, bottom = 60)
                     }
                     setTextColor(Color.BLACK)
-                    text = "Recovery codes placeholder"
+                    text = "Connected device: ${intent.getStringExtra("device")}"
                 },
             )
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
@@ -118,7 +118,8 @@ class SyncActivity : DuckDuckGoActivity() {
         when (result) {
             is SyncThisDeviceContract.Output.BackedUp -> {
                 viewModel.onDeviceConnected()
-                startActivity(Intent(this, RecoveryCodeActivity::class.java))
+                val intent = Intent(this, RecoveryCodeActivity::class.java).putExtra("device", result.device.deviceName)
+                startActivity(intent)
             }
 
             is SyncThisDeviceContract.Output.Canceled -> {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
@@ -116,17 +116,17 @@ class SyncActivity : DuckDuckGoActivity() {
         SyncThisDeviceContract(),
     ) { result ->
         when (result) {
-            SyncThisDeviceContract.Output.BackedUp -> {
+            is SyncThisDeviceContract.Output.BackedUp -> {
                 viewModel.onDeviceConnected()
                 startActivity(Intent(this, RecoveryCodeActivity::class.java))
             }
 
-            SyncThisDeviceContract.Output.Canceled -> {
+            is SyncThisDeviceContract.Output.Canceled -> {
                 viewModel.onSyncThisDeviceCanceled()
                 viewModel.onConnectionCancelled()
             }
 
-            SyncThisDeviceContract.Output.RequestSyncWithAnotherDevice -> {
+            is SyncThisDeviceContract.Output.RequestSyncWithAnotherDevice -> {
                 viewModel.onSyncThisDeviceCanceled()
                 viewModel.onConnectionCancelled()
             }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncThisDeviceActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncThisDeviceActivity.kt
@@ -34,6 +34,8 @@ import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.databinding.ActivitySyncV2ThisDeviceBinding
+import com.duckduckgo.sync.impl.ui.v2.SyncThisDeviceContract.Companion.RESULT_DEVICE_BACKED_UP
+import com.duckduckgo.sync.impl.ui.v2.SyncThisDeviceContract.Companion.RESULT_SYNC_WITH_ANOTHER_DEVICE
 import com.duckduckgo.sync.impl.wideevents.SyncSetupWideEvent
 import com.google.android.material.progressindicator.CircularProgressIndicatorSpec
 import com.google.android.material.progressindicator.IndeterminateDrawable
@@ -117,7 +119,7 @@ class SyncThisDeviceActivity : DuckDuckGoActivity() {
             }
 
             is SyncThisDeviceViewModel.Command.FinishSyncing -> {
-                setResult(RESULT_OK)
+                setResult(RESULT_DEVICE_BACKED_UP, SyncThisDeviceContract.resultIntent(command.device))
                 finish()
             }
 
@@ -176,8 +178,6 @@ class SyncThisDeviceActivity : DuckDuckGoActivity() {
     }
 
     companion object {
-        const val RESULT_SYNC_WITH_ANOTHER_DEVICE = 200
-
         private const val LAUNCH_SOURCE_EXTRA_KEY = "launch_source"
 
         fun intent(

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncThisDeviceContract.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncThisDeviceContract.kt
@@ -16,10 +16,11 @@
 
 package com.duckduckgo.sync.impl.ui.v2
 
-import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
+import androidx.core.content.IntentCompat
+import com.duckduckgo.sync.impl.ConnectedDevice
 import com.duckduckgo.sync.impl.ui.v2.SyncThisDeviceContract.Input
 import com.duckduckgo.sync.impl.ui.v2.SyncThisDeviceContract.Output
 import com.duckduckgo.sync.impl.ui.v2.SyncThisDeviceContract.Output.BackedUp
@@ -39,8 +40,15 @@ class SyncThisDeviceContract : ActivityResultContract<Input, Output>() {
         intent: Intent?,
     ): Output {
         return when (resultCode) {
-            Activity.RESULT_OK -> BackedUp
-            SyncThisDeviceActivity.RESULT_SYNC_WITH_ANOTHER_DEVICE -> RequestSyncWithAnotherDevice
+            RESULT_DEVICE_BACKED_UP -> {
+                val device = intent
+                    ?.let { IntentCompat.getParcelableExtra(it, DEVICE_KEY, ParcelableDevice::class.java) }
+                    ?.toConnectedDevice()
+                if (device != null) BackedUp(device) else Canceled
+            }
+
+            RESULT_SYNC_WITH_ANOTHER_DEVICE -> RequestSyncWithAnotherDevice
+
             else -> Canceled
         }
     }
@@ -49,9 +57,21 @@ class SyncThisDeviceContract : ActivityResultContract<Input, Output>() {
         val source: String?,
     )
 
-    enum class Output {
-        BackedUp,
-        Canceled,
-        RequestSyncWithAnotherDevice,
+    sealed interface Output {
+        data class BackedUp(
+            val device: ConnectedDevice,
+        ) : Output
+
+        data object Canceled : Output
+
+        data object RequestSyncWithAnotherDevice : Output
+    }
+
+    companion object {
+        const val DEVICE_KEY = "device"
+        const val RESULT_DEVICE_BACKED_UP = 200
+        const val RESULT_SYNC_WITH_ANOTHER_DEVICE = 201
+
+        fun resultIntent(device: ConnectedDevice) = Intent().putExtra(DEVICE_KEY, ParcelableDevice.fromConnectedDevice(device))
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncThisDeviceViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncThisDeviceViewModel.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.sync.impl.ConnectedDevice
 import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncAccountRepository
@@ -54,15 +55,29 @@ class SyncThisDeviceViewModel @Inject constructor(
 
         viewModelScope.launch(dispatchers.io()) {
             syncSetupWideEvent.onSyncEnabled()
+
+            suspend fun getDeviceAndFinish() {
+                val device = syncAccountRepository.getThisConnectedDevice()
+                if (device != null) {
+                    _commands.send(Command.FinishSyncing(device))
+                } else {
+                    syncSetupWideEvent.onAccountCreationFailed()
+                    _commands.send(
+                        Command.ShowError(R.string.sync_create_account_generic_error),
+                    )
+                }
+            }
+
             if (syncAccountRepository.isSignedIn()) {
-                _commands.send(Command.FinishSyncing)
+                getDeviceAndFinish()
             } else {
                 when (val result = syncAccountRepository.createAccount()) {
                     is Result.Success<*> -> {
                         syncSetupWideEvent.onAccountCreated()
                         syncPixels.fireSignupDirectPixel(source)
-                        _commands.send(Command.FinishSyncing)
+                        getDeviceAndFinish()
                     }
+
                     is Result.Error -> {
                         syncSetupWideEvent.onAccountCreationFailed()
                         _commands.send(
@@ -108,7 +123,9 @@ class SyncThisDeviceViewModel @Inject constructor(
     )
 
     sealed interface Command {
-        data object FinishSyncing : Command
+        data class FinishSyncing(
+            val device: ConnectedDevice,
+        ) : Command
 
         data object SyncWithAnotherDevice : Command
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/SyncThisDeviceViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/SyncThisDeviceViewModelTest.kt
@@ -18,6 +18,8 @@ package com.duckduckgo.sync.impl.ui.v2
 
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.sync.impl.ConnectedDevice
+import com.duckduckgo.sync.impl.DeviceType
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.pixels.SyncPixels
@@ -27,8 +29,10 @@ import com.duckduckgo.sync.impl.ui.v2.SyncThisDeviceViewModel.Command.ShowError
 import com.duckduckgo.sync.impl.ui.v2.SyncThisDeviceViewModel.Command.SyncWithAnotherDevice
 import com.duckduckgo.sync.impl.wideevents.SyncSetupWideEvent
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.mock
@@ -42,6 +46,13 @@ class SyncThisDeviceViewModelTest {
     @get:Rule
     val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
 
+    private val connectedDevice = ConnectedDevice(
+        thisDevice = true,
+        deviceName = "Device Name",
+        deviceId = "device-id",
+        deviceType = DeviceType(deviceFactor = "phone"),
+    )
+
     private val syncAccountRepository = mock<SyncAccountRepository>()
     private val syncPixels = mock<SyncPixels>()
     private val syncSetupWideEvent = mock<SyncSetupWideEvent>()
@@ -53,6 +64,11 @@ class SyncThisDeviceViewModelTest {
         syncSetupWideEvent,
     )
 
+    @Before
+    fun setup() {
+        whenever(syncAccountRepository.getThisConnectedDevice()).thenReturn(connectedDevice)
+    }
+
     @Test
     fun `when the user is already signed in then syncing finishes`() = runTest {
         whenever(syncAccountRepository.isSignedIn()).thenReturn(true)
@@ -60,6 +76,18 @@ class SyncThisDeviceViewModelTest {
         testee.commands.test {
             testee.syncThisDevice(source = null)
             assertIs<FinishSyncing>(awaitItem())
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when syncing finishes then the connected device is included`() = runTest {
+        whenever(syncAccountRepository.isSignedIn()).thenReturn(true)
+
+        testee.commands.test {
+            testee.syncThisDevice(source = null)
+            assertEquals(connectedDevice, (awaitItem() as FinishSyncing).device)
 
             cancel()
         }
@@ -165,6 +193,34 @@ class SyncThisDeviceViewModelTest {
             assertIs<ShowError>(awaitItem())
 
             verifyNoInteractions(syncPixels)
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when the connected device cannot be retrieved then an error is shown`() = runTest {
+        whenever(syncAccountRepository.isSignedIn()).thenReturn(true)
+        whenever(syncAccountRepository.getThisConnectedDevice()).thenReturn(null)
+
+        testee.commands.test {
+            testee.syncThisDevice(source = null)
+            assertIs<ShowError>(awaitItem())
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when the connected device cannot be retrieved then the account creation failed event is tracked`() = runTest {
+        whenever(syncAccountRepository.isSignedIn()).thenReturn(true)
+        whenever(syncAccountRepository.getThisConnectedDevice()).thenReturn(null)
+
+        testee.commands.test {
+            testee.syncThisDevice(source = null)
+            skipItems(1)
+
+            verify(syncSetupWideEvent).onAccountCreationFailed()
 
             cancel()
         }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216103556496795/task/1216777745759901?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1216103556496795/task/1216509582049467?focus=true

### Description

Extends the simplified Sync This Device flow so its contract returns the newly connected device to the caller, and displays that device's name on the recovery code placeholder screen. This is needed as the new designs of recovery codes display the connected device name.

Contract:
- `SyncThisDeviceContract.Output` becomes a sealed interface — `BackedUp` now carries the `ConnectedDevice`. The result is parsed from a dedicated `RESULT_DEVICE_BACKED_UP` code plus a `ParcelableDevice` extra (built via the new `resultIntent(device)` helper); a missing device extra is treated as `Canceled`.
- The `RESULT_SYNC_WITH_ANOTHER_DEVICE` code moved from `SyncThisDeviceActivity` into the contract's companion, so all result codes live next to the contract that interprets them.
- `ParcelableDevice` moved out of `EditDeviceContract.kt` into its own top-level file, since it's now shared by both the edit-device and sync-this-device contracts.

ViewModel:
- `Command.FinishSyncing` now carries the `ConnectedDevice`, fetched via `SyncAccountRepository.getThisConnectedDevice()` after sign-in or account creation. If the device can't be retrieved, the generic error dialog is shown and the account creation failure is reported to the wide event.

UI:
- `SyncActivity` passes the returned device name to `RecoveryCodeActivity`, whose placeholder text now shows `Connected device: <name>`. Contract outputs are referenced via full imports in the result callbacks.

### Steps to test this PR

_Return the connected device_
- [ ] Open Sync Dev Settings → Launch Sync Settings V2.
- [ ] Tap Sync This Device and complete the flow.
- [ ] The recovery code placeholder screen opens and shows "Connected device: <this device's name>".

### UI changes
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Sync v2 UI and activity-result wiring with added ViewModel tests; no changes to sync auth, encryption, or server APIs.
> 
> **Overview**
> **Sync This Device** now returns the **`ConnectedDevice`** to callers when backup succeeds, so the recovery-code step can show the connected device name.
> 
> `SyncThisDeviceContract.Output` is a sealed interface: **`BackedUp`** carries the device, parsed from **`RESULT_DEVICE_BACKED_UP`** and a **`ParcelableDevice`** intent extra (missing extra → **`Canceled`**). Result codes and **`resultIntent(device)`** live on the contract companion; **`ParcelableDevice`** is extracted to its own file for reuse with **`EditDeviceContract`**.
> 
> **`SyncThisDeviceViewModel`** loads **`getThisConnectedDevice()`** after sign-in or account creation before finishing; a null device shows the generic error and fires the account-creation-failed wide event.
> 
> **`SyncActivity`** forwards **`deviceName`** into **`RecoveryCodeActivity`**; the placeholder UI shows **Connected device: &lt;name&gt;**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0528cc504029479be23a0c913692b6d4a425229. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->