### PR TITLE
Android/Contextual/NativeInput: Request for translations

### DIFF
--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1004,7 +1004,7 @@
 
     <!-- Pre-onboarding: add to home screen -->
     <string name="preOnboardingAddToDockTitle">Добавьте меня в нижнюю часть экрана.</string>
-    <string name="preOnboardingAddToDockBody">Найдите значок DuckDuckGo на главном экране и перетащите его в нужное место. Готово!</string>
+    <string name="preOnboardingAddToDockBody">Найдите значок DuckDuckGo на главном экране. Затем нажмите и перетащите виджет на нужное место. Готово!</string>
     <string name="preOnboardingAddToDockPrimaryCta">Понятно</string>
 
     <!-- In-context onboarding. -->

--- a/duckchat/duckchat-impl/src/main/res/values-bg/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-bg/strings-duckchat.xml
@@ -263,4 +263,8 @@
 
     <!-- Settings -->
     <string name="duckAiSettingsTitle">Настройки на Duck.ai</string>
+
+    <!-- File/image attachment menu options -->
+    <string name="duckChatContextualAskAboutTab">Попитайте за раздела</string>
+    <string name="duckChatContextualAskAboutPage">Попитайте за страницата</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-cs/strings-duckchat.xml
@@ -265,4 +265,8 @@
 
     <!-- Settings -->
     <string name="duckAiSettingsTitle">Nastavení Duck.ai</string>
+
+    <!-- File/image attachment menu options -->
+    <string name="duckChatContextualAskAboutTab">Zeptat se ohledně karty</string>
+    <string name="duckChatContextualAskAboutPage">Zeptat se ohledně stránky</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-da/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-da/strings-duckchat.xml
@@ -263,4 +263,8 @@
 
     <!-- Settings -->
     <string name="duckAiSettingsTitle">Duck.ai-indstillinger</string>
+
+    <!-- File/image attachment menu options -->
+    <string name="duckChatContextualAskAboutTab">Spørg om fanen</string>
+    <string name="duckChatContextualAskAboutPage">Spørg om siden</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-de/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-de/strings-duckchat.xml
@@ -263,4 +263,8 @@
 
     <!-- Settings -->
     <string name="duckAiSettingsTitle">Duck.ai-Einstellungen</string>
+
+    <!-- File/image attachment menu options -->
+    <string name="duckChatContextualAskAboutTab">Frage zum Tab</string>
+    <string name="duckChatContextualAskAboutPage">Frage zur Seite</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-el/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-el/strings-duckchat.xml
@@ -263,4 +263,8 @@
 
     <!-- Settings -->
     <string name="duckAiSettingsTitle">Ρυθμίσεις Duck.ai</string>
+
+    <!-- File/image attachment menu options -->
+    <string name="duckChatContextualAskAboutTab">Ρώτα για την καρτέλα</string>
+    <string name="duckChatContextualAskAboutPage">Ρώτα για τη σελίδα</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-es/strings-duckchat.xml
@@ -263,4 +263,8 @@
 
     <!-- Settings -->
     <string name="duckAiSettingsTitle">Configuración de Duck.ai</string>
+
+    <!-- File/image attachment menu options -->
+    <string name="duckChatContextualAskAboutTab">Preguntar sobre la pestaña</string>
+    <string name="duckChatContextualAskAboutPage">Preguntar sobre la página</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-et/strings-duckchat.xml
@@ -263,4 +263,8 @@
 
     <!-- Settings -->
     <string name="duckAiSettingsTitle">Duck.ai seaded</string>
+
+    <!-- File/image attachment menu options -->
+    <string name="duckChatContextualAskAboutTab">Küsi vahekaardi kohta</string>
+    <string name="duckChatContextualAskAboutPage">Küsi lehe kohta</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-fi/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fi/strings-duckchat.xml
@@ -263,4 +263,8 @@
 
     <!-- Settings -->
     <string name="duckAiSettingsTitle">Duck.ai-asetukset</string>
+
+    <!-- File/image attachment menu options -->
+    <string name="duckChatContextualAskAboutTab">Kysy välilehdestä</string>
+    <string name="duckChatContextualAskAboutPage">Kysy sivusta</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
@@ -265,6 +265,6 @@
     <string name="duckAiSettingsTitle">Paramètres Duck.ai</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Poser des questions sur l\'onglet</string>
-    <string name="duckChatContextualAskAboutPage">Poser des questions sur la page</string>
+    <string name="duckChatContextualAskAboutTab">Posez des questions sur l\'onglet</string>
+    <string name="duckChatContextualAskAboutPage">Posez des questions sur la page</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-fr/strings-duckchat.xml
@@ -263,4 +263,8 @@
 
     <!-- Settings -->
     <string name="duckAiSettingsTitle">Paramètres Duck.ai</string>
