### PR TITLE
Display camera preview during simplifed sync

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/CameraScannerFragment.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/CameraScannerFragment.kt
@@ -19,6 +19,7 @@ package com.duckduckgo.sync.impl.ui.v2
 import android.Manifest
 import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
+import android.animation.ValueAnimator
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -26,8 +27,10 @@ import android.provider.Settings
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.animation.AccelerateDecelerateInterpolator
 import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
 import androidx.core.view.OneShotPreDrawListener
+import androidx.core.view.doOnLayout
 import androidx.core.view.doOnPreDraw
 import androidx.core.view.isGone
 import androidx.core.view.isVisible
@@ -37,12 +40,15 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoFragment
+import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.utils.FragmentViewModelFactory
 import com.duckduckgo.di.scopes.FragmentScope
 import com.duckduckgo.sync.impl.databinding.FragmentSyncV2CameraScannerBinding
 import com.duckduckgo.sync.impl.ui.v2.IntroAnimationViewModel.Command
+import com.duckduckgo.sync.impl.ui.v2.IntroAnimationViewModel.Command.ExpandScannerCutout
 import com.duckduckgo.sync.impl.ui.v2.IntroAnimationViewModel.Command.PlayIntroAnimation
 import com.duckduckgo.sync.impl.ui.v2.IntroAnimationViewModel.Command.RequestCameraPermission
+import com.duckduckgo.sync.impl.ui.v2.IntroAnimationViewModel.Command.ResumeCamera
 import com.duckduckgo.sync.impl.ui.v2.IntroAnimationViewModel.ViewMode
 import com.duckduckgo.sync.impl.ui.v2.IntroAnimationViewModel.ViewState
 import kotlinx.coroutines.flow.launchIn
@@ -67,6 +73,7 @@ class CameraScannerFragment : DuckDuckGoFragment() {
     }
 
     private var resetAnimationListener: OneShotPreDrawListener? = null
+    private var cutoutAnimator: ValueAnimator? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -86,6 +93,7 @@ class CameraScannerFragment : DuckDuckGoFragment() {
         configureIntroAnimation()
         configureReadyToScanButtons()
         configureGoToSettingsButton()
+        configureCutout()
 
         observeUiEvents()
     }
@@ -97,7 +105,9 @@ class CameraScannerFragment : DuckDuckGoFragment() {
     }
 
     override fun onPause() {
+        binding.includeCamera.barcodeView.pause()
         binding.includeIntro.introAnimation.pauseAnimation()
+
         // onPause can fire while the view is still on screen so rewinding immediately
         // would show a visible jump. By the next pre-draw the view is guaranteed
         // to be off-screen, so the rewind is never seen.
@@ -109,10 +119,22 @@ class CameraScannerFragment : DuckDuckGoFragment() {
                 binding.includeIntro.introAnimation.progress = 0f
             }
         }
+
+        cutoutAnimator?.cancel()
+        cutoutAnimator = null
+        // Reset only on a pager page switch, which pauses just this fragment once its page is
+        // already off-screen. Anything that pauses the whole activity (closing, minimizing,
+        // system dialogs) keeps the view visible, where the resize would show as a jump.
+        val isPageSwitch = requireActivity().lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)
+        if (isPageSwitch) {
+            binding.includeCamera.scannerOverlay.cutoutSizeFraction = CUTOUT_FRACTION_START
+        }
         super.onPause()
     }
 
     override fun onDestroyView() {
+        cutoutAnimator?.cancel()
+        cutoutAnimator = null
         resetAnimationListener = null
         _binding = null
         super.onDestroyView()
@@ -156,6 +178,14 @@ class CameraScannerFragment : DuckDuckGoFragment() {
 
             RequestCameraPermission -> {
                 cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
+            }
+
+            ResumeCamera -> {
+                if (isResumed) binding.includeCamera.barcodeView.resume()
+            }
+
+            ExpandScannerCutout -> {
+                runCutoutAnimation()
             }
         }
     }
@@ -201,5 +231,56 @@ class CameraScannerFragment : DuckDuckGoFragment() {
             )
             startActivity(intent)
         }
