### PR TITLE
Pixels: Add unified_input_surface to unified input action pixels

### DIFF
--- a/PixelDefinitions/pixels/definitions/duck_chat.json5
+++ b/PixelDefinitions/pixels/definitions/duck_chat.json5
@@ -906,140 +906,140 @@
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_image_generation_selected_daily": {
         "description": "(Daily Pixel) User selected the image generation tool in the Unified Input",
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_image_generation_deselected_count": {
         "description": "User deselected the image generation tool in the Unified Input",
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_image_generation_deselected_daily": {
         "description": "(Daily Pixel) User deselected the image generation tool in the Unified Input",
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_image_generation_submitted_count": {
         "description": "User submitted a prompt with the image generation tool selected in the Unified Input",
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_image_generation_submitted_daily": {
         "description": "(Daily Pixel) User submitted a prompt with the image generation tool selected in the Unified Input",
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_web_search_selected_count": {
         "description": "User selected the web search tool in the Unified Input",
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_web_search_selected_daily": {
         "description": "(Daily Pixel) User selected the web search tool in the Unified Input",
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_web_search_deselected_count": {
         "description": "User deselected the web search tool in the Unified Input",
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_web_search_deselected_daily": {
         "description": "(Daily Pixel) User deselected the web search tool in the Unified Input",
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_web_search_submitted_count": {
         "description": "User submitted a prompt with the web search tool selected in the Unified Input",
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_web_search_submitted_daily": {
         "description": "(Daily Pixel) User submitted a prompt with the web search tool selected in the Unified Input",
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_customize_responses_selected_count": {
         "description": "User selected the Customize Responses action in the Unified Input options menu",
         "owners": ["joshliebe"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_customize_responses_selected_daily": {
         "description": "(Daily Pixel) User selected the Customize Responses action in the Unified Input options menu",
         "owners": ["joshliebe"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_image_removed_count": {
         "description": "User removed an attached image from the Unified Input",
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_image_removed_daily": {
         "description": "(Daily Pixel) User removed an attached image from the Unified Input",
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_file_attached_count": {
         "description": "User attached a file in the Unified Input",
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_file_attached_daily": {
         "description": "(Daily Pixel) User attached a file in the Unified Input",
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_file_removed_count": {
         "description": "User removed an attached file from the Unified Input",
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_file_removed_daily": {
         "description": "(Daily Pixel) User removed an attached file from the Unified Input",
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_voice_tapped_count": {
         "description": "User tapped the voice button in the Unified Input",
@@ -1062,6 +1062,7 @@
         "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
+            "unifiedInputSurface",
             {
                 "key": "source",
                 "type": "string",
@@ -1077,6 +1078,7 @@
         "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
+            "unifiedInputSurface",
             {
                 "key": "source",
                 "type": "string",
@@ -1107,6 +1109,7 @@
         "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
+            "unifiedInputSurface",
             {
                 "key": "reason",
                 "type": "string",
@@ -1122,6 +1125,7 @@
         "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
+            "unifiedInputSurface",
             {
                 "key": "reason",
                 "type": "string",
@@ -1137,6 +1141,7 @@
         "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
+            "unifiedInputSurface",
             {
                 "key": "reason",
                 "type": "string",
@@ -1152,6 +1157,7 @@
         "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
+            "unifiedInputSurface",
             {
                 "key": "reason",
                 "type": "string",
@@ -1167,6 +1173,7 @@
         "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
+            "unifiedInputSurface",
             {
                 "key": "selected_tool",
                 "type": "string",
@@ -1192,6 +1199,7 @@
         "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
+            "unifiedInputSurface",
             {
                 "key": "selected_tool",
                 "type": "string",
@@ -1229,14 +1237,18 @@
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_unified_input_model_selected": {
         "description": "User selected a model in the Unified Input model picker",
         "owners": ["malmstein"],
         "triggers": ["other"],
         "suffixes": ["form_factor"],
-        "parameters": ["appVersion", { "key": "model_id", "type": "string", "description": "Identifier of the selected model" }]
+        "parameters": [
+            "appVersion",
+            "unifiedInputSurface",
+            { "key": "model_id", "type": "string", "description": "Identifier of the selected model" }
+        ]
     },
     "m_aichat_unified_input_reasoning_effort_selected": {
         "description": "User selected a reasoning effort level in the Unified Input",
@@ -1245,6 +1257,7 @@
         "suffixes": ["form_factor"],
         "parameters": [
             "appVersion",
+            "unifiedInputSurface",
             {
                 "key": "effort_level",
                 "type": "string",
@@ -1286,7 +1299,7 @@
         "owners": ["YoussefKeyrouz"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "aichat_unified_input_submit_change_model": {
         "description": "FE recovery flow: the user's chosen model was reported to the FE via submitChangeModelAction",
@@ -1295,6 +1308,7 @@
         "suffixes": ["first_daily_count", "form_factor"],
         "parameters": [
             "appVersion",
+            "unifiedInputSurface",
             { "key": "model_id", "type": "string", "description": "Identifier of the model the user recovered to" }
         ]
     },
@@ -1303,7 +1317,7 @@
         "owners": ["YoussefKeyrouz"],
         "triggers": ["other"],
         "suffixes": ["first_daily_count", "form_factor"],
-        "parameters": ["appVersion"]
+        "parameters": ["appVersion", "unifiedInputSurface"]
     },
     "m_aichat_contextual_quick_action_ask_about_page_selected_count": {
         "description": "User tapped the Ask About Page quick action in the Contextual sheet",

--- a/PixelDefinitions/pixels/params_dictionary.json
+++ b/PixelDefinitions/pixels/params_dictionary.json
@@ -9,6 +9,12 @@
         "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)?$",
         "examples": ["0.89.3"]
     },
+    "unifiedInputSurface": {
+        "key": "surface",
+        "type": "string",
+        "description": "The Unified Input surface the pixel was fired from, distinguishing the contextual chat sheet from the Duck.ai tab and the address bar",
+        "enum": ["address_bar", "duck_ai", "contextual_chat"]
+    },
     "osVersion": {
         "key": "os_version",
         "type": "integer",

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/helper/DuckChatJSHelper.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.common.ui.view.encodeBitmapToBase64
 import com.duckduckgo.common.utils.ConflatedJob
 import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
 import com.duckduckgo.duckchat.impl.ChatState
 import com.duckduckgo.duckchat.impl.ChatState.HIDE
@@ -35,6 +36,7 @@ import com.duckduckgo.duckchat.impl.ReportMetric
 import com.duckduckgo.duckchat.impl.feature.DuckChatFeature
 import com.duckduckgo.duckchat.impl.messaging.sync.isSyncable
 import com.duckduckgo.duckchat.impl.models.AIChatAttachmentUsage
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelSurface
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.store.DuckChatDataStore
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.LimitsHandler
@@ -110,6 +112,7 @@ class RealDuckChatJSHelper @Inject constructor(
     private val voiceSessionStateManager: VoiceSessionStateManager,
     private val limitsHandler: LimitsHandler,
     private val nativeInputStatePublisher: NativeInputStatePublisher,
+    private val nativeInputStateProvider: NativeInputStateProvider,
     private val appInstall: AppInstall,
     private val appBuildConfig: AppBuildConfig,
     private val subscriptions: Subscriptions,
@@ -215,7 +218,8 @@ class RealDuckChatJSHelper @Inject constructor(
             METHOD_SHOW_MODEL_PICKER -> {
                 if (tabId.isNotEmpty()) {
                     duckChat.requestShowModelPicker(tabId)
-                    duckChatPixels.fireShowModelPicker()
+                    val surface = DuckChatPixelSurface.from(nativeInputStateProvider.stateForTab(tabId).value.inputContext)
+                    duckChatPixels.fireShowModelPicker(surface)
                 }
                 null
             }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/pixel/DuckChatPixels.kt
@@ -23,6 +23,7 @@ import com.duckduckgo.common.utils.DispatcherProvider
 import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin
 import com.duckduckgo.common.utils.plugins.pixel.PixelParamRemovalPlugin.PixelParameter
 import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
 import com.duckduckgo.duckchat.impl.ModelTier
 import com.duckduckgo.duckchat.impl.ReportMetric
 import com.duckduckgo.duckchat.impl.ReportMetric.USER_DID_CREATE_NEW_CHAT
@@ -109,6 +110,30 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
+/**
+ * The Unified Input surface a pixel is fired from, sent as the `surface` param. Distinguishes the
+ * contextual chat sheet from the Duck.ai tab and the address bar.
+ */
+enum class DuckChatPixelSurface(val value: String) {
+    /** The address bar / omnibar (any omnibar surface that isn't the Duck.ai tab). */
+    ADDRESS_BAR("address_bar"),
+
+    /** The dedicated Duck.ai tab. */
+    DUCK_AI("duck_ai"),
+
+    /** The contextual chat sheet presented over a web page. */
+    CONTEXTUAL_CHAT("contextual_chat"),
+    ;
+
+    companion object {
+        fun from(inputContext: NativeInputState.InputContext): DuckChatPixelSurface = when (inputContext) {
+            NativeInputState.InputContext.BROWSER -> ADDRESS_BAR
+            NativeInputState.InputContext.DUCK_AI -> DUCK_AI
+            NativeInputState.InputContext.DUCK_AI_CONTEXTUAL -> CONTEXTUAL_CHAT
+        }
+    }
+}
+
 interface DuckChatPixels {
     fun sendReportMetricPixel(reportMetric: ReportMetric, modelTier: ModelTier? = null)
     fun reportOpen()
@@ -152,12 +177,12 @@ interface DuckChatPixels {
     fun reportVoiceServiceStarted()
     fun reportVoiceServiceKilled()
 
-    fun fireImageGenerationSelected()
-    fun fireImageGenerationDeselected()
-    fun fireImageGenerationSubmitted()
-    fun fireWebSearchSelected()
-    fun fireWebSearchDeselected()
-    fun fireWebSearchSubmitted()
+    fun fireImageGenerationSelected(surface: DuckChatPixelSurface)
+    fun fireImageGenerationDeselected(surface: DuckChatPixelSurface)
+    fun fireImageGenerationSubmitted(surface: DuckChatPixelSurface)
+    fun fireWebSearchSelected(surface: DuckChatPixelSurface)
+    fun fireWebSearchDeselected(surface: DuckChatPixelSurface)
+    fun fireWebSearchSubmitted(surface: DuckChatPixelSurface)
     fun firePromptSubmitted(
         selectedTool: String,
         modelId: String?,
@@ -165,37 +190,38 @@ interface DuckChatPixels {
         hasImageAttachment: Boolean,
         hasFileAttachment: Boolean,
         hasText: Boolean,
+        surface: DuckChatPixelSurface,
     )
 
     /** Prompt submitted while the unified input is in a Duck.ai chat context. Fires alongside [firePromptSubmitted]. */
     fun fireSentPromptInChat()
-    fun fireModelSelected(modelId: String)
-    fun fireReasoningEffortSelected(effortLevel: String)
+    fun fireModelSelected(modelId: String, surface: DuckChatPixelSurface)
+    fun fireReasoningEffortSelected(effortLevel: String, surface: DuckChatPixelSurface)
 
     /** FE recovery flow: native model picker opened in response to a `showModelPicker` message. */
-    fun fireShowModelPicker()
+    fun fireShowModelPicker(surface: DuckChatPixelSurface)
 
     /** FE recovery flow: the chosen model reported back to the FE via `submitChangeModelAction`. */
-    fun fireSubmitChangeModel(modelId: String)
+    fun fireSubmitChangeModel(modelId: String, surface: DuckChatPixelSurface)
 
     /** FE recovery flow: a prompt submitted after recovering the chat's model. */
-    fun fireSubmitChangeModelPromptSent()
+    fun fireSubmitChangeModelPromptSent(surface: DuckChatPixelSurface)
 
     fun fireSubscriptionUpsellTriggered(source: String, currentTier: String, requiredTier: String, flowType: String)
-    fun fireImageAttached(source: String)
-    fun fireImageValidationFailed(reason: String)
-    fun fireImageRemoved()
-    fun fireFileAttached()
-    fun fireFileRemoved()
-    fun fireFileValidationFailed(reason: String)
+    fun fireImageAttached(source: String, surface: DuckChatPixelSurface)
+    fun fireImageValidationFailed(reason: String, surface: DuckChatPixelSurface)
+    fun fireImageRemoved(surface: DuckChatPixelSurface)
+    fun fireFileAttached(surface: DuckChatPixelSurface)
+    fun fireFileRemoved(surface: DuckChatPixelSurface)
+    fun fireFileValidationFailed(reason: String, surface: DuckChatPixelSurface)
     fun fireVoiceTapped()
-    fun fireStopGenerationTapped()
+    fun fireStopGenerationTapped(surface: DuckChatPixelSurface)
     fun fireDuckAiChatHistorySuggestionClicked()
     fun fireDuckAiSearchDuckDuckGoSuggestionClicked()
     fun fireRecentChatDeleteButtonTapped()
     fun fireRecentChatDeleteConfirmed()
     fun fireRecentChatDeleteCancelled()
-    fun fireCustomizeResponsesSelected()
+    fun fireCustomizeResponsesSelected(surface: DuckChatPixelSurface)
     fun fireOmnibarShown()
     fun fireOmnibarTextAreaFocused(landscape: Boolean)
     fun fireOmnibarQuerySubmitted(query: String)
@@ -229,6 +255,9 @@ class RealDuckChatPixels @Inject constructor(
             pixel.fire(daily, parameters = parameters, type = Pixel.PixelType.Daily())
         }
     }
+
+    private fun surfaceParams(surface: DuckChatPixelSurface): Map<String, String> =
+        mapOf(DuckChatPixelParameters.SURFACE to surface.value)
 
     override fun sendReportMetricPixel(reportMetric: ReportMetric, modelTier: ModelTier?) {
         appCoroutineScope.launch(dispatcherProvider.io()) {
@@ -532,34 +561,40 @@ class RealDuckChatPixels @Inject constructor(
         pixel.fire(DuckChatPixelName.DUCK_CHAT_VOICE_SERVICE_KILLED)
     }
 
-    override fun fireImageGenerationSelected() = fireCountAndDaily(
+    override fun fireImageGenerationSelected(surface: DuckChatPixelSurface) = fireCountAndDaily(
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_SELECTED_COUNT,
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_SELECTED_DAILY,
+        surfaceParams(surface),
     )
 
-    override fun fireImageGenerationDeselected() = fireCountAndDaily(
+    override fun fireImageGenerationDeselected(surface: DuckChatPixelSurface) = fireCountAndDaily(
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_DESELECTED_COUNT,
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_DESELECTED_DAILY,
+        surfaceParams(surface),
     )
 
-    override fun fireImageGenerationSubmitted() = fireCountAndDaily(
+    override fun fireImageGenerationSubmitted(surface: DuckChatPixelSurface) = fireCountAndDaily(
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_SUBMITTED_COUNT,
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_SUBMITTED_DAILY,
+        surfaceParams(surface),
     )
 
-    override fun fireWebSearchSelected() = fireCountAndDaily(
+    override fun fireWebSearchSelected(surface: DuckChatPixelSurface) = fireCountAndDaily(
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_SELECTED_COUNT,
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_SELECTED_DAILY,
+        surfaceParams(surface),
     )
 
-    override fun fireWebSearchDeselected() = fireCountAndDaily(
+    override fun fireWebSearchDeselected(surface: DuckChatPixelSurface) = fireCountAndDaily(
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_DESELECTED_COUNT,
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_DESELECTED_DAILY,
+        surfaceParams(surface),
     )
 
-    override fun fireWebSearchSubmitted() = fireCountAndDaily(
+    override fun fireWebSearchSubmitted(surface: DuckChatPixelSurface) = fireCountAndDaily(
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_SUBMITTED_COUNT,
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_SUBMITTED_DAILY,
+        surfaceParams(surface),
     )
 
     override fun firePromptSubmitted(
@@ -569,6 +604,7 @@ class RealDuckChatPixels @Inject constructor(
         hasImageAttachment: Boolean,
         hasFileAttachment: Boolean,
         hasText: Boolean,
+        surface: DuckChatPixelSurface,
     ) {
         val params = buildMap {
             put(DuckChatPixelParameters.SELECTED_TOOL, selectedTool)
@@ -577,6 +613,7 @@ class RealDuckChatPixels @Inject constructor(
             put(DuckChatPixelParameters.HAS_IMAGE_ATTACHMENT, hasImageAttachment.toString())
             put(DuckChatPixelParameters.HAS_FILE_ATTACHMENT, hasFileAttachment.toString())
             put(DuckChatPixelParameters.HAS_TEXT, hasText.toString())
+            put(DuckChatPixelParameters.SURFACE, surface.value)
         }
         fireCountAndDaily(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_PROMPT_SUBMITTED_COUNT,
@@ -590,47 +627,62 @@ class RealDuckChatPixels @Inject constructor(
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SENT_PROMPT_IN_CHAT_DAILY,
     )
 
-    override fun fireModelSelected(modelId: String) {
-        appCoroutineScope.launch(dispatcherProvider.io()) {
-            pixel.fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_MODEL_SELECTED, parameters = mapOf(DuckChatPixelParameters.MODEL_ID to modelId))
-        }
-    }
-
-    override fun fireReasoningEffortSelected(effortLevel: String) {
+    override fun fireModelSelected(modelId: String, surface: DuckChatPixelSurface) {
         appCoroutineScope.launch(dispatcherProvider.io()) {
             pixel.fire(
-                DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_REASONING_EFFORT_SELECTED,
-                parameters = mapOf(DuckChatPixelParameters.EFFORT_LEVEL to effortLevel),
+                DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_MODEL_SELECTED,
+                parameters = mapOf(
+                    DuckChatPixelParameters.MODEL_ID to modelId,
+                    DuckChatPixelParameters.SURFACE to surface.value,
+                ),
             )
         }
     }
 
-    override fun fireShowModelPicker() {
+    override fun fireReasoningEffortSelected(effortLevel: String, surface: DuckChatPixelSurface) {
+        appCoroutineScope.launch(dispatcherProvider.io()) {
+            pixel.fire(
+                DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_REASONING_EFFORT_SELECTED,
+                parameters = mapOf(
+                    DuckChatPixelParameters.EFFORT_LEVEL to effortLevel,
+                    DuckChatPixelParameters.SURFACE to surface.value,
+                ),
+            )
+        }
+    }
+
+    override fun fireShowModelPicker(surface: DuckChatPixelSurface) {
         fireCountAndDaily(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SHOW_MODEL_PICKER_COUNT,
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SHOW_MODEL_PICKER_DAILY,
+            surfaceParams(surface),
         )
     }
 
-    override fun fireCustomizeResponsesSelected() {
+    override fun fireCustomizeResponsesSelected(surface: DuckChatPixelSurface) {
         fireCountAndDaily(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_CUSTOMIZE_RESPONSES_SELECTED_COUNT,
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_CUSTOMIZE_RESPONSES_SELECTED_DAILY,
+            surfaceParams(surface),
         )
     }
 
-    override fun fireSubmitChangeModel(modelId: String) {
+    override fun fireSubmitChangeModel(modelId: String, surface: DuckChatPixelSurface) {
         fireCountAndDaily(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SUBMIT_CHANGE_MODEL_COUNT,
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SUBMIT_CHANGE_MODEL_DAILY,
-            parameters = mapOf(DuckChatPixelParameters.MODEL_ID to modelId),
+            parameters = mapOf(
+                DuckChatPixelParameters.MODEL_ID to modelId,
+                DuckChatPixelParameters.SURFACE to surface.value,
+            ),
         )
     }
 
-    override fun fireSubmitChangeModelPromptSent() {
+    override fun fireSubmitChangeModelPromptSent(surface: DuckChatPixelSurface) {
         fireCountAndDaily(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SUBMIT_CHANGE_MODEL_PROMPT_SENT_COUNT,
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SUBMIT_CHANGE_MODEL_PROMPT_SENT_DAILY,
+            surfaceParams(surface),
         )
     }
 
@@ -648,37 +700,49 @@ class RealDuckChatPixels @Inject constructor(
         }
     }
 
-    override fun fireImageAttached(source: String) = fireCountAndDaily(
+    override fun fireImageAttached(source: String, surface: DuckChatPixelSurface) = fireCountAndDaily(
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_ATTACHED_COUNT,
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_ATTACHED_DAILY,
-        mapOf(DuckChatPixelParameters.ATTACHMENT_SOURCE to source),
+        mapOf(
+            DuckChatPixelParameters.ATTACHMENT_SOURCE to source,
+            DuckChatPixelParameters.SURFACE to surface.value,
+        ),
     )
 
-    override fun fireImageRemoved() = fireCountAndDaily(
+    override fun fireImageRemoved(surface: DuckChatPixelSurface) = fireCountAndDaily(
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_REMOVED_COUNT,
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_REMOVED_DAILY,
+        surfaceParams(surface),
     )
 
-    override fun fireImageValidationFailed(reason: String) = fireCountAndDaily(
+    override fun fireImageValidationFailed(reason: String, surface: DuckChatPixelSurface) = fireCountAndDaily(
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_VALIDATION_FAILED_COUNT,
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_VALIDATION_FAILED_DAILY,
-        mapOf(DuckChatPixelParameters.FILE_VALIDATION_REASON to reason),
+        mapOf(
+            DuckChatPixelParameters.FILE_VALIDATION_REASON to reason,
+            DuckChatPixelParameters.SURFACE to surface.value,
+        ),
     )
 
-    override fun fireFileAttached() = fireCountAndDaily(
+    override fun fireFileAttached(surface: DuckChatPixelSurface) = fireCountAndDaily(
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_ATTACHED_COUNT,
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_ATTACHED_DAILY,
+        surfaceParams(surface),
     )
 
-    override fun fireFileRemoved() = fireCountAndDaily(
+    override fun fireFileRemoved(surface: DuckChatPixelSurface) = fireCountAndDaily(
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_REMOVED_COUNT,
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_REMOVED_DAILY,
+        surfaceParams(surface),
     )
 
-    override fun fireFileValidationFailed(reason: String) = fireCountAndDaily(
+    override fun fireFileValidationFailed(reason: String, surface: DuckChatPixelSurface) = fireCountAndDaily(
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_VALIDATION_FAILED_COUNT,
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_VALIDATION_FAILED_DAILY,
-        mapOf(DuckChatPixelParameters.FILE_VALIDATION_REASON to reason),
+        mapOf(
+            DuckChatPixelParameters.FILE_VALIDATION_REASON to reason,
+            DuckChatPixelParameters.SURFACE to surface.value,
+        ),
     )
 
     override fun fireVoiceTapped() = fireCountAndDaily(
@@ -686,9 +750,12 @@ class RealDuckChatPixels @Inject constructor(
         DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_VOICE_TAPPED_DAILY,
     )
 
-    override fun fireStopGenerationTapped() {
+    override fun fireStopGenerationTapped(surface: DuckChatPixelSurface) {
         appCoroutineScope.launch(dispatcherProvider.io()) {
-            pixel.fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_STOP_GENERATION_TAPPED)
+            pixel.fire(
+                DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_STOP_GENERATION_TAPPED,
+                parameters = surfaceParams(surface),
+            )
         }
     }
 
@@ -1074,6 +1141,7 @@ object DuckChatPixelParameters {
     const val HAS_TEXT = "has_text"
     const val ATTACHMENT_SOURCE = "source"
     const val FILE_VALIDATION_REASON = "reason"
+    const val SURFACE = "surface"
     const val UPSELL_SOURCE = "source"
     const val UPSELL_CURRENT_TIER = "current_tier"
     const val UPSELL_REQUIRED_TIER = "required_tier"

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/AttachmentViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/AttachmentViewModel.kt
@@ -36,6 +36,7 @@ import com.duckduckgo.duckchat.impl.DuckChatInternal
 import com.duckduckgo.duckchat.impl.R
 import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.impl.models.ImageLimits
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelSurface
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.ImageAttachment
 import com.duckduckgo.duckchat.impl.ui.nativeinput.attachment.LimitsHandler
@@ -108,6 +109,10 @@ class AttachmentViewModel @Inject constructor(
         .map { it.inputContext != NativeInputState.InputContext.BROWSER }
         .stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
+    private val surface: StateFlow<DuckChatPixelSurface> = nativeInputStateProvider.state
+        .map { DuckChatPixelSurface.from(it.inputContext) }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, DuckChatPixelSurface.ADDRESS_BAR)
+
     val attachmentState: StateFlow<AttachmentState> = combine(
         combine(imageAttachments, _fileAttachments, _pageContextAttachment) { images, files, pageContext ->
             Triple(images, files, pageContext)
@@ -148,7 +153,7 @@ class AttachmentViewModel @Inject constructor(
             uris.forEach { uri ->
                 val attachment = withContext(dispatchers.io()) { processImage(uri) }
                 if (attachment == null) {
-                    duckChatPixels.fireImageValidationFailed(IMAGE_VALIDATION_OTHER)
+                    duckChatPixels.fireImageValidationFailed(IMAGE_VALIDATION_OTHER, surface.value)
                     return@forEach
                 }
                 imageAttachments.update { it + attachment }
@@ -162,7 +167,7 @@ class AttachmentViewModel @Inject constructor(
             for (uri in uris) {
                 val attachment = fileAttachmentProcessor.processFile(context, uri)
                 if (attachment == null) {
-                    duckChatPixels.fireFileValidationFailed(FILE_VALIDATION_OTHER)
+                    duckChatPixels.fireFileValidationFailed(FILE_VALIDATION_OTHER, surface.value)
                     continue
                 }
                 _fileAttachments.update { it + attachment }
@@ -180,7 +185,7 @@ class AttachmentViewModel @Inject constructor(
             imageUris.forEach { uri ->
                 val attachment = withContext(dispatchers.io()) { processImage(uri) }
                 if (attachment == null) {
-                    duckChatPixels.fireImageValidationFailed(IMAGE_VALIDATION_OTHER)
+                    duckChatPixels.fireImageValidationFailed(IMAGE_VALIDATION_OTHER, surface.value)
                     return@forEach
                 }
                 imageAttachments.update { it + attachment }
@@ -189,7 +194,7 @@ class AttachmentViewModel @Inject constructor(
             for (uri in fileUris) {
                 val attachment = fileAttachmentProcessor.processFile(context, uri)
                 if (attachment == null) {
-                    duckChatPixels.fireFileValidationFailed(FILE_VALIDATION_OTHER)
+                    duckChatPixels.fireFileValidationFailed(FILE_VALIDATION_OTHER, surface.value)
                     continue
                 }
                 _fileAttachments.update { it + attachment }
@@ -206,9 +211,9 @@ class AttachmentViewModel @Inject constructor(
     private fun fireFileAcceptedOrRejectedPixel(added: FileAttachment) {
         val reason = resolveFileValidationReason(added)
         if (reason != null) {
-            duckChatPixels.fireFileValidationFailed(reason)
+            duckChatPixels.fireFileValidationFailed(reason, surface.value)
         } else {
-            duckChatPixels.fireFileAttached()
+            duckChatPixels.fireFileAttached(surface.value)
         }
     }
 
@@ -220,9 +225,9 @@ class AttachmentViewModel @Inject constructor(
     private fun fireImageAcceptedOrRejectedPixel(source: ImageSource) {
         val reason = resolveImageValidationReason()
         if (reason != null) {
-            duckChatPixels.fireImageValidationFailed(reason)
+            duckChatPixels.fireImageValidationFailed(reason, surface.value)
         } else {
-            duckChatPixels.fireImageAttached(source.pixelValue)
+            duckChatPixels.fireImageAttached(source.pixelValue, surface.value)
         }
     }
 
@@ -263,7 +268,7 @@ class AttachmentViewModel @Inject constructor(
             removed = match != null
             list.filter { it.id != id }
         }
-        if (removed) duckChatPixels.fireImageRemoved()
+        if (removed) duckChatPixels.fireImageRemoved(surface.value)
         viewModelScope.launch { toRecycle?.recycle() }
     }
 
@@ -273,7 +278,7 @@ class AttachmentViewModel @Inject constructor(
             removed = list.any { it.id == id }
             list.filter { it.id != id }
         }
-        if (removed) duckChatPixels.fireFileRemoved()
+        if (removed) duckChatPixels.fireFileRemoved(surface.value)
     }
 
     fun setPageContext(attachment: PageContextAttachment) {

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModel.kt
@@ -56,6 +56,7 @@ import com.duckduckgo.duckchat.impl.models.ReasoningResolver
 import com.duckduckgo.duckchat.impl.models.Tool
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelSurface
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.impl.store.DefaultTogglePosition
 import com.duckduckgo.duckchat.store.impl.DuckAiChat
@@ -217,6 +218,13 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         return nativeInputStateProvider.stateForTab(tabId).value.selectedTool
     }
 
+    /** The pixel surface for the active tab, derived from its published input context. */
+    private fun currentSurface(): DuckChatPixelSurface {
+        val inputContext = activeTabId.value?.let { nativeInputStateProvider.stateForTab(it).value.inputContext }
+            ?: NativeInputState.InputContext.BROWSER
+        return DuckChatPixelSurface.from(inputContext)
+    }
+
     /**
      * Fires the unified prompt-submitted pixel plus, when a tool is selected, the matching per-tool
      * submitted pixel. Called exactly once per Duck.ai (AI-chat) submission by the widget. Attachment
@@ -233,6 +241,7 @@ class NativeInputModeWidgetViewModel @Inject constructor(
             Tool.WEB_SEARCH -> "web_search"
             null -> "none"
         }
+        val surface = currentSurface()
         duckChatPixels.firePromptSubmitted(
             selectedTool = selectedToolParam,
             modelId = getSelectedModelId(),
@@ -240,10 +249,11 @@ class NativeInputModeWidgetViewModel @Inject constructor(
             hasImageAttachment = hasImageAttachment,
             hasFileAttachment = hasFileAttachment,
             hasText = hasText,
+            surface = surface,
         )
         when (tool) {
-            Tool.IMAGE_GENERATION -> duckChatPixels.fireImageGenerationSubmitted()
-            Tool.WEB_SEARCH -> duckChatPixels.fireWebSearchSubmitted()
+            Tool.IMAGE_GENERATION -> duckChatPixels.fireImageGenerationSubmitted(surface)
+            Tool.WEB_SEARCH -> duckChatPixels.fireWebSearchSubmitted(surface)
             null -> {}
         }
     }
@@ -252,7 +262,7 @@ class NativeInputModeWidgetViewModel @Inject constructor(
 
     fun fireVoiceTapped() = duckChatPixels.fireVoiceTapped()
 
-    fun fireStopGenerationTapped() = duckChatPixels.fireStopGenerationTapped()
+    fun fireStopGenerationTapped() = duckChatPixels.fireStopGenerationTapped(currentSurface())
 
     fun fireClearPressed(isSearchMode: Boolean) = duckChatPixels.fireOmnibarClearButtonPressed(isSearchMode)
     fun fireKeyboardGoPressed(isSearchMode: Boolean) = duckChatPixels.fireOmnibarKeyboardGoPressed(isSearchMode)
@@ -438,7 +448,7 @@ class NativeInputModeWidgetViewModel @Inject constructor(
         // recovering the chat's model — report it before the window is cleared below.
         val tabId = activeTabId.value
         if (tabId != null && nativeInputStateProvider.stateForTab(tabId).value.modelChangeMode) {
-            duckChatPixels.fireSubmitChangeModelPromptSent()
+            duckChatPixels.fireSubmitChangeModelPromptSent(currentSurface())
         }
         // Ends the FE recovery model-change window for the active tab.
         endModelChangeMode()

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ModelPickerViewModel.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.duckchat.impl.models.ModelProvider
 import com.duckduckgo.duckchat.impl.models.ModelState
 import com.duckduckgo.duckchat.impl.models.Tool
 import com.duckduckgo.duckchat.impl.models.UserTier
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelSurface
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.store.impl.DuckAiChat
 import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
@@ -70,6 +71,10 @@ class ModelPickerViewModel @Inject constructor(
 
     private var modelChangeMode: Boolean = false
 
+    // The pixel surface for the active tab, tracked from the published input context.
+    // Named distinctly from the [PickerSurface] param on [onModelTapped] to avoid shadowing.
+    private var pixelSurface: DuckChatPixelSurface = DuckChatPixelSurface.ADDRESS_BAR
+
     // The model picked during the current recovery flow. Display-only: it drives the chip and the
     // picker's selected tick immediately, without waiting for the FE to sync the chat's model back
     // to native storage. Cleared when the recovery window ends.
@@ -88,6 +93,7 @@ class ModelPickerViewModel @Inject constructor(
         viewModelScope.launch {
             nativeInputStateProvider.state.collect { state ->
                 modelChangeMode = state.modelChangeMode
+                pixelSurface = DuckChatPixelSurface.from(state.inputContext)
                 if (!state.modelChangeMode) recoverySelectedModelId.value = null
             }
         }
@@ -172,14 +178,14 @@ class ModelPickerViewModel @Inject constructor(
                 // pick immediately on the chip + tick rather than waiting for that sync.
                 // Fire the same selection pixel as the normal flow (skip a re-tap of the same pick).
                 if (model.id != recoverySelectedModelId.value) {
-                    duckChatPixels.fireModelSelected(model.id)
+                    duckChatPixels.fireModelSelected(model.id, pixelSurface)
                 }
-                duckChatPixels.fireSubmitChangeModel(model.id)
+                duckChatPixels.fireSubmitChangeModel(model.id, pixelSurface)
                 recoverySelectedModelId.value = model.id
                 modelChangeChannel.trySend(PickerModelChange.ChangeModel(model.id))
             } else {
                 if (model.id != modelManager.getSelectedModelId()) {
-                    duckChatPixels.fireModelSelected(model.id)
+                    duckChatPixels.fireModelSelected(model.id, pixelSurface)
                 }
                 viewModelScope.launch { modelManager.selectModel(model) }
             }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsViewModel.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.anvil.annotations.ContributesViewModel
 import com.duckduckgo.di.scopes.ViewScope
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.impl.models.Tool
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelSurface
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -41,6 +42,10 @@ class OptionsViewModel @Inject constructor(
         .map { state -> state.selectedTool?.let { Tool.from(it) } }
         .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
+    private val surface: StateFlow<DuckChatPixelSurface> = nativeInputStateProvider.state
+        .map { DuckChatPixelSurface.from(it.inputContext) }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, DuckChatPixelSurface.ADDRESS_BAR)
+
     private val _visibleTools = MutableStateFlow(Tool.entries.toSet())
     val visibleTools: StateFlow<Set<Tool>> = _visibleTools.asStateFlow()
 
@@ -59,19 +64,19 @@ class OptionsViewModel @Inject constructor(
 
     fun onToolSelectedByUser(tool: Tool) {
         when (tool) {
-            Tool.IMAGE_GENERATION -> duckChatPixels.fireImageGenerationSelected()
-            Tool.WEB_SEARCH -> duckChatPixels.fireWebSearchSelected()
+            Tool.IMAGE_GENERATION -> duckChatPixels.fireImageGenerationSelected(surface.value)
+            Tool.WEB_SEARCH -> duckChatPixels.fireWebSearchSelected(surface.value)
         }
     }
 
     fun onToolDeselectedByUser(tool: Tool) {
         when (tool) {
-            Tool.IMAGE_GENERATION -> duckChatPixels.fireImageGenerationDeselected()
-            Tool.WEB_SEARCH -> duckChatPixels.fireWebSearchDeselected()
+            Tool.IMAGE_GENERATION -> duckChatPixels.fireImageGenerationDeselected(surface.value)
+            Tool.WEB_SEARCH -> duckChatPixels.fireWebSearchDeselected(surface.value)
         }
     }
 
     fun onCustomizeResponsesClicked() {
-        duckChatPixels.fireCustomizeResponsesSelected()
+        duckChatPixels.fireCustomizeResponsesSelected(surface.value)
     }
 }

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerViewModel.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/ReasoningModePickerViewModel.kt
@@ -30,6 +30,7 @@ import com.duckduckgo.duckchat.impl.models.DuckAiModelManager
 import com.duckduckgo.duckchat.impl.models.ModelState
 import com.duckduckgo.duckchat.impl.models.ReasoningMode
 import com.duckduckgo.duckchat.impl.models.ReasoningResolver
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelSurface
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.store.impl.DuckAiChat
 import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
@@ -74,6 +75,10 @@ class ReasoningModePickerViewModel @Inject constructor(
 
     private val currentChat = MutableStateFlow<DuckAiChat?>(null)
 
+    // The pixel surface for the active tab, tracked from the published input context.
+    // Named distinctly from the [PickerSurface] param on [onModeTapped] to avoid shadowing.
+    private var pixelSurface: DuckChatPixelSurface = DuckChatPixelSurface.ADDRESS_BAR
+
     init {
         viewModelScope.launch {
             // collectLatest: cancel in-flight lookup on chatId flip to avoid stale currentChat.
@@ -83,6 +88,9 @@ class ReasoningModePickerViewModel @Inject constructor(
                 .collectLatest { chatId ->
                     currentChat.value = if (chatId == null) null else duckAiChatStore.getChatById(chatId)
                 }
+        }
+        viewModelScope.launch {
+            nativeInputStateProvider.state.collect { pixelSurface = DuckChatPixelSurface.from(it.inputContext) }
         }
     }
 
@@ -137,7 +145,7 @@ class ReasoningModePickerViewModel @Inject constructor(
             // Mirror the model picker: only report a selection when it actually changes, not on
             // re-tapping the already-selected effort. The persisted selection still updates below.
             if (mode != state.value.displayedMode) {
-                duckChatPixels.fireReasoningEffortSelected(mode.toEffortParam())
+                duckChatPixels.fireReasoningEffortSelected(mode.toEffortParam(), pixelSurface)
             }
             if (chatResolution != null) {
                 viewModelScope.launch { modelManager.setChatScopedReasoningMode(mode) }

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsAttachmentsTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsAttachmentsTest.kt
@@ -51,81 +51,96 @@ class RealDuckChatPixelsAttachmentsTest {
 
     @Test
     fun whenImageAttachedFromCameraThenSourceParam() = runTest {
-        testee.fireImageAttached(source = "camera")
+        testee.fireImageAttached(source = "camera", surface = DuckChatPixelSurface.DUCK_AI)
 
+        val params = mapOf(
+            DuckChatPixelParameters.ATTACHMENT_SOURCE to "camera",
+            DuckChatPixelParameters.SURFACE to "duck_ai",
+        )
         verify(pixel).fire(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_ATTACHED_COUNT,
-            parameters = mapOf(DuckChatPixelParameters.ATTACHMENT_SOURCE to "camera"),
+            parameters = params,
         )
         verify(pixel).fire(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_ATTACHED_DAILY,
-            parameters = mapOf(DuckChatPixelParameters.ATTACHMENT_SOURCE to "camera"),
+            parameters = params,
             type = Pixel.PixelType.Daily(),
         )
     }
 
     @Test
     fun whenImageRemovedThenCountAndDaily() = runTest {
-        testee.fireImageRemoved()
+        testee.fireImageRemoved(DuckChatPixelSurface.DUCK_AI)
 
-        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_REMOVED_COUNT, parameters = emptyMap())
+        val params = mapOf(DuckChatPixelParameters.SURFACE to "duck_ai")
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_REMOVED_COUNT, parameters = params)
         verify(pixel).fire(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_REMOVED_DAILY,
-            parameters = emptyMap(),
+            parameters = params,
             type = Pixel.PixelType.Daily(),
         )
     }
 
     @Test
     fun whenImageValidationFailedThenReasonParam() = runTest {
-        testee.fireImageValidationFailed(reason = "count_exceeded")
+        testee.fireImageValidationFailed(reason = "count_exceeded", surface = DuckChatPixelSurface.DUCK_AI)
 
+        val params = mapOf(
+            DuckChatPixelParameters.FILE_VALIDATION_REASON to "count_exceeded",
+            DuckChatPixelParameters.SURFACE to "duck_ai",
+        )
         verify(pixel).fire(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_VALIDATION_FAILED_COUNT,
-            parameters = mapOf(DuckChatPixelParameters.FILE_VALIDATION_REASON to "count_exceeded"),
+            parameters = params,
         )
         verify(pixel).fire(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_VALIDATION_FAILED_DAILY,
-            parameters = mapOf(DuckChatPixelParameters.FILE_VALIDATION_REASON to "count_exceeded"),
+            parameters = params,
             type = Pixel.PixelType.Daily(),
         )
     }
 
     @Test
     fun whenFileAttachedThenCountAndDaily() = runTest {
-        testee.fireFileAttached()
+        testee.fireFileAttached(DuckChatPixelSurface.DUCK_AI)
 
-        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_ATTACHED_COUNT, parameters = emptyMap())
+        val params = mapOf(DuckChatPixelParameters.SURFACE to "duck_ai")
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_ATTACHED_COUNT, parameters = params)
         verify(pixel).fire(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_ATTACHED_DAILY,
-            parameters = emptyMap(),
+            parameters = params,
             type = Pixel.PixelType.Daily(),
         )
     }
 
     @Test
     fun whenFileRemovedThenCountAndDaily() = runTest {
-        testee.fireFileRemoved()
+        testee.fireFileRemoved(DuckChatPixelSurface.DUCK_AI)
 
-        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_REMOVED_COUNT, parameters = emptyMap())
+        val params = mapOf(DuckChatPixelParameters.SURFACE to "duck_ai")
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_REMOVED_COUNT, parameters = params)
         verify(pixel).fire(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_REMOVED_DAILY,
-            parameters = emptyMap(),
+            parameters = params,
             type = Pixel.PixelType.Daily(),
         )
     }
 
     @Test
     fun whenFileValidationFailedThenReasonParam() = runTest {
-        testee.fireFileValidationFailed(reason = "size_exceeded")
+        testee.fireFileValidationFailed(reason = "size_exceeded", surface = DuckChatPixelSurface.DUCK_AI)
 
+        val params = mapOf(
+            DuckChatPixelParameters.FILE_VALIDATION_REASON to "size_exceeded",
+            DuckChatPixelParameters.SURFACE to "duck_ai",
+        )
         verify(pixel).fire(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_VALIDATION_FAILED_COUNT,
-            parameters = mapOf(DuckChatPixelParameters.FILE_VALIDATION_REASON to "size_exceeded"),
+            parameters = params,
         )
         verify(pixel).fire(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_FILE_VALIDATION_FAILED_DAILY,
-            parameters = mapOf(DuckChatPixelParameters.FILE_VALIDATION_REASON to "size_exceeded"),
+            parameters = params,
             type = Pixel.PixelType.Daily(),
         )
     }
@@ -144,8 +159,11 @@ class RealDuckChatPixelsAttachmentsTest {
 
     @Test
     fun whenStopTappedThenSingleCount() = runTest {
-        testee.fireStopGenerationTapped()
+        testee.fireStopGenerationTapped(DuckChatPixelSurface.DUCK_AI)
 
-        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_STOP_GENERATION_TAPPED)
+        verify(pixel).fire(
+            DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_STOP_GENERATION_TAPPED,
+            parameters = mapOf(DuckChatPixelParameters.SURFACE to "duck_ai"),
+        )
     }
 }

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsPickerTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsPickerTest.kt
@@ -51,19 +51,25 @@ class RealDuckChatPixelsPickerTest {
 
     @Test
     fun whenModelSelectedThenSingleCountWithModelId() = runTest {
-        testee.fireModelSelected(modelId = "gpt-5")
+        testee.fireModelSelected(modelId = "gpt-5", surface = DuckChatPixelSurface.DUCK_AI)
         verify(pixel).fire(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_MODEL_SELECTED,
-            parameters = mapOf(DuckChatPixelParameters.MODEL_ID to "gpt-5"),
+            parameters = mapOf(
+                DuckChatPixelParameters.MODEL_ID to "gpt-5",
+                DuckChatPixelParameters.SURFACE to "duck_ai",
+            ),
         )
     }
 
     @Test
     fun whenReasoningSelectedThenSingleCountWithEffort() = runTest {
-        testee.fireReasoningEffortSelected(effortLevel = "extended_reasoning")
+        testee.fireReasoningEffortSelected(effortLevel = "extended_reasoning", surface = DuckChatPixelSurface.DUCK_AI)
         verify(pixel).fire(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_REASONING_EFFORT_SELECTED,
-            parameters = mapOf(DuckChatPixelParameters.EFFORT_LEVEL to "extended_reasoning"),
+            parameters = mapOf(
+                DuckChatPixelParameters.EFFORT_LEVEL to "extended_reasoning",
+                DuckChatPixelParameters.SURFACE to "duck_ai",
+            ),
         )
     }
 
@@ -83,21 +89,25 @@ class RealDuckChatPixelsPickerTest {
 
     @Test
     fun whenShowModelPickerThenFiresCountAndDaily() = runTest {
-        testee.fireShowModelPicker()
+        testee.fireShowModelPicker(DuckChatPixelSurface.DUCK_AI)
 
-        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SHOW_MODEL_PICKER_COUNT, parameters = emptyMap())
+        val params = mapOf(DuckChatPixelParameters.SURFACE to "duck_ai")
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SHOW_MODEL_PICKER_COUNT, parameters = params)
         verify(pixel).fire(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SHOW_MODEL_PICKER_DAILY,
-            parameters = emptyMap(),
+            parameters = params,
             type = Pixel.PixelType.Daily(),
         )
     }
 
     @Test
     fun whenSubmitChangeModelThenFiresCountAndDailyWithModelId() = runTest {
-        testee.fireSubmitChangeModel(modelId = "gpt-5")
+        testee.fireSubmitChangeModel(modelId = "gpt-5", surface = DuckChatPixelSurface.DUCK_AI)
 
-        val params = mapOf(DuckChatPixelParameters.MODEL_ID to "gpt-5")
+        val params = mapOf(
+            DuckChatPixelParameters.MODEL_ID to "gpt-5",
+            DuckChatPixelParameters.SURFACE to "duck_ai",
+        )
         verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SUBMIT_CHANGE_MODEL_COUNT, parameters = params)
         verify(pixel).fire(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SUBMIT_CHANGE_MODEL_DAILY,
@@ -108,12 +118,13 @@ class RealDuckChatPixelsPickerTest {
 
     @Test
     fun whenSubmitChangeModelPromptSentThenFiresCountAndDaily() = runTest {
-        testee.fireSubmitChangeModelPromptSent()
+        testee.fireSubmitChangeModelPromptSent(DuckChatPixelSurface.DUCK_AI)
 
-        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SUBMIT_CHANGE_MODEL_PROMPT_SENT_COUNT, parameters = emptyMap())
+        val params = mapOf(DuckChatPixelParameters.SURFACE to "duck_ai")
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SUBMIT_CHANGE_MODEL_PROMPT_SENT_COUNT, parameters = params)
         verify(pixel).fire(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_SUBMIT_CHANGE_MODEL_PROMPT_SENT_DAILY,
-            parameters = emptyMap(),
+            parameters = params,
             type = Pixel.PixelType.Daily(),
         )
     }

--- a/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsToolsTest.kt
+++ b/duckchat/duckchat-impl/src/test/java/com/duckduckgo/duckchat/impl/pixel/RealDuckChatPixelsToolsTest.kt
@@ -49,86 +49,88 @@ class RealDuckChatPixelsToolsTest {
         termsOfServiceHandler = termsOfServiceHandler,
     )
 
+    private val surfaceParams = mapOf(DuckChatPixelParameters.SURFACE to "contextual_chat")
+
     @Test
     fun whenImageGenerationSelectedThenFiresCountAndDaily() = runTest {
-        testee.fireImageGenerationSelected()
+        testee.fireImageGenerationSelected(DuckChatPixelSurface.CONTEXTUAL_CHAT)
 
-        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_SELECTED_COUNT, parameters = emptyMap())
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_SELECTED_COUNT, parameters = surfaceParams)
         verify(pixel).fire(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_SELECTED_DAILY,
-            parameters = emptyMap(),
+            parameters = surfaceParams,
             type = Pixel.PixelType.Daily(),
         )
     }
 
     @Test
     fun whenImageGenerationDeselectedThenFiresCountAndDaily() = runTest {
-        testee.fireImageGenerationDeselected()
+        testee.fireImageGenerationDeselected(DuckChatPixelSurface.CONTEXTUAL_CHAT)
 
-        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_DESELECTED_COUNT, parameters = emptyMap())
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_DESELECTED_COUNT, parameters = surfaceParams)
         verify(pixel).fire(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_DESELECTED_DAILY,
-            parameters = emptyMap(),
+            parameters = surfaceParams,
             type = Pixel.PixelType.Daily(),
         )
     }
 
     @Test
     fun whenImageGenerationSubmittedThenFiresCountAndDaily() = runTest {
-        testee.fireImageGenerationSubmitted()
+        testee.fireImageGenerationSubmitted(DuckChatPixelSurface.CONTEXTUAL_CHAT)
 
-        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_SUBMITTED_COUNT, parameters = emptyMap())
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_SUBMITTED_COUNT, parameters = surfaceParams)
         verify(pixel).fire(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_IMAGE_GENERATION_SUBMITTED_DAILY,
-            parameters = emptyMap(),
+            parameters = surfaceParams,
             type = Pixel.PixelType.Daily(),
         )
     }
 
     @Test
     fun whenWebSearchSelectedThenFiresCountAndDaily() = runTest {
-        testee.fireWebSearchSelected()
+        testee.fireWebSearchSelected(DuckChatPixelSurface.CONTEXTUAL_CHAT)
 
-        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_SELECTED_COUNT, parameters = emptyMap())
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_SELECTED_COUNT, parameters = surfaceParams)
         verify(pixel).fire(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_SELECTED_DAILY,
-            parameters = emptyMap(),
+            parameters = surfaceParams,
             type = Pixel.PixelType.Daily(),
         )
     }
 
     @Test
     fun whenWebSearchDeselectedThenFiresCountAndDaily() = runTest {
-        testee.fireWebSearchDeselected()
+        testee.fireWebSearchDeselected(DuckChatPixelSurface.CONTEXTUAL_CHAT)
 
-        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_DESELECTED_COUNT, parameters = emptyMap())
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_DESELECTED_COUNT, parameters = surfaceParams)
         verify(pixel).fire(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_DESELECTED_DAILY,
-            parameters = emptyMap(),
+            parameters = surfaceParams,
             type = Pixel.PixelType.Daily(),
         )
     }
 
     @Test
     fun whenWebSearchSubmittedThenFiresCountAndDaily() = runTest {
-        testee.fireWebSearchSubmitted()
+        testee.fireWebSearchSubmitted(DuckChatPixelSurface.CONTEXTUAL_CHAT)
 
-        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_SUBMITTED_COUNT, parameters = emptyMap())
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_SUBMITTED_COUNT, parameters = surfaceParams)
         verify(pixel).fire(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_WEB_SEARCH_SUBMITTED_DAILY,
-            parameters = emptyMap(),
+            parameters = surfaceParams,
             type = Pixel.PixelType.Daily(),
         )
     }
 
     @Test
     fun whenCustomizeResponsesSelectedThenFiresCountAndDaily() = runTest {
-        testee.fireCustomizeResponsesSelected()
+        testee.fireCustomizeResponsesSelected(DuckChatPixelSurface.CONTEXTUAL_CHAT)
 
-        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_CUSTOMIZE_RESPONSES_SELECTED_COUNT, parameters = emptyMap())
+        verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_CUSTOMIZE_RESPONSES_SELECTED_COUNT, parameters = surfaceParams)
         verify(pixel).fire(
             DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_CUSTOMIZE_RESPONSES_SELECTED_DAILY,
-            parameters = emptyMap(),
+            parameters = surfaceParams,
             type = Pixel.PixelType.Daily(),
         )
     }
@@ -142,6 +144,7 @@ class RealDuckChatPixelsToolsTest {
             hasImageAttachment = true,
             hasFileAttachment = false,
             hasText = true,
+            surface = DuckChatPixelSurface.CONTEXTUAL_CHAT,
         )
 
         val params = mapOf(
@@ -151,6 +154,7 @@ class RealDuckChatPixelsToolsTest {
             DuckChatPixelParameters.HAS_IMAGE_ATTACHMENT to "true",
             DuckChatPixelParameters.HAS_FILE_ATTACHMENT to "false",
             DuckChatPixelParameters.HAS_TEXT to "true",
+            DuckChatPixelParameters.SURFACE to "contextual_chat",
         )
         verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_PROMPT_SUBMITTED_COUNT, parameters = params)
         verify(pixel).fire(
@@ -169,6 +173,7 @@ class RealDuckChatPixelsToolsTest {
             hasImageAttachment = false,
             hasFileAttachment = false,
             hasText = true,
+            surface = DuckChatPixelSurface.ADDRESS_BAR,
         )
 
         val params = mapOf(
@@ -176,6 +181,7 @@ class RealDuckChatPixelsToolsTest {
             DuckChatPixelParameters.HAS_IMAGE_ATTACHMENT to "false",
             DuckChatPixelParameters.HAS_FILE_ATTACHMENT to "false",
             DuckChatPixelParameters.HAS_TEXT to "true",
+            DuckChatPixelParameters.SURFACE to "address_bar",
         )
         verify(pixel).fire(DuckChatPixelName.DUCK_CHAT_UNIFIED_INPUT_PROMPT_SUBMITTED_COUNT, parameters = params)
         verify(pixel).fire(

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/helper/RealDuckChatJSHelperTest.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.browser.api.install.AppInstall
 import com.duckduckgo.browsermode.api.BrowserMode
 import com.duckduckgo.common.test.CoroutineTestRule
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputState
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputStateProvider
 import com.duckduckgo.duckchat.api.nativeinput.NativeInputStatePublisher
 import com.duckduckgo.duckchat.impl.ChatState
 import com.duckduckgo.duckchat.impl.DuckChatInternal
@@ -45,6 +46,7 @@ import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.js.messaging.api.JsCallbackData
 import com.duckduckgo.subscriptions.api.Subscriptions
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.json.JSONObject
@@ -87,6 +89,9 @@ class RealDuckChatJSHelperTest {
     private val mockVoiceSessionStateManager: VoiceSessionStateManager = mock()
     private val mockLimitsHandler: LimitsHandler = mock()
     private val mockNativeInputStatePublisher: NativeInputStatePublisher = mock()
+    private val mockNativeInputStateProvider: NativeInputStateProvider = mock {
+        on { stateForTab(any()) } doReturn MutableStateFlow(NativeInputState.zero())
+    }
     private val mockAppInstall: AppInstall = mock {
         onBlocking { getInstallAge() } doReturn Duration.ZERO
     }
@@ -109,6 +114,7 @@ class RealDuckChatJSHelperTest {
         voiceSessionStateManager = mockVoiceSessionStateManager,
         limitsHandler = mockLimitsHandler,
         nativeInputStatePublisher = mockNativeInputStatePublisher,
+        nativeInputStateProvider = mockNativeInputStateProvider,
         appInstall = mockAppInstall,
         appBuildConfig = mockAppBuildConfig,
         subscriptions = mockSubscriptions,
@@ -1309,14 +1315,14 @@ class RealDuckChatJSHelperTest {
     fun whenShowModelPickerThenShowModelPickerPixelFired() = runTest {
         testee.processJsCallbackMessage("aiChat", "showModelPicker", "123", null, tabId = "tab-1")
 
-        verify(mockDuckChatPixels).fireShowModelPicker()
+        verify(mockDuckChatPixels).fireShowModelPicker(any())
     }
 
     @Test
     fun whenShowModelPickerWithEmptyTabIdThenShowModelPickerPixelNotFired() = runTest {
         testee.processJsCallbackMessage("aiChat", "showModelPicker", "123", null, tabId = "")
 
-        verify(mockDuckChatPixels, never()).fireShowModelPicker()
+        verify(mockDuckChatPixels, never()).fireShowModelPicker(any())
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/AttachmentViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/AttachmentViewModelTest.kt
@@ -58,6 +58,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -729,7 +730,7 @@ class AttachmentViewModelTest {
         viewModel.onImagesPicked(listOf(uri), AttachmentViewModel.ImageSource.PHOTO_LIBRARY)
         advanceUntilIdle()
 
-        verify(duckChatPixels).fireImageAttached("photo_library")
+        verify(duckChatPixels).fireImageAttached(eq("photo_library"), any())
     }
 
     @Test
@@ -739,7 +740,7 @@ class AttachmentViewModelTest {
         viewModel.onImagesPicked(listOf(uri), AttachmentViewModel.ImageSource.CAMERA)
         advanceUntilIdle()
 
-        verify(duckChatPixels).fireImageAttached("camera")
+        verify(duckChatPixels).fireImageAttached(eq("camera"), any())
     }
 
     @Test
@@ -752,7 +753,7 @@ class AttachmentViewModelTest {
         viewModel.onImagesPicked(listOf(uri), AttachmentViewModel.ImageSource.PHOTO_LIBRARY)
         advanceUntilIdle()
 
-        verify(duckChatPixels, never()).fireImageAttached(any())
+        verify(duckChatPixels, never()).fireImageAttached(any(), any())
     }
 
     @Test
@@ -764,8 +765,8 @@ class AttachmentViewModelTest {
         viewModel.onImagesPicked(listOf(uri), AttachmentViewModel.ImageSource.PHOTO_LIBRARY)
         advanceUntilIdle()
 
-        verify(duckChatPixels).fireImageValidationFailed("count_exceeded")
-        verify(duckChatPixels, never()).fireImageAttached(any())
+        verify(duckChatPixels).fireImageValidationFailed(eq("count_exceeded"), any())
+        verify(duckChatPixels, never()).fireImageAttached(any(), any())
     }
 
     @Test
@@ -778,8 +779,8 @@ class AttachmentViewModelTest {
         viewModel.onImagesPicked(listOf(uri), AttachmentViewModel.ImageSource.PHOTO_LIBRARY)
         advanceUntilIdle()
 
-        verify(duckChatPixels).fireImageValidationFailed("other")
-        verify(duckChatPixels, never()).fireImageAttached(any())
+        verify(duckChatPixels).fireImageValidationFailed(eq("other"), any())
+        verify(duckChatPixels, never()).fireImageAttached(any(), any())
     }
 
     @Test
@@ -789,7 +790,7 @@ class AttachmentViewModelTest {
 
         viewModel.removeImageAttachment(id)
 
-        verify(duckChatPixels).fireImageRemoved()
+        verify(duckChatPixels).fireImageRemoved(any())
     }
 
     @Test
@@ -798,7 +799,7 @@ class AttachmentViewModelTest {
 
         viewModel.removeFileAttachment("file-1")
 
-        verify(duckChatPixels).fireFileRemoved()
+        verify(duckChatPixels).fireFileRemoved(any())
     }
 
     @Test
@@ -806,7 +807,7 @@ class AttachmentViewModelTest {
         addFiles(aFileAttachment())
         advanceUntilIdle()
 
-        verify(duckChatPixels).fireFileAttached()
+        verify(duckChatPixels).fireFileAttached(any())
     }
 
     @Test
@@ -814,7 +815,7 @@ class AttachmentViewModelTest {
         addFiles(aFileAttachment())
         advanceUntilIdle()
 
-        verify(duckChatPixels, never()).fireFileValidationFailed(any())
+        verify(duckChatPixels, never()).fireFileValidationFailed(any(), any())
     }
 
     @Test
@@ -825,8 +826,8 @@ class AttachmentViewModelTest {
         addFiles(aFileAttachment(sizeBytes = maxBytes + 1))
         advanceUntilIdle()
 
-        verify(duckChatPixels).fireFileValidationFailed("size_exceeded")
-        verify(duckChatPixels, never()).fireFileAttached()
+        verify(duckChatPixels).fireFileValidationFailed(eq("size_exceeded"), any())
+        verify(duckChatPixels, never()).fireFileAttached(any())
     }
 
     @Test
@@ -840,8 +841,8 @@ class AttachmentViewModelTest {
         addFiles(aFileAttachment())
         advanceUntilIdle()
 
-        verify(duckChatPixels).fireFileValidationFailed("count_exceeded")
-        verify(duckChatPixels, never()).fireFileAttached()
+        verify(duckChatPixels).fireFileValidationFailed(eq("count_exceeded"), any())
+        verify(duckChatPixels, never()).fireFileAttached(any())
     }
 
     @Test
@@ -851,8 +852,8 @@ class AttachmentViewModelTest {
         addFiles(aFileAttachment(pageCount = 11))
         advanceUntilIdle()
 
-        verify(duckChatPixels).fireFileValidationFailed("page_count_exceeded")
-        verify(duckChatPixels, never()).fireFileAttached()
+        verify(duckChatPixels).fireFileValidationFailed(eq("page_count_exceeded"), any())
+        verify(duckChatPixels, never()).fireFileAttached(any())
     }
 
     @Test
@@ -862,8 +863,8 @@ class AttachmentViewModelTest {
         viewModel.onFilesPicked(listOf(uri))
         advanceUntilIdle()
 
-        verify(duckChatPixels).fireFileValidationFailed("other")
-        verify(duckChatPixels, never()).fireFileAttached()
+        verify(duckChatPixels).fireFileValidationFailed(eq("other"), any())
+        verify(duckChatPixels, never()).fireFileAttached(any())
     }
 
     private fun givenImageDecodes(): Uri {

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ModelPickerViewModelTest.kt
@@ -47,6 +47,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -243,7 +244,7 @@ class ModelPickerViewModelTest {
         testee.onModelTapped(model, PickerSurface.MODEL_PICKER_ADDRESS_BAR)
         runCurrent()
 
-        verify(duckChatPixels).fireModelSelected("new")
+        verify(duckChatPixels).fireModelSelected(eq("new"), any())
     }
 
     @Test
@@ -254,7 +255,7 @@ class ModelPickerViewModelTest {
         testee.onModelTapped(model, PickerSurface.MODEL_PICKER_ADDRESS_BAR)
         runCurrent()
 
-        verify(duckChatPixels, never()).fireModelSelected(any())
+        verify(duckChatPixels, never()).fireModelSelected(any(), any())
     }
 
     @Test
@@ -271,7 +272,7 @@ class ModelPickerViewModelTest {
             requiredTier = "plus",
             flowType = "purchase",
         )
-        verify(duckChatPixels, never()).fireModelSelected(any())
+        verify(duckChatPixels, never()).fireModelSelected(any(), any())
     }
 
     @Test
@@ -296,7 +297,7 @@ class ModelPickerViewModelTest {
 
         testee.onModelTapped(model, PickerSurface.MODEL_PICKER_ADDRESS_BAR)
 
-        verify(duckChatPixels).fireModelSelected("new-model")
+        verify(duckChatPixels).fireModelSelected(eq("new-model"), any())
     }
 
     @Test
@@ -307,7 +308,7 @@ class ModelPickerViewModelTest {
 
         testee.onModelTapped(model, PickerSurface.MODEL_PICKER_ADDRESS_BAR)
 
-        verify(duckChatPixels).fireSubmitChangeModel("new-model")
+        verify(duckChatPixels).fireSubmitChangeModel(eq("new-model"), any())
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/NativeInputModeWidgetViewModelTest.kt
@@ -59,6 +59,7 @@ import com.duckduckgo.duckchat.impl.nativeinput.NativeInputHost
 import com.duckduckgo.duckchat.impl.nativeinput.NativeInputPlugin
 import com.duckduckgo.duckchat.impl.nativeinput.RealNativeInputStateStore
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelName
+import com.duckduckgo.duckchat.impl.pixel.DuckChatPixelSurface
 import com.duckduckgo.duckchat.impl.pixel.DuckChatPixels
 import com.duckduckgo.duckchat.store.impl.DuckAiChat
 import com.duckduckgo.duckchat.store.impl.DuckAiChatStore
@@ -882,7 +883,7 @@ class NativeInputModeWidgetViewModelTest {
 
         viewModel.onPromptSubmitted()
 
-        verify(duckChatPixels).fireSubmitChangeModelPromptSent()
+        verify(duckChatPixels).fireSubmitChangeModelPromptSent(any())
     }
 
     @Test
@@ -893,7 +894,7 @@ class NativeInputModeWidgetViewModelTest {
 
         viewModel.onPromptSubmitted()
 
-        verify(duckChatPixels, never()).fireSubmitChangeModelPromptSent()
+        verify(duckChatPixels, never()).fireSubmitChangeModelPromptSent(any())
     }
 
     @Test
@@ -1572,9 +1573,10 @@ class NativeInputModeWidgetViewModelTest {
             hasImageAttachment = true,
             hasFileAttachment = false,
             hasText = true,
+            surface = DuckChatPixelSurface.DUCK_AI,
         )
-        verify(duckChatPixels).fireImageGenerationSubmitted()
-        verify(duckChatPixels, never()).fireWebSearchSubmitted()
+        verify(duckChatPixels).fireImageGenerationSubmitted(any())
+        verify(duckChatPixels, never()).fireWebSearchSubmitted(any())
     }
 
     @Test
@@ -1595,9 +1597,10 @@ class NativeInputModeWidgetViewModelTest {
             hasImageAttachment = false,
             hasFileAttachment = false,
             hasText = true,
+            surface = DuckChatPixelSurface.DUCK_AI,
         )
-        verify(duckChatPixels, never()).fireImageGenerationSubmitted()
-        verify(duckChatPixels, never()).fireWebSearchSubmitted()
+        verify(duckChatPixels, never()).fireImageGenerationSubmitted(any())
+        verify(duckChatPixels, never()).fireWebSearchSubmitted(any())
     }
 
     @Test
@@ -1619,9 +1622,10 @@ class NativeInputModeWidgetViewModelTest {
             hasImageAttachment = false,
             hasFileAttachment = false,
             hasText = true,
+            surface = DuckChatPixelSurface.DUCK_AI,
         )
-        verify(duckChatPixels).fireWebSearchSubmitted()
-        verify(duckChatPixels, never()).fireImageGenerationSubmitted()
+        verify(duckChatPixels).fireWebSearchSubmitted(any())
+        verify(duckChatPixels, never()).fireImageGenerationSubmitted(any())
     }
 
     // endregion
@@ -1637,7 +1641,7 @@ class NativeInputModeWidgetViewModelTest {
     @Test
     fun whenStopGenerationTappedThenStopPixel() {
         testee.fireStopGenerationTapped()
-        verify(duckChatPixels).fireStopGenerationTapped()
+        verify(duckChatPixels).fireStopGenerationTapped(any())
     }
 
     // endregion

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ReasoningModePickerViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/ReasoningModePickerViewModelTest.kt
@@ -48,6 +48,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doSuspendableAnswer
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.stub
@@ -186,7 +187,7 @@ class ReasoningModePickerViewModelTest {
         testee.onModeTapped(ReasoningMode.REASONING, PickerSurface.REASONING_PICKER_ADDRESS_BAR)
         runCurrent()
 
-        verify(duckChatPixels).fireReasoningEffortSelected("reasoning")
+        verify(duckChatPixels).fireReasoningEffortSelected(eq("reasoning"), any())
     }
 
     @Test
@@ -204,7 +205,7 @@ class ReasoningModePickerViewModelTest {
         testee.onModeTapped(ReasoningMode.FAST, PickerSurface.REASONING_PICKER_ADDRESS_BAR)
         runCurrent()
 
-        verify(duckChatPixels, never()).fireReasoningEffortSelected(any())
+        verify(duckChatPixels, never()).fireReasoningEffortSelected(any(), any())
     }
 
     @Test
@@ -228,7 +229,7 @@ class ReasoningModePickerViewModelTest {
             requiredTier = "pro",
             flowType = "upgrade",
         )
-        verify(duckChatPixels, never()).fireReasoningEffortSelected(any())
+        verify(duckChatPixels, never()).fireReasoningEffortSelected(any(), any())
     }
 
     @Test

--- a/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsViewModelTest.kt
+++ b/duckchat/duckchat-impl/src/test/kotlin/com/duckduckgo/duckchat/impl/ui/nativeinput/views/OptionsViewModelTest.kt
@@ -37,6 +37,7 @@ import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
@@ -116,31 +117,31 @@ class OptionsViewModelTest {
     @Test
     fun whenImageGenSelectedByUserThenSelectedPixel() {
         testee.onToolSelectedByUser(Tool.IMAGE_GENERATION)
-        verify(duckChatPixels).fireImageGenerationSelected()
+        verify(duckChatPixels).fireImageGenerationSelected(any())
     }
 
     @Test
     fun whenWebSearchDeselectedByUserThenDeselectedPixel() {
         testee.onToolDeselectedByUser(Tool.WEB_SEARCH)
-        verify(duckChatPixels).fireWebSearchDeselected()
+        verify(duckChatPixels).fireWebSearchDeselected(any())
     }
 
     @Test
     fun whenWebSearchSelectedByUserThenSelectedPixel() {
         testee.onToolSelectedByUser(Tool.WEB_SEARCH)
-        verify(duckChatPixels).fireWebSearchSelected()
+        verify(duckChatPixels).fireWebSearchSelected(any())
     }
 
     @Test
     fun whenImageGenDeselectedByUserThenDeselectedPixel() {
         testee.onToolDeselectedByUser(Tool.IMAGE_GENERATION)
-        verify(duckChatPixels).fireImageGenerationDeselected()
+        verify(duckChatPixels).fireImageGenerationDeselected(any())
     }
 
     @Test
     fun whenCustomizeResponsesClickedThenFireCustomizeResponsesPixel() {
         testee.onCustomizeResponsesClicked()
-        verify(duckChatPixels).fireCustomizeResponsesSelected()
+        verify(duckChatPixels).fireCustomizeResponsesSelected(any())
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/task/1216706777618506?focus=true
Tech Design URL (if applicable):  N/A
API Proposals URL(s) (if applicable): N/A

### Description
Adds a surface parameter (`unifiedInputSurface`) to the contextual Unified Input UTI pixels, distinguishing where each pixel was fired from: address_bar, duck_ai, or contextual_chat.
  - Introduces a DuckChatPixelSurface enum with a from(NativeInputState.InputContext) mapping (BROWSER → address_bar, DUCK_AI → duck_ai, DUCK_AI_CONTEXTUAL → contextual_chat).
  - Threads the surface through all Unified Input pixel firing methods (tool select/deselect/submit, model & reasoning pickers, attachments, stop generation, customize responses) so callers pass the originating surface.
  - Registers the new unifiedInputSurface param in params_dictionary.json and adds it to the affected m_aichat_unified_input_* pixel definitions in duck_chat.json5.
  - Updates the ViewModels (attachments, native input mode widget, model/reasoning/options pickers) to supply the current surface when firing pixels.
 
### Steps to test this PR
1. Address bar (`surface=address_bar`)
  - [x] Open the Unified Input from the address bar / omnibar
  - [x] Toggle a tool (web search / image generation), open the model picker, and attach/remove an image
  - [x] Each fired m_aichat_unified_input_* pixel includes `surface=address_bar`

  2. Duck.ai tab `(surface=duck_ai)`
  - [x] Repeat the same interactions from the dedicated Duck.ai tab
  - [x] Each fired pixel includes surface=duck_ai

  3. Contextual chat sheet (`surface=contextual_chat`)
  - [x] Open the contextual chat sheet over a web page
  - [x] Repeat the same interactions
  - [x] Each fired pixel includes surface=contextual_chat


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only pixel schema and firing changes with no auth, data handling, or user-facing behavior changes.
> 
> **Overview**
> Unified Input analytics now record **where** an interaction happened by adding a `surface` parameter (`address_bar`, `duck_ai`, or `contextual_chat`) to the relevant `m_aichat_unified_input_*` pixel definitions and wiring it through the app.
> 
> A **`DuckChatPixelSurface`** enum maps **`NativeInputState.InputContext`** to those values; **`DuckChatPixels`** APIs for tools, prompts, model/reasoning pickers, attachments, stop generation, customize responses, and FE recovery flows now require a surface and send it as **`surface`** on the wire. ViewModels derive the current surface from native input state when firing pixels. **`unifiedInputSurface`** is registered in **`params_dictionary.json`**. Unit tests were updated to expect the new parameter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3720d32e57259b9b05a47ae28253e41dd49aacd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->