### PR TITLE
Show notifications banner in sync settings

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
@@ -248,6 +248,7 @@ class SyncActivity : DuckDuckGoActivity() {
     }
 
     private fun renderViewState(viewState: ViewState) {
+        binding.notifyMeContainer.isVisible = viewState.showAccount
         binding.syncHeader.setState(
             isSyncEnabled = viewState.showAccount,
             isDuckAiAvailable = viewState.aiChatSyncEnabled,

--- a/sync/sync-impl/src/main/res/layout/activity_sync_v2.xml
+++ b/sync/sync-impl/src/main/res/layout/activity_sync_v2.xml
@@ -15,6 +15,7 @@
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -35,6 +36,23 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical">
+
+            <FrameLayout
+                android:id="@+id/notifyMeContainer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:visibility="gone">
+
+                <com.duckduckgo.common.ui.notifyme.NotifyMeView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:visibility="gone"
+                    app:contentOrientation="start"
+                    app:dismissIcon="true"
+                    app:primaryText="@string/sync_notify_me_title"
+                    app:secondaryText="@string/sync_notify_me_description"
+                    app:sharedPrefsKeyForDismiss="key_component_dismissed_in_sync_settings" />
+            </FrameLayout>
 
             <com.duckduckgo.sync.impl.ui.v2.SyncHeaderView
                 android:id="@+id/syncHeader"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216585846803584?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/72649045549333/task/1216509582049467?focus=true

### Description

Shows the notifications banner in the simplified Sync Settings screen. The banner tells the user that notifications are disabled and lets them enable notifications so they can be alerted if Sync & Backup encounters an error.

- The banner appears at the top of the screen, above the sync header, only while sync is enabled on the device.
- It is only shown when notifications are disabled for the app and the user has not dismissed it before.
- Tapping "Notify me" requests the notification permission on Android 13 and above, or opens the system notification settings on older versions.
- Tapping the dismiss icon hides the banner permanently.
- The banner reuses the same `NotifyMeView` component and dismissal preference as the existing Sync Settings screen, so dismissing it on either screen hides it on both.

### Steps to test this PR

_Show the banner_
- [ ] Disable notifications for the app in the system settings.
- [ ] Open Sync Dev Settings on a device with sync enabled.
- [ ] Tap "Launch Sync Settings V2".
- [ ] Verify a "Notifications are disabled" banner is shown at the top of the screen.

_Enable notifications from the banner_
- [ ] Tap "Notify me".
- [ ] Allow notifications when prompted.
- [ ] Verify the banner disappears.

_Dismiss the banner_
- [ ] Disable notifications for the app again.
- [ ] Reopen the simplified Sync Settings screen.
- [ ] Tap the dismiss icon on the banner.
- [ ] Verify the banner disappears.
- [ ] Reopen the screen.
- [ ] Verify the banner is not shown.

_Sync disabled_
- [ ] Turn off the sync toggle.
- [ ] Verify the banner is not shown, even though notifications are disabled.

### UI changes
| Before  | After |
| ------ | ----- |
| <img width="540" alt="Screenshot_20260723-112428" src="https://github.com/user-attachments/assets/53a5e70b-0ff5-46d8-b199-eab9318069e8" /> | <img width="540" alt="Screenshot_20260723-110358" src="https://github.com/user-attachments/assets/29a8d235-dfb3-4945-8a84-92276e635d09" /> |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and visibility wiring in sync settings with no changes to sync logic or auth.
> 
> **Overview**
> Adds the existing **notifications disabled** `NotifyMeView` banner to the simplified Sync Settings V2 screen, placed above the sync header.
> 
> `notifyMeContainer` visibility is tied to `viewState.showAccount`, so the banner slot only appears when sync is enabled on the device; `NotifyMeView` still handles notification state, permission/settings flows, and dismiss via the shared `key_component_dismissed_in_sync_settings` preference (same as the legacy sync settings layout).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d890ee142b8b86c96e0687c63d070973915b38e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->