### PR TITLE
[Android]: Add impression pixels for "ask about page"

### DIFF
--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -1457,5 +1457,12 @@
         "triggers": ["other"],
         "suffixes": ["first_daily_count", "form_factor"],
         "parameters": ["appVersion"]
+    },
+    "m_aichat_contextual_quick_action_ask_about_page_shown": {
+        "description": "The Ask About Page quick action pill was shown in the Contextual sheet",
+        "owners": ["karlenDimla"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": ["appVersion"]
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -301,6 +301,9 @@ class DuckChatContextualViewModel @Inject constructor(
                 withContext(dispatchers.main()) {
                     logcat { "Duck.ai: reopenSheet in Input mode" }
                     commandChannel.trySend(Command.ChangeSheetState(BottomSheetBehavior.STATE_HALF_EXPANDED))
+                    if (_viewState.value.showsAskAboutPageQuickAction()) {
+                        duckChatPixels.reportContextualAskAboutPageShown()
+                    }
                 }
             }
         }
@@ -377,6 +380,9 @@ class DuckChatContextualViewModel @Inject constructor(
                 }
                 if (_viewState.value.showsAttachContextPlaceholder()) {
                     duckChatPixels.reportContextualPlaceholderContextShown()
+                }
+                if (_viewState.value.showsAskAboutPageQuickAction()) {
+                    duckChatPixels.reportContextualAskAboutPageShown()
                 }
                 return@launch
             }
@@ -654,6 +660,9 @@ class DuckChatContextualViewModel @Inject constructor(
         if (_viewState.value.showsAttachContextPlaceholder()) {
             duckChatPixels.reportContextualPlaceholderContextShown()
         }
+        if (_viewState.value.showsAskAboutPageQuickAction()) {
+            duckChatPixels.reportContextualAskAboutPageShown()
+        }
         duckChatPixels.reportContextualPageContextRemovedNative()
     }
 
@@ -716,6 +725,10 @@ class DuckChatContextualViewModel @Inject constructor(
         sheetMode == SheetMode.INPUT &&
             quickActionState != QuickActionState.ASK_ABOUT_PAGE &&
             !showContext
+
+    private fun ViewState.showsAskAboutPageQuickAction(): Boolean =
+        sheetMode == SheetMode.INPUT &&
+            quickActionState == QuickActionState.ASK_ABOUT_PAGE
 
     fun replacePrompt(
         input: String,
@@ -1022,6 +1035,9 @@ class DuckChatContextualViewModel @Inject constructor(
 
                     if (sheetState == BottomSheetBehavior.STATE_HALF_EXPANDED && _viewState.value.showsAttachContextPlaceholder()) {
                         duckChatPixels.reportContextualPlaceholderContextShown()
+                    }
+                    if (sheetState == BottomSheetBehavior.STATE_HALF_EXPANDED && _viewState.value.showsAskAboutPageQuickAction()) {
+                        duckChatPixels.reportContextualAskAboutPageShown()
                     }
 
                     val subscriptionEvent = duckChatJSHelper.onNativeAction(NativeAction.NEW_CHAT)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -129,6 +129,7 @@ interface DuckChatPixels {
     fun reportContextualSettingAutomaticPageContentToggled(enabled: Boolean)
     fun reportContextualSummarizePromptSelected()
     fun reportContextualAskAboutPageSelected()
+    fun reportContextualAskAboutPageShown()
     fun reportContextualChatsMenuTapped()
     fun reportContextualRecentChatsPopupDisplayed()
     fun reportContextualRecentChatSelected()
@@ -404,6 +405,13 @@ class RealDuckChatPixels @Inject constructor(
         appCoroutineScope.launch(dispatcherProvider.io()) {
             pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_QUICK_ACTION_ASK_ABOUT_PAGE_SELECTED_COUNT)
             pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_QUICK_ACTION_ASK_ABOUT_PAGE_SELECTED_DAILY, type = Pixel.PixelType.Daily())
+        }
+    }
+
+    override fun reportContextualAskAboutPageShown() {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_QUICK_ACTION_ASK_ABOUT_PAGE_SHOWN_COUNT)
+            pixel.fire(DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_QUICK_ACTION_ASK_ABOUT_PAGE_SHOWN_DAILY, type = Pixel.PixelType.Daily())
         }
     }
 
