### PR TITLE
Sync: Accept keysize when generating RSA keypair

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ProtectedKeyMinting.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ProtectedKeyMinting.kt
@@ -43,8 +43,9 @@ internal fun mintDdgWrappedProtectedKey(
     syncJweCrypto: SyncJweCrypto,
     nativeLib: SyncLib,
     errorPrefix: String,
+    keySizeBits: Int,
 ): Result<MintedProtectedKey> {
-    val rsa = runCatching { syncJweCrypto.generateRsaKeyPair() }
+    val rsa = runCatching { syncJweCrypto.generateRsaKeyPair(keySizeBits) }
         .getOrElse { return it.asLoggedError("$errorPrefix: failed to generate RSA keypair") }
     val (n, e) = runCatching { syncJweCrypto.extractJwkComponents(rsa.publicKeyBase64) }
         .getOrElse { return it.asLoggedError("$errorPrefix: failed to extract JWK components") }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ThirdPartyCredentialManager.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ThirdPartyCredentialManager.kt
@@ -296,6 +296,7 @@ class RealThirdPartyCredentialManager @Inject constructor(
                 syncJweCrypto = syncJweCrypto,
                 nativeLib = nativeLib,
                 errorPrefix = "MintAiChatsKey",
+                keySizeBits = AI_CHATS_RSA_KEY_SIZE,
             )
         ) {
             is Success -> r.data
@@ -494,6 +495,9 @@ class RealThirdPartyCredentialManager @Inject constructor(
     }
 
     companion object {
+        // RSA modulus size (bits) for the ai_chats protected keypair.
+        private const val AI_CHATS_RSA_KEY_SIZE = 2048
+
         const val MAX_RATE_LIMIT_RETRIES = 3
         private const val RATE_LIMIT_RETRY_DELAY_MILLIS = 1_000L
 

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/crypto/SyncJweCrypto.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/crypto/SyncJweCrypto.kt
@@ -43,7 +43,10 @@ import javax.inject.Inject
 private const val JWE_CONTENT_TYPE_OCTET_STREAM = "application/octet-stream"
 
 interface SyncJweCrypto {
-    fun generateRsaKeyPair(): RsaKeyPair
+    /**
+     * Generate an RSA keypair of [keySizeBits] bits.
+     */
+    fun generateRsaKeyPair(keySizeBits: Int): RsaKeyPair
 
     /**
      * JWE-encrypt content with a symmetric AES-256 key using direct encryption (alg=dir, enc=A256GCM).
@@ -94,10 +97,10 @@ class RealSyncJweCrypto @Inject constructor() : SyncJweCrypto {
 
     private val secureRandom = SecureRandom()
 
-    override fun generateRsaKeyPair(): RsaKeyPair {
-        logcat { "Sync-ScopedToken: generating RSA-$RSA_KEY_SIZE keypair" }
+    override fun generateRsaKeyPair(keySizeBits: Int): RsaKeyPair {
+        logcat { "Sync-ScopedToken: generating RSA-$keySizeBits keypair" }
         val keyPairGenerator = KeyPairGenerator.getInstance("RSA")
-        keyPairGenerator.initialize(RSA_KEY_SIZE)
+        keyPairGenerator.initialize(keySizeBits)
         val keyPair: KeyPair = keyPairGenerator.generateKeyPair()
 
         return RsaKeyPair(
@@ -242,7 +245,6 @@ class RealSyncJweCrypto @Inject constructor() : SyncJweCrypto {
     }
 
     companion object {
-        private const val RSA_KEY_SIZE = 2048
         private const val AES_KEY_BYTES = 32 // 256-bit AES
         private const val GCM_IV_BYTES = 12
         private const val GCM_TAG_BYTES = 16

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/exchange/v2/ExchangeV2Runner.kt
@@ -239,7 +239,7 @@ class RealExchangeV2Runner @Inject constructor(
      * (in which case an error event was already emitted).
      */
     private suspend fun bootstrapLocked(role: PairingRole): RsaKeyPair? {
-        val keyPair = jweCrypto.generateRsaKeyPair()
+        val keyPair = jweCrypto.generateRsaKeyPair(EXCHANGE_RSA_KEY_SIZE)
         ownKeyPair = keyPair
         repeat(MAX_CHANNEL_CREATE_RETRIES) { attempt ->
             val candidate = UUID.randomUUID().toString()
@@ -870,6 +870,9 @@ class RealExchangeV2Runner @Inject constructor(
     }
 
     companion object {
+        // RSA modulus size (bits) for the v2 exchange pairing keypair.
+        private const val EXCHANGE_RSA_KEY_SIZE = 2048
+
         private const val REPLAY = 100
 
         // Transport TD 1214486492252757 §Session Lifecycle: 5-minute client session deadline.

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ThirdPartyCredentialManagerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ThirdPartyCredentialManagerTest.kt
@@ -237,7 +237,7 @@ class ThirdPartyCredentialManagerTest {
         // call, eliminating the native-vs-embedded-FE race documented in 1216006812462330.
         primeCreate()
         whenever(syncApi.getProtectedKeys(token)).thenReturn(Success(emptyList()))
-        whenever(syncJweCrypto.generateRsaKeyPair()).thenReturn(RsaKeyPair("pubKey", "cHJpdktleQ"))
+        whenever(syncJweCrypto.generateRsaKeyPair(any())).thenReturn(RsaKeyPair("pubKey", "cHJpdktleQ"))
         whenever(syncJweCrypto.extractJwkComponents(anyString())).thenReturn("modulus" to "AQAB")
         whenever(nativeLib.encryptData(any<ByteArray>(), eq(secretKey)))
             .thenReturn(EncryptBytesResult(0, "ddg_wrapped".toByteArray()))
@@ -245,6 +245,8 @@ class ThirdPartyCredentialManagerTest {
         val result = manager.create()
 
         assertEquals(Success(true), result)
+        // The locally-minted ai_chats keypair must use 2048-bit size
+        verify(syncJweCrypto).generateRsaKeyPair(2048)
         // getProtectedKeys called once (no re-fetch after local mint).
         verify(syncApi, times(1)).getProtectedKeys(token)
         verify(syncApi).createAccessCredential(

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/exchange/v2/RealExchangeV2RunnerTest.kt
@@ -83,7 +83,7 @@ class RealExchangeV2RunnerTest {
             ExchangeV2CodeParseResult.LinkingV2(channelId = "peer-channel", publicKey = "peer-pubkey", version = "2"),
         )
         whenever(qrCode.buildLinkingCode(any(), any(), any())).thenReturn("https://duckduckgo.com/sync/pairing/#&code2=fake")
-        whenever(jweCrypto.generateRsaKeyPair()).thenReturn(RsaKeyPair(publicKeyBase64 = "own-pub", privateKeyBase64 = "own-priv"))
+        whenever(jweCrypto.generateRsaKeyPair(any())).thenReturn(RsaKeyPair(publicKeyBase64 = "own-pub", privateKeyBase64 = "own-priv"))
         whenever(channel.createChannel(any())).thenReturn(Result.Success(Unit))
         whenever(channel.poll(any(), any())).thenReturn(emptyFlow())
         whenever(channel.sendMessage(any(), any(), any(), any())).thenReturn(Result.Success(Unit))
@@ -96,6 +96,13 @@ class RealExchangeV2RunnerTest {
         runner.startScan(pastedUrl = "ignored")
 
         assertSame(ExchangeV2State.Negotiating, runner.currentState)
+    }
+
+    @Test fun `bootstrap generates a 2048-bit RSA keypair`() = runTest {
+        val runner = newRunner()
+        runner.startScan(pastedUrl = "ignored")
+
+        verify(jweCrypto).generateRsaKeyPair(2048)
     }
 
     @Test fun `cancel abandons the session`() = runTest {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1216856074810008?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
No behavioral change; the two existing places where create a keypair in sync using RSA-2048 continue to do so. This change is preparation for upcoming functionality where we will need to use a different size.

### Steps to test this PR

- QA optional; no functional changes