### PR TITLE
Contextual/NativeInput: Always show options for native input regardless of focus state

### DIFF
--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/contextual/DuckChatContextualFragment.kt
@@ -48,6 +48,7 @@ import androidx.activity.OnBackPressedCallback
 import androidx.annotation.AnyThread
 import androidx.core.content.ContextCompat
 import androidx.core.view.isInvisible
+import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.setFragmentResult
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModelProvider
@@ -231,6 +232,7 @@ class DuckChatContextualFragment :
     private val keyboardVisibilityListener =
         ViewTreeObserver.OnGlobalLayoutListener {
             runCatching {
+                updateContentAreaHeight()
                 val rootView = binding.root
                 val rect = Rect()
                 rootView.getWindowVisibleDisplayFrame(rect)
@@ -262,12 +264,14 @@ class DuckChatContextualFragment :
                     viewModel.onSheetClosed()
                 }
                 backPressedCallback.isEnabled = newState != BottomSheetBehavior.STATE_HIDDEN
+                updateContentAreaHeight()
             }
 
             override fun onSlide(
                 bottomSheet: View,
                 slideOffset: Float,
             ) {
+                updateContentAreaHeight()
             }
         }
 
@@ -539,8 +543,44 @@ class DuckChatContextualFragment :
         bottomSheetBehavior.skipCollapsed = true
         bottomSheetBehavior.isDraggable = true
         bottomSheetBehavior.isHideable = true
-        bottomSheetBehavior.isFitToContents = true
+        bottomSheetBehavior.isFitToContents = false
         bottomSheetBehavior.expandedOffset = 0
