### PR TITLE
Display sync warning messages

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
@@ -43,11 +43,13 @@ import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.DaggerMap
+import com.duckduckgo.di.DaggerSet
 import com.duckduckgo.di.scopes.ActivityScope
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.navigation.api.getActivityParams
 import com.duckduckgo.settings.api.SettingsWebViewScreenWithParams
 import com.duckduckgo.sync.api.SyncActivityWithAnotherDevice
+import com.duckduckgo.sync.api.SyncMessagePlugin
 import com.duckduckgo.sync.api.SyncSettingsPlugin
 import com.duckduckgo.sync.impl.ConnectedDevice
 import com.duckduckgo.sync.impl.R
@@ -105,6 +107,12 @@ class SyncActivity : DuckDuckGoActivity() {
     private val viewModel by bindViewModel<SyncActivityViewModel>()
 
     @Inject
+    lateinit var syncSettingsPlugin: DaggerMap<Int, SyncSettingsPlugin>
+
+    @Inject
+    lateinit var syncMessagesPlugin: DaggerSet<SyncMessagePlugin>
+
+    @Inject
     lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
 
     @Inject
@@ -115,9 +123,6 @@ class SyncActivity : DuckDuckGoActivity() {
 
     @Inject
     lateinit var syncSetupWideEvent: SyncSetupWideEvent
-
-    @Inject
-    lateinit var syncSettingsPlugin: DaggerMap<Int, SyncSettingsPlugin>
 
     @Inject
     lateinit var appBuildConfig: AppBuildConfig
@@ -222,6 +227,7 @@ class SyncActivity : DuckDuckGoActivity() {
         configureSyncThisDeviceCta()
         configureDevicesRecyclerView()
         configureBookmarksSection()
+        configureMessageWarnings()
         configureRecoverySection()
         configureGetOnOtherPlatformsItem()
         configureDataExpirationNotice()
@@ -450,6 +456,19 @@ class SyncActivity : DuckDuckGoActivity() {
             if (hasPlugins) {
                 syncSettingsPlugin.toSortedMap().forEach { (_, plugin) ->
                     bookmarksSectionContainer += plugin.getView(this@SyncActivity)
+                }
+            }
+        }
+    }
+
+    private fun configureMessageWarnings() {
+        binding.includeEnabledView.apply {
+            val hasPlugins = syncMessagesPlugin.isNotEmpty()
+            warningsContainer.isVisible = hasPlugins
+
+            if (hasPlugins) {
+                syncMessagesPlugin.forEach { plugin ->
+                    warningsContainer += plugin.getView(this@SyncActivity)
                 }
             }
         }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncActivity.kt
@@ -227,7 +227,7 @@ class SyncActivity : DuckDuckGoActivity() {
         configureSyncThisDeviceCta()
         configureDevicesRecyclerView()
         configureBookmarksSection()
-        configureMessageWarnings()
+        configureWarningMessages()
         configureRecoverySection()
         configureGetOnOtherPlatformsItem()
         configureDataExpirationNotice()
@@ -461,7 +461,7 @@ class SyncActivity : DuckDuckGoActivity() {
         }
     }
 
-    private fun configureMessageWarnings() {
+    private fun configureWarningMessages() {
         binding.includeEnabledView.apply {
             val hasPlugins = syncMessagesPlugin.isNotEmpty()
             warningsContainer.isVisible = hasPlugins

--- a/sync/sync-impl/src/main/res/layout/view_sync_v2_enabled.xml
+++ b/sync/sync-impl/src/main/res/layout/view_sync_v2_enabled.xml
@@ -25,7 +25,11 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/keyline_2" />
 
-    <!-- TODO Warnings container -->
+    <LinearLayout
+        android:id="@+id/warningsContainer"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical" />
 
     <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
         android:layout_width="match_parent"

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/TestSyncWarningPlugin.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/TestSyncWarningPlugin.kt
@@ -77,8 +77,8 @@ class TestSyncWarningPlugin @Inject constructor() : SyncMessagePlugin {
 
             val lifecycleOwner = findViewTreeLifecycleOwner()!!
             stateJob += stateHolder.isEnabled
-                .onEach { render(it) }
                 .flowWithLifecycle(lifecycleOwner.lifecycle)
+                .onEach { render(it) }
                 .launchIn(lifecycleOwner.lifecycleScope)
         }
 

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/TestSyncWarningPlugin.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/TestSyncWarningPlugin.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.internal
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.View
+import android.widget.FrameLayout
+import androidx.core.view.isVisible
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import com.duckduckgo.anvil.annotations.InjectWith
+import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.ConflatedJob
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.di.scopes.ViewScope
+import com.duckduckgo.sync.api.SyncMessagePlugin
+import com.duckduckgo.sync.internal.databinding.TestSyncMessagePluginBinding
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import dagger.android.support.AndroidSupportInjection
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+
+@ContributesMultibinding(scope = ActivityScope::class, boundType = SyncMessagePlugin::class)
+class TestSyncWarningPlugin @Inject constructor() : SyncMessagePlugin {
+    override fun getView(context: Context): View {
+        return TestSyncMessageView(context)
+    }
+
+    @SingleInstanceIn(scope = AppScope::class)
+    class StateHolder @Inject constructor() {
+        val isEnabled = MutableStateFlow(false)
+    }
+
+    @InjectWith(ViewScope::class)
+    class TestSyncMessageView @JvmOverloads constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+        defStyle: Int = 0,
+    ) : FrameLayout(context, attrs, defStyle) {
+        private val binding by viewBinding<TestSyncMessagePluginBinding>()
+
+        @Inject
+        lateinit var stateHolder: StateHolder
+
+        private val stateJob = ConflatedJob()
+
+        init {
+            binding.root.setText("This is a test warning triggered from the internal dev settings. You can dismiss it by tapping it.")
+            setOnClickListener {
+                stateHolder.isEnabled.value = false
+            }
+        }
+
+        override fun onAttachedToWindow() {
+            AndroidSupportInjection.inject(this)
+            super.onAttachedToWindow()
+
+            val lifecycleOwner = findViewTreeLifecycleOwner()!!
+            stateJob += stateHolder.isEnabled
+                .onEach { render(it) }
+                .flowWithLifecycle(lifecycleOwner.lifecycle)
+                .launchIn(lifecycleOwner.lifecycleScope)
+        }
+
+        override fun onDetachedFromWindow() {
+            super.onDetachedFromWindow()
+            stateJob.cancel()
+        }
+
+        private fun render(isEnabled: Boolean) {
+            isVisible = isEnabled
+        }
+    }
+}

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
@@ -23,6 +23,7 @@ import android.content.Intent
 import android.graphics.Bitmap
 import android.os.Bundle
 import android.util.Base64
+import android.widget.CompoundButton
 import android.widget.Toast
 import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle
@@ -98,6 +99,10 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         }
     }
 
+    private val testSyncWarningListener = CompoundButton.OnCheckedChangeListener { _, isChecked ->
+        viewModel.enableTestSyncWarning(isChecked)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableTransparentEdgeToEdge()
@@ -151,6 +156,7 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         binding.syncFaviconsPromptCta.setOnClickListener {
             viewModel.resetFaviconsPrompt()
         }
+        binding.testSyncWarningToggle.setOnCheckedChangeListener(testSyncWarningListener)
         binding.clearHistoryBookmarkAddedDialogPromo.setOnClickListener { viewModel.onClearHistoryBookmarkAddedDialogPromoClicked() }
         binding.clearHistoryBookmarkScreenPromo.setOnClickListener { viewModel.onClearHistoryBookmarkScreenPromoClicked() }
         binding.clearHistoryPasswordScreenPromo.setOnClickListener { viewModel.onClearHistoryPasswordScreenPromoClicked() }
@@ -342,5 +348,6 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
                 }
             }
         }
+        binding.testSyncWarningToggle.quietlySetIsChecked(viewState.isTestSyncWarningEnabled, testSyncWarningListener)
     }
 }

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
@@ -46,6 +46,7 @@ import com.duckduckgo.sync.impl.promotion.SyncPromotionDataStore.PromotionType.B
 import com.duckduckgo.sync.impl.promotion.SyncPromotionDataStore.PromotionType.BookmarksScreen
 import com.duckduckgo.sync.impl.promotion.SyncPromotionDataStore.PromotionType.ChatTabPage
 import com.duckduckgo.sync.impl.promotion.SyncPromotionDataStore.PromotionType.PasswordsScreen
