### PR TITLE
Android/Contextual/NativeInput: Enable to internal

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -327,6 +327,6 @@ interface DuckChatFeature {
      * the legacy input for INPUT mode while still using the native widget in WEBVIEW (in-chat) mode.
      * When native chat input is off, this has no effect (everything falls back to legacy/web input).
      */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
     fun contextualNativeInput(): Toggle
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1216749666596866?focus=true
Tech Design URL (if applicable): 

### Description
Enable nativeinput for contextual sheet to INTERNAL

### Steps to test this PR
Qa-optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single annotation default change on a gated Duck.ai UI toggle; no logic or security surface changes in this diff.
> 
> **Overview**
> Changes the **`contextualNativeInput`** remote-feature default from **`FALSE`** to **`INTERNAL`** on `DuckChatFeature`.
> 
> When remote config omits this sub-flag, the contextual Duck.ai sheet’s initial **INPUT** state will now follow the same **internal-by-default** rollout pattern as related flags (`nativeChatInput`, `nativeInputField`), instead of staying off until explicitly enabled. Behavior when the flag is present in remote config is unchanged; only the fallback default moves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6151f24c899872cad4097f2ad4f3e4adcfbdb3be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->