### PR TITLE
Handle get desktop browser sync setting action

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/GetOnOtherPlatformsListItem.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/GetOnOtherPlatformsListItem.kt
@@ -24,7 +24,7 @@ import androidx.core.view.isGone
 import androidx.core.view.isVisible
 import com.duckduckgo.sync.impl.databinding.ViewSyncV2OtherPlatformsListItemBinding
 
-internal class SyncOnOtherPlatformsListItem @JvmOverloads constructor(
+internal class GetOnOtherPlatformsListItem @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0,

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
@@ -44,6 +44,7 @@ import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.DaggerMap
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.navigation.api.getActivityParams
 import com.duckduckgo.sync.api.SyncActivityWithAnotherDevice
 import com.duckduckgo.sync.api.SyncSettingsPlugin
@@ -56,6 +57,7 @@ import com.duckduckgo.sync.impl.auth.DeviceAuthenticator.AuthResult.Error
 import com.duckduckgo.sync.impl.auth.DeviceAuthenticator.AuthResult.Success
 import com.duckduckgo.sync.impl.auth.DeviceAuthenticator.AuthResult.UserCancelled
 import com.duckduckgo.sync.impl.databinding.ActivitySyncV2Binding
+import com.duckduckgo.sync.impl.promotion.SyncGetOnOtherPlatformsParams
 import com.duckduckgo.sync.impl.ui.DeviceUnsupportedActivity
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel
 import com.duckduckgo.sync.impl.ui.SyncActivityViewModel.Command
@@ -121,6 +123,9 @@ class SyncActivity : DuckDuckGoActivity() {
 
     @Inject
     lateinit var shareAction: ShareAction
+
+    @Inject
+    lateinit var globalActivityStarter: GlobalActivityStarter
 
     private val launchSource
         get() = intent.getActivityParams(SyncActivityWithSourceParams::class.java)?.source
@@ -217,6 +222,7 @@ class SyncActivity : DuckDuckGoActivity() {
         configureDevicesRecyclerView()
         configureBookmarksSection()
         configureRecoverySection()
+        configureGetOnOtherPlatformsItem()
         configureDataExpirationNotice()
         configureDataDeletionItem()
 
@@ -253,7 +259,7 @@ class SyncActivity : DuckDuckGoActivity() {
         syncedDeviceAdapter.submitList(viewState.syncedDevices)
         binding.includeEnabledView.apply {
             root.isVisible = viewState.showAccount
-            syncOnOtherPlatformsItem.setState(
+            getOnOtherPlatformsItem.setState(
                 isNewDesktopBrowserAvailable = viewState.newDesktopBrowserSettingEnabled,
             )
             restoreOnReinstallItem.isVisible = viewState.showAutoRestoreToggle
@@ -270,7 +276,7 @@ class SyncActivity : DuckDuckGoActivity() {
         binding.includeDisabledView.apply {
             root.isGone = viewState.showAccount
             syncThisDeviceToggle.quietlySetIsChecked(viewState.isThisDeviceSyncing, syncThisDeviceListener)
-            syncOnOtherPlatformsItem.setState(
+            getOnOtherPlatformsItem.setState(
                 isNewDesktopBrowserAvailable = viewState.newDesktopBrowserSettingEnabled,
             )
             syncWithAnotherDeviceButton.isEnabled = CreateAccountFlow !in viewState.disabledSetupFlows
@@ -362,7 +368,7 @@ class SyncActivity : DuckDuckGoActivity() {
             }
 
             is LaunchSyncGetOnOtherPlatforms -> {
-                logcat { "TODO: Handle ${command.javaClass.simpleName} command" }
+                globalActivityStarter.start(this, SyncGetOnOtherPlatformsParams(command.source))
             }
 
             is RecoveryCodePDFSuccess -> {
@@ -454,6 +460,31 @@ class SyncActivity : DuckDuckGoActivity() {
                 viewModel.onCopyRecoveryCodeClicked()
             }
         }
+    }
+
+    private fun configureGetOnOtherPlatformsItem() {
+        binding.includeEnabledView.getOnOtherPlatformsItem.setListener(
+            object : GetOnOtherPlatformsListItem.Listener {
+                override fun onClickGetDesktopBrowser() {
+                    viewModel.onGetOnOtherPlatformsClickedWhenSyncEnabled()
+                }
+
+                override fun onClickGetOnOtherPlatforms() {
+                    viewModel.onGetOnOtherPlatformsClickedWhenSyncEnabled()
+                }
+            },
+        )
+        binding.includeDisabledView.getOnOtherPlatformsItem.setListener(
+            object : GetOnOtherPlatformsListItem.Listener {
+                override fun onClickGetDesktopBrowser() {
+                    viewModel.onGetOnOtherPlatformsClickedWhenSyncDisabled()
+                }
+
+                override fun onClickGetOnOtherPlatforms() {
+                    viewModel.onGetOnOtherPlatformsClickedWhenSyncDisabled()
+                }
+            },
+        )
     }
 
     private fun configureDataExpirationNotice() {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncOnOtherPlatformsListItem.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncOnOtherPlatformsListItem.kt
@@ -37,4 +37,20 @@ internal class SyncOnOtherPlatformsListItem @JvmOverloads constructor(
         binding.getDesktopBrowserItem.isVisible = isNewDesktopBrowserAvailable
         binding.getOnOtherPlatformsItem.isGone = isNewDesktopBrowserAvailable
     }
+
+    fun setListener(listener: Listener?) {
+        if (listener == null) {
+            binding.getDesktopBrowserItem.setOnClickListener(null)
+            binding.getOnOtherPlatformsItem.setOnClickListener(null)
+        } else {
+            binding.getDesktopBrowserItem.setOnClickListener { listener.onClickGetDesktopBrowser() }
+            binding.getOnOtherPlatformsItem.setOnClickListener { listener.onClickGetOnOtherPlatforms() }
+        }
+    }
+
+    interface Listener {
+        fun onClickGetDesktopBrowser()
+
+        fun onClickGetOnOtherPlatforms()
+    }
 }

--- a/sync/sync-impl/src/main/res/layout/view_sync_v2_disabled.xml
+++ b/sync/sync-impl/src/main/res/layout/view_sync_v2_disabled.xml
@@ -63,8 +63,8 @@
         android:layout_height="wrap_content"
         android:layout_marginVertical="@dimen/keyline_4" />
 
-    <com.duckduckgo.sync.impl.ui.v2.SyncOnOtherPlatformsListItem
-        android:id="@+id/sync_on_other_platforms_item"
+    <com.duckduckgo.sync.impl.ui.v2.GetOnOtherPlatformsListItem
+        android:id="@+id/get_on_other_platforms_item"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 

--- a/sync/sync-impl/src/main/res/layout/view_sync_v2_enabled.xml
+++ b/sync/sync-impl/src/main/res/layout/view_sync_v2_enabled.xml
@@ -55,8 +55,8 @@
         android:layout_height="wrap_content"
         app:primaryText="@string/sync_settings_v2_download_section_header" />
 
-    <com.duckduckgo.sync.impl.ui.v2.SyncOnOtherPlatformsListItem
-        android:id="@+id/sync_on_other_platforms_item"
+    <com.duckduckgo.sync.impl.ui.v2.GetOnOtherPlatformsListItem
+        android:id="@+id/get_on_other_platforms_item"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216781820998554?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1216103556496795/task/1216509582049467?focus=true

### Description

Makes the download promotion item in the simplified Sync Settings screen tappable. Previously the item was displayed but tapping it did nothing. Now it opens the existing "Get DuckDuckGo" screen, where the user can share or copy the download link.

- The item works both when sync is disabled and when it is enabled, where it sits in the "Download" section.
- The item has two variants: "Get Desktop Browser" when the `newDesktopBrowserSettingEnabled` flag in `SettingsPageFeature` is enabled (always the case on internal builds), and "Get DuckDuckGo on Other Devices" when it is not. Tapping either variant opens the same screen.

The list item component was renamed from `SyncOnOtherPlatformsListItem` to `GetOnOtherPlatformsListItem` and now exposes a click listener for both variants.

### Steps to test this PR

_Open the screen when sync is disabled_
- [ ] Install the internal build (the item shows as "Get Desktop Browser" because the `newDesktopBrowserSettingEnabled` flag is always enabled internally).
- [ ] Open Sync Dev Settings.
- [ ] Tap "Launch Sync Settings V2".
- [ ] Tap "Get Desktop Browser".
- [ ] Verify the "Get DuckDuckGo" screen opens.

_Open the screen when sync is enabled_
- [ ] Enable sync on the device.
- [ ] Open Sync Dev Settings.
- [ ] Tap "Launch Sync Settings V2".
- [ ] Tap "Get Desktop Browser" in the "Download" section.
- [ ] Verify the "Get DuckDuckGo" screen opens.

### UI changes
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI wiring and navigation to an existing screen; no auth, sync engine, or data-handling changes in this diff.
> 
> **Overview**
> Makes the **Get Desktop Browser** / **Get DuckDuckGo on Other Devices** row in Sync Settings V2 actually respond to taps by opening the existing **Get DuckDuckGo** promotion flow.
> 
> `GetOnOtherPlatformsListItem` (renamed from `SyncOnOtherPlatformsListItem`) gains a `Listener` and `setListener()` so both visible variants forward clicks. **Sync V2** `SyncActivity` registers listeners for enabled and disabled layouts, routes to the existing view-model handlers, and implements `LaunchSyncGetOnOtherPlatforms` via `GlobalActivityStarter` + `SyncGetOnOtherPlatformsParams` instead of a TODO. Layout IDs were updated to match the rename.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c727c526b7be40472272f24aeca61fd337237e10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->