+        bottomSheetBehavior.halfExpandedRatio = HALF_EXPANDED_RATIO
+    }
+
+    private fun updateContentAreaHeight() {
+        // contextualContentArea holds either the contextual prompts or the chat webview.
+        val contentArea = binding.contextualContentArea
+        // Let the content area flex (weight 1) to fill the remaining height, input kept as wrap_content
+        // below it, when:
+        //  - WEBVIEW mode: the webview should always take the rest; never resize it per-frame (glitches).
+        //  - Expanded: the sheet fills the coordinator, so BrowserActivity's adjustResize can lift the
+        //    input above the keyboard natively instead of the per-frame resize below fighting the IME.
+        val isWebViewMode = viewModel.viewState.value.sheetMode == DuckChatContextualViewModel.SheetMode.WEBVIEW
+        if (isWebViewMode || bottomSheetBehavior.state == BottomSheetBehavior.STATE_EXPANDED) {
+            val params = contentArea.layoutParams as LinearLayout.LayoutParams
+            if (params.height != 0 || params.weight != 1f) {
+                contentArea.updateLayoutParams<LinearLayout.LayoutParams> {
+                    weight = 1f
+                    height = 0
+                }
+            }
+            return
+        }
+
+        val sheet = binding.contextualModeRoot.parent as? View ?: return
+        val coordinatorHeight = (sheet.parent as? View)?.height ?: return
+        if (coordinatorHeight <= 0) return
+        val visibleSheetHeight = (coordinatorHeight - sheet.top).coerceAtLeast(0)
+        val chromeHeight = binding.contextualModeButtons.height + binding.contextualInputContainer.height
+        val contentHeight = (visibleSheetHeight - chromeHeight).coerceAtLeast(0)
+        // Size the middle to the visible sheet minus header + input, so the input sits on the visible edge.
+        if (contentArea.layoutParams.height != contentHeight) {
+            contentArea.updateLayoutParams<LinearLayout.LayoutParams> {
+                weight = 0f
+                height = contentHeight
+            }
+        }
     }
 
     private fun setupBackPressHandling() {
@@ -1212,6 +1252,7 @@ class DuckChatContextualFragment :
     }
 
     companion object {
+        private const val HALF_EXPANDED_RATIO = 0.5f
         private const val MAX_CHAT_TITLE_LINES = 1
         private const val PERMISSION_REQUEST_WRITE_EXTERNAL_STORAGE = 200
         private const val CUSTOM_UA =

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -638,7 +638,7 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val bottomRow = findViewById<View?>(R.id.inputModeWidgetBottomRow) ?: return
         val suppress = nativeInputState?.shouldSuppressBottomRow() == true
         val visible = isChatTabSelected() &&
-            (inputField.hasFocus() || previewEnterFocus) &&
+            (inputField.hasFocus() || previewEnterFocus || isContextualWidget) &&
             !isStreaming &&
             !suppress
         bottomRow.visibility = if (visible) VISIBLE else GONE

--- a/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai_native.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/fragment_contextual_duck_ai_native.xml
@@ -117,43 +117,48 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <LinearLayout
-        android:id="@+id/contextualModePrompts"
-        android:layout_width="match_parent"
-        android:layout_height="200dp"
-        android:orientation="vertical"
-        android:paddingHorizontal="@dimen/keyline_4"
-        android:gravity="bottom"
-        android:paddingTop="@dimen/keyline_4"
-        android:paddingBottom="@dimen/keyline_1"
-        app:layout_constraintBottom_toTopOf="@id/inputModeWidgetCard"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/contextualModeInputSpacer">
-
-        <com.duckduckgo.common.ui.view.text.DaxTextView
-            android:id="@+id/contextualPromptQuickAction"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:background="@drawable/duck_ai_prompt_background"
-            android:drawableStart="@drawable/ic_arrow_down_right_16"
-            android:drawablePadding="@dimen/keyline_2"
-            android:padding="@dimen/keyline_2"
-            tools:text="@string/duckAIContextualPromptSummarize"
-            app:typography="body2_bold" />
-
-    </LinearLayout>
-
     <FrameLayout
-        android:id="@+id/contextualWebviewContainer"
+        android:id="@+id/contextualContentArea"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1">
 
-        <WebView
-            android:id="@+id/simpleWebview"
+        <LinearLayout
+            android:id="@+id/contextualModePrompts"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            android:paddingHorizontal="@dimen/keyline_4"
+            android:gravity="bottom"
+            android:paddingTop="@dimen/keyline_4"
+            android:paddingBottom="@dimen/keyline_1">
+
+            <com.duckduckgo.common.ui.view.text.DaxTextView
+                android:id="@+id/contextualPromptQuickAction"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/duck_ai_prompt_background"
+                android:drawableStart="@drawable/ic_arrow_down_right_16"
+                android:drawablePadding="@dimen/keyline_2"
+                android:padding="@dimen/keyline_2"
+                tools:text="@string/duckAIContextualPromptSummarize"
+                app:typography="body2_bold" />
+
+        </LinearLayout>
+
+        <FrameLayout
+            android:id="@+id/contextualWebviewContainer"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <WebView
+                android:id="@+id/simpleWebview"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+
+        </FrameLayout>
 
     </FrameLayout>
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/488551667048375/task/1216783690854365?focus=true
Tech Design URL (if applicable): N/A
API Proposals URL(s) (if applicable): N/A

### Description
 - Show the contextual Duck.ai unified input bottom view at all times, regardless of input focus (the bottom row now stays visible for the contextual widget instead of only when the field is focused).
 - Turn the contextual sheet into a proper sliding sheet with real half-expanded and expanded detents (isFitToContents = false + halfExpandedRatio).
  - Keep the native input anchored to the visible bottom edge of the sheet in every position: while half/dragging the middle content area is sized to visible sheet height − header − input; once expanded it flexes by weight so adjustResize lifts the input above the keyboard natively instead of fighting the IME with per-frame resizes.

### Steps to test this PR
_contextualNativeInput ENABLED_
- [x] Install internal build + feature is enabled by default here
- [x] Open a website
- [x] Click on the contextual chat entry point
- [x] Verify that sheet appears normally (no visible glitches)
- [x] Verify that all options on the native input are visible (attach, model, reasoning etc).
- [x] Click on Ask about page
- [x] Verify that  context is attached, input is focused and completely visible and keyboard is show
- [x] Dismiss keyboard and manually drag sheet to become full screen
- [x] Verify that it looks OK visually
- [x] Focus input again and verify that keyboard is shown with no issues and native input is visible.
- [x] Select Summarize page
- [x] Verify that chat view looks OK (native input completely shown at the bottom, chat webview is completely shown)
- [x] close sheet and reopen again
- [x] Verify it looks OK.

_contextualNativeInput DISABLED_
- [x] Go to FF inventory -> toggle contextualNativeInput to OFF and restart the app
- [x] Open a website
- [x] Click on the contextual chat entry point
- [x] Verify that sheet appears normally (no visible glitches)
- [x] Verify that all options on the native input are visible (attach, model, reasoning etc).
- [x] Click on Ask about page
- [x] Verify that  context is attached, input is focused and completely visible and keyboard is show
- [x] Dismiss keyboard and manually drag sheet to become full screen
- [x] Verify that it looks OK visually
- [x] Focus input again and verify that keyboard is shown with no issues and native input is visible.
- [x] Select Summarize page
- [x] Verify that chat view looks OK (native input completely shown at the bottom, chat webview is completely shown)
- [x] close sheet and reopen again
- [x] Verify it looks OK.

Before: 
https://github.com/user-attachments/assets/150d5242-978c-4308-a803-18fbdcb09c06

After:
- Contextual Native OFF: https://github.com/user-attachments/assets/005a4585-9eb6-4fb1-b6b8-a6157b6bcbd6
- Contextual Native ON: https://github.com/user-attachments/assets/9287bf3d-48ee-4c49-9981-1564abb26291



<!-- CURSOR_SUMMARY -->
---



> [!NOTE]
> **Medium Risk**
> Touches bottom-sheet layout, IME/keyboard interaction, and contextual UI timing; regressions could show as sheet glitches or clipped input, but changes are scoped to contextual Duck.ai flows.
> 
> **Overview**
> Improves the contextual Duck.ai bottom sheet so the native input **bottom row** (attach, model, reasoning, etc.) stays visible for the contextual widget even when the field isn’t focused, and the sheet behaves like a real half-expanded / expanded sliding sheet.
> 
> **Sheet behavior:** `BottomSheetBehavior` now uses `isFitToContents = false` with `halfExpandedRatio` (0.5). **`updateContentAreaHeight()`** runs on sheet slide/state changes and keyboard layout updates to size `contextualContentArea` to visible sheet height minus header and input while dragging at half-expanded; in **WEBVIEW** mode or when **fully expanded**, the middle area flexes with `layout_weight` so `adjustResize` can lift the input above the IME instead of per-frame height fights.
> 
> **Layout:** Prompts and chat WebView are grouped under a shared **`contextualContentArea`** container (WebView stack starts `gone` until chat mode).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 403f781ef5292e82e18c64ce6df86abfc819e3f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->