### PR TITLE
Replace the 4×.replace() with a single-pass template fill

### DIFF
--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/ContentScopeScriptsFeature.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/ContentScopeScriptsFeature.kt
@@ -34,4 +34,14 @@ interface ContentScopeScriptsFeature {
 
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun useWebMessageListener(): Toggle
+
+    /**
+     * Kill-switch for the ContentScopeScripts injection performance work.
+     * When enabled, the optimized injection path is used.
+     * @return `true` when the remote config has the global "optimizeContentScopeInjection" clientContentFeatures
+     * sub-feature flag enabled.
+     * If the remote feature is not present defaults to `internal`
+     */
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun optimizeContentScopeInjection(): Toggle
 }

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
@@ -73,6 +73,8 @@ class RealContentScopeScripts @Inject constructor(
 
     private lateinit var cachedContentScopeJS: String
 
+    private var cachedTemplateSegments: List<TemplateSegment>? = null
+
     override val secret: String = getSecret()
     override val javascriptInterface: String = getSecret()
     override val callbackName: String = getSecret()
@@ -169,13 +171,74 @@ class RealContentScopeScripts @Inject constructor(
 
     private fun cacheContentScopeJS() {
         val contentScopeJS = contentScopeJSReader.getContentScopeJS()
+        val messagingParameters = "${getSecretKeyValuePair()},${getCallbackKeyValuePair()},${getInterfaceKeyValuePair()}"
 
-        cachedContentScopeJS =
+        cachedContentScopeJS = if (contentScopeScriptsFeature.optimizeContentScopeInjection().isEnabled()) {
+            assembleContentScopeJS(contentScopeJS, messagingParameters)
+        } else {
             contentScopeJS
                 .replace(CONTENT_SCOPE, cachedContentScopeJson)
                 .replace(USER_UNPROTECTED_DOMAINS, cachedUserUnprotectedDomainsJson)
                 .replace(USER_PREFERENCES, cachedUserPreferencesJson)
-                .replace(MESSAGING_PARAMETERS, "${getSecretKeyValuePair()},${getCallbackKeyValuePair()},${getInterfaceKeyValuePair()}")
+                .replace(MESSAGING_PARAMETERS, messagingParameters)
+        }
+    }
+
+    private fun assembleContentScopeJS(
+        template: String,
+        messagingParameters: String,
+    ): String {
+        val segments = cachedTemplateSegments ?: splitTemplate(template).also { cachedTemplateSegments = it }
+        val builder = StringBuilder(
+            template.length +
+                cachedContentScopeJson.length +
+                cachedUserUnprotectedDomainsJson.length +
+                cachedUserPreferencesJson.length +
+                messagingParameters.length,
+        )
+        segments.forEach { segment ->
+            when (segment) {
+                is TemplateSegment.Literal -> builder.append(segment.text)
+                TemplateSegment.ContentScope -> builder.append(cachedContentScopeJson)
+                TemplateSegment.UserUnprotectedDomains -> builder.append(cachedUserUnprotectedDomainsJson)
+                TemplateSegment.UserPreferences ->
+                    builder.append(cachedUserPreferencesJson.replace(MESSAGING_PARAMETERS, messagingParameters))
+                TemplateSegment.MessagingParameters -> builder.append(messagingParameters)
+            }
+        }
+        return builder.toString()
+    }
+
+    private fun splitTemplate(template: String): List<TemplateSegment> {
+        val tokens = listOf(
+            CONTENT_SCOPE to TemplateSegment.ContentScope,
+            USER_UNPROTECTED_DOMAINS to TemplateSegment.UserUnprotectedDomains,
+            USER_PREFERENCES to TemplateSegment.UserPreferences,
+            MESSAGING_PARAMETERS to TemplateSegment.MessagingParameters,
+        )
+        val segments = mutableListOf<TemplateSegment>()
+        var cursor = 0
+        while (cursor <= template.length) {
+            var matchIndex = -1
+            var matchToken = ""
+            var matchMarker: TemplateSegment? = null
+            for ((token, marker) in tokens) {
+                val index = template.indexOf(token, cursor)
+                if (index != -1 && (matchIndex == -1 || index < matchIndex)) {
+                    matchIndex = index
+                    matchToken = token
+                    matchMarker = marker
+                }
+            }
+            if (matchMarker == null) {
+                if (cursor < template.length) segments.add(TemplateSegment.Literal(template.substring(cursor)))
+                break
+            }
+            if (matchIndex > cursor) segments.add(TemplateSegment.Literal(template.substring(cursor, matchIndex)))
+            segments.add(matchMarker)
+            cursor = matchIndex + matchToken.length
+        }
+        return segments
     }
 
     private fun getUserUnprotectedDomainsJson(userUnprotectedDomains: List<String>): String {
@@ -266,3 +329,11 @@ data class Experiment(
     val subfeature: String,
     val cohort: String?,
 )
+
+private sealed interface TemplateSegment {
+    class Literal(val text: String) : TemplateSegment
+    object ContentScope : TemplateSegment
+    object UserUnprotectedDomains : TemplateSegment
+    object UserPreferences : TemplateSegment
+    object MessagingParameters : TemplateSegment
+}

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.feature.toggles.api.Toggle.State.Cohort
 import com.duckduckgo.fingerprintprotection.api.FingerprintProtectionManager
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
+import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
 import kotlinx.coroutines.test.runTest
@@ -339,6 +340,30 @@ class RealContentScopeScriptsTest {
         val js = testee.getScript(null, listOf())
         verifyJsScript(js)
         verify(mockContentScopeJsReader).getContentScopeJS()
+    }
+
+    @Test
+    fun whenOptimizeInjectionEnabledThenOutputIsByteIdenticalToFallbackPath() {
+        // Fallback path (chained String.replace).
+        contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = false))
+        val fallbackJs = testee.getScript(null, listOf())
+
+        // Optimized path (single-pass StringBuilder). Fresh instance so its caches build under the flag.
+        val optimizedTestee = RealContentScopeScripts(
+            mockPluginPoint,
+            mockUserAllowListRepository,
+            mockContentScopeJsReader,
+            mockAppBuildConfig,
+            mockUnprotectedTemporary,
+            mockFingerprintProtectionManager,
+            contentScopeScriptsFeature,
+        )
+        contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = true))
+        val optimizedJs = optimizedTestee.getScript(null, listOf())
+
+        // The three messaging secrets are random per instance; normalise them before the byte comparison.
+        val secret = Regex("[\\da-f]{32}")
+        assertEquals(secret.replace(fallbackJs, "SECRET"), secret.replace(optimizedJs, "SECRET"))
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200581511062568/task/1216781919152120?focus=true
Tech Design URL (if applicable):

