### PR TITLE
Add feature flag to restore native input search only mode

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -182,6 +182,7 @@ class RealNativeInputManager @Inject constructor(
     private val duckChatInputModeState: DuckChatInputModeState,
     private val pixel: Pixel,
     private val nativeInputStateBugKillSwitch: NativeInputStateBugKillSwitch,
+    private val nativeInputSearchOnlyFeature: NativeInputSearchOnlyFeature,
     private val nativeInputEventListener: NativeInputEventListener,
 ) : NativeInputManager {
     private lateinit var omnibarController: NativeInputOmnibarController
@@ -283,9 +284,12 @@ class RealNativeInputManager @Inject constructor(
 
     override fun isNativeInputActive(): Boolean {
         if (!isNativeInputFieldEnabled) return false
-        // Duck.ai always uses the native input; the browser omnibar only does so outside search-only.
+        // Duck.ai always uses the native input; the browser omnibar only does so outside search-only,
+        // unless the search-only feature flag is on.
         val inDuckAi = ::omnibarController.isInitialized && omnibarController.isDuckAiMode()
-        return inDuckAi || inputModeCapability != NativeInputState.InputMode.SEARCH_ONLY
+        return inDuckAi ||
+            inputModeCapability != NativeInputState.InputMode.SEARCH_ONLY ||
+            nativeInputSearchOnlyFeature.self().isEnabled()
     }
 
     override fun isNativeInputShown(): Boolean {

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputSearchOnlyFeature.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputSearchOnlyFeature.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.nativeinput
+
+import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+
+/**
+ * Gates using the native input field for the browser omnibar while the address bar is in search-only
+ * mode (Duck.ai off in the address bar). When disabled, search-only falls back to the legacy omnibar
+ */
+@ContributesRemoteFeature(
+    scope = AppScope::class,
+    featureName = "nativeInputSearchOnly",
+)
+interface NativeInputSearchOnlyFeature {
+
+    @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
+    fun self(): Toggle
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModel.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.app.browser.animations.AddressBarTrackersAnimationManager
 import com.duckduckgo.app.browser.customtabs.CustomTabPixelNames
 import com.duckduckgo.app.browser.menu.BrowserMenuHighlight
 import com.duckduckgo.app.browser.menu.BrowserViewMode
+import com.duckduckgo.app.browser.nativeinput.NativeInputSearchOnlyFeature
 import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode
 import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode.Browser
 import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode.CustomTab
@@ -125,6 +126,7 @@ class OmnibarLayoutViewModel @Inject constructor(
     private val addressBarTrackersAnimationManager: AddressBarTrackersAnimationManager,
     private val standardizedLeadingIconToggle: StandardizedLeadingIconFeatureToggle,
     private val progressBarUpgradeFeature: ProgressBarUpgradeFeature,
+    private val nativeInputSearchOnlyFeature: NativeInputSearchOnlyFeature,
     private val browserMode: BrowserMode,
 ) : ViewModel() {
 
@@ -266,6 +268,7 @@ class OmnibarLayoutViewModel @Inject constructor(
         val showShadows: Boolean = false,
         val inputScreenEnabled: Boolean = false,
         val isSearchOnly: Boolean = false,
+        val searchOnlyRestoreEnabled: Boolean = false,
         val showFindInPage: Boolean = false,
         val showDuckAIHeader: Boolean = false,
         val showDuckAISidebar: Boolean = false,
@@ -295,7 +298,8 @@ class OmnibarLayoutViewModel @Inject constructor(
          * focuses it directly. Derived from flags + viewMode so it can't drift out of sync.
          */
         val showTextInputClickCatcher: Boolean
-            get() = inputScreenEnabled || (isNativeInputEnabled && (viewMode is ViewMode.DuckAI || !isSearchOnly))
+            get() = inputScreenEnabled ||
+                (isNativeInputEnabled && (viewMode is ViewMode.DuckAI || !isSearchOnly || searchOnlyRestoreEnabled))
 
         fun shouldUpdateOmnibarText(
             isFullUrlEnabled: Boolean,
@@ -357,13 +361,15 @@ class OmnibarLayoutViewModel @Inject constructor(
             duckChat.observeNativeInputFieldUserSettingEnabled(),
             duckChat.observeNativeChatInputEnabled(),
             duckChatInputModeState.inputModeCapability,
-        ) { inputScreenEnabled, nativeInputEnabled, nativeChatInputEnabled, inputModeCapability ->
+            nativeInputSearchOnlyFeature.self().enabled(),
+        ) { inputScreenEnabled, nativeInputEnabled, nativeChatInputEnabled, inputModeCapability, searchOnlyRestoreEnabled ->
             _viewState.update {
                 it.copy(
                     inputScreenEnabled = inputScreenEnabled,
                     isSearchOnly = inputModeCapability == NativeInputState.InputMode.SEARCH_ONLY,
                     isNativeInputEnabled = nativeInputEnabled,
                     isNativeChatInputEnabled = nativeChatInputEnabled,
+                    searchOnlyRestoreEnabled = searchOnlyRestoreEnabled,
                 )
             }
         }.launchIn(viewModelScope)

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/RealNativeInputManagerTest.kt
@@ -41,6 +41,7 @@ import com.duckduckgo.duckchat.api.DuckChatInputModeState
 import com.duckduckgo.duckchat.api.NativeInputEventListener
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.voice.api.VoiceSearchAvailability
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -77,6 +78,7 @@ class RealNativeInputManagerTest {
     private val pixel: Pixel = mock()
     private val nativeInputEventListener: NativeInputEventListener = mock()
     private val nativeInputStateBugKillSwitch = FakeFeatureToggleFactory.create(NativeInputStateBugKillSwitch::class.java)
+    private val nativeInputSearchOnlyFeature = FakeFeatureToggleFactory.create(NativeInputSearchOnlyFeature::class.java)
 
     private val context: Context = ApplicationProvider.getApplicationContext()
     private val rootView: ViewGroup = FrameLayout(context)
@@ -91,6 +93,7 @@ class RealNativeInputManagerTest {
     fun setUp() {
         whenever(duckChatInputModeState.inputModeCapability).thenReturn(inputModeCapabilityFlow)
         whenever(duckChat.observeNativeInputNavBarEnabled()).thenReturn(MutableStateFlow(false))
+        nativeInputSearchOnlyFeature.self().setRawStoredState(State(enable = false))
         testee = RealNativeInputManager(
             duckChat,
             animator,
@@ -101,6 +104,7 @@ class RealNativeInputManagerTest {
             duckChatInputModeState,
             pixel,
             nativeInputStateBugKillSwitch,
+            nativeInputSearchOnlyFeature,
             nativeInputEventListener,
         )
     }

--- a/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/omnibar/OmnibarLayoutViewModelTest.kt
@@ -11,6 +11,7 @@ import com.duckduckgo.app.browser.animations.AddressBarTrackersAnimationManager
 import com.duckduckgo.app.browser.customtabs.CustomTabPixelNames
 import com.duckduckgo.app.browser.menu.BrowserMenuHighlight
 import com.duckduckgo.app.browser.menu.BrowserViewMode
+import com.duckduckgo.app.browser.nativeinput.NativeInputSearchOnlyFeature
 import com.duckduckgo.app.browser.omnibar.Omnibar.ViewMode
 import com.duckduckgo.app.browser.omnibar.OmnibarLayoutViewModel.Command
 import com.duckduckgo.app.browser.omnibar.OmnibarLayoutViewModel.Command.LaunchInputScreen
@@ -50,6 +51,7 @@ import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
 import com.duckduckgo.feature.toggles.api.FakeToggleStore
 import com.duckduckgo.feature.toggles.api.FeatureToggles
 import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.feature.toggles.api.Toggle.State
 import com.duckduckgo.privacy.dashboard.impl.pixels.PrivacyDashboardPixels
 import com.duckduckgo.serp.logos.api.SerpEasterEggLogosToggles
 import com.duckduckgo.serp.logos.api.SerpLogo
@@ -107,6 +109,7 @@ class OmnibarLayoutViewModelTest {
     private val duckAiShowInputScreenFlow = MutableStateFlow(false)
     private val nativeInputFieldSettingFlow = MutableStateFlow(false)
     private val nativeChatInputEnabledFlow = MutableStateFlow(false)
+    private val fakeNativeInputSearchOnlyFeature = FakeFeatureToggleFactory.create(NativeInputSearchOnlyFeature::class.java)
     private val inputScreenUserSettingFlow = MutableStateFlow(false)
     private val activeVoiceSessionsFlow = MutableStateFlow<Set<String>>(emptySet())
     private val selectedTabFlow = MutableStateFlow<TabEntity?>(null)
@@ -155,6 +158,7 @@ class OmnibarLayoutViewModelTest {
         whenever(duckAiFeatureState.showInputScreen).thenReturn(duckAiShowInputScreenFlow)
         whenever(duckChat.observeNativeInputFieldUserSettingEnabled()).thenReturn(nativeInputFieldSettingFlow)
         whenever(duckChat.observeNativeChatInputEnabled()).thenReturn(nativeChatInputEnabledFlow)
+        fakeNativeInputSearchOnlyFeature.self().setRawStoredState(State(enable = false))
         whenever(duckChatInputModeState.inputModeCapability).thenReturn(inputModeCapabilityFlow)
         whenever(duckChat.activeVoiceChatSessions).thenReturn(activeVoiceSessionsFlow)
         whenever(duckChat.observeInputScreenUserSettingEnabled()).thenReturn(inputScreenUserSettingFlow)
@@ -215,6 +219,7 @@ class OmnibarLayoutViewModelTest {
             addressBarTrackersAnimationManager = addressBarTrackersAnimationManager,
             standardizedLeadingIconToggle = fakeStandardizedLeadingIconToggle,
             progressBarUpgradeFeature = fakeProgressBarUpgradeFeature,
+            nativeInputSearchOnlyFeature = fakeNativeInputSearchOnlyFeature,
             browserMode = browserMode,
         )
     }
@@ -1654,6 +1659,20 @@ class OmnibarLayoutViewModelTest {
         testee.viewState.test {
             val viewState = expectMostRecentItem()
             assertFalse(viewState.showTextInputClickCatcher)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun whenSearchOnlyAndRestoreFlagEnabledThenShowClickCatcherTrue() = runTest {
+        fakeNativeInputSearchOnlyFeature.self().setRawStoredState(State(enable = true))
+        nativeInputFieldSettingFlow.value = true
+        inputModeCapabilityFlow.value = NativeInputState.InputMode.SEARCH_ONLY
+        initializeViewModel()
+
+        testee.viewState.test {
+            val viewState = expectMostRecentItem()
+            assertTrue(viewState.showTextInputClickCatcher)
             cancelAndIgnoreRemainingEvents()
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1216642253022044?focus=true 
Tech Design URL (if applicable): 

## Description
Adds a new app feature flag `nativeInputSearchOnly` (**defaults off**) that re-enables the native (unified) input field for the browser omnibar in **search-only** mode. 

Note this only restores the native input no changes has been done on it yet.

- **Off (default):** search-only keeps the legacy omnibar (current production behaviour).
- **On:** tapping the omnibar in search-only opens the native input overlay again.

No changes to the unfocused omnibar, Search + Duck.ai mode, or Duck.ai input.

## Steps to test this PR
Toggle `nativeInputSearchOnly` via the internal feature-flag dev settings (or remote config).

**Flag OFF (default):**
- [x] Search-only (Settings → Duck.ai → address bar → "Search only"): tap the omnibar → legacy text input focuses directly (unchanged from production).
- [x] Search + Duck.ai: tap the omnibar → native input opens (unchanged).

**Flag ON:**
- [x] Search-only: tap the omnibar → the native input overlay opens (restored).
- [x] Search + Duck.ai: tap the omnibar → native input opens (unchanged).
- [x] Verify search-only behaviour on both **top and bottom** address bar positions.


### UI changes
| Before  | After |
No UI Changes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is behind a remote flag defaulting off; scope is limited to omnibar tap routing and native-input activation in search-only mode.
> 
> **Overview**
> Introduces **`nativeInputSearchOnly`**, a remote feature toggle that defaults **off** and gates whether the browser omnibar uses the native (unified) input while Duck.ai is disabled in the address bar (**search-only** mode).
> 
> When the flag is **on**, **`RealNativeInputManager.isNativeInputActive()`** treats search-only like other modes (native input can open), and **`OmnibarLayoutViewModel`** exposes **`searchOnlyRestoreEnabled`** so **`showTextInputClickCatcher`** is shown in search-only—omnibar taps launch the native overlay via **`LaunchInputScreen`** instead of focusing the legacy field. **Off** preserves current production: search-only keeps the legacy omnibar.
> 
> Tests wire the fake toggle and assert the click catcher is shown when search-only and the flag is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9269aa87ba1598f04ecad97c7c4dae3e00eea5b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->