### PR TITLE
Add DaxProgressSpinner composable to ADS

### DIFF
--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/Component.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/Component.kt
@@ -45,4 +45,5 @@ enum class Component {
     TWO_LINE_LIST_ITEM,
     SETTINGS_LIST_ITEM,
     SECTION_DIVIDER,
+    PROGRESS_SPINNER,
 }

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentOtherFragment.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentOtherFragment.kt
@@ -18,6 +18,6 @@ package com.duckduckgo.common.ui.internal.ui.component
 
 class ComponentOtherFragment : ComponentFragment() {
     override fun getComponents(): List<Component> {
-        return listOf(Component.SECTION_DIVIDER)
+        return listOf(Component.SECTION_DIVIDER, Component.PROGRESS_SPINNER)
     }
 }

--- a/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentViewHolder.kt
+++ b/android-design-system/design-system-internal/src/main/java/com/duckduckgo/common/ui/internal/ui/component/ComponentViewHolder.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -66,6 +67,7 @@ import com.duckduckgo.common.ui.compose.message.remote.DaxPromoSingleActionMessa
 import com.duckduckgo.common.ui.compose.message.remote.DaxSmallMessage
 import com.duckduckgo.common.ui.compose.panel.DaxAlertPanel
 import com.duckduckgo.common.ui.compose.panel.DaxInfoPanel
+import com.duckduckgo.common.ui.compose.progress.DaxProgressSpinner
 import com.duckduckgo.common.ui.compose.radiobutton.DaxRadioButton
 import com.duckduckgo.common.ui.compose.snackbar.DaxSnackbar
 import com.duckduckgo.common.ui.compose.switch.DaxSwitch
@@ -789,6 +791,26 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
         }
     }
 
