### PR TITLE
Add PT_GNU_RELRO 16 KB check to check_elf_alignment.sh

### DIFF
--- a/scripts/check_elf_alignment.sh
+++ b/scripts/check_elf_alignment.sh
@@ -12,6 +12,8 @@ usage() {
   echo "Host side script to check the ELF alignment of shared libraries."
   echo "Shared libraries are reported ALIGNED when their ELF regions are"
   echo "16 KB or 64 KB aligned. Otherwise they are reported as UNALIGNED."
+  echo "Libraries whose PT_GNU_RELRO segment cannot be protected at a 16 KB"
+  echo "page size are additionally reported as RELRO MISALIGNED."
   echo
   echo "Usage: ${progname} [input-path|input-APK|input-APEX]"
 }
@@ -67,6 +69,64 @@ RED=$(tput setaf 1)
 GREEN=$(tput setaf 2)
 ENDCOLOR=$(tput sgr0)
 unaligned_libs=()
+
+# >>> DDG local addition: PT_GNU_RELRO 16 KB alignment (not in upstream AOSP) >>>
+misaligned_relro_libs=()
+
+# Echoes the RELRO end address when the segment cannot be protected at a 16 KB
+# page size, and nothing otherwise.
+#
+# To protect RELRO the loader must round its end up to a page boundary. That is
+# only safe when no writable data lives between the real end and that boundary,
+# so the test is whether any writable LOAD segment has bytes inside
+# [relro_end, round_up(relro_end, 16 KB)) -- this is what upstream tooling calls
+# "RELRO is not a suffix".
+#
+# Testing relro_end against a writable segment's end for equality is wrong: lld
+# pads PT_GNU_RELRO's p_memsz up to max-page-size, so a safe RELRO usually
+# overshoots its segment and keeps real writable data in a later LOAD segment on
+# a later page. Only the interval test above distinguishes the two cases.
+#
+# objdump is used rather than llvm-readelf to keep this script free of any NDK
+# dependency. It splits each program header over two lines:
+#    RELRO off 0x..1e8c20 vaddr 0x..1ecc20 paddr 0x..1ecc20 align 2**0
+#          filesz 0x..163e0 memsz 0x..163e0 flags r--
+relro_misaligned_end() {
+  # not named "rm": bash locals are dynamically scoped and would shadow the command
+  local elf="${1}" phdrs rv rmemsz relro_end pad_end v m
+  phdrs="$(objdump -p "${elf}" 2>/dev/null | awk '
+    /^ *(LOAD|RELRO) +off/ { type = $1; vaddr = $5; next }
+    /^ *filesz/ {
+      if (type == "RELRO") print "RELRO", vaddr, $4
+      else if (type == "LOAD" && $6 ~ /w/) print "LOADW", vaddr, $4
+      type = ""
+    }')"
+
+  rv="$(echo "${phdrs}" | awk '$1 == "RELRO" { print $2; exit }')"
+  rmemsz="$(echo "${phdrs}" | awk '$1 == "RELRO" { print $3; exit }')"
+  [ -z "${rv}" ] && return 0  # no PT_GNU_RELRO segment, nothing to check
+
+  rv=$(( rv ))
+  relro_end=$(( rv + rmemsz ))
+  (( relro_end % 16384 == 0 )) && return 0
+
+  pad_end=$(( (relro_end + 16383) / 16384 * 16384 ))
+
+  # read must be told to split on spaces: the caller sets IFS=$'\n'
+  while IFS=' ' read -r _ v m; do
+    [ -z "${v}" ] && continue
+    v=$(( v )); m=$(( m ))
+    # does [v, v+m) overlap the padding range [relro_end, pad_end)?
+    if (( v < pad_end && v + m > relro_end )); then
+      printf '0x%x\n' "${relro_end}"
+      return 0
+    fi
+  done <<< "$(echo "${phdrs}" | grep '^LOADW')"
+
+  return 0  # nothing writable in the padding range, safe to round up
+}
+# <<< DDG local addition <<<
+
 echo
 echo "=== ELF alignment ==="
 matches="$(find "${dir}" -type f)"
@@ -78,10 +138,19 @@ for match in $matches; do
   [[ "${match}" == *".apex" ]] && echo "WARNING: doesn't recursively inspect .apex file: ${match}"
   [[ $(file "${match}") == *"ELF"* ]] || continue
   res="$(objdump -p "${match}" | grep LOAD | awk '{ print $NF }' | head -1)"
+  # >>> DDG local addition >>>
+  relro_note=""
+  relro_end="$(relro_misaligned_end "${match}")"
+  if [ -n "${relro_end}" ]; then
+    relro_note=" ${RED}RELRO MISALIGNED${ENDCOLOR} (end=${relro_end})"
+    misaligned_relro_libs+=("${match}")
+    exit_code=1
+  fi
+  # <<< DDG local addition <<<
   if [[ $res =~ 2\*\*(1[4-9]|[2-9][0-9]|[1-9][0-9]{2,}) ]]; then
