### PR TITLE
Handle recovery code actions in simplifed sync settings

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivity.kt
@@ -64,6 +64,7 @@ import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.AskDeleteAccoun
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.AskEditDevice
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.AskRemoveDevice
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.AskSetupSyncDeepLink
+import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.AskToCopyRecoveryCode
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.AskTurnOffSync
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.CheckIfUserHasStoragePermission
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.DeepLinkIntoSetup
@@ -77,6 +78,7 @@ import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.RequestSetupAut
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowDeviceConnected
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowDeviceUnsupported
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowError
+import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowMessage
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowPreviousSessionReady
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowRecoveryCode
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.SyncWithAnotherDevice
@@ -427,12 +429,20 @@ class SyncActivity : DuckDuckGoActivity() {
 
             is AskRemoveDevice -> askRemoveDevice(command.device)
             is AskEditDevice -> askEditDevice(command.device)
+            is AskToCopyRecoveryCode -> {
+                authenticate {
+                    viewModel.onCopyRecoveryCodeAuthenticated()
+                }
+            }
             is AddAnotherDevice -> {
                 authenticate {
                     syncWithAnotherDeviceFlow.launch(null)
                 }
             }
             is ShowError -> showError(command)
+            is ShowMessage -> {
+                binding.root.makeSnackbarWithNoBottomInset(command.message, Snackbar.LENGTH_LONG).show()
+            }
             is ShowDeviceUnsupported -> {
                 startActivity(DeviceUnsupportedActivity.intent(this))
                 finish()

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
@@ -21,6 +21,7 @@ import androidx.annotation.StringRes
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.app.clipboard.ClipboardInteractor
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -52,6 +53,7 @@ import com.duckduckgo.sync.impl.promotion.SyncGetOnOtherPlatformsLaunchSource.SO
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.AskDeleteAccount
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.AskEditDevice
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.AskRemoveDevice
+import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.AskToCopyRecoveryCode
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.AskTurnOffSync
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.CheckIfUserHasStoragePermission
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.IntroCreateAccount
@@ -60,6 +62,7 @@ import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.RecoveryCodePDF
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.RequestSetupAuthentication
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowDeviceUnsupported
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowError
+import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowMessage
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowPreviousSessionReady
 import com.duckduckgo.sync.impl.ui.SyncDeviceListItem.LoadingItem
 import com.duckduckgo.sync.impl.ui.SyncDeviceListItem.SyncedDevice
@@ -89,6 +92,7 @@ import javax.inject.Inject
 class SyncActivityViewModel @Inject constructor(
     private val deviceAuthenticator: DeviceAuthenticator,
     private val recoveryCodePDF: RecoveryCodePDF,
+    private val clipboard: ClipboardInteractor,
     private val syncAccountRepository: SyncAccountRepository,
     private val syncStateMonitor: SyncStateMonitor,
     private val syncEngine: SyncEngine,
@@ -245,11 +249,16 @@ class SyncActivityViewModel @Inject constructor(
         data object AskDeleteAccount : Command()
         data object CheckIfUserHasStoragePermission : Command()
         data class RecoveryCodePDFSuccess(val recoveryCodePDFFile: File) : Command()
+        data object AskToCopyRecoveryCode : Command()
         data class AskRemoveDevice(val device: ConnectedDevice) : Command()
         data class AskEditDevice(val device: ConnectedDevice, val requireAuthentication: Boolean) : Command()
         data class ShowError(
             @StringRes val message: Int,
             val reason: String = "",
+        ) : Command()
+
+        data class ShowMessage(
+            @StringRes val message: Int,
         ) : Command()
 
         data object ShowDeviceUnsupported : Command()
@@ -430,6 +439,31 @@ class SyncActivityViewModel @Inject constructor(
         viewModelScope.launch {
             requiresSetupAuthentication {
                 command.send(CheckIfUserHasStoragePermission)
+            }
+        }
+    }
+
+    fun onCopyRecoveryCodeClicked() {
+        viewModelScope.launch {
+            requiresSetupAuthentication {
+                command.send(AskToCopyRecoveryCode)
+            }
+        }
+    }
+
+    fun onCopyRecoveryCodeAuthenticated() {
+        viewModelScope.launch(dispatchers.io()) {
+            when (val result = syncAccountRepository.getRecoveryCode()) {
+                is Success -> {
+                    val isNotificationShown = clipboard.copyToClipboard(result.data.rawCode, isSensitive = true)
+                    if (!isNotificationShown) {
+                        command.send(ShowMessage(R.string.sync_code_copied_message))
+                    }
+                }
+
+                is Error -> {
+                    command.send(ShowError(R.string.sync_general_error, result.reason))
+                }
             }
         }
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
@@ -16,10 +16,12 @@
 
 package com.duckduckgo.sync.impl.ui.v2
 
+import android.Manifest
 import android.content.res.ColorStateList
 import android.os.Bundle
 import android.view.View
 import android.widget.CompoundButton.OnCheckedChangeListener
+import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import androidx.core.view.plusAssign
@@ -28,6 +30,7 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.spans.DuckDuckGoClickableSpan
 import com.duckduckgo.common.ui.view.addClickableSpan
@@ -44,6 +47,7 @@ import com.duckduckgo.sync.api.SyncActivityWithAnotherDevice
 import com.duckduckgo.sync.api.SyncSettingsPlugin
 import com.duckduckgo.sync.impl.ConnectedDevice
 import com.duckduckgo.sync.impl.R
+import com.duckduckgo.sync.impl.ShareAction
 import com.duckduckgo.sync.impl.auth.DeviceAuthenticator
 import com.duckduckgo.sync.impl.auth.DeviceAuthenticator.AuthConfiguration
 import com.duckduckgo.sync.impl.auth.DeviceAuthenticator.AuthResult.Error
@@ -79,6 +83,7 @@ import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.SetupFlows.SignInFlow
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.ViewState
 import com.duckduckgo.sync.impl.ui.SyncActivityWithSourceParams
 import com.duckduckgo.sync.impl.wideevents.SyncSetupWideEvent
+import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -106,6 +111,12 @@ class SyncActivity : DuckDuckGoActivity() {
 
     @Inject
     lateinit var syncSettingsPlugin: DaggerMap<Int, SyncSettingsPlugin>
+
+    @Inject
+    lateinit var appBuildConfig: AppBuildConfig
+
+    @Inject
+    lateinit var shareAction: ShareAction
 
     private val launchSource
         get() = intent.getActivityParams(SyncActivityWithSourceParams::class.java)?.source
@@ -158,6 +169,14 @@ class SyncActivity : DuckDuckGoActivity() {
         if (!isSuccess) {
             viewModel.onSyncThisDeviceCanceled()
             viewModel.onConnectionCancelled()
+        }
+    }
+
+    private val downloadPdfPermissionLauncher = registerForActivityResult(RequestPermission()) { isGranted ->
+        if (isGranted) {
+            lifecycleScope.launch { viewModel.generateRecoveryCode(this@SyncActivity) }
+        } else {
+            Snackbar.make(binding.root, R.string.sync_permission_required_store_recovery_code, Snackbar.LENGTH_LONG).show()
         }
     }
 
@@ -285,7 +304,11 @@ class SyncActivity : DuckDuckGoActivity() {
             }
 
             is CheckIfUserHasStoragePermission -> {
-                logcat { "TODO: Handle ${command.javaClass.simpleName} command" }
+                if (appBuildConfig.sdkInt < 30) {
+                    downloadPdfPermissionLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                } else {
+                    lifecycleScope.launch { viewModel.generateRecoveryCode(this@SyncActivity) }
+                }
             }
 
             is DeepLinkIntoSetup -> {
@@ -331,7 +354,9 @@ class SyncActivity : DuckDuckGoActivity() {
             }
 
             is RecoveryCodePDFSuccess -> {
-                logcat { "TODO: Handle ${command.javaClass.simpleName} command" }
+                authenticate {
+                    shareAction.shareFile(this, command.recoveryCodePDFFile)
+                }
             }
 
             is RequestSetupAuthentication -> {
@@ -404,7 +429,12 @@ class SyncActivity : DuckDuckGoActivity() {
     }
 
     private fun configureRecoverySection() {
-        binding.includeEnabledView.restoreOnReinstallItem.setOnCheckedChangeListener(autoRestoreListener)
+        binding.includeEnabledView.apply {
+            restoreOnReinstallItem.setOnCheckedChangeListener(autoRestoreListener)
+            downloadRecoveryCodeItem.setOnClickListener {
+                viewModel.onSaveRecoveryCodeClicked()
+            }
+        }
     }
 
     private fun configureDataExpirationNotice() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
@@ -62,6 +62,7 @@ import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.AskDeleteAccoun
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.AskEditDevice
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.AskRemoveDevice
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.AskSetupSyncDeepLink
+import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.AskToCopyRecoveryCode
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.AskTurnOffSync
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.CheckIfUserHasStoragePermission
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.DeepLinkIntoSetup
@@ -75,6 +76,7 @@ import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.RequestSetupAut
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowDeviceConnected
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowDeviceUnsupported
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowError
+import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowMessage
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowPreviousSessionReady
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowRecoveryCode
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.SyncWithAnotherDevice
@@ -299,6 +301,12 @@ class SyncActivity : DuckDuckGoActivity() {
                 logcat { "TODO: Handle ${command.javaClass.simpleName} command" }
             }
 
+            is AskToCopyRecoveryCode -> {
+                authenticate {
+                    viewModel.onCopyRecoveryCodeAuthenticated()
+                }
+            }
+
             is AskTurnOffSync -> {
                 logcat { "TODO: Handle ${command.javaClass.simpleName} command" }
             }
@@ -376,6 +384,10 @@ class SyncActivity : DuckDuckGoActivity() {
                 showError(command)
             }
 
+            is ShowMessage -> {
+                Snackbar.make(binding.root, command.message, Snackbar.LENGTH_LONG).show()
+            }
+
             is ShowPreviousSessionReady -> {
                 logcat { "TODO: Handle ${command.javaClass.simpleName} command" }
             }
@@ -433,6 +445,9 @@ class SyncActivity : DuckDuckGoActivity() {
             restoreOnReinstallItem.setOnCheckedChangeListener(autoRestoreListener)
             downloadRecoveryCodeItem.setOnClickListener {
                 viewModel.onSaveRecoveryCodeClicked()
+            }
+            copyRecoveryCodeItem.setOnClickListener {
+                viewModel.onCopyRecoveryCodeClicked()
             }
         }
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
@@ -176,7 +176,7 @@ class SyncActivity : DuckDuckGoActivity() {
 
     private val downloadPdfPermissionLauncher = registerForActivityResult(RequestPermission()) { isGranted ->
         if (isGranted) {
-            lifecycleScope.launch { viewModel.generateRecoveryCode(this@SyncActivity) }
+            viewModel.generateRecoveryCode(this)
         } else {
             Snackbar.make(binding.root, R.string.sync_permission_required_store_recovery_code, Snackbar.LENGTH_LONG).show()
         }
@@ -315,7 +315,7 @@ class SyncActivity : DuckDuckGoActivity() {
                 if (appBuildConfig.sdkInt < 30) {
                     downloadPdfPermissionLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
                 } else {
-                    lifecycleScope.launch { viewModel.generateRecoveryCode(this@SyncActivity) }
+                    viewModel.generateRecoveryCode(this)
                 }
             }
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModelTest.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.sync.impl.ui
 import android.annotation.SuppressLint
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
+import com.duckduckgo.app.clipboard.ClipboardInteractor
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.Toggle.State
@@ -35,6 +36,7 @@ import com.duckduckgo.sync.api.SyncState.READY
 import com.duckduckgo.sync.api.SyncStateMonitor
 import com.duckduckgo.sync.api.engine.SyncEngine
 import com.duckduckgo.sync.api.engine.SyncEngine.SyncTrigger.FEATURE_READ
+import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.RecoveryCodePDF
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.Result.Success
@@ -47,6 +49,7 @@ import com.duckduckgo.sync.impl.autorestore.SyncAutoRestoreManager
 import com.duckduckgo.sync.impl.pixels.SyncPixels
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.AskEditDevice
+import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.AskToCopyRecoveryCode
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.AskTurnOffSync
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.CheckIfUserHasStoragePermission
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.IntroCreateAccount
@@ -55,6 +58,7 @@ import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.LaunchLearnMore
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.LaunchSyncGetOnOtherPlatforms
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.RecoveryCodePDFSuccess
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.RequestSetupAuthentication
+import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowMessage
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command.ShowPreviousSessionReady
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.OriginalFlow
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.SetupFlows.CreateAccountFlow
@@ -94,6 +98,7 @@ class SyncActivityViewModelTest {
     val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
 
     private val recoveryPDF: RecoveryCodePDF = mock()
+    private val clipboardInteractor: ClipboardInteractor = mock()
     private val syncAccountRepository: SyncAccountRepository = mock()
     private val syncStateMonitor: SyncStateMonitor = mock()
     private val syncEngine: SyncEngine = mock()
@@ -118,6 +123,7 @@ class SyncActivityViewModelTest {
             syncStateMonitor = syncStateMonitor,
             syncEngine = syncEngine,
             recoveryCodePDF = recoveryPDF,
+            clipboard = clipboardInteractor,
             syncFeatureToggle = syncFeatureToggle,
             settingsPageFeature = fakeSettingsPageFeature,
             syncPixels = syncPixels,
@@ -742,6 +748,77 @@ class SyncActivityViewModelTest {
             testee.generateRecoveryCode(mock())
             val command = awaitItem()
             assertTrue(command is RecoveryCodePDFSuccess)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenUserClicksOnCopyRecoveryCodeThenEmitAskToCopyRecoveryCodeCommand() = runTest {
+        givenUserHasDeviceAuthentication(true)
+        testee.commands().test {
+            testee.onCopyRecoveryCodeClicked()
+            val command = awaitItem()
+            assertTrue(command is AskToCopyRecoveryCode)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenUserClicksOnCopyRecoveryCodeWithoutDeviceAuthenticationThenEmitCommandRequestSetupAuthentication() = runTest {
+        givenUserHasDeviceAuthentication(false)
+        testee.commands().test {
+            testee.onCopyRecoveryCodeClicked()
+            val command = awaitItem()
+            assertTrue(command is RequestSetupAuthentication)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenCopyRecoveryCodeAuthenticatedThenCodeIsCopiedToClipboard() = runTest {
+        val authCodeToUse = AuthCode(qrCode = jsonRecoveryKeyEncoded, rawCode = "something else")
+        whenever(syncAccountRepository.getRecoveryCode()).thenReturn(Result.Success(authCodeToUse))
+
+        testee.onCopyRecoveryCodeAuthenticated()
+
+        verify(clipboardInteractor).copyToClipboard(authCodeToUse.rawCode, isSensitive = true)
+    }
+
+    @Test
+    fun whenCopyRecoveryCodeAuthenticatedAndSystemShowsNoNotificationThenEmitShowMessageCommand() = runTest {
+        val authCodeToUse = AuthCode(qrCode = jsonRecoveryKeyEncoded, rawCode = "something else")
+        whenever(syncAccountRepository.getRecoveryCode()).thenReturn(Result.Success(authCodeToUse))
+        whenever(clipboardInteractor.copyToClipboard(any(), any())).thenReturn(false)
+
+        testee.commands().test {
+            testee.onCopyRecoveryCodeAuthenticated()
+            val command = awaitItem()
+            assertTrue(command is ShowMessage)
+            assertEquals(R.string.sync_code_copied_message, (command as ShowMessage).message)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenCopyRecoveryCodeAuthenticatedAndSystemShowsNotificationThenNoMessageShown() = runTest {
+        val authCodeToUse = AuthCode(qrCode = jsonRecoveryKeyEncoded, rawCode = "something else")
+        whenever(syncAccountRepository.getRecoveryCode()).thenReturn(Result.Success(authCodeToUse))
+        whenever(clipboardInteractor.copyToClipboard(any(), any())).thenReturn(true)
+
+        testee.commands().test {
+            testee.onCopyRecoveryCodeAuthenticated()
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenCopyRecoveryCodeAuthenticatedAndGettingRecoveryCodeFailsThenEmitShowErrorCommand() = runTest {
+        whenever(syncAccountRepository.getRecoveryCode()).thenReturn(Result.Error(reason = "error"))
+
+        testee.commands().test {
+            testee.onCopyRecoveryCodeAuthenticated()
+            awaitItem().assertCommandType(Command.ShowError::class)
             cancelAndIgnoreRemainingEvents()
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216781820998550?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1216103556496795/task/1216509582049467?focus=true

### Description

Wires up the recovery code items in the Recovery section of the simplified Sync Settings screen.

Copy Your Recovery Code:
- Tapping the item first checks that device authentication is set up. If it is not, the existing prompt to secure the device is shown.
- After the user authenticates, the recovery code is fetched and copied to the clipboard as sensitive content.
- A "Recovery Code Copied" snackbar confirms the action, unless the system already shows its own clipboard confirmation.
- If fetching the recovery code fails, an error dialog is shown.

Download Your Recovery Code:
- Tapping the item follows the same device authentication requirement, then generates the recovery PDF and opens the system share sheet after the user authenticates.
- On Android 10 and below the storage permission is requested first. If denied, an explanatory snackbar is shown.
- If generating the PDF fails, an error dialog is shown and an error pixel is fired.

The new `AskToCopyRecoveryCode` and `ShowMessage` commands are shared through the common `SyncActivityViewModel`, so the existing Sync Settings screen handles them as well (although they are not triggered there).

### Steps to test this PR

_Copy the recovery code_
- Open Sync Dev Settings and launch Sync Settings V2 on a device with sync enabled.
- Tap Copy Your Recovery Code in the Recovery section.
- Complete the device authentication prompt.
- The code is in the clipboard and a confirmation is shown, either the system clipboard notification or a "Recovery Code Copied" snackbar.

_Download the recovery PDF_
- Tap Download Your Recovery Code.
- On Android 10 or lower a storage permission prompt appears first.
- Complete the device authentication prompt.
- A share sheet opens with the generated PDF.

_No device authentication set up_
- On a device without a PIN or biometrics, tap either item.
- A prompt to set up device authentication is shown.

### UI changes
N/A


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches recovery-code retrieval, sensitive clipboard handling, and device authentication; scope is limited to sync settings UI with added ViewModel tests.
> 
> **Overview**
> Wires **Copy** and **Download** recovery code actions in simplified Sync Settings (v2), reusing the shared `SyncActivityViewModel` flow used by the legacy screen.
> 
> **Copy recovery code:** New `onCopyRecoveryCodeClicked` / `onCopyRecoveryCodeAuthenticated` path fetches the code and copies it via `ClipboardInteractor` as sensitive content. `AskToCopyRecoveryCode` triggers device auth in both activities; a `ShowMessage` snackbar appears only when the OS does not show its own clipboard confirmation.
> 
> **Download recovery PDF:** v2 hooks `downloadRecoveryCodeItem` to the existing save flow, implements `CheckIfUserHasStoragePermission` (pre-API 30 storage permission + denial snackbar), and shares the generated PDF via `ShareAction` after auth on `RecoveryCodePDFSuccess`.
> 
> Legacy `SyncActivity` gains handlers for the new commands so behavior stays consistent if those commands are emitted there.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 392a1e7bb1a233e06bc54a1c20c3de2ee9a0a5d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->