### PR TITLE
Install status-bar scrim in browser to fix omnibar/status bar overlap

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserActivity.kt
@@ -919,7 +919,9 @@ open class BrowserActivity : DuckDuckGoActivity() {
                 SystemBarStyle.light(toolbarColor, toolbarColor)
             }
             enableEdgeToEdge(statusBarStyle = barStyle, navigationBarStyle = barStyle)
-            edgeToEdgeHandler.applyStatusBarAndHorizontalInsets(binding.root, installScrim = false)
+            // Scrim needed: SystemBarStyle colours are no-ops on Android 15+, and views that disable
+            // ancestor clipping (pulse animation, card shadows) can otherwise draw over the status bar.
+            edgeToEdgeHandler.applyStatusBarAndHorizontalInsets(binding.root)
             edgeToEdgeHandler.applyNavigationBarInsets(binding.navigationBarMockup.root)
             edgeToEdgeHandler.applyNavigationBarInsets(binding.bottomMockupToolbar.appBarLayoutMockup)
             applyDisplayCutoutMode(resources.configuration.orientation)

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeFeature.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeFeature.kt
@@ -20,6 +20,7 @@ import com.duckduckgo.anvil.annotations.ContributesRemoteFeature
 import com.duckduckgo.di.scopes.AppScope
 import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
+import com.duckduckgo.feature.toggles.api.Toggle.InternalAlwaysEnabled
 
 @ContributesRemoteFeature(
     scope = AppScope::class,
@@ -28,32 +29,42 @@ import com.duckduckgo.feature.toggles.api.Toggle.DefaultFeatureValue
 interface EdgeToEdgeFeature {
 
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @InternalAlwaysEnabled
     fun self(): Toggle
 
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @InternalAlwaysEnabled
     fun browser(): Toggle
 
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @InternalAlwaysEnabled
     fun settings(): Toggle
 
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @InternalAlwaysEnabled
     fun autofill(): Toggle
 
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @InternalAlwaysEnabled
     fun sync(): Toggle
 
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @InternalAlwaysEnabled
     fun vpn(): Toggle
 
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @InternalAlwaysEnabled
     fun webview(): Toggle
 
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @InternalAlwaysEnabled
     fun onboarding(): Toggle
 
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @InternalAlwaysEnabled
     fun misc(): Toggle
 
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    @InternalAlwaysEnabled
     fun bottomSheets(): Toggle
 }

--- a/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeHandler.kt
+++ b/common/common-utils/src/main/java/com/duckduckgo/common/utils/edgetoedge/EdgeToEdgeHandler.kt
@@ -326,27 +326,30 @@ class EdgeToEdgeHandler @Inject constructor() {
      * screen; a no-op when the colour can't be resolved.
      */
     private fun installStatusBarScrim(anchor: View) {
-        val contentRoot = anchor.rootView?.findViewById<ViewGroup>(android.R.id.content) ?: return
-        if (contentRoot.findViewWithTag<View>(STATUS_BAR_SCRIM_TAG) != null) return
-        val scrimColor = anchor.context.resolveStatusBarScrimColor() ?: return
+        // Deferred until attach: before setContentView there is no window content frame to add the scrim to.
+        anchor.doOnAttach {
+            val contentRoot = anchor.rootView?.findViewById<ViewGroup>(android.R.id.content) ?: return@doOnAttach
+            if (contentRoot.findViewWithTag<View>(STATUS_BAR_SCRIM_TAG) != null) return@doOnAttach
+            val scrimColor = anchor.context.resolveStatusBarScrimColor() ?: return@doOnAttach
 
-        val scrim = View(anchor.context).apply {
-            tag = STATUS_BAR_SCRIM_TAG
-            setBackgroundColor(scrimColor)
-            layoutParams = FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, 0, Gravity.TOP)
-        }
-        contentRoot.addView(scrim)
-
-        ViewCompat.setOnApplyWindowInsetsListener(scrim) { v, insets ->
-            val top = insets.getInsets(
-                WindowInsetsCompat.Type.statusBars() or WindowInsetsCompat.Type.displayCutout(),
-            ).top
-            if (v.layoutParams.height != top) {
-                v.updateLayoutParams { height = top }
+            val scrim = View(anchor.context).apply {
+                tag = STATUS_BAR_SCRIM_TAG
+                setBackgroundColor(scrimColor)
+                layoutParams = FrameLayout.LayoutParams(FrameLayout.LayoutParams.MATCH_PARENT, 0, Gravity.TOP)
             }
-            insets
+            contentRoot.addView(scrim)
+
+            ViewCompat.setOnApplyWindowInsetsListener(scrim) { v, insets ->
+                val top = insets.getInsets(
+                    WindowInsetsCompat.Type.statusBars() or WindowInsetsCompat.Type.displayCutout(),
+                ).top
+                if (v.layoutParams.height != top) {
+                    v.updateLayoutParams { height = top }
+                }
+                insets
+            }
+            ViewCompat.requestApplyInsets(scrim)
         }
-        ViewCompat.requestApplyInsets(scrim)
     }
 
     /**


### PR DESCRIPTION
Task/Issue URL: 
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
On Android 16 (targetSdk 36) edge-to-edge is enforced: the opt-out theme attribute is ignored and status-bar colours become no-ops, leaving the status-bar strip transparent. Views that disable ancestor clipping to draw outside their bounds (pulse animation, card shadows via setAllParentsClip) then let the scrolled-away omnibar paint over the status bar.

Install the EdgeToEdgeHandler status-bar scrim in BrowserActivity, restoring the opaque strip previously drawn by the decor. Scrim installation is deferred to view attach because configureEdgeToEdge() runs before setContentView, where the window content frame doesn't exist yet and the scrim would silently not install.

Also mark the edgeToEdge feature flags InternalAlwaysEnabled so internal builds always exercise the edge-to-edge paths.

### Steps to test this PR

_Feature 1_
- [ ]
- [ ]

### UI changes
| Before  | After |
| ------ | ----- |
!(Upload before screenshot)|(Upload after screenshot)|
