### PR TITLE
Capture GH runner hardware, name, environment and region on build scans

### DIFF
--- a/.github/actions/develocity-runner-info/action.yml
+++ b/.github/actions/develocity-runner-info/action.yml
@@ -1,0 +1,81 @@
+name: 'Develocity Runner Info'
+description: 'Capture GitHub Actions runner hardware and region as Develocity build scan custom values'
+
+inputs:
+  runner-type:
+    description: >-
+      Optional human-readable label for the runner (e.g. "ubuntu-latest-4-core").
+      Only needed if you want a friendly name alongside the auto-detected VM size,
+      CPU count and region below. Leave unset to rely purely on runtime detection,
+      which needs no maintenance as runner sizes change.
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Capture runner info
+      shell: bash
+      # Context values are passed through env vars and referenced as $VARS below, rather
+      # than interpolated as ${{ }} directly into the script. ${{ }} is expanded before the
+      # shell runs, so a value containing a newline or shell metacharacter could otherwise
+      # inject entries into $GITHUB_ENV or arbitrary commands (GitHub's script-injection
+      # hardening guidance). These particular contexts are trusted, but the pattern is cheap.
+      env:
+        RUNNER_TYPE: ${{ inputs.runner-type }}
+        RUNNER_NAME: ${{ runner.name }}
+        RUNNER_ENVIRONMENT: ${{ runner.environment }}
+      run: |
+        # Every value below is exposed to the Gradle build as an env var; settings.gradle
+        # reads them and publishes them as build scan custom values.
+        #
+        # DuckDuckGo's build scans are PUBLIC. On GitHub-hosted runners every value below
+        # describes GitHub's shared Azure fleet (already public knowledge), so it is safe
+        # to publish. On self-hosted runners the same values would describe OUR OWN
+        # machines — hostname, hardware, location — so host-identifying details are guarded
+        # behind a github-hosted check and omitted otherwise.
+
+        # Optional human label — only emitted if the caller passed one.
+        if [ -n "$RUNNER_TYPE" ]; then
+          echo "DDG_RUNNER_TYPE=$RUNNER_TYPE" >> "$GITHUB_ENV"
+        fi
+
+        # Environment (github-hosted vs self-hosted) is not host-identifying and drives the
+        # guard below. os/arch are omitted on purpose — the build scan records them natively.
+        echo "DDG_RUNNER_ENVIRONMENT=$RUNNER_ENVIRONMENT" >> "$GITHUB_ENV"
+
+        # CPU count is a non-identifying aggregate and is available on every runner.
+        CPU_COUNT="$(nproc 2>/dev/null || echo '')"
+        if [ -n "$CPU_COUNT" ]; then
+          echo "DDG_RUNNER_CPU_COUNT=$CPU_COUNT" >> "$GITHUB_ENV"
+        fi
+
+        # Everything below identifies the specific machine/location. On self-hosted runners
+        # that is our infrastructure, and our build scans are public — so capture it only on
+        # GitHub-hosted runners, where it describes GitHub's shared fleet. Gating the IMDS
+        # calls here also avoids probing the Azure link-local address on non-Azure hardware.
+        if [ "$RUNNER_ENVIRONMENT" = "github-hosted" ]; then
+          # Runner name from the runner context (generic on hosted; a hostname on self-hosted).
+          echo "DDG_RUNNER_NAME=$RUNNER_NAME" >> "$GITHUB_ENV"
+
+          # GitHub-hosted runners are Azure VMs. Query the Azure Instance Metadata Service
+          # (IMDS) for the authoritative VM size and region — no hardcoding, self-updating
+          # as GitHub changes runner SKUs. Best-effort: this must never fail the build.
+          IMDS='http://169.254.169.254/metadata/instance/compute'
+          VM_SIZE="$(curl --silent --fail --max-time 5 -H 'Metadata: true' "$IMDS/vmSize?api-version=2021-02-01&format=text" || true)"
+          REGION="$(curl --silent --fail --max-time 5 -H 'Metadata: true' "$IMDS/location?api-version=2021-02-01&format=text" || true)"
+          if [ -n "$VM_SIZE" ]; then
+            echo "DDG_RUNNER_VM_SIZE=$VM_SIZE" >> "$GITHUB_ENV"
+          fi
+          if [ -n "$REGION" ]; then
+            echo "DDG_RUNNER_REGION=$REGION" >> "$GITHUB_ENV"
+          fi
+        fi
+
+        # Diagnostic log. Note CI logs on this public repo are also public, so the runner
+        # name (a hostname on self-hosted) is only logged on github-hosted runners.
+        if [ "$RUNNER_ENVIRONMENT" = "github-hosted" ]; then
+          echo "Runner: name='$RUNNER_NAME' env='$RUNNER_ENVIRONMENT' type='$RUNNER_TYPE' vmSize='${VM_SIZE:-?}' cpus='${CPU_COUNT:-?}' region='${REGION:-?}'"
+        else
+          echo "Runner: env='$RUNNER_ENVIRONMENT' type='$RUNNER_TYPE' cpus='${CPU_COUNT:-?}' (host-identifying details omitted from public build scan/logs)"
+        fi

