### PR TITLE
Move Moshi initialization outside of the navigation flow

### DIFF
--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScripts.kt
@@ -28,6 +28,7 @@ import com.duckduckgo.fingerprintprotection.api.FingerprintProtectionManager
 import com.duckduckgo.privacy.config.api.UnprotectedTemporary
 import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
 import com.squareup.moshi.Moshi.Builder
 import com.squareup.moshi.Types
 import dagger.SingleInstanceIn
@@ -61,6 +62,15 @@ class RealContentScopeScripts @Inject constructor(
     private val fingerprintProtectionManager: FingerprintProtectionManager,
     private val contentScopeScriptsFeature: ContentScopeScriptsFeature,
 ) : CoreContentScopeScripts {
+    // These adapters must be declared before cachedContentScopeJson.
+    private val reusableMoshi: Moshi = Builder().build()
+    private val userUnprotectedDomainsAdapter: JsonAdapter<List<String>> =
+        reusableMoshi.adapter(Types.newParameterizedType(MutableList::class.java, String::class.java))
+    private val unprotectedTemporaryAdapter: JsonAdapter<List<FeatureException>> =
+        reusableMoshi.adapter(Types.newParameterizedType(MutableList::class.java, FeatureException::class.java))
+    private val experimentsAdapter: JsonAdapter<List<Experiment>> =
+        reusableMoshi.adapter(Types.newParameterizedType(List::class.java, Experiment::class.java))
+
     private var cachedContentScopeJson: String = getContentScopeJson("", emptyList())
 
     private var cachedUserUnprotectedDomains = CopyOnWriteArrayList<String>()
@@ -116,6 +126,8 @@ class RealContentScopeScripts @Inject constructor(
     }
 
     override fun isEnabled(): Boolean = contentScopeScriptsFeature.self().isEnabled()
+
+    private fun optimizeInjectionEnabled(): Boolean = contentScopeScriptsFeature.optimizeContentScopeInjection().isEnabled()
 
     private fun getSecretKeyValuePair() = "\"messageSecret\":\"$secret\""
 
@@ -173,7 +185,7 @@ class RealContentScopeScripts @Inject constructor(
         val contentScopeJS = contentScopeJSReader.getContentScopeJS()
         val messagingParameters = "${getSecretKeyValuePair()},${getCallbackKeyValuePair()},${getInterfaceKeyValuePair()}"
 
-        cachedContentScopeJS = if (contentScopeScriptsFeature.optimizeContentScopeInjection().isEnabled()) {
+        cachedContentScopeJS = if (optimizeInjectionEnabled()) {
             assembleContentScopeJS(contentScopeJS, messagingParameters)
         } else {
             contentScopeJS
@@ -242,17 +254,25 @@ class RealContentScopeScripts @Inject constructor(
     }
 
     private fun getUserUnprotectedDomainsJson(userUnprotectedDomains: List<String>): String {
-        val type = Types.newParameterizedType(MutableList::class.java, String::class.java)
-        val moshi = Builder().build()
-        val jsonAdapter: JsonAdapter<List<String>> = moshi.adapter(type)
-        return jsonAdapter.toJson(userUnprotectedDomains)
+        if (optimizeInjectionEnabled()) {
+            return userUnprotectedDomainsAdapter.toJson(userUnprotectedDomains)
+        } else {
+            val type = Types.newParameterizedType(MutableList::class.java, String::class.java)
+            val moshi = Builder().build()
+            val jsonAdapter: JsonAdapter<List<String>> = moshi.adapter(type)
+            return jsonAdapter.toJson(userUnprotectedDomains)
+        }
     }
 
     private fun getUnprotectedTemporaryJson(unprotectedTemporaryExceptions: List<FeatureException>): String {
-        val type = Types.newParameterizedType(MutableList::class.java, FeatureException::class.java)
-        val moshi = Builder().build()
-        val jsonAdapter: JsonAdapter<List<FeatureException>> = moshi.adapter(type)
-        return jsonAdapter.toJson(unprotectedTemporaryExceptions)
+        if (optimizeInjectionEnabled()) {
+            return unprotectedTemporaryAdapter.toJson(unprotectedTemporaryExceptions)
+        } else {
+            val type = Types.newParameterizedType(MutableList::class.java, FeatureException::class.java)
+            val moshi = Builder().build()
+            val jsonAdapter: JsonAdapter<List<FeatureException>> = moshi.adapter(type)
+            return jsonAdapter.toJson(unprotectedTemporaryExceptions)
+        }
     }
 
     private fun getUserPreferencesJson(
@@ -282,9 +302,13 @@ class RealContentScopeScripts @Inject constructor(
 
     private fun getExperimentsKeyValuePair(activeExperiments: List<Toggle>): String {
         return runBlocking {
-            val type = Types.newParameterizedType(List::class.java, Experiment::class.java)
-            val moshi = Builder().build()
-            val jsonAdapter: JsonAdapter<List<Experiment>> = moshi.adapter(type)
+            val jsonAdapter: JsonAdapter<List<Experiment>> = if (optimizeInjectionEnabled()) {
+                experimentsAdapter
+            } else {
+                val type = Types.newParameterizedType(List::class.java, Experiment::class.java)
+                val moshi = Builder().build()
+                moshi.adapter(type)
+            }
             activeExperiments
                 .filter { it.getCohort() != null && it.featureName().parentName != null }
                 .map {

--- a/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealWebViewCompatContentScopeScripts.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/main/java/com/duckduckgo/contentscopescripts/impl/RealWebViewCompatContentScopeScripts.kt
@@ -65,6 +65,12 @@ class RealWebViewCompatContentScopeScripts @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
 ) : WebViewCompatContentScopeScripts {
 
+    // NOTE: this class is intentionally NOT in sync with RealContentScopeScripts anymore.
+    // RealContentScopeScripts now builds a single Moshi and reuses its list adapters across getScript() calls
+    // (gated behind the optimizeContentScopeInjection flag), whereas this class still builds a fresh
+    // Moshi.Builder().build() per JSON serialization. This was deliberately left out of that change.
+    // TODO: port the shared-adapter optimization here as part of the effort to re-enable these flags,
+    // in a separate project. Keep the two implementations aligned once that happens.
     private var cachedContentScopeJson: String = getContentScopeJson("", emptyList())
 
     private var cachedUserUnprotectedDomains = CopyOnWriteArrayList<String>()

--- a/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
+++ b/content-scope-scripts/content-scope-scripts-impl/src/test/java/com/duckduckgo/contentscopescripts/impl/RealContentScopeScriptsTest.kt
@@ -58,15 +58,7 @@ class RealContentScopeScriptsTest {
 
     @Before
     fun setup() {
-        testee = RealContentScopeScripts(
-            mockPluginPoint,
-            mockUserAllowListRepository,
-            mockContentScopeJsReader,
-            mockAppBuildConfig,
-            mockUnprotectedTemporary,
-            mockFingerprintProtectionManager,
-            contentScopeScriptsFeature,
-        )
+        testee = createTestee()
         whenever(mockPlugin1.config()).thenReturn(config1)
         whenever(mockPlugin2.config()).thenReturn(config2)
         whenever(mockPluginPoint.getPlugins()).thenReturn(listOf(mockPlugin1, mockPlugin2))
@@ -344,26 +336,105 @@ class RealContentScopeScriptsTest {
 
     @Test
     fun whenOptimizeInjectionEnabledThenOutputIsByteIdenticalToFallbackPath() {
+        // getScript memoizes cachedContentScopeJS, so each path uses its own fresh instance to force a real build.
         // Fallback path (chained String.replace).
         contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = false))
-        val fallbackJs = testee.getScript(null, listOf())
+        val fallbackTestee = createTestee()
+        val fallbackJs = fallbackTestee.getScript(null, listOf())
 
-        // Optimized path (single-pass StringBuilder). Fresh instance so its caches build under the flag.
-        val optimizedTestee = RealContentScopeScripts(
-            mockPluginPoint,
-            mockUserAllowListRepository,
-            mockContentScopeJsReader,
-            mockAppBuildConfig,
-            mockUnprotectedTemporary,
-            mockFingerprintProtectionManager,
-            contentScopeScriptsFeature,
-        )
+        // Optimized path (single-pass StringBuilder).
         contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = true))
+        val optimizedTestee = createTestee()
         val optimizedJs = optimizedTestee.getScript(null, listOf())
 
         // The three messaging secrets are random per instance; normalise them before the byte comparison.
         val secret = Regex("[\\da-f]{32}")
         assertEquals(secret.replace(fallbackJs, "SECRET"), secret.replace(optimizedJs, "SECRET"))
+    }
+
+    @Test
+    fun whenOptimizeInjectionEnabledAndUnprotectedTemporaryChangesThenReusedAdapterSerializesNewValue() {
+        // Build the testee with the flag on so the list adapters are created once, up front, and then reused.
+        contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = true))
+        val optimizedTestee = createTestee()
+
+        // First call serialises both exceptions through the cached adapter.
+        verifyJsScript(optimizedTestee.getScript(null, listOf()))
+
+        // Change the exceptions: the reused adapter must serialise the new list, not a stale cached result.
+        val newRegEx = Regex(
+            "^processConfig\\(\\{\"features\":\\{" +
+                "\"config1\":\\{\"state\":\"enabled\"\\}," +
+                "\"config2\":\\{\"state\":\"disabled\"\\}\\}," +
+                "\"unprotectedTemporary\":\\[" +
+                "\\{\"domain\":\"example\\.com\",\"reason\":\"reason\"\\}\\]\\}, \\[\"example\\.com\"\\], " +
+                "\\{\"currentCohorts\":\\[\\],\"versionNumber\":1234,\"platform\":\\{\"name\":\"android\",\"internal\":true\\}," +
+                "\"locale\":\"en\",\"sessionKey\":\"5678\"," +
+                "\"desktopModeEnabled\":false," +
+                "\"messageSecret\":\"([\\da-f]{32})\"," +
+                "\"messageCallback\":\"([\\da-f]{32})\"," +
+                "\"javascriptInterface\":\"([\\da-f]{32})\"\\}\\)$",
+        )
+        whenever(mockUnprotectedTemporary.unprotectedTemporaryExceptions).thenReturn(listOf(unprotectedTemporaryException))
+        verifyJsScript(optimizedTestee.getScript(null, listOf()), newRegEx)
+    }
+
+    @Test
+    fun whenOptimizeInjectionEnabledAndCohortsChangeThenReusedExperimentsAdapterSerializesNewValue() = runTest {
+        contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = true))
+        val optimizedTestee = createTestee()
+
+        // First call with no experiments builds and caches the experiments adapter (empty currentCohorts).
+        verifyJsScript(optimizedTestee.getScript(false, listOf()))
+
+        // A later call with cohorts must serialise them through the same reused adapter.
+        val newRegEx = Regex(
+            "^processConfig\\(\\{\"features\":\\{" +
+                "\"config1\":\\{\"state\":\"enabled\"\\}," +
+                "\"config2\":\\{\"state\":\"disabled\"\\}\\}," +
+                "\"unprotectedTemporary\":\\[" +
+                "\\{\"domain\":\"example\\.com\",\"reason\":\"reason\"\\}," +
+                "\\{\"domain\":\"foo\\.com\",\"reason\":\"reason2\"\\}\\]\\}, \\[\"example\\.com\"\\], " +
+                "\\{\"currentCohorts\":\\[\\{\"cohort\":\"control\",\"feature\":\"contentScopeExperiments\",\"subfeature\":\"test\"}]," +
+                "\"versionNumber\":1234,\"platform\":\\{\"name\":\"android\",\"internal\":true\\}," +
+                "\"locale\":\"en\",\"sessionKey\":\"5678\"," +
+                "\"desktopModeEnabled\":false,\"messageSecret\":\"([\\da-f]{32})\"," +
+                "\"messageCallback\":\"([\\da-f]{32})\"," +
+                "\"javascriptInterface\":\"([\\da-f]{32})\"\\}\\)$",
+        )
+
+        val mockToggle = mock<Toggle>()
+        whenever(mockToggle.getCohort()).thenReturn(Cohort("control", weight = 1))
+        whenever(mockToggle.featureName()).thenReturn(FeatureName("contentScopeExperiments", "test"))
+
+        verifyJsScript(optimizedTestee.getScript(false, listOf(mockToggle)), newRegEx)
+    }
+
+    @Test
+    fun whenOptimizeInjectionEnabledAndAllowListChangesThenReusedAdapterSerializesNewValue() {
+        contentScopeScriptsFeature.optimizeContentScopeInjection().setRawStoredState(State(enable = true))
+        val optimizedTestee = createTestee()
+
+        // First call serialises the initial allow-list through the cached domains adapter.
+        verifyJsScript(optimizedTestee.getScript(null, listOf()))
+
+        // Change the allow-list: the reused adapter must serialise the new domain.
+        val newRegEx = Regex(
+            "^processConfig\\(\\{\"features\":\\{" +
+                "\"config1\":\\{\"state\":\"enabled\"\\}," +
+                "\"config2\":\\{\"state\":\"disabled\"\\}\\}," +
+                "\"unprotectedTemporary\":\\[" +
+                "\\{\"domain\":\"example\\.com\",\"reason\":\"reason\"\\}," +
+                "\\{\"domain\":\"foo\\.com\",\"reason\":\"reason2\"\\}\\]\\}, \\[\"foo\\.com\"\\], " +
+                "\\{\"currentCohorts\":\\[\\],\"versionNumber\":1234," +
+                "\"platform\":\\{\"name\":\"android\",\"internal\":true\\},\"locale\":\"en\"," +
+                "\"sessionKey\":\"5678\",\"desktopModeEnabled\":false," +
+                "\"messageSecret\":\"([\\da-f]{32})\"," +
+                "\"messageCallback\":\"([\\da-f]{32})\"," +
+                "\"javascriptInterface\":\"([\\da-f]{32})\"\\}\\)$",
+        )
+        whenever(mockUserAllowListRepository.domainsInUserAllowList()).thenReturn(listOf(exampleUrl2))
+        verifyJsScript(optimizedTestee.getScript(null, listOf()), newRegEx)
     }
 
     @Test
@@ -456,6 +527,16 @@ class RealContentScopeScriptsTest {
         assertFalse("preferences must not contain a double comma", js.contains(",,"))
         assertTrue(js.contains("\"globalPrivacyControlValue\":true"))
     }
+
+    private fun createTestee(): CoreContentScopeScripts = RealContentScopeScripts(
+        mockPluginPoint,
+        mockUserAllowListRepository,
+        mockContentScopeJsReader,
+        mockAppBuildConfig,
+        mockUnprotectedTemporary,
+        mockFingerprintProtectionManager,
+        contentScopeScriptsFeature,
+    )
 
     private fun verifyJsScript(js: String, regex: Regex = contentScopeRegex) {
         val matchResult = regex.find(js)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1200581511062568/task/1216781919152122?focus=true
Tech Design URL (if applicable):

### Description

RealContentScopeScripts.getScript() runs on every content-scope script injection, and each call constructed fresh Moshi.Builder().build() instances: one in getUnprotectedTemporaryJson() (via getContentScopeJson) and one in getExperimentsKeyValuePair() (via getUserPreferencesJson), plus a third in getUserUnprotectedDomainsJson() whenever the allow-list changed. 

This PR builds one Moshi and the three list adapters (List\<String>, List\<FeatureException>, List\<Experiment>) once as instance fields and reuses them. Moshi JsonAdapters are immutable and thread-safe, so sharing them from this AppScope singleton is safe, and serialization output is unchanged.

The reuse is gated behind the existing optimizeContentScopeInjection flag, read live per call (via a small optimizeInjectionEnabled() helper shared with the JS-assembly gate) so the flag remains a runtime kill-switch:

- Flag on → the cached adapters are used; zero Builder().build() in getScript().
- Flag off → each method builds a fresh Moshi/adapter per call, byte-for-byte the original behavior.

No API or behavior change; this is a performance refactor. RealWebViewCompatContentScopeScripts (same pattern) is intentionally left untouched and can follow separately.

Tests added:

- Output with the flag on is byte-identical to the flag-off path.
- Each of the three reused adapters serializes changed data correctly across successive getScript() calls (exceptions list, allow-list, and experiment cohorts) — guarding against accidentally caching serialized output instead of the stateless
adapter.

### Steps to test this PR

1. All tests should pass.
2. Install the app and browse a few sites; confirm privacy protections behave normally (tracker blocking, fingerprinting protection, GPC); content-scope scripts still inject and function.
3. Toggle optimizeContentScopeInjection off (remote config / internal settings) and repeat step 2 to confirm the fallback path produces identical, working scripts.

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the per-navigation content-scope script hot path that drives privacy protections, but behavior is kill-switch gated and tests assert byte-identical output and correct serialization when inputs change.
> 
> **Overview**
> **`RealContentScopeScripts`** no longer builds a fresh `Moshi.Builder().build()` on every `getScript()` when **`optimizeContentScopeInjection`** is on. It now keeps one `Moshi` instance and three shared list adapters (allow-list domains, temporary unprotect exceptions, experiment cohorts) and routes `getUserUnprotectedDomainsJson`, `getUnprotectedTemporaryJson`, and `getExperimentsKeyValuePair` through them. A small **`optimizeInjectionEnabled()`** helper gates that path (and aligns with the existing optimized JS assembly gate); with the flag off, each call still uses per-call Moshi construction so output stays the same.
> 
> **`RealWebViewCompatContentScopeScripts`** is unchanged on purpose; a comment notes it still allocates Moshi per serialization and should be aligned in a follow-up.
> 
> Tests add **`createTestee()`**, tighten the byte-identical flag on/off comparison with separate instances, and assert reused adapters still serialize updated allow-lists, exceptions, and cohorts across successive `getScript()` calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9074e165d743a02b542cde837a087094732cbc20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->