-    echo -e "${match}: ${GREEN}ALIGNED${ENDCOLOR} ($res)"
+    echo -e "${match}: ${GREEN}ALIGNED${ENDCOLOR} ($res)${relro_note}"
   else
-    echo -e "${match}: ${RED}UNALIGNED${ENDCOLOR} ($res)"
+    echo -e "${match}: ${RED}UNALIGNED${ENDCOLOR} ($res)${relro_note}"
     unaligned_libs+=("${match}")
     exit_code=1
   fi
@@ -89,9 +158,16 @@ done
 
 if [ ${#unaligned_libs[@]} -gt 0 ]; then
   echo -e "${RED}Found ${#unaligned_libs[@]} unaligned libs (only arm64-v8a/x86_64 libs need to be aligned).${ENDCOLOR}"
-  cleanup_trap 1  # Exit with error code 1 when unaligned libs are found
-elif [ -n "${dir_filename}" ]; then
+fi
+# >>> DDG local addition >>>
+# Reported separately: a misaligned RELRO end needs the library relinked, so it
+# is not fixable by repackaging the way a zip-alignment failure is.
+if [ ${#misaligned_relro_libs[@]} -gt 0 ]; then
+  echo -e "${RED}Found ${#misaligned_relro_libs[@]} libs with a misaligned PT_GNU_RELRO segment (only arm64-v8a/x86_64 libs need to be aligned).${ENDCOLOR}"
+fi
+# <<< DDG local addition <<<
+if [ ${exit_code} -eq 0 ] && [ -n "${dir_filename}" ]; then
   echo -e "ELF Verification Successful"
 fi
 echo "====================="
-cleanup_trap 0  # Exit with code 0 only if no unaligned libs were found
+cleanup_trap ${exit_code}  # Exit with code 0 only if no findings were reported


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1208589375218614/task/1216907917649404?focus=true
Tech Design URL (if applicable):
API Proposals URL(s) (if applicable):

### Description

Play Console flags our release bundle with:

```
PT_GNU_RELRO start: 0x001ecc20 end: 0x00203000 align: 0x00000001
RELRO is not a suffix and its end is not 16 KB aligned
```

`scripts/check_elf_alignment.sh` (a vendored copy of the AOSP script) reported the same APK as completely clean, because it only checks two things: zip alignment of  `.so` entries inside the APK, and `PT_LOAD` `p_align`. Every native library we ship passes both — all 40 are `2**14` aligned. `PT_GNU_RELRO` is a third, independent condition that nothing in our tooling looked at, so the only way to see this finding
was to upload a build and read the Play Console report.

This adds that check. Libraries are now additionally reported as `RELRO MISALIGNED`, appended to the existing per-library line so output length is unchanged.  
  
Two further notes:

- **`objdump`** **is used rather than** **`llvm-readelf`**, matching what the script already calls, so it keeps working with no NDK on `PATH`.
- **The exit code now covers both checks.** A library can pass `PT_LOAD` while failing RELRO — exactly our case — so the script previously exited 0 while printing findings. This also fixes a pre-existing bug where the unaligned-libs branch called `cleanup_trap` directly and skipped the closing `=====` separator.

Additions are fenced with `>>> DDG local addition >>>` markers. The file is otherwise a verbatim copy of the upstream AOSP script, so a future refresh from `android.googlesource.com` will need them re-applied — the markers make that conflict obvious rather than silent.

This PR only improves _detection_; it does not fix the warning. 

### Steps to test this PR

- [ ] `./scripts/check_elf_alignment.sh <ADD_HERE_AAB>` reports `ALIGNED (2**14) RELRO MISALIGNED (end=0x203000)` and exits **1**. The `end` value matches the address in the Play Console report exactly.

### NO UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only a host-side validation script used in CI; no app runtime, auth, or data-path impact.
> 
> **Overview**
> Extends the vendored AOSP **`check_elf_alignment.sh`** so local runs can surface the same **Play Console** finding that **`PT_GNU_RELRO`** is not 16 KB–safe when writable LOAD data sits in the padding range after RELRO (“RELRO is not a suffix”).
> 
> A new **`relro_misaligned_end`** helper parses **`objdump -p`** (no NDK) and flags libs as **`RELRO MISALIGNED`** on the existing per-library line, with a separate summary count. **Exit behavior** is unified: RELRO failures set **`exit_code=1`**, the script always prints the closing separator, and **`cleanup_trap`** runs with that code—fixing the case where PT_LOAD looked clean but RELRO failed yet the script exited 0, and the old early exit that skipped the footer on unaligned LOAD libs.
> 
> DDG-local blocks are marked for future AOSP refreshes. This is **detection only**; it does not relink or fix native libs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ef2b254eb6eb73630bfc2b96ad76601bb47d2ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->