--- a/.github/workflows/build-debug-apk.yaml
+++ b/.github/workflows/build-debug-apk.yaml
@@ -62,6 +62,9 @@ jobs:
           cache-disabled: true # Develocity Artifact Cache supersedes setup-gradle's Gradle Home caching
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
+      - name: Capture runner info for build scans
+        uses: ./.github/actions/develocity-runner-info
+
       - name: Restore Develocity Setup + Artifact Cache
         uses: ./.github/actions/develocity-artifact-cache
         with:

--- a/settings.gradle
+++ b/settings.gradle
@@ -33,6 +33,25 @@ develocity {
         def diFrameworkTag = providers.gradleProperty('ddg.di').getOrElse('AnvilDagger')
         tag(diFrameworkTag)
         value('ddg.di', diFrameworkTag)
+
+        // Runner metadata, populated on CI by the develocity-runner-info action.
+        // Captured as custom values (not tags) so each dimension stays named and
+        // independently queryable when correlating Artifact Cache overhead with the
+        // runner hardware/region. Each is guarded so local builds emit nothing and so
+        // a runner without Azure IMDS (self-hosted) simply omits what it can't detect.
+        [
+            'Runner Type'       : 'DDG_RUNNER_TYPE',        // optional human label, if the CI step set one
+            'Runner Name'       : 'DDG_RUNNER_NAME',        // runner name from the runner context
+            'Runner Environment': 'DDG_RUNNER_ENVIRONMENT', // github-hosted vs self-hosted (runner context)
+            'Runner VM Size'    : 'DDG_RUNNER_VM_SIZE',     // authoritative Azure SKU from IMDS
+            'Runner CPU Count'  : 'DDG_RUNNER_CPU_COUNT',   // from nproc; works everywhere
+            'Runner Region'     : 'DDG_RUNNER_REGION',      // Azure region from IMDS
+        ].each { name, envVar ->
+            def v = System.getenv(envVar)
+            if (v) {
+                value(name, v)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216709520359699/task/1216792408428991?focus=true
Tech Design URL (if applicable): N/A

### Description
Adds runner metadata to Develocity build scans so Artifact Cache restore overhead can be correlated with the runner hardware and region.

- New `develocity-runner-info` composite action, **auto-detecting at runtime** (no hardcoding to maintain):
  - `Runner VM Size` — the authoritative Azure VM SKU, read from the Azure Instance Metadata Service (IMDS). Self-updates as GitHub changes runner sizes.
  - `Runner CPU Count` — from `nproc`; works on every runner, including self-hosted.
  - `Runner Region` — the Azure region, from IMDS.
  - `Runner Environment` — `github-hosted` vs `self-hosted`, from the `runner` context.
  - `Runner Name` — the runner name, from the `runner` context.
  - `Runner Type` — *optional* human-readable label via the `runner-type` input, only if a team wants a friendly name in addition to the detected hardware. Not required.
  - All IMDS calls are best-effort: they never fail the build and simply omit what a self-hosted/restricted runner can't provide.
- `settings.gradle` publishes each as a build scan custom value, guarded so local builds emit nothing.
- Wired into `build-debug-apk` (currently the only workflow using the Artifact Cache) with **no inputs** — it detects everything itself. Add the same step to other workflows as needed.

### Steps to test this PR

_Runner info custom values_
- [x] Trigger the `Build debug apk` workflow.
- [x] Confirm the "Capture runner info for build scans" step logs a line like `Runner: name='GitHub Actions 3' env='github-hosted' type='' vmSize='Standard_...' cpus='4' region='eastus'`.
- [x] Open the build scan on https://duckduckgo.develocity.cloud → Custom values, and confirm `Runner VM Size`, `Runner CPU Count`, `Runner Region`, `Runner Environment` and `Runner Name` are present with correct values.
- [x] Run a local build (e.g. `./gradlew help`) and confirm none of the `Runner *` values appear on the local scan.

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/observability only; no app or auth changes, IMDS is best-effort, and self-hosted host details are deliberately withheld from public scans.
> 
> **Overview**
> Adds **runner metadata to public Develocity build scans** so Artifact Cache restore time can be correlated with hardware and region.
> 
> A new composite action **`develocity-runner-info`** runs before Gradle on CI: it sets `DDG_*` env vars for optional `runner-type`, always for environment and CPU count (`nproc`), and on **github-hosted** runners only for name, Azure VM size, and region via **best-effort Azure IMDS** (`curl` with timeouts; failures are ignored). Self-hosted runs omit host-identifying fields from scans and logs because scans are public. Inputs use env indirection instead of `${{ }}` in the shell script to reduce injection risk.
> 
> **`settings.gradle`** maps those env vars to named build scan custom values when present (nothing on local builds). **`build-debug-apk`** invokes the action with no inputs so detection is automatic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c9b0c7408d5f4495c3d9372eb41374f379bc683. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->