+
+    <!-- File/image attachment menu options -->
+    <string name="duckChatContextualAskAboutTab">Poser des questions sur l\'onglet</string>
+    <string name="duckChatContextualAskAboutPage">Poser des questions sur la page</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-hr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hr/strings-duckchat.xml
@@ -265,4 +265,8 @@
 
     <!-- Settings -->
     <string name="duckAiSettingsTitle">Postavke usluge Duck.ai</string>
+
+    <!-- File/image attachment menu options -->
+    <string name="duckChatContextualAskAboutTab">Pitaj o kartici</string>
+    <string name="duckChatContextualAskAboutPage">Pitaj o stranici</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-hu/strings-duckchat.xml
@@ -263,4 +263,8 @@
 
     <!-- Settings -->
     <string name="duckAiSettingsTitle">Duck.ai-beállítások</string>
+
+    <!-- File/image attachment menu options -->
+    <string name="duckChatContextualAskAboutTab">Kérdés a lapról</string>
+    <string name="duckChatContextualAskAboutPage">Kérdés az oldalról</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
@@ -263,4 +263,8 @@
 
     <!-- Settings -->
     <string name="duckAiSettingsTitle">Impostazioni di Duck.ai</string>
+
+    <!-- File/image attachment menu options -->
+    <string name="duckChatContextualAskAboutTab">Chiedi informazioni sulla scheda</string>
+    <string name="duckChatContextualAskAboutPage">Chiedi informazioni sulla pagina</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-it/strings-duckchat.xml
@@ -266,5 +266,5 @@
 
     <!-- File/image attachment menu options -->
     <string name="duckChatContextualAskAboutTab">Chiedi informazioni sulla scheda</string>
-    <string name="duckChatContextualAskAboutPage">Chiedi informazioni sulla pagina</string>
+    <string name="duckChatContextualAskAboutPage">Richiedi informazioni sulla pagina</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
@@ -265,4 +265,8 @@
 
     <!-- Settings -->
     <string name="duckAiSettingsTitle">„Duck.ai“ nuostatos</string>
+
+    <!-- File/image attachment menu options -->
+    <string name="duckChatContextualAskAboutTab">Klausti apie kortelę</string>
+    <string name="duckChatContextualAskAboutPage">Klausti apie puslapį</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lt/strings-duckchat.xml
@@ -268,5 +268,5 @@
 
     <!-- File/image attachment menu options -->
     <string name="duckChatContextualAskAboutTab">Klausti apie kortelę</string>
-    <string name="duckChatContextualAskAboutPage">Klausti apie puslapį</string>
+    <string name="duckChatContextualAskAboutPage">Klausk apie puslapį</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-lv/strings-duckchat.xml
@@ -264,4 +264,8 @@
 
     <!-- Settings -->
     <string name="duckAiSettingsTitle">Duck.ai iestatījumi</string>
+
+    <!-- File/image attachment menu options -->
+    <string name="duckChatContextualAskAboutTab">Jautā par cilni</string>
+    <string name="duckChatContextualAskAboutPage">Jautā par lapu</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nb/strings-duckchat.xml
@@ -263,4 +263,8 @@
 
     <!-- Settings -->
     <string name="duckAiSettingsTitle">Innstillinger for Duck.ai</string>
+
+    <!-- File/image attachment menu options -->
+    <string name="duckChatContextualAskAboutTab">Spør om fanen</string>
+    <string name="duckChatContextualAskAboutPage">Spør om siden</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-nl/strings-duckchat.xml
@@ -263,4 +263,8 @@
 
     <!-- Settings -->
     <string name="duckAiSettingsTitle">Instellingen Duck.ai</string>
+
+    <!-- File/image attachment menu options -->
+    <string name="duckChatContextualAskAboutTab">Stel een vraag over het tabblad</string>
+    <string name="duckChatContextualAskAboutPage">Stel een vraag over de pagina</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-pl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pl/strings-duckchat.xml
@@ -265,4 +265,8 @@
 
     <!-- Settings -->
     <string name="duckAiSettingsTitle">Ustawienia Duck.ai</string>
+
+    <!-- File/image attachment menu options -->
+    <string name="duckChatContextualAskAboutTab">Zapytaj o kartę</string>
+    <string name="duckChatContextualAskAboutPage">Zapytaj o stronę</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-pt/strings-duckchat.xml
@@ -263,4 +263,8 @@
 
     <!-- Settings -->
     <string name="duckAiSettingsTitle">Definições do Duck.ai</string>
+
+    <!-- File/image attachment menu options -->
+    <string name="duckChatContextualAskAboutTab">Perguntar sobre o separador</string>
+    <string name="duckChatContextualAskAboutPage">Perguntar sobre a página</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-ro/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ro/strings-duckchat.xml
@@ -264,4 +264,8 @@
 
     <!-- Settings -->
     <string name="duckAiSettingsTitle">Setări Duck.ai</string>
+
+    <!-- File/image attachment menu options -->
+    <string name="duckChatContextualAskAboutTab">Întreabă despre filă</string>
+    <string name="duckChatContextualAskAboutPage">Întreabă despre pagină</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
@@ -265,4 +265,8 @@
 
     <!-- Settings -->
     <string name="duckAiSettingsTitle">Настройки Duck.ai</string>
+
+    <!-- File/image attachment menu options -->
+    <string name="duckChatContextualAskAboutTab">Задайте вопрос о вкладке</string>
+    <string name="duckChatContextualAskAboutPage">Задайте вопрос о странице</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-ru/strings-duckchat.xml
@@ -267,6 +267,6 @@
     <string name="duckAiSettingsTitle">Настройки Duck.ai</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Задайте вопрос о вкладке</string>
-    <string name="duckChatContextualAskAboutPage">Задайте вопрос о странице</string>
+    <string name="duckChatContextualAskAboutTab">Задать вопрос о вкладке</string>
+    <string name="duckChatContextualAskAboutPage">Задать вопрос о странице</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sk/strings-duckchat.xml
@@ -265,4 +265,8 @@
 
     <!-- Settings -->
     <string name="duckAiSettingsTitle">Nastavenia Duck.ai</string>
+
+    <!-- File/image attachment menu options -->
+    <string name="duckChatContextualAskAboutTab">Opýtaj sa na kartu</string>
+    <string name="duckChatContextualAskAboutPage">Opýtaj sa na stránku</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sl/strings-duckchat.xml
@@ -265,4 +265,8 @@
 
     <!-- Settings -->
     <string name="duckAiSettingsTitle">Nastavitve Duck.ai</string>
+
+    <!-- File/image attachment menu options -->
+    <string name="duckChatContextualAskAboutTab">Vprašajte o zavihku</string>
+    <string name="duckChatContextualAskAboutPage">Vprašajte o strani</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-sv/strings-duckchat.xml
@@ -263,4 +263,8 @@
 
     <!-- Settings -->
     <string name="duckAiSettingsTitle">Duck.ai-inställningar</string>
+
+    <!-- File/image attachment menu options -->
+    <string name="duckChatContextualAskAboutTab">Fråga om fliken</string>
+    <string name="duckChatContextualAskAboutPage">Fråga om sidan</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
@@ -263,4 +263,8 @@
 
     <!-- Settings -->
     <string name="duckAiSettingsTitle">Duck.ai Ayarları</string>
+
+    <!-- File/image attachment menu options -->
+    <string name="duckChatContextualAskAboutTab">Sekme hakkında soru sor</string>
+    <string name="duckChatContextualAskAboutPage">Sayfa hakkında soru sor</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values-tr/strings-duckchat.xml
@@ -265,6 +265,6 @@
     <string name="duckAiSettingsTitle">Duck.ai Ayarları</string>
 
     <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Sekme hakkında soru sor</string>
-    <string name="duckChatContextualAskAboutPage">Sayfa hakkında soru sor</string>
+    <string name="duckChatContextualAskAboutTab">Sekme Hakkında Soru Sor</string>
+    <string name="duckChatContextualAskAboutPage">Sayfa Hakkında Soru Sor</string>
 </resources>

--- a/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/donottranslate.xml
@@ -24,10 +24,6 @@
     <string name="subscriptionOnboardingDuckAiText">Duck.ai onboarding step</string>
     <string name="subscriptionOnboardingDuckAiNext">Next</string>
 
-    <!-- File/image attachment menu options -->
-    <string name="duckChatContextualAskAboutTab">Ask About Tab</string>
-    <string name="duckChatContextualAskAboutPage">Ask About Page</string>
-
     <!-- Page context attachment -->
     <string name="duckChatPageContextRemoveContentDescription">Remove page context</string>
 

--- a/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
+++ b/duckchat/duckchat-impl/src/main/res/values/strings-duckchat.xml
@@ -262,4 +262,8 @@
 
     <!-- Settings -->
     <string name="duckAiSettingsTitle">Duck.ai Settings</string>
+
+    <!-- File/image attachment menu options -->
+    <string name="duckChatContextualAskAboutTab">Ask About Tab</string>
+    <string name="duckChatContextualAskAboutPage">Ask About Page</string>
 </resources>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1216799974582901?focus=true
Tech Design URL (if applicable): 

### Description
Request for translations for new contextual native input changes

### Steps to test this PR
QA-optional


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only localization with no application logic changes; low risk aside from possible copy or translation quality issues.
> 
> **Overview**
> Adds **localized strings** for the contextual native Duck.ai input attachment menu: **`duckChatContextualAskAboutTab`** and **`duckChatContextualAskAboutPage`** (labels for asking about the current tab vs. the attached page context).
> 
> Those keys are **moved out of** `donottranslate.xml` into the default `strings-duckchat.xml` and **translated** across duckchat locale resource files. A separate **Russian** tweak updates **`preOnboardingAddToDockBody`** to mention tapping and dragging the widget, not just the icon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2d60b88087878400d5aa2d245a176af4b7d88a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->