### PR TITLE
Set TRUNCATE journaling mode for the history.db and tab_visited_sites.db

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/fire/store/TabVisitedSitesModule.kt
+++ b/app/src/main/java/com/duckduckgo/app/fire/store/TabVisitedSitesModule.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.app.fire.store
 
 import android.content.Context
 import androidx.room.Room
+import androidx.room.RoomDatabase
 import com.duckduckgo.di.scopes.AppScope
 import com.squareup.anvil.annotations.ContributesTo
 import dagger.Module
@@ -32,6 +33,7 @@ class TabVisitedSitesModule {
     @Provides
     fun provideDatabase(context: Context): TabVisitedSitesDatabase {
         return Room.databaseBuilder(context, TabVisitedSitesDatabase::class.java, "tab_visited_sites.db")
+            .setJournalMode(RoomDatabase.JournalMode.TRUNCATE)
             .fallbackToDestructiveMigration()
             .build()
     }

--- a/history/history-impl/src/main/java/com/duckduckgo/history/impl/HistoryModule.kt
+++ b/history/history-impl/src/main/java/com/duckduckgo/history/impl/HistoryModule.kt
@@ -18,6 +18,7 @@ package com.duckduckgo.history.impl
 
 import android.content.Context
 import androidx.room.Room
+import androidx.room.RoomDatabase
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.history.impl.store.ALL_MIGRATIONS
@@ -51,6 +52,7 @@ class HistoryModule {
     @Provides
     fun provideDatabase(context: Context): HistoryDatabase {
         return Room.databaseBuilder(context, HistoryDatabase::class.java, "history.db")
+            .setJournalMode(RoomDatabase.JournalMode.TRUNCATE)
             .fallbackToDestructiveMigration()
             .addMigrations(*ALL_MIGRATIONS)
             .build()


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1216780670689923?focus=true

### Description

This PR sets the `TRUNCATE` journaling mode for `tab_visited_sites.db` and `history.db`, which removes the data residue after clearing data with the Fire button.

### Steps to test this PR

QA-optional

Smoke test data clearing and make sure everything works as expected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small builder-only change aligned with existing TRUNCATE usage on other Fire-related databases; no schema or query logic changes.
> 
> **Overview**
> Configures Room to use **`TRUNCATE`** journaling for **`history.db`** and **`tab_visited_sites.db`**, matching **`app.db`** and **`fire_mode.db`**.
> 
> The change is only in the Dagger `Room.databaseBuilder` setup in `HistoryModule` and `TabVisitedSitesModule` via `.setJournalMode(RoomDatabase.JournalMode.TRUNCATE)`. That reduces leftover SQLite journal/WAL residue after Fire-driven data clearing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1da690711e5b86bbdaa75049744537e8bc2bf0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->