### PR TITLE
Add after idle launch option pixels

### DIFF
--- a/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
+++ b/PixelDefinitions/pixels/definitions/ntp_after_idle.json5
@@ -310,6 +310,27 @@
         "suffixes": ["first_daily_count", "form_factor"],
         "parameters": ["appVersion"]
     },
+    "m_ntp_after_idle_launch_option_new_tab_page": {
+        "description": "User selected 'New Tab Page' as the after-inactivity launch option.",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_launch_option_last_opened_tab": {
+        "description": "User selected 'Last Opened Tab' as the after-inactivity launch option.",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": ["appVersion"]
+    },
+    "m_ntp_after_idle_launch_option_specific_page": {
+        "description": "User selected 'Specific Page' (custom URL) as the after-inactivity launch option.",
+        "owners": ["YoussefKeyrouz"],
+        "triggers": ["other"],
+        "suffixes": ["first_daily_count", "form_factor"],
+        "parameters": ["appVersion"]
+    },
 
     // Daily state-snapshot pixels: one per active user per day reflecting the current setting
     "m_ntp_after_idle_return_to_last_tab_enabled_daily": {

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchPixelName.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchPixelName.kt
@@ -25,4 +25,12 @@ enum class ShowOnAppLaunchPixelName(override val pixelName: String) : Pixel.Pixe
     LAST_TAB_SHORTCUT_SETTING_ENABLED_DAILY("m_ntp_after_idle_last_tab_shortcut_setting_enabled_daily"),
     LAST_TAB_SHORTCUT_SETTING_DISABLED("m_ntp_after_idle_last_tab_shortcut_setting_disabled_count"),
     LAST_TAB_SHORTCUT_SETTING_DISABLED_DAILY("m_ntp_after_idle_last_tab_shortcut_setting_disabled_daily"),
+
+    // After-inactivity launch option selected pixels (New Tab Page / Last Opened Tab / Specific Page)
+    LAUNCH_OPTION_NEW_TAB_PAGE("m_ntp_after_idle_launch_option_new_tab_page_count"),
+    LAUNCH_OPTION_NEW_TAB_PAGE_DAILY("m_ntp_after_idle_launch_option_new_tab_page_daily"),
+    LAUNCH_OPTION_LAST_OPENED_TAB("m_ntp_after_idle_launch_option_last_opened_tab_count"),
+    LAUNCH_OPTION_LAST_OPENED_TAB_DAILY("m_ntp_after_idle_launch_option_last_opened_tab_daily"),
+    LAUNCH_OPTION_SPECIFIC_PAGE("m_ntp_after_idle_launch_option_specific_page_count"),
+    LAUNCH_OPTION_SPECIFIC_PAGE_DAILY("m_ntp_after_idle_launch_option_specific_page_daily"),
 }

