### PR TITLE
PIR: Make the number of PIR webviews configurable

### DIFF
--- a/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/PirEndToEndTest.kt
+++ b/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/PirEndToEndTest.kt
@@ -33,6 +33,7 @@ import com.duckduckgo.pir.impl.common.PirRunStateHandler
 import com.duckduckgo.pir.impl.common.RealBrokerStepsParser
 import com.duckduckgo.pir.impl.common.RealEmailDataResolver
 import com.duckduckgo.pir.impl.common.RealPirRunStateHandler
+import com.duckduckgo.pir.impl.common.RealPirWebViewCountProvider
 import com.duckduckgo.pir.impl.common.actions.BrokerActionFailedEventHandler
 import com.duckduckgo.pir.impl.common.actions.BrokerStepCompletedEventHandler
 import com.duckduckgo.pir.impl.common.actions.CaptchaInfoReceivedEventHandler
@@ -322,6 +323,11 @@ class PirEndToEndTest {
 
         val pirCallbacksPluginPoint = FakePluginPoint<PirCallbacks>()
 
+        val pirWebViewCountProvider = RealPirWebViewCountProvider(
+            pirRemoteFeatures = FakeFeatureToggleFactory.create(PirRemoteFeatures::class.java),
+            dispatcherProvider = dispatcherProvider,
+        )
+
         pirScan = RealPirScan(
             repository = pirRepository,
             eventsRepository = pirEventsRepository,
@@ -332,6 +338,7 @@ class PirEndToEndTest {
             dispatcherProvider = dispatcherProvider,
             callbacks = pirCallbacksPluginPoint,
             webViewDataCleaner = fakePirWebViewDataCleaner,
+            pirWebViewCountProvider = pirWebViewCountProvider,
         )
 
         pirOptOut = RealPirOptOut(
@@ -344,6 +351,7 @@ class PirEndToEndTest {
             dispatcherProvider = dispatcherProvider,
             callbacks = pirCallbacksPluginPoint,
             webViewDataCleaner = fakePirWebViewDataCleaner,
+            pirWebViewCountProvider = pirWebViewCountProvider,
         )
 
         eligibleScanJobProvider = RealEligibleScanJobProvider(
@@ -374,6 +382,7 @@ class PirEndToEndTest {
             pirScanWideEvent = NoOpPirScanWideEvent,
             pirInitialScanCompletionWideEvent = NoOpPirInitialScanCompletionWideEvent,
             networkProtectionState = fakeNetworkProtectionState,
+            pirWebViewCountProvider = pirWebViewCountProvider,
         )
 
         pirEmailConfirmation = RealPirEmailConfirmation(
@@ -384,6 +393,7 @@ class PirEndToEndTest {
             dispatcherProvider = dispatcherProvider,
             callbacks = pirCallbacksPluginPoint,
             webViewDataCleaner = fakePirWebViewDataCleaner,
+            pirWebViewCountProvider = pirWebViewCountProvider,
         )
 
         pirEmailConfirmationJobsRunner = RealPirEmailConfirmationJobsRunner(

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirJobConstants.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirJobConstants.kt
@@ -19,7 +19,10 @@ package com.duckduckgo.pir.impl.common
 object PirJobConstants {
     const val DBP_INITIAL_URL = "dbp://blank"
     const val RECOVERY_URL = "https://duckduckgo.com/"
-    const val MAX_DETACHED_WEBVIEW_COUNT = 20
+
+    const val DEFAULT_MAX_DETACHED_WEBVIEW_COUNT = 20
+    const val MIN_DETACHED_WEBVIEW_COUNT = 1
+    const val MAX_DETACHED_WEBVIEW_COUNT_CEILING = 40
     const val SCHEDULED_SCAN_INTERVAL_HOURS = 4L
     const val EMAIL_CONFIRMATION_INTERVAL_HOURS = 8L
     const val CUSTOM_PIXEL_INTERVAL_HOURS = 5L

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirWebViewCountProvider.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirWebViewCountProvider.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.common
+
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.pir.impl.PirRemoteFeatures
+import com.duckduckgo.pir.impl.common.PirJobConstants.DEFAULT_MAX_DETACHED_WEBVIEW_COUNT
+import com.duckduckgo.pir.impl.common.PirJobConstants.MAX_DETACHED_WEBVIEW_COUNT_CEILING
+import com.duckduckgo.pir.impl.common.PirJobConstants.MIN_DETACHED_WEBVIEW_COUNT
+import com.squareup.anvil.annotations.ContributesBinding
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import javax.inject.Inject
+
+interface PirWebViewCountProvider {
+    /**
+     * Resolves the maximum number of detached WebViews (runners) to use for the next run.
+     */
+    suspend fun getMaxWebViewCount(): Int
+}
+
+@ContributesBinding(AppScope::class)
+class RealPirWebViewCountProvider @Inject constructor(
+    private val pirRemoteFeatures: PirRemoteFeatures,
+    private val dispatcherProvider: DispatcherProvider,
+) : PirWebViewCountProvider {
+
+    override suspend fun getMaxWebViewCount(): Int = withContext(dispatcherProvider.io()) {
+        runCatching {
+            val settings = pirRemoteFeatures.self().getSettings() ?: return@runCatching DEFAULT_MAX_DETACHED_WEBVIEW_COUNT
+            val json = JSONObject(settings)
+            if (!json.has(SETTINGS_KEY_WEBVIEW_COUNT)) {
+                return@runCatching DEFAULT_MAX_DETACHED_WEBVIEW_COUNT
+            }
+            json.getInt(SETTINGS_KEY_WEBVIEW_COUNT)
+                .coerceIn(MIN_DETACHED_WEBVIEW_COUNT, MAX_DETACHED_WEBVIEW_COUNT_CEILING)
+        }.getOrDefault(DEFAULT_MAX_DETACHED_WEBVIEW_COUNT)
+    }
+
+    companion object {
+        private const val SETTINGS_KEY_WEBVIEW_COUNT = "detachedWebViewCount"
+    }
+}

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/email/PirEmailConfirmation.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/email/PirEmailConfirmation.kt
@@ -28,7 +28,7 @@ import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep
 import com.duckduckgo.pir.impl.common.PirActionsRunner
 import com.duckduckgo.pir.impl.common.PirJob
 import com.duckduckgo.pir.impl.common.PirJob.RunType
-import com.duckduckgo.pir.impl.common.PirJobConstants.MAX_DETACHED_WEBVIEW_COUNT
+import com.duckduckgo.pir.impl.common.PirWebViewCountProvider
 import com.duckduckgo.pir.impl.common.PirWebViewDataCleaner
 import com.duckduckgo.pir.impl.common.RealPirActionsRunner
 import com.duckduckgo.pir.impl.common.splitIntoParts
@@ -80,6 +80,7 @@ class RealPirEmailConfirmation @Inject constructor(
     private val pirActionsRunnerFactory: RealPirActionsRunner.Factory,
     private val dispatcherProvider: DispatcherProvider,
     private val webViewDataCleaner: PirWebViewDataCleaner,
+    private val pirWebViewCountProvider: PirWebViewCountProvider,
     callbacks: PluginPoint<PirCallbacks>,
 ) : PirJob(callbacks),
     PirEmailConfirmation {
@@ -106,7 +107,7 @@ class RealPirEmailConfirmation @Inject constructor(
         }
 
         val script = pirCssScriptLoader.getScript()
-        maxWebViewCount = minOf(processedJobRecords.size, MAX_DETACHED_WEBVIEW_COUNT)
+        maxWebViewCount = minOf(processedJobRecords.size, pirWebViewCountProvider.getMaxWebViewCount())
 
         logcat { "PIR-EMAIL-CONFIRMATION: Attempting to create $maxWebViewCount parallel runners on ${Thread.currentThread().name}" }
         // Initiate runners

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/optout/PirOptOut.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/optout/PirOptOut.kt
@@ -30,7 +30,7 @@ import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.OptOutStep
 import com.duckduckgo.pir.impl.common.PirActionsRunner
 import com.duckduckgo.pir.impl.common.PirJob
 import com.duckduckgo.pir.impl.common.PirJob.RunType.OPTOUT
-import com.duckduckgo.pir.impl.common.PirJobConstants.MAX_DETACHED_WEBVIEW_COUNT
+import com.duckduckgo.pir.impl.common.PirWebViewCountProvider
 import com.duckduckgo.pir.impl.common.PirWebViewDataCleaner
 import com.duckduckgo.pir.impl.common.RealPirActionsRunner
 import com.duckduckgo.pir.impl.common.splitIntoParts
@@ -113,6 +113,7 @@ class RealPirOptOut @Inject constructor(
     private val currentTimeProvider: CurrentTimeProvider,
     private val dispatcherProvider: DispatcherProvider,
     private val webViewDataCleaner: PirWebViewDataCleaner,
+    private val pirWebViewCountProvider: PirWebViewCountProvider,
     callbacks: PluginPoint<PirCallbacks>,
 ) : PirOptOut, PirJob(callbacks) {
     private val runners: MutableList<PirActionsRunner> = mutableListOf()
@@ -152,7 +153,7 @@ class RealPirOptOut @Inject constructor(
         }
 
         val script = pirCssScriptLoader.getScript()
-        maxWebViewCount = minOf(processedJobRecords.size, MAX_DETACHED_WEBVIEW_COUNT)
+        maxWebViewCount = minOf(processedJobRecords.size, pirWebViewCountProvider.getMaxWebViewCount())
 
         logcat { "PIR-OPT-OUT: Attempting to create $maxWebViewCount parallel runners on ${Thread.currentThread().name}" }
 
@@ -348,7 +349,7 @@ class RealPirOptOut @Inject constructor(
             }.flatten().map { step -> profileQuery to step }
         }.flatten()
 
-        maxWebViewCount = minOf(allSteps.size, MAX_DETACHED_WEBVIEW_COUNT)
+        maxWebViewCount = minOf(allSteps.size, pirWebViewCountProvider.getMaxWebViewCount())
 
         // Assign steps to runners based on the maximum number of WebViews we can use
         val stepsPerRunner = allSteps.splitIntoParts(maxWebViewCount)

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scan/PirScan.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scan/PirScan.kt
@@ -29,7 +29,7 @@ import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep
 import com.duckduckgo.pir.impl.common.PirActionsRunner
 import com.duckduckgo.pir.impl.common.PirJob
 import com.duckduckgo.pir.impl.common.PirJob.RunType
-import com.duckduckgo.pir.impl.common.PirJobConstants.MAX_DETACHED_WEBVIEW_COUNT
+import com.duckduckgo.pir.impl.common.PirWebViewCountProvider
 import com.duckduckgo.pir.impl.common.PirWebViewDataCleaner
 import com.duckduckgo.pir.impl.common.RealPirActionsRunner
 import com.duckduckgo.pir.impl.common.splitIntoParts
@@ -120,6 +120,7 @@ class RealPirScan @Inject constructor(
     private val currentTimeProvider: CurrentTimeProvider,
     private val dispatcherProvider: DispatcherProvider,
     private val webViewDataCleaner: PirWebViewDataCleaner,
+    private val pirWebViewCountProvider: PirWebViewCountProvider,
     callbacks: PluginPoint<PirCallbacks>,
 ) : PirScan, PirJob(callbacks) {
 
@@ -167,7 +168,7 @@ class RealPirScan @Inject constructor(
         }
 
         val script = pirCssScriptLoader.getScript()
-        maxWebViewCount = minOf(processedJobRecords.size, MAX_DETACHED_WEBVIEW_COUNT)
+        maxWebViewCount = minOf(processedJobRecords.size, pirWebViewCountProvider.getMaxWebViewCount())
 
         logcat { "PIR-SCAN: Attempting to create $maxWebViewCount parallel runners on ${Thread.currentThread().name}" }
         // Initiate runners
@@ -332,7 +333,7 @@ class RealPirScan @Inject constructor(
         logcat { "PIR-SCAN: Running scan on profiles: $profileQueries on ${Thread.currentThread().name}" }
 
         val script = pirCssScriptLoader.getScript()
-        maxWebViewCount = minOf(brokers.size * profileQueries.size, MAX_DETACHED_WEBVIEW_COUNT)
+        maxWebViewCount = minOf(brokers.size * profileQueries.size, pirWebViewCountProvider.getMaxWebViewCount())
 
         logcat { "PIR-SCAN: Attempting to create $maxWebViewCount parallel runners on ${Thread.currentThread().name}" }
 

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
@@ -27,7 +27,7 @@ import com.duckduckgo.networkprotection.api.NetworkProtectionState
 import com.duckduckgo.pir.impl.PirRemoteFeatures
 import com.duckduckgo.pir.impl.brokers.BrokerJsonUpdater
 import com.duckduckgo.pir.impl.common.PirJob.RunType
-import com.duckduckgo.pir.impl.common.PirJobConstants.MAX_DETACHED_WEBVIEW_COUNT
+import com.duckduckgo.pir.impl.common.PirWebViewCountProvider
 import com.duckduckgo.pir.impl.models.ProfileQuery
 import com.duckduckgo.pir.impl.models.scheduling.JobRecord.OptOutJobRecord
 import com.duckduckgo.pir.impl.models.scheduling.JobRecord.ScanJobRecord
@@ -82,6 +82,7 @@ class RealPirJobsRunner @Inject constructor(
     private val pirScanWideEvent: PirScanWideEvent,
     private val pirInitialScanCompletionWideEvent: PirInitialScanCompletionWideEvent,
     private val networkProtectionState: NetworkProtectionState,
+    private val pirWebViewCountProvider: PirWebViewCountProvider,
 ) : PirJobsRunner {
     override suspend fun runEligibleJobs(
         context: Context,
@@ -156,7 +157,7 @@ class RealPirJobsRunner @Inject constructor(
         val batteryOptimizationsEnabled = !context.isIgnoringBatteryOptimizations()
         val notificationsPermissionGranted = context.areNotificationsPermissionGranted()
         val isTrackerBlockingEnabled = pirRemoteFeatures.trackerBlocking().isEnabled()
-        val webViewCount = minOf(eligibleJobs.size, MAX_DETACHED_WEBVIEW_COUNT)
+        val webViewCount = minOf(eligibleJobs.size, pirWebViewCountProvider.getMaxWebViewCount())
 
         pirScanWideEvent.onRunStarted(
             executionType = executionType,

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/common/RealPirWebViewCountProviderTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/common/RealPirWebViewCountProviderTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2025 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.common
+
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.pir.impl.PirRemoteFeatures
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class RealPirWebViewCountProviderTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val mockPirRemoteFeatures: PirRemoteFeatures = mock()
+    private val mockSelfToggle: Toggle = mock()
+
+    private lateinit var testee: RealPirWebViewCountProvider
+
+    @Before
+    fun setUp() {
+        whenever(mockPirRemoteFeatures.self()).thenReturn(mockSelfToggle)
+        testee = RealPirWebViewCountProvider(
+            pirRemoteFeatures = mockPirRemoteFeatures,
+            dispatcherProvider = coroutineRule.testDispatcherProvider,
+        )
+    }
+
+    @Test
+    fun whenSettingsNullThenReturnsDefault() = runTest {
+        whenever(mockSelfToggle.getSettings()).thenReturn(null)
+
+        assertEquals(20, testee.getMaxWebViewCount())
+    }
+
+    @Test
+    fun whenSettingsMissingKeyThenReturnsDefault() = runTest {
+        whenever(mockSelfToggle.getSettings()).thenReturn("{}")
+
+        assertEquals(20, testee.getMaxWebViewCount())
+    }
+
+    @Test
+    fun whenSettingsMalformedJsonThenReturnsDefault() = runTest {
+        whenever(mockSelfToggle.getSettings()).thenReturn("not-json")
+
+        assertEquals(20, testee.getMaxWebViewCount())
+    }
+
+    @Test
+    fun whenSettingsValueNotAnIntegerThenReturnsDefault() = runTest {
+        whenever(mockSelfToggle.getSettings()).thenReturn("""{"detachedWebViewCount": "abc"}""")
+
+        assertEquals(20, testee.getMaxWebViewCount())
+    }
+
+    @Test
+    fun whenValidInRangeValueThenReturnsValue() = runTest {
+        whenever(mockSelfToggle.getSettings()).thenReturn("""{"detachedWebViewCount": 8}""")
+
+        assertEquals(8, testee.getMaxWebViewCount())
+    }
+
+    @Test
+    fun whenValueBelowMinThenClampedToMin() = runTest {
+        whenever(mockSelfToggle.getSettings()).thenReturn("""{"detachedWebViewCount": 0}""")
+
+        assertEquals(1, testee.getMaxWebViewCount())
+    }
+
+    @Test
+    fun whenValueNegativeThenClampedToMin() = runTest {
+        whenever(mockSelfToggle.getSettings()).thenReturn("""{"detachedWebViewCount": -5}""")
+
+        assertEquals(1, testee.getMaxWebViewCount())
+    }
+
+    @Test
+    fun whenValueAboveCeilingThenClampedToCeiling() = runTest {
+        whenever(mockSelfToggle.getSettings()).thenReturn("""{"detachedWebViewCount": 100}""")
+
+        assertEquals(40, testee.getMaxWebViewCount())
+    }
+
+    @Test
+    fun whenValueEqualsCeilingThenReturnsCeiling() = runTest {
+        whenever(mockSelfToggle.getSettings()).thenReturn("""{"detachedWebViewCount": 40}""")
+
+        assertEquals(40, testee.getMaxWebViewCount())
+    }
+}

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/email/RealPirEmailConfirmationTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/email/RealPirEmailConfirmationTest.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.pir.impl.common.BrokerStepsParser
 import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.EmailConfirmationStep
 import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.OptOutStepActions
 import com.duckduckgo.pir.impl.common.PirJob.RunType
+import com.duckduckgo.pir.impl.common.PirWebViewCountProvider
 import com.duckduckgo.pir.impl.common.PirWebViewDataCleaner
 import com.duckduckgo.pir.impl.common.RealPirActionsRunner
 import com.duckduckgo.pir.impl.models.Broker
@@ -62,10 +63,13 @@ class RealPirEmailConfirmationTest {
     private val mockContext: Context = mock()
     private val mockPirActionsRunner: RealPirActionsRunner = mock()
     private val mockWebViewDataCleaner: PirWebViewDataCleaner = mock()
+    private val mockPirWebViewCountProvider: PirWebViewCountProvider = mock()
 
     @Before
     fun setUp() {
         whenever(mockCallbacks.getPlugins()).thenReturn(emptyList())
+
+        kotlinx.coroutines.runBlocking { whenever(mockPirWebViewCountProvider.getMaxWebViewCount()).thenReturn(20) }
 
         testee = RealPirEmailConfirmation(
             repository = mockRepository,
@@ -75,6 +79,7 @@ class RealPirEmailConfirmationTest {
             dispatcherProvider = coroutineRule.testDispatcherProvider,
             callbacks = mockCallbacks,
             webViewDataCleaner = mockWebViewDataCleaner,
+            pirWebViewCountProvider = mockPirWebViewCountProvider,
         )
     }
 

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/optout/RealPirOptOutTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/optout/RealPirOptOutTest.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.pir.impl.common.BrokerStepsParser
 import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.OptOutStep
 import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.OptOutStepActions
 import com.duckduckgo.pir.impl.common.PirJob.RunType.OPTOUT
+import com.duckduckgo.pir.impl.common.PirWebViewCountProvider
 import com.duckduckgo.pir.impl.common.PirWebViewDataCleaner
 import com.duckduckgo.pir.impl.common.RealPirActionsRunner
 import com.duckduckgo.pir.impl.models.Broker
@@ -66,10 +67,13 @@ class RealPirOptOutTest {
     private val mockContext: Context = mock()
     private val mockPirActionsRunner: RealPirActionsRunner = mock()
     private val mockWebViewDataCleaner: PirWebViewDataCleaner = mock()
+    private val mockPirWebViewCountProvider: PirWebViewCountProvider = mock()
 
     @Before
     fun setUp() {
         whenever(mockCallbacks.getPlugins()).thenReturn(emptyList())
+
+        kotlinx.coroutines.runBlocking { whenever(mockPirWebViewCountProvider.getMaxWebViewCount()).thenReturn(20) }
 
         testee = RealPirOptOut(
             repository = mockRepository,
@@ -81,6 +85,7 @@ class RealPirOptOutTest {
             dispatcherProvider = coroutineRule.testDispatcherProvider,
             callbacks = mockCallbacks,
             webViewDataCleaner = mockWebViewDataCleaner,
+            pirWebViewCountProvider = mockPirWebViewCountProvider,
         )
     }
 

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scan/RealPirScanTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scan/RealPirScanTest.kt
@@ -26,6 +26,7 @@ import com.duckduckgo.pir.impl.common.BrokerStepsParser
 import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStep.ScanStep
 import com.duckduckgo.pir.impl.common.BrokerStepsParser.BrokerStepActions.ScanStepActions
 import com.duckduckgo.pir.impl.common.PirJob.RunType
+import com.duckduckgo.pir.impl.common.PirWebViewCountProvider
 import com.duckduckgo.pir.impl.common.PirWebViewDataCleaner
 import com.duckduckgo.pir.impl.common.RealPirActionsRunner
 import com.duckduckgo.pir.impl.models.Broker
@@ -63,10 +64,12 @@ class RealPirScanTest {
     private val mockContext: Context = mock()
     private val mockPirActionsRunner: RealPirActionsRunner = mock()
     private val mockWebViewDataCleaner: PirWebViewDataCleaner = mock()
+    private val mockPirWebViewCountProvider: PirWebViewCountProvider = mock()
 
     @Before
     fun setUp() {
         whenever(mockCallbacks.getPlugins()).thenReturn(emptyList())
+        kotlinx.coroutines.runBlocking { whenever(mockPirWebViewCountProvider.getMaxWebViewCount()).thenReturn(20) }
 
         testee = RealPirScan(
             repository = mockRepository,
@@ -78,6 +81,7 @@ class RealPirScanTest {
             dispatcherProvider = coroutineRule.testDispatcherProvider,
             callbacks = mockCallbacks,
             webViewDataCleaner = mockWebViewDataCleaner,
+            pirWebViewCountProvider = mockPirWebViewCountProvider,
         )
     }
 

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealPirJobsRunnerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealPirJobsRunnerTest.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.networkprotection.api.NetworkProtectionState
 import com.duckduckgo.pir.impl.PirRemoteFeatures
 import com.duckduckgo.pir.impl.brokers.BrokerJsonUpdater
 import com.duckduckgo.pir.impl.common.PirJob.RunType
+import com.duckduckgo.pir.impl.common.PirWebViewCountProvider
 import com.duckduckgo.pir.impl.models.ExtractedProfile
 import com.duckduckgo.pir.impl.models.ProfileQuery
 import com.duckduckgo.pir.impl.models.scheduling.JobRecord.OptOutJobRecord
@@ -86,6 +87,7 @@ class RealPirJobsRunnerTest {
     private val mockPirScanWideEvent: PirScanWideEvent = mock()
     private val mockPirInitialScanCompletionWideEvent: PirInitialScanCompletionWideEvent = mock()
     private val mockNetworkProtectionState: NetworkProtectionState = mock()
+    private val mockPirWebViewCountProvider: PirWebViewCountProvider = mock()
 
     @Before
     fun setUp() = kotlinx.coroutines.runBlocking {
@@ -98,6 +100,7 @@ class RealPirJobsRunnerTest {
         whenever(mockPirRemoteFeatures.trackerBlocking()).thenReturn(mockTrackerBlockingToggle)
         whenever(mockTrackerBlockingToggle.isEnabled()).thenReturn(false)
         whenever(mockNetworkProtectionState.isRunning()).thenReturn(false)
+        whenever(mockPirWebViewCountProvider.getMaxWebViewCount()).thenReturn(20)
 
         testee = RealPirJobsRunner(
             dispatcherProvider = coroutineRule.testDispatcherProvider,
@@ -114,6 +117,7 @@ class RealPirJobsRunnerTest {
             pirScanWideEvent = mockPirScanWideEvent,
             pirInitialScanCompletionWideEvent = mockPirInitialScanCompletionWideEvent,
             networkProtectionState = mockNetworkProtectionState,
+            pirWebViewCountProvider = mockPirWebViewCountProvider,
         )
     }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203581873609357/task/1216621438089875?focus=true
Tech Design URL (if applicable): N/A

### Description
Makes the number of WebViews in PIR configurable remotely.

### Steps to test this PR

_Feature 1_
- [ ] Run a smoke check with default values and check that the scan completes normally 
- [ ] (optional) Set the new remote settings value to 15 for example and run again

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how many concurrent WebViews PIR spawns, which affects memory, battery, and scan/opt-out timing; remote misconfiguration could stress devices though values are clamped and default to current behavior.
> 
> **Overview**
> PIR no longer caps parallel detached WebViews at a fixed **20** everywhere. A new **`PirWebViewCountProvider`** resolves the limit per run from **`PirRemoteFeatures.self()`** settings JSON (`detachedWebViewCount`), with **default 20**, clamped to **1–40**, and safe fallbacks when settings are missing or invalid.
> 
> **Scan**, **opt-out**, **email confirmation**, and **`RealPirJobsRunner`** (wide-event `webViewCount`) now call `getMaxWebViewCount()` instead of `PirJobConstants.MAX_DETACHED_WEBVIEW_COUNT`. Constants were renamed/split (`DEFAULT_MAX_DETACHED_WEBVIEW_COUNT`, min/ceiling). Unit tests cover the provider; existing job tests wire a mock returning 20.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05ec2ecee85dc8a4183aef81f4b91812f5274503. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->