### PR TITLE
Remove rememberTogglePosition feature flag

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/RealDuckChat.kt
@@ -1026,7 +1026,7 @@ class RealDuckChat @Inject constructor(
 
             areMultipleContentAttachmentsEnabled = isContextualModeEnabled && duckChatFeature.supportsMultipleContexts().isEnabled()
 
-            if (duckChatFeature.rememberTogglePosition().isEnabled() && duckChatFeatureRepository.getDefaultTogglePosition() == null) {
+            if (duckChatFeatureRepository.getDefaultTogglePosition() == null) {
                 val default = if (appBuildConfig.isNewInstall()) DefaultTogglePosition.LAST_USED else DefaultTogglePosition.SEARCH
                 duckChatFeatureRepository.setDefaultTogglePosition(default.name)
             }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/feature/DuckChatFeature.kt
@@ -218,13 +218,6 @@ interface DuckChatFeature {
     fun duckAiVoiceEntryPoint(): Toggle
 
     /**
-     * @return `true` when the "Default Toggle Position" setting should be visible in AI Features Settings.
-     * If the remote feature is not present defaults to `false`
-     */
-    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
-    fun rememberTogglePosition(): Toggle
-
-    /**
      * @return `true` when the fire button is shown in the contextual Duck.ai sheet,
      * allowing the user to clear their current chat.
      * If the remote feature is not present defaults to `internal`

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/InputScreenFragment.kt
@@ -330,7 +330,7 @@ class InputScreenFragment : DuckDuckGoFragment(R.layout.fragment_input_screen) {
         val launchOnChat = when (params?.initialInputMode) {
             InputMode.SEARCH -> false
             InputMode.DUCK_AI -> true
-            null -> if (duckChatFeature.rememberTogglePosition().isEnabled() && params?.isNewTab == true) {
+            null -> if (params?.isNewTab == true) {
                 viewModel.getNewTabTogglePosition() == DefaultTogglePosition.DUCK_AI
             } else {
                 false

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/ChatTabFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/tabs/ChatTabFragment.kt
@@ -38,7 +38,6 @@ import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.utils.FragmentViewModelFactory
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.duckchat.impl.R
-import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenConfigResolver
 import com.duckduckgo.duckchat.impl.inputscreen.ui.InputScreenFragment
 import com.duckduckgo.duckchat.impl.inputscreen.ui.suggestions.ChatHistoryShortcutAdapter
@@ -64,9 +63,6 @@ class ChatTabFragment : DuckDuckGoFragment(R.layout.fragment_chat_tab) {
     @Inject
     lateinit var inputScreenConfigResolver: InputScreenConfigResolver
 
-    @Inject
-    lateinit var duckChatFeature: DuckChatFeature
-
     private val viewModel: InputScreenViewModel by lazy {
         ViewModelProvider(requireParentFragment(), viewModelFactory)[InputScreenViewModel::class.java]
     }
@@ -88,9 +84,7 @@ class ChatTabFragment : DuckDuckGoFragment(R.layout.fragment_chat_tab) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         configureChatSuggestions()
-        if (duckChatFeature.rememberTogglePosition().isEnabled()) {
-            configureChatUrlSuggestions()
-        }
+        configureChatUrlSuggestions()
         configureObservers()
         configureBottomBlur()
     }
@@ -131,11 +125,6 @@ class ChatTabFragment : DuckDuckGoFragment(R.layout.fragment_chat_tab) {
     private fun configureObservers() {
         val parentFragment = requireParentFragment() as InputScreenFragment
 
-        if (!duckChatFeature.rememberTogglePosition().isEnabled()) {
-            configureLegacyObservers(parentFragment)
-            return
-        }
-
         combine(
             viewModel.chatSuggestions,
             viewModel.chatUrlSuggestions,
@@ -171,17 +160,6 @@ class ChatTabFragment : DuckDuckGoFragment(R.layout.fragment_chat_tab) {
 
                 val hasAnySuggestions = hasChatSuggestions || isTyping
                 parentFragment.updateChatSuggestionsVisibility(hasAnySuggestions)
-            }.launchIn(viewLifecycleOwner.lifecycleScope)
-    }
-
-    private fun configureLegacyObservers(parentFragment: InputScreenFragment) {
-        viewModel.chatSuggestions
-            .flowWithLifecycle(viewLifecycleOwner.lifecycle, Lifecycle.State.STARTED)
-            .onEach { suggestions ->
-                chatSuggestionsAdapter.submitList(suggestions)
-                if (!viewModel.visibilityState.value.searchMode) {
-                    parentFragment.updateChatSuggestionsVisibility(suggestions.isNotEmpty())
-                }
             }.launchIn(viewLifecycleOwner.lifecycleScope)
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/inputscreen/ui/viewmodel/InputScreenViewModel.kt
@@ -222,20 +222,12 @@ class InputScreenViewModel @AssistedInject constructor(
     private val refreshSuggestions = MutableSharedFlow<Unit>()
 
     private val defaultTogglePosition: StateFlow<DefaultTogglePosition> =
-        if (duckChatFeature.rememberTogglePosition().isEnabled()) {
-            duckChat.observeDefaultTogglePosition()
-                .stateIn(appCoroutineScope, SharingStarted.Eagerly, DefaultTogglePosition.SEARCH)
-        } else {
-            MutableStateFlow(DefaultTogglePosition.SEARCH)
-        }
+        duckChat.observeDefaultTogglePosition()
+            .stateIn(appCoroutineScope, SharingStarted.Eagerly, DefaultTogglePosition.SEARCH)
 
     private val lastUsedTogglePosition: StateFlow<String?> =
-        if (duckChatFeature.rememberTogglePosition().isEnabled()) {
-            duckChat.observeLastUsedTogglePosition()
-                .stateIn(appCoroutineScope, SharingStarted.Eagerly, null)
-        } else {
-            MutableStateFlow(null)
-        }
+        duckChat.observeLastUsedTogglePosition()
+            .stateIn(appCoroutineScope, SharingStarted.Eagerly, null)
 
     /**
      * This becomes true when either:
@@ -293,34 +285,30 @@ class InputScreenViewModel @AssistedInject constructor(
 
     @OptIn(ExperimentalCoroutinesApi::class, FlowPreview::class)
     val chatUrlSuggestions: StateFlow<AutoCompleteResult> =
-        if (duckChatFeature.rememberTogglePosition().isEnabled()) {
-            combine(
-                chatInputTextState.debounceExceptFirst(timeoutMillis = 100),
-                autoCompleteSuggestionsEnabled,
-            ) { chatInput, autoCompleteEnabled ->
-                if (autoCompleteEnabled && chatInput.isNotEmpty()) chatInput else null
-            }.distinctUntilChanged()
-                .flatMapLatest { query ->
-                    if (query != null) {
-                        autoComplete.autoComplete(query).map { result ->
-                            result.copy(
-                                suggestions = result.suggestions.filter {
-                                    it is AutoCompleteBookmarkSuggestion ||
-                                        it is AutoCompleteSwitchToTabSuggestion ||
-                                        it is AutoCompleteHistorySuggestion ||
-                                        (it is AutoCompleteSearchSuggestion && it.isUrl)
-                                }.take(duckAiChatHistoryFeature.maxUrlSuggestions()),
-                            )
-                        }
-                    } else {
-                        flowOf(AutoCompleteResult("", emptyList()))
+        combine(
+            chatInputTextState.debounceExceptFirst(timeoutMillis = 100),
+            autoCompleteSuggestionsEnabled,
+        ) { chatInput, autoCompleteEnabled ->
+            if (autoCompleteEnabled && chatInput.isNotEmpty()) chatInput else null
+        }.distinctUntilChanged()
+            .flatMapLatest { query ->
+                if (query != null) {
+                    autoComplete.autoComplete(query).map { result ->
+                        result.copy(
+                            suggestions = result.suggestions.filter {
+                                it is AutoCompleteBookmarkSuggestion ||
+                                    it is AutoCompleteSwitchToTabSuggestion ||
+                                    it is AutoCompleteHistorySuggestion ||
+                                    (it is AutoCompleteSearchSuggestion && it.isUrl)
+                            }.take(duckAiChatHistoryFeature.maxUrlSuggestions()),
+                        )
                     }
-                }.flowOn(dispatchers.io())
-                .catch { t -> logcat(WARN) { "Failed to get chat URL suggestions: ${t.asLog()}" } }
-                .stateIn(viewModelScope, SharingStarted.Eagerly, AutoCompleteResult("", emptyList()))
-        } else {
-            MutableStateFlow(AutoCompleteResult("", emptyList()))
-        }
+                } else {
+                    flowOf(AutoCompleteResult("", emptyList()))
+                }
+            }.flowOn(dispatchers.io())
+            .catch { t -> logcat(WARN) { "Failed to get chat URL suggestions: ${t.asLog()}" } }
+            .stateIn(viewModelScope, SharingStarted.Eagerly, AutoCompleteResult("", emptyList()))
 
     private val _inputFieldState = MutableStateFlow(InputFieldState(canExpand = false))
     val inputFieldState: StateFlow<InputFieldState> = _inputFieldState.asStateFlow()
@@ -412,7 +400,7 @@ class InputScreenViewModel @AssistedInject constructor(
         }.onEach { (chatSuggestions, urlSuggestions, chatInput) ->
             val hasChatSuggestions = chatSuggestions.isNotEmpty()
             val hasUrlSuggestions = urlSuggestions.suggestions.isNotEmpty()
-            val hasSearchRow = duckChatFeature.rememberTogglePosition().isEnabled() && chatInput.isNotEmpty()
+            val hasSearchRow = chatInput.isNotEmpty()
             _visibilityState.update {
                 it.copy(
                     showChatLogo = !hasChatSuggestions && !hasUrlSuggestions && !hasSearchRow,
@@ -457,7 +445,7 @@ class InputScreenViewModel @AssistedInject constructor(
         fromChatUrlSuggestions: Boolean = false,
     ) {
         appCoroutineScope.launch(dispatchers.io()) {
-            val suggestions = if (duckChatFeature.rememberTogglePosition().isEnabled() && fromChatUrlSuggestions) {
+            val suggestions = if (fromChatUrlSuggestions) {
                 chatUrlSuggestions.value.suggestions
             } else {
                 autoCompleteSuggestionResults.value.suggestions
@@ -838,9 +826,7 @@ class InputScreenViewModel @AssistedInject constructor(
                 if (directionToSearch) "to_search" else "to_duckai",
             )
             put("had_text", hadText.toString())
-            if (duckChatFeature.rememberTogglePosition().isEnabled()) {
-                put(DuckChatPixelParameters.DEFAULT_TOGGLE_POSITION, defaultTogglePosition.value.pixelValue)
-            }
+            put(DuckChatPixelParameters.DEFAULT_TOGGLE_POSITION, defaultTogglePosition.value.pixelValue)
         }
         pixel.fire(pixel = DUCK_CHAT_EXPERIMENTAL_OMNIBAR_MODE_SWITCHED, parameters = params)
     }
@@ -1034,8 +1020,6 @@ class InputScreenViewModel @AssistedInject constructor(
     }
 
     fun getNewTabTogglePosition(): DefaultTogglePosition {
-        if (!duckChatFeature.rememberTogglePosition().isEnabled()) return DefaultTogglePosition.SEARCH
-
         val position = defaultTogglePosition.value
         return if (position == DefaultTogglePosition.LAST_USED) {
             DefaultTogglePosition.fromName(lastUsedTogglePosition.value)
@@ -1045,7 +1029,6 @@ class InputScreenViewModel @AssistedInject constructor(
     }
 
     private fun saveLastUsedTogglePosition() {
-        if (!duckChatFeature.rememberTogglePosition().isEnabled()) return
         val position = if (isSearchModeFlow.value) DefaultTogglePosition.SEARCH else DefaultTogglePosition.DUCK_AI
         appCoroutineScope.launch(dispatchers.io()) {
             duckChat.saveLastUsedTogglePosition(position.name)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -61,7 +61,6 @@ import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InteractionLock
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.impl.ChatState
 import com.duckduckgo.duckchat.impl.R
-import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.helper.PendingNativeFile
 import com.duckduckgo.duckchat.impl.helper.PendingNativeImage
 import com.duckduckgo.duckchat.impl.inputscreen.ui.view.InputModeWidget
@@ -231,9 +230,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
     private val viewModel: NativeInputModeWidgetViewModel by lazy {
         ViewModelProvider(findViewTreeViewModelStoreOwner()!!, viewModelFactory)[NativeInputModeWidgetViewModel::class.java]
     }
-
-    @Inject
-    lateinit var duckChatFeature: DuckChatFeature
 
     @Inject
     lateinit var dispatchers: DispatcherProvider
@@ -1097,7 +1093,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
 
     override fun applyDefaultTogglePosition() {
         doOnAttach {
-            if (!duckChatFeature.rememberTogglePosition().isEnabled()) return@doOnAttach
             findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
                 // Wait for the first state emission so we know whether the toggle row is even shown.
                 // For SEARCH_ONLY users (input-screen setting off) the toggle is hidden, and flipping
@@ -1119,7 +1114,6 @@ class NativeInputModeWidget @JvmOverloads constructor(
     }
 
     override fun saveLastUsedTogglePosition(isChat: Boolean) {
-        if (!duckChatFeature.rememberTogglePosition().isEnabled()) return
         val position = if (isChat) DefaultTogglePosition.DUCK_AI else DefaultTogglePosition.SEARCH
         findViewTreeLifecycleOwner()?.lifecycleScope?.launch(dispatchers.io()) {
             viewModel.saveLastUsedTogglePosition(position.name)

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModel.kt
@@ -98,7 +98,6 @@ class DuckChatSettingsViewModel @AssistedInject constructor(
 
     private data class FeatureVisibility(
         val isHideGeneratedImagesOptionVisible: Boolean,
-        val isRememberTogglePositionVisible: Boolean,
         val isNativeControlsEnabled: Boolean,
     )
 
@@ -122,7 +121,6 @@ class DuckChatSettingsViewModel @AssistedInject constructor(
             emit(
                 FeatureVisibility(
                     isHideGeneratedImagesOptionVisible = duckChatFeature.showHideAiGeneratedImages().isEnabled(),
-                    isRememberTogglePositionVisible = duckChatFeature.rememberTogglePosition().isEnabled(),
                     isNativeControlsEnabled = duckChatFeature.aiFeaturesNativeControls().isEnabled(),
                 ),
             )
@@ -154,7 +152,7 @@ class DuckChatSettingsViewModel @AssistedInject constructor(
                 isAutomaticContextEnabled = featureState.isAutomaticContextEnabled,
                 isAutomaticContextVisible = isDuckChatUserEnabled && duckChatFeature.automaticContextAttachment().isEnabled(),
                 isDefaultTogglePositionVisible = isDuckChatUserEnabled && isInputScreenEnabled &&
-                    duckChat.isInputScreenFeatureAvailable() && featureVisibility.isRememberTogglePositionVisible,
+                    duckChat.isInputScreenFeatureAvailable(),
                 defaultTogglePosition = defaultTogglePosition,
                 isNativeControlsEnabled = featureVisibility.isNativeControlsEnabled,
                 searchAssistVisibility = resolvedSearchAssistVisibility,

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/RealDuckChatTest.kt
@@ -71,6 +71,7 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.spy
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.clearInvocations
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -1764,12 +1765,12 @@ class RealDuckChatTest {
         assertEquals("SEARCH", result)
     }
 
-    @Suppress("DenyListedApi")
     @Test
     fun `when new user then default toggle position is set to LAST_USED`() = runTest {
-        duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
         whenever(mockDuckChatFeatureRepository.getDefaultTogglePosition()).thenReturn(null)
         whenever(mockAppBuildConfig.isNewInstall()).thenReturn(true)
+        // Ignore the defaulting that runs during testee init, before these stubs were applied.
+        clearInvocations(mockDuckChatFeatureRepository)
 
         testee.onPrivacyConfigDownloaded()
         coroutineRule.testScope.advanceUntilIdle()
@@ -1777,12 +1778,12 @@ class RealDuckChatTest {
         verify(mockDuckChatFeatureRepository).setDefaultTogglePosition(DefaultTogglePosition.LAST_USED.name)
     }
 
-    @Suppress("DenyListedApi")
     @Test
     fun `when existing user then default toggle position is set to SEARCH`() = runTest {
-        duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
         whenever(mockDuckChatFeatureRepository.getDefaultTogglePosition()).thenReturn(null)
         whenever(mockAppBuildConfig.isNewInstall()).thenReturn(false)
+        // Ignore the defaulting that runs during testee init, before these stubs were applied.
+        clearInvocations(mockDuckChatFeatureRepository)
 
         testee.onPrivacyConfigDownloaded()
         coroutineRule.testScope.advanceUntilIdle()
@@ -1790,23 +1791,11 @@ class RealDuckChatTest {
         verify(mockDuckChatFeatureRepository).setDefaultTogglePosition(DefaultTogglePosition.SEARCH.name)
     }
 
-    @Suppress("DenyListedApi")
     @Test
     fun `when default toggle position already set then do not overwrite`() = runTest {
-        duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
         whenever(mockDuckChatFeatureRepository.getDefaultTogglePosition()).thenReturn("DUCK_AI")
-
-        testee.onPrivacyConfigDownloaded()
-        coroutineRule.testScope.advanceUntilIdle()
-
-        verify(mockDuckChatFeatureRepository, never()).setDefaultTogglePosition(any())
-    }
-
-    @Suppress("DenyListedApi")
-    @Test
-    fun `when feature flag off then default toggle position is not set`() = runTest {
-        duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = false))
-        whenever(mockDuckChatFeatureRepository.getDefaultTogglePosition()).thenReturn(null)
+        // Ignore the defaulting that runs during testee init, before these stubs were applied.
+        clearInvocations(mockDuckChatFeatureRepository)
 
         testee.onPrivacyConfigDownloaded()
         coroutineRule.testScope.advanceUntilIdle()

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/inputscreen/InputScreenViewModelTest.kt
@@ -128,6 +128,8 @@ class InputScreenViewModelTest {
             whenever(duckChat.getDuckChatUrl(any(), any(), any())).thenReturn(duckChatURL)
             whenever(duckChat.buildChatUrl(any())).thenAnswer { "$duckChatURL&chatID=${it.arguments[0]}" }
             whenever(duckChat.observeChatSuggestionsUserSettingEnabled()).thenReturn(flowOf(true))
+            whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.SEARCH))
+            whenever(duckChat.observeLastUsedTogglePosition()).thenReturn(flowOf(null))
             whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
             whenever(inputScreenConfigResolver.useTopBar()).thenReturn(true)
             whenever(voiceSearchAvailability.isVoiceSearchAvailable).thenReturn(true)
@@ -598,16 +600,17 @@ class InputScreenViewModelTest {
     }
 
     @Test
-    fun `when onChatInputTextChanged with different text than initial then showChatLogo should be true`() {
+    fun `when onChatInputTextChanged with non-empty text then showChatLogo is hidden`() {
         val viewModel = createViewModel("initial text")
 
+        // Non-empty chat input shows the search row, which hides the chat logo
         viewModel.onChatInputTextChanged("different text")
 
-        assertTrue(viewModel.visibilityState.value.showChatLogo)
+        assertFalse(viewModel.visibilityState.value.showChatLogo)
     }
 
     @Test
-    fun `when onChatInputTextChanged with same initial text but autocomplete suggestions visible then showChatLogo should be true`() =
+    fun `when onChatInputTextChanged with same initial text then showChatLogo is hidden`() =
         runTest {
             val initialText = "test query"
             val viewModel = createViewModel(initialText)
@@ -616,22 +619,21 @@ class InputScreenViewModelTest {
 
             viewModel.onChatInputTextChanged(initialText)
 
-            assertTrue(viewModel.visibilityState.value.showChatLogo)
+            assertFalse(viewModel.visibilityState.value.showChatLogo)
         }
 
     @Test
-    fun `when onChatInputTextChanged with web URL then showChatLogo is always true`() {
+    fun `when onChatInputTextChanged then showChatLogo reflects whether input is empty`() {
         val viewModel = createViewModel("https://example.com")
 
-        // Initially true (same as initial text, no autocomplete suggestions for URL)
+        // Non-empty input shows the search row, hiding the chat logo
         viewModel.onChatInputTextChanged("https://example.com")
-        assertTrue(viewModel.visibilityState.value.showChatLogo)
+        assertFalse(viewModel.visibilityState.value.showChatLogo)
 
-        // Change to different URL - should still be true
         viewModel.onChatInputTextChanged("https://different.com")
-        assertTrue(viewModel.visibilityState.value.showChatLogo)
+        assertFalse(viewModel.visibilityState.value.showChatLogo)
 
-        // Change to empty - should be true
+        // Empty input shows the chat logo
         viewModel.onChatInputTextChanged("")
         assertTrue(viewModel.visibilityState.value.showChatLogo)
     }
@@ -1041,6 +1043,7 @@ class InputScreenViewModelTest {
                 mapOf(
                     "direction" to "to_search",
                     "had_text" to "true",
+                    DuckChatPixelParameters.DEFAULT_TOGGLE_POSITION to "search",
                 )
             verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_MODE_SWITCHED, expectedParams)
         }
@@ -1057,6 +1060,7 @@ class InputScreenViewModelTest {
                 mapOf(
                     "direction" to "to_search",
                     "had_text" to "false",
+                    DuckChatPixelParameters.DEFAULT_TOGGLE_POSITION to "search",
                 )
             verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_MODE_SWITCHED, expectedParams)
         }
@@ -1084,6 +1088,7 @@ class InputScreenViewModelTest {
                 mapOf(
                     "direction" to "to_duckai",
                     "had_text" to "true",
+                    DuckChatPixelParameters.DEFAULT_TOGGLE_POSITION to "search",
                 )
             verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_MODE_SWITCHED, expectedParams)
         }
@@ -1100,6 +1105,7 @@ class InputScreenViewModelTest {
                 mapOf(
                     "direction" to "to_duckai",
                     "had_text" to "false",
+                    DuckChatPixelParameters.DEFAULT_TOGGLE_POSITION to "search",
                 )
             verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_MODE_SWITCHED, expectedParams)
         }
@@ -1231,6 +1237,7 @@ class InputScreenViewModelTest {
                 mapOf(
                     "direction" to "to_search",
                     "had_text" to "true", // Should be true because we have trimmed text
+                    DuckChatPixelParameters.DEFAULT_TOGGLE_POSITION to "search",
                 )
             verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_MODE_SWITCHED, expectedParams)
         }
@@ -1251,6 +1258,7 @@ class InputScreenViewModelTest {
                 mapOf(
                     "direction" to "to_search",
                     "had_text" to "false", // Should be false because trimmed text is empty
+                    DuckChatPixelParameters.DEFAULT_TOGGLE_POSITION to "search",
                 )
             verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_MODE_SWITCHED, expectedParams)
         }
@@ -2836,22 +2844,8 @@ class InputScreenViewModelTest {
     // region default toggle position
 
     @Test
-    fun `getNewTabTogglePosition returns SEARCH when feature flag is off`() =
-        runTest {
-            @Suppress("DenyListedApi")
-            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = false))
-            whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.DUCK_AI))
-
-            val viewModel = createViewModel()
-
-            assertEquals(DefaultTogglePosition.SEARCH, viewModel.getNewTabTogglePosition())
-        }
-
-    @Test
     fun `getNewTabTogglePosition returns SEARCH when setting is SEARCH`() =
         runTest {
-            @Suppress("DenyListedApi")
-            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
             whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.SEARCH))
             whenever(duckChat.observeLastUsedTogglePosition()).thenReturn(flowOf(null))
 
@@ -2863,8 +2857,6 @@ class InputScreenViewModelTest {
     @Test
     fun `getNewTabTogglePosition returns DUCK_AI when setting is DUCK_AI`() =
         runTest {
-            @Suppress("DenyListedApi")
-            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
             whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.DUCK_AI))
             whenever(duckChat.observeLastUsedTogglePosition()).thenReturn(flowOf(null))
 
@@ -2876,8 +2868,6 @@ class InputScreenViewModelTest {
     @Test
     fun `getNewTabTogglePosition returns SEARCH when setting is LAST_USED and last used is null`() =
         runTest {
-            @Suppress("DenyListedApi")
-            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
             whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.LAST_USED))
             whenever(duckChat.observeLastUsedTogglePosition()).thenReturn(flowOf(null))
 
@@ -2889,8 +2879,6 @@ class InputScreenViewModelTest {
     @Test
     fun `getNewTabTogglePosition returns DUCK_AI when setting is LAST_USED and last used is DUCK_AI`() =
         runTest {
-            @Suppress("DenyListedApi")
-            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
             whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.LAST_USED))
             whenever(duckChat.observeLastUsedTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.DUCK_AI.name))
 
@@ -2900,28 +2888,8 @@ class InputScreenViewModelTest {
         }
 
     @Test
-    fun `saveLastUsedTogglePosition never called when feature flag is off`() =
-        runTest {
-            @Suppress("DenyListedApi")
-            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = false))
-            whenever(queryUrlPredictor.isUrl(any())).thenReturn(false)
-
-            val viewModel = createViewModel()
-            viewModel.onSearchSubmitted("test query")
-            viewModel.onChatSelected()
-            viewModel.onChatSubmitted("test prompt")
-            viewModel.onUserSubmittedQuery("test autocomplete")
-            viewModel.userSelectedAutocomplete(AutoCompleteSuggestion.AutoCompleteDuckAIPrompt("test ai prompt"))
-            viewModel.onChatSuggestionSelected("chat-id", pinned = false)
-
-            verify(duckChat, never()).saveLastUsedTogglePosition(any())
-        }
-
-    @Test
     fun `saveLastUsedTogglePosition called with SEARCH on search submission`() =
         runTest {
-            @Suppress("DenyListedApi")
-            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
             whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.SEARCH))
             whenever(duckChat.observeLastUsedTogglePosition()).thenReturn(flowOf(null))
 
@@ -2934,8 +2902,6 @@ class InputScreenViewModelTest {
     @Test
     fun `saveLastUsedTogglePosition called with DUCK_AI on chat submission`() =
         runTest {
-            @Suppress("DenyListedApi")
-            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
             whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.SEARCH))
             whenever(duckChat.observeLastUsedTogglePosition()).thenReturn(flowOf(null))
             whenever(queryUrlPredictor.isUrl(any())).thenReturn(false)
@@ -2950,8 +2916,6 @@ class InputScreenViewModelTest {
     @Test
     fun `saveLastUsedTogglePosition called with SEARCH on autocomplete selection`() =
         runTest {
-            @Suppress("DenyListedApi")
-            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
             whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.SEARCH))
             whenever(duckChat.observeLastUsedTogglePosition()).thenReturn(flowOf(null))
 
@@ -2964,8 +2928,6 @@ class InputScreenViewModelTest {
     @Test
     fun `saveLastUsedTogglePosition called with DUCK_AI on duck ai prompt autocomplete`() =
         runTest {
-            @Suppress("DenyListedApi")
-            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
             whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.SEARCH))
             whenever(duckChat.observeLastUsedTogglePosition()).thenReturn(flowOf(null))
 
@@ -2979,8 +2941,6 @@ class InputScreenViewModelTest {
     @Test
     fun `saveLastUsedTogglePosition called with DUCK_AI on chat suggestion selected`() =
         runTest {
-            @Suppress("DenyListedApi")
-            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
             whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.SEARCH))
             whenever(duckChat.observeLastUsedTogglePosition()).thenReturn(flowOf(null))
 
@@ -2996,10 +2956,8 @@ class InputScreenViewModelTest {
     // region mode switched pixel
 
     @Test
-    fun `mode switched pixel includes default_position when feature flag is on`() =
+    fun `mode switched pixel includes default_position`() =
         runTest {
-            @Suppress("DenyListedApi")
-            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
             whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.DUCK_AI))
             whenever(duckChat.observeLastUsedTogglePosition()).thenReturn(flowOf(null))
 
@@ -3017,46 +2975,13 @@ class InputScreenViewModelTest {
             )
         }
 
-    @Test
-    fun `mode switched pixel excludes default_position when feature flag is off`() =
-        runTest {
-            @Suppress("DenyListedApi")
-            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = false))
-
-            val viewModel = createViewModel()
-            viewModel.onSearchSelected()
-            viewModel.onChatSelected()
-
-            verify(pixel).fire(
-                pixel = DuckChatPixelName.DUCK_CHAT_EXPERIMENTAL_OMNIBAR_MODE_SWITCHED,
-                parameters = mapOf(
-                    "direction" to "to_duckai",
-                    "had_text" to "false",
-                ),
-            )
-        }
-
     // endregion
 
     // region chat URL suggestions
 
-    @Suppress("DenyListedApi")
     @Test
-    fun `chatUrlSuggestions is empty and autocomplete not called when feature flag is off`() =
+    fun `chatUrlSuggestions filters out non-URL suggestions`() =
         runTest {
-            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = false))
-
-            val viewModel = createViewModel()
-
-            assertTrue(viewModel.chatUrlSuggestions.value.suggestions.isEmpty())
-            verify(autoComplete, never()).autoComplete(any())
-        }
-
-    @Suppress("DenyListedApi")
-    @Test
-    fun `chatUrlSuggestions filters out non-URL suggestions when feature flag is on`() =
-        runTest {
-            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
             whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
 
             val bookmarkSuggestion = AutoCompleteSuggestion.AutoCompleteUrlSuggestion.AutoCompleteBookmarkSuggestion(
@@ -3090,11 +3015,9 @@ class InputScreenViewModelTest {
             assertTrue((result.suggestions[1] as AutoCompleteSearchSuggestion).isUrl)
         }
 
-    @Suppress("DenyListedApi")
     @Test
     fun `chatUrlSuggestions is empty when chat input is empty`() =
         runTest {
-            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
             whenever(duckChat.observeDefaultTogglePosition()).thenReturn(flowOf(DefaultTogglePosition.SEARCH))
             whenever(duckChat.observeLastUsedTogglePosition()).thenReturn(flowOf(null))
             whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
@@ -3108,11 +3031,9 @@ class InputScreenViewModelTest {
             verify(autoComplete, never()).autoComplete("")
         }
 
-    @Suppress("DenyListedApi")
     @Test
     fun `chatUrlSuggestions shows alongside chat suggestions when both exist`() =
         runTest {
-            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
             whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(
                 listOf(ChatSuggestion(chatId = "1", title = "Test Chat", lastEdit = LocalDateTime.now(), pinned = false)),
             )
@@ -3128,11 +3049,9 @@ class InputScreenViewModelTest {
             assertTrue(viewModel.chatUrlSuggestions.value.suggestions.isNotEmpty())
         }
 
-    @Suppress("DenyListedApi")
     @Test
     fun `chatUrlSuggestions is limited to max configured count`() =
         runTest {
-            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
             whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
             whenever(autoComplete.autoComplete(any())).thenReturn(
                 flowOf(
@@ -3157,11 +3076,9 @@ class InputScreenViewModelTest {
             assertEquals(3, viewModel.chatUrlSuggestions.value.suggestions.size)
         }
 
-    @Suppress("DenyListedApi")
     @Test
     fun `chatUrlSuggestions is empty when autocomplete suggestions disabled`() =
         runTest {
-            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
             whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
             whenever(autoCompleteSettings.autoCompleteSuggestionsEnabled).thenReturn(false)
 
@@ -3173,11 +3090,9 @@ class InputScreenViewModelTest {
             assertTrue(viewModel.chatUrlSuggestions.value.suggestions.isEmpty())
         }
 
-    @Suppress("DenyListedApi")
     @Test
     fun `chatSuggestionsVisible is true when only URL suggestions exist`() =
         runTest {
-            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
             whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
             whenever(autoComplete.autoComplete(any())).thenReturn(
                 flowOf(
@@ -3198,11 +3113,9 @@ class InputScreenViewModelTest {
             assertFalse(viewModel.visibilityState.value.showChatLogo)
         }
 
-    @Suppress("DenyListedApi")
     @Test
     fun `chatSuggestionsVisible is true and logo hidden when typing with no results`() =
         runTest {
-            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
             whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
 
             val viewModel = createViewModel()
@@ -3214,11 +3127,9 @@ class InputScreenViewModelTest {
             assertFalse(viewModel.visibilityState.value.showChatLogo)
         }
 
-    @Suppress("DenyListedApi")
     @Test
     fun `chatInputText exposes current chat input`() =
         runTest {
-            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
             whenever(chatSuggestionsReader.fetchSuggestions(any())).thenReturn(emptyList())
 
             val viewModel = createViewModel()

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/settings/DuckChatSettingsViewModelTest.kt
@@ -1270,8 +1270,6 @@ class DuckChatSettingsViewModelTest {
             whenever(duckChat.observeEnableDuckChatUserSetting()).thenReturn(flowOf(true))
             whenever(duckChat.observeInputScreenUserSettingEnabled()).thenReturn(flowOf(true))
             whenever(duckChat.isInputScreenFeatureAvailable()).thenReturn(true)
-            @Suppress("DenyListedApi")
-            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
             testee = DuckChatSettingsViewModel(
                 duckChatActivityParams = DuckChatSettingsNoParams,
                 duckChat = duckChat,
@@ -1295,8 +1293,6 @@ class DuckChatSettingsViewModelTest {
             whenever(duckChat.observeEnableDuckChatUserSetting()).thenReturn(flowOf(false))
             whenever(duckChat.observeInputScreenUserSettingEnabled()).thenReturn(flowOf(true))
             whenever(duckChat.isInputScreenFeatureAvailable()).thenReturn(true)
-            @Suppress("DenyListedApi")
-            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
             testee = DuckChatSettingsViewModel(
                 duckChatActivityParams = DuckChatSettingsNoParams,
                 duckChat = duckChat,
@@ -1320,33 +1316,6 @@ class DuckChatSettingsViewModelTest {
             whenever(duckChat.observeEnableDuckChatUserSetting()).thenReturn(flowOf(true))
             whenever(duckChat.observeInputScreenUserSettingEnabled()).thenReturn(flowOf(false))
             whenever(duckChat.isInputScreenFeatureAvailable()).thenReturn(true)
-            @Suppress("DenyListedApi")
-            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
-            testee = DuckChatSettingsViewModel(
-                duckChatActivityParams = DuckChatSettingsNoParams,
-                duckChat = duckChat,
-                pixel = mockPixel,
-                inputScreenDiscoveryFunnel = mockInputScreenDiscoveryFunnel,
-                settingsPageFeature = settingsPageFeature,
-                duckChatPixels = mockDuckChatPixels,
-                dispatcherProvider = coroutineRule.testDispatcherProvider,
-                duckChatFeature = duckChatFeature,
-                serpSettingsDataProvider = serpSettingsDataProvider,
-            )
-
-            testee.viewState.test {
-                assertFalse(awaitItem().isDefaultTogglePositionVisible)
-            }
-        }
-
-    @Test
-    fun `default toggle position - hidden when feature flag disabled`() =
-        runTest {
-            whenever(duckChat.observeEnableDuckChatUserSetting()).thenReturn(flowOf(true))
-            whenever(duckChat.observeInputScreenUserSettingEnabled()).thenReturn(flowOf(true))
-            whenever(duckChat.isInputScreenFeatureAvailable()).thenReturn(true)
-            @Suppress("DenyListedApi")
-            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = false))
             testee = DuckChatSettingsViewModel(
                 duckChatActivityParams = DuckChatSettingsNoParams,
                 duckChat = duckChat,
@@ -1370,8 +1339,6 @@ class DuckChatSettingsViewModelTest {
             whenever(duckChat.observeEnableDuckChatUserSetting()).thenReturn(flowOf(true))
             whenever(duckChat.observeInputScreenUserSettingEnabled()).thenReturn(flowOf(true))
             whenever(duckChat.isInputScreenFeatureAvailable()).thenReturn(false)
-            @Suppress("DenyListedApi")
-            duckChatFeature.rememberTogglePosition().setRawStoredState(State(enable = true))
             testee = DuckChatSettingsViewModel(
                 duckChatActivityParams = DuckChatSettingsNoParams,
                 duckChat = duckChat,


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1214162858846528
Tech Design URL (if applicable): 

### Description
Remove rememberTogglePosition feature flag. This flag controls the setting which remembers the last used tab (Search vs Duck.ai) by the user and apply it the next time they open the NTP.

### Steps to test this PR
_Smoke test the feature_
- [x] Go to settings -> Ai features -> Select "Toggle between Search and Duck.ai" and select "Last Used" for New tab toggle position
- [x] Open a NTP and switch to Duck.ai then submit a prompt to duck.ai
- [x] Open a NTP -> Verify Duck.ai is the default selected toggle now
- [x] Switch to Search and perform any search
- [x] Open a NTP -> Verify Search is the default selected toggle 

### UI changes

No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior that was behind a remote flag (NTP tab default, chat URL suggestions, settings visibility) is now unconditional for eligible users—rollout risk shifts from remote kill-switch to always-on UX and telemetry.
> 
> **Overview**
> Removes the **`rememberTogglePosition`** remote feature flag and makes **default / last-used Search vs Duck.ai toggle** behavior always on where it was previously gated.
> 
> **Default toggle position** is still initialized on privacy config when unset (new installs → **Last Used**, existing → **Search**), without checking the flag. **AI Features** still shows **New tab toggle position** when Duck.ai and the input screen are enabled—visibility no longer depends on the removed toggle.
> 
> **Input screen & native input:** new-tab launch respects `getNewTabTogglePosition()`; **chat URL autocomplete**, combined chat-tab observers, **last-used** persistence, and mode-switch pixels always include **default toggle position**. Legacy chat-tab observer paths and unused `DuckChatFeature` injections are deleted.
> 
> Tests drop flag-off cases and align expectations (e.g. non-empty chat input hides the chat logo; defaulting tests use `clearInvocations` after init).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 631774e5f09642010db1440f231156548c18aa7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->