### PR TITLE
Android: Update targetSdk to Android 16

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1731,9 +1731,11 @@ class BrowserTabFragment :
             omnibar.configureCustomTab(
                 customTabToolbarColor,
             )
-            requireActivity().window.navigationBarColor = customTabToolbarColor
-            requireActivity().window.statusBarColor = customTabToolbarColor
 
+            if (!edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BROWSER)) {
+                requireActivity().window.navigationBarColor = customTabToolbarColor
+                requireActivity().window.statusBarColor = customTabToolbarColor
+            }
             // Update status bar icon colors based on toolbar color luminance
             updateStatusBarIconColors(customTabToolbarColor)
 

--- a/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabActivity.kt
@@ -63,8 +63,10 @@ class CustomTabActivity : DuckDuckGoActivity() {
         super.onCreate(savedInstanceState)
         viewModel.onShowCustomTab()
 
+        val toolbarColor =
+            intent.getIntExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR, getColorFromAttr(com.duckduckgo.mobile.android.R.attr.preferredStatusBarColor))
+
         if (edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BROWSER)) {
-            val toolbarColor = getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorToolbar)
             val barStyle = if (isDarkThemeEnabled()) {
                 SystemBarStyle.dark(toolbarColor)
             } else {
@@ -78,8 +80,6 @@ class CustomTabActivity : DuckDuckGoActivity() {
         setContentView(binding.root)
 
         val url = intent.intentText
-        val toolbarColor =
-            intent.getIntExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR, getColorFromAttr(com.duckduckgo.mobile.android.R.attr.preferredStatusBarColor))
 
         logcat { "onCreate called with url=$url and toolbar color=$toolbarColor" }
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,8 @@ buildscript {
 
     ext {
         min_sdk = 26
-        target_sdk = 35
-        compile_sdk = 35
+        target_sdk = 36
+        compile_sdk = 36
 
         // Calculate lint_version (must always be gradle_plugin + 23)
         def gradle_plugin_version = versionFor(project, Android.tools.build.gradlePlugin)

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeFeature.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeFeature.kt
@@ -27,33 +27,33 @@ import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 )
 interface EdgeToEdgeFeature {
 
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun self(): Toggle
 
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun browser(): Toggle
 
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun settings(): Toggle
 
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun autofill(): Toggle
 
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun sync(): Toggle
 
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun vpn(): Toggle
 
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun webview(): Toggle
 
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun onboarding(): Toggle
 
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun misc(): Toggle
 
-    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @Toggle.DefaultValue(DefaultFeatureValue.TRUE)
     fun bottomSheets(): Toggle
 }

--- a/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/DisplayModeSyncSetting.kt
+++ b/saved-sites/saved-sites-impl/src/main/java/com/duckduckgo/savedsites/impl/sync/DisplayModeSyncSetting.kt
@@ -19,7 +19,6 @@ package com.duckduckgo.savedsites.impl.sync
 import android.content.*
 import android.util.*
 import android.widget.*
-import android.widget.CompoundButton.OnCheckedChangeListener
 import androidx.lifecycle.*
 import com.duckduckgo.anvil.annotations.*
 import com.duckduckgo.common.ui.viewbinding.viewBinding
@@ -59,13 +58,7 @@ class DisplayModeSyncSetting @JvmOverloads constructor(
         AndroidSupportInjection.inject(this)
         super.onAttachedToWindow()
 
-        binding.syncSettingsOptionFavourites.setOnCheckedChangeListener(
-            object : OnCheckedChangeListener {
-                override fun onCheckedChanged(buttonView: CompoundButton?, isChecked: Boolean) {
-                    viewModel.onDisplayModeChanged(isChecked)
-                }
-            },
-        )
+        binding.syncSettingsOptionFavourites.setOnCheckedChangeListener { _, isChecked -> viewModel.onDisplayModeChanged(isChecked) }
 
         job += viewModel.viewState()
             .onEach { render(it) }

--- a/versions.properties
+++ b/versions.properties
@@ -21,7 +21,7 @@ plugin.com.diffplug.spotless=8.0.0
 
 version.android.billingclient=8.3.0
 
-version.androidx.activity=1.10.1
+version.androidx.activity=1.13.0
 
 version.androidx.autofill=1.1.0
 
@@ -39,7 +39,7 @@ version.androidx.constraintlayout=2.1.4
 
 version.androidx.biometric=1.1.0
 
-version.androidx.core-splashscreen=1.0.1
+version.androidx.core-splashscreen=1.2.0
 
 version.androidx.datastore=1.1.6
 
@@ -47,7 +47,7 @@ version.androidx.localbroadcastmanager=1.1.0
 
 version.androidx.recyclerview=1.3.2
 
-version.androidx.core=1.16.0
+version.androidx.core=1.17.0
 
 version.androidx.fragment=1.8.9
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1216819733640273?focus=true
Tech Design URL (if applicable): 

### Description
Update the targetSdk and compileSdk to Android 16 (36)

### Steps to test this PR
Add `@Toggle.InternalAlwaysEnabled` to all features under `EdgeToEdgeFeature` and smoke test the app.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Platform SDK 36 affects the entire app build and runtime behavior, and default-on edge-to-edge changes system UI across browser, settings, and other buckets—regression risk on custom tabs and insets is meaningful.
> 
> **Overview**
> Raises **`compile_sdk`** and **`target_sdk`** to **36** (Android 16) and bumps related AndroidX versions (`activity`, `core`, `core-splashscreen`).
> 
> To align with Android 16 expectations, **edge-to-edge** remote feature toggles under `EdgeToEdgeFeature` now default to **enabled** (`TRUE` instead of `INTERNAL`). **Custom tab** flows are adjusted so system bars follow the **Custom Tabs toolbar color** from the intent when edge-to-edge is on, and `BrowserTabFragment` no longer forces legacy `window` status/navigation bar colors in that mode.
> 
> Includes a small refactor in `DisplayModeSyncSetting` (checked-change listener as a lambda).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a22164e28196452d9eb4b50574f8f81a3f01f5fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->