### PR TITLE
Handle delete account action in simplified sync

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivity.kt
@@ -336,7 +336,7 @@ class SyncActivity : DuckDuckGoActivity() {
         }
 
         binding.viewSyncEnabled.deleteAccountButton.setOnClickListener {
-            viewModel.onDeleteAccountClicked()
+            viewModel.onDeleteAccountClicked(requireAuth = false)
         }
 
         binding.viewSyncEnabled.syncAnotherDeviceItem.setOnClickListener {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
@@ -409,9 +409,15 @@ class SyncActivityViewModel @Inject constructor(
         showAccountDetailsIfNeeded()
     }
 
-    fun onDeleteAccountClicked() {
+    fun onDeleteAccountClicked(requireAuth: Boolean) {
         viewModelScope.launch {
-            command.send(AskDeleteAccount)
+            if (requireAuth) {
+                requiresSetupAuthentication {
+                    command.send(AskDeleteAccount)
+                }
+            } else {
+                command.send(AskDeleteAccount)
+            }
         }
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
@@ -518,8 +518,13 @@ class SyncActivity : DuckDuckGoActivity() {
                     override fun onNegativeButtonClicked() {
                         viewModel.onDeleteAccountCancelled()
                     }
+
+                    override fun onDialogCancelled() {
+                        viewModel.onDeleteAccountCancelled()
+                    }
                 },
             )
+            .setCancellable(true)
             .show()
     }
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
@@ -34,6 +34,8 @@ import com.duckduckgo.appbuildconfig.api.AppBuildConfig
 import com.duckduckgo.common.ui.DuckDuckGoActivity
 import com.duckduckgo.common.ui.spans.DuckDuckGoClickableSpan
 import com.duckduckgo.common.ui.view.addClickableSpan
+import com.duckduckgo.common.ui.view.button.ButtonType.DESTRUCTIVE
+import com.duckduckgo.common.ui.view.button.ButtonType.GHOST_ALT
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.getColorFromAttr
 import com.duckduckgo.common.ui.viewbinding.viewBinding
@@ -284,7 +286,9 @@ class SyncActivity : DuckDuckGoActivity() {
             }
 
             is AskDeleteAccount -> {
-                logcat { "TODO: Handle ${command.javaClass.simpleName} command" }
+                authenticate {
+                    showDeleteAccountDialog()
+                }
             }
 
             is AskEditDevice -> {
@@ -470,6 +474,7 @@ class SyncActivity : DuckDuckGoActivity() {
         binding.includeEnabledView.deleteAccountItem.apply {
             leadingIcon().imageTintList = color
             setPrimaryTextColorStateList(color)
+            setOnClickListener { viewModel.onDeleteAccountClicked(requireAuth = true) }
         }
     }
 
@@ -495,6 +500,26 @@ class SyncActivity : DuckDuckGoActivity() {
                 },
             )
             .setCancellable(true)
+            .show()
+    }
+
+    private fun showDeleteAccountDialog() {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_settings_v2_delete_server_data_dialog_title)
+            .setMessage(getString(R.string.sync_settings_v2_delete_server_data_dialog_body))
+            .setPositiveButton(R.string.sync_delete_server_data_dialog_primary_button, DESTRUCTIVE)
+            .setNegativeButton(R.string.sync_delete_server_data_dialog_secondary_button, GHOST_ALT)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() {
+                        viewModel.onDeleteAccountConfirmed()
+                    }
+
+                    override fun onNegativeButtonClicked() {
+                        viewModel.onDeleteAccountCancelled()
+                    }
+                },
+            )
             .show()
     }
 

--- a/sync/sync-impl/src/main/res/values/donottranslate.xml
+++ b/sync/sync-impl/src/main/res/values/donottranslate.xml
@@ -29,6 +29,8 @@
     <string name="sync_settings_v2_copy_recovery_code_item">Copy Your Recovery Code</string>
     <string name="sync_settings_v2_delete_account_item">Turn Off and Delete Server Data</string>
     <string name="sync_settings_v2_bookmarks_section_header">Bookmarks</string>
+    <string name="sync_settings_v2_delete_server_data_dialog_title">Turn Off Sync &amp; Backup and Delete Server Data?</string>
+    <string name="sync_settings_v2_delete_server_data_dialog_body">All devices using Sync &amp; Backup will be disconnected and your synced data will be deleted from the server.</string>
     <string name="sync_setup_v2_header_headline">Sync this device with a nearby computer.</string>
     <string name="sync_setup_v2_header_body">We’ll help you sync your devices.</string>
     <string name="sync_setup_v2_this_device_cta_title">Sync This Device Only</string>

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModelTest.kt
@@ -472,11 +472,39 @@ class SyncActivityViewModelTest {
     }
 
     @Test
