### PR TITLE
Android/Contextual: Reset sheet when contextual chat has been deleted

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -48,6 +48,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -208,7 +209,6 @@ class DuckChatContextualViewModel @Inject constructor(
             }
             if (isContextualSheetImprovementsEnabled) {
                 observeRecentChats()
-                observeCurrentChatDeletion()
             }
         }
 
@@ -217,35 +217,10 @@ class DuckChatContextualViewModel @Inject constructor(
             .launchIn(viewModelScope)
     }
 
-    // Last chat id we confirmed exists in history. A brand-new chat sets _chatId (from the loaded
-    // URL) before it is persisted, so "absent from history" only means "deleted" once we've actually
-    // seen it present — this field is what distinguishes the two.
-    private var lastSeenChatId: String? = null
-
-    private fun observeCurrentChatDeletion() {
-        combine(chatHistoryRepository.observeChats(), _chatId) { chats, currentChatId ->
-            currentChatId to chats.any { it.chatId == currentChatId }
-        }
-            .flowOn(dispatchers.io())
-            .onEach { (currentChatId, isPresent) ->
-                if (isPresent) {
-                    lastSeenChatId = currentChatId
-                } else if (currentChatId != null && currentChatId == lastSeenChatId && _viewState.value.sheetMode == SheetMode.WEBVIEW) {
-                    // A chat we had seen in history is now gone -> deleted elsewhere. Clear
-                    // synchronously so repeat emissions for the same id don't retrigger before the
-                    // reset propagates to _chatId/sheetMode.
-                    lastSeenChatId = null
-                    handleLoadedChatDeleted()
-                }
-            }
-            .launchIn(viewModelScope)
-    }
-
-    private fun handleLoadedChatDeleted() {
-        logcat { "Duck.ai Contextual: loaded chat deleted elsewhere, resetting sheet" }
-        // Reset session/state but leave the sheet position untouched (sheetState = null):
-        // if visible it swaps to INPUT in place; if hidden it stays hidden and opens fresh next time.
-        renderNewChatState(sheetState = null)
+    private suspend fun isStoredChatMissingFromHistory(url: String?): Boolean {
+        val chatId = extractChatId(url) ?: return false
+        val chats = chatHistoryRepository.observeChats().firstOrNull() ?: return false
+        return chats.none { it.chatId == chatId }
     }
 
     private fun observeRecentChats() {
@@ -316,6 +291,10 @@ class DuckChatContextualViewModel @Inject constructor(
             return
         }
         val existingChatUrl = contextualDataStore.getTabChatUrl(tabId)
+        if (isStoredChatMissingFromHistory(existingChatUrl)) {
+            renderNewChatState()
+            return
+        }
         withContext(dispatchers.main()) {
             commandChannel.trySend(Command.ChangeSheetState(BottomSheetBehavior.STATE_EXPANDED))
         }
@@ -381,7 +360,8 @@ class DuckChatContextualViewModel @Inject constructor(
                 return@launch
             }
 
-            val shouldReuseUrl = shouldReuseStoredChatUrl(tabId)
+            val shouldReuseUrl = shouldReuseStoredChatUrl(tabId) &&
+                !isStoredChatMissingFromHistory(existingChatUrl)
             if (shouldReuseUrl) {
                 logcat { "Duck.ai: tab=$tabId has an existing url and don't need to restart the session" }
                 val hasChatHistory = hasChatId(existingChatUrl)

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -1274,6 +1274,7 @@ class DuckChatContextualViewModelTest {
         val tabId = "tab-1"
         val storedUrl = "https://duck.ai/chat?chatID=123"
         contextualDataStore.persistTabChatUrl(tabId, storedUrl)
+        recentChatsFlow.value = listOf(fakeChat("123", "Chat", 1L))
 
         testee.commands.test {
             testee.onSheetOpened(tabId)
@@ -1400,6 +1401,7 @@ class DuckChatContextualViewModelTest {
         val tabId = "tab-1"
         val storedUrl = "https://duck.ai/chat?chatID=abc-123"
         contextualDataStore.persistTabChatUrl(tabId, storedUrl)
+        recentChatsFlow.value = listOf(fakeChat("abc-123", "Chat", 1L))
 
         testee.onSheetOpened(tabId)
         coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
@@ -1412,6 +1414,7 @@ class DuckChatContextualViewModelTest {
         val tabId = "tab-1"
         val storedUrl = "https://duck.ai/chat?chatID=abc-123"
         contextualDataStore.persistTabChatUrl(tabId, storedUrl)
+        recentChatsFlow.value = listOf(fakeChat("abc-123", "Chat", 1L))
         testee.onSheetOpened(tabId)
         coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
 
@@ -1441,6 +1444,7 @@ class DuckChatContextualViewModelTest {
         val tabId = "tab-1"
         val storedUrl = "https://duck.ai/chat?chatID=abc-123"
         contextualDataStore.persistTabChatUrl(tabId, storedUrl)
+        recentChatsFlow.value = listOf(fakeChat("abc-123", "Chat", 1L))
         testee.onSheetOpened(tabId)
         coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
         assertEquals("abc-123", testee.chatId.value)
@@ -2527,77 +2531,13 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
-    fun `when loaded chat deleted elsewhere then sheet resets to input without forcing sheet open`() = runTest {
+    fun `when sheet opened and stored chat was deleted while away then sheet resets to input`() = runTest {
         whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
-        recentChatsFlow.value = listOf(fakeChat("current", "Current", 10L), fakeChat("a", "A", 5L))
+        recentChatsFlow.value = listOf(fakeChat("other", "Other", 5L))
+        contextualDataStore.persistTabChatUrl("tab-1", "https://duckduckgo.com/?chatID=current")
         val testee = buildViewModel()
+
         testee.onSheetOpened("tab-1")
-        testee.onPromptSent("hi")
-        testee.onChatPageLoaded("https://duckduckgo.com/?chatID=current")
-        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
-        assertEquals("current", testee.chatId.value)
-
-        testee.commands.test {
-            expectMostRecentItem() // drain setup commands
-            recentChatsFlow.value = listOf(fakeChat("a", "A", 5L)) // current chat deleted elsewhere
-            coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
-            expectNoEvents() // no ChangeSheetState command -> sheet position untouched
-            cancelAndIgnoreRemainingEvents()
-        }
-
-        assertEquals(DuckChatContextualViewModel.SheetMode.INPUT, testee.viewState.value.sheetMode)
-        assertNull(testee.chatId.value)
-        assertNull(contextualDataStore.getTabChatUrl("tab-1"))
-        verify(duckChatJSHelper).onNativeAction(NativeAction.NEW_CHAT)
-    }
-
-    @Test
-    fun `when brand new chat not yet persisted then sheet is not reset`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
-        recentChatsFlow.value = emptyList()
-        val testee = buildViewModel()
-        testee.onSheetOpened("tab-1")
-        testee.onPromptSent("hi")
-        testee.onChatPageLoaded("https://duckduckgo.com/?chatID=new")
-        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
-
-        // List changes but never contained the new chat -> it was never seen, so do not treat as deletion.
-        recentChatsFlow.value = listOf(fakeChat("unrelated", "Unrelated", 1L))
-        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
-
-        assertEquals(DuckChatContextualViewModel.SheetMode.WEBVIEW, testee.viewState.value.sheetMode)
-        assertEquals("new", testee.chatId.value)
-        verify(duckChatJSHelper, never()).onNativeAction(NativeAction.NEW_CHAT)
-    }
-
-    @Test
-    fun `when a different chat is deleted then loaded chat sheet is not reset`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
-        recentChatsFlow.value = listOf(fakeChat("current", "Current", 10L), fakeChat("other", "Other", 5L))
-        val testee = buildViewModel()
-        testee.onSheetOpened("tab-1")
-        testee.onPromptSent("hi")
-        testee.onChatPageLoaded("https://duckduckgo.com/?chatID=current")
-        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
-
-        recentChatsFlow.value = listOf(fakeChat("current", "Current", 10L)) // a different chat deleted
-        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
-
-        assertEquals(DuckChatContextualViewModel.SheetMode.WEBVIEW, testee.viewState.value.sheetMode)
-        assertEquals("current", testee.chatId.value)
-    }
-
-    @Test
-    fun `when all chats deleted while a chat is loaded then sheet resets to input`() = runTest {
-        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
-        recentChatsFlow.value = listOf(fakeChat("current", "Current", 10L))
-        val testee = buildViewModel()
-        testee.onSheetOpened("tab-1")
-        testee.onPromptSent("hi")
-        testee.onChatPageLoaded("https://duckduckgo.com/?chatID=current")
-        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
-
-        recentChatsFlow.value = emptyList() // e.g. clear-all / fire button
         coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(DuckChatContextualViewModel.SheetMode.INPUT, testee.viewState.value.sheetMode)
@@ -2606,41 +2546,32 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
-    fun `when chat history keeps updating after a deletion then sheet is reset only once`() = runTest {
+    fun `when sheet opened and stored chat still in history then session is restored to webview`() = runTest {
         whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         recentChatsFlow.value = listOf(fakeChat("current", "Current", 10L))
+        contextualDataStore.persistTabChatUrl("tab-1", "https://duckduckgo.com/?chatID=current")
         val testee = buildViewModel()
+
         testee.onSheetOpened("tab-1")
-        testee.onPromptSent("hi")
-        testee.onChatPageLoaded("https://duckduckgo.com/?chatID=current")
         coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
 
-        recentChatsFlow.value = emptyList() // loaded chat deleted -> reset
-        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
-        // Further history emissions that still lack the (now cleared) chat must not retrigger the reset.
-        recentChatsFlow.value = listOf(fakeChat("unrelated", "Unrelated", 1L))
-        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
-
-        assertEquals(DuckChatContextualViewModel.SheetMode.INPUT, testee.viewState.value.sheetMode)
-        verify(duckChatJSHelper, times(1)).onNativeAction(NativeAction.NEW_CHAT)
+        assertEquals(DuckChatContextualViewModel.SheetMode.WEBVIEW, testee.viewState.value.sheetMode)
+        assertEquals("current", testee.chatId.value)
     }
 
     @Test
-    fun `when improvements disabled and loaded chat deleted then sheet is not reset`() = runTest {
+    fun `when improvements disabled and stored chat was deleted while away then sheet still resets to input`() = runTest {
         whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(false)
-        recentChatsFlow.value = listOf(fakeChat("current", "Current", 10L))
-        val testee = buildViewModel()
-        testee.onSheetOpened("tab-1")
-        testee.onPromptSent("hi")
-        testee.onChatPageLoaded("https://duckduckgo.com/?chatID=current")
-        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
-
         recentChatsFlow.value = emptyList()
+        contextualDataStore.persistTabChatUrl("tab-1", "https://duckduckgo.com/?chatID=current")
+        val testee = buildViewModel()
+
+        testee.onSheetOpened("tab-1")
         coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
 
-        // Deletion observation is gated behind contextualSheetImprovements, so nothing resets when it is off.
-        assertEquals(DuckChatContextualViewModel.SheetMode.WEBVIEW, testee.viewState.value.sheetMode)
-        assertEquals("current", testee.chatId.value)
+        assertEquals(DuckChatContextualViewModel.SheetMode.INPUT, testee.viewState.value.sheetMode)
+        assertNull(testee.chatId.value)
+        assertNull(contextualDataStore.getTabChatUrl("tab-1"))
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1216752685086432?focus=true
Tech Design URL (if applicable): 

### Description
 - When the contextual Duck.ai sheet reopens onto a stored session whose chat is no longer in history (deleted while the sheet was away), it now resets to the input state instead of restoring WEBVIEW mode on a chat that no longer loads.
  - The check runs synchronously at session-restore time in onSheetOpened and reopenWebViewState (isStoredChatMissingFromHistory), so a dead chat URL is never loaded into the WebView.
  - Removed the live observeCurrentChatDeletion observer (plus handleLoadedChatDeleted and lastSeenChatId) in favor of the restore-time check — the reset now happens on next open rather than live. There are no real scenarios when this could happen (aside from chat sync - but that is  very edge case)


### Steps to test this PR
Test: 
- https://app.asana.com/1/137249556945/task/1215727998445071/comment/1215764372557473?focus=true to ensure this scenario is still fixed - original observe was added for this scenario
- https://app.asana.com/1/137249556945/project/1202552961248957/task/1216662041783905?focus=true - issue to be fixed


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches contextual session restore and WebView load paths; UX differs from live reset (deletion while sheet is open is deferred until reopen), and a brand-new chat not yet in history could be treated as missing if opened before persistence.
> 
> **Overview**
> **Replaces live “chat deleted elsewhere” handling with a restore-time check** so the contextual sheet does not reopen into **WEBVIEW** on a stored URL whose `chatID` is no longer in chat history.
> 
> The flow observer (`observeCurrentChatDeletion`, `lastSeenChatId`, `handleLoadedChatDeleted`) is removed. **`isStoredChatMissingFromHistory`** compares the stored URL’s chat id to a one-shot read of `chatHistoryRepository.observeChats()` and, when missing, calls **`renderNewChatState()`** from **`onSheetOpened`** and **`reopenWebViewState`** instead of loading the dead URL. Session reuse now requires both a valid timeout and the chat still being in history.
> 
> **Behavior change:** reset happens on the **next open/reopen**, not while the sheet stays visible with a loaded chat. The deletion check is **not** gated on `contextualSheetImprovements` (tests cover improvements on and off). Unit tests were narrowed to open-time scenarios; restore tests seed history when reusing stored URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 195e8ebeee9dff76f2642996d8ef7e7b8d9bf01b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->