### PR TITLE
Bump gh-asana sync version to support trigger phrase

### DIFF
--- a/.github/workflows/action-pr-merged.yaml
+++ b/.github/workflows/action-pr-merged.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add PR merged comment
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         if: github.event.pull_request.merged
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
@@ -18,7 +18,7 @@ jobs:
           is-complete: true
       - name: If merged to the default branch, add to Waiting for release
         if: github.event.pull_request.merged && github.event.pull_request.base.ref == github.event.repository.default_branch
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ vars.GH_ANDROID_RELEASE_BOARD_PROJECT_ID }}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211760946270935/task/1216784625625463?focus=true
Tech Design URL (if applicable): 

### Description

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency pin change with no application code or secret handling changes beyond the existing workflow.
> 
> **Overview**
> Updates the **PR merged** GitHub Actions workflow so both Asana sync steps use `duckduckgo/native-github-asana-sync@v2.6.0` instead of `@v2.0`.
> 
> The steps still notify Asana on merge and move tasks to **Waiting for release** when the PR targets the default branch, with the same `trigger-phrase: "Task/Issue URL:"` inputs—this version bump aligns the action with trigger-phrase support described in the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 273985e910f9a8f555f7a7ff2181a6980b611d0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->