+    }
+
+    private fun configureCutout() {
+        binding.includeCamera.scannerOverlay.cutoutSizeFraction = CUTOUT_FRACTION_START
+    }
+
+    private fun runCutoutAnimation() {
+        if (cutoutAnimator?.isStarted == true) return
+
+        binding.includeCamera.scannerHeader.doOnLayout {
+            val overlay = _binding?.includeCamera?.scannerOverlay ?: return@doOnLayout
+            val header = _binding?.includeCamera?.scannerHeader ?: return@doOnLayout
+            if (cutoutAnimator?.isStarted == true) return@doOnLayout
+
+            // On tall phone screens the expanded cutout never reaches the header. But on frames with
+            // less free height (tablets, split screen, landscape) the square would collide with the
+            // text, so its size is capped instead.
+            val minDimension = minOf(overlay.width, overlay.height).toFloat()
+            val clearance = header.bottom + CUTOUT_HEADER_GAP_DP.toPx()
+            val maxSide = overlay.height - clearance / CameraScannerOverlayView.CUTOUT_TOP_SPACE_FRACTION
+            val endFraction = CUTOUT_FRACTION_END
+                .coerceAtMost(maxSide / minDimension)
+                .coerceAtLeast(CUTOUT_MIN_SIDE_DP.toPx() / minDimension)
+            val startFraction = CUTOUT_FRACTION_START.coerceAtMost(endFraction)
+
+            if (overlay.cutoutSizeFraction == endFraction) return@doOnLayout
+            if (startFraction == endFraction) {
+                overlay.cutoutSizeFraction = endFraction
+                return@doOnLayout
+            }
+
+            cutoutAnimator = ValueAnimator.ofFloat(startFraction, endFraction).apply {
+                startDelay = CUTOUT_ANIMATION_START_DELAY_MS // Short delay to let the camera initialize
+                duration = CUTOUT_ANIMATION_DURATION_MS
+                interpolator = AccelerateDecelerateInterpolator()
+                addUpdateListener { animator ->
+                    overlay.cutoutSizeFraction = animator.animatedValue as Float
+                }
+                start()
+            }
+        }
+    }
+
+    companion object {
+        private const val CUTOUT_FRACTION_START = 0.53f
+        private const val CUTOUT_FRACTION_END = 0.72f
+        private const val CUTOUT_HEADER_GAP_DP = 16
+        private const val CUTOUT_MIN_SIDE_DP = 140f
+
+        private const val CUTOUT_ANIMATION_START_DELAY_MS = 100L
+        private const val CUTOUT_ANIMATION_DURATION_MS = 450L
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/CameraScannerOverlayView.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/CameraScannerOverlayView.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui.v2
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Matrix
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.RectF
+import android.util.AttributeSet
+import android.view.View
+import androidx.annotation.FloatRange
+import androidx.core.content.ContextCompat
+import com.duckduckgo.common.ui.view.toPx
+import com.duckduckgo.mobile.android.R as CommonR
+
+class CameraScannerOverlayView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+) : View(context, attrs) {
+    private val scrimPath = Path().apply {
+        fillType = Path.FillType.EVEN_ODD
+    }
+    private val scrimPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = SCRIM_COLOR
+    }
+    private val cutoutRect = RectF()
+
+    private val cornerRect = RectF()
+    private val cornerRadius = CUTOUT_CORNER_RADIUS_DP.toPx()
+
+    private val armPath = Path()
+    private val cornerPath = Path()
+    private val mirrorMatrix = Matrix()
+    private val armPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        style = Paint.Style.STROKE
+        strokeWidth = ARM_STROKE_WIDTH_DP.toPx()
+        strokeCap = Paint.Cap.ROUND
+        strokeJoin = Paint.Join.ROUND
+        color = ContextCompat.getColor(context, CommonR.color.blue20)
+    }
+
+    @FloatRange(from = 0.0, to = 1.0)
+    var cutoutSizeFraction: Float = 0.5f
+        set(value) {
+            if (field == value) return
+            field = value
+            rebuildGeometry()
+            invalidate()
+        }
+
+    override fun onSizeChanged(
+        w: Int,
+        h: Int,
+        oldw: Int,
+        oldh: Int,
+    ) {
+        super.onSizeChanged(w, h, oldw, oldh)
+        rebuildGeometry()
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        canvas.drawPath(scrimPath, scrimPaint)
+        canvas.drawPath(armPath, armPaint)
+    }
+
+    private fun rebuildGeometry() {
+        if (width == 0 || height == 0) return
+
+        val side = minOf(width, height) * cutoutSizeFraction
+        val top = (height - side) * CUTOUT_TOP_SPACE_FRACTION
+        cutoutRect.set((width - side) / 2, top, (width + side) / 2, top + side)
+
+        scrimPath.reset()
+        scrimPath.addRect(0f, 0f, width.toFloat(), height.toFloat(), Path.Direction.CW)
+        scrimPath.addRoundRect(cutoutRect, cornerRadius, cornerRadius, Path.Direction.CW)
+
+        // the other three corners are mirror images of the top-left one around the cutout center
+        buildTopLeftCutoutCorner()
+        armPath.rewind()
+        for (scaleX in MIRROR_SCALES) {
+            for (scaleY in MIRROR_SCALES) {
+                mirrorMatrix.setScale(scaleX, scaleY, cutoutRect.centerX(), cutoutRect.centerY())
+                armPath.addPath(cornerPath, mirrorMatrix)
+            }
+        }
+    }
+
+    private fun buildTopLeftCutoutCorner() {
+        val r = cornerRadius
+        val arm = cutoutRect.width() * ARM_LENGTH_FRACTION
+        cornerPath.rewind()
+        with(cutoutRect) {
+            cornerRect.set(left, top, left + 2 * r, top + 2 * r)
+            cornerPath.moveTo(left, top + r + arm)
+            cornerPath.arcTo(cornerRect, 180f, 90f)
+            cornerPath.lineTo(left + r + arm, top)
+        }
+    }
+
+    companion object {
+        const val CUTOUT_TOP_SPACE_FRACTION = 0.55f
+
+        private val MIRROR_SCALES = listOf(1f, -1f)
+        private const val SCRIM_COLOR = 0x80000000.toInt()
+        private const val CUTOUT_CORNER_RADIUS_DP = 28f
+        private const val ARM_STROKE_WIDTH_DP = 4f
+        private const val ARM_LENGTH_FRACTION = 0.2f
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/CodeExchangeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/CodeExchangeActivity.kt
@@ -17,11 +17,15 @@
 package com.duckduckgo.sync.impl.ui.v2
 
 import android.content.Intent
+import android.graphics.Outline
 import android.os.Bundle
+import android.view.View
+import android.view.ViewOutlineProvider
 import androidx.fragment.app.Fragment
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.view.toPx
 import com.duckduckgo.common.ui.viewbinding.viewBinding
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
 import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
@@ -56,6 +60,7 @@ class CodeExchangeActivity : DuckDuckGoActivity() {
 
         configureToolbar()
         configureContentAdapter()
+        configureContentCorners()
     }
 
     private fun configureEdgeToEdgeInsets() {
@@ -94,6 +99,20 @@ class CodeExchangeActivity : DuckDuckGoActivity() {
             }
         }
         mediator.attach()
+    }
+
+    private fun configureContentCorners() {
+        val radius = 28f.toPx()
+        binding.contentPager.outlineProvider = object : ViewOutlineProvider() {
+            override fun getOutline(
+                view: View,
+                outline: Outline,
+            ) {
+                // Extend the rect past the bottom so only the top corners are rounded
+                outline.setRoundRect(0, 0, view.width, view.height + radius.toInt(), radius)
+            }
+        }
+        binding.contentPager.clipToOutline = true
     }
 
     companion object {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/IntroAnimationViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/IntroAnimationViewModel.kt
@@ -20,8 +20,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.di.scopes.FragmentScope
+import com.duckduckgo.sync.impl.ui.v2.IntroAnimationViewModel.Command.ExpandScannerCutout
 import com.duckduckgo.sync.impl.ui.v2.IntroAnimationViewModel.Command.PlayIntroAnimation
 import com.duckduckgo.sync.impl.ui.v2.IntroAnimationViewModel.Command.RequestCameraPermission
+import com.duckduckgo.sync.impl.ui.v2.IntroAnimationViewModel.Command.ResumeCamera
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -65,6 +67,7 @@ class IntroAnimationViewModel @Inject constructor(
                     state
                 }
             }
