### PR TITLE
Bump native-github-asana-sync to v2.6.0

### DIFF
--- a/.github/actions/assign-release-task/action.yml
+++ b/.github/actions/assign-release-task/action.yml
@@ -24,7 +24,7 @@ runs:
   steps:
     - name: Find Asana User ID
       id: find-asana-user-id
-      uses: duckduckgo/native-github-asana-sync@v2.3
+      uses: duckduckgo/native-github-asana-sync@v2.6.0
       with:
         action: 'get-asana-user-id'
         github-username: ${{ github.actor }}

--- a/.github/actions/maestro-cloud-asana-reporter/action.yml
+++ b/.github/actions/maestro-cloud-asana-reporter/action.yml
@@ -110,7 +110,7 @@ runs:
     - name: Create Asana task when Maestro tests failed
       if: always() && inputs.create_asana_error_task == 'true' && steps.analyze-maestro.outputs.flow_summary_status == 'failure' && github.event_name != 'workflow_dispatch'
       id: create-maestro-failure-task
-      uses: duckduckgo/native-github-asana-sync@v2.0
+      uses: duckduckgo/native-github-asana-sync@v2.6.0
       with:
         asana-pat: ${{ inputs.asana_pat }}
         asana-project: ${{ inputs.asana_project_id }}
@@ -125,7 +125,7 @@ runs:
 
     - name: Adding as a release blocker
       if: always() && inputs.is_release_blocker == 'true' && steps.create-maestro-failure-task.outputs.taskId != ''
-      uses: duckduckgo/native-github-asana-sync@v2.0
+      uses: duckduckgo/native-github-asana-sync@v2.6.0
       with:
         asana-pat: ${{ inputs.asana_pat }}
         asana-project: ${{ inputs.asana_releases_project_id }}

--- a/.github/workflows/action-agentic-maintenance-pr.yaml
+++ b/.github/workflows/action-agentic-maintenance-pr.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Find Asana Task ID from PR body
         id: find-asana-task
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           trigger-phrase: "Task/Issue URL:"
@@ -21,7 +21,7 @@ jobs:
 
       - name: Move task to In Review in Agentic Backlog
         if: ${{ steps.find-asana-task.outputs.asanaTaskId != '' }}
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ vars.GH_AGENTIC_BACKLOG_PROJECT_ID }}

--- a/.github/workflows/action-issue-opened.yaml
+++ b/.github/workflows/action-issue-opened.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create Asana task
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: '414730916066338'

--- a/.github/workflows/action-pr-opened.yaml
+++ b/.github/workflows/action-pr-opened.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Find Asana Task ID
         if: ${{ github.event.pull_request.base.ref == github.event.repository.default_branch }}
         id: find-asana-task
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           trigger-phrase: ${{ vars.ASANA_TASK_TRIGGER_PHRASE }}
@@ -22,7 +22,7 @@ jobs:
       - name: Add comment with PR link in Asana task
         continue-on-error: true
         if: ${{ github.actor == github.event.pull_request.user.login && ( github.event.action == 'opened' || github.event.action == 'reopened') }}
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           trigger-phrase: ${{ vars.ASANA_TASK_TRIGGER_PHRASE }}
@@ -31,7 +31,7 @@ jobs:
 
       - name: Add task to Asana project section
         if: ${{ steps.find-asana-task.outcome == 'success' && steps.find-asana-task.outputs.asanaTaskId != '' }}
-        uses: duckduckgo/native-github-asana-sync@v2.0
+        uses: duckduckgo/native-github-asana-sync@v2.6.0
         with:
           asana-pat: ${{ secrets.ASANA_ACCESS_TOKEN }}
           asana-project: ${{ vars.GH_ANDROID_RELEASE_BOARD_PROJECT_ID }}

--- a/.github/workflows/privacy-review.yml
+++ b/.github/workflows/privacy-review.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout native actions repo
         uses: actions/checkout@v4
         with:
-            ref: v2.4
+            ref: v2.6.0
             # Do not change the below path (downstream actions expect it)
             path: native-github-asana-sync
             repository: duckduckgo/native-github-asana-sync


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1211760946270935/task/1216784636217276?focus=true
Tech Design URL (if applicable): 

### Description

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only CI dependency bump with no app or workflow behavior changes beyond the shared action release.
> 
> **Overview**
> Standardizes all GitHub ↔ Asana automation on **`duckduckgo/native-github-asana-sync@v2.6.0`**, replacing mixed pins (`v2.0`, `v2.3`, `v2.4`).
> 
> **Composite actions** (`assign-release-task`, `maestro-cloud-asana-reporter`) and **workflows** (issue/PR opened, agentic maintenance, privacy review) now reference the same tag; the privacy-review workflow’s checkout of the sync repo is bumped from `v2.4` to **`v2.6.0`** as well. No input names, secrets, or workflow logic change—only the action/repo version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b211022f32e818de32b857325717a806ee61ccf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->