### PR TITLE
[Drift Audit] Update ADS rule doc to cover the Compose component surface

### DIFF
--- a/.cursor/rules/android-design-system.mdc
+++ b/.cursor/rules/android-design-system.mdc
@@ -8,11 +8,15 @@ The DuckDuckGo Android Design System lives in `android-design-system/design-syst
 
 **Never use raw platform widgets** (`Button`, `TextView`, `Switch`, `AlertDialog`, `BottomSheetDialog`, etc.) — lint detects and fails on these. Always use the ADS equivalent.
 
+The same applies in Compose: **never use raw Material3 composables** (`Button`, `Snackbar`, `Surface`, `AlertDialog`, `Switch`, `Checkbox`, `RadioButton`, `HorizontalDivider`, `VerticalDivider`) — lint fails on these outside the design-system module itself. Use the `Dax*` composable equivalent.
+
 ---
 
 ## Package
 
-All components live under `com.duckduckgo.common.ui.view.*`. Use this package in both Kotlin code and XML layouts.
+View-based components live under `com.duckduckgo.common.ui.view.*`. Use this package in both Kotlin code and XML layouts.
+
+Compose components live under `com.duckduckgo.common.ui.compose.*` (e.g. `com.duckduckgo.common.ui.compose.snackbar.DaxSnackbar`, `...compose.button.DaxPrimaryButton`, `...compose.text.DaxText`). Theming for Compose comes from `com.duckduckgo.common.ui.compose.theme.*` — wrap screens in `DuckDuckGoTheme` and take colors from it rather than hardcoding.
 
 ---
 
@@ -117,7 +121,7 @@ fun removeEndIcon()
 fun doOnTextChanged(action: (CharSequence?, Int, Int, Int) -> Unit)
 ```
 
-Use `error` only for invalid user input. For network/external errors, use a Snackbar instead.
+Use `error` only for invalid user input. For network/external errors, use a snackbar instead — see *Snackbars* below.
 
 ---
 
@@ -335,6 +339,30 @@ Self-hiding component that shows a notification prompt when system notifications
 
 ---
 
+## Snackbars
+
+Compose only — `com.duckduckgo.common.ui.compose.snackbar.DaxSnackbar`. Never use the raw Material3 `Snackbar`; lint breaks the build.
+
+Two overloads:
+```kotlin
+// Direct — you control visibility
+DaxSnackbar(
+    message: String,
+    modifier: Modifier = Modifier,
+    action: DaxAction? = null,
+)
+
+// Inside a SnackbarHost — driven by SnackbarHostState
+DaxSnackbar(
+    snackbarData: SnackbarData,
+    modifier: Modifier = Modifier,
+)
+```
+
+To show snackbars from a screen, pass the `SnackbarData` overload to a `SnackbarHost`. The optional action takes a `DaxAction` (`text` + `onClick`) and renders as a ghost button.
+
+---
+
 ## Colors
 
 **Never use `@color/` references directly in XML** — lint breaks the build. Always use `?attr/daxColor*` theme attributes.
@@ -412,6 +440,25 @@ These are enforced at compile time:
 | `NoBottomSheetDialogDetector` | Raw `BottomSheetDialog` without ADS style |
 | `SkeletonViewBackgroundDetector` | `background_skeleton` drawable on `SkeletonView` |
 | `WrongStyleDetector` | Styles not prefixed `Widget.DuckDuckGo.` |
+
+Compose-specific rules, also build-breaking. The raw-Material3 substitution rules (`NoRawM3*` / `NoMaterial3*`) are skipped inside the design-system module itself, since that is where the `Dax*` wrappers are built; the `Dax*` usage rules below them apply everywhere.
+
+| Rule | What it prevents |
+|---|---|
+| `NoRawM3ButtonUsageDetector` | Raw Material3 button composables (use `DaxButton` variants) |
+| `NoRawM3SnackbarUsageDetector` | Raw Material3 `Snackbar` (use `DaxSnackbar`) |
+| `NoRawM3SurfaceUsageDetector` | Raw Material3 `Surface` (use `DaxSurface`) |
+| `NoRawM3AlertDialogUsageDetector` | Raw Material3 alert dialogs (use `DaxAlertDialog` / `DaxTextAlertDialog`) |
+| `NoMaterial3SwitchUsageDetector` | Material3 `Switch` (use `DaxSwitch`) |
+| `NoMaterial3CheckboxUsageDetector` | Material3 `Checkbox` (use `DaxCheckbox`) |
+| `NoMaterial3RadioButtonUsageDetector` | Material3 `RadioButton` (use `DaxRadioButton`) |
+| `NoMaterial3DividerUsageDetector` | Material3 `HorizontalDivider` / `VerticalDivider` (use `DaxHorizontalDivider` / `DaxVerticalDivider`) |
+| `DaxTextColorUsageDetector` | `DaxText` colors outside `DuckDuckGoTheme` semantic text colors |
+| `DaxDividerColorUsageDetector` | Divider colors outside `DuckDuckGoTheme` semantic colors |
+| `DaxTextFieldTrailingIconDetector` | `DaxTextField` `trailingIcon` outside `DaxTextFieldTrailingIconScope` |
+| `DaxSecureTextFieldTrailingIconDetector` | `DaxSecureTextField` `trailingIcon` outside `DaxTextFieldTrailingIconScope` |
+| `NoComposeViewUsageDetector` | `ComposeView` in XML layouts or custom views |
+| `NoSetContentDetector` | `setContent` in Activities |
 
 ---
 