### Description

RealContentScopeScripts.getScript() runs on the main thread for every page load. On a cache-miss rebuild, cacheContentScopeJS() did four sequential String.replace() passes over the ~515 KB content-scope JS blob to substitute `$CONTENT_SCOPE$`, `$USER_UNPROTECTED_DOMAINS$`, `$USER_PREFERENCES$`, and `$ANDROID_MESSAGING_PARAMETERS$`.

This PR replaces those four passes with a single-pass assembly: the JS template is split into literal/placeholder segments once (built lazily from the immutable, reader-cached blob), and each rebuild walks those segments into one pre-sized StringBuilder.

Notes:

- Gated behind a new optimizeContentScopeInjection() remote feature flag (default INTERNAL), which acts as a kill-switch — when off, the original chained .replace() path runs unchanged.
- Output is byte-for-byte identical to the old path, including the intentional cascade where the user-preferences value itself embeds the messaging-parameters token (resolved on that small value as it's appended).
- Handles placeholders in any order, repeated, or absent.
- Scope is the live RealContentScopeScripts only; RealWebViewCompatContentScopeScripts is intentionally untouched.
- Added a test asserting the flag-on and flag-off paths produce identical output.

### Steps to test this PR

1. On an internal build, the `optimizeContentScopeInjection` sub-feature of `clientContentFeatures` is enabled.
2. Browse several sites (e.g. bbc.com, wikipedia.org) and confirm pages load and privacy protections work as before — no visible regression.
3. Toggle the flag off and confirm behaviour is unchanged (kill-switch works).

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches every page-load content-scope injection on the main thread; wrong assembly would break privacy protections, mitigated by kill-switch and parity test.
> 
> **Overview**
> **Speeds up main-thread content-scope script assembly** on cache rebuilds by replacing four sequential `String.replace()` passes over the large JS template with one pre-sized `StringBuilder` walk over cached literal/placeholder segments.
> 
> The new path is gated behind **`optimizeContentScopeInjection`** on `clientContentFeatures` (default **INTERNAL**); when off, the original chained `.replace()` behavior is unchanged. The optimized assembler still resolves messaging parameters inside the user-preferences placeholder so output stays **byte-for-byte identical** to the legacy path.
> 
> Adds a test that normalizes per-instance messaging secrets and asserts flag-on vs flag-off output match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4061a962f807dcf25f291cf830c76ee8cef903d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->