--- a/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModel.kt
@@ -100,6 +100,16 @@ class ShowOnAppLaunchViewModel @Inject constructor(
     fun onShowOnAppLaunchOptionChanged(option: ShowOnAppLaunchOption) {
         viewModelScope.launch(dispatcherProvider.io()) {
             showOnAppLaunchOptionDataStore.setShowOnAppLaunchOption(option)
+            val (countPixel, dailyPixel) = when (option) {
+                ShowOnAppLaunchOption.LastOpenedTab ->
+                    ShowOnAppLaunchPixelName.LAUNCH_OPTION_LAST_OPENED_TAB to ShowOnAppLaunchPixelName.LAUNCH_OPTION_LAST_OPENED_TAB_DAILY
+                ShowOnAppLaunchOption.NewTabPage ->
+                    ShowOnAppLaunchPixelName.LAUNCH_OPTION_NEW_TAB_PAGE to ShowOnAppLaunchPixelName.LAUNCH_OPTION_NEW_TAB_PAGE_DAILY
+                is ShowOnAppLaunchOption.SpecificPage ->
+                    ShowOnAppLaunchPixelName.LAUNCH_OPTION_SPECIFIC_PAGE to ShowOnAppLaunchPixelName.LAUNCH_OPTION_SPECIFIC_PAGE_DAILY
+            }
+            pixel.fire(countPixel, type = Count)
+            pixel.fire(dailyPixel, type = Daily())
         }
     }
 

--- a/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/generalsettings/showonapplaunch/ShowOnAppLaunchViewModelTest.kt
@@ -20,6 +20,7 @@ import app.cash.turbine.test
 import com.duckduckgo.app.generalsettings.showonapplaunch.ShowOnAppLaunchViewModel.Command.ShowTimeoutDialog
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.LastOpenedTab
 import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.NewTabPage
+import com.duckduckgo.app.generalsettings.showonapplaunch.model.ShowOnAppLaunchOption.SpecificPage
 import com.duckduckgo.app.generalsettings.showonapplaunch.store.FakeShowOnAppLaunchOptionDataStore
 import com.duckduckgo.app.pixels.AppPixelName.SETTINGS_AFTER_INACTIVITY_TIMEOUT_CHANGED
 import com.duckduckgo.app.pixels.remoteconfig.AndroidBrowserConfigFeature
@@ -243,6 +244,33 @@ class ShowOnAppLaunchViewModelTest {
         verify(ntpAfterIdleManager).setReturnToLastTabEnabled(true)
         verify(pixel).fire(ShowOnAppLaunchPixelName.LAST_TAB_SHORTCUT_SETTING_ENABLED, type = Count)
         verify(pixel).fire(ShowOnAppLaunchPixelName.LAST_TAB_SHORTCUT_SETTING_ENABLED_DAILY, type = Daily())
+    }
+
+    @Test
+    fun whenLaunchOptionChangedToNewTabPageThenPixelsFired() = runTest {
+        testee.onShowOnAppLaunchOptionChanged(NewTabPage)
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(pixel).fire(ShowOnAppLaunchPixelName.LAUNCH_OPTION_NEW_TAB_PAGE, type = Count)
+        verify(pixel).fire(ShowOnAppLaunchPixelName.LAUNCH_OPTION_NEW_TAB_PAGE_DAILY, type = Daily())
+    }
+
+    @Test
+    fun whenLaunchOptionChangedToLastOpenedTabThenPixelsFired() = runTest {
+        testee.onShowOnAppLaunchOptionChanged(LastOpenedTab)
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(pixel).fire(ShowOnAppLaunchPixelName.LAUNCH_OPTION_LAST_OPENED_TAB, type = Count)
+        verify(pixel).fire(ShowOnAppLaunchPixelName.LAUNCH_OPTION_LAST_OPENED_TAB_DAILY, type = Daily())
+    }
+
+    @Test
+    fun whenLaunchOptionChangedToSpecificPageThenPixelsFired() = runTest {
+        testee.onShowOnAppLaunchOptionChanged(SpecificPage("example.com"))
+        coroutineTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(pixel).fire(ShowOnAppLaunchPixelName.LAUNCH_OPTION_SPECIFIC_PAGE, type = Count)
+        verify(pixel).fire(ShowOnAppLaunchPixelName.LAUNCH_OPTION_SPECIFIC_PAGE_DAILY, type = Daily())
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1216783639447263?focus=true 
Tech Design URL (if applicable): 

### Description

Adds pixels for when a user changes the after-inactivity "on app launch" option
(New Tab Page / Last Opened Tab / Specific Page).

### Steps to test this PR
- [x] Filter on “pixel sent” in logcat
- [x] Open Settings → General → On app launch and pick each
      option → the matching `m_ntp_after_idle_launch_option_<option>_count` fires
      (and `_daily` once/day)

### UI changes
Telemetry only.
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only changes in settings; no auth, data handling, or launch-behavior logic changes beyond firing pixels after the existing persist path.
> 
> **Overview**
> Adds **telemetry** when users pick an after-inactivity launch option on the Show on App Launch settings screen: **New Tab Page**, **Last Opened Tab**, or **Specific Page** (custom URL).
> 
> Three new pixel definitions land in `ntp_after_idle.json5`, with matching `ShowOnAppLaunchPixelName` entries. `ShowOnAppLaunchViewModel.onShowOnAppLaunchOptionChanged` still persists the choice, then fires a **count** and **daily** pixel per option (same pattern as the Return To Last Tab toggle). Unit tests assert the correct pixels fire for each option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4160dc41e6e94993783492dc498b7599acef10f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->