### PR TITLE
Android/Contextual/NativeInput: Update new strings case

### DIFF
--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -25,8 +25,8 @@
     <string name="subscriptionOnboardingDuckAiNext">Next</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Ask about tab</string>
-    <string name="duckChatContextualAskAboutPage">Ask about page</string>
+    <string name="duckChatContextualAskAboutTab">Ask About Tab</string>
+    <string name="duckChatContextualAskAboutPage">Ask About Page</string>
 
     <!-- Page context attachment -->
     <string name="duckChatPageContextRemoveContentDescription">Remove page context</string>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1216788152184705?focus=true
Tech Design URL (if applicable): 

### Description
Update case of new contextual native input strings

### Steps to test this PR
QA-optional

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only string resource changes with no logic, security, or data-handling impact.
> 
> **Overview**
> Updates the Duck Chat contextual attachment menu labels in `donottranslate.xml` from sentence case to title case: **Ask about tab** → **Ask About Tab** and **Ask about page** → **Ask About Page**.
> 
> Those strings drive the native input attachment popup (`AttachmentView`) and the default prompt text when the user chooses “ask about page” (`DuckChatContextualViewModel`); only the displayed/sent copy changes, not behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbb50c7daa9e3c31486d98450a2e99d8bf7c67a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->