### PR TITLE
Update PIR broker bundle - 2026-07-27

### DIFF
--- a/pir/pir-impl/src/main/assets/brokers/beenverified.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/beenverified.com.json
@@ -1,70 +1,70 @@
 {
   "name": "BeenVerified",
   "url": "beenverified.com",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "optOutUrl": "https://www.beenverified.com/svc/optout/search/optouts",
   "mirrorSites": [
     {
       "name": "Background Checks.org",
       "url": "backgroundchecks.org",
       "addedAt": 1745317273356,
-      "removedAt": null,
+      "removedAt": 1784914357590,
       "optOutUrl": "https://www.beenverified.com/svc/optout/search/optouts"
     },
     {
       "name": "DOBSearch",
       "url": "DOBsearch.com",
       "addedAt": 1745317273356,
-      "removedAt": null,
+      "removedAt": 1784914357590,
       "optOutUrl": "https://www.beenverified.com/svc/optout/search/optouts"
     },
     {
       "name": "EmailTracer",
       "url": "emailtracer.com",
       "addedAt": 1745317273356,
-      "removedAt": null,
+      "removedAt": 1784914357590,
       "optOutUrl": "https://www.beenverified.com/svc/optout/search/optouts"
     },
     {
       "name": "Government Registry",
       "url": "governmentregistry.org",
       "addedAt": 1745317273356,
-      "removedAt": null,
+      "removedAt": 1784914357590,
       "optOutUrl": "https://www.beenverified.com/svc/optout/search/optouts"
     },
     {
       "name": "Open Public Records",
       "url": "open-public-records.com",
       "addedAt": 1745317273356,
-      "removedAt": null,
+      "removedAt": 1784914357590,
       "optOutUrl": "https://www.beenverified.com/svc/optout/search/optouts"
     },
     {
       "name": "Phone Lookup California",
       "url": "californiaphonelookup.com",
       "addedAt": 1745317273356,
-      "removedAt": null,
+      "removedAt": 1784914357590,
       "optOutUrl": "https://www.beenverified.com/svc/optout/search/optouts"
     },
     {
       "name": "Phone Lookup Florida",
       "url": "floridaphonelookup.com",
       "addedAt": 1745317273356,
-      "removedAt": null,
+      "removedAt": 1784914357590,
       "optOutUrl": "https://www.beenverified.com/svc/optout/search/optouts"
     },
     {
       "name": "SearchSystems",
       "url": "publicrecords.searchsystems.net",
       "addedAt": 1745317273356,
-      "removedAt": null,
+      "removedAt": 1784914357590,
       "optOutUrl": "https://www.beenverified.com/svc/optout/search/optouts"
     },
     {
       "name": "yellowbook",
       "url": "yellowbook.com",
       "addedAt": 1745317273356,
-      "removedAt": null,
+      "removedAt": 1784914357590,
       "optOutUrl": "https://www.beenverified.com/svc/optout/search/optouts"
     }
   ],
@@ -539,5 +539,5 @@
     "maxAttempts": -1
   },
   "addedDatetime": 1744978506975,
-  "removedAt": null
+  "removedAt": 1784914357590
 }

--- a/pir/pir-impl/src/main/assets/brokers/mylife.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/mylife.com.json
@@ -1,7 +1,7 @@
 {
   "name": "mylife",
   "url": "mylife.com",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "addedDatetime": 1715797497496,
   "optOutUrl": "https://mylife.jotform.com/260284407610047",
   "steps": [
@@ -179,5 +179,5 @@
     "maintenanceScan": 120,
     "maxAttempts": -1
   },
-  "removedAt": null
+  "removedAt": 1784914357595
 }

--- a/pir/pir-impl/src/main/assets/brokers/neighborwho.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/neighborwho.com.json
@@ -1,7 +1,7 @@
 {
   "name": "NeighborWho",
   "url": "neighborwho.com",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "parent": "beenverified.com",
   "optOutUrl": "https://www.neighborwho.com/svc/optout/search/optouts",
   "mirrorSites": [
@@ -9,7 +9,7 @@
       "name": "Background Checks.me",
       "url": "backgroundchecks.me",
       "addedAt": 1745317273356,
-      "removedAt": null,
+      "removedAt": 1784914357592,
       "optOutUrl": "https://www.neighborwho.com/svc/optout/search/optouts"
     }
   ],
@@ -226,5 +226,5 @@
     "maxAttempts": -1
   },
   "addedDatetime": 1745320348502,
-  "removedAt": null
+  "removedAt": 1784914357592
 }

--- a/pir/pir-impl/src/main/assets/brokers/peoplelooker.com.json
+++ b/pir/pir-impl/src/main/assets/brokers/peoplelooker.com.json
@@ -1,7 +1,7 @@
 {
   "name": "PeopleLooker",
   "url": "peoplelooker.com",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "parent": "beenverified.com",
   "optOutUrl": "https://www.peoplelooker.com/svc/optout/search/optouts",
   "steps": [
@@ -217,5 +217,5 @@
     "maxAttempts": -1
   },
   "addedDatetime": 1745320373493,
-  "removedAt": null
+  "removedAt": 1784914357593
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/414730916066338/task/1216888276554635

## PIR Broker Bundle Update

Automated update of PIR broker JSON files from the remote bundle.

### Changes

**Updated (4):**
- beenverified.com.json (0.10.1 → 0.11.0)
- mylife.com.json (0.8.0 → 0.9.0)
- neighborwho.com.json (0.6.1 → 0.7.0)
- peoplelooker.com.json (0.6.1 → 0.7.0)

### Checklist

- [ ] Verify broker changes look correct
- [ ] All tests must pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removing active brokers stops new scans/opt-outs for those sites; incorrect timestamps could retire brokers too early or leave stale ones active.
> 
> **Overview**
> This bundle update **retires four PIR brokers** by setting `removedAt` (from `null` to scheduled removal timestamps) and bumping each file’s `version`. **BeenVerified** (`beenverified.com`, 0.10.1 → 0.11.0) is removed along with all nine **mirror sites** on that config. **MyLife**, **NeighborWho**, and **PeopleLooker** are removed as well (NeighborWho and PeopleLooker remain child configs of BeenVerified but are also marked removed).
> 
> There are **no changes to scan/opt-out step definitions** in this diff—only metadata/version/removal fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e74ee7577c8a3cd650b16e5e1701200051e6a04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->