+            requestCameraActivation()
         }
     }
 
@@ -75,11 +78,13 @@ class IntroAnimationViewModel @Inject constructor(
                 viewMode = if (cameraAccess.isPermissionGranted()) ViewMode.Camera else it.viewMode,
             )
         }
+        requestCameraActivation()
     }
 
     fun onScanButtonClicked() = withCameraHardware {
         if (cameraAccess.isPermissionGranted()) {
             _viewState.update { it.copy(animationFinished = true, viewMode = ViewMode.Camera) }
+            requestCameraActivation()
         } else {
             _viewState.update { it.copy(animationFinished = true) }
             viewModelScope.launch {
@@ -92,6 +97,18 @@ class IntroAnimationViewModel @Inject constructor(
         val isGranted = cameraAccess.isPermissionGranted()
         _viewState.update {
             it.copy(viewMode = if (isGranted) ViewMode.Camera else ViewMode.NoCameraPermission)
+        }
+        if (isGranted) {
+            requestCameraActivation()
+        }
+    }
+
+    private fun requestCameraActivation() {
+        if (viewState.value.viewMode == ViewMode.Camera) {
+            viewModelScope.launch {
+                _command.send(ResumeCamera)
+                _command.send(ExpandScannerCutout)
+            }
         }
     }
 
@@ -116,5 +133,7 @@ class IntroAnimationViewModel @Inject constructor(
     sealed class Command {
         data object PlayIntroAnimation : Command()
         data object RequestCameraPermission : Command()
+        data object ResumeCamera : Command()
+        data object ExpandScannerCutout : Command()
     }
 }

--- a/sync/sync-impl/src/main/res/layout/fragment_sync_v2_camera_scanner_camera.xml
+++ b/sync/sync-impl/src/main/res/layout/fragment_sync_v2_camera_scanner_camera.xml
@@ -21,12 +21,24 @@
     android:layout_height="match_parent"
     tools:showIn="@layout/fragment_sync_v2_camera_scanner">
 
-    <com.duckduckgo.common.ui.view.text.DaxTextView
-        android:layout_width="wrap_content"
+    <com.journeyapps.barcodescanner.BarcodeView
+        android:id="@+id/barcodeView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <com.duckduckgo.sync.impl.ui.v2.CameraScannerOverlayView
+        android:id="@+id/scannerOverlay"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:importantForAccessibility="no" />
+
+    <com.duckduckgo.sync.impl.ui.v2.CodeExchangeHeaderView
+        android:id="@+id/scannerHeader"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:text="Camera UI"
-        app:typography="h2"
-        tools:ignore="HardcodedText" />
+        android:layout_marginHorizontal="@dimen/keyline_4"
+        android:layout_marginTop="@dimen/keyline_5"
+        app:bodyText="@string/sync_scanner_v2_scan_qr_code_body"
+        app:headlineText="@string/sync_scanner_v2_scan_qr_code_headline" />
 
 </FrameLayout>

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/IntroAnimationViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/IntroAnimationViewModelTest.kt
@@ -18,8 +18,10 @@ package com.duckduckgo.sync.impl.ui.v2
 
 import app.cash.turbine.test
 import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.sync.impl.ui.v2.IntroAnimationViewModel.Command.ExpandScannerCutout
 import com.duckduckgo.sync.impl.ui.v2.IntroAnimationViewModel.Command.PlayIntroAnimation
 import com.duckduckgo.sync.impl.ui.v2.IntroAnimationViewModel.Command.RequestCameraPermission
+import com.duckduckgo.sync.impl.ui.v2.IntroAnimationViewModel.Command.ResumeCamera
 import com.duckduckgo.sync.impl.ui.v2.IntroAnimationViewModel.ViewMode
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -230,6 +232,123 @@ class IntroAnimationViewModelTest {
 
         assertEquals(ViewMode.NoCameraAvailable, testee.viewState.value.viewMode)
         assertFalse(testee.viewState.value.animationFinished)
+    }
+
+    @Test
+    fun `when the scan button is clicked with camera permission granted then the camera resume and cutout expand commands are sent`() = runTest {
+        whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
+        whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
+
+        testee.commands.test {
+            testee.onScanButtonClicked()
+            assertIs<ResumeCamera>(awaitItem())
+            assertIs<ExpandScannerCutout>(awaitItem())
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when the scan button is clicked without camera permission then only the permission request command is sent`() = runTest {
+        whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
+        whenever(cameraAccess.isPermissionGranted()).thenReturn(false)
+
+        testee.commands.test {
+            testee.onScanButtonClicked()
+            assertIs<RequestCameraPermission>(awaitItem())
+            expectNoEvents()
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when the permission request is granted then the camera resume and cutout expand commands are sent`() = runTest {
+        whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
+        whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
+
+        testee.commands.test {
+            testee.onCameraPermissionResult()
+            assertIs<ResumeCamera>(awaitItem())
+            assertIs<ExpandScannerCutout>(awaitItem())
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when the permission request is denied then no camera commands are sent`() = runTest {
+        whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
+        whenever(cameraAccess.isPermissionGranted()).thenReturn(false)
+
+        testee.commands.test {
+            testee.onCameraPermissionResult()
+            expectNoEvents()
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when the animation finishes with camera permission granted then the camera resume and cutout expand commands are sent`() = runTest {
+        whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
+        whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
+
+        testee.commands.test {
+            testee.onAnimationFinished()
+            assertIs<ResumeCamera>(awaitItem())
+            assertIs<ExpandScannerCutout>(awaitItem())
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when refreshing shows the camera then the camera resume and cutout expand commands are sent`() = runTest {
+        whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
+        whenever(cameraAccess.isPermissionGranted()).thenReturn(false)
+        testee.onCameraPermissionResult()
+
+        whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
+
+        testee.commands.test {
+            testee.refreshCameraPermissionState()
+            assertIs<ResumeCamera>(awaitItem())
+            assertIs<ExpandScannerCutout>(awaitItem())
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when refreshing while the camera is already shown then the camera resume and cutout expand commands are sent again`() = runTest {
+        whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
+        whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
+
+        testee.commands.test {
+            testee.onScanButtonClicked()
+            assertIs<ResumeCamera>(awaitItem())
+            assertIs<ExpandScannerCutout>(awaitItem())
+
+            testee.refreshCameraPermissionState()
+            assertIs<ResumeCamera>(awaitItem())
+            assertIs<ExpandScannerCutout>(awaitItem())
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when refreshing while the intro is still running then no camera commands are sent`() = runTest {
+        whenever(cameraAccess.isHardwareAvailable()).thenReturn(true)
+        whenever(cameraAccess.isPermissionGranted()).thenReturn(true)
+
+        testee.commands.test {
+            testee.refreshCameraPermissionState()
+            expectNoEvents()
+
+            cancel()
+        }
     }
 }
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216103556496795/task/1216909296832820?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1216103556496795/task/1216509582049467?focus=true
API Proposals URL(s) (if applicable): N/A

### Description

Replaces the camera placeholder on the "Scan QR" tab of the simplified Sync code exchange screen with a live camera preview and a scanner overlay.

- Once camera permission is granted, the "Scan QR" tab shows the live camera feed with the "Scan QR Code" header on top.
- A dark scrim covers the feed, with a rounded square cutout in the middle marking the scan area, framed by corner brackets.
- When the camera appears, the cutout expands with a short animation. This happens after the intro animation finishes, after tapping "I’m Ready to Scan" with permission already granted, after granting the permission, or when returning to the tab.
- Switching to the "Enter Code" tab and back replays the expand animation. Leaving and returning to the app does not, the cutout stays expanded so there is no visible jump.
- The camera feed pauses when the user leaves the screen and resumes on return.
- Scanning a QR code does not do anything yet, decoding will be wired up separately.

### Steps to test this PR

_Show the camera preview_
- [ ] Open Sync Dev Settings.
- [ ] Tap "Launch Sync Settings V2".
- [ ] Tap "Sync With Another Device".
- [ ] Complete the device authentication prompt.
- [ ] Tap "I’m Ready to Scan".
- [ ] Grant the camera permission when prompted.
- [ ] Verify the live camera preview is shown behind a dark overlay with a rounded square cutout in the middle.
- [ ] Verify the cutout expands with a short animation shortly after the camera appears.

_Replay the animation on tab switch_
- [ ] Switch to the "Enter Code" tab.
- [ ] Switch back to the "Scan QR" tab.
- [ ] Verify the cutout expand animation plays again.

_Keep the size when returning to the app_
- [ ] With the camera visible, send the app to the background.
- [ ] Return to the app.
- [ ] Verify the cutout is still expanded and the animation does not replay.

### UI changes
<img width="540" alt="Screenshot_20260727-144209" src="https://github.com/user-attachments/assets/b8ec6751-dd66-456a-ae25-288c1fd83e39" />


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sync v2 scanner UI and camera lifecycle only; no sync protocol or QR processing changes yet.
> 
> **Overview**
> Replaces the **Scan QR** tab placeholder with a live `BarcodeView` preview, a **Scan QR Code** header, and a new `CameraScannerOverlayView` (dark scrim, rounded cutout, corner brackets).
> 
> When camera mode is shown—after intro, **I'm Ready to Scan**, permission grant, or tab return—the view model emits **resume camera** and **expand cutout** commands. The cutout animates from a smaller fraction to a larger one, capped on short layouts so it does not overlap the header. **Pause** stops the preview and cancels the cutout animation; cutout size resets only on ViewPager tab switches (activity still resumed), not when the app goes to background, so returning does not replay the expand animation.
> 
> `CodeExchangeActivity` clips the tab content with rounded top corners. QR decode handling is not in this change. Tests cover the new view model commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73e7284a15b4f3ae2f93e9f053148884ed07b812. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->