### PR TITLE
Onboarding: Add Try It button to the Duck.ai fire button CTA

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -3107,6 +3107,8 @@ class BrowserTabFragment :
                 browserActivity?.launchFire()
             }
 
+            is Command.LaunchDuckAiOnboardingFireDialog -> browserActivity?.launchFire(isDuckAiOnboarding = true)
+
             is Command.SwitchToTab -> {
                 binding.focusedView.gone()
                 if (binding.autoCompleteSuggestionsList.isVisible) {

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabViewModel.kt
@@ -113,6 +113,7 @@ import com.duckduckgo.app.browser.commands.Command.InjectEmailAddress
 import com.duckduckgo.app.browser.commands.Command.LaunchAddWidgetOnboarding
 import com.duckduckgo.app.browser.commands.Command.LaunchAutofillSettings
 import com.duckduckgo.app.browser.commands.Command.LaunchBookmarksActivity
+import com.duckduckgo.app.browser.commands.Command.LaunchDuckAiOnboardingFireDialog
 import com.duckduckgo.app.browser.commands.Command.LaunchFireDialogFromOnboardingDialog
 import com.duckduckgo.app.browser.commands.Command.LaunchInputScreen
 import com.duckduckgo.app.browser.commands.Command.LaunchNewTab
@@ -5318,7 +5319,14 @@ class BrowserTabViewModel @Inject constructor(
     }
 
     private fun onOnboardingCtaOkButtonClicked(onboardingCta: OnboardingDaxDialogCta): Command? {
-        onUserDismissedCta(onboardingCta)
+        val shouldDismiss = when (onboardingCta) {
+            is DaxDuckAiFireButtonBrandDesignUpdateContextualCta -> false
+            else -> true
+        }
+        if (shouldDismiss) {
+            onUserDismissedCta(onboardingCta)
+        }
+
         return when (onboardingCta) {
             is OnboardingDaxDialogCta.DaxSerpCta,
             is DaxSerpBrandDesignUpdateContextualCta,
@@ -5363,6 +5371,8 @@ class BrowserTabViewModel @Inject constructor(
             is OnboardingDaxDialogCta.DaxFireButtonCta,
             is DaxFireButtonBrandDesignUpdateContextualCta,
             -> LaunchFireDialogFromOnboardingDialog(onboardingCta)
+            is DaxDuckAiFireButtonBrandDesignUpdateContextualCta,
+            -> LaunchDuckAiOnboardingFireDialog
 
             else -> HideOnboardingDaxDialog(onboardingCta)
         }

--- a/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/commands/Command.kt
@@ -484,6 +484,8 @@ sealed class Command {
         val onboardingCta: OnboardingDaxDialogCta,
     ) : Command()
 
+    data object LaunchDuckAiOnboardingFireDialog : Command()
+
     data class SwitchToTab(
         val tabId: String,
     ) : Command()

--- a/app/src/main/java/com/duckduckgo/app/cta/ui/DaxDuckAiFireButtonBrandDesignUpdateContextualCta.kt
+++ b/app/src/main/java/com/duckduckgo/app/cta/ui/DaxDuckAiFireButtonBrandDesignUpdateContextualCta.kt
@@ -36,7 +36,7 @@ data class DaxDuckAiFireButtonBrandDesignUpdateContextualCta(
 ) : OnboardingDaxDialogCta.BrandDesignContextualDaxDialogCta(
     ctaId = CtaId.DAX_DUCK_AI_FIRE_BUTTON,
     description = R.string.onboardingDuckAiFireButtonDaxDialogDescription,
-    buttonText = null,
+    buttonText = R.string.onboardingFireButtonDaxDialogOkButton,
     shownPixel = AppPixelName.ONBOARDING_DAX_CTA_SHOWN,
     okPixel = AppPixelName.ONBOARDING_DAX_CTA_OK_BUTTON,
     cancelPixel = null,
@@ -49,7 +49,7 @@ data class DaxDuckAiFireButtonBrandDesignUpdateContextualCta(
     backgroundRes = R.drawable.bg_onboarding_fire_button,
 ),
     OnboardingDaxDialogCta.ShowsWingBottom {
-    override val activeIncludeId: Int = R.id.contextualBrandDesignNoCtaContent
+    override val activeIncludeId: Int = R.id.contextualBrandDesignPrimaryCtaContent
 
     override val showArrow: Boolean = true
 
@@ -61,5 +61,11 @@ data class DaxDuckAiFireButtonBrandDesignUpdateContextualCta(
             ?.setText(R.string.onboardingDuckAiFireButtonDaxDialogTitle)
         view.findViewById<DaxTextView>(R.id.contextualBrandDesignDescription)?.text =
             context.getString(R.string.onboardingDuckAiFireButtonDaxDialogDescription).html(context)
+    }
+
+    override fun setOnPrimaryCtaClicked(onButtonClicked: () -> Unit) {
+        ctaView?.findViewById<View>(R.id.contextualBrandDesignPrimaryCta)?.setOnClickListener {
+            onButtonClicked.invoke()
+        }
     }
 }

--- a/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/BrowserTabViewModelTest.kt
@@ -12424,6 +12424,17 @@ class BrowserTabViewModelTest {
     }
 
     @Test
+    fun whenBrandDesignDuckAiFireButtonCtaOkClickedThenFireDialogLaunchedAndCtaNotDismissed() = runTest {
+        dismissedCtaDaoChannel.send(emptyList())
+
+        testee.onUserClickCtaOkButton(brandDesignDuckAiFireButtonCta())
+        advanceUntilIdle()
+
+        assertCommandIssued<Command.LaunchDuckAiOnboardingFireDialog>()
+        verify(mockDismissedCtaDao, never()).insert(DismissedCta(CtaId.DAX_DUCK_AI_FIRE_BUTTON))
+    }
+
+    @Test
     fun whenDismissDuckAiFireOnboardingCtaCalledWithDuckAiFireCtaThenCtaDismissed() = runTest {
         dismissedCtaDaoChannel.send(emptyList())
         val cta = DaxDuckAiFireButtonCta(mockOnboardingStore, mockAppInstallStore)

--- a/app/src/test/java/com/duckduckgo/app/cta/ui/DaxDuckAiFireButtonBrandDesignUpdateContextualCtaTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/cta/ui/DaxDuckAiFireButtonBrandDesignUpdateContextualCtaTest.kt
@@ -24,6 +24,7 @@ import com.duckduckgo.adblocking.api.duckplayer.DuckPlayer.DuckPlayerState.DISAB
 import com.duckduckgo.adblocking.api.duckplayer.DuckPlayer.UserPreferences
 import com.duckduckgo.adblocking.api.duckplayer.PrivatePlayerMode.AlwaysAsk
 import com.duckduckgo.app.browser.DuckDuckGoUrlDetectorImpl
+import com.duckduckgo.app.browser.R
 import com.duckduckgo.app.cta.db.DismissedCtaDao
 import com.duckduckgo.app.cta.model.CtaId
 import com.duckduckgo.app.cta.model.DismissedCta
@@ -256,9 +257,11 @@ class DaxDuckAiFireButtonBrandDesignUpdateContextualCtaTest {
     }
 
     @Test
-    fun brandDesignCtaSuppressesDismissAndButton() {
+    fun brandDesignCtaShowsTryItButtonAndSuppressesDismiss() {
         val cta = newBrandDesignCta()
 
+        assertEquals(R.string.onboardingFireButtonDaxDialogOkButton, cta.buttonText)
+        assertEquals(R.id.contextualBrandDesignPrimaryCtaContent, cta.activeIncludeId)
         assertFalse(cta.showDismiss)
         assertTrue(cta.showArrow)
         assertTrue(cta is OnboardingDaxDialogCta.ShowsWingBottom)


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208671518894266/task/1216829123556667?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
The `DAX_FIRE_BUTTON` CTA offers a "Try It" button that opens the fire dialog, so the user can act on the prompt without hunting for the highlighted fire button. Give `DAX_DUCK_AI_FIRE_BUTTON` the same affordance.

Changes are limited to native input widget impl, legacy Input Screen is descoped.

### Steps to test this PR

_base path_
- [x] Clean install the app.
- [x] Go through onboarding and change tab to "Duck.ai" on input preview step.
- [x] Submit a prompt.
- [x] Verify "Try it" button is visible in the bubble.
- [x] Verify clicking the button does not dismiss the CTA.
- [x] Verify the fire dialog shows up and you can burn the tab.

_custom AI path_
- [x] Apply below patch:
```diff
diff --git a/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt b/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
index fe3752cbb2..af220bb09d 100644
--- a/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
+++ b/app/src/main/java/com/duckduckgo/app/onboarding/CustomAiOnboardingStore.kt
@@ -100,6 +100,7 @@ class CustomAiOnboardingStoreImpl @Inject constructor(
     }
 
     override suspend fun resolve() = resolveMutex.withLock {
+        return@withLock true
         withContext(dispatcherProvider.io()) {
             // Ensure the install referrer (and therefore the processing function) has resolved before reading.
             withTimeoutOrNull(MAX_REFERRER_WAIT_TIME_MS) { referrerStateListener.get().waitForReferrerCode() }
@@ -116,6 +117,7 @@ class CustomAiOnboardingStoreImpl @Inject constructor(
     }
 
     override suspend fun isEnabled(): Boolean = resolveMutex.withLock {
+        return@withLock true
         withContext(dispatcherProvider.io()) {
             preferences.getBoolean(PREFS_KEY_ENABLED, false)
         }
```
- [x] Clean install the app.
- [x] Submit a prompt.
- [x] Verify "Try it" button is visible in the bubble.
- [x] Verify clicking the button does not dismiss the CTA.
- [x] Verify the fire dialog shows up and you can burn the tab.

### UI changes
| Before  | After |
| ------ | ----- |
<img width="480" height="1071" alt="image" src="https://github.com/user-attachments/assets/ffd84a74-7150-4325-8fe7-d6c1c42af801" />|<img width="480" height="1071" alt="image" src="https://github.com/user-attachments/assets/36afaa57-4cdf-4a72-b0c4-f8cf0b66cd80" />|

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding UI and command routing only; reuses existing Duck.ai onboarding fire paths with added tests.
> 
> **Overview**
> The Duck.ai fire-button onboarding bubble now matches the standard fire-button CTA: it shows a **Try It** primary button and wires it to open the fire dialog instead of leaving users to find the highlighted fire control.
> 
> `DaxDuckAiFireButtonBrandDesignUpdateContextualCta` switches from the no-button layout to `contextualBrandDesignPrimaryCtaContent`, reuses the fire dialog OK string, and registers a primary click handler. OK handling in `BrowserTabViewModel` routes this CTA through a new `LaunchDuckAiOnboardingFireDialog` command (instead of `LaunchFireDialogFromOnboardingDialog`), skips dismissing the CTA on OK, and `BrowserTabFragment` calls `launchFire(isDuckAiOnboarding = true)` so the bubble stays visible until the user actually clears via fire—aligned with existing `pendingDuckAiOnboardingFire` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2316c36794084374a2d090ca586cf1fdedb5afc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->