+import com.duckduckgo.sync.internal.TestSyncWarningPlugin
 import com.duckduckgo.sync.internal.ui.SyncInternalSettingsViewModel.Command.ReadConnectQR
 import com.duckduckgo.sync.internal.ui.SyncInternalSettingsViewModel.Command.ReadQR
 import com.duckduckgo.sync.internal.ui.SyncInternalSettingsViewModel.Command.ShowMessage
@@ -79,6 +80,7 @@ constructor(
     private val syncFeature: SyncFeature,
     private val appBuildConfig: AppBuildConfig,
     private val syncApi: SyncApi,
+    private val testSyncWarningState: TestSyncWarningPlugin.StateHolder,
     @field:SuppressLint("StaticFieldLeak") private val context: Context,
 ) : ViewModel() {
 
@@ -120,6 +122,7 @@ constructor(
         val v2StoreFieldsText: String = "",
         val createThirdPartyResult: String = "",
         val keysText: String = "",
+        val isTestSyncWarningEnabled: Boolean = false,
     )
 
     sealed class BlockStoreValue {
@@ -145,6 +148,7 @@ constructor(
             checkBlockStoreAvailability()
             refreshBlockStoreValue()
         }
+        observeTestSyncWarningState()
     }
 
     fun onResume() {
@@ -784,5 +788,17 @@ constructor(
     private fun isDeviceSecureLockEnabled(): Boolean {
         val keyguardManager = context.getSystemService(KeyguardManager::class.java)
         return keyguardManager?.isDeviceSecure == true
+    }
+
+    fun enableTestSyncWarning(enable: Boolean) {
+        testSyncWarningState.isEnabled.value = enable
+    }
+
+    private fun observeTestSyncWarningState() {
+        viewModelScope.launch {
+            testSyncWarningState.isEnabled.collect { isEnabled ->
+                viewState.update { it.copy(isTestSyncWarningEnabled = isEnabled) }
+            }
+        }
     }
 }

--- a/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
+++ b/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
@@ -426,6 +426,13 @@
             app:daxButtonSize="large"
             android:text="@string/sync_internal_favicons_prompt_cta"/>
 
+        <com.duckduckgo.common.ui.view.listitem.OneLineListItem
+            android:id="@+id/test_sync_warning_toggle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:primaryText="Enable test sync warning"
+            app:showSwitch="true" />
+
         <com.duckduckgo.common.ui.view.divider.HorizontalDivider
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />

--- a/sync/sync-internal/src/main/res/layout/test_sync_message_plugin.xml
+++ b/sync/sync-internal/src/main/res/layout/test_sync_message_plugin.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<com.duckduckgo.common.ui.view.InfoPanel xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    style="@style/Widget.DuckDuckGo.InfoPanel"
+    android:layout_margin="@dimen/keyline_4"
+    app:panelBackground="@drawable/info_panel_alert_background"
+    app:panelDrawable="@drawable/ic_exclamation_yellow_16" />


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/72649045549333/task/1216585846803586?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/72649045549333/task/1216509582049467?focus=true

### Description

Adds support for displaying warning messages on the simplified Sync Settings screen, so that sync warnings can be surfaced to the user directly in the settings UI.

- When sync is enabled, warning views contributed through the existing `SyncMessagePlugin` extension point are shown at the top of the screen, above the "My Devices" section.
- The warnings container is hidden when no plugins are registered.
- Internal builds include a test warning plugin so the feature can be easily tested. It shows a yellow alert panel with a test message, controlled by a new "Enable test sync warning" toggle in Sync Dev Settings.
- Tapping the test warning dismisses it, which also turns the "Enable test sync warning" toggle off.

### Steps to test this PR

_Show the test warning_
- [ ] Enable sync on the device.
- [ ] Open Sync Dev Settings.
- [ ] Scroll down to "Device Settings".
- [ ] Turn on "Enable test sync warning".
- [ ] Tap "Launch Sync Settings V2".
- [ ] Verify a yellow warning panel with a test message is shown above the "My Devices" section.
- [ ] Tap the warning banner.
- [ ] Verify the warning disappears.
- [ ] Go back to Sync Dev Settings.
- [ ] Verify the "Enable test sync warning" toggle is off.

### UI changes
| Before  | After |
| ------ | ----- |
| <img width="540" alt="Screenshot_20260723-143141" src="https://github.com/user-attachments/assets/d03bb48f-46ca-489d-87af-bf3ae6fd5280" /> | <img width="540" alt="Screenshot_20260723-143154" src="https://github.com/user-attachments/assets/29a13f9e-a2ac-4c6e-9b8b-24e301a056a7" /> |


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only extension-point wiring and internal dev tooling; no changes to sync auth, account APIs, or production sync logic.
> 
> **Overview**
> **Sync Settings V2** now surfaces contributor warning UI when sync is enabled: injected `SyncMessagePlugin` implementations are added to a new `warningsContainer` above **My Devices**, and that section stays hidden when no plugins are registered (same pattern as `SyncSettingsPlugin` for bookmarks).
> 
> The enabled-state layout replaces the warnings placeholder with a vertical container. **Internal builds** add `TestSyncWarningPlugin` (yellow `InfoPanel`), an app-scoped `StateHolder`, and an **Enable test sync warning** switch in Sync Dev Settings; dismissing the banner clears the shared enabled state so the dev toggle stays in sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d28fb402f47b41f3f9e20a2f30cf59deffea135. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->