### PR TITLE
Handle learn more sync setting action

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
@@ -46,6 +46,7 @@ import com.duckduckgo.di.DaggerMap
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.navigation.api.getActivityParams
+import com.duckduckgo.settings.api.SettingsWebViewScreenWithParams
 import com.duckduckgo.sync.api.SyncActivityWithAnotherDevice
 import com.duckduckgo.sync.api.SyncSettingsPlugin
 import com.duckduckgo.sync.impl.ConnectedDevice
@@ -360,7 +361,10 @@ class SyncActivity : DuckDuckGoActivity() {
             }
 
             is LaunchLearnMore -> {
-                logcat { "TODO: Handle ${command.javaClass.simpleName} command" }
+                globalActivityStarter.start(
+                    this,
+                    SettingsWebViewScreenWithParams(url = command.url, screenTitle = getString(R.string.sync_screen_title)),
+                )
             }
 
             is LaunchOriginalFlow -> {
@@ -493,7 +497,7 @@ class SyncActivity : DuckDuckGoActivity() {
             spans = listOf(
                 "learn_more_link" to object : DuckDuckGoClickableSpan() {
                     override fun onClick(widget: View) {
-                        logcat { "Learn more clicked" }
+                        viewModel.onLearnMoreClicked()
                     }
                 },
             ),


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216781820998553?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/72649045549333/task/1216509582049467?focus=true

### Description

Wires up the "Learn more" link in the data expiration notice on the simplified Sync Settings screen. Tapping "Learn more" opens the sync help page, anchored to the data expiration section, in the in-app web view with the "Sync & Backup" title.

### Steps to test this PR

_Open the data expiration help page_
- [ ] Open Sync Dev Settings.
- [ ] Tap "Launch Sync Settings V2".
- [ ] Back up your device if it's not backed up already.
- [ ] Scroll to the data expiration notice at the bottom of the screen.
- [ ] Tap "Learn more".
- [ ] Verify an in-app web page titled "Sync & Backup" opens on the help page section about data expiration.

### UI changes
N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI navigation wiring only; reuses existing ViewModel command and the same web view pattern as v1 sync settings.
> 
> **Overview**
> **Sync Settings V2** now opens the sync help article when users tap **Learn more** on the data expiration notice, instead of leaving those paths as TODO/log-only stubs.
> 
> The data expiration span calls `viewModel.onLearnMoreClicked()`, which emits `LaunchLearnMore`; **SyncActivity** (v2) handles that command by launching the in-app settings web view via `SettingsWebViewScreenWithParams` with the command URL and the **Sync & Backup** screen title—matching the existing v1 **SyncActivity** behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6465d8fa618e94bae4744c2c3d921ffba658ea07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->