### PR TITLE
Only add merged PRs targetting default branch to waiting for release

### DIFF
--- a/.github/workflows/action-pr-merged.yaml
+++ b/.github/workflows/action-pr-merged.yaml
@@ -1,17 +1,27 @@
-name: Mark task as complete on merge
+name: Mark task as complete and move PRs merged to the default branch to Waiting for release
 
 on:
   pull_request:
     types: [closed]
 
 jobs:
-  add-pr-merged-comment:
+  add-pr-comment-and-move-to-section:
     runs-on: ubuntu-latest
     steps:
-      - uses: duckduckgo/native-github-asana-sync@v2.0
+      - name: Add PR merged comment
+        uses: duckduckgo/native-github-asana-sync@v2.0
         if: github.event.pull_request.merged
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           trigger-phrase: "Task/Issue URL:"
           action: 'notify-pr-merged'
           is-complete: true
+      - name: If merged to the default branch, add to Waiting for release
+        if: github.event.pull_request.merged && github.event.pull_request.base.ref == github.event.repository.default_branch
+        uses: duckduckgo/native-github-asana-sync@v2.0
+        with:
+          asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
+          asana-project: ${{ vars.GH_ANDROID_RELEASE_BOARD_PROJECT_ID }}
+          asana-section: ${{ vars.GH_ANDROID_RELEASE_BOARD_WAITING_FOR_RELEASE_SECTION_ID }}
+          trigger-phrase: "Task/Issue URL:"
+          action: 'add-task-asana-project'


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211760946270935/task/1214505597588360?focus=true
Tech Design URL (if applicable): 

### Description

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Asana sync with an extra branch guard; no app runtime or credential changes beyond existing secret/var usage.
> 
> **Overview**
> Updates **`action-pr-merged.yaml`** so release-board automation matches merge intent: merged PRs still get the usual **notify / complete** Asana step, while the **“Waiting for release”** move is a separate step that runs only when **`base.ref` equals the repository default branch**.
> 
> The workflow/job naming is aligned with that behavior (clearer step names; job renamed from `add-pr-merged-comment` to `add-pr-comment-and-move-to-section`). Merges into non-default branches no longer land in the release waiting section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65a545115484d5290513e34df5ca5efd48cb73e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->