-    fun whenDeleteAccountClickedThenAskDeleteAccount() = runTest {
-        testee.onDeleteAccountClicked()
+    fun whenDeleteAccountClickedWithoutRequireAuthThenAskDeleteAccount() = runTest {
+        givenUserHasDeviceAuthentication(false)
+
+        testee.onDeleteAccountClicked(requireAuth = false)
 
         testee.commands().test {
             awaitItem().assertCommandType(Command.AskDeleteAccount::class)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenDeleteAccountClickedWithRequireAuthAndDeviceAuthenticationThenAskDeleteAccount() = runTest {
+        givenUserHasDeviceAuthentication(true)
+
+        testee.onDeleteAccountClicked(requireAuth = true)
+
+        testee.commands().test {
+            awaitItem().assertCommandType(Command.AskDeleteAccount::class)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenDeleteAccountClickedWithRequireAuthWithoutDeviceAuthenticationThenRequestSetupAuthentication() = runTest {
+        givenUserHasDeviceAuthentication(false)
+
+        testee.onDeleteAccountClicked(requireAuth = true)
+
+        testee.commands().test {
+            val command = awaitItem()
+            command.assertCommandType(RequestSetupAuthentication::class)
+            assertFalse((command as RequestSetupAuthentication).forSyncThisDevice)
             cancelAndIgnoreRemainingEvents()
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216103556496795/task/1216781820998552?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1216103556496795/task/1216509582049467?focus=true

### Description

Wires up the "Turn Off and Delete Server Data" item in the simplified Sync Settings screen. Tapping it previously did nothing.

- Tapping the item first checks that device authentication is set up. If it is not, the existing prompt to secure the device is shown.
- After the user authenticates, a confirmation dialog explains that all devices using Sync & Backup will be disconnected and the synced data will be deleted from the server.
- Tapping "Delete Server Data", shown as a destructive action, deletes the data and returns the screen to the sync setup state.
- If the deletion fails, an error dialog is shown and sync stays enabled.
- Tapping "Cancel" dismisses the dialog and leaves sync unchanged.

The shared view model action now takes a `requireAuth` flag. The existing Sync Settings screen passes `false`, so its behavior is unchanged and it keeps showing the confirmation dialog without requiring device authentication.

### Steps to test this PR

_Delete server data_
- [ ] Open Sync Dev Settings on a device with sync enabled.
- [ ] Tap "Launch Sync Settings V2".
- [ ] Tap "Turn Off and Delete Server Data".
- [ ] Complete the device authentication prompt.
- [ ] Verify a dialog appears with the title "Turn Off Sync & Backup and Delete Server Data?".
- [ ] Tap "Cancel".
- [ ] Verify sync stays enabled and settings screen is unchanged.
- [ ] Tap "Copy Your Recovery Code".
- [ ] Tap "Turn Off and Delete Server Data".
- [ ] Tap "Delete Server Data".
- [ ] Verify the screen returns to the sync setup state.
- [ ] Go to the legacy Sync Settings.
- [ ] Tap "Recover Sync Data".
- [ ] Use your recovery code from the clipboard.
- [ ] Verify that the account cannot be recovered.

_No device authentication set up_
- [ ] On a device without a PIN or biometrics, tap "Turn Off and Delete Server Data".
- [ ] Verify a prompt to set up device authentication is shown.

_Existing Sync Settings screen_
- [ ] Open the existing Sync Settings screen from Settings.
- [ ] Tap "Turn Off and Delete Server Data".
- [ ] Verify the confirmation dialog appears without a device authentication prompt.

### UI changes
| Delete dialog |
| ------ |
| <img width="540" alt="image" src="https://github.com/user-attachments/assets/613ffc52-333f-470d-9be2-1be92ce82f5a" /> |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a destructive sync account deletion path and auth gating, though confirmations and tests limit accidental data loss.
> 
> **Overview**
> **Turn Off and Delete Server Data** on simplified Sync Settings (V2) is now fully wired: the row calls `onDeleteAccountClicked(requireAuth = true)`, the view model can gate on setup/device auth, and V2 handles `AskDeleteAccount` with biometric/PIN auth plus a new confirmation dialog (V2 copy strings; destructive primary button).
> 
> `SyncActivityViewModel.onDeleteAccountClicked` gains a **`requireAuth`** flag—when true it runs `requiresSetupAuthentication` (or `RequestSetupAuthentication` if the device isn’t secured); when false it emits `AskDeleteAccount` immediately. **Legacy Sync Settings** passes `requireAuth = false`, so it still shows the existing delete dialog without an extra auth step.
> 
> View-model tests cover all three delete-click paths (no auth required, auth required with enrollment, auth required without enrollment).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5c7c3c7617ca7655de9e4a1aae0b4cda633ed34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->