### PR DESCRIPTION
Task/Issue URL: (app.asana.com/redacted)
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable):

### Description
`.cursor/rules/android-design-system.mdc` — the doc was last updated 2026-04-07 (`aaf176d01`) and describes ADS as an XML/View-only design system. ADS has since grown a Compose surface (49 files under `com.duckduckgo.common.ui.compose.*`) with its own build-breaking lint rules, so three of the doc's claims no longer match the code.

**The code change that surfaced it:** [`#9044` — Compose: Add DaxSnackbar to ADS](https://github.com/duckduckgo/Android/pull/9044) (`fc83357cc`, 2026-07-22) added `com.duckduckgo.common.ui.compose.snackbar.DaxSnackbar` plus a new build-breaking lint rule, `NoRawM3SnackbarUsageDetector` (registered as `NO_RAW_M3_SNACKBAR_USAGE` in `DuckDuckGoIssueRegistry`, `Severity.ERROR`). The doc told readers "For network/external errors, use a Snackbar instead" with no pointer to an ADS component — following that in a Compose screen now fails the build.

Pulling that thread showed the same gap in two adjacent claims:

1. **"Package" section** described: *"All components live under `com.duckduckgo.common.ui.view.*`."* That is now false — Compose components live under `com.duckduckgo.common.ui.compose.*`, with theming in `...compose.theme.*` (`DuckDuckGoTheme` exists both as an object and as a composable wrapper in `theme/Theme.kt`). **Now reads:** names both packages and points at `DuckDuckGoTheme` for Compose theming.

2. **"Lint Rules (build-breaking)" table** listed 10 detectors and claimed to be what "is enforced at compile time". It omitted 14 registered, build-breaking ADS rules. **Now reads:** the original table is unchanged, followed by a second table for the Compose rules. Every row was verified present in `DuckDuckGoIssueRegistry.issues` and its `briefDescription` read from the detector: `NoRawM3Button/Snackbar/Surface/AlertDialogUsageDetector`, `NoMaterial3Switch/Checkbox/RadioButton/DividerUsageDetector`, `DaxTextColorUsageDetector`, `DaxDividerColorUsageDetector`, `DaxTextField`/`DaxSecureTextFieldTrailingIconDetector`, `NoComposeViewUsageDetector`, `NoSetContentDetector`.

3. **Snackbar guidance** — added a short *Snackbars* section with the two real `DaxSnackbar` overloads (`message`/`action` and `SnackbarData`) taken from the source, and corrected the text-input line to link to it.

I also checked the design-system-module exemption per detector rather than generalising from the snackbar one: the eight `NoRawM3*`/`NoMaterial3*` rules skip the design-system module (`isInDesignSystemModule`), the four `Dax*` usage rules do not. The doc says exactly that.

Only prose was changed — no code, and only the canonical `.cursor/rules/*.mdc` file (the `.claude/rules` symlink is untouched).

Two areas I deliberately left alone as **not** drift:
- **`.cursor/rules/pixels.mdc`** vs [`#9190` — Disable ATB by default for pixels](https://github.com/duckduckgo/Android/pull/9190), which added the `PixelRequiringAtbPlugin` plugin point and reworked `RxPixelSender`. The doc never mentions ATB, so nothing it states became false. Worth a human deciding whether ATB attachment *should* be documented — that would be new content, not a drift fix.
- **`.cursor/rules/maestro-ui-tests.mdc`** — `.maestro/**` changed a lot in this window, but the changes were test content and patch files, not the tags/config/run mechanics the doc describes.

🤖 AI-docs Drift Auditor

### Steps to test this PR

_Compose lint rules_
- [ ] Read the updated "Lint Rules (build-breaking)" Compose table against `DuckDuckGoIssueRegistry.issues` and confirm each detector is registered and does what the row says.
- [ ] Confirm the exemption note matches the code: `isInDesignSystemModule` is present in the eight `NoRawM3*`/`NoMaterial3*` detectors and absent from the four `Dax*` usage detectors.

_Snackbars & package_
- [ ] Read the new *Snackbars* section against `compose/snackbar/DaxSnackbar.kt` and confirm both overload signatures and the `DaxAction` (`text` + `onClick`) description match.
- [ ] Confirm the "Package" section matches reality: View components under `com.duckduckgo.common.ui.view.*`, Compose under `com.duckduckgo.common.ui.compose.*`.

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |




> [!NOTE]
> <details>
> <summary><b>🔒 Integrity filter blocked 3 items</b></summary>
>
> The following items were blocked because they don't meet the GitHub integrity level.
>
> - [#8891](https://github.com/duckduckgo/Android/pull/8891) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#8811](https://github.com/duckduckgo/Android/pull/8811) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#8809](https://github.com/duckduckgo/Android/pull/8809) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
>
> To allow these resources, lower `min-integrity` in your GitHub frontmatter:
>
> ```yaml
> tools:
>   github:
>     min-integrity: approved  # merged | approved | unapproved | none
> ```
>
> </details>


> Generated by [AI-docs Semantic Drift Audit](https://github.com/duckduckgo/Android/actions/runs/30146566938/agentic_workflow) · [◷](https://github.com/search?q=repo%3Aduckduckgo%2FAndroid+%22gh-aw-workflow-id%3A+drift-audit%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: AI-docs Semantic Drift Audit, engine: claude, model: auto, id: 30146566938, workflow_id: drift-audit, run: https://github.com/duckduckgo/Android/actions/runs/30146566938 -->

<!-- gh-aw-workflow-id: drift-audit -->