### PR TITLE
Integrate NTP promos into modal coordinator

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -1319,7 +1319,6 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun onViewVisible() {
-        // This tab is the visible one, so it owns the NTP modal presenter surface.
         newTabPageModalPresenterRegistry.register(this)
         setAdClickActiveTabData(url)
 
@@ -3772,50 +3771,37 @@ class BrowserTabViewModel @Inject constructor(
         return null
     }
 
-    /**
-     * [NewTabPageModalPresenter] entry point for the Privacy Pro promo, called by the modal
-     * coordinator. Must be called on the main thread. Returns true if accepted for display.
-     */
-    override fun showSubscriptionPromo(
+    override suspend fun showSubscriptionPromo(
         flow: SubscriptionPromoFlow,
         isFreeTrialCopy: Boolean,
-    ): Boolean {
-        if (currentGlobalLayoutState() !is Browser) return false
+    ): Boolean = withContext(dispatchers.main()) {
+        if (!canShowPromo()) return@withContext false
         val currentUrl = url
-        if (currentUrl != null && duckChat.isDuckChatUrl(currentUrl.toUri())) return false
-        // A malicious-site warning owns the screen; a promo must never obscure a security warning.
-        if (currentBrowserViewState().maliciousSiteBlocked) return false
-        if (!currentBrowserViewState().browserShowing && currentCtaViewState().cta != null) return false
+        if (currentUrl != null && duckChat.isDuckChatUrl(currentUrl.toUri())) return@withContext false
+        if (!currentBrowserViewState().browserShowing && currentCtaViewState().cta != null) return@withContext false
         ctaViewState.value = currentCtaViewState().copy(
             cta = SubscriptionPromoModalCta(isFreeTrialCopy = isFreeTrialCopy, flow = flow),
             isBrowserShowing = currentBrowserViewState().browserShowing,
-            isErrorShowing = currentBrowserViewState().maliciousSiteBlocked,
+            isErrorShowing = false,
         )
-        return true
+        true
     }
 
-    /**
-     * [NewTabPageModalPresenter] entry point for the Add Widget promo, called by the modal
-     * coordinator. Only shown on the New Tab Page. Must be called on the main thread. Returns true
-     * if accepted for display.
-     */
-    override fun showAddWidgetPromo(supportsAutomaticAdd: Boolean): Boolean {
-        if (currentGlobalLayoutState() !is Browser) return false
-        if (currentBrowserViewState().browserShowing) return false
-        // A malicious-site warning also reports browserShowing = false, and a promo must never
-        // obscure a security warning.
-        if (currentBrowserViewState().maliciousSiteBlocked) return false
-        // Add Widget is the lowest-priority home CTA: it must never replace a CTA that already owns
-        // the NTP slot (RMF message, subscription promo, etc.).
-        if (currentCtaViewState().cta != null) return false
+    override suspend fun showAddWidgetPromo(supportsAutomaticAdd: Boolean): Boolean = withContext(dispatchers.main()) {
+        if (!canShowPromo()) return@withContext false
+        if (currentBrowserViewState().browserShowing) return@withContext false
+        if (currentCtaViewState().cta != null) return@withContext false
         val cta = if (supportsAutomaticAdd) HomePanelCta.AddWidgetAutoOnboarding else HomePanelCta.AddWidgetInstructions
         ctaViewState.value = currentCtaViewState().copy(
             cta = cta,
             isBrowserShowing = false,
-            isErrorShowing = currentBrowserViewState().maliciousSiteBlocked,
+            isErrorShowing = false,
         )
-        return true
+        true
     }
+
+    private fun canShowPromo(): Boolean =
+        currentGlobalLayoutState() is Browser && !currentBrowserViewState().maliciousSiteBlocked
 
     private fun showOrHideKeyboard(cta: Cta?) {
         // we hide the keyboard when showing a DialogCta and HomeCta type in the home screen otherwise we show it

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -198,6 +198,8 @@ import com.duckduckgo.app.browser.logindetection.LoginDetected
 import com.duckduckgo.app.browser.logindetection.NavigationAwareLoginDetector
 import com.duckduckgo.app.browser.logindetection.NavigationEvent
 import com.duckduckgo.app.browser.menu.VpnMenuStateProvider
+import com.duckduckgo.app.browser.modals.NewTabPageModalPresenter
+import com.duckduckgo.app.browser.modals.NewTabPageModalPresenterRegistry
 import com.duckduckgo.app.browser.model.BasicAuthenticationCredentials
 import com.duckduckgo.app.browser.model.BasicAuthenticationRequest
 import com.duckduckgo.app.browser.model.LongPressTarget
@@ -265,6 +267,7 @@ import com.duckduckgo.app.cta.ui.DaxTryASearchBrandDesignUpdateBubbleCta
 import com.duckduckgo.app.cta.ui.DaxVisitSiteOptionsBrandDesignUpdateBubbleCta
 import com.duckduckgo.app.cta.ui.HomePanelCta
 import com.duckduckgo.app.cta.ui.OnboardingDaxDialogCta
+import com.duckduckgo.app.cta.ui.SubscriptionPromoFlow
 import com.duckduckgo.app.cta.ui.SubscriptionPromoModalCta
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.dispatchers.ExternalIntentProcessingState
@@ -388,6 +391,7 @@ import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed
 import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed.MALWARE
 import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed.PHISHING
 import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed.SCAM
+import com.duckduckgo.modalcoordinator.api.NewTabPageModalTrigger
 import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
 import com.duckduckgo.newtabpage.impl.pixels.NewTabPixels
 import com.duckduckgo.privacy.config.api.AmpLinkInfo
@@ -589,12 +593,15 @@ class BrowserTabViewModel @Inject constructor(
     private val desktopModeSettings: DesktopModeSettings,
     private val rememberDesktopModeFeature: RememberDesktopModeFeature,
     private val adBlockingOmnibarAnimationProvider: AdBlockingOmnibarAnimationProvider,
+    private val newTabPageModalPresenterRegistry: NewTabPageModalPresenterRegistry,
+    private val newTabPageModalTrigger: NewTabPageModalTrigger,
 ) : ViewModel(),
     WebViewClientListener,
     EditSavedSiteListener,
     DeleteBookmarkListener,
     UrlExtractionListener,
-    NavigationHistoryListener {
+    NavigationHistoryListener,
+    NewTabPageModalPresenter {
     private var buildingSiteFactoryJob: Job? = null
     private var pendingVoiceSessionEndJob: Job? = null
     private var lastAutoCompleteState: AutoCompleteViewState? = null
@@ -636,7 +643,6 @@ class BrowserTabViewModel @Inject constructor(
     val liveSelectedTab: LiveData<TabEntity> = tabRepository.liveSelectedTab
     val command: SingleLiveEvent<Command> = SingleLiveEvent()
     private var refreshOnViewVisible = MutableStateFlow(true)
-    private var ctaChangedTicker = MutableStateFlow("")
     val hiddenIds = MutableStateFlow(HiddenBookmarksIds())
 
     private var activeExperiments: List<Toggle>? = null
@@ -919,30 +925,6 @@ class BrowserTabViewModel @Inject constructor(
                 browserViewState.value = currentBrowserViewState().copy(bookmark = bookmark?.copy(isFavorite = isFavorite))
             }.flowOn(dispatchers.main())
             .launchIn(viewModelScope)
-
-        viewModelScope.launch(dispatchers.io()) {
-            ctaChangedTicker
-                .asStateFlow()
-                .onEach { ticker ->
-                    logcat(VERBOSE) { "RMF: $ticker" }
-
-                    if (ticker.isEmpty()) return@onEach
-                    if (currentBrowserViewState().browserShowing) return@onEach
-
-                    val cta =
-                        currentCtaViewState().cta?.takeUnless { it ->
-                            it is HomePanelCta
-                        }
-
-                    withContext(dispatchers.main()) {
-                        ctaViewState.value =
-                            currentCtaViewState().copy(
-                                cta = cta,
-                            )
-                    }
-                }.flowOn(dispatchers.io())
-                .launchIn(viewModelScope)
-        }
 
         duckPlayer
             .observeUserPreferences()
@@ -1304,6 +1286,7 @@ class BrowserTabViewModel @Inject constructor(
 
     @VisibleForTesting
     public override fun onCleared() {
+        newTabPageModalPresenterRegistry.unregister(this)
         buildingSiteFactoryJob?.cancel()
         autoCompleteJob.cancel()
         fireproofWebsiteState.removeObserver(fireproofWebsitesObserver)
@@ -1336,20 +1319,21 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun onViewVisible() {
+        // This tab is the visible one, so it owns the NTP modal presenter surface.
+        newTabPageModalPresenterRegistry.register(this)
         setAdClickActiveTabData(url)
 
         // we expect refreshCta to be called when a site is fully loaded if browsingShowing -trackers data available-.
         if (!currentBrowserViewState().browserShowing && !currentBrowserViewState().maliciousSiteBlocked) {
             viewModelScope.launch {
-                if (checkSubscriptionPromoOnForeground()) return@launch
                 val cta = refreshCta()
                 showOrHideKeyboard(cta)
+                if (cta == null) {
+                    newTabPageModalTrigger.onNewTabPageShown()
+                }
             }
         } else {
             command.value = HideKeyboard
-            if (currentBrowserViewState().browserShowing && !currentBrowserViewState().maliciousSiteBlocked) {
-                viewModelScope.launch { checkSubscriptionPromoOnForeground() }
-            }
         }
 
         browserViewState.value =
@@ -1375,6 +1359,7 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun onViewHidden() {
+        newTabPageModalPresenterRegistry.unregister(this)
         ctaViewState.value?.cta.let {
             if (it is BrokenSitePromptDialogCta) {
                 command.value = HideBrokenSitePromptCta(it)
@@ -3782,27 +3767,54 @@ class BrowserTabViewModel @Inject constructor(
                     isBrowserShowing = isBrowserShowing,
                     isErrorShowing = isErrorShowing,
                 )
-            ctaChangedTicker.emit(System.currentTimeMillis().toString())
             return cta
         }
         return null
     }
 
-    private suspend fun checkSubscriptionPromoOnForeground(): Boolean {
+    /**
+     * [NewTabPageModalPresenter] entry point for the Privacy Pro promo, called by the modal
+     * coordinator. Must be called on the main thread. Returns true if accepted for display.
+     */
+    override fun showSubscriptionPromo(
+        flow: SubscriptionPromoFlow,
+        isFreeTrialCopy: Boolean,
+    ): Boolean {
         if (currentGlobalLayoutState() !is Browser) return false
         val currentUrl = url
         if (currentUrl != null && duckChat.isDuckChatUrl(currentUrl.toUri())) return false
-        val cta = withContext(dispatchers.io()) { ctaViewModel.getPromoCtaOnForeground() }
-        if (cta != null) {
-            ctaViewState.value = currentCtaViewState().copy(
-                cta = cta,
-                isBrowserShowing = currentBrowserViewState().browserShowing,
-                isErrorShowing = currentBrowserViewState().maliciousSiteBlocked,
-            )
-            ctaChangedTicker.emit(System.currentTimeMillis().toString())
-            return true
-        }
-        return false
+        // A malicious-site warning owns the screen; a promo must never obscure a security warning.
+        if (currentBrowserViewState().maliciousSiteBlocked) return false
+        if (!currentBrowserViewState().browserShowing && currentCtaViewState().cta != null) return false
+        ctaViewState.value = currentCtaViewState().copy(
+            cta = SubscriptionPromoModalCta(isFreeTrialCopy = isFreeTrialCopy, flow = flow),
+            isBrowserShowing = currentBrowserViewState().browserShowing,
+            isErrorShowing = currentBrowserViewState().maliciousSiteBlocked,
+        )
+        return true
+    }
+
+    /**
+     * [NewTabPageModalPresenter] entry point for the Add Widget promo, called by the modal
+     * coordinator. Only shown on the New Tab Page. Must be called on the main thread. Returns true
+     * if accepted for display.
+     */
+    override fun showAddWidgetPromo(supportsAutomaticAdd: Boolean): Boolean {
+        if (currentGlobalLayoutState() !is Browser) return false
+        if (currentBrowserViewState().browserShowing) return false
+        // A malicious-site warning also reports browserShowing = false, and a promo must never
+        // obscure a security warning.
+        if (currentBrowserViewState().maliciousSiteBlocked) return false
+        // Add Widget is the lowest-priority home CTA: it must never replace a CTA that already owns
+        // the NTP slot (RMF message, subscription promo, etc.).
+        if (currentCtaViewState().cta != null) return false
+        val cta = if (supportsAutomaticAdd) HomePanelCta.AddWidgetAutoOnboarding else HomePanelCta.AddWidgetInstructions
+        ctaViewState.value = currentCtaViewState().copy(
+            cta = cta,
+            isBrowserShowing = false,
+            isErrorShowing = currentBrowserViewState().maliciousSiteBlocked,
+        )
+        return true
     }
 
     private fun showOrHideKeyboard(cta: Cta?) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -3822,6 +3822,7 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun onUserClickCtaOkButton(cta: Cta) {
+        releaseAddWidgetModalSlot(cta)
         viewModelScope.launch {
             ctaViewModel.onUserClickCtaOkButton(cta)
         }
@@ -3848,12 +3849,18 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun onUserClickCtaSecondaryButton(cta: Cta) {
+        releaseAddWidgetModalSlot(cta)
         viewModelScope.launch {
             ctaViewModel.onUserDismissedCta(cta)
             if (cta is BrokenSitePromptDialogCta) {
                 onBrokenSiteCtaDismissButtonClicked(cta)
             }
         }
+    }
+
+    private fun releaseAddWidgetModalSlot(cta: Cta) {
+        if (cta !is HomePanelCta) return
+        ctaViewState.value = currentCtaViewState().copy(cta = null)
     }
 
     fun onPrivacyProSkippedOnboardingDismissed() {
@@ -3869,6 +3876,7 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     fun onUserClickCtaDismissButton(cta: Cta) {
+        releaseAddWidgetModalSlot(cta)
         viewModelScope.launch {
             ctaViewModel.onUserDismissedCta(cta, viaCloseBtn = true)
             if (cta is DaxBubbleCta) {

--- a/app/src/main/java/com/duckduckgo/app/browser/modals/AddWidgetModalEvaluator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/modals/AddWidgetModalEvaluator.kt
@@ -33,12 +33,8 @@ import logcat.logcat
 import javax.inject.Inject
 
 /**
- * Coordinates the "Add Widget" promo. Runs on [ModalTrigger.NTP_RENDER] because the promo is
- * render-bound to the empty New Tab Page (including mid-session new tabs that produce no app
- * foreground), so it cannot rely on [ModalTrigger.APP_RESUME] alone.
- *
- * The promo is a bottom sheet owned by the visible browser tab, so rendering is delegated to the
- * [NewTabPageModalPresenter] that tab registers.
+ * Coordinates the "Add Widget" promo. Uses [ModalTrigger.NTP_RENDER] because mid-session new tabs
+ * render the NTP without foregrounding the app.
  */
 @ContributesMultibinding(
     scope = AppScope::class,
@@ -59,8 +55,6 @@ class AddWidgetModalEvaluator @Inject constructor(
     override val trigger: ModalTrigger = ModalTrigger.NTP_RENDER
 
     override suspend fun evaluate(): ModalEvaluator.EvaluationResult = withContext(dispatchers.io()) {
-        // Onboarding CTAs own the NTP during onboarding (as they did when Add Widget lived in
-        // getHomeCta); don't interrupt them.
         if (!onboardingFlowChecker.isOnboardingComplete()) {
             logcat { "AddWidgetModalEvaluator: skipped, onboarding not complete" }
             return@withContext ModalEvaluator.EvaluationResult.Skipped
@@ -81,9 +75,7 @@ class AddWidgetModalEvaluator @Inject constructor(
             logcat { "AddWidgetModalEvaluator: skipped, no presenter registered" }
             return@withContext ModalEvaluator.EvaluationResult.Skipped
         }
-        val shown = withContext(dispatchers.main()) {
-            presenter.showAddWidgetPromo(widgetCapabilities.supportsAutomaticWidgetAdd)
-        }
+        val shown = presenter.showAddWidgetPromo(widgetCapabilities.supportsAutomaticWidgetAdd)
         if (shown) {
             ModalEvaluator.EvaluationResult.ModalShown
         } else {

--- a/app/src/main/java/com/duckduckgo/app/browser/modals/AddWidgetModalEvaluator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/modals/AddWidgetModalEvaluator.kt
@@ -18,7 +18,6 @@ package com.duckduckgo.app.browser.modals
 
 import com.duckduckgo.app.cta.db.DismissedCtaDao
 import com.duckduckgo.app.cta.model.CtaId
-import com.duckduckgo.app.onboarding.OnboardingFlowChecker
 import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.duckduckgo.common.utils.DispatcherProvider
@@ -45,7 +44,6 @@ class AddWidgetModalEvaluator @Inject constructor(
     private val widgetCapabilities: WidgetCapabilities,
     private val dismissedCtaDao: DismissedCtaDao,
     private val presenterRegistry: NewTabPageModalPresenterRegistry,
-    private val onboardingFlowChecker: OnboardingFlowChecker,
     private val onboardingStore: OnboardingStore,
     private val dispatchers: DispatcherProvider,
 ) : ModalEvaluator {
@@ -55,11 +53,6 @@ class AddWidgetModalEvaluator @Inject constructor(
     override val trigger: ModalTrigger = ModalTrigger.NTP_RENDER
 
     override suspend fun evaluate(): ModalEvaluator.EvaluationResult = withContext(dispatchers.io()) {
-        if (!onboardingFlowChecker.isOnboardingComplete()) {
-            logcat { "AddWidgetModalEvaluator: skipped, onboarding not complete" }
-            return@withContext ModalEvaluator.EvaluationResult.Skipped
-        }
-
         if (!canShowWidgetCta()) {
             logcat {
                 "AddWidgetModalEvaluator: skipped, not eligible " +

--- a/app/src/main/java/com/duckduckgo/app/browser/modals/AddWidgetModalEvaluator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/modals/AddWidgetModalEvaluator.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.modals
+
+import com.duckduckgo.app.cta.db.DismissedCtaDao
+import com.duckduckgo.app.cta.model.CtaId
+import com.duckduckgo.app.onboarding.OnboardingFlowChecker
+import com.duckduckgo.app.onboarding.store.OnboardingStore
+import com.duckduckgo.app.widget.ui.WidgetCapabilities
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.modalcoordinator.api.ModalEvaluator
+import com.duckduckgo.modalcoordinator.api.ModalTrigger
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import logcat.logcat
+import javax.inject.Inject
+
+/**
+ * Coordinates the "Add Widget" promo. Runs on [ModalTrigger.NTP_RENDER] because the promo is
+ * render-bound to the empty New Tab Page (including mid-session new tabs that produce no app
+ * foreground), so it cannot rely on [ModalTrigger.APP_RESUME] alone.
+ *
+ * The promo is a bottom sheet owned by the visible browser tab, so rendering is delegated to the
+ * [NewTabPageModalPresenter] that tab registers.
+ */
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = ModalEvaluator::class,
+)
+@SingleInstanceIn(scope = AppScope::class)
+class AddWidgetModalEvaluator @Inject constructor(
+    private val widgetCapabilities: WidgetCapabilities,
+    private val dismissedCtaDao: DismissedCtaDao,
+    private val presenterRegistry: NewTabPageModalPresenterRegistry,
+    private val onboardingFlowChecker: OnboardingFlowChecker,
+    private val onboardingStore: OnboardingStore,
+    private val dispatchers: DispatcherProvider,
+) : ModalEvaluator {
+
+    override val priority: Int = PRIORITY
+    override val evaluatorId: String = "add_widget_modal"
+    override val trigger: ModalTrigger = ModalTrigger.NTP_RENDER
+
+    override suspend fun evaluate(): ModalEvaluator.EvaluationResult = withContext(dispatchers.io()) {
+        // Onboarding CTAs own the NTP during onboarding (as they did when Add Widget lived in
+        // getHomeCta); don't interrupt them.
+        if (!onboardingFlowChecker.isOnboardingComplete()) {
+            logcat { "AddWidgetModalEvaluator: skipped, onboarding not complete" }
+            return@withContext ModalEvaluator.EvaluationResult.Skipped
+        }
+
+        if (!canShowWidgetCta()) {
+            logcat {
+                "AddWidgetModalEvaluator: skipped, not eligible " +
+                    "(hasInstalledWidgets=${widgetCapabilities.hasInstalledWidgets}, " +
+                    "dismissed=${dismissedCtaDao.exists(CtaId.ADD_WIDGET)}, " +
+                    "linearPlanWidgetPromptShown=${onboardingStore.linearPlanWidgetPromptShown})"
+            }
+            return@withContext ModalEvaluator.EvaluationResult.Skipped
+        }
+        delay(MODAL_DISPLAY_DELAY)
+        val presenter = presenterRegistry.current()
+        if (presenter == null) {
+            logcat { "AddWidgetModalEvaluator: skipped, no presenter registered" }
+            return@withContext ModalEvaluator.EvaluationResult.Skipped
+        }
+        val shown = withContext(dispatchers.main()) {
+            presenter.showAddWidgetPromo(widgetCapabilities.supportsAutomaticWidgetAdd)
+        }
+        if (shown) {
+            ModalEvaluator.EvaluationResult.ModalShown
+        } else {
+            logcat { "AddWidgetModalEvaluator: skipped, presenter declined (not on New Tab Page)" }
+            ModalEvaluator.EvaluationResult.Skipped
+        }
+    }
+
+    private fun canShowWidgetCta(): Boolean =
+        !widgetCapabilities.hasInstalledWidgets &&
+            !dismissedCtaDao.exists(CtaId.ADD_WIDGET) &&
+            !onboardingStore.linearPlanWidgetPromptShown
+
+    companion object {
+        private const val PRIORITY = 5
+        private const val MODAL_DISPLAY_DELAY = 250L
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/modals/NewTabPageModalPresenter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/modals/NewTabPageModalPresenter.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.modals
+
+import com.duckduckgo.app.cta.ui.SubscriptionPromoFlow
+import com.duckduckgo.di.scopes.AppScope
+import dagger.SingleInstanceIn
+import javax.inject.Inject
+
+/**
+ * Renders coordinator-arbitrated New Tab Page promos as bottom sheets.
+ *
+ * The modal coordinator runs in [AppScope] and cannot attach a bottom sheet to a fragment, so the
+ * currently visible browser tab registers an implementation of this interface with the
+ * [NewTabPageModalPresenterRegistry] while it is on screen. Evaluators resolve the current presenter
+ * and ask it to render; the presenter reuses the existing CTA render path so all pixels and dismiss
+ * handling stay intact.
+ *
+ * All methods must be called on the main thread and return true only if the promo was accepted for
+ * display on the current surface (e.g. the tab is on a valid screen). A false return tells the
+ * evaluator the modal was not shown, so no cooldown is recorded.
+ */
+interface NewTabPageModalPresenter {
+
+    /** Shows the Privacy Pro promo. Valid on the NTP or over a website (never over Duck.ai). */
+    fun showSubscriptionPromo(
+        flow: SubscriptionPromoFlow,
+        isFreeTrialCopy: Boolean,
+    ): Boolean
+
+    /** Shows the Add Widget promo. Valid only on the New Tab Page. */
+    fun showAddWidgetPromo(supportsAutomaticAdd: Boolean): Boolean
+}
+
+/**
+ * Holds the presenter for the currently visible browser tab. "Last registered wins", so the most
+ * recently visible tab is the active presenter; a tab only clears the presenter if it is still the
+ * registered one, making stale unregister calls safe.
+ */
+@SingleInstanceIn(AppScope::class)
+class NewTabPageModalPresenterRegistry @Inject constructor() {
+
+    @Volatile
+    private var presenter: NewTabPageModalPresenter? = null
+
+    fun register(presenter: NewTabPageModalPresenter) {
+        this.presenter = presenter
+    }
+
+    fun unregister(presenter: NewTabPageModalPresenter) {
+        if (this.presenter === presenter) {
+            this.presenter = null
+        }
+    }
+
+    fun current(): NewTabPageModalPresenter? = presenter
+}

--- a/app/src/main/java/com/duckduckgo/app/browser/modals/NewTabPageModalPresenter.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/modals/NewTabPageModalPresenter.kt
@@ -22,34 +22,26 @@ import dagger.SingleInstanceIn
 import javax.inject.Inject
 
 /**
- * Renders coordinator-arbitrated New Tab Page promos as bottom sheets.
+ * Renders New Tab Page promos as bottom sheets. The coordinator runs in [AppScope] and cannot attach
+ * one to a fragment, so the visible browser tab registers an implementation while it is on screen.
  *
- * The modal coordinator runs in [AppScope] and cannot attach a bottom sheet to a fragment, so the
- * currently visible browser tab registers an implementation of this interface with the
- * [NewTabPageModalPresenterRegistry] while it is on screen. Evaluators resolve the current presenter
- * and ask it to render; the presenter reuses the existing CTA render path so all pixels and dismiss
- * handling stay intact.
- *
- * All methods must be called on the main thread and return true only if the promo was accepted for
- * display on the current surface (e.g. the tab is on a valid screen). A false return tells the
- * evaluator the modal was not shown, so no cooldown is recorded.
+ * Returning false means the promo was not shown, so no cooldown is recorded.
  */
 interface NewTabPageModalPresenter {
 
     /** Shows the Privacy Pro promo. Valid on the NTP or over a website (never over Duck.ai). */
-    fun showSubscriptionPromo(
+    suspend fun showSubscriptionPromo(
         flow: SubscriptionPromoFlow,
         isFreeTrialCopy: Boolean,
     ): Boolean
 
     /** Shows the Add Widget promo. Valid only on the New Tab Page. */
-    fun showAddWidgetPromo(supportsAutomaticAdd: Boolean): Boolean
+    suspend fun showAddWidgetPromo(supportsAutomaticAdd: Boolean): Boolean
 }
 
 /**
- * Holds the presenter for the currently visible browser tab. "Last registered wins", so the most
- * recently visible tab is the active presenter; a tab only clears the presenter if it is still the
- * registered one, making stale unregister calls safe.
+ * Holds the presenter for the visible browser tab: last registered wins, and a tab only clears the
+ * presenter if it is still the registered one, so stale unregister calls are safe.
  */
 @SingleInstanceIn(AppScope::class)
 class NewTabPageModalPresenterRegistry @Inject constructor() {

--- a/app/src/main/java/com/duckduckgo/app/browser/modals/SubscriptionPromoModalEvaluator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/modals/SubscriptionPromoModalEvaluator.kt
@@ -28,14 +28,6 @@ import kotlinx.coroutines.withContext
 import logcat.logcat
 import javax.inject.Inject
 
-/**
- * Coordinates the Privacy Pro promo modal. Runs on [ModalTrigger.APP_RESUME] (app foreground),
- * replacing the previous `checkSubscriptionPromoOnForeground` path so the promo now respects the
- * coordinator's priority ordering and 24-hour cooldown alongside the other app-originated modals.
- *
- * The promo is a bottom sheet owned by the visible browser tab, so rendering is delegated to the
- * [NewTabPageModalPresenter] that tab registers.
- */
 @ContributesMultibinding(
     scope = AppScope::class,
     boundType = ModalEvaluator::class,
@@ -62,9 +54,7 @@ class SubscriptionPromoModalEvaluator @Inject constructor(
             return@withContext ModalEvaluator.EvaluationResult.Skipped
         }
 
-        val shown = withContext(dispatchers.main()) {
-            presenter.showSubscriptionPromo(decision.flow, decision.isFreeTrialCopy)
-        }
+        val shown = presenter.showSubscriptionPromo(decision.flow, decision.isFreeTrialCopy)
         if (shown) {
             ModalEvaluator.EvaluationResult.ModalShown
         } else {

--- a/app/src/main/java/com/duckduckgo/app/browser/modals/SubscriptionPromoModalEvaluator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/modals/SubscriptionPromoModalEvaluator.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.modals
+
+import com.duckduckgo.app.cta.ui.SubscriptionPromoModalDecider
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.modalcoordinator.api.ModalEvaluator
+import com.duckduckgo.modalcoordinator.api.ModalTrigger
+import com.squareup.anvil.annotations.ContributesMultibinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import logcat.logcat
+import javax.inject.Inject
+
+/**
+ * Coordinates the Privacy Pro promo modal. Runs on [ModalTrigger.APP_RESUME] (app foreground),
+ * replacing the previous `checkSubscriptionPromoOnForeground` path so the promo now respects the
+ * coordinator's priority ordering and 24-hour cooldown alongside the other app-originated modals.
+ *
+ * The promo is a bottom sheet owned by the visible browser tab, so rendering is delegated to the
+ * [NewTabPageModalPresenter] that tab registers.
+ */
+@ContributesMultibinding(
+    scope = AppScope::class,
+    boundType = ModalEvaluator::class,
+)
+@SingleInstanceIn(scope = AppScope::class)
+class SubscriptionPromoModalEvaluator @Inject constructor(
+    private val decider: SubscriptionPromoModalDecider,
+    private val presenterRegistry: NewTabPageModalPresenterRegistry,
+    private val dispatchers: DispatcherProvider,
+) : ModalEvaluator {
+
+    override val priority: Int = PRIORITY
+    override val evaluatorId: String = "subscription_promo_modal"
+    override val trigger: ModalTrigger = ModalTrigger.APP_RESUME
+
+    override suspend fun evaluate(): ModalEvaluator.EvaluationResult = withContext(dispatchers.io()) {
+        val decision = decider.decide()
+            ?: return@withContext ModalEvaluator.EvaluationResult.Skipped
+
+        delay(MODAL_DISPLAY_DELAY)
+        val presenter = presenterRegistry.current()
+        if (presenter == null) {
+            logcat { "SubscriptionPromoModalEvaluator: no presenter registered, skipping" }
+            return@withContext ModalEvaluator.EvaluationResult.Skipped
+        }
+
+        val shown = withContext(dispatchers.main()) {
+            presenter.showSubscriptionPromo(decision.flow, decision.isFreeTrialCopy)
+        }
+        if (shown) {
+            ModalEvaluator.EvaluationResult.ModalShown
+        } else {
+            ModalEvaluator.EvaluationResult.Skipped
+        }
+    }
+
+    companion object {
+        private const val PRIORITY = 5
+        private const val MODAL_DISPLAY_DELAY = 250L
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -63,7 +63,6 @@ import com.duckduckgo.onboarding.api.LinearOnboardingState
 import com.duckduckgo.onboarding.api.cta.ContextualCtaSuppressorPlugin
 import com.duckduckgo.onboarding.api.forPlan
 import com.duckduckgo.subscriptions.api.SubscriptionPromoCtaShownPlugin
-import com.duckduckgo.subscriptions.api.SubscriptionStatus
 import com.duckduckgo.subscriptions.api.Subscriptions
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
@@ -136,9 +135,6 @@ class CtaViewModel @Inject constructor(
             .launchIn(coroutineScope)
     }
 
-    private suspend fun isSubscriptionCtaAvailable(): Boolean =
-        subscriptions.isEligible() && hasNoSubscription() && extendedOnboardingFeatureToggles.privacyProCta().isEnabled()
-
     private suspend fun isBrandDesignUpdateEnabled(): Boolean = withContext(dispatchers.io()) {
         onboardingBrandDesignUpdateToggles.brandDesignUpdate().isEnabled()
     }
@@ -188,12 +184,12 @@ class CtaViewModel @Inject constructor(
         return when {
             onboardingStore.isDuckAiOnboardingFlow() -> {
                 mutableListOf(CtaId.DAX_DUCK_AI_FIRE_BUTTON, CtaId.DAX_DUCK_AI_END).also {
-                    if (isSubscriptionCtaAvailable()) {
+                    if (subscriptionPromoModalDecider.isSubscriptionCtaAvailable()) {
                         it.add(CtaId.DAX_INTRO_PRIVACY_PRO)
                     }
                 }
             }
-            isSubscriptionCtaAvailable() -> {
+            subscriptionPromoModalDecider.isSubscriptionCtaAvailable() -> {
                 listOf(
                     CtaId.DAX_INTRO,
                     CtaId.DAX_DIALOG_SERP,
@@ -515,7 +511,7 @@ class CtaViewModel @Inject constructor(
 
     @WorkerThread
     private suspend fun canShowSubscriptionCta(): Boolean {
-        if (hideTips() || daxDialogSubscriptionShown() || !isSubscriptionCtaAvailable()) return false
+        if (hideTips() || daxDialogSubscriptionShown() || !subscriptionPromoModalDecider.isSubscriptionCtaAvailable()) return false
 
         return daxOnboardingActive()
     }
@@ -684,7 +680,7 @@ class CtaViewModel @Inject constructor(
     suspend fun areBubbleDaxDialogsCompleted(): Boolean {
         return withContext(dispatchers.io()) {
             val isLastContextDialogShown = when {
-                isSubscriptionCtaAvailable() -> daxDialogSubscriptionShown()
+                subscriptionPromoModalDecider.isSubscriptionCtaAvailable() -> daxDialogSubscriptionShown()
                 onboardingStore.isDuckAiOnboardingFlow() -> duckAiEndShown()
                 else -> daxDialogEndShown()
             }
@@ -830,8 +826,6 @@ class CtaViewModel @Inject constructor(
     fun isSuggestedSiteOption(query: String): Boolean = onboardingStore.getSitesOptions().map { it.link }.contains(query)
 
     suspend fun isPromoOnboardingDialogShowing(): Boolean = subscriptionPromoModalDecider.decide() != null
-
-    private suspend fun hasNoSubscription(): Boolean = subscriptions.getSubscriptionStatus() == SubscriptionStatus.UNKNOWN
 
     companion object {
         private const val MAX_TABS_OPEN_FIRE_EDUCATION = 2

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/CtaViewModel.kt
@@ -27,11 +27,8 @@ import com.duckduckgo.app.browser.omnibar.OmnibarType
 import com.duckduckgo.app.cta.db.DismissedCtaDao
 import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.app.cta.model.DismissedCta
-import com.duckduckgo.app.cta.ui.HomePanelCta.AddWidgetAutoOnboarding
-import com.duckduckgo.app.cta.ui.HomePanelCta.AddWidgetInstructions
 import com.duckduckgo.app.di.AppCoroutineScope
 import com.duckduckgo.app.global.install.AppInstallStore
-import com.duckduckgo.app.global.install.daysInstalled
 import com.duckduckgo.app.global.model.Site
 import com.duckduckgo.app.global.model.domain
 import com.duckduckgo.app.global.model.orderedTrackerBlockedEntities
@@ -51,7 +48,6 @@ import com.duckduckgo.app.privacy.db.UserAllowListRepository
 import com.duckduckgo.app.settings.db.SettingsDataStore
 import com.duckduckgo.app.statistics.pixels.Pixel
 import com.duckduckgo.app.tabs.model.AggregateTabProvider
-import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.duckduckgo.brokensite.api.BrokenSitePrompt
 import com.duckduckgo.brokensite.api.RefreshPattern
 import com.duckduckgo.common.ui.store.AppTheme
@@ -92,7 +88,7 @@ import kotlin.coroutines.CoroutineContext
 class CtaViewModel @Inject constructor(
     private val appInstallStore: AppInstallStore,
     private val pixel: Pixel,
-    private val widgetCapabilities: WidgetCapabilities,
+    private val subscriptionPromoModalDecider: SubscriptionPromoModalDecider,
     private val dismissedCtaDao: DismissedCtaDao,
     private val userAllowListRepository: UserAllowListRepository,
     private val settingsDataStore: SettingsDataStore,
@@ -355,24 +351,6 @@ class CtaViewModel @Inject constructor(
         }
     }
 
-    suspend fun getPromoCtaOnForeground(): Cta? {
-        return withContext(dispatchers.io()) {
-            when {
-                canShowSubscriptionCtaForSkippedOnboarding() -> SubscriptionPromoModalCta(
-                    isFreeTrialCopy = freeTrialCopyAvailable(),
-                    flow = SubscriptionPromoFlow.SKIPPED_ONBOARDING,
-                )
-
-                canShowSubscriptionPromoCta() -> SubscriptionPromoModalCta(
-                    isFreeTrialCopy = freeTrialCopyAvailable(),
-                    flow = SubscriptionPromoFlow.NUDGE,
-                )
-
-                else -> null
-            }
-        }
-    }
-
     suspend fun getFireDialogCta(): OnboardingDaxDialogCta? {
         return withContext(dispatchers.io()) {
             if (!daxOnboardingActive() || daxDialogFireEducationShown()) return@withContext null
@@ -516,16 +494,6 @@ class CtaViewModel @Inject constructor(
                     )
                 }
             }
-
-            // Add Widget
-            canShowWidgetCta() -> {
-                if (widgetCapabilities.supportsAutomaticWidgetAdd) {
-                    AddWidgetAutoOnboarding
-                } else {
-                    AddWidgetInstructions
-                }
-            }
-
             else -> null
         }
     }
@@ -550,28 +518,6 @@ class CtaViewModel @Inject constructor(
         if (hideTips() || daxDialogSubscriptionShown() || !isSubscriptionCtaAvailable()) return false
 
         return daxOnboardingActive()
-    }
-
-    @WorkerThread
-    private suspend fun canShowSubscriptionCtaForSkippedOnboarding(): Boolean =
-        extendedOnboardingFeatureToggles.subscriptionPromoModalCta().isEnabled() &&
-            hideTips() &&
-            appInstallStore.daysInstalled() >= SUBSCRIPTION_SKIPPED_ONBOARDING_MIN_DAYS &&
-            !daxDialogSubscriptionShown() &&
-            isSubscriptionCtaAvailable()
-
-    @WorkerThread
-    private suspend fun canShowSubscriptionPromoCta(): Boolean =
-        extendedOnboardingFeatureToggles.subscriptionPromoModalCtaExistingUsers().isEnabled() &&
-            appInstallStore.daysInstalled() >= SUBSCRIPTION_SKIPPED_ONBOARDING_MIN_DAYS &&
-            !daxDialogSubscriptionShown() &&
-            isSubscriptionCtaAvailable()
-
-    @WorkerThread
-    private fun canShowWidgetCta(): Boolean {
-        return !widgetCapabilities.hasInstalledWidgets &&
-            !dismissedCtaDao.exists(CtaId.ADD_WIDGET) &&
-            !onboardingStore.linearPlanWidgetPromptShown
     }
 
     private suspend fun freeTrialCopyAvailable(): Boolean =
@@ -883,15 +829,11 @@ class CtaViewModel @Inject constructor(
 
     fun isSuggestedSiteOption(query: String): Boolean = onboardingStore.getSitesOptions().map { it.link }.contains(query)
 
-    suspend fun isPromoOnboardingDialogShowing(): Boolean =
-        withContext(dispatchers.io()) {
-            canShowSubscriptionCtaForSkippedOnboarding() || canShowSubscriptionPromoCta()
-        }
+    suspend fun isPromoOnboardingDialogShowing(): Boolean = subscriptionPromoModalDecider.decide() != null
 
     private suspend fun hasNoSubscription(): Boolean = subscriptions.getSubscriptionStatus() == SubscriptionStatus.UNKNOWN
 
     companion object {
         private const val MAX_TABS_OPEN_FIRE_EDUCATION = 2
-        private const val SUBSCRIPTION_SKIPPED_ONBOARDING_MIN_DAYS = 7L
     }
 }

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/SubscriptionPromoModalDecider.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/SubscriptionPromoModalDecider.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.cta.ui
+
+import com.duckduckgo.app.cta.db.DismissedCtaDao
+import com.duckduckgo.app.cta.model.CtaId
+import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.global.install.daysInstalled
+import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardingFeatureToggles
+import com.duckduckgo.app.settings.db.SettingsDataStore
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.subscriptions.api.SubscriptionStatus
+import com.duckduckgo.subscriptions.api.Subscriptions
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+/**
+ * Decides whether the Privacy Pro promo modal is currently eligible to be shown, and with which
+ * flow and copy. This is the single source of truth shared by the modal coordinator's
+ * [com.duckduckgo.app.cta.ui.SubscriptionPromoModalEvaluator] and by [CtaViewModel] (which uses it
+ * to know when a pending promo should suppress other onboarding surfaces).
+ *
+ * The eligibility rules mirror the historical `getPromoCtaOnForeground` logic exactly.
+ */
+interface SubscriptionPromoModalDecider {
+
+    /**
+     * @return the promo to show, or null when no promo is currently eligible.
+     */
+    suspend fun decide(): SubscriptionPromoModalDecision?
+}
+
+data class SubscriptionPromoModalDecision(
+    val flow: SubscriptionPromoFlow,
+    val isFreeTrialCopy: Boolean,
+)
+
+@ContributesBinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
+class RealSubscriptionPromoModalDecider @Inject constructor(
+    private val extendedOnboardingFeatureToggles: ExtendedOnboardingFeatureToggles,
+    private val appInstallStore: AppInstallStore,
+    private val settingsDataStore: SettingsDataStore,
+    private val dismissedCtaDao: DismissedCtaDao,
+    private val subscriptions: Subscriptions,
+    private val dispatchers: DispatcherProvider,
+) : SubscriptionPromoModalDecider {
+
+    override suspend fun decide(): SubscriptionPromoModalDecision? = withContext(dispatchers.io()) {
+        when {
+            canShowSubscriptionCtaForSkippedOnboarding() -> SubscriptionPromoModalDecision(
+                flow = SubscriptionPromoFlow.SKIPPED_ONBOARDING,
+                isFreeTrialCopy = freeTrialCopyAvailable(),
+            )
+
+            canShowSubscriptionPromoCta() -> SubscriptionPromoModalDecision(
+                flow = SubscriptionPromoFlow.NUDGE,
+                isFreeTrialCopy = freeTrialCopyAvailable(),
+            )
+
+            else -> null
+        }
+    }
+
+    private suspend fun canShowSubscriptionCtaForSkippedOnboarding(): Boolean =
+        extendedOnboardingFeatureToggles.subscriptionPromoModalCta().isEnabled() &&
+            settingsDataStore.hideTips &&
+            appInstallStore.daysInstalled() >= SUBSCRIPTION_SKIPPED_ONBOARDING_MIN_DAYS &&
+            !subscriptionPromoModalShown() &&
+            isSubscriptionCtaAvailable()
+
+    private suspend fun canShowSubscriptionPromoCta(): Boolean =
+        extendedOnboardingFeatureToggles.subscriptionPromoModalCtaExistingUsers().isEnabled() &&
+            appInstallStore.daysInstalled() >= SUBSCRIPTION_SKIPPED_ONBOARDING_MIN_DAYS &&
+            !subscriptionPromoModalShown() &&
+            isSubscriptionCtaAvailable()
+
+    private fun subscriptionPromoModalShown(): Boolean = dismissedCtaDao.exists(CtaId.DAX_INTRO_PRIVACY_PRO)
+
+    private suspend fun isSubscriptionCtaAvailable(): Boolean =
+        subscriptions.isEligible() &&
+            subscriptions.getSubscriptionStatus() == SubscriptionStatus.UNKNOWN &&
+            extendedOnboardingFeatureToggles.privacyProCta().isEnabled()
+
+    private suspend fun freeTrialCopyAvailable(): Boolean =
+        extendedOnboardingFeatureToggles.freeTrialCopy().isEnabled() && subscriptions.isFreeTrialEligible()
+
+    companion object {
+        private const val SUBSCRIPTION_SKIPPED_ONBOARDING_MIN_DAYS = 7L
+    }
+}

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/SubscriptionPromoModalDecider.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/SubscriptionPromoModalDecider.kt
@@ -39,6 +39,9 @@ interface SubscriptionPromoModalDecider {
 
     /** @return the promo to show, or null when none is eligible. */
     suspend fun decide(): SubscriptionPromoModalDecision?
+
+    /** Whether a Privacy Pro CTA can be offered at all, regardless of which promo flow wants it. */
+    suspend fun isSubscriptionCtaAvailable(): Boolean
 }
 
 data class SubscriptionPromoModalDecision(
@@ -88,7 +91,7 @@ class RealSubscriptionPromoModalDecider @Inject constructor(
 
     private fun subscriptionPromoModalShown(): Boolean = dismissedCtaDao.exists(CtaId.DAX_INTRO_PRIVACY_PRO)
 
-    private suspend fun isSubscriptionCtaAvailable(): Boolean =
+    override suspend fun isSubscriptionCtaAvailable(): Boolean =
         subscriptions.isEligible() &&
             subscriptions.getSubscriptionStatus() == SubscriptionStatus.UNKNOWN &&
             extendedOnboardingFeatureToggles.privacyProCta().isEnabled()

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/SubscriptionPromoModalDecider.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/SubscriptionPromoModalDecider.kt
@@ -32,18 +32,12 @@ import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 /**
- * Decides whether the Privacy Pro promo modal is currently eligible to be shown, and with which
- * flow and copy. This is the single source of truth shared by the modal coordinator's
- * [com.duckduckgo.app.cta.ui.SubscriptionPromoModalEvaluator] and by [CtaViewModel] (which uses it
- * to know when a pending promo should suppress other onboarding surfaces).
- *
- * The eligibility rules mirror the historical `getPromoCtaOnForeground` logic exactly.
+ * Single source of truth for Privacy Pro promo modal eligibility, shared by the modal evaluator and
+ * by [CtaViewModel], which uses it to suppress other onboarding surfaces while a promo is pending.
  */
 interface SubscriptionPromoModalDecider {
 
-    /**
-     * @return the promo to show, or null when no promo is currently eligible.
-     */
+    /** @return the promo to show, or null when none is eligible. */
     suspend fun decide(): SubscriptionPromoModalDecision?
 }
 

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -124,6 +124,7 @@ import com.duckduckgo.app.browser.logindetection.NavigationAwareLoginDetector
 import com.duckduckgo.app.browser.logindetection.NavigationEvent
 import com.duckduckgo.app.browser.logindetection.NavigationEvent.LoginAttempt
 import com.duckduckgo.app.browser.menu.VpnMenuStateProvider
+import com.duckduckgo.app.browser.modals.NewTabPageModalPresenterRegistry
 import com.duckduckgo.app.browser.model.BasicAuthenticationCredentials
 import com.duckduckgo.app.browser.model.BasicAuthenticationRequest
 import com.duckduckgo.app.browser.model.LongPressTarget
@@ -169,7 +170,6 @@ import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.app.cta.model.CtaId.DAX_DIALOG_NETWORK
 import com.duckduckgo.app.cta.model.CtaId.DAX_DIALOG_TRACKERS_FOUND
 import com.duckduckgo.app.cta.model.CtaId.DAX_END
-import com.duckduckgo.app.cta.model.CtaId.DAX_INTRO_PRIVACY_PRO
 import com.duckduckgo.app.cta.model.DismissedCta
 import com.duckduckgo.app.cta.ui.BrokenSitePromptDialogCta
 import com.duckduckgo.app.cta.ui.Cta
@@ -191,6 +191,8 @@ import com.duckduckgo.app.cta.ui.OnboardingDaxDialogCta.DaxSerpCta
 import com.duckduckgo.app.cta.ui.OnboardingDaxDialogCta.DaxTrackersBlockedCta
 import com.duckduckgo.app.cta.ui.SubscriptionPromoFlow
 import com.duckduckgo.app.cta.ui.SubscriptionPromoModalCta
+import com.duckduckgo.app.cta.ui.SubscriptionPromoModalDecider
+import com.duckduckgo.app.cta.ui.SubscriptionPromoModalDecision
 import com.duckduckgo.app.dispatchers.ExternalIntentProcessingState
 import com.duckduckgo.app.fire.fireproofwebsite.data.FireproofWebsiteDao
 import com.duckduckgo.app.fire.fireproofwebsite.data.FireproofWebsiteEntity
@@ -483,6 +485,9 @@ class BrowserTabViewModelTest {
     private val mockAutoCompleteScorer: AutoCompleteScorer = mock()
 
     private val mockWidgetCapabilities: WidgetCapabilities = mock()
+
+    // Default (unstubbed) decide() returns null, i.e. no promo eligible.
+    private val mockSubscriptionPromoModalDecider: SubscriptionPromoModalDecider = mock()
 
     private val mockUserStageStore: UserStageStore = mock()
 
@@ -849,7 +854,7 @@ class BrowserTabViewModelTest {
                 CtaViewModel(
                     appInstallStore = mockAppInstallStore,
                     pixel = mockPixel,
-                    widgetCapabilities = mockWidgetCapabilities,
+                    subscriptionPromoModalDecider = mockSubscriptionPromoModalDecider,
                     dismissedCtaDao = mockDismissedCtaDao,
                     userAllowListRepository = mockUserAllowListRepository,
                     settingsDataStore = ctaViewModelMockSettingsStore,
@@ -1066,6 +1071,8 @@ class BrowserTabViewModelTest {
                 desktopModeSettings = mockDesktopModeSettings,
                 rememberDesktopModeFeature = fakeRememberDesktopModeFeature,
                 adBlockingOmnibarAnimationProvider = mockAdBlockingOmnibarAnimationProvider,
+                newTabPageModalPresenterRegistry = NewTabPageModalPresenterRegistry(),
+                newTabPageModalTrigger = mock(),
             )
 
         testee.loadData("abc", null, false, false)
@@ -3977,40 +3984,148 @@ class BrowserTabViewModelTest {
         }
     }
 
+    // The Privacy Pro promo is now decided by the modal coordinator; the view-model only renders it
+    // (via showSubscriptionPromo) subject to the surface guards below.
     @Test
-    fun whenOnViewVisibleAndOnDuckAiUrlThenSubscriptionPromoModalNotShown() =
+    fun whenShowSubscriptionPromoModalCtaAndOnDuckAiUrlThenNotShown() =
         runTest {
-            givenSubscriptionPromoModalCtaEligible()
             whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(true)
             loadUrl("https://duck.ai/", isBrowserShowing = true)
             testee.globalLayoutState.value = GlobalLayoutViewState.Browser(isNewTabState = false)
 
-            testee.onViewVisible()
+            val shown = testee.showSubscriptionPromo(SubscriptionPromoFlow.NUDGE, isFreeTrialCopy = false)
 
+            assertFalse(shown)
             assertFalse(testee.ctaViewState.value?.cta is SubscriptionPromoModalCta)
         }
 
     @Test
-    fun whenOnViewVisibleAndOnNonDuckAiUrlThenSubscriptionPromoModalShown() =
+    fun whenShowSubscriptionPromoModalCtaAndOnNonDuckAiUrlThenShown() =
         runTest {
-            givenSubscriptionPromoModalCtaEligible()
             whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(false)
             loadUrl(exampleUrl, isBrowserShowing = true)
             testee.globalLayoutState.value = GlobalLayoutViewState.Browser(isNewTabState = false)
 
-            testee.onViewVisible()
+            val shown = testee.showSubscriptionPromo(SubscriptionPromoFlow.NUDGE, isFreeTrialCopy = false)
 
+            assertTrue(shown)
             assertTrue(testee.ctaViewState.value?.cta is SubscriptionPromoModalCta)
         }
 
-    private suspend fun givenSubscriptionPromoModalCtaEligible() {
-        whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCtaExistingUsers()).thenReturn(mockEnabledToggle)
-        whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
-        whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - 8 * 24 * 3600 * 1000L)
-        whenever(mockDismissedCtaDao.exists(DAX_INTRO_PRIVACY_PRO)).thenReturn(false)
-        whenever(subscriptions.isEligible()).thenReturn(true)
-        whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
-    }
+    @Test
+    fun whenShowSubscriptionPromoModalCtaOnNewTabPageAndSlotFreeThenShown() =
+        runTest {
+            testee.globalLayoutState.value = GlobalLayoutViewState.Browser(isNewTabState = true)
+            setBrowserShowing(false)
+
+            val shown = testee.showSubscriptionPromo(SubscriptionPromoFlow.NUDGE, isFreeTrialCopy = false)
+
+            assertTrue(shown)
+            assertTrue(testee.ctaViewState.value?.cta is SubscriptionPromoModalCta)
+        }
+
+    @Test
+    fun whenShowSubscriptionPromoModalCtaOnNewTabPageButCtaSlotOccupiedThenDeclined() =
+        runTest {
+            testee.globalLayoutState.value = GlobalLayoutViewState.Browser(isNewTabState = true)
+            setBrowserShowing(false)
+            // An onboarding CTA already owns the NTP slot: the promo must not clobber it.
+            val onboardingCta = DaxBubbleCta.DaxSubscriptionCta(
+                mockOnboardingStore,
+                mockAppInstallStore,
+                isFreeTrialCopy = false,
+            )
+            setCta(onboardingCta)
+
+            val shown = testee.showSubscriptionPromo(SubscriptionPromoFlow.NUDGE, isFreeTrialCopy = false)
+
+            assertFalse(shown)
+            assertEquals(onboardingCta, testee.ctaViewState.value?.cta)
+        }
+
+    @Test
+    fun whenShowSubscriptionPromoModalCtaAndMaliciousSiteWarningShowingThenNotShown() =
+        runTest {
+            testee.globalLayoutState.value = GlobalLayoutViewState.Browser(isNewTabState = false)
+            // A malicious-site warning reports browserShowing = false with maliciousSiteBlocked = true.
+            testee.browserViewState.value = browserViewState().copy(browserShowing = false, maliciousSiteBlocked = true)
+
+            val shown = testee.showSubscriptionPromo(SubscriptionPromoFlow.NUDGE, isFreeTrialCopy = false)
+
+            assertFalse(shown)
+            assertFalse(testee.ctaViewState.value?.cta is SubscriptionPromoModalCta)
+        }
+
+    @Test
+    fun whenShowAddWidgetModalCtaAndMaliciousSiteWarningShowingThenNotShown() =
+        runTest {
+            testee.globalLayoutState.value = GlobalLayoutViewState.Browser(isNewTabState = true)
+            testee.browserViewState.value = browserViewState().copy(browserShowing = false, maliciousSiteBlocked = true)
+
+            val shown = testee.showAddWidgetPromo(supportsAutomaticAdd = true)
+
+            assertFalse(shown)
+            assertNull(testee.ctaViewState.value?.cta)
+        }
+
+    @Test
+    fun whenShowSubscriptionPromoModalCtaWhileBrowsingAndCtaSlotOccupiedThenStillShown() =
+        runTest {
+            whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(false)
+            loadUrl(exampleUrl, isBrowserShowing = true)
+            testee.globalLayoutState.value = GlobalLayoutViewState.Browser(isNewTabState = false)
+            // The slot guard is scoped to the New Tab Page; over a website the promo keeps its
+            // long-standing behaviour of taking the slot.
+            setCta(
+                DaxBubbleCta.DaxSubscriptionCta(
+                    mockOnboardingStore,
+                    mockAppInstallStore,
+                    isFreeTrialCopy = false,
+                ),
+            )
+
+            val shown = testee.showSubscriptionPromo(SubscriptionPromoFlow.NUDGE, isFreeTrialCopy = false)
+
+            assertTrue(shown)
+            assertTrue(testee.ctaViewState.value?.cta is SubscriptionPromoModalCta)
+        }
+
+    @Test
+    fun whenShowAddWidgetModalCtaWhileBrowsingThenNotShown() =
+        runTest {
+            loadUrl(exampleUrl, isBrowserShowing = true)
+            testee.globalLayoutState.value = GlobalLayoutViewState.Browser(isNewTabState = false)
+
+            val shown = testee.showAddWidgetPromo(supportsAutomaticAdd = true)
+
+            assertFalse(shown)
+            assertFalse(testee.ctaViewState.value?.cta is HomePanelCta.AddWidgetAutoOnboarding)
+        }
+
+    @Test
+    fun whenShowAddWidgetModalCtaOnNewTabPageThenAccepted() =
+        runTest {
+            testee.globalLayoutState.value = GlobalLayoutViewState.Browser(isNewTabState = true)
+            setBrowserShowing(false)
+
+            val shown = testee.showAddWidgetPromo(supportsAutomaticAdd = true)
+
+            assertTrue(shown)
+        }
+
+    @Test
+    fun whenShowAddWidgetModalCtaOnNewTabPageButCtaSlotOccupiedThenDeclined() =
+        runTest {
+            testee.globalLayoutState.value = GlobalLayoutViewState.Browser(isNewTabState = true)
+            setBrowserShowing(false)
+            // A higher-priority CTA already owns the NTP slot: Add Widget must not clobber it.
+            setCta(SubscriptionPromoModalCta(isFreeTrialCopy = false, flow = SubscriptionPromoFlow.NUDGE))
+
+            val shown = testee.showAddWidgetPromo(supportsAutomaticAdd = true)
+
+            assertFalse(shown)
+            assertTrue(testee.ctaViewState.value?.cta is SubscriptionPromoModalCta)
+        }
 
     @Test
     fun whenUserDismissedCtaThenFirePixel() =
@@ -9905,13 +10020,10 @@ class BrowserTabViewModelTest {
             whenever(mockTabRepository.getTab(ntpTabId)).thenReturn(ntpTab)
             flowSelectedTab.emit(initialTab)
 
-            whenever(ctaViewModelMockSettingsStore.hideTips).thenReturn(true)
-            whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - 8 * 24 * 3600 * 1000L)
-            whenever(mockDismissedCtaDao.exists(DAX_INTRO_PRIVACY_PRO)).thenReturn(false)
-            whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCta()).thenReturn(mockEnabledToggle)
-            whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
-            whenever(subscriptions.isEligible()).thenReturn(true)
-            whenever(subscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
+            // isPromoOnboardingDialogShowing() now delegates to the decider, so stub it directly.
+            whenever(mockSubscriptionPromoModalDecider.decide()).thenReturn(
+                SubscriptionPromoModalDecision(flow = SubscriptionPromoFlow.SKIPPED_ONBOARDING, isFreeTrialCopy = false),
+            )
 
             testee.loadData(tabId = ntpTabId, initialUrl = null, skipHome = false, isExternal = false)
             testee.observeSelectedTab(isRestored = false)

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -486,7 +486,6 @@ class BrowserTabViewModelTest {
 
     private val mockWidgetCapabilities: WidgetCapabilities = mock()
 
-    // Default (unstubbed) decide() returns null, i.e. no promo eligible.
     private val mockSubscriptionPromoModalDecider: SubscriptionPromoModalDecider = mock()
 
     private val mockUserStageStore: UserStageStore = mock()
@@ -3984,8 +3983,6 @@ class BrowserTabViewModelTest {
         }
     }
 
-    // The Privacy Pro promo is now decided by the modal coordinator; the view-model only renders it
-    // (via showSubscriptionPromo) subject to the surface guards below.
     @Test
     fun whenShowSubscriptionPromoModalCtaAndOnDuckAiUrlThenNotShown() =
         runTest {
@@ -4029,7 +4026,6 @@ class BrowserTabViewModelTest {
         runTest {
             testee.globalLayoutState.value = GlobalLayoutViewState.Browser(isNewTabState = true)
             setBrowserShowing(false)
-            // An onboarding CTA already owns the NTP slot: the promo must not clobber it.
             val onboardingCta = DaxBubbleCta.DaxSubscriptionCta(
                 mockOnboardingStore,
                 mockAppInstallStore,
@@ -4047,7 +4043,6 @@ class BrowserTabViewModelTest {
     fun whenShowSubscriptionPromoModalCtaAndMaliciousSiteWarningShowingThenNotShown() =
         runTest {
             testee.globalLayoutState.value = GlobalLayoutViewState.Browser(isNewTabState = false)
-            // A malicious-site warning reports browserShowing = false with maliciousSiteBlocked = true.
             testee.browserViewState.value = browserViewState().copy(browserShowing = false, maliciousSiteBlocked = true)
 
             val shown = testee.showSubscriptionPromo(SubscriptionPromoFlow.NUDGE, isFreeTrialCopy = false)
@@ -4074,8 +4069,6 @@ class BrowserTabViewModelTest {
             whenever(mockDuckChat.isDuckChatUrl(any())).thenReturn(false)
             loadUrl(exampleUrl, isBrowserShowing = true)
             testee.globalLayoutState.value = GlobalLayoutViewState.Browser(isNewTabState = false)
-            // The slot guard is scoped to the New Tab Page; over a website the promo keeps its
-            // long-standing behaviour of taking the slot.
             setCta(
                 DaxBubbleCta.DaxSubscriptionCta(
                     mockOnboardingStore,
@@ -4118,7 +4111,6 @@ class BrowserTabViewModelTest {
         runTest {
             testee.globalLayoutState.value = GlobalLayoutViewState.Browser(isNewTabState = true)
             setBrowserShowing(false)
-            // A higher-priority CTA already owns the NTP slot: Add Widget must not clobber it.
             setCta(SubscriptionPromoModalCta(isFreeTrialCopy = false, flow = SubscriptionPromoFlow.NUDGE))
 
             val shown = testee.showAddWidgetPromo(supportsAutomaticAdd = true)
@@ -10020,7 +10012,6 @@ class BrowserTabViewModelTest {
             whenever(mockTabRepository.getTab(ntpTabId)).thenReturn(ntpTab)
             flowSelectedTab.emit(initialTab)
 
-            // isPromoOnboardingDialogShowing() now delegates to the decider, so stub it directly.
             whenever(mockSubscriptionPromoModalDecider.decide()).thenReturn(
                 SubscriptionPromoModalDecision(flow = SubscriptionPromoFlow.SKIPPED_ONBOARDING, isFreeTrialCopy = false),
             )

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -325,6 +325,7 @@ import com.duckduckgo.js.messaging.api.JsCallbackData
 import com.duckduckgo.js.messaging.api.SubscriptionEventData
 import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed
 import com.duckduckgo.malicioussiteprotection.api.MaliciousSiteProtection.Feed.MALWARE
+import com.duckduckgo.modalcoordinator.api.NewTabPageModalTrigger
 import com.duckduckgo.newtabpage.api.NtpAfterIdleManager
 import com.duckduckgo.newtabpage.impl.pixels.NewTabPixels
 import com.duckduckgo.onboarding.api.LinearOnboardingOrchestrator
@@ -472,6 +473,8 @@ class BrowserTabViewModelTest {
     private val mockPixel: Pixel = mock()
 
     private val mockNewTabPixels: NewTabPixels = mock()
+
+    private val mockNewTabPageModalTrigger: NewTabPageModalTrigger = mock()
 
     private val mockHttpErrorPixels: HttpErrorPixels = mock()
 
@@ -832,6 +835,7 @@ class BrowserTabViewModelTest {
             whenever(mockSitePermissionsManager.hasSitePermanentPermission(any(), any())).thenReturn(false)
             whenever(mockToggleReports.shouldPrompt()).thenReturn(false)
             whenever(subscriptions.isEligible()).thenReturn(false)
+            whenever(mockSubscriptionPromoModalDecider.isSubscriptionCtaAvailable()).thenReturn(false)
             whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCta()).thenReturn(mockDisabledToggle)
             whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCtaExistingUsers()).thenReturn(mockDisabledToggle)
             whenever(mockExtendedOnboardingFeatureToggles.freeTrialCopy()).thenReturn(mockDisabledToggle)
@@ -1071,7 +1075,7 @@ class BrowserTabViewModelTest {
                 rememberDesktopModeFeature = fakeRememberDesktopModeFeature,
                 adBlockingOmnibarAnimationProvider = mockAdBlockingOmnibarAnimationProvider,
                 newTabPageModalPresenterRegistry = NewTabPageModalPresenterRegistry(),
-                newTabPageModalTrigger = mock(),
+                newTabPageModalTrigger = mockNewTabPageModalTrigger,
             )
 
         testee.loadData("abc", null, false, false)
@@ -3982,6 +3986,39 @@ class BrowserTabViewModelTest {
             assertEquals("funnel_modal_android__subscriptionnudge", uri.getQueryParameter("origin"))
         }
     }
+
+    @Test
+    fun whenViewVisibleOnNewTabPageAndNoCtaThenModalTriggerNotified() =
+        runTest {
+            testee.globalLayoutState.value = GlobalLayoutViewState.Browser(isNewTabState = true)
+            testee.browserViewState.value = browserViewState().copy(browserShowing = false, maliciousSiteBlocked = false)
+
+            testee.onViewVisible()
+
+            verify(mockNewTabPageModalTrigger).onNewTabPageShown()
+        }
+
+    @Test
+    fun whenViewVisibleWhileBrowsingThenModalTriggerNotNotified() =
+        runTest {
+            testee.globalLayoutState.value = GlobalLayoutViewState.Browser(isNewTabState = false)
+            testee.browserViewState.value = browserViewState().copy(browserShowing = true, maliciousSiteBlocked = false)
+
+            testee.onViewVisible()
+
+            verify(mockNewTabPageModalTrigger, never()).onNewTabPageShown()
+        }
+
+    @Test
+    fun whenViewVisibleAndMaliciousSiteBlockedThenModalTriggerNotNotified() =
+        runTest {
+            testee.globalLayoutState.value = GlobalLayoutViewState.Browser(isNewTabState = true)
+            testee.browserViewState.value = browserViewState().copy(browserShowing = false, maliciousSiteBlocked = true)
+
+            testee.onViewVisible()
+
+            verify(mockNewTabPageModalTrigger, never()).onNewTabPageShown()
+        }
 
     @Test
     fun whenShowSubscriptionPromoModalCtaAndOnDuckAiUrlThenNotShown() =

--- a/app/src/test/java/com/duckduckgo/app/browser/modals/AddWidgetModalEvaluatorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/modals/AddWidgetModalEvaluatorTest.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.modals
+
+import com.duckduckgo.app.cta.db.DismissedCtaDao
+import com.duckduckgo.app.cta.model.CtaId
+import com.duckduckgo.app.cta.ui.SubscriptionPromoFlow
+import com.duckduckgo.app.onboarding.OnboardingFlowChecker
+import com.duckduckgo.app.onboarding.store.OnboardingStore
+import com.duckduckgo.app.widget.ui.WidgetCapabilities
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.modalcoordinator.api.ModalEvaluator
+import com.duckduckgo.modalcoordinator.api.ModalTrigger
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class AddWidgetModalEvaluatorTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val widgetCapabilities: WidgetCapabilities = mock()
+    private val dismissedCtaDao: DismissedCtaDao = mock()
+    private val registry = NewTabPageModalPresenterRegistry()
+    private val onboardingFlowChecker: OnboardingFlowChecker = mock()
+    private val onboardingStore: OnboardingStore = mock()
+
+    private lateinit var testee: AddWidgetModalEvaluator
+
+    @Before
+    fun before() = runTest {
+        // Default: eligible (onboarding complete, no widgets installed, not dismissed, no linear-plan widget prompt).
+        whenever(onboardingFlowChecker.isOnboardingComplete()).thenReturn(true)
+        whenever(widgetCapabilities.hasInstalledWidgets).thenReturn(false)
+        whenever(dismissedCtaDao.exists(CtaId.ADD_WIDGET)).thenReturn(false)
+        whenever(widgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
+        whenever(onboardingStore.linearPlanWidgetPromptShown).thenReturn(false)
+
+        testee = AddWidgetModalEvaluator(
+            widgetCapabilities,
+            dismissedCtaDao,
+            registry,
+            onboardingFlowChecker,
+            onboardingStore,
+            coroutineRule.testDispatcherProvider,
+        )
+    }
+
+    @Test
+    fun whenOnboardingNotCompleteThenSkipped() = runTest {
+        whenever(onboardingFlowChecker.isOnboardingComplete()).thenReturn(false)
+        registry.register(FakePresenter())
+
+        assertEquals(ModalEvaluator.EvaluationResult.Skipped, testee.evaluate())
+    }
+
+    @Test
+    fun triggerIsNtpRender() {
+        assertEquals(ModalTrigger.NTP_RENDER, testee.trigger)
+    }
+
+    @Test
+    fun whenWidgetsAlreadyInstalledThenSkipped() = runTest {
+        whenever(widgetCapabilities.hasInstalledWidgets).thenReturn(true)
+        registry.register(FakePresenter())
+
+        assertEquals(ModalEvaluator.EvaluationResult.Skipped, testee.evaluate())
+    }
+
+    @Test
+    fun whenAddWidgetCtaDismissedThenSkipped() = runTest {
+        whenever(dismissedCtaDao.exists(CtaId.ADD_WIDGET)).thenReturn(true)
+        registry.register(FakePresenter())
+
+        assertEquals(ModalEvaluator.EvaluationResult.Skipped, testee.evaluate())
+    }
+
+    @Test
+    fun whenLinearPlanWidgetPromptShownThenSkipped() = runTest {
+        whenever(onboardingStore.linearPlanWidgetPromptShown).thenReturn(true)
+        registry.register(FakePresenter())
+
+        assertEquals(ModalEvaluator.EvaluationResult.Skipped, testee.evaluate())
+    }
+
+    @Test
+    fun whenEligibleButNoPresenterRegisteredThenSkipped() = runTest {
+        assertEquals(ModalEvaluator.EvaluationResult.Skipped, testee.evaluate())
+    }
+
+    @Test
+    fun whenEligibleAndPresenterShowsThenModalShownWithAutomaticAddFlag() = runTest {
+        whenever(widgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
+        val presenter = FakePresenter(widgetResult = true)
+        registry.register(presenter)
+
+        val result = testee.evaluate()
+
+        assertEquals(ModalEvaluator.EvaluationResult.ModalShown, result)
+        assertTrue(presenter.widgetShown)
+        assertTrue(presenter.shownSupportsAutomaticAdd == true)
+    }
+
+    @Test
+    fun whenEligibleButPresenterDeclinesThenSkipped() = runTest {
+        registry.register(FakePresenter(widgetResult = false))
+
+        assertEquals(ModalEvaluator.EvaluationResult.Skipped, testee.evaluate())
+    }
+
+    private class FakePresenter(
+        private val widgetResult: Boolean = true,
+    ) : NewTabPageModalPresenter {
+        var widgetShown = false
+        var shownSupportsAutomaticAdd: Boolean? = null
+
+        override fun showSubscriptionPromo(
+            flow: SubscriptionPromoFlow,
+            isFreeTrialCopy: Boolean,
+        ): Boolean = false
+
+        override fun showAddWidgetPromo(supportsAutomaticAdd: Boolean): Boolean {
+            widgetShown = true
+            shownSupportsAutomaticAdd = supportsAutomaticAdd
+            return widgetResult
+        }
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/modals/AddWidgetModalEvaluatorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/modals/AddWidgetModalEvaluatorTest.kt
@@ -49,7 +49,6 @@ class AddWidgetModalEvaluatorTest {
 
     @Before
     fun before() = runTest {
-        // Default: eligible (onboarding complete, no widgets installed, not dismissed, no linear-plan widget prompt).
         whenever(onboardingFlowChecker.isOnboardingComplete()).thenReturn(true)
         whenever(widgetCapabilities.hasInstalledWidgets).thenReturn(false)
         whenever(dismissedCtaDao.exists(CtaId.ADD_WIDGET)).thenReturn(false)
@@ -134,12 +133,12 @@ class AddWidgetModalEvaluatorTest {
         var widgetShown = false
         var shownSupportsAutomaticAdd: Boolean? = null
 
-        override fun showSubscriptionPromo(
+        override suspend fun showSubscriptionPromo(
             flow: SubscriptionPromoFlow,
             isFreeTrialCopy: Boolean,
         ): Boolean = false
 
-        override fun showAddWidgetPromo(supportsAutomaticAdd: Boolean): Boolean {
+        override suspend fun showAddWidgetPromo(supportsAutomaticAdd: Boolean): Boolean {
             widgetShown = true
             shownSupportsAutomaticAdd = supportsAutomaticAdd
             return widgetResult

--- a/app/src/test/java/com/duckduckgo/app/browser/modals/AddWidgetModalEvaluatorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/modals/AddWidgetModalEvaluatorTest.kt
@@ -19,7 +19,6 @@ package com.duckduckgo.app.browser.modals
 import com.duckduckgo.app.cta.db.DismissedCtaDao
 import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.app.cta.ui.SubscriptionPromoFlow
-import com.duckduckgo.app.onboarding.OnboardingFlowChecker
 import com.duckduckgo.app.onboarding.store.OnboardingStore
 import com.duckduckgo.app.widget.ui.WidgetCapabilities
 import com.duckduckgo.common.test.CoroutineTestRule
@@ -42,14 +41,12 @@ class AddWidgetModalEvaluatorTest {
     private val widgetCapabilities: WidgetCapabilities = mock()
     private val dismissedCtaDao: DismissedCtaDao = mock()
     private val registry = NewTabPageModalPresenterRegistry()
-    private val onboardingFlowChecker: OnboardingFlowChecker = mock()
     private val onboardingStore: OnboardingStore = mock()
 
     private lateinit var testee: AddWidgetModalEvaluator
 
     @Before
     fun before() = runTest {
-        whenever(onboardingFlowChecker.isOnboardingComplete()).thenReturn(true)
         whenever(widgetCapabilities.hasInstalledWidgets).thenReturn(false)
         whenever(dismissedCtaDao.exists(CtaId.ADD_WIDGET)).thenReturn(false)
         whenever(widgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
@@ -59,18 +56,9 @@ class AddWidgetModalEvaluatorTest {
             widgetCapabilities,
             dismissedCtaDao,
             registry,
-            onboardingFlowChecker,
             onboardingStore,
             coroutineRule.testDispatcherProvider,
         )
-    }
-
-    @Test
-    fun whenOnboardingNotCompleteThenSkipped() = runTest {
-        whenever(onboardingFlowChecker.isOnboardingComplete()).thenReturn(false)
-        registry.register(FakePresenter())
-
-        assertEquals(ModalEvaluator.EvaluationResult.Skipped, testee.evaluate())
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/browser/modals/SubscriptionPromoModalEvaluatorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/modals/SubscriptionPromoModalEvaluatorTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.modals
+
+import com.duckduckgo.app.cta.ui.SubscriptionPromoFlow
+import com.duckduckgo.app.cta.ui.SubscriptionPromoModalDecider
+import com.duckduckgo.app.cta.ui.SubscriptionPromoModalDecision
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.modalcoordinator.api.ModalEvaluator
+import com.duckduckgo.modalcoordinator.api.ModalTrigger
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class SubscriptionPromoModalEvaluatorTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val decider: SubscriptionPromoModalDecider = mock()
+    private val registry = NewTabPageModalPresenterRegistry()
+
+    private lateinit var testee: SubscriptionPromoModalEvaluator
+
+    @Before
+    fun before() {
+        testee = SubscriptionPromoModalEvaluator(decider, registry, coroutineRule.testDispatcherProvider)
+    }
+
+    @Test
+    fun triggerIsAppResume() {
+        assertEquals(ModalTrigger.APP_RESUME, testee.trigger)
+    }
+
+    @Test
+    fun whenNotEligibleThenSkipped() = runTest {
+        whenever(decider.decide()).thenReturn(null)
+
+        assertEquals(ModalEvaluator.EvaluationResult.Skipped, testee.evaluate())
+    }
+
+    @Test
+    fun whenEligibleButNoPresenterRegisteredThenSkipped() = runTest {
+        whenever(decider.decide()).thenReturn(SubscriptionPromoModalDecision(SubscriptionPromoFlow.NUDGE, isFreeTrialCopy = false))
+
+        assertEquals(ModalEvaluator.EvaluationResult.Skipped, testee.evaluate())
+    }
+
+    @Test
+    fun whenEligibleAndPresenterShowsThenModalShown() = runTest {
+        whenever(decider.decide()).thenReturn(SubscriptionPromoModalDecision(SubscriptionPromoFlow.SKIPPED_ONBOARDING, isFreeTrialCopy = true))
+        val presenter = FakePresenter(subscriptionResult = true)
+        registry.register(presenter)
+
+        val result = testee.evaluate()
+
+        assertEquals(ModalEvaluator.EvaluationResult.ModalShown, result)
+        assertTrue(presenter.subscriptionShown)
+        assertEquals(SubscriptionPromoFlow.SKIPPED_ONBOARDING, presenter.shownFlow)
+        assertTrue(presenter.shownFreeTrialCopy)
+    }
+
+    @Test
+    fun whenEligibleButPresenterDeclinesThenSkipped() = runTest {
+        whenever(decider.decide()).thenReturn(SubscriptionPromoModalDecision(SubscriptionPromoFlow.NUDGE, isFreeTrialCopy = false))
+        registry.register(FakePresenter(subscriptionResult = false))
+
+        assertEquals(ModalEvaluator.EvaluationResult.Skipped, testee.evaluate())
+    }
+
+    private class FakePresenter(
+        private val subscriptionResult: Boolean = true,
+    ) : NewTabPageModalPresenter {
+        var subscriptionShown = false
+        var shownFlow: SubscriptionPromoFlow? = null
+        var shownFreeTrialCopy = false
+
+        override fun showSubscriptionPromo(
+            flow: SubscriptionPromoFlow,
+            isFreeTrialCopy: Boolean,
+        ): Boolean {
+            subscriptionShown = true
+            shownFlow = flow
+            shownFreeTrialCopy = isFreeTrialCopy
+            return subscriptionResult
+        }
+
+        override fun showAddWidgetPromo(supportsAutomaticAdd: Boolean): Boolean = false
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/browser/modals/SubscriptionPromoModalEvaluatorTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/modals/SubscriptionPromoModalEvaluatorTest.kt
@@ -94,7 +94,7 @@ class SubscriptionPromoModalEvaluatorTest {
         var shownFlow: SubscriptionPromoFlow? = null
         var shownFreeTrialCopy = false
 
-        override fun showSubscriptionPromo(
+        override suspend fun showSubscriptionPromo(
             flow: SubscriptionPromoFlow,
             isFreeTrialCopy: Boolean,
         ): Boolean {
@@ -104,6 +104,6 @@ class SubscriptionPromoModalEvaluatorTest {
             return subscriptionResult
         }
 
-        override fun showAddWidgetPromo(supportsAutomaticAdd: Boolean): Boolean = false
+        override suspend fun showAddWidgetPromo(supportsAutomaticAdd: Boolean): Boolean = false
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -119,7 +119,7 @@ class CtaViewModelTest {
 
     private val mockWidgetCapabilities: WidgetCapabilities = mock()
 
-    private val mockSubscriptionPromoModalDecider: SubscriptionPromoModalDecider = mock()
+    private lateinit var subscriptionPromoModalDecider: SubscriptionPromoModalDecider
 
     private val mockDismissedCtaDao: DismissedCtaDao = mock()
 
@@ -201,7 +201,6 @@ class CtaViewModelTest {
         val mockDisabledToggle: Toggle = mock { on { it.isEnabled() } doReturn false }
         whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCta()).thenReturn(mockDisabledToggle)
         whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCtaExistingUsers()).thenReturn(mockDisabledToggle)
-        whenever(mockSubscriptionPromoModalDecider.decide()).thenReturn(null)
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1))
         whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)
         whenever(mockDismissedCtaDao.dismissedCtas()).thenReturn(db.dismissedCtaDao().dismissedCtas())
@@ -220,10 +219,19 @@ class CtaViewModelTest {
         whenever(mockOnboardingBrandDesignUpdateToggles.onboardingImprovements()).thenReturn(mockEnabledToggle)
         whenever(mockOnboardingBrandDesignUpdateToggles.onboardingImprovementsV2()).thenReturn(mockEnabledToggle)
 
+        subscriptionPromoModalDecider = RealSubscriptionPromoModalDecider(
+            extendedOnboardingFeatureToggles = mockExtendedOnboardingFeatureToggles,
+            appInstallStore = mockAppInstallStore,
+            settingsDataStore = mockSettingsDataStore,
+            dismissedCtaDao = mockDismissedCtaDao,
+            subscriptions = mockSubscriptions,
+            dispatchers = coroutineRule.testDispatcherProvider,
+        )
+
         testee = CtaViewModel(
             appInstallStore = mockAppInstallStore,
             pixel = mockPixel,
-            subscriptionPromoModalDecider = mockSubscriptionPromoModalDecider,
+            subscriptionPromoModalDecider = subscriptionPromoModalDecider,
             dismissedCtaDao = mockDismissedCtaDao,
             userAllowListRepository = mockUserAllowListRepository,
             settingsDataStore = mockSettingsDataStore,

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/CtaViewModelTest.kt
@@ -119,6 +119,8 @@ class CtaViewModelTest {
 
     private val mockWidgetCapabilities: WidgetCapabilities = mock()
 
+    private val mockSubscriptionPromoModalDecider: SubscriptionPromoModalDecider = mock()
+
     private val mockDismissedCtaDao: DismissedCtaDao = mock()
 
     private val mockPixel: Pixel = mock()
@@ -199,6 +201,7 @@ class CtaViewModelTest {
         val mockDisabledToggle: Toggle = mock { on { it.isEnabled() } doReturn false }
         whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCta()).thenReturn(mockDisabledToggle)
         whenever(mockExtendedOnboardingFeatureToggles.subscriptionPromoModalCtaExistingUsers()).thenReturn(mockDisabledToggle)
+        whenever(mockSubscriptionPromoModalDecider.decide()).thenReturn(null)
         whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1))
         whenever(mockUserAllowListRepository.isDomainInUserAllowList(any())).thenReturn(false)
         whenever(mockDismissedCtaDao.dismissedCtas()).thenReturn(db.dismissedCtaDao().dismissedCtas())
@@ -220,7 +223,7 @@ class CtaViewModelTest {
         testee = CtaViewModel(
             appInstallStore = mockAppInstallStore,
             pixel = mockPixel,
-            widgetCapabilities = mockWidgetCapabilities,
+            subscriptionPromoModalDecider = mockSubscriptionPromoModalDecider,
             dismissedCtaDao = mockDismissedCtaDao,
             userAllowListRepository = mockUserAllowListRepository,
             settingsDataStore = mockSettingsDataStore,
@@ -469,37 +472,6 @@ class CtaViewModelTest {
             site = site,
             detectedRefreshPatterns = detectedRefreshPatterns,
         )
-        assertNull(value)
-    }
-
-    @Test
-    fun whenRefreshCtaOnHomeTabAndHideTipsIsTrueThenReturnAddWidgetAutoOnboardingExperiment() = runTest {
-        whenever(mockSettingsDataStore.hideTips).thenReturn(true)
-        whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
-        whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(false)
-
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
-        assertTrue(value is HomePanelCta.AddWidgetAutoOnboarding)
-    }
-
-    @Test
-    fun whenRefreshCtaOnHomeTabAndHideTipsIsTrueThenReturnWidgetInstructionsCta() = runTest {
-        whenever(mockSettingsDataStore.hideTips).thenReturn(true)
-        whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(false)
-        whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(false)
-
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
-        assertTrue(value is HomePanelCta.AddWidgetInstructions)
-    }
-
-    @Test
-    fun whenRefreshCtaOnHomeTabAndLinearPlanWidgetPromptShownThenReturnNull() = runTest {
-        whenever(mockSettingsDataStore.hideTips).thenReturn(true)
-        whenever(mockWidgetCapabilities.supportsAutomaticWidgetAdd).thenReturn(true)
-        whenever(mockWidgetCapabilities.hasInstalledWidgets).thenReturn(false)
-        whenever(mockOnboardingStore.linearPlanWidgetPromptShown).thenReturn(true)
-
-        val value = testee.refreshCta(coroutineRule.testDispatcher, isBrowserShowing = false, detectedRefreshPatterns = detectedRefreshPatterns)
         assertNull(value)
     }
 
@@ -1458,40 +1430,6 @@ class CtaViewModelTest {
             detectedRefreshPatterns = detectedRefreshPatterns,
         )
         assertFalse(value is SubscriptionPromoModalCta)
-    }
-
-    @Test
-    fun givenForegroundAndEligibleWhenGetPromoCtaOnForegroundThenReturnSubscriptionPromoModalCta() = runTest {
-        givenSubscriptionPromoEligible()
-        val value = testee.getPromoCtaOnForeground()
-        assertTrue(value is SubscriptionPromoModalCta)
-    }
-
-    @Test
-    fun givenForegroundButToggleDisabledWhenGetPromoCtaOnForegroundThenDontReturnSubscriptionPromoModalCta() = runTest {
-        whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(8))
-        whenever(mockExtendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
-        whenever(mockSubscriptions.isEligible()).thenReturn(true)
-        val value = testee.getPromoCtaOnForeground()
-        assertFalse(value is SubscriptionPromoModalCta)
-    }
-
-    @Test
-    fun givenForegroundAndSubscriptionModalAlreadyShownWhenGetPromoCtaOnForegroundThenDontReturnSubscriptionPromoModalCta() = runTest {
-        givenSubscriptionPromoEligible()
-        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_PRIVACY_PRO)).thenReturn(true)
-        val value = testee.getPromoCtaOnForeground()
-        assertFalse(value is SubscriptionPromoModalCta)
-    }
-
-    @Test
-    fun givenForegroundWithFreeTrialCopyWhenGetPromoCtaOnForegroundThenReturnSubscriptionPromoModalCtaWithFreeTrialCopy() = runTest {
-        givenSubscriptionPromoEligible()
-        whenever(mockExtendedOnboardingFeatureToggles.freeTrialCopy()).thenReturn(mockEnabledToggle)
-        whenever(mockSubscriptions.isFreeTrialEligible()).thenReturn(true)
-        val value = testee.getPromoCtaOnForeground()
-        assertTrue(value is SubscriptionPromoModalCta)
-        assertTrue((value as SubscriptionPromoModalCta).isFreeTrialCopy)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxDuckAiFireButtonBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxDuckAiFireButtonBrandDesignUpdateContextualCtaTest.kt
@@ -152,7 +152,7 @@ class DaxDuckAiFireButtonBrandDesignUpdateContextualCtaTest {
         testee = CtaViewModel(
             appInstallStore = mockAppInstallStore,
             pixel = mockPixel,
-            widgetCapabilities = mockWidgetCapabilities,
+            subscriptionPromoModalDecider = mock(),
             dismissedCtaDao = mockDismissedCtaDao,
             userAllowListRepository = mockUserAllowListRepository,
             settingsDataStore = mockSettingsDataStore,

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxDuckAiFireButtonBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxDuckAiFireButtonBrandDesignUpdateContextualCtaTest.kt
@@ -152,7 +152,14 @@ class DaxDuckAiFireButtonBrandDesignUpdateContextualCtaTest {
         testee = CtaViewModel(
             appInstallStore = mockAppInstallStore,
             pixel = mockPixel,
-            subscriptionPromoModalDecider = mock(),
+            subscriptionPromoModalDecider = RealSubscriptionPromoModalDecider(
+                extendedOnboardingFeatureToggles = mockExtendedOnboardingFeatureToggles,
+                appInstallStore = mockAppInstallStore,
+                settingsDataStore = mockSettingsDataStore,
+                dismissedCtaDao = mockDismissedCtaDao,
+                subscriptions = mockSubscriptions,
+                dispatchers = coroutineRule.testDispatcherProvider,
+            ),
             dismissedCtaDao = mockDismissedCtaDao,
             userAllowListRepository = mockUserAllowListRepository,
             settingsDataStore = mockSettingsDataStore,

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateContextualCtaTest.kt
@@ -144,7 +144,7 @@ class DaxEndBrandDesignUpdateContextualCtaTest {
         testee = CtaViewModel(
             appInstallStore = mockAppInstallStore,
             pixel = mockPixel,
-            widgetCapabilities = mockWidgetCapabilities,
+            subscriptionPromoModalDecider = mock(),
             dismissedCtaDao = mockDismissedCtaDao,
             userAllowListRepository = mockUserAllowListRepository,
             settingsDataStore = mockSettingsDataStore,

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxEndBrandDesignUpdateContextualCtaTest.kt
@@ -144,7 +144,14 @@ class DaxEndBrandDesignUpdateContextualCtaTest {
         testee = CtaViewModel(
             appInstallStore = mockAppInstallStore,
             pixel = mockPixel,
-            subscriptionPromoModalDecider = mock(),
+            subscriptionPromoModalDecider = RealSubscriptionPromoModalDecider(
+                extendedOnboardingFeatureToggles = mockExtendedOnboardingFeatureToggles,
+                appInstallStore = mockAppInstallStore,
+                settingsDataStore = mockSettingsDataStore,
+                dismissedCtaDao = mockDismissedCtaDao,
+                subscriptions = mockSubscriptions,
+                dispatchers = coroutineRule.testDispatcherProvider,
+            ),
             dismissedCtaDao = mockDismissedCtaDao,
             userAllowListRepository = mockUserAllowListRepository,
             settingsDataStore = mockSettingsDataStore,

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxFireButtonBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxFireButtonBrandDesignUpdateContextualCtaTest.kt
@@ -141,7 +141,7 @@ class DaxFireButtonBrandDesignUpdateContextualCtaTest {
         testee = CtaViewModel(
             appInstallStore = mockAppInstallStore,
             pixel = mockPixel,
-            widgetCapabilities = mockWidgetCapabilities,
+            subscriptionPromoModalDecider = mock(),
             dismissedCtaDao = mockDismissedCtaDao,
             userAllowListRepository = mockUserAllowListRepository,
             settingsDataStore = mockSettingsDataStore,

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxFireButtonBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxFireButtonBrandDesignUpdateContextualCtaTest.kt
@@ -141,7 +141,14 @@ class DaxFireButtonBrandDesignUpdateContextualCtaTest {
         testee = CtaViewModel(
             appInstallStore = mockAppInstallStore,
             pixel = mockPixel,
-            subscriptionPromoModalDecider = mock(),
+            subscriptionPromoModalDecider = RealSubscriptionPromoModalDecider(
+                extendedOnboardingFeatureToggles = mockExtendedOnboardingFeatureToggles,
+                appInstallStore = mockAppInstallStore,
+                settingsDataStore = mockSettingsDataStore,
+                dismissedCtaDao = mockDismissedCtaDao,
+                subscriptions = mockSubscriptions,
+                dispatchers = coroutineRule.testDispatcherProvider,
+            ),
             dismissedCtaDao = mockDismissedCtaDao,
             userAllowListRepository = mockUserAllowListRepository,
             settingsDataStore = mockSettingsDataStore,

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCtaTest.kt
@@ -161,7 +161,7 @@ class DaxMainNetworkBrandDesignUpdateContextualCtaTest {
         testee = CtaViewModel(
             appInstallStore = mockAppInstallStore,
             pixel = mockPixel,
-            widgetCapabilities = mockWidgetCapabilities,
+            subscriptionPromoModalDecider = mock(),
             dismissedCtaDao = mockDismissedCtaDao,
             userAllowListRepository = mockUserAllowListRepository,
             settingsDataStore = mockSettingsDataStore,

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxMainNetworkBrandDesignUpdateContextualCtaTest.kt
@@ -161,7 +161,14 @@ class DaxMainNetworkBrandDesignUpdateContextualCtaTest {
         testee = CtaViewModel(
             appInstallStore = mockAppInstallStore,
             pixel = mockPixel,
-            subscriptionPromoModalDecider = mock(),
+            subscriptionPromoModalDecider = RealSubscriptionPromoModalDecider(
+                extendedOnboardingFeatureToggles = mockExtendedOnboardingFeatureToggles,
+                appInstallStore = mockAppInstallStore,
+                settingsDataStore = mockSettingsDataStore,
+                dismissedCtaDao = mockDismissedCtaDao,
+                subscriptions = mockSubscriptions,
+                dispatchers = coroutineRule.testDispatcherProvider,
+            ),
             dismissedCtaDao = mockDismissedCtaDao,
             userAllowListRepository = mockUserAllowListRepository,
             settingsDataStore = mockSettingsDataStore,

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxNoTrackersBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxNoTrackersBrandDesignUpdateContextualCtaTest.kt
@@ -150,7 +150,7 @@ class DaxNoTrackersBrandDesignUpdateContextualCtaTest {
         testee = CtaViewModel(
             appInstallStore = mockAppInstallStore,
             pixel = mockPixel,
-            widgetCapabilities = mockWidgetCapabilities,
+            subscriptionPromoModalDecider = mock(),
             dismissedCtaDao = mockDismissedCtaDao,
             userAllowListRepository = mockUserAllowListRepository,
             settingsDataStore = mockSettingsDataStore,

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxNoTrackersBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxNoTrackersBrandDesignUpdateContextualCtaTest.kt
@@ -150,7 +150,14 @@ class DaxNoTrackersBrandDesignUpdateContextualCtaTest {
         testee = CtaViewModel(
             appInstallStore = mockAppInstallStore,
             pixel = mockPixel,
-            subscriptionPromoModalDecider = mock(),
+            subscriptionPromoModalDecider = RealSubscriptionPromoModalDecider(
+                extendedOnboardingFeatureToggles = mockExtendedOnboardingFeatureToggles,
+                appInstallStore = mockAppInstallStore,
+                settingsDataStore = mockSettingsDataStore,
+                dismissedCtaDao = mockDismissedCtaDao,
+                subscriptions = mockSubscriptions,
+                dispatchers = coroutineRule.testDispatcherProvider,
+            ),
             dismissedCtaDao = mockDismissedCtaDao,
             userAllowListRepository = mockUserAllowListRepository,
             settingsDataStore = mockSettingsDataStore,

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxSerpBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxSerpBrandDesignUpdateContextualCtaTest.kt
@@ -156,7 +156,7 @@ class DaxSerpBrandDesignUpdateContextualCtaTest {
         testee = CtaViewModel(
             appInstallStore = mockAppInstallStore,
             pixel = mockPixel,
-            widgetCapabilities = mockWidgetCapabilities,
+            subscriptionPromoModalDecider = mock(),
             dismissedCtaDao = mockDismissedCtaDao,
             userAllowListRepository = mockUserAllowListRepository,
             settingsDataStore = mockSettingsDataStore,

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxSerpBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxSerpBrandDesignUpdateContextualCtaTest.kt
@@ -156,7 +156,14 @@ class DaxSerpBrandDesignUpdateContextualCtaTest {
         testee = CtaViewModel(
             appInstallStore = mockAppInstallStore,
             pixel = mockPixel,
-            subscriptionPromoModalDecider = mock(),
+            subscriptionPromoModalDecider = RealSubscriptionPromoModalDecider(
+                extendedOnboardingFeatureToggles = mockExtendedOnboardingFeatureToggles,
+                appInstallStore = mockAppInstallStore,
+                settingsDataStore = mockSettingsDataStore,
+                dismissedCtaDao = mockDismissedCtaDao,
+                subscriptions = mockSubscriptions,
+                dispatchers = coroutineRule.testDispatcherProvider,
+            ),
             dismissedCtaDao = mockDismissedCtaDao,
             userAllowListRepository = mockUserAllowListRepository,
             settingsDataStore = mockSettingsDataStore,

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxSiteSuggestionsBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxSiteSuggestionsBrandDesignUpdateContextualCtaTest.kt
@@ -164,7 +164,7 @@ class DaxSiteSuggestionsBrandDesignUpdateContextualCtaTest {
         testee = CtaViewModel(
             appInstallStore = mockAppInstallStore,
             pixel = mockPixel,
-            widgetCapabilities = mockWidgetCapabilities,
+            subscriptionPromoModalDecider = mock(),
             dismissedCtaDao = mockDismissedCtaDao,
             userAllowListRepository = mockUserAllowListRepository,
             settingsDataStore = mockSettingsDataStore,

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxSiteSuggestionsBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxSiteSuggestionsBrandDesignUpdateContextualCtaTest.kt
@@ -164,7 +164,14 @@ class DaxSiteSuggestionsBrandDesignUpdateContextualCtaTest {
         testee = CtaViewModel(
             appInstallStore = mockAppInstallStore,
             pixel = mockPixel,
-            subscriptionPromoModalDecider = mock(),
+            subscriptionPromoModalDecider = RealSubscriptionPromoModalDecider(
+                extendedOnboardingFeatureToggles = mockExtendedOnboardingFeatureToggles,
+                appInstallStore = mockAppInstallStore,
+                settingsDataStore = mockSettingsDataStore,
+                dismissedCtaDao = mockDismissedCtaDao,
+                subscriptions = mockSubscriptions,
+                dispatchers = coroutineRule.testDispatcherProvider,
+            ),
             dismissedCtaDao = mockDismissedCtaDao,
             userAllowListRepository = mockUserAllowListRepository,
             settingsDataStore = mockSettingsDataStore,

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxTrackersBlockedBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxTrackersBlockedBrandDesignUpdateContextualCtaTest.kt
@@ -142,7 +142,7 @@ class DaxTrackersBlockedBrandDesignUpdateContextualCtaTest {
         testee = CtaViewModel(
             appInstallStore = mockAppInstallStore,
             pixel = mockPixel,
-            widgetCapabilities = mockWidgetCapabilities,
+            subscriptionPromoModalDecider = mock(),
             dismissedCtaDao = mockDismissedCtaDao,
             userAllowListRepository = mockUserAllowListRepository,
             settingsDataStore = mockSettingsDataStore,

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxTrackersBlockedBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxTrackersBlockedBrandDesignUpdateContextualCtaTest.kt
@@ -142,7 +142,14 @@ class DaxTrackersBlockedBrandDesignUpdateContextualCtaTest {
         testee = CtaViewModel(
             appInstallStore = mockAppInstallStore,
             pixel = mockPixel,
-            subscriptionPromoModalDecider = mock(),
+            subscriptionPromoModalDecider = RealSubscriptionPromoModalDecider(
+                extendedOnboardingFeatureToggles = mockExtendedOnboardingFeatureToggles,
+                appInstallStore = mockAppInstallStore,
+                settingsDataStore = mockSettingsDataStore,
+                dismissedCtaDao = mockDismissedCtaDao,
+                subscriptions = mockSubscriptions,
+                dispatchers = coroutineRule.testDispatcherProvider,
+            ),
             dismissedCtaDao = mockDismissedCtaDao,
             userAllowListRepository = mockUserAllowListRepository,
             settingsDataStore = mockSettingsDataStore,

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/OnboardingDaxDialogTests.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/OnboardingDaxDialogTests.kt
@@ -58,12 +58,10 @@ import com.duckduckgo.onboarding.api.LinearOnboardingOrchestrator
 import com.duckduckgo.onboarding.api.LinearOnboardingState
 import com.duckduckgo.onboarding.api.cta.ContextualCtaSuppressorPlugin
 import com.duckduckgo.subscriptions.api.SubscriptionPromoCtaShownPlugin
-import com.duckduckgo.subscriptions.api.SubscriptionStatus
 import com.duckduckgo.subscriptions.api.Subscriptions
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertFalse
-import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -131,7 +129,7 @@ class OnboardingDaxDialogTests {
         testee = CtaViewModel(
             appInstallStore,
             pixel,
-            widgetCapabilities,
+            mock<SubscriptionPromoModalDecider>(),
             dismissedCtaDao,
             userAllowListRepository,
             settingsDataStore,
@@ -294,24 +292,6 @@ class OnboardingDaxDialogTests {
 
         val inContextDaxDialogsComplete = testee.areInContextDaxDialogsCompleted()
         assertTrue(inContextDaxDialogsComplete)
-    }
-
-    @Test
-    fun whenHideTipsAndSevenDaysSinceInstallAndSubscriptionNotShownThenGetPromoCtaOnForegroundReturnsSubscriptionCta() = runTest {
-        whenever(settingsDataStore.hideTips).thenReturn(true)
-        whenever(appInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - 8 * 24 * 3600 * 1000L)
-        whenever(dismissedCtaDao.exists(DAX_INTRO_PRIVACY_PRO)).thenReturn(false)
-        whenever(extendedOnboardingFeatureToggles.privacyProCta()).thenReturn(mockEnabledToggle)
-        whenever(extendedOnboardingFeatureToggles.subscriptionPromoModalCta()).thenReturn(mockEnabledToggle)
-        whenever(extendedOnboardingFeatureToggles.freeTrialCopy()).thenReturn(mockDisabledToggle)
-        whenever(mockSubscriptions.isEligible()).thenReturn(true)
-        whenever(mockSubscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
-        whenever(mockSubscriptions.isFreeTrialEligible()).thenReturn(true)
-
-        val result = testee.getPromoCtaOnForeground()
-
-        assertNotNull(result)
-        assertTrue(result is SubscriptionPromoModalCta)
     }
 
     @Test

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/OnboardingDaxDialogTests.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/OnboardingDaxDialogTests.kt
@@ -129,7 +129,14 @@ class OnboardingDaxDialogTests {
         testee = CtaViewModel(
             appInstallStore,
             pixel,
-            mock<SubscriptionPromoModalDecider>(),
+            RealSubscriptionPromoModalDecider(
+                extendedOnboardingFeatureToggles,
+                appInstallStore,
+                settingsDataStore,
+                dismissedCtaDao,
+                mockSubscriptions,
+                coroutineRule.testDispatcherProvider,
+            ),
             dismissedCtaDao,
             userAllowListRepository,
             settingsDataStore,

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/SubscriptionPromoModalDeciderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/SubscriptionPromoModalDeciderTest.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.cta.ui
+
+import com.duckduckgo.app.cta.db.DismissedCtaDao
+import com.duckduckgo.app.cta.model.CtaId
+import com.duckduckgo.app.global.install.AppInstallStore
+import com.duckduckgo.app.onboarding.ui.page.extendedonboarding.ExtendedOnboardingFeatureToggles
+import com.duckduckgo.app.settings.db.SettingsDataStore
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.Toggle
+import com.duckduckgo.subscriptions.api.SubscriptionStatus
+import com.duckduckgo.subscriptions.api.Subscriptions
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.util.concurrent.TimeUnit
+
+class SubscriptionPromoModalDeciderTest {
+
+    @get:Rule
+    val coroutineRule = CoroutineTestRule()
+
+    private val mockToggles: ExtendedOnboardingFeatureToggles = mock()
+    private val mockAppInstallStore: AppInstallStore = mock()
+    private val mockSettingsDataStore: SettingsDataStore = mock()
+    private val mockDismissedCtaDao: DismissedCtaDao = mock()
+    private val mockSubscriptions: Subscriptions = mock()
+
+    private val enabledToggle: Toggle = mock { on { isEnabled() } doReturn true }
+    private val disabledToggle: Toggle = mock { on { isEnabled() } doReturn false }
+
+    private lateinit var testee: RealSubscriptionPromoModalDecider
+
+    @Before
+    fun before() = runTest {
+        // Defaults: subscription is available but neither promo toggle is enabled -> not eligible.
+        whenever(mockToggles.subscriptionPromoModalCta()).thenReturn(disabledToggle)
+        whenever(mockToggles.subscriptionPromoModalCtaExistingUsers()).thenReturn(disabledToggle)
+        whenever(mockToggles.privacyProCta()).thenReturn(enabledToggle)
+        whenever(mockToggles.freeTrialCopy()).thenReturn(disabledToggle)
+        whenever(mockSettingsDataStore.hideTips).thenReturn(false)
+        whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(8))
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_PRIVACY_PRO)).thenReturn(false)
+        whenever(mockSubscriptions.isEligible()).thenReturn(true)
+        whenever(mockSubscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.UNKNOWN)
+        whenever(mockSubscriptions.isFreeTrialEligible()).thenReturn(false)
+
+        testee = RealSubscriptionPromoModalDecider(
+            extendedOnboardingFeatureToggles = mockToggles,
+            appInstallStore = mockAppInstallStore,
+            settingsDataStore = mockSettingsDataStore,
+            dismissedCtaDao = mockDismissedCtaDao,
+            subscriptions = mockSubscriptions,
+            dispatchers = coroutineRule.testDispatcherProvider,
+        )
+    }
+
+    @Test
+    fun whenNeitherToggleEnabledThenNull() = runTest {
+        assertNull(testee.decide())
+    }
+
+    @Test
+    fun whenSkippedOnboardingEligibleThenSkippedOnboardingFlow() = runTest {
+        whenever(mockToggles.subscriptionPromoModalCta()).thenReturn(enabledToggle)
+        whenever(mockSettingsDataStore.hideTips).thenReturn(true)
+
+        assertEquals(SubscriptionPromoFlow.SKIPPED_ONBOARDING, testee.decide()?.flow)
+    }
+
+    @Test
+    fun whenSkippedOnboardingToggleEnabledButHideTipsFalseThenNull() = runTest {
+        whenever(mockToggles.subscriptionPromoModalCta()).thenReturn(enabledToggle)
+        whenever(mockSettingsDataStore.hideTips).thenReturn(false)
+
+        assertNull(testee.decide())
+    }
+
+    @Test
+    fun whenNudgeEligibleThenNudgeFlow() = runTest {
+        whenever(mockToggles.subscriptionPromoModalCtaExistingUsers()).thenReturn(enabledToggle)
+
+        assertEquals(SubscriptionPromoFlow.NUDGE, testee.decide()?.flow)
+    }
+
+    @Test
+    fun whenAlreadyShownThenNull() = runTest {
+        whenever(mockToggles.subscriptionPromoModalCtaExistingUsers()).thenReturn(enabledToggle)
+        whenever(mockDismissedCtaDao.exists(CtaId.DAX_INTRO_PRIVACY_PRO)).thenReturn(true)
+
+        assertNull(testee.decide())
+    }
+
+    @Test
+    fun whenInstalledLessThanMinDaysThenNull() = runTest {
+        whenever(mockToggles.subscriptionPromoModalCtaExistingUsers()).thenReturn(enabledToggle)
+        whenever(mockAppInstallStore.installTimestamp).thenReturn(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1))
+
+        assertNull(testee.decide())
+    }
+
+    @Test
+    fun whenNotSubscriptionEligibleThenNull() = runTest {
+        whenever(mockToggles.subscriptionPromoModalCtaExistingUsers()).thenReturn(enabledToggle)
+        whenever(mockSubscriptions.isEligible()).thenReturn(false)
+
+        assertNull(testee.decide())
+    }
+
+    @Test
+    fun whenAlreadySubscribedThenNull() = runTest {
+        whenever(mockToggles.subscriptionPromoModalCtaExistingUsers()).thenReturn(enabledToggle)
+        whenever(mockSubscriptions.getSubscriptionStatus()).thenReturn(SubscriptionStatus.AUTO_RENEWABLE)
+
+        assertNull(testee.decide())
+    }
+
+    @Test
+    fun whenFreeTrialCopyEnabledAndEligibleThenFreeTrialCopyTrue() = runTest {
+        whenever(mockToggles.subscriptionPromoModalCtaExistingUsers()).thenReturn(enabledToggle)
+        whenever(mockToggles.freeTrialCopy()).thenReturn(enabledToggle)
+        whenever(mockSubscriptions.isFreeTrialEligible()).thenReturn(true)
+
+        assertTrue(testee.decide()?.isFreeTrialCopy == true)
+    }
+}

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/SubscriptionPromoModalDeciderTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/SubscriptionPromoModalDeciderTest.kt
@@ -55,7 +55,6 @@ class SubscriptionPromoModalDeciderTest {
 
     @Before
     fun before() = runTest {
-        // Defaults: subscription is available but neither promo toggle is enabled -> not eligible.
         whenever(mockToggles.subscriptionPromoModalCta()).thenReturn(disabledToggle)
         whenever(mockToggles.subscriptionPromoModalCtaExistingUsers()).thenReturn(disabledToggle)
         whenever(mockToggles.privacyProCta()).thenReturn(enabledToggle)

--- a/modal-coordinator/modal-coordinator-api/src/main/java/com/duckduckgo/modalcoordinator/api/ModalEvaluator.kt
+++ b/modal-coordinator/modal-coordinator-api/src/main/java/com/duckduckgo/modalcoordinator/api/ModalEvaluator.kt
@@ -34,6 +34,16 @@ interface ModalEvaluator {
     val evaluatorId: String
 
     /**
+     * Declares which lifecycle event should cause the coordinator to evaluate this modal.
+     *
+     * Defaults to [ModalTrigger.APP_RESUME] so existing evaluators keep their process-foreground
+     * behaviour without any change. Evaluators tied to the New Tab Page (e.g. inline promos) should
+     * override this with [ModalTrigger.NTP_RENDER].
+     */
+    val trigger: ModalTrigger
+        get() = ModalTrigger.APP_RESUME
+
+    /**
      * Evaluates whether this modal should be shown.
      * Called by coordinator only if not blocked by 24-hour window (cooldown period).
      *

--- a/modal-coordinator/modal-coordinator-api/src/main/java/com/duckduckgo/modalcoordinator/api/ModalEvaluator.kt
+++ b/modal-coordinator/modal-coordinator-api/src/main/java/com/duckduckgo/modalcoordinator/api/ModalEvaluator.kt
@@ -34,11 +34,8 @@ interface ModalEvaluator {
     val evaluatorId: String
 
     /**
-     * Declares which lifecycle event should cause the coordinator to evaluate this modal.
-     *
-     * Defaults to [ModalTrigger.APP_RESUME] so existing evaluators keep their process-foreground
-     * behaviour without any change. Evaluators tied to the New Tab Page (e.g. inline promos) should
-     * override this with [ModalTrigger.NTP_RENDER].
+     * Which lifecycle event causes the coordinator to evaluate this modal. Evaluators tied to the
+     * New Tab Page should override with [ModalTrigger.NTP_RENDER].
      */
     val trigger: ModalTrigger
         get() = ModalTrigger.APP_RESUME

--- a/modal-coordinator/modal-coordinator-api/src/main/java/com/duckduckgo/modalcoordinator/api/ModalTrigger.kt
+++ b/modal-coordinator/modal-coordinator-api/src/main/java/com/duckduckgo/modalcoordinator/api/ModalTrigger.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.modalcoordinator.api
+
+/**
+ * Declares which lifecycle event should cause the coordinator to evaluate a [ModalEvaluator].
+ *
+ * A single coordinated evaluation only considers evaluators matching the trigger that started it,
+ * so evaluators opting into different triggers never compete within the same pass.
+ */
+enum class ModalTrigger {
+
+    /**
+     * Evaluated when the app process comes to the foreground (process-level onResume).
+     * This is the default and matches the historical behaviour of every evaluator.
+     */
+    APP_RESUME,
+
+    /**
+     * Evaluated when the New Tab Page is rendered, including mid-session renders (e.g. opening a
+     * fresh tab while the app is already foregrounded) that do not produce an [APP_RESUME].
+     */
+    NTP_RENDER,
+}

--- a/modal-coordinator/modal-coordinator-api/src/main/java/com/duckduckgo/modalcoordinator/api/ModalTrigger.kt
+++ b/modal-coordinator/modal-coordinator-api/src/main/java/com/duckduckgo/modalcoordinator/api/ModalTrigger.kt
@@ -17,22 +17,14 @@
 package com.duckduckgo.modalcoordinator.api
 
 /**
- * Declares which lifecycle event should cause the coordinator to evaluate a [ModalEvaluator].
- *
- * A single coordinated evaluation only considers evaluators matching the trigger that started it,
- * so evaluators opting into different triggers never compete within the same pass.
+ * Which lifecycle event causes the coordinator to evaluate a [ModalEvaluator]. A pass only considers
+ * evaluators matching the trigger that started it, so different triggers never compete.
  */
 enum class ModalTrigger {
 
-    /**
-     * Evaluated when the app process comes to the foreground (process-level onResume).
-     * This is the default and matches the historical behaviour of every evaluator.
-     */
+    /** The app process came to the foreground (process-level onResume). */
     APP_RESUME,
 
-    /**
-     * Evaluated when the New Tab Page is rendered, including mid-session renders (e.g. opening a
-     * fresh tab while the app is already foregrounded) that do not produce an [APP_RESUME].
-     */
+    /** The New Tab Page was rendered, including mid-session renders that produce no [APP_RESUME]. */
     NTP_RENDER,
 }

--- a/modal-coordinator/modal-coordinator-api/src/main/java/com/duckduckgo/modalcoordinator/api/NewTabPageModalTrigger.kt
+++ b/modal-coordinator/modal-coordinator-api/src/main/java/com/duckduckgo/modalcoordinator/api/NewTabPageModalTrigger.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.modalcoordinator.api
+
+/**
+ * Lets New Tab Page hosts notify the coordinator that the NTP has just been rendered, so that
+ * evaluators declaring [ModalTrigger.NTP_RENDER] can be coordinated.
+ *
+ * This is the counterpart to the process-level onResume trigger the coordinator observes itself:
+ * mid-session NTP renders (e.g. opening a fresh tab while foregrounded) do not produce an
+ * [ModalTrigger.APP_RESUME], so hosts must surface them explicitly.
+ */
+interface NewTabPageModalTrigger {
+
+    /**
+     * Notifies the coordinator that the New Tab Page has been rendered. Safe to call on every
+     * render; the coordinator applies its own mutex, cooldown and priority rules.
+     */
+    fun onNewTabPageShown()
+}

--- a/modal-coordinator/modal-coordinator-api/src/main/java/com/duckduckgo/modalcoordinator/api/NewTabPageModalTrigger.kt
+++ b/modal-coordinator/modal-coordinator-api/src/main/java/com/duckduckgo/modalcoordinator/api/NewTabPageModalTrigger.kt
@@ -17,18 +17,11 @@
 package com.duckduckgo.modalcoordinator.api
 
 /**
- * Lets New Tab Page hosts notify the coordinator that the NTP has just been rendered, so that
- * evaluators declaring [ModalTrigger.NTP_RENDER] can be coordinated.
- *
- * This is the counterpart to the process-level onResume trigger the coordinator observes itself:
- * mid-session NTP renders (e.g. opening a fresh tab while foregrounded) do not produce an
- * [ModalTrigger.APP_RESUME], so hosts must surface them explicitly.
+ * Lets New Tab Page hosts report a render, which the coordinator cannot observe itself: mid-session
+ * NTP renders produce no [ModalTrigger.APP_RESUME].
  */
 interface NewTabPageModalTrigger {
 
-    /**
-     * Notifies the coordinator that the New Tab Page has been rendered. Safe to call on every
-     * render; the coordinator applies its own mutex, cooldown and priority rules.
-     */
+    /** Safe to call on every render; the coordinator applies its own mutex, cooldown and priority. */
     fun onNewTabPageShown()
 }

--- a/modal-coordinator/modal-coordinator-impl/src/main/java/com/duckduckgo/modalcoordinator/impl/ModalEvaluatorCoordinator.kt
+++ b/modal-coordinator/modal-coordinator-impl/src/main/java/com/duckduckgo/modalcoordinator/impl/ModalEvaluatorCoordinator.kt
@@ -23,7 +23,10 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.modalcoordinator.api.ModalEvaluator
+import com.duckduckgo.modalcoordinator.api.ModalTrigger
+import com.duckduckgo.modalcoordinator.api.NewTabPageModalTrigger
 import com.duckduckgo.modalcoordinator.impl.store.ModalEvaluatorCompletionStore
+import com.squareup.anvil.annotations.ContributesBinding
 import com.squareup.anvil.annotations.ContributesMultibinding
 import dagger.SingleInstanceIn
 import kotlinx.coroutines.CoroutineScope
@@ -37,8 +40,12 @@ import javax.inject.Inject
  * Coordinates evaluation of modal evaluators with priority ordering and 24-hour blocking.
  *
  * Key behaviors:
+ * - Each coordinated pass is started by a [ModalTrigger] and only considers evaluators declaring
+ *   that trigger (see [ModalEvaluator.trigger]); evaluators on different triggers never compete
+ * - [ModalTrigger.APP_RESUME] passes run on process foreground (onResume)
+ * - [ModalTrigger.NTP_RENDER] passes run when a host reports a New Tab Page render
  * - Evaluators are sorted by priority (lowest number = highest priority)
- * - Only one evaluator runs per lifecycle resume
+ * - Only one evaluator runs per coordinated pass
  * - Evaluators blocked by 24-hour window are skipped entirely (evaluate() not called)
  * - When evaluation completes (with or without action), timestamp is recorded
  */
@@ -46,25 +53,35 @@ import javax.inject.Inject
     scope = AppScope::class,
     boundType = MainProcessLifecycleObserver::class,
 )
+@ContributesBinding(
+    scope = AppScope::class,
+    boundType = NewTabPageModalTrigger::class,
+)
 @SingleInstanceIn(AppScope::class)
 class ModalEvaluatorCoordinator @Inject constructor(
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val modalEvaluatorPluginPoint: PluginPoint<ModalEvaluator>,
     private val completionStore: ModalEvaluatorCompletionStore,
     private val dispatchers: DispatcherProvider,
-) : MainProcessLifecycleObserver {
+) : MainProcessLifecycleObserver, NewTabPageModalTrigger {
 
     private val evaluationMutex = Mutex()
 
     override fun onResume(owner: LifecycleOwner) {
         super.onResume(owner)
         appCoroutineScope.launch(dispatchers.io()) {
-            coordinateEvaluation()
+            coordinateEvaluation(ModalTrigger.APP_RESUME)
         }
     }
 
-    private suspend fun coordinateEvaluation() = evaluationMutex.withLock {
-        logcat { "ModalEvaluatorCoordinator: Starting coordinated evaluation" }
+    override fun onNewTabPageShown() {
+        appCoroutineScope.launch(dispatchers.io()) {
+            coordinateEvaluation(ModalTrigger.NTP_RENDER)
+        }
+    }
+
+    private suspend fun coordinateEvaluation(trigger: ModalTrigger) = evaluationMutex.withLock {
+        logcat { "ModalEvaluatorCoordinator: Starting coordinated evaluation for trigger $trigger" }
 
         // Check 24-hour blocking first
         if (completionStore.isBlockedBy24HourWindow()) {
@@ -72,8 +89,10 @@ class ModalEvaluatorCoordinator @Inject constructor(
             return@withLock
         }
 
-        val evaluators = modalEvaluatorPluginPoint.getPlugins().sortedBy { it.priority }
-        logcat { "ModalEvaluatorCoordinator: Found ${evaluators.size} evaluators" }
+        val evaluators = modalEvaluatorPluginPoint.getPlugins()
+            .filter { it.trigger == trigger }
+            .sortedBy { it.priority }
+        logcat { "ModalEvaluatorCoordinator: Found ${evaluators.size} evaluators for trigger $trigger" }
 
         for (evaluator in evaluators) {
             logcat { "ModalEvaluatorCoordinator: Evaluating '${evaluator.evaluatorId}' (priority ${evaluator.priority})" }
@@ -91,6 +110,6 @@ class ModalEvaluatorCoordinator @Inject constructor(
             }
         }
 
-        logcat { "ModalEvaluatorCoordinator: Coordination complete, no action taken" }
+        logcat { "ModalEvaluatorCoordinator: Coordination complete for trigger $trigger, no action taken" }
     }
 }

--- a/modal-coordinator/modal-coordinator-impl/src/main/java/com/duckduckgo/modalcoordinator/impl/ModalEvaluatorCoordinator.kt
+++ b/modal-coordinator/modal-coordinator-impl/src/main/java/com/duckduckgo/modalcoordinator/impl/ModalEvaluatorCoordinator.kt
@@ -40,10 +40,7 @@ import javax.inject.Inject
  * Coordinates evaluation of modal evaluators with priority ordering and 24-hour blocking.
  *
  * Key behaviors:
- * - Each coordinated pass is started by a [ModalTrigger] and only considers evaluators declaring
- *   that trigger (see [ModalEvaluator.trigger]); evaluators on different triggers never compete
- * - [ModalTrigger.APP_RESUME] passes run on process foreground (onResume)
- * - [ModalTrigger.NTP_RENDER] passes run when a host reports a New Tab Page render
+ * - A pass only considers evaluators declaring the [ModalTrigger] that started it
  * - Evaluators are sorted by priority (lowest number = highest priority)
  * - Only one evaluator runs per coordinated pass
  * - Evaluators blocked by 24-hour window are skipped entirely (evaluate() not called)

--- a/modal-coordinator/modal-coordinator-impl/src/test/java/com/duckduckgo/modalcoordinator/impl/ModalEvaluatorCoordinatorTest.kt
+++ b/modal-coordinator/modal-coordinator-impl/src/test/java/com/duckduckgo/modalcoordinator/impl/ModalEvaluatorCoordinatorTest.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.LifecycleOwner
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.common.utils.plugins.PluginPoint
 import com.duckduckgo.modalcoordinator.api.ModalEvaluator
+import com.duckduckgo.modalcoordinator.api.ModalTrigger
 import com.duckduckgo.modalcoordinator.impl.store.ModalEvaluatorCompletionStore
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -171,14 +172,57 @@ class ModalEvaluatorCoordinatorTest {
         verify(mockCompletionStore).recordCompletion()
     }
 
+    @Test
+    fun whenOnResumeThenOnlyAppResumeEvaluatorsAreCalled() = runTest {
+        whenever(mockCompletionStore.isBlockedBy24HourWindow()).thenReturn(false)
+        val appResumeEvaluator = createMockEvaluator("resume", 1, ModalEvaluator.EvaluationResult.Skipped, ModalTrigger.APP_RESUME)
+        val ntpEvaluator = createMockEvaluator("ntp", 2, ModalEvaluator.EvaluationResult.Skipped, ModalTrigger.NTP_RENDER)
+        whenever(mockPluginPoint.getPlugins()).thenReturn(listOf(appResumeEvaluator, ntpEvaluator))
+
+        testee.onResume(mockLifecycleOwner)
+        coroutinesTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(appResumeEvaluator).evaluate()
+        verify(ntpEvaluator, never()).evaluate()
+    }
+
+    @Test
+    fun whenNewTabPageShownThenOnlyNtpRenderEvaluatorsAreCalled() = runTest {
+        whenever(mockCompletionStore.isBlockedBy24HourWindow()).thenReturn(false)
+        val appResumeEvaluator = createMockEvaluator("resume", 1, ModalEvaluator.EvaluationResult.Skipped, ModalTrigger.APP_RESUME)
+        val ntpEvaluator = createMockEvaluator("ntp", 2, ModalEvaluator.EvaluationResult.Skipped, ModalTrigger.NTP_RENDER)
+        whenever(mockPluginPoint.getPlugins()).thenReturn(listOf(appResumeEvaluator, ntpEvaluator))
+
+        testee.onNewTabPageShown()
+        coroutinesTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(ntpEvaluator).evaluate()
+        verify(appResumeEvaluator, never()).evaluate()
+    }
+
+    @Test
+    fun whenNewTabPageShownAndBlockedBy24HourWindowThenNoEvaluatorsAreCalled() = runTest {
+        whenever(mockCompletionStore.isBlockedBy24HourWindow()).thenReturn(true)
+        val ntpEvaluator = createMockEvaluator("ntp", 1, ModalEvaluator.EvaluationResult.ModalShown, ModalTrigger.NTP_RENDER)
+        whenever(mockPluginPoint.getPlugins()).thenReturn(listOf(ntpEvaluator))
+
+        testee.onNewTabPageShown()
+        coroutinesTestRule.testScope.testScheduler.advanceUntilIdle()
+
+        verify(ntpEvaluator, never()).evaluate()
+        verify(mockCompletionStore, never()).recordCompletion()
+    }
+
     private suspend fun createMockEvaluator(
         id: String,
         priority: Int,
         result: ModalEvaluator.EvaluationResult = ModalEvaluator.EvaluationResult.Skipped,
+        trigger: ModalTrigger = ModalTrigger.APP_RESUME,
     ): ModalEvaluator {
         return mock<ModalEvaluator>().apply {
             whenever(this.evaluatorId).thenReturn(id)
             whenever(this.priority).thenReturn(priority)
+            whenever(this.trigger).thenReturn(trigger)
             whenever(this.evaluate()).thenReturn(result)
         }
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212608036467427/task/1216784009478502?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/481882893211075/task/1216385362902812
API Proposals: https://app.asana.com/1/137249556945/project/1212087397361015/task/1216899714454492

### Description
Collapse the New Tab Page's app-originated prompt systems from four to two by absorbing the Privacy Pro foreground promo and the Add Widget promo into the modal coordinator, so they now share its priority ordering and 24-hour cooldown instead of racing each other.

- ModalEvaluator gains a declared ModalTrigger (APP_RESUME default so the existing four evaluators are unchanged; NTP_RENDER is new).
- Coordinator filters evaluators by trigger: process onResume drives APP_RESUME; the new NewTabPageModalTrigger.onNewTabPageShown() drives NTP_RENDER.
- Privacy Pro (APP_RESUME) and Add Widget (NTP_RENDER) become ModalEvaluators that render via NewTabPageModalPresenter, which the visible tab's BrowserTabViewModel implements and registers while visible, reusing the existing CTA bottom-sheet path (pixels and dismiss handling unchanged).
- Eligibility for the Privacy Pro promo is extracted into a shared SubscriptionPromoModalDecider; the old checkSubscriptionPromoOnForeground path and the Add Widget branch of getHomeCta are removed, closing the double-prompt window.


### Steps to test this PR
To test Add Widget prompt
- Clean install of the app => go through onboarding => Add widget prompt should show at the end of onboarding.
- - same as above, then dismiss the prompt => prompt should not show again.
- Clean install of the app => skip onboarding => Add widget prompt should NOT show at the end of onboarding.

To test Subscription promo:
- you need to make a local change to override the eligibility SubscriptionPromoModalDecider.decide() to 

```
override suspend fun decide(): SubscriptionPromoModalDecision? = withContext(dispatchers.io()) {
       return@withContext SubscriptionPromoModalDecision(SubscriptionPromoFlow.NUDGE, isFreeTrialCopy = false) // DEV: force eligibility
```

Then relaunch the app:
- on app resume on NTP or while browsing => should show the prompt.
- on app resume on Duck.ai => should not show the prompt.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and how high-visibility subscription and widget promos appear, including mid-session NTP opens and app resume; regressions could mean missed promos, double prompts, or promos on wrong surfaces (e.g. Duck.ai).
> 
> **Overview**
> Moves **Privacy Pro** and **Add Widget** promos off ad-hoc CTA/foreground paths into the shared modal coordinator so they participate in the same **priority ordering** and **24-hour cooldown** as other modals.
> 
> The coordinator now supports **`ModalTrigger`** (`APP_RESUME` vs **`NTP_RENDER`**). **`NewTabPageModalTrigger.onNewTabPageShown()`** kicks off NTP-only evaluators when the new tab page is visible without a competing CTA. **`BrowserTabViewModel`** registers as **`NewTabPageModalPresenter`** to show bottom sheets via the existing CTA UI; **`SubscriptionPromoModalDecider`** centralizes Privacy Pro eligibility. Removed: **`checkSubscriptionPromoOnForeground`**, **`ctaChangedTicker`**, Add Widget from **`getHomeCta`**, and **`getPromoCtaOnForeground`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2618b162f04e2ddbf476c1586f62fd17427ab68a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->