@@ -893,6 +901,8 @@ enum class DuckChatPixelName(override val pixelName: String) : Pixel.PixelName {
     DUCK_CHAT_CONTEXTUAL_QUICK_ACTION_SUMMARISE_SELECTED_DAILY("m_aichat_contextual_quick_action_summarize_selected_daily"),
     DUCK_CHAT_CONTEXTUAL_QUICK_ACTION_ASK_ABOUT_PAGE_SELECTED_COUNT("m_aichat_contextual_quick_action_ask_about_page_selected_count"),
     DUCK_CHAT_CONTEXTUAL_QUICK_ACTION_ASK_ABOUT_PAGE_SELECTED_DAILY("m_aichat_contextual_quick_action_ask_about_page_selected_daily"),
+    DUCK_CHAT_CONTEXTUAL_QUICK_ACTION_ASK_ABOUT_PAGE_SHOWN_COUNT("m_aichat_contextual_quick_action_ask_about_page_shown_count"),
+    DUCK_CHAT_CONTEXTUAL_QUICK_ACTION_ASK_ABOUT_PAGE_SHOWN_DAILY("m_aichat_contextual_quick_action_ask_about_page_shown_daily"),
     DUCK_CHAT_CONTEXTUAL_CHATS_BUTTON_TAPPED_COUNT("m_aichat_contextual_chats_button_tapped_count"),
     DUCK_CHAT_CONTEXTUAL_CHATS_BUTTON_TAPPED_DAILY("m_aichat_contextual_chats_button_tapped_daily"),
     DUCK_CHAT_CONTEXTUAL_RECENT_CHATS_POPUP_DISPLAYED_COUNT("m_aichat_contextual_recent_chats_popup_displayed_count"),
@@ -1179,6 +1189,8 @@ class DuckChatParamRemovalPlugin @Inject constructor() : PixelParamRemovalPlugin
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_QUICK_ACTION_SUMMARISE_SELECTED_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_QUICK_ACTION_ASK_ABOUT_PAGE_SELECTED_COUNT.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_QUICK_ACTION_ASK_ABOUT_PAGE_SELECTED_DAILY.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_QUICK_ACTION_ASK_ABOUT_PAGE_SHOWN_COUNT.pixelName to PixelParameter.removeAtb(),
+            DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_QUICK_ACTION_ASK_ABOUT_PAGE_SHOWN_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_CHATS_BUTTON_TAPPED_COUNT.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_CHATS_BUTTON_TAPPED_DAILY.pixelName to PixelParameter.removeAtb(),
             DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_RECENT_CHATS_POPUP_DISPLAYED_COUNT.pixelName to PixelParameter.removeAtb(),

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -1099,6 +1099,62 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
+    fun `when sheet opened fresh with improvements enabled then ask about page shown pixel fired`() = runTest {
+        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        val testee = buildViewModel()
+
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        verify(duckChatPixels).reportContextualAskAboutPageShown()
+    }
+
+    @Test
+    fun `when sheet opened in legacy mode then ask about page shown pixel not fired`() = runTest {
+        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(false)
+        val testee = buildViewModel()
+
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        verify(duckChatPixels, never()).reportContextualAskAboutPageShown()
+    }
+
+    @Test
+    fun `when sheet reopened in input mode with improvements enabled then ask about page shown pixel fired`() = runTest {
+        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.onSheetReopened()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        // Once when the sheet is opened, once when it is reopened showing the pill again.
+        verify(duckChatPixels, times(2)).reportContextualAskAboutPageShown()
+    }
+
+    @Test
+    fun `when page context removed reverting to ask about page then shown pixel fired`() = runTest {
+        whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
+        whenever(duckChatInternal.isAutomaticContextAttachmentEnabled()).thenReturn(false)
+        val testee = buildViewModel()
+        testee.onSheetOpened("tab-1")
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+        val pageContext = """{"title":"Page","url":"https://example.com","content":"text"}"""
+        testee.onPageContextReceived("tab-1", pageContext)
+        testee.onQuickActionClicked("") // ASK_ABOUT_PAGE -> SUBMIT_SUMMARIZE, attaches context
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.removePageContext()
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        assertEquals(DuckChatContextualViewModel.QuickActionState.ASK_ABOUT_PAGE, testee.viewState.value.quickActionState)
+        // Once when the sheet is opened, once when removing the attachment reverts the pill to Ask About Page.
+        verify(duckChatPixels, times(2)).reportContextualAskAboutPageShown()
+    }
+
+    @Test
     fun `when prompt sent then attached page context is cleared from input`() = runTest {
         whenever(contextualSheetImprovementsToggle.isEnabled()).thenReturn(true)
         val testee = buildViewModel()

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsTest.kt
@@ -48,6 +48,8 @@ import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_CONTEXTUAL
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PROMPT_SUBMITTED_WITHOUT_CONTEXT_NATIVE_DAILY
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PROMPT_SUBMITTED_WITH_CONTEXT_NATIVE_COUNT
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_PROMPT_SUBMITTED_WITH_CONTEXT_NATIVE_DAILY
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_QUICK_ACTION_ASK_ABOUT_PAGE_SHOWN_COUNT
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_QUICK_ACTION_ASK_ABOUT_PAGE_SHOWN_DAILY
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_QUICK_ACTION_SUMMARISE_SELECTED_COUNT
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_QUICK_ACTION_SUMMARISE_SELECTED_DAILY
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName.DUCK_CHAT_CONTEXTUAL_SETTING_AUTOMATIC_PAGE_CONTENT_DISABLED_COUNT
@@ -333,6 +335,16 @@ class RealDuckChatPixelsTest {
 
         verify(mockPixel).fire(DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_SHOWN_COUNT)
         verify(mockPixel).fire(DUCK_CHAT_CONTEXTUAL_PAGE_CONTEXT_PLACEHOLDER_SHOWN_DAILY, type = Pixel.PixelType.Daily())
+    }
+
+    @Test
+    fun `when reportContextualAskAboutPageShown then fires count and daily`() = runTest {
+        testee.reportContextualAskAboutPageShown()
+
+        advanceUntilIdle()
+
+        verify(mockPixel).fire(DUCK_CHAT_CONTEXTUAL_QUICK_ACTION_ASK_ABOUT_PAGE_SHOWN_COUNT)
+        verify(mockPixel).fire(DUCK_CHAT_CONTEXTUAL_QUICK_ACTION_ASK_ABOUT_PAGE_SHOWN_DAILY, type = Pixel.PixelType.Daily())
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1216590095234411?focus=true 
Tech Design URL (if applicable): 

### Description
Adds the `m_aichat_contextual_quick_action_ask_about_page_shown` impression pixel (count + daily), tracking when the Ask About Page quick action pill is displayed in the Contextual sheet.
  - Fires the pixel whenever the pill becomes visible in INPUT mode: when the sheet is opened, when it's reopened, on new/reset chat, and when the user removes an attachment and the pill reverts to Ask About Page.

### Steps to test this PR
Setup
  - [x] Filter `Pixel sent: m_aichat_contextual` from your logcat

  1. Sheet opened fresh (no prior chat on tab)
  - [x] Open the Contextual sheet on a tab with no existing chat session
  - [x] The Ask about page quick action pill IS visible in INPUT mode
  - [x] `m_aichat_contextual_quick_action_ask_about_page_shown_count` fires once
  - [x] `m_aichat_contextual_quick_action_ask_about_page_shown_daily` fires (first time that day)

  2. Sheet reopened in INPUT mode
  - [x] From case 1 (still in INPUT mode), dismiss the sheet then reopen it on the same tab
  - [x] The Ask about page pill IS visible again
  - [x] `m_aichat_contextual_quick_action_ask_about_page_shown_count` fires again on reopen

  3. Remove attachment reverts pill to Ask About Page
  - [x] With automatic context attachment OFF, tap the Ask about page pill to attach context (pill becomes Summarize/submit state, context chip shown)
  - [x] `m_aichat_contextual_quick_action_ask_about_page_shown_count` is NOT fired
  - [x] Remove the attached page context
  - [x] The quick action pill reverts to Ask about page and IS visible
  - [x] `m_aichat_contextual_quick_action_ask_about_page_shown_count` fires on removal
  - [x] Attach context again (click Ask about page)
  - [x] Close the sheet and re-open
  - [x] Verify summarize quick action is shown 
  - [x] `m_aichat_contextual_quick_action_ask_about_page_shown_count` is NOT fired

  4. New/reset chat
  - [x] With the sheet open, trigger a new chat (chats/new-chat icon) so the sheet resets to INPUT half-expanded (You need a few chat history items to have this option)
  - [x] The Ask about page pill IS visible
  - [x] `m_aichat_contextual_quick_action_ask_about_page_shown_count` fires on the reset

  5. Existing chat restored (WebView mode)
  - [x] Open the sheet on a tab that has an active chat session so it restores directly into WebView mode
  - [x] The Ask about page pill is NOT visible
  - [x] `m_aichat_contextual_quick_action_ask_about_page_shown_count` NOT fire

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only changes with no product logic or data-handling impact; behavior is covered by unit tests.
> 
> **Overview**
> Adds **impression** analytics for the contextual sheet’s **Ask About Page** quick-action pill, complementing the existing tap pixel (`ask_about_page_selected`).
> 
> A new pixel `m_aichat_contextual_quick_action_ask_about_page_shown` (with count/daily variants) is registered in pixel definitions and wired through `reportContextualAskAboutPageShown()`. `DuckChatContextualViewModel` fires it when the pill would be visible—using a new `showsAskAboutPageQuickAction()` guard (INPUT mode + `QuickActionState.ASK_ABOUT_PAGE`)—on fresh sheet open, reopen in input mode, after removing attached page context (pill returns), and when starting a new chat at half-expanded.
> 
> Unit tests assert firing only when contextual sheet improvements are enabled and cover reopen/remove-context paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34819084355df73b49834a8534b1d89d8fcfc33b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->