+    class ProgressSpinnerComponentViewHolder(
+        parent: ViewGroup,
+        private val isDarkTheme: Boolean,
+    ) : ComponentViewHolder(inflate(parent, R.layout.component_progress_spinner)) {
+        override fun bind(component: Component) {
+            view.setupThemedComposeView(id = R.id.compose_dax_progress_spinner, isDarkTheme = isDarkTheme) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    DaxProgressSpinner()
+                    DaxProgressSpinner(
+                        modifier = Modifier.size(24.dp),
+                        strokeWidth = 2.dp,
+                    )
+                }
+            }
+        }
+    }
+
     class SettingsListItemComponentViewHolder(parent: ViewGroup) :
         ComponentViewHolder(inflate(parent, R.layout.component_settings)) {
         override fun bind(component: Component) {
@@ -821,6 +843,7 @@ sealed class ComponentViewHolder(val view: View) : RecyclerView.ViewHolder(view)
                 Component.SINGLE_LINE_LIST_ITEM -> OneLineListItemComponentViewHolder(parent)
                 Component.TWO_LINE_LIST_ITEM -> TwoLineItemComponentViewHolder(parent)
                 Component.SECTION_DIVIDER -> DividerComponentViewHolder(parent, isDarkTheme)
+                Component.PROGRESS_SPINNER -> ProgressSpinnerComponentViewHolder(parent, isDarkTheme)
                 Component.CARD -> CardComponentViewHolder(parent, isDarkTheme)
                 Component.SETTINGS_LIST_ITEM -> SettingsListItemComponentViewHolder(parent)
                 else -> {

--- a/android-design-system/design-system-internal/src/main/res/layout/component_progress_spinner.xml
+++ b/android-design-system/design-system-internal/src/main/res/layout/component_progress_spinner.xml
@@ -14,13 +14,6 @@
   ~ limitations under the License.
   -->
 
-<!--
-  ~ Showcase of the circular loading spinners currently used across the app's real screens.
-  ~ There is no shared ADS/Dax spinner yet; each of these is reproduced faithfully from its
-  ~ source screen so we can compare them before designing the Compose DaxProgressSpinner.
-  ~ Spinners that use a white tint in-app (Fire dialog, User survey) sit on an inverted-background
-  ~ chip here purely so they remain visible in light theme.
-  -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
@@ -30,7 +23,6 @@
     android:paddingEnd="@dimen/keyline_4"
     android:paddingBottom="@dimen/keyline_5">
 
-    <!-- Material CircularProgressIndicator: Privacy Dashboard (default size, accent) -->
     <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -44,7 +36,6 @@
         android:indeterminate="true"
         app:indicatorColor="?attr/daxColorAccentBlue" />
 
-    <!-- Material CircularProgressIndicator: Sync (16dp, 1dp track, accent) -->
     <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -61,7 +52,6 @@
         app:indicatorSize="16dp"
         app:trackThickness="1dp" />
 
-    <!-- Material CircularProgressIndicator: Fire dialog (default size, white) -->
     <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -85,7 +75,6 @@
             app:indicatorColor="?attr/daxColorWhite" />
     </LinearLayout>
 
-    <!-- Raw Android ProgressBar: User survey (stock circular, white) -->
     <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -110,7 +99,6 @@
             android:indeterminateTintMode="src_in" />
     </LinearLayout>
 
-    <!-- Compose DaxProgressSpinner (ADS) -->
     <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/android-design-system/design-system-internal/src/main/res/layout/component_progress_spinner.xml
+++ b/android-design-system/design-system-internal/src/main/res/layout/component_progress_spinner.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2025 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!--
+  ~ Showcase of the circular loading spinners currently used across the app's real screens.
+  ~ There is no shared ADS/Dax spinner yet; each of these is reproduced faithfully from its
+  ~ source screen so we can compare them before designing the Compose DaxProgressSpinner.
+  ~ Spinners that use a white tint in-app (Fire dialog, User survey) sit on an inverted-background
+  ~ chip here purely so they remain visible in light theme.
+  -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:paddingTop="@dimen/keyline_5"
+    android:paddingEnd="@dimen/keyline_4"
+    android:paddingBottom="@dimen/keyline_5">
+
+    <!-- Material CircularProgressIndicator: Privacy Dashboard (default size, accent) -->
+    <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:primaryText="Material CircularProgressIndicator — default size (Privacy Dashboard, accent)" />
+
+    <com.google.android.material.progressindicator.CircularProgressIndicator
+        android:id="@+id/spinner_material_default"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/keyline_4"
+        android:indeterminate="true"
+        app:indicatorColor="?attr/daxColorAccentBlue" />
+
+    <!-- Material CircularProgressIndicator: Sync (16dp, 1dp track, accent) -->
+    <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="@dimen/keyline_5"
+        app:primaryText="Material CircularProgressIndicator — 16dp / 1dp track (Sync, accent)" />
+
+    <com.google.android.material.progressindicator.CircularProgressIndicator
+        android:id="@+id/spinner_material_small"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/keyline_4"
+        android:indeterminate="true"
+        app:indicatorColor="?attr/daxColorAccentBlue"
+        app:indicatorSize="16dp"
+        app:trackThickness="1dp" />
+
+    <!-- Material CircularProgressIndicator: Fire dialog (default size, white) -->
+    <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="@dimen/keyline_5"
+        app:primaryText="Material CircularProgressIndicator — white (Fire dialog, on dark scrim)" />
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/keyline_4"
+        android:background="?attr/daxColorBackgroundInverted"
+        android:gravity="center"
+        android:orientation="horizontal"
+        android:padding="@dimen/keyline_4">
+
+        <com.google.android.material.progressindicator.CircularProgressIndicator
+            android:id="@+id/spinner_material_white"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:indeterminate="true"
+            app:indicatorColor="?attr/daxColorWhite" />
+    </LinearLayout>
+
+    <!-- Raw Android ProgressBar: User survey (stock circular, white) -->
+    <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="@dimen/keyline_5"
+        app:primaryText="Raw Android ProgressBar — stock circular (User survey, white on dark)" />
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/keyline_4"
+        android:background="?attr/daxColorBackgroundInverted"
+        android:gravity="center"
+        android:orientation="horizontal"
+        android:padding="@dimen/keyline_4">
+
+        <ProgressBar
+            android:id="@+id/spinner_progressbar_stock"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:indeterminate="true"
+            android:indeterminateTint="?attr/daxColorWhite"
+            android:indeterminateTintMode="src_in" />
+    </LinearLayout>
+
+    <!-- Compose DaxProgressSpinner (ADS) -->
+    <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="@dimen/keyline_5"
+        app:primaryText="Compose DaxProgressSpinner (ADS) — default 40dp + resized 24dp (strokeWidth 2dp)" />
+
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/compose_dax_progress_spinner"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/keyline_4" />
+
+</LinearLayout>

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/progress/DaxProgressSpinner.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/progress/DaxProgressSpinner.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.common.ui.compose.progress
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.duckduckgo.common.ui.compose.theme.DuckDuckGoTheme
+import com.duckduckgo.common.ui.compose.tools.PreviewBox
+
+/**
+ * DuckDuckGo design system indeterminate circular progress spinner.
+ *
+ * Wraps Material3 [CircularProgressIndicator] with DuckDuckGo theme colors.
+ *
+ * @param modifier the [Modifier] to apply.
+ * @param strokeWidth the stroke width of the track and indicator. Defaults to 4dp (the Material3
+ *   default at 40dp); reduce it when displaying the spinner at a smaller size.
+ *
+ * Asana Task: https://app.asana.com/1/137249556945/project/1202857801505092/task/1216871244926850?focus=true
+ * Figma reference: https://www.figma.com/design/BOHDESHODUXK7wSRNBOHdu/%F0%9F%A4%96-Android-Components?node-id=6655-46405&m=dev
+ */
+@Composable
+fun DaxProgressSpinner(
+    modifier: Modifier = Modifier,
+    strokeWidth: Dp = DaxProgressSpinnerDefaults.strokeWidth,
+) {
+    CircularProgressIndicator(
+        modifier = modifier,
+        color = DaxProgressSpinnerDefaults.headColor,
+        trackColor = DaxProgressSpinnerDefaults.trackColor,
+        strokeWidth = strokeWidth,
+        gapSize = 0.dp,
+    )
+}
+
+private object DaxProgressSpinnerDefaults {
+    val strokeWidth: Dp = 4.dp
+
+    val trackColor: Color
+        @Composable
+        @ReadOnlyComposable
+        get() = DuckDuckGoTheme.colors.system.progressSpinnerTrack
+
+    val headColor: Color
+        @Composable
+        @ReadOnlyComposable
+        get() = DuckDuckGoTheme.colors.system.progressSpinnerIndicator
+}
+
+@PreviewLightDark
+@Composable
+private fun DaxProgressSpinnerPreview() {
+    PreviewBox {
+        Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+            DaxProgressSpinner()
+            DaxProgressSpinner(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
+        }
+    }
+}

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/progress/DaxProgressSpinner.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/progress/DaxProgressSpinner.kt
@@ -45,26 +45,27 @@ import com.duckduckgo.common.ui.compose.tools.PreviewBox
 @Composable
 fun DaxProgressSpinner(
     modifier: Modifier = Modifier,
-    strokeWidth: Dp = DaxProgressSpinnerDefaults.strokeWidth,
+    strokeWidth: Dp = DaxProgressSpinnerDefaults.StrokeWidth,
 ) {
     CircularProgressIndicator(
         modifier = modifier,
-        color = DaxProgressSpinnerDefaults.headColor,
-        trackColor = DaxProgressSpinnerDefaults.trackColor,
+        color = DaxProgressSpinnerDefaults.HeadColor,
+        trackColor = DaxProgressSpinnerDefaults.TrackColor,
         strokeWidth = strokeWidth,
-        gapSize = 0.dp,
+        gapSize = DaxProgressSpinnerDefaults.TrackGapSize,
     )
 }
 
 private object DaxProgressSpinnerDefaults {
-    val strokeWidth: Dp = 4.dp
+    val StrokeWidth: Dp = 4.dp
+    val TrackGapSize: Dp = 0.dp
 
-    val trackColor: Color
+    val TrackColor: Color
         @Composable
         @ReadOnlyComposable
         get() = DuckDuckGoTheme.colors.system.progressSpinnerTrack
 
-    val headColor: Color
+    val HeadColor: Color
         @Composable
         @ReadOnlyComposable
         get() = DuckDuckGoTheme.colors.system.progressSpinnerIndicator

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/theme/Color.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/theme/Color.kt
@@ -109,6 +109,8 @@ data class DuckDuckGoSystemColors(
     val sliderTrackInactive: Color,
     val textInputEnabledOutline: Color,
     val touchFeedback: Color,
+    val progressSpinnerTrack: Color,
+    val progressSpinnerIndicator: Color,
 )
 
 @Immutable
@@ -124,6 +126,7 @@ val LocalDuckDuckGoColors = staticCompositionLocalOf<DuckDuckGoColors> {
 //region Black color variants
 val Black84 = Color(0xD6000000)
 val Black60 = Color(0x99000000)
+val Black54 = Color(0x8A000000)
 val Black50 = Color(0x80000000)
 val Black48 = Color(0x7A000000)
 val Black40 = Color(0x66000000)
@@ -142,6 +145,7 @@ val Black = Color(0xFF000000)
 val White84 = Color(0xD6FFFFFF)
 val White78 = Color(0xC7FFFFFF)
 val White60 = Color(0x99FFFFFF)
+val White54 = Color(0x8AFFFFFF)
 val White48 = Color(0x7AFFFFFF)
 val White40 = Color(0x66FFFFFF)
 val White36 = Color(0x5CFFFFFF)

--- a/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/theme/Theme.kt
+++ b/android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/theme/Theme.kt
@@ -126,6 +126,8 @@ fun DuckDuckGoTheme(
             sliderTrackInactive = Gray60_50,
             textInputEnabledOutline = Black30,
             touchFeedback = colorResource(R.color.controls_fill_primary_light),
+            progressSpinnerTrack = Black18,
+            progressSpinnerIndicator = Black54,
         ),
         infoPanel = DuckDuckGoInfoPanelColors(
             backgroundBlue = Blue0_50,
@@ -186,6 +188,8 @@ fun DuckDuckGoTheme(
             sliderTrackInactive = Gray40_50,
             textInputEnabledOutline = White30,
             touchFeedback = colorResource(R.color.controls_fill_primary_dark),
+            progressSpinnerTrack = White18,
+            progressSpinnerIndicator = White54,
         ),
         infoPanel = DuckDuckGoInfoPanelColors(
             backgroundBlue = Blue50_12,

--- a/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/registry/DuckDuckGoIssueRegistry.kt
@@ -55,6 +55,7 @@ import com.duckduckgo.lint.ui.NoRawM3SurfaceUsageDetector.Companion.NO_RAW_M3_SU
 import com.duckduckgo.lint.ui.DaxTextFieldTrailingIconDetector.Companion.INVALID_DAX_TEXT_FIELD_TRAILING_ICON_USAGE
 import com.duckduckgo.lint.ui.DaxSecureTextFieldTrailingIconDetector.Companion.INVALID_DAX_SECURE_TEXT_FIELD_TRAILING_ICON_USAGE
 import com.duckduckgo.lint.ui.NoMaterial3CheckboxUsageDetector.Companion.NO_MATERIAL3_CHECKBOX_USAGE
+import com.duckduckgo.lint.ui.NoMaterial3CircularProgressIndicatorUsageDetector.Companion.NO_MATERIAL3_CIRCULAR_PROGRESS_INDICATOR_USAGE
 import com.duckduckgo.lint.ui.NoMaterial3DividerUsageDetector.Companion.NO_MATERIAL3_HORIZONTAL_DIVIDER_USAGE
 import com.duckduckgo.lint.ui.NoMaterial3DividerUsageDetector.Companion.NO_MATERIAL3_VERTICAL_DIVIDER_USAGE
 import com.duckduckgo.lint.ui.NoMaterial3RadioButtonUsageDetector.Companion.NO_MATERIAL3_RADIO_BUTTON_USAGE
@@ -122,6 +123,7 @@ class DuckDuckGoIssueRegistry : IssueRegistry() {
             NO_MATERIAL3_SWITCH_USAGE,
             NO_MATERIAL3_RADIO_BUTTON_USAGE,
             NO_MATERIAL3_CHECKBOX_USAGE,
+            NO_MATERIAL3_CIRCULAR_PROGRESS_INDICATOR_USAGE,
             NO_MATERIAL3_HORIZONTAL_DIVIDER_USAGE,
             NO_MATERIAL3_VERTICAL_DIVIDER_USAGE,
             NO_RAW_M3_BUTTON_USAGE,

--- a/lint-rules/src/main/java/com/duckduckgo/lint/ui/NoMaterial3CircularProgressIndicatorUsageDetector.kt
+++ b/lint-rules/src/main/java/com/duckduckgo/lint/ui/NoMaterial3CircularProgressIndicatorUsageDetector.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint.ui
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Category.Companion.CUSTOM_LINT_CHECKS
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.android.tools.lint.detector.api.TextFormat
+import org.jetbrains.uast.UCallExpression
+import java.util.EnumSet
+
+@Suppress("UnstableApiUsage")
+class NoMaterial3CircularProgressIndicatorUsageDetector : Detector(), SourceCodeScanner {
+
+    override fun getApplicableUastTypes() = listOf(UCallExpression::class.java)
+
+    override fun createUastHandler(context: JavaContext): UElementHandler = CircularProgressIndicatorUsageHandler(context)
+
+    internal class CircularProgressIndicatorUsageHandler(private val context: JavaContext) : UElementHandler() {
+
+        override fun visitCallExpression(node: UCallExpression) {
+            if (isInDesignSystemModule()) return
+
+            val methodName = node.methodName ?: return
+            if (methodName == "CircularProgressIndicator") {
+                val resolved = node.resolve() ?: return
+                val qualifiedName = context.evaluator.getPackage(resolved)?.qualifiedName ?: return
+                if (qualifiedName == MATERIAL3_PACKAGE) {
+                    context.report(
+                        issue = NO_MATERIAL3_CIRCULAR_PROGRESS_INDICATOR_USAGE,
+                        location = context.getLocation(node),
+                        message = NO_MATERIAL3_CIRCULAR_PROGRESS_INDICATOR_USAGE.getExplanation(TextFormat.RAW),
+                    )
+                }
+            }
+        }
+
+        private fun isInDesignSystemModule(): Boolean {
+            return context.project.name in DESIGN_SYSTEM_MODULES
+        }
+    }
+
+    companion object {
+        private const val MATERIAL3_PACKAGE = "androidx.compose.material3"
+        private val DESIGN_SYSTEM_MODULES = setOf("design-system", "design-system-internal")
+
+        val NO_MATERIAL3_CIRCULAR_PROGRESS_INDICATOR_USAGE = Issue
+            .create(
+                id = "NoMaterial3CircularProgressIndicatorUsage",
+                briefDescription = "Use DaxProgressSpinner instead of Material3 CircularProgressIndicator",
+                explanation = "Use `DaxProgressSpinner` from the design system instead of the Material3 `CircularProgressIndicator` composable " +
+                    "to ensure consistent styling across the app.",
+                moreInfo = "",
+                category = CUSTOM_LINT_CHECKS,
+                priority = 10,
+                severity = Severity.ERROR,
+                androidSpecific = true,
+                implementation = Implementation(
+                    NoMaterial3CircularProgressIndicatorUsageDetector::class.java,
+                    EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES),
+                ),
+            )
+    }
+}

--- a/lint-rules/src/test/java/com/duckduckgo/lint/ui/NoMaterial3CircularProgressIndicatorUsageDetectorTest.kt
+++ b/lint-rules/src/test/java/com/duckduckgo/lint/ui/NoMaterial3CircularProgressIndicatorUsageDetectorTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.lint.ui
+
+import com.android.tools.lint.checks.infrastructure.TestFiles.kotlin
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import com.duckduckgo.lint.ui.NoMaterial3CircularProgressIndicatorUsageDetector.Companion.NO_MATERIAL3_CIRCULAR_PROGRESS_INDICATOR_USAGE
+import org.junit.Test
+
+class NoMaterial3CircularProgressIndicatorUsageDetectorTest {
+
+    private val circularProgressIndicatorStub = kotlin(
+        """
+        package androidx.compose.material3
+
+        fun CircularProgressIndicator() {}
+        """.trimIndent(),
+    ).indented()
+
+    private val daxProgressSpinnerStub = kotlin(
+        """
+        package com.duckduckgo.common.ui.compose.progress
+
+        fun DaxProgressSpinner() {}
+        """.trimIndent(),
+    ).indented()
+
+    @Test
+    fun whenMaterial3CircularProgressIndicatorUsedThenError() {
+        lint()
+            .files(
+                circularProgressIndicatorStub,
+                kotlin(
+                    """
+                    package com.example.test
+
+                    import androidx.compose.material3.CircularProgressIndicator
+
+                    fun MyScreen() {
+                        CircularProgressIndicator()
+                    }
+                    """.trimIndent(),
+                ).indented(),
+            )
+            .issues(NO_MATERIAL3_CIRCULAR_PROGRESS_INDICATOR_USAGE)
+            .run()
+            .expect(
+                """
+                src/com/example/test/test.kt:6: Error: Use DaxProgressSpinner from the design system instead of the Material3 CircularProgressIndicator composable to ensure consistent styling across the app. [NoMaterial3CircularProgressIndicatorUsage]
+                    CircularProgressIndicator()
+                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                1 errors, 0 warnings
+                """.trimIndent(),
+            )
+    }
+
+    @Test
+    fun whenDaxProgressSpinnerUsedThenNoError() {
+        lint()
+            .files(
+                daxProgressSpinnerStub,
+                kotlin(
+                    """
+                    package com.example.test
+
+                    import com.duckduckgo.common.ui.compose.progress.DaxProgressSpinner
+
+                    fun MyScreen() {
+                        DaxProgressSpinner()
+                    }
+                    """.trimIndent(),
+                ).indented(),
+            )
+            .issues(NO_MATERIAL3_CIRCULAR_PROGRESS_INDICATOR_USAGE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun whenNoCircularProgressIndicatorUsedThenNoError() {
+        lint()
+            .files(
+                kotlin(
+                    """
+                    package com.example.test
+
+                    fun MyScreen() {
+                        val loading = true
+                    }
+                    """.trimIndent(),
+                ).indented(),
+            )
+            .issues(NO_MATERIAL3_CIRCULAR_PROGRESS_INDICATOR_USAGE)
+            .run()
+            .expectClean()
+    }
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1211670072079715?focus=true
Tech Design URL (if applicable): N/A
API Proposals URL(s) (if applicable): N/A

### Description
Adds a new DaxProgressSpinner composable to ADS.

### Steps to test this PR

_Android Design System Preview_
- [ ] Go to Android Design System Preview -> Other and scroll to bottom
- [ ] Compare the Compose component against Figma (do not compare against XML as it's not based on Figma)

### UI changes
See Android Design System Preview and Figma

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New ADS component, theme tokens, and lint rule only; no changes to app feature flows or security-sensitive logic.
> 
> **Overview**
> Introduces **`DaxProgressSpinner`**, a themed indeterminate circular spinner for Compose that wraps Material3’s indicator with **`DuckDuckGoTheme`** track/indicator colors (light: `Black18` / `Black54`, dark: `White18` / `White54`), configurable **`strokeWidth`**, and zero track gap.
> 
> **Theme** adds `progressSpinnerTrack` and `progressSpinnerIndicator` on system colors plus **`Black54`** / **`White54`** constants.
> 
> **Design-system-internal** registers **`PROGRESS_SPINNER`** on the Other components screen: XML showcases legacy Material/`ProgressBar` spinners for comparison and a Compose preview (default + 24dp / 2dp stroke).
> 
> **Lint** adds **`NoMaterial3CircularProgressIndicatorUsage`** (ERROR outside `design-system` / `design-system-internal`) directing apps to **`DaxProgressSpinner`**, with unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a56b430673e922a6f1e3c03025a7500ce4d85e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->