### PR TITLE
Update Artifact Cache CLI to 1.4.0

### DIFF
--- a/.github/actions/develocity-artifact-cache/action.yml
+++ b/.github/actions/develocity-artifact-cache/action.yml
@@ -25,7 +25,7 @@ inputs:
   cli-version:
     description: 'Artifact Cache CLI version'
     required: false
-    default: '1.3.0'
+    default: '1.4.0'
   cli-filename:
     description: 'Artifact Cache CLI artifact id / filename (without extension)'
     required: false


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216709520359699/task/1216510939202624?focus=true
Tech Design URL (if applicable): N/A

### Description
Updates the Artifact Cache CLI from 1.3.0 to 1.4.0 to fix issues with negative reported values in build scans.

### Steps to test this PR
- [x] Trigger the Build debug apk workflow (open/push a PR against develop): https://github.com/duckduckgo/Android/actions/runs/29934617341
- [ ]  In the "Restore Develocity Setup + Artifact Cache" step logs, confirm Downloading Artifact Cache CLI v1.4.0... (or a tool-cache hit for the 1.4.0 jar).
- [ ]  Open the resulting build scan on https://duckduckgo.develocity.cloud/ and confirm the Artifact Cache restore-size custom values are non-negative.

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single default version bump in CI tooling with restore/store failures already non-blocking; no app or auth changes.
> 
> **Overview**
> Bumps the default **Artifact Cache CLI** version in the `develocity-artifact-cache` composite action from **1.3.0** to **1.4.0**, so CI workflows that rely on the default input download and run the newer jar (still overridable via `cli-version`).
> 
> This targets incorrect **negative restore-size** values reported in Develocity build scans from the older CLI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f14207d7782ec136e57b4720d692cafc4279e0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->