### PR TITLE
Contextual/NativeInput: Add support for voice controls

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
@@ -36,6 +36,7 @@ import com.google.android.material.card.MaterialCardView
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.json.JSONArray
@@ -290,7 +291,12 @@ class RealContextualNativeInputManager @Inject constructor(
         widget: NativeInputModeWidget,
         lifecycleOwner: LifecycleOwner,
     ) {
-        voiceSearchAvailability.observeVoiceSearchAvailability()
+        combine(
+            voiceSearchAvailability.observeVoiceSearchAvailability(),
+            duckAiFeatureState.showVoiceSearchToggle,
+        ) { deviceAvailable, duckAiEntryEnabled ->
+            deviceAvailable && duckAiEntryEnabled
+        }
             .onEach { widget.setVoiceSearchAvailable(it) }
             .launchIn(lifecycleOwner.lifecycleScope)
     }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
@@ -23,6 +23,7 @@ import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.common.ui.view.gone
 import com.duckduckgo.common.ui.view.show
 import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
 import com.duckduckgo.duckchat.impl.DuckChatInternal
@@ -71,6 +72,7 @@ interface ContextualNativeInputManager {
         onAskAboutTab: () -> Unit = {},
         onAskAboutPage: () -> Unit = {},
         onPageContextRemoved: () -> Unit = {},
+        onVoiceChatRequested: () -> Unit = {},
     )
 
     fun onWebViewMode()
@@ -97,6 +99,7 @@ interface ContextualNativeInputManager {
 class RealContextualNativeInputManager @Inject constructor(
     private val duckChatInternal: DuckChatInternal,
     private val nativeInputStatePublisher: NativeInputStatePublisher,
+    private val duckAiFeatureState: DuckAiFeatureState,
 ) : ContextualNativeInputManager {
 
     private var isNativeInputEnabled = false
@@ -123,6 +126,7 @@ class RealContextualNativeInputManager @Inject constructor(
         onAskAboutTab: () -> Unit,
         onAskAboutPage: () -> Unit,
         onPageContextRemoved: () -> Unit,
+        onVoiceChatRequested: () -> Unit,
     ) {
         this.card = card
         this.jsMessaging = jsMessaging
@@ -133,8 +137,10 @@ class RealContextualNativeInputManager @Inject constructor(
             tabId, widget, chatIdFlow, onSearchSubmitted,
             onCameraCaptureRequested, onFilePickerRequested,
             onPromptSubmitted, onAskAboutTab, onAskAboutPage, onPageContextRemoved,
+            onVoiceChatRequested,
         )
         observeNativeInputSetting(lifecycleOwner)
+        observeVoiceChatEntry(widget, lifecycleOwner)
     }
 
     override fun onContextualClosed(tabId: String) {
@@ -206,12 +212,14 @@ class RealContextualNativeInputManager @Inject constructor(
         onAskAboutTab: () -> Unit,
         onAskAboutPage: () -> Unit,
         onPageContextRemoved: () -> Unit,
+        onVoiceChatRequested: () -> Unit,
     ) {
         widget.configureContextual(tabId)
         widget.bindChatIdSource(chatIdFlow)
         widget.bindModelPickerEnabledSource(modelPickerEnabled)
         widget.hideMainButtons()
         widget.onStopTapped = ::sendStopEvent
+        widget.onVoiceChatClick = onVoiceChatRequested
         widget.bindAttachmentCallbacks(
             onCameraCaptureRequested = onCameraCaptureRequested,
             onFilePickerRequested = onFilePickerRequested,
@@ -259,6 +267,15 @@ class RealContextualNativeInputManager @Inject constructor(
                     null -> {}
                 }
             }
+            .launchIn(lifecycleOwner.lifecycleScope)
+    }
+
+    private fun observeVoiceChatEntry(
+        widget: NativeInputModeWidget,
+        lifecycleOwner: LifecycleOwner,
+    ) {
+        duckAiFeatureState.showVoiceChatEntry
+            .onEach { widget.setVoiceChatAvailable(it) }
             .launchIn(lifecycleOwner.lifecycleScope)
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/ContextualNativeInputManager.kt
@@ -31,6 +31,7 @@ import com.duckduckgo.duckchat.impl.helper.RealDuckChatJSHelper
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.NativeInputModeWidget
 import com.duckduckgo.js.messaging.api.JsMessaging
 import com.duckduckgo.js.messaging.api.SubscriptionEventData
+import com.duckduckgo.voice.api.VoiceSearchAvailability
 import com.google.android.material.card.MaterialCardView
 import com.squareup.anvil.annotations.ContributesBinding
 import kotlinx.coroutines.flow.Flow
@@ -73,6 +74,7 @@ interface ContextualNativeInputManager {
         onAskAboutPage: () -> Unit = {},
         onPageContextRemoved: () -> Unit = {},
         onVoiceChatRequested: () -> Unit = {},
+        onVoiceSearchRequested: () -> Unit = {},
     )
 
     fun onWebViewMode()
@@ -100,6 +102,7 @@ class RealContextualNativeInputManager @Inject constructor(
     private val duckChatInternal: DuckChatInternal,
     private val nativeInputStatePublisher: NativeInputStatePublisher,
     private val duckAiFeatureState: DuckAiFeatureState,
+    private val voiceSearchAvailability: VoiceSearchAvailability,
 ) : ContextualNativeInputManager {
 
     private var isNativeInputEnabled = false
@@ -127,6 +130,7 @@ class RealContextualNativeInputManager @Inject constructor(
         onAskAboutPage: () -> Unit,
         onPageContextRemoved: () -> Unit,
         onVoiceChatRequested: () -> Unit,
+        onVoiceSearchRequested: () -> Unit,
     ) {
         this.card = card
         this.jsMessaging = jsMessaging
@@ -137,10 +141,11 @@ class RealContextualNativeInputManager @Inject constructor(
             tabId, widget, chatIdFlow, onSearchSubmitted,
             onCameraCaptureRequested, onFilePickerRequested,
             onPromptSubmitted, onAskAboutTab, onAskAboutPage, onPageContextRemoved,
-            onVoiceChatRequested,
+            onVoiceChatRequested, onVoiceSearchRequested,
         )
         observeNativeInputSetting(lifecycleOwner)
         observeVoiceChatEntry(widget, lifecycleOwner)
+        observeVoiceSearchEntry(widget, lifecycleOwner)
     }
 
     override fun onContextualClosed(tabId: String) {
@@ -213,6 +218,7 @@ class RealContextualNativeInputManager @Inject constructor(
         onAskAboutPage: () -> Unit,
         onPageContextRemoved: () -> Unit,
         onVoiceChatRequested: () -> Unit,
+        onVoiceSearchRequested: () -> Unit,
     ) {
         widget.configureContextual(tabId)
         widget.bindChatIdSource(chatIdFlow)
@@ -220,6 +226,7 @@ class RealContextualNativeInputManager @Inject constructor(
         widget.hideMainButtons()
         widget.onStopTapped = ::sendStopEvent
         widget.onVoiceChatClick = onVoiceChatRequested
+        widget.onVoiceSearchClick = onVoiceSearchRequested
         widget.bindAttachmentCallbacks(
             onCameraCaptureRequested = onCameraCaptureRequested,
             onFilePickerRequested = onFilePickerRequested,
@@ -276,6 +283,15 @@ class RealContextualNativeInputManager @Inject constructor(
     ) {
         duckAiFeatureState.showVoiceChatEntry
             .onEach { widget.setVoiceChatAvailable(it) }
+            .launchIn(lifecycleOwner.lifecycleScope)
+    }
+
+    private fun observeVoiceSearchEntry(
+        widget: NativeInputModeWidget,
+        lifecycleOwner: LifecycleOwner,
+    ) {
+        voiceSearchAvailability.observeVoiceSearchAvailability()
+            .onEach { widget.setVoiceSearchAvailable(it) }
             .launchIn(lifecycleOwner.lifecycleScope)
     }
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -104,6 +104,9 @@ import com.duckduckgo.js.messaging.api.SubscriptionEventData
 import com.duckduckgo.navigation.api.GlobalActivityStarter
 import com.duckduckgo.subscriptions.api.SUBSCRIPTIONS_FEATURE_NAME
 import com.duckduckgo.subscriptions.api.SubscriptionsJSHelper
+import com.duckduckgo.voice.api.VoiceSearchLauncher
+import com.duckduckgo.voice.api.VoiceSearchLauncher.Source.BROWSER
+import com.duckduckgo.voice.api.VoiceSearchLauncher.VoiceSearchMode
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
@@ -198,6 +201,9 @@ class DuckChatContextualFragment :
     lateinit var contextualNativeInputManager: ContextualNativeInputManager
 
     @Inject
+    lateinit var voiceSearchLauncher: VoiceSearchLauncher
+
+    @Inject
     lateinit var webViewModeInitializer: WebViewModeInitializer
 
     @Inject
@@ -267,6 +273,25 @@ class DuckChatContextualFragment :
 
     private var lastWebViewX = 0f
     private var lastWebViewY = 0f
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        voiceSearchLauncher.registerResultsCallback(this, requireActivity(), BROWSER) { event ->
+            if (event is VoiceSearchLauncher.Event.VoiceRecognitionSuccess) {
+                when (val result = event.result) {
+                    is VoiceSearchLauncher.VoiceRecognitionResult.SearchResult -> {
+                        viewModel.onContextualClose()
+                        startActivity(browserNav.openInNewTab(requireContext(), result.query))
+                    }
+
+                    is VoiceSearchLauncher.VoiceRecognitionResult.DuckAiResult -> {
+                        viewModel.onContextualClose()
+                        duckChat.openDuckChatWithAutoPrompt(result.query)
+                    }
+                }
+            }
+        }
+    }
 
     @SuppressLint("SetJavaScriptEnabled")
     override fun onViewCreated(
@@ -495,6 +520,10 @@ class DuckChatContextualFragment :
             onVoiceChatRequested = {
                 viewModel.onContextualClose()
                 duckChat.openVoiceDuckChat()
+            },
+            onVoiceSearchRequested = {
+                activity?.hideKeyboard()
+                voiceSearchLauncher.launch(requireActivity(), VoiceSearchMode.DUCK_AI)
             },
         )
         observeViewModel()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -278,17 +278,11 @@ class DuckChatContextualFragment :
         super.onCreate(savedInstanceState)
         voiceSearchLauncher.registerResultsCallback(this, requireActivity(), BROWSER) { event ->
             if (event is VoiceSearchLauncher.Event.VoiceRecognitionSuccess) {
-                when (val result = event.result) {
-                    is VoiceSearchLauncher.VoiceRecognitionResult.SearchResult -> {
-                        viewModel.onContextualClose()
-                        startActivity(browserNav.openInNewTab(requireContext(), result.query))
-                    }
-
-                    is VoiceSearchLauncher.VoiceRecognitionResult.DuckAiResult -> {
-                        viewModel.onContextualClose()
-                        duckChat.openDuckChatWithAutoPrompt(result.query)
-                    }
-                }
+                val result = event.result
+                viewModel.onVoiceRecognitionSuccess(
+                    query = result.query,
+                    isDuckAiResult = result is VoiceSearchLauncher.VoiceRecognitionResult.DuckAiResult,
+                )
             }
         }
     }
@@ -707,6 +701,16 @@ class DuckChatContextualFragment :
                     is DuckChatContextualViewModel.Command.LaunchChatHistory -> {
                         viewModel.onContextualClose()
                         globalActivityStarter.start(requireContext(), DuckChatHistoryNoParams)
+                    }
+
+                    is DuckChatContextualViewModel.Command.OpenSearchInNewTab -> {
+                        viewModel.onContextualClose()
+                        startActivity(browserNav.openInNewTab(requireContext(), command.query))
+                    }
+
+                    is DuckChatContextualViewModel.Command.OpenDuckAiWithPrompt -> {
+                        viewModel.onContextualClose()
+                        duckChat.openDuckChatWithAutoPrompt(command.query)
                     }
 
                     is DuckChatContextualViewModel.Command.FocusInput -> {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -492,6 +492,10 @@ class DuckChatContextualFragment :
             onAskAboutTab = { viewModel.onAskAboutTabClicked() },
             onAskAboutPage = { viewModel.onAskAboutPageClicked() },
             onPageContextRemoved = { viewModel.removePageContext() },
+            onVoiceChatRequested = {
+                viewModel.onContextualClose()
+                duckChat.openVoiceDuckChat()
+            },
         )
         observeViewModel()
 

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModel.kt
@@ -159,6 +159,8 @@ class DuckChatContextualViewModel @Inject constructor(
         ) : Command()
         data object LaunchChatHistory : Command()
         data object FocusInput : Command()
+        data class OpenSearchInNewTab(val query: String) : Command()
+        data class OpenDuckAiWithPrompt(val query: String) : Command()
     }
 
     private val _viewState: MutableStateFlow<ViewState> =
@@ -430,6 +432,24 @@ class DuckChatContextualViewModel @Inject constructor(
                     ),
                 )
             }
+        }
+    }
+
+    fun onVoiceRecognitionSuccess(
+        query: String,
+        isDuckAiResult: Boolean,
+    ) {
+        if (query.isBlank()) return
+        when {
+            !isDuckAiResult -> emitCommand(Command.OpenSearchInNewTab(query))
+            _viewState.value.sheetMode == SheetMode.WEBVIEW -> onPromptSent(query)
+            else -> emitCommand(Command.OpenDuckAiWithPrompt(query))
+        }
+    }
+
+    private fun emitCommand(command: Command) {
+        viewModelScope.launch(dispatchers.main()) {
+            commandChannel.trySend(command)
         }
     }
 

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualViewModelTest.kt
@@ -1144,6 +1144,76 @@ class DuckChatContextualViewModelTest {
     }
 
     @Test
+    fun `when voice search result received in input state then search opens in a new tab`() = runTest {
+        val testee = buildViewModel()
+
+        testee.commands.test {
+            testee.onVoiceRecognitionSuccess(query = "cats", isDuckAiResult = false)
+            val command = expectMostRecentItem()
+            assertTrue(command is DuckChatContextualViewModel.Command.OpenSearchInNewTab)
+            assertEquals("cats", (command as DuckChatContextualViewModel.Command.OpenSearchInNewTab).query)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when voice search result received while chat is running then search still opens in a new tab`() = runTest {
+        val testee = buildViewModel()
+        testee.onPromptSent(prompt = "first") // INPUT -> WEBVIEW
+        coroutineRule.testDispatcher.scheduler.advanceUntilIdle()
+
+        testee.commands.test {
+            testee.onVoiceRecognitionSuccess(query = "cats", isDuckAiResult = false)
+            val command = expectMostRecentItem()
+            assertTrue(command is DuckChatContextualViewModel.Command.OpenSearchInNewTab)
+            assertEquals("cats", (command as DuckChatContextualViewModel.Command.OpenSearchInNewTab).query)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when voice duck ai result received in input state then duck ai opens with prompt`() = runTest {
+        val testee = buildViewModel()
+
+        testee.commands.test {
+            testee.onVoiceRecognitionSuccess(query = "why is the sky blue", isDuckAiResult = true)
+            val command = expectMostRecentItem()
+            assertTrue(command is DuckChatContextualViewModel.Command.OpenDuckAiWithPrompt)
+            assertEquals("why is the sky blue", (command as DuckChatContextualViewModel.Command.OpenDuckAiWithPrompt).query)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when voice duck ai result received while chat is running then it is submitted to the current chat`() = runTest {
+        val testee = buildViewModel()
+
+        testee.subscriptionEventDataFlow.test {
+            testee.onPromptSent(prompt = "first") // INPUT -> WEBVIEW
+            awaitItem() // consume the initial prompt event
+
+            testee.onVoiceRecognitionSuccess(query = "follow up question", isDuckAiResult = true)
+
+            val event = awaitItem()
+            assertEquals(RealDuckChatJSHelper.DUCK_CHAT_FEATURE_NAME, event.featureName)
+            assertEquals("submitAIChatNativePrompt", event.subscriptionName)
+            assertEquals("follow up question", event.params.getJSONObject("query").getString("prompt"))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `when voice result is blank then no action is taken`() = runTest {
+        val testee = buildViewModel()
+
+        testee.commands.test {
+            testee.onVoiceRecognitionSuccess(query = "   ", isDuckAiResult = true)
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `when replace prompt with previous input then prompt is appended`() =
         runTest {
             testee.viewState.test {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealContextualNativeInputManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealContextualNativeInputManagerTest.kt
@@ -23,6 +23,7 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.duckchat.api.DuckAiFeatureState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
 import com.duckduckgo.duckchat.impl.DuckChatInternal
@@ -56,7 +57,11 @@ class RealContextualNativeInputManagerTest {
 
     private val duckChatInternal: DuckChatInternal = mock()
     private val publisher: NativeInputStatePublisher = mock()
-    private val testee = RealContextualNativeInputManager(duckChatInternal, publisher)
+    private val showVoiceChatEntry = MutableStateFlow(false)
+    private val duckAiFeatureState: DuckAiFeatureState = mock {
+        whenever(it.showVoiceChatEntry).thenReturn(showVoiceChatEntry)
+    }
+    private val testee = RealContextualNativeInputManager(duckChatInternal, publisher, duckAiFeatureState)
 
     @Test
     fun `when onContextualClosed called with blank tabId then publisher is not touched`() {
@@ -293,6 +298,68 @@ class RealContextualNativeInputManagerTest {
 
         assertEquals("hello", submitted?.prompt)
         verify(jsMessaging, never()).sendSubscriptionEvent(any())
+    }
+
+    @Test
+    fun `when voice chat entry enabled then widget voice chat is made available`() {
+        val enabled = MutableStateFlow(true)
+        whenever(duckChatInternal.observeNativeChatInputEnabled()).thenReturn(enabled)
+        showVoiceChatEntry.value = true
+        val widget = mock<NativeInputModeWidget>()
+        testee.init(
+            tabId = "tab",
+            card = mockCard(),
+            widget = widget,
+            jsMessaging = mock<JsMessaging>(),
+            lifecycleOwner = lifecycleOwner(),
+            chatIdFlow = emptyFlow(),
+            onSearchSubmitted = {},
+        )
+
+        verify(widget).setVoiceChatAvailable(true)
+    }
+
+    @Test
+    fun `when voice chat entry disabled then widget voice chat is not available`() {
+        val enabled = MutableStateFlow(true)
+        whenever(duckChatInternal.observeNativeChatInputEnabled()).thenReturn(enabled)
+        showVoiceChatEntry.value = false
+        val widget = mock<NativeInputModeWidget>()
+        testee.init(
+            tabId = "tab",
+            card = mockCard(),
+            widget = widget,
+            jsMessaging = mock<JsMessaging>(),
+            lifecycleOwner = lifecycleOwner(),
+            chatIdFlow = emptyFlow(),
+            onSearchSubmitted = {},
+        )
+
+        verify(widget).setVoiceChatAvailable(false)
+    }
+
+    @Test
+    fun `when init then widget voice chat click is wired to requested callback`() {
+        val enabled = MutableStateFlow(true)
+        whenever(duckChatInternal.observeNativeChatInputEnabled()).thenReturn(enabled)
+        val widget = mock<NativeInputModeWidget>()
+        var voiceChatRequested = false
+        testee.init(
+            tabId = "tab",
+            card = mockCard(),
+            widget = widget,
+            jsMessaging = mock<JsMessaging>(),
+            lifecycleOwner = lifecycleOwner(),
+            chatIdFlow = emptyFlow(),
+            onSearchSubmitted = {},
+            onVoiceChatRequested = { voiceChatRequested = true },
+        )
+
+        val captor = argumentCaptor<() -> Unit>()
+        verify(widget).onVoiceChatClick = captor.capture()
+        captor.firstValue.invoke()
+
+        assertTrue(voiceChatRequested)
     }
 
     private fun mockCard(): MaterialCardView {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealContextualNativeInputManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealContextualNativeInputManagerTest.kt
@@ -59,8 +59,10 @@ class RealContextualNativeInputManagerTest {
     private val duckChatInternal: DuckChatInternal = mock()
     private val publisher: NativeInputStatePublisher = mock()
     private val showVoiceChatEntry = MutableStateFlow(false)
+    private val showVoiceSearchToggle = MutableStateFlow(true)
     private val duckAiFeatureState: DuckAiFeatureState = mock {
         whenever(it.showVoiceChatEntry).thenReturn(showVoiceChatEntry)
+        whenever(it.showVoiceSearchToggle).thenReturn(showVoiceSearchToggle)
     }
     private val voiceSearchAvailable = MutableStateFlow(false)
     private val voiceSearchAvailability: VoiceSearchAvailability = mock {
@@ -368,10 +370,11 @@ class RealContextualNativeInputManagerTest {
     }
 
     @Test
-    fun `when voice search available then widget voice search is made available`() {
+    fun `when voice search device available and duck ai toggle on then widget voice search is made available`() {
         val enabled = MutableStateFlow(true)
         whenever(duckChatInternal.observeNativeChatInputEnabled()).thenReturn(enabled)
         voiceSearchAvailable.value = true
+        showVoiceSearchToggle.value = true
         val widget = mock<NativeInputModeWidget>()
         testee.init(
             tabId = "tab",
@@ -387,10 +390,11 @@ class RealContextualNativeInputManagerTest {
     }
 
     @Test
-    fun `when voice search unavailable then widget voice search is not available`() {
+    fun `when voice search device unavailable then widget voice search is not available`() {
         val enabled = MutableStateFlow(true)
         whenever(duckChatInternal.observeNativeChatInputEnabled()).thenReturn(enabled)
         voiceSearchAvailable.value = false
+        showVoiceSearchToggle.value = true
         val widget = mock<NativeInputModeWidget>()
         testee.init(
             tabId = "tab",
@@ -401,6 +405,50 @@ class RealContextualNativeInputManagerTest {
             chatIdFlow = emptyFlow(),
             onSearchSubmitted = {},
         )
+
+        verify(widget).setVoiceSearchAvailable(false)
+    }
+
+    @Test
+    fun `when voice search device available but duck ai toggle off then widget voice search is not available`() {
+        val enabled = MutableStateFlow(true)
+        whenever(duckChatInternal.observeNativeChatInputEnabled()).thenReturn(enabled)
+        voiceSearchAvailable.value = true
+        showVoiceSearchToggle.value = false
+        val widget = mock<NativeInputModeWidget>()
+        testee.init(
+            tabId = "tab",
+            card = mockCard(),
+            widget = widget,
+            jsMessaging = mock<JsMessaging>(),
+            lifecycleOwner = lifecycleOwner(),
+            chatIdFlow = emptyFlow(),
+            onSearchSubmitted = {},
+        )
+
+        verify(widget).setVoiceSearchAvailable(false)
+    }
+
+    @Test
+    fun `when duck ai voice search toggle turns off then widget voice search becomes unavailable`() {
+        val enabled = MutableStateFlow(true)
+        whenever(duckChatInternal.observeNativeChatInputEnabled()).thenReturn(enabled)
+        voiceSearchAvailable.value = true
+        showVoiceSearchToggle.value = true
+        val widget = mock<NativeInputModeWidget>()
+        testee.init(
+            tabId = "tab",
+            card = mockCard(),
+            widget = widget,
+            jsMessaging = mock<JsMessaging>(),
+            lifecycleOwner = lifecycleOwner(),
+            chatIdFlow = emptyFlow(),
+            onSearchSubmitted = {},
+        )
+        verify(widget).setVoiceSearchAvailable(true)
+
+        // Toggling the Duck.ai voice-search entry point off must re-emit and hide the mic immediately.
+        showVoiceSearchToggle.value = false
 
         verify(widget).setVoiceSearchAvailable(false)
     }

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealContextualNativeInputManagerTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/contextual/RealContextualNativeInputManagerTest.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
 import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.ui.nativeinput.views.NativeInputModeWidget
 import com.duckduckgo.js.messaging.api.JsMessaging
+import com.duckduckgo.voice.api.VoiceSearchAvailability
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.shape.ShapeAppearanceModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -61,7 +62,11 @@ class RealContextualNativeInputManagerTest {
     private val duckAiFeatureState: DuckAiFeatureState = mock {
         whenever(it.showVoiceChatEntry).thenReturn(showVoiceChatEntry)
     }
-    private val testee = RealContextualNativeInputManager(duckChatInternal, publisher, duckAiFeatureState)
+    private val voiceSearchAvailable = MutableStateFlow(false)
+    private val voiceSearchAvailability: VoiceSearchAvailability = mock {
+        whenever(it.observeVoiceSearchAvailability()).thenReturn(voiceSearchAvailable)
+    }
+    private val testee = RealContextualNativeInputManager(duckChatInternal, publisher, duckAiFeatureState, voiceSearchAvailability)
 
     @Test
     fun `when onContextualClosed called with blank tabId then publisher is not touched`() {
@@ -360,6 +365,68 @@ class RealContextualNativeInputManagerTest {
         captor.firstValue.invoke()
 
         assertTrue(voiceChatRequested)
+    }
+
+    @Test
+    fun `when voice search available then widget voice search is made available`() {
+        val enabled = MutableStateFlow(true)
+        whenever(duckChatInternal.observeNativeChatInputEnabled()).thenReturn(enabled)
+        voiceSearchAvailable.value = true
+        val widget = mock<NativeInputModeWidget>()
+        testee.init(
+            tabId = "tab",
+            card = mockCard(),
+            widget = widget,
+            jsMessaging = mock<JsMessaging>(),
+            lifecycleOwner = lifecycleOwner(),
+            chatIdFlow = emptyFlow(),
+            onSearchSubmitted = {},
+        )
+
+        verify(widget).setVoiceSearchAvailable(true)
+    }
+
+    @Test
+    fun `when voice search unavailable then widget voice search is not available`() {
+        val enabled = MutableStateFlow(true)
+        whenever(duckChatInternal.observeNativeChatInputEnabled()).thenReturn(enabled)
+        voiceSearchAvailable.value = false
+        val widget = mock<NativeInputModeWidget>()
+        testee.init(
+            tabId = "tab",
+            card = mockCard(),
+            widget = widget,
+            jsMessaging = mock<JsMessaging>(),
+            lifecycleOwner = lifecycleOwner(),
+            chatIdFlow = emptyFlow(),
+            onSearchSubmitted = {},
+        )
+
+        verify(widget).setVoiceSearchAvailable(false)
+    }
+
+    @Test
+    fun `when init then widget voice search click is wired to requested callback`() {
+        val enabled = MutableStateFlow(true)
+        whenever(duckChatInternal.observeNativeChatInputEnabled()).thenReturn(enabled)
+        val widget = mock<NativeInputModeWidget>()
+        var voiceSearchRequested = false
+        testee.init(
+            tabId = "tab",
+            card = mockCard(),
+            widget = widget,
+            jsMessaging = mock<JsMessaging>(),
+            lifecycleOwner = lifecycleOwner(),
+            chatIdFlow = emptyFlow(),
+            onSearchSubmitted = {},
+            onVoiceSearchRequested = { voiceSearchRequested = true },
+        )
+
+        val captor = argumentCaptor<() -> Unit>()
+        verify(widget).onVoiceSearchClick = captor.capture()
+        captor.firstValue.invoke()
+
+        assertTrue(voiceSearchRequested)
     }
 
     private fun mockCard(): MaterialCardView {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1216824829833249?focus=true
Tech Design URL (if applicable): 

### Description

- Wired Duck.ai voice chat into the contextual native input, gated on the showVoiceChatEntry flag. Tapping it closes the sheet and opens voice Duck.ai; hidden while text/attachment present.
- Wired private voice search into the contextual composer, gated on device voice-search availability and the Duck.ai showVoiceSearchToggle entry point. The mic appears/disappears immediately on toggle.
- Voice results now route through the view model: while a chat is running (WEBVIEW) a Duck.ai voice result is submitted into that chat as a follow-up; a search result opens a new tab; a Duck.ai result from the initial input opens Duck.ai.

## Steps to test this PR
Setup
  - [x] Contextual native input enabled; open the contextual Duck.ai sheet on a tab

  1. Voice chat entry enabled (Settings > AI Features >Duck.ai shortcuts > Voice Chat
  - [x] Voice chat button (wave icon) IS visible in the input
  - [x] Typing text or adding an attachment hides the voice chat button
  - [x] Tapping it closes the sheet and opens voice Duck.ai on a different tab

  2. Voice chat entry disabled (Settings > AI Features >Duck.ai shortcuts > Voice Chat
  - [x] Voice chat button is NOT visible on the contextual sheet
  
  3. Voice search entry enabled (Settings > AI Features >Duck.ai shortcuts > Voice Search AND Settings > General > Private Voice Search enabled.
  - [x] In the contextual sheet, In-field microphone IS visible
  - [x] Tapping it opens Private voice search in Duck.ai mode
  - [x] Cancel it and verify that you return to contextual sheet
  - [x] Speak and verify that the generated text is submit to duck.ai on a separate tab
  - [x] Go back to tab and open contextual sheet
  - [x] Tap in the microphone and switch to Search
  - [x] Speak and verify that the generated text is submit to search instead
  - [x] Go back to tab and open contextual sheet
  - [x] Summarize page
  - [x] In the chat mode, press the microphone icon
  - [x] Speak and verify that the generated text is submit to duck.ai on the contextual sheet webview

  4. Voice search entry disabled (Settings > AI Features >Duck.ai shortcuts > Voice Search
  - [x] In-field microphone is NOT visible

  Regression checks
  - [x] Main omnibar native input voice search/chat unaffected
  - [x] Input screen (InputScreenViewModel) voice buttons unaffected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches navigation (new tab, fullscreen Duck.ai, voice chat) and voice-result routing across sheet modes; behavior is covered by new ViewModel and manager tests but user-facing flows are moderately complex.
> 
> **Overview**
> Adds **voice chat** and **voice search** to the contextual sheet’s native input widget, gated by the same Duck.ai feature flags and device voice-search availability as the main omnibar input.
> 
> `ContextualNativeInputManager` now wires widget voice buttons to new callbacks, observes `showVoiceChatEntry` and the combined voice-search availability, and updates `setVoiceChatAvailable` / `setVoiceSearchAvailable` on the widget.
> 
> `DuckChatContextualFragment` registers `VoiceSearchLauncher`, launches Duck.ai voice search from the mic, closes the sheet and opens voice Duck Chat on voice-chat tap, and handles recognition results via the ViewModel. **`onVoiceRecognitionSuccess`** routes non–Duck.ai transcripts to a new search tab, Duck.ai prompts in INPUT mode to fullscreen Duck.ai with auto-prompt, and Duck.ai prompts during an active chat through the existing **`onPromptSent`** / JS submit path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c55f02a772ec591b30d5180d451897ded5ef829. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->