### PR TITLE
[Android] RealSubscriptionsUrlProvider and SubscriptionPixelSenderImpl objects

### DIFF
--- a/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/ExperimentFiltersManager.kt
+++ b/experiments/experiments-impl/src/main/java/com/duckduckgo/experiments/impl/ExperimentFiltersManager.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.experiments.impl.ExperimentFiltersManagerImpl.ExperimentFi
 import com.duckduckgo.experiments.impl.ExperimentFiltersManagerImpl.ExperimentFilterType.SUBSCRIPTION_ELIGIBLE
 import com.duckduckgo.subscriptions.api.Subscriptions
 import com.squareup.anvil.annotations.ContributesBinding
+import dagger.Lazy
 import kotlinx.coroutines.runBlocking
 import java.util.Locale
 import javax.inject.Inject
@@ -40,7 +41,7 @@ interface ExperimentFiltersManager {
 @ContributesBinding(AppScope::class)
 class ExperimentFiltersManagerImpl @Inject constructor(
     private val appBuildConfig: AppBuildConfig,
-    private val subscriptions: Subscriptions,
+    private val subscriptions: Lazy<Subscriptions>,
     private val dispatcherProvider: DispatcherProvider,
 ) : ExperimentFiltersManager {
     override fun computeFilters(entity: VariantConfig): (AppBuildConfig) -> Boolean {
@@ -63,7 +64,7 @@ class ExperimentFiltersManagerImpl @Inject constructor(
             filters[ANDROID_VERSION] = entity.filters!!.androidVersion.contains(userAndroidVersion)
         }
         if (entity.filters?.privacyProEligible != null) {
-            val isEligible = runBlocking(dispatcherProvider.io()) { subscriptions.isEligible() }
+            val isEligible = runBlocking(dispatcherProvider.io()) { subscriptions.get().isEligible() }
             filters[SUBSCRIPTION_ELIGIBLE] = entity.filters?.privacyProEligible == isEligible
         }
 

--- a/experiments/experiments-impl/src/test/java/com/duckduckgo/experiments/impl/ExperimentFiltersManagerImplTest.kt
+++ b/experiments/experiments-impl/src/test/java/com/duckduckgo/experiments/impl/ExperimentFiltersManagerImplTest.kt
@@ -45,7 +45,7 @@ class ExperimentFiltersManagerImplTest {
     fun setup() {
         testee = ExperimentFiltersManagerImpl(
             mockAppBuildConfig,
-            mockSubscriptions,
+            { mockSubscriptions },
             coroutineRule.testDispatcherProvider,
         )
     }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/EntitlementTargetMatcherPlugin.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/EntitlementTargetMatcherPlugin.kt
@@ -20,18 +20,19 @@ import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.subscriptions.api.Subscriptions
 import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.Lazy
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
 @ContributesMultibinding(AppScope::class)
 class EntitlementTargetMatcherPlugin @Inject constructor(
-    private val subscriptions: Subscriptions,
+    private val subscriptions: Lazy<Subscriptions>,
 ) : Toggle.TargetMatcherPlugin {
     override fun matchesTargetProperty(target: Toggle.State.Target): Boolean {
         return target.entitlement?.let { entitlement ->
             runBlocking {
-                subscriptions.getEntitlementStatus().firstOrNull()?.any { it.value.lowercase() == entitlement.lowercase() } ?: false
+                subscriptions.get().getEntitlementStatus().firstOrNull()?.any { it.value.lowercase() == entitlement.lowercase() } ?: false
             }
         } ?: true
     }

--- a/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsToggleTargetMatcherPlugin.kt
+++ b/subscriptions/subscriptions-impl/src/main/java/com/duckduckgo/subscriptions/impl/SubscriptionsToggleTargetMatcherPlugin.kt
@@ -21,17 +21,18 @@ import com.duckduckgo.feature.toggles.api.Toggle.State.Target
 import com.duckduckgo.feature.toggles.api.Toggle.TargetMatcherPlugin
 import com.duckduckgo.subscriptions.api.Subscriptions
 import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.Lazy
 import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
 @ContributesMultibinding(AppScope::class)
 class SubscriptionsToggleTargetMatcherPlugin @Inject constructor(
-    private val subscriptions: Subscriptions,
+    private val subscriptions: Lazy<Subscriptions>,
 ) : TargetMatcherPlugin {
     override fun matchesTargetProperty(target: Target): Boolean {
         return target.isPrivacyProEligible?.let { isEligible ->
             // runBlocking sucks I know :shrug:
-            isEligible == runBlocking { subscriptions.isEligible() }
+            isEligible == runBlocking { subscriptions.get().isEligible() }
         } ?: true
     }
 }

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/EntitlementTargetMatcherPluginTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/EntitlementTargetMatcherPluginTest.kt
@@ -36,7 +36,7 @@ class EntitlementTargetMatcherPluginTest {
 
     @Before
     fun setup() {
-        matcher = EntitlementTargetMatcherPlugin(subscriptions)
+        matcher = EntitlementTargetMatcherPlugin { subscriptions }
     }
 
     @Test

--- a/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/SubscriptionsToggleTargetMatcherPluginTest.kt
+++ b/subscriptions/subscriptions-impl/src/test/java/com/duckduckgo/subscriptions/impl/SubscriptionsToggleTargetMatcherPluginTest.kt
@@ -12,7 +12,7 @@ import org.mockito.kotlin.whenever
 class SubscriptionsToggleTargetMatcherPluginTest {
 
     private val subscriptions: Subscriptions = mock()
-    private val matcher = SubscriptionsToggleTargetMatcherPlugin(subscriptions)
+    private val matcher = SubscriptionsToggleTargetMatcherPlugin { subscriptions }
 
     @Test
     fun whenIsEligibleAndNullTargetThenReturnTrue() = runTest {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200905986587319/task/1214778996231727?focus=true
Tech Design URL (if applicable):

### Description

Feature-flag targeting evaluates a set of TargetMatcherPlugins (and experiment filters). A few of these consult subscription state: isPrivacyProEligible, entitlement, and the SUBSCRIPTION_ELIGIBLE experiment filter and they injected Subscriptions directly. Because these plugins are collected into a Dagger plugin point that gets provisioned early, this eagerly constructed RealSubscriptions along with its whole dependency subgraph, even though the vast majority of feature flags never evaluate a subscription-related target.

This PR changes those three injection sites to inject Lazy\<Subscriptions> instead, so RealSubscriptions is only constructed on first use. In practice very few flags do, so this significantly cuts unnecessary RealSubscriptions allocations.

Files changed:

- ExperimentFiltersManagerImpl — Subscriptions → Lazy\<Subscriptions>
- EntitlementTargetMatcherPlugin — Subscriptions → Lazy\<Subscriptions>
- SubscriptionsToggleTargetMatcherPlugin — Subscriptions → Lazy\<Subscriptions>

No behavioural change. The same subscription state is read, just deferred until needed.

### Steps to test this PR

- [x] Verify subscription-targeted feature flags still resolve correctly:
    - A flag with an isPrivacyProEligible / entitlement target enables/disables as expected for both eligible and non-eligible accounts.
    - An experiment variant gated on privacyProEligible is assigned correctly.
- [x] Confirm non-subscription flags and experiments behave exactly as before.
- [x] Smoke-test the Privacy Pro flow (eligibility check, purchase launch, entitlement status) to confirm RealSubscriptions still initialises correctly when first accessed.
- [x] ./gradlew :subscriptions-impl:testDebugUnitTest :experiments-impl:testDebugUnitTest pass.

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical DI deferral with identical call sites after `.get()`; unit tests updated, though subscription-gated flags and experiments are the affected paths if lazy wiring regressed.
> 
> **Overview**
> **Defers construction of `RealSubscriptions`** for early-bound feature-toggle and experiment code by switching three injection sites from `Subscriptions` to `Lazy<Subscriptions>` and calling `subscriptions.get()` only when subscription state is actually needed.
> 
> `ExperimentFiltersManagerImpl` now resolves the `privacyProEligible` experiment filter lazily. `EntitlementTargetMatcherPlugin` and `SubscriptionsToggleTargetMatcherPlugin` defer reads of entitlement status and Privacy Pro eligibility until their target properties are set. Unit tests pass a lazy provider (e.g. `{ mockSubscriptions }`) instead of a direct mock.
> 
> **No intended behavior change**—the same APIs run with the same `runBlocking` patterns; `RealSubscriptions` and its dependency graph are simply not built at app/plugin wiring time unless a flag or variant evaluates a subscription-related target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41eefa0410042e4a75966882ac6f77c463aa510d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->