### PR TITLE
Sync: Add dev setting to create & register account_info keypair

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountInfoKeyManager.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountInfoKeyManager.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.crypto.SyncLib
+import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.duckduckgo.sync.store.SyncStore
+import com.squareup.anvil.annotations.ContributesBinding
+import dagger.SingleInstanceIn
+import kotlinx.coroutines.withContext
+import logcat.LogPriority.ERROR
+import logcat.logcat
+import javax.inject.Inject
+
+/**
+ * The unified-devices `account_info` keypair MUST be created as RSA-3072.
+ * Implementations must not assume a fixed modulus size when importing or validating this key.
+ */
+internal const val RSA_KEY_SIZE_ACCOUNT_INFO = 3072
+
+/**
+ * Owns the account-wide `account_info` protected key — the RSA keypair that will encrypt the unified cross-credential `device_info` blob.
+ */
+interface AccountInfoKeyManager {
+
+    /**
+     * Mints a fresh `account_info` keypair, wraps it for every credential this account currently holds
+     * (ddg always, 3party if a scoped password exists), and registers it with the server via set-if-absent.
+     *
+     * If another device already registered a key for this purpose first, the local mint is discarded and the server's key is adopted instead.
+     * The winning public key is returned in [AccountInfoKeyResult].
+     */
+    suspend fun ensureKeyRegistered(): Result<AccountInfoKeyResult>
+}
+
+data class AccountInfoKeyResult(
+    val kid: String,
+    val publicKey: RsaJwk?,
+    val created: Boolean,
+    val wrapsSent: Int,
+)
+
+@ContributesBinding(AppScope::class)
+@SingleInstanceIn(AppScope::class)
+class RealAccountInfoKeyManager @Inject constructor(
+    private val syncStore: SyncStore,
+    private val syncApi: SyncApi,
+    private val syncJweCrypto: SyncJweCrypto,
+    private val nativeLib: SyncLib,
+    private val thirdPartyKeyWrapper: ThirdPartyKeyWrapper,
+    private val dispatchers: DispatcherProvider,
+) : AccountInfoKeyManager {
+
+    override suspend fun ensureKeyRegistered(): Result<AccountInfoKeyResult> = withContext(dispatchers.io()) {
+        val token = syncStore.token.takeUnless { it.isNullOrEmpty() }
+            ?: return@withContext Error(reason = "CreateAccountInfoKey: not signed in")
+        val accountSecretKey = syncStore.secretKey
+            ?: return@withContext Error(reason = "CreateAccountInfoKey: no account secret key")
+
+        val minted = when (val result = mintKeypair(accountSecretKey)) {
+            is Success -> result.data
+            is Error -> return@withContext result
+        }
+
+        val entries = when (val result = wrapForCredentials(minted)) {
+            is Success -> result.data
+            is Error -> return@withContext result
+        }
+
+        logcat { "Sync-UnifiedDevices: registering $SYNC_PURPOSE_ACCOUNT_INFO key (kid=${minted.entry.kid}, wraps=${entries.size})" }
+        when (val result = syncApi.setKeysIfAbsent(token, SYNC_PURPOSE_ACCOUNT_INFO, entries)) {
+            is Success -> onSetIfAbsentSuccess(minted, entries.size, result.data)
+            is Error -> {
+                logcat(ERROR) { "Sync-UnifiedDevices: setKeysIfAbsent failed: ${result.reason}" }
+                result
+            }
+        }
+    }
+
+    private fun mintKeypair(accountSecretKey: String): Result<MintedProtectedKey> =
+        mintDdgWrappedProtectedKey(
+            purpose = SYNC_PURPOSE_ACCOUNT_INFO,
+            accountSecretKey = accountSecretKey,
+            syncJweCrypto = syncJweCrypto,
+            nativeLib = nativeLib,
+            errorPrefix = "CreateAccountInfoKey",
+            keySizeBits = RSA_KEY_SIZE_ACCOUNT_INFO,
+        )
+
+    private fun wrapForCredentials(minted: MintedProtectedKey): Result<List<ProtectedKeyEntry>> {
+        val entries = mutableListOf(minted.entry)
+        val scopedPassword = syncStore.scopedPassword
+        val userId = syncStore.userId
+        if (scopedPassword != null && userId != null) {
+            entries += when (val result = thirdPartyKeyWrapper.wrap(minted, SYNC_PURPOSE_ACCOUNT_INFO, scopedPassword, userId)) {
+                is Success -> result.data
+                is Error -> return result
+            }
+        }
+        return Success(entries)
+    }
+
+    private fun onSetIfAbsentSuccess(
+        minted: MintedProtectedKey,
+        wrapsSent: Int,
+        outcome: SetKeysIfAbsentResult,
+    ): Result<AccountInfoKeyResult> {
+        return when (outcome) {
+            SetKeysIfAbsentResult.Created -> {
+                logcat { "Sync-UnifiedDevices: our key won (kid=${minted.entry.kid})" }
+                Success(
+                    AccountInfoKeyResult(kid = minted.entry.kid, publicKey = minted.entry.publicKey, created = true, wrapsSent = wrapsSent),
+                )
+            }
+            is SetKeysIfAbsentResult.Existing -> {
+                logcat { "Sync-UnifiedDevices: another device's key won (kid=${outcome.kid}); discarding local mint" }
+                Success(
+                    AccountInfoKeyResult(kid = outcome.kid, publicKey = outcome.publicKey, created = false, wrapsSent = wrapsSent),
+                )
+            }
+        }
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ProtectedKeyMinting.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ProtectedKeyMinting.kt
@@ -25,7 +25,7 @@ import java.util.UUID
 /** A freshly-minted protected key with its ddg-wrap [entry] and the underlying raw private bytes,
  *  so callers can produce additional wrappings (e.g. 3party) under the same `kid` without
  *  decrypting the ddg-wrap a second time. */
-internal data class MintedProtectedKey(
+class MintedProtectedKey(
     val entry: ProtectedKeyEntry,
     val rawPrivateKeyBytes: ByteArray,
 )

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SetKeysIfAbsentCall.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SetKeysIfAbsentCall.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import androidx.annotation.WorkerThread
+import com.duckduckgo.di.scopes.AppScope
+import com.squareup.anvil.annotations.ContributesBinding
+import logcat.LogPriority.INFO
+import logcat.logcat
+import retrofit2.HttpException
+import retrofit2.Response
+import javax.inject.Inject
+
+/** Runs the POST /sync/keys/purpose/{purpose}/set-if-absent request and maps its outcome. */
+@WorkerThread
+interface SetKeysIfAbsentCall {
+    fun execute(
+        token: String,
+        purpose: String,
+        keys: List<ProtectedKeyEntry>,
+    ): Result<SetKeysIfAbsentResult>
+}
+
+@ContributesBinding(AppScope::class)
+class RealSetKeysIfAbsentCall @Inject constructor(
+    private val syncService: SyncService,
+) : SetKeysIfAbsentCall {
+    override fun execute(
+        token: String,
+        purpose: String,
+        keys: List<ProtectedKeyEntry>,
+    ): Result<SetKeysIfAbsentResult> {
+        return runCatching {
+            logcat { "Sync-UnifiedDevices: setKeysIfAbsent purpose=$purpose, wraps=${keys.size}" }
+            val response = syncService.setKeysIfAbsent("Bearer $token", purpose, SetKeysIfAbsentRequest(keys)).execute()
+
+            if (response.isSuccessful) {
+                if (response.code() == 201) {
+                    Result.Success(SetKeysIfAbsentResult.Created)
+                } else {
+                    val existing = response.body()?.keys?.firstOrNull() ?: return Result.Error(reason = "SetKeysIfAbsent: 200 response missing keys")
+
+                    Result.Success(SetKeysIfAbsentResult.Existing(existing.kid, existing.publicKey))
+                }
+            } else {
+                mapError(response)
+            }
+        }.getOrElse { throwable ->
+            logcat(INFO) { "Sync-UnifiedDevices: setKeysIfAbsent error ${throwable.localizedMessage}" }
+            if (throwable is HttpException) {
+                Result.Error(code = throwable.code(), reason = "unexpected status code")
+            } else {
+                Result.Error(reason = "internal error")
+            }
+        }
+    }
+
+    private fun mapError(response: Response<SetKeyIfAbsentResponse?>): Result<SetKeysIfAbsentResult> {
+        val errorBody = response.errorBody()
+        val hasErrorBody = runCatching {
+            errorBody != null && errorBody.string().isNotEmpty()
+        }.getOrDefault(false)
+        return if (hasErrorBody) {
+            Result.Error(code = response.code(), reason = "unexpected status code")
+        } else {
+            Result.Error(code = response.code(), reason = "empty response")
+        }
+    }
+}

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncAccountRepository.kt
@@ -1391,6 +1391,9 @@ internal const val CREDENTIAL_ID_3PARTY = "3party"
 // when authenticating against a 3party-restricted credential.
 internal const val SYNC_SCOPE_AI_CHATS = "ai_chats"
 
+// Purpose for the account-wide `device_info` protected key (unified cross-credential device list)
+internal const val SYNC_PURPOSE_ACCOUNT_INFO = "account_info"
+
 // Recovery code version emitted in v2 recovery codes per the Recovery Payload Shape RFC
 // (Asana 1214804486778180). Format is "major.minor" — clients in major version 2 accept 2.x
 // codes (ignoring unknown fields) and must reject codes with major version >2.

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncService.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncService.kt
@@ -136,6 +136,16 @@ interface SyncService {
         @Header("Authorization") token: String,
     ): Call<ProtectedKeysResponse>
 
+    /**
+     * First-writer-wins registration for a purpose-scoped protected key.
+     */
+    @POST("$SYNC_PROD_ENVIRONMENT_URL/sync/keys/purpose/{purpose}/set-if-absent")
+    fun setKeysIfAbsent(
+        @Header("Authorization") token: String,
+        @Path("purpose") purpose: String,
+        @Body request: SetKeysIfAbsentRequest,
+    ): Call<SetKeyIfAbsentResponse>
+
     @GET("$SYNC_PROD_ENVIRONMENT_URL/sync/access-credentials")
     fun getAccessCredentials(
         @Header("Authorization") token: String,
@@ -272,6 +282,24 @@ data class TokenRescopeResponse(
 /** Response from GET /sync/keys — the account's protected keys for all purposes. */
 data class ProtectedKeysResponse(
     val keys: List<ProtectedKeyEntry>,
+)
+
+/**
+ * Request body for POST /sync/keys/purpose/{purpose}/set-if-absent
+ * one entry per credential (ddg/3party) so both wrapped copies are stored atomically.
+ * */
+data class SetKeysIfAbsentRequest(
+    val keys: List<ProtectedKeyEntry>,
+)
+
+data class SetKeyIfAbsentResponse(
+    val keys: List<AccountInfoKeyWire> = emptyList(),
+)
+
+// Response only returns the winning key ID + public key
+data class AccountInfoKeyWire(
+    val kid: String,
+    @field:Json(name = "public_key") val publicKey: RsaJwk? = null,
 )
 
 data class AccessCredentialsResponse(

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
@@ -119,6 +119,14 @@ interface SyncApi {
     /** List this account's protected keys across all purposes. */
     fun getProtectedKeys(token: String): Result<List<ProtectedKeyEntry>>
 
+    /** First-writer-wins registration of a purpose-scoped protected key. On [SetKeysIfAbsentResult.Existing]
+     *  the caller must discard its own minted keypair and adopt the returned one instead. */
+    fun setKeysIfAbsent(
+        token: String,
+        purpose: String,
+        keys: List<ProtectedKeyEntry>,
+    ): Result<SetKeysIfAbsentResult>
+
     fun getAccessCredentials(token: String): Result<List<AccessCredentialEntry>>
 
     fun createAccessCredential(
@@ -140,10 +148,19 @@ interface SyncApi {
     fun deleteExchangeChannel(channelId: String): Result<Unit>
 }
 
+sealed class SetKeysIfAbsentResult {
+    /** Our posted keys won (server returned 201). */
+    data object Created : SetKeysIfAbsentResult()
+
+    /** Another device's key already existed (server returned 200); this is the one that won. */
+    data class Existing(val kid: String, val publicKey: RsaJwk?) : SetKeysIfAbsentResult()
+}
+
 @ContributesBinding(AppScope::class)
 class SyncServiceRemote @Inject constructor(
     private val syncService: SyncService,
     private val syncStore: SyncStore,
+    private val setKeysIfAbsentCall: SetKeysIfAbsentCall,
 ) : SyncApi {
     override fun createAccount(
         userID: String,
@@ -548,6 +565,16 @@ class SyncServiceRemote @Inject constructor(
             val keys = response.body()?.keys ?: emptyList()
             Result.Success(keys)
         }
+    }
+
+    override fun setKeysIfAbsent(
+        token: String,
+        purpose: String,
+        keys: List<ProtectedKeyEntry>,
+    ): Result<SetKeysIfAbsentResult> {
+        val result = setKeysIfAbsentCall.execute(token, purpose, keys)
+        if (result is Result.Error) result.removeKeysIfInvalid()
+        return result
     }
 
     override fun getAccessCredentials(token: String): Result<List<AccessCredentialEntry>> {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ThirdPartyKeyWrapper.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ThirdPartyKeyWrapper.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import androidx.annotation.WorkerThread
+import com.duckduckgo.di.scopes.AppScope
+import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.duckduckgo.sync.store.ScopedPassword
+import com.squareup.anvil.annotations.ContributesBinding
+import javax.inject.Inject
+
+/** Wraps a freshly-minted keypair's private key for the 3party credential. */
+@WorkerThread
+interface ThirdPartyKeyWrapper {
+    fun wrap(
+        minted: MintedProtectedKey,
+        purpose: String,
+        scopedPassword: ScopedPassword,
+        userId: String,
+    ): Result<ProtectedKeyEntry>
+}
+
+@ContributesBinding(AppScope::class)
+class RealThirdPartyKeyWrapper @Inject constructor(
+    private val syncJweCrypto: SyncJweCrypto,
+) : ThirdPartyKeyWrapper {
+
+    override fun wrap(
+        minted: MintedProtectedKey,
+        purpose: String,
+        scopedPassword: ScopedPassword,
+        userId: String,
+    ): Result<ProtectedKeyEntry> {
+        // main encryption key, derived from the scoped password
+        val scopedPasswordMainEncryptionKey = kotlin.runCatching {
+            syncJweCrypto.hkdfDeriveBytes(
+                base64Key = scopedPassword.raw,
+                salt = userId.toByteArray(Charsets.UTF_8),
+                info = MAIN_KEY_HKDF_INFO,
+                outBytes = MAIN_KEY_LENGTH_BYTES,
+            )
+        }.getOrElse { return it.asLoggedError("ThirdPartyKeyWrap: failed to derive 3party MEK") }
+
+        val encryptedPrivateKey = kotlin.runCatching {
+            syncJweCrypto.jweEncryptSymmetric(
+                plaintext = minted.rawPrivateKeyBytes,
+                symmetricKey = scopedPasswordMainEncryptionKey,
+                kid = CREDENTIAL_ID_3PARTY,
+            )
+        }.getOrElse { return it.asLoggedError("ThirdPartyKeyWrap: failed to JWE-encrypt private key for 3party") }
+
+        return Success(
+            ProtectedKeyEntry(
+                kid = minted.entry.kid,
+                purpose = purpose,
+                encryptedWith = CREDENTIAL_ID_3PARTY,
+                encryptedPrivateKey = encryptedPrivateKey,
+                publicKey = minted.entry.publicKey,
+            ),
+        )
+    }
+
+    companion object {
+        // HKDF info label and output length for deriving a credential's main encryption key (MEK).
+        private const val MAIN_KEY_HKDF_INFO = "Main Key"
+        private const val MAIN_KEY_LENGTH_BYTES = 32
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AccountInfoKeyManagerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AccountInfoKeyManagerTest.kt
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.sync.TestSyncFixtures.secretKey
+import com.duckduckgo.sync.TestSyncFixtures.token
+import com.duckduckgo.sync.TestSyncFixtures.userId
+import com.duckduckgo.sync.crypto.EncryptBytesResult
+import com.duckduckgo.sync.crypto.SyncLib
+import com.duckduckgo.sync.impl.Result.Error
+import com.duckduckgo.sync.impl.Result.Success
+import com.duckduckgo.sync.impl.crypto.RsaKeyPair
+import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.duckduckgo.sync.store.ScopedPassword
+import com.duckduckgo.sync.store.SyncStore
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.check
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class AccountInfoKeyManagerTest {
+
+    private val syncStore: SyncStore = mock()
+    private val syncApi: SyncApi = mock()
+    private val syncJweCrypto: SyncJweCrypto = mock()
+    private val nativeLib: SyncLib = mock()
+
+    @get:Rule
+    val coroutineTestRule = CoroutineTestRule()
+
+    private lateinit var manager: AccountInfoKeyManager
+
+    @Before
+    fun before() {
+        manager = RealAccountInfoKeyManager(
+            syncStore = syncStore,
+            syncApi = syncApi,
+            syncJweCrypto = syncJweCrypto,
+            nativeLib = nativeLib,
+            thirdPartyKeyWrapper = RealThirdPartyKeyWrapper(syncJweCrypto),
+            dispatchers = coroutineTestRule.testDispatcherProvider,
+        )
+        configureForSuccessfulKeypairMint()
+    }
+
+    private fun configureForSuccessfulKeypairMint() {
+        whenever(syncStore.token).thenReturn(token)
+        whenever(syncStore.secretKey).thenReturn(secretKey)
+        whenever(syncJweCrypto.generateRsaKeyPair(any())).thenReturn(RsaKeyPair("pubKey", "cHJpdktleQ"))
+        whenever(syncJweCrypto.extractJwkComponents(anyString())).thenReturn("modulus" to "AQAB")
+        whenever(nativeLib.encryptData(any<ByteArray>(), eq(secretKey)))
+            .thenReturn(EncryptBytesResult(0, "ddg_wrapped".toByteArray()))
+    }
+
+    private fun configureForNotSignedIn() {
+        whenever(syncStore.token).thenReturn(null)
+    }
+
+    private fun configureForMissingAccountSecretKey() {
+        whenever(syncStore.secretKey).thenReturn(null)
+    }
+
+    private fun configureForKeypairMintFailure() {
+        whenever(syncJweCrypto.generateRsaKeyPair(any())).thenThrow(RuntimeException("boom"))
+    }
+
+    private fun configureForSetIfAbsentFailure() {
+        whenever(syncApi.setKeysIfAbsent(eq(token), eq("account_info"), any())).thenReturn(Error(code = 500, reason = "server error"))
+    }
+
+    @Test
+    fun whenNotSignedInThenReturnsError() = runTest {
+        configureForNotSignedIn()
+
+        val result = manager.ensureKeyRegistered()
+
+        assertTrue(result is Error)
+    }
+
+    @Test
+    fun whenNoSecretKeyThenReturnsError() = runTest {
+        configureForMissingAccountSecretKey()
+
+        val result = manager.ensureKeyRegistered()
+
+        assertTrue(result is Error)
+    }
+
+    @Test
+    fun whenNoScopedPasswordThenOnlyDdgWrapIsSent() = runTest {
+        whenever(syncStore.scopedPassword).thenReturn(null)
+        whenever(syncApi.setKeysIfAbsent(eq(token), eq("account_info"), any())).thenReturn(Success(SetKeysIfAbsentResult.Created))
+
+        val result = manager.ensureKeyRegistered() as Success
+
+        assertEquals(RsaJwk(n = "modulus", e = "AQAB"), result.data.publicKey)
+        assertTrue(result.data.created)
+        assertEquals(1, result.data.wrapsSent)
+        verify(syncJweCrypto).generateRsaKeyPair(3072)
+        verify(syncApi).setKeysIfAbsent(
+            eq(token),
+            eq("account_info"),
+            check { keys ->
+                assertEquals(1, keys.size)
+                assertEquals("ddg", keys.first().encryptedWith)
+                assertEquals("account_info", keys.first().purpose)
+            },
+        )
+    }
+
+    @Test
+    fun whenScopedPasswordPresentThenBothWrapsAreSentSharingOneKid() = runTest {
+        whenever(syncStore.scopedPassword).thenReturn(ScopedPassword("c3BSYXc="))
+        whenever(syncStore.userId).thenReturn(userId)
+        whenever(syncJweCrypto.hkdfSha256SingleBlock(any(), any(), any(), any())).thenReturn(ByteArray(32))
+        whenever(syncJweCrypto.jweEncryptSymmetric(any(), any(), anyOrNull())).thenReturn("3party_wrapped")
+        whenever(syncApi.setKeysIfAbsent(eq(token), eq("account_info"), any())).thenReturn(Success(SetKeysIfAbsentResult.Created))
+
+        val result = manager.ensureKeyRegistered()
+
+        assertTrue(result is Success)
+        assertEquals(2, (result as Success).data.wrapsSent)
+        verify(syncApi).setKeysIfAbsent(
+            eq(token),
+            eq("account_info"),
+            check { keys ->
+                assertEquals(2, keys.size)
+                assertEquals(1, keys.map { it.kid }.toSet().size)
+                assertEquals(setOf("ddg", "3party"), keys.map { it.encryptedWith }.toSet())
+            },
+        )
+    }
+
+    @Test
+    fun whenSetIfAbsentCreatedThenReturnsCreatedTrueWithOwnPublicKey() = runTest {
+        whenever(syncStore.scopedPassword).thenReturn(null)
+        whenever(syncApi.setKeysIfAbsent(eq(token), eq("account_info"), any())).thenReturn(Success(SetKeysIfAbsentResult.Created))
+
+        val result = manager.ensureKeyRegistered() as Success
+
+        assertTrue(result.data.created)
+        assertEquals(1, result.data.wrapsSent)
+        assertEquals(RsaJwk(n = "modulus", e = "AQAB"), result.data.publicKey)
+    }
+
+    @Test
+    fun whenSetIfAbsentExistingThenAdoptsReturnedKeyAndReturnsCreatedFalse() = runTest {
+        whenever(syncStore.scopedPassword).thenReturn(null)
+        whenever(syncApi.setKeysIfAbsent(eq(token), eq("account_info"), any()))
+            .thenReturn(Success(SetKeysIfAbsentResult.Existing(kid = "other-kid", publicKey = RsaJwk(n = "other-mod", e = "AQAB"))))
+
+        val result = manager.ensureKeyRegistered() as Success
+
+        assertEquals("other-kid", result.data.kid)
+        assertEquals(RsaJwk(n = "other-mod", e = "AQAB"), result.data.publicKey)
+        assertTrue(!result.data.created)
+    }
+
+    @Test
+    fun whenSetIfAbsentFailsThenReturnsError() = runTest {
+        configureForSetIfAbsentFailure()
+
+        val result = manager.ensureKeyRegistered()
+
+        assertTrue(result is Error)
+    }
+
+    @Test
+    fun whenGenerateRsaKeyPairFailsThenReturnsErrorBeforeCallingServer() = runTest {
+        configureForKeypairMintFailure()
+
+        val result = manager.ensureKeyRegistered()
+
+        assertTrue(result is Error)
+        verify(syncApi, never()).setKeysIfAbsent(anyString(), anyString(), any())
+    }
+
+    @Test
+    fun whenNoUserIdThenScopedPasswordIsIgnoredAndOnlyDdgWrapSent() = runTest {
+        // userId is required to derive the 3party MEK; if it's missing, skip the 3party wrap rather than fail the whole registration.
+        whenever(syncStore.scopedPassword).thenReturn(ScopedPassword("c3BSYXc="))
+        whenever(syncStore.userId).thenReturn(null)
+        whenever(syncApi.setKeysIfAbsent(eq(token), eq("account_info"), any())).thenReturn(Success(SetKeysIfAbsentResult.Created))
+
+        val result = manager.ensureKeyRegistered() as Success
+
+        assertEquals(1, result.data.wrapsSent)
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/SetKeysIfAbsentCallTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/SetKeysIfAbsentCallTest.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.sync.TestSyncFixtures.token
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import retrofit2.Call
+import retrofit2.Response
+
+@RunWith(AndroidJUnit4::class)
+class SetKeysIfAbsentCallTest {
+
+    private val syncService: SyncService = mock()
+    val retrofitCall: Call<SetKeyIfAbsentResponse> = mock()
+    private val call = RealSetKeysIfAbsentCall(syncService)
+
+    private val accountInfoKey = ProtectedKeyEntry(
+        kid = "k-account-info",
+        purpose = "account_info",
+        encryptedWith = "ddg",
+        encryptedPrivateKey = "AAAA",
+        publicKey = RsaJwk(n = "mod", e = "AQAB"),
+    )
+
+    @Test
+    fun whenResponseIs201ThenReturnCreated() {
+        stubResponse(Response.success(201, SetKeyIfAbsentResponse(keys = emptyList())))
+
+        val result = call.execute(token, "account_info", listOf(accountInfoKey))
+
+        assertEquals(Result.Success(SetKeysIfAbsentResult.Created), result)
+    }
+
+    @Test
+    fun whenResponseIs200ThenReturnExistingWithServerKey() {
+        val existingKey = AccountInfoKeyWire(kid = "server-kid", publicKey = RsaJwk(n = "server-mod", e = "AQAB"))
+        stubResponse(Response.success(200, SetKeyIfAbsentResponse(keys = listOf(existingKey))))
+
+        val result = call.execute(token, "account_info", listOf(accountInfoKey))
+
+        assertEquals(Result.Success(SetKeysIfAbsentResult.Existing(kid = "server-kid", publicKey = RsaJwk(n = "server-mod", e = "AQAB"))), result)
+    }
+
+    @Test
+    fun whenResponseIs200WithNoKeyThenReturnError() {
+        stubResponse(Response.success(200, SetKeyIfAbsentResponse(keys = emptyList())))
+
+        val result = call.execute(token, "account_info", listOf(accountInfoKey))
+
+        assertEquals(Result.Error(reason = "SetKeysIfAbsent: 200 response missing keys"), result)
+    }
+
+    @Test
+    fun whenResponseIsErrorThenReturnUnexpectedStatusCode() {
+        stubResponse(
+            Response.error(
+                500,
+                """{"error":"server error"}""".toResponseBody("application/json".toMediaTypeOrNull()),
+            ),
+        )
+
+        val result = call.execute(token, "account_info", listOf(accountInfoKey))
+
+        assertEquals(Result.Error(code = 500, reason = "unexpected status code"), result)
+    }
+
+    @Test
+    fun whenCallThrowsThenReturnInternalError() {
+        whenever(syncService.setKeysIfAbsent(anyString(), eq("account_info"), any())).thenReturn(retrofitCall)
+        whenever(retrofitCall.execute()).thenThrow(RuntimeException("Network error"))
+
+        val result = call.execute(token, "account_info", listOf(accountInfoKey))
+
+        assertEquals(Result.Error(reason = "internal error"), result)
+    }
+
+    private fun stubResponse(response: Response<SetKeyIfAbsentResponse>) {
+        whenever(syncService.setKeysIfAbsent(anyString(), eq("account_info"), any())).thenReturn(retrofitCall)
+        whenever(retrofitCall.execute()).thenReturn(response)
+    }
+}

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/SyncServiceRemoteTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/SyncServiceRemoteTest.kt
@@ -85,7 +85,8 @@ class SyncServiceRemoteTest {
 
     private val syncService: SyncService = mock()
     private val syncStore: SyncStore = mock()
-    private val syncRemote = SyncServiceRemote(syncService, syncStore)
+    private val setKeysIfAbsentCall: SetKeysIfAbsentCall = mock()
+    private val syncRemote = SyncServiceRemote(syncService, syncStore, setKeysIfAbsentCall)
 
     @Test
     fun whenCreateAccountSucceedsThenReturnAccountCreatedSuccess() {
@@ -407,5 +408,15 @@ class SyncServiceRemoteTest {
         val result = syncRemote.getAccessCredentials(token)
 
         assertEquals(Result.Error(reason = "GetAccessCredentials: empty body"), result)
+    }
+
+    @Test
+    fun whenSetKeysIfAbsentReturnsInvalidCredentialsThenClearStore() {
+        whenever(setKeysIfAbsentCall.execute(any(), any(), any()))
+            .thenReturn(Result.Error(code = API_CODE.INVALID_LOGIN_CREDENTIALS.code, reason = "unexpected status code"))
+
+        syncRemote.setKeysIfAbsent(token, "account_info", emptyList())
+
+        verify(syncStore).clearAll()
     }
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ThirdPartyKeyWrapperTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ThirdPartyKeyWrapperTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.duckduckgo.sync.store.ScopedPassword
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+@RunWith(AndroidJUnit4::class)
+class ThirdPartyKeyWrapperTest {
+
+    private val syncJweCrypto: SyncJweCrypto = mock()
+    private val wrapper = RealThirdPartyKeyWrapper(syncJweCrypto)
+
+    private val minted = MintedProtectedKey(
+        entry = ProtectedKeyEntry(
+            kid = "kid-1",
+            purpose = "account_info",
+            encryptedWith = "ddg",
+            encryptedPrivateKey = "ddg-wrapped",
+            publicKey = RsaJwk(n = "modulus", e = "AQAB"),
+        ),
+        rawPrivateKeyBytes = "priv".toByteArray(),
+    )
+
+    @Test
+    fun whenWrapSucceedsThenReturns3partyEntrySharingKidAndPublicKey() {
+        whenever(syncJweCrypto.hkdfSha256SingleBlock(any(), any(), any(), any())).thenReturn(ByteArray(32))
+        whenever(syncJweCrypto.jweEncryptSymmetric(any(), any(), anyOrNull())).thenReturn("3party-wrapped")
+
+        val result = wrapper.wrap(minted, "account_info", ScopedPassword("c3BSYXc="), "user-id") as Result.Success
+
+        val entry = result.data
+        assertEquals("kid-1", entry.kid)
+        assertEquals("account_info", entry.purpose)
+        assertEquals("3party", entry.encryptedWith)
+        assertEquals("3party-wrapped", entry.encryptedPrivateKey)
+        assertEquals(RsaJwk(n = "modulus", e = "AQAB"), entry.publicKey)
+    }
+
+    @Test
+    fun whenMekDerivationFailsThenReturnsError() {
+        whenever(syncJweCrypto.hkdfSha256SingleBlock(any(), any(), any(), any())).thenThrow(RuntimeException())
+
+        val result = wrapper.wrap(minted, "account_info", ScopedPassword("c3BSYXc="), "user-id")
+
+        assertTrue(result is Result.Error)
+    }
+
+    @Test
+    fun whenEncryptionFailsThenReturnsError() {
+        whenever(syncJweCrypto.hkdfSha256SingleBlock(any(), any(), any(), any())).thenReturn(ByteArray(32))
+        whenever(syncJweCrypto.jweEncryptSymmetric(any(), any(), anyOrNull())).thenThrow(RuntimeException())
+
+        val result = wrapper.wrap(minted, "account_info", ScopedPassword("c3BSYXc="), "user-id")
+
+        assertTrue(result is Result.Error)
+    }
+}

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
@@ -184,6 +184,7 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         binding.fetchAccessCredentialsButton.setOnClickListener { viewModel.onFetchAccessCredentialsClicked() }
         binding.requestScopedTokenButton.setOnClickListener { viewModel.onRequestScopedTokenClicked() }
         binding.fetchKeysButton.setOnClickListener { viewModel.onFetchKeysClicked() }
+        binding.createAccountInfoKeyButton.setOnClickListener { viewModel.onCreateAccountInfoKeyClicked() }
         binding.createThirdPartyCredentialButton.setOnClickListener { viewModel.onCreateThirdPartyCredentialClicked() }
         binding.refreshThirdPartyCredentialButton.setOnClickListener { viewModel.onRefreshThirdPartyCredentialClicked() }
         binding.showThirdPartyRecoveryQrButton.setOnClickListener { viewModel.onShowThirdPartyRecoveryQrClicked() }
@@ -339,6 +340,7 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         binding.scopedTokenResultTextView.text = viewState.scopedTokenResult
         binding.v2StoreFieldsTextView.text = viewState.v2StoreFieldsText
         binding.keysTextView.text = viewState.keysText
+        binding.accountInfoKeyResultTextView.text = viewState.accountInfoKeyResult
         if (viewState.isSignedIn) {
             viewState.connectedDevices.forEach { device ->
                 val connectedBinding = ItemConnectedDeviceBinding.inflate(layoutInflater, binding.connectedDevicesList, true)

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
@@ -29,6 +29,7 @@ import com.duckduckgo.feature.toggles.api.Toggle
 import com.duckduckgo.persistentstorage.api.PersistentStorage
 import com.duckduckgo.persistentstorage.api.PersistentStorageAvailability
 import com.duckduckgo.sync.api.favicons.FaviconsFetchingStore
+import com.duckduckgo.sync.impl.AccountInfoKeyManager
 import com.duckduckgo.sync.impl.ConnectedDevice
 import com.duckduckgo.sync.impl.Result
 import com.duckduckgo.sync.impl.Result.Error
@@ -81,6 +82,7 @@ constructor(
     private val appBuildConfig: AppBuildConfig,
     private val syncApi: SyncApi,
     private val testSyncWarningState: TestSyncWarningPlugin.StateHolder,
+    private val accountInfoKeyManager: AccountInfoKeyManager,
     @field:SuppressLint("StaticFieldLeak") private val context: Context,
 ) : ViewModel() {
 
@@ -123,6 +125,7 @@ constructor(
         val createThirdPartyResult: String = "",
         val keysText: String = "",
         val isTestSyncWarningEnabled: Boolean = false,
+        val accountInfoKeyResult: String = "",
     )
 
     sealed class BlockStoreValue {
@@ -306,6 +309,9 @@ constructor(
                 canUseV2ConnectFlowEnabled = syncFeature.canUseV2ConnectFlow().isEnabled(),
                 canShowV2ConnectCodeEnabled = syncFeature.canShowV2ConnectCode().isEnabled(),
                 v2StoreFieldsText = buildV2StoreFieldsText(),
+                // Clear per-session dev-tool results once signed out so stale keys aren't shown.
+                keysText = if (accountInfo.isSignedIn) viewState.value.keysText else "",
+                accountInfoKeyResult = if (accountInfo.isSignedIn) viewState.value.accountInfoKeyResult else "",
             ),
         )
     }
@@ -612,6 +618,27 @@ constructor(
                 logcat(LogPriority.ERROR) { "Sync-ScopedToken: fetch keys failed: $text" }
                 viewState.update { it.copy(keysText = text) }
                 command.send(ShowMessage(text))
+            }
+        }
+    }
+
+    fun onCreateAccountInfoKeyClicked() {
+        viewModelScope.launch(dispatchers.io()) {
+            logcat { "Sync-UnifiedDevices: creating & registering account_info key from dev screen" }
+            when (val result = accountInfoKeyManager.ensureKeyRegistered()) {
+                is Success -> {
+                    val outcome = if (result.data.created) "201 created (ours won)" else "200 existing (adopted)"
+                    val text = "kid=${result.data.kid}, wraps_sent=${result.data.wrapsSent}, outcome=$outcome"
+                    logcat { "Sync-UnifiedDevices: $text" }
+                    viewState.update { it.copy(accountInfoKeyResult = text) }
+                    command.send(ShowMessage(text))
+                }
+                is Error -> {
+                    val text = "Error: ${result.reason} (code: ${result.code})"
+                    logcat(LogPriority.ERROR) { "Sync-UnifiedDevices: create/register key failed: $text" }
+                    viewState.update { it.copy(accountInfoKeyResult = text) }
+                    command.send(ShowMessage(text))
+                }
             }
         }
     }

--- a/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
+++ b/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
@@ -172,6 +172,22 @@
             android:layout_marginBottom="@dimen/keyline_4"
             app:typography="body2" />
 
+        <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+            android:id="@+id/createAccountInfoKeyButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:text="Create &amp; Register account_info Key" />
+
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/accountInfoKeyResultTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/keyline_4"
+            android:layout_marginEnd="@dimen/keyline_4"
+            android:layout_marginBottom="@dimen/keyline_4"
+            app:typography="body2" />
+
         <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
             android:layout_width="match_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1216856074810006?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/72649045549333/task/1215838110052947?focus=true
API Proposals URL(s) (if applicable):

### Description
Add dev setting to create and register `account_info` keypair. Introduces `AccountInfoKeyManager` which mints an `RSA-3072` `account_info` keypair, wraps the private key for every credential the account holds (`ddg`, plus `3party` when a scoped password exists), and registers them in a single call to the backend.

The backend is set to be a first-writer-wins meaning what we post might not be what the account uses, and we might get back what we should use instead. 

Handing HTTP 409 responses not included in this PR; will come in a later PR.

### Steps to test this PR

#### Setup
- [ ] Fresh install `internal` variant of the app
- [ ] Set up device to sync (`Sync and Back Up This Device` or from dev settings)

#### Create `account_info` where we're the winner
- [ ] Open `Sync Dev Settings` 
- [ ] Tap `Create & Register account_info key` button
- Verify label under button shows: 
    - [ ] `wrap_sent=1`
    - [ ] `ours won` (indicating that the server had no `account_info` already and so accepted ours
- [ ] Tap `Fetch Keys` and verify its label shows `purpose=account_info` which is `encrypted_with=ddg`
- [ ] Tap `Create & Register account_info key` button again. This time verify the label says `adopted` 
- [ ] Verify `kid` under `Fetch Keys` and `Create & Register...` buttons match

#### Wrapped for 3rd party too
- [ ] Scroll down and tap `DeleteAccount` button to reset, then tap `Create Account` to log into sync
- [ ] Tap `Create 3party credential` button and wait for the toast confirmation it's succeeded
- [ ] Tap `Create & Register account_info key` button. 
- Verify its label shows:
    - [ ] `wraps_sent=2`
- [ ] Tap `Fetch keys` and verify you see 4 entries:
    - 2 for `purpose=ai_chats`
    - 2 for `purpose=account_info`, and in these you'll see `encrypted_with=ddg` and `encrypted_with=3party`  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches account crypto (RSA-3072 mint, MEK derivation, multi-credential wraps) and a new protected-key API path; exposure is mainly via internal dev UI, with solid test coverage and no new hardcoded secrets in the diff.
> 
> **Overview**
> Adds **unified-devices `account_info` key registration**: mint an RSA-3072 keypair, wrap the private key for `ddg` (and `3party` when scoped password + user id exist), and register via **first-writer-wins** `POST /sync/keys/purpose/{purpose}/set-if-absent`.
> 
> **`AccountInfoKeyManager`** orchestrates minting (via existing `mintDdgWrappedProtectedKey`), optional 3party JWE wrap, and interprets outcomes: **201** means the local key won; **200** means another device’s key wins and the caller adopts the returned `kid` / public key.
> 
> **Sync stack** gains `setKeysIfAbsent` on Retrofit/`SyncApi`, a dedicated **`SetKeysIfAbsentCall`** mapper, `SYNC_PURPOSE_ACCOUNT_INFO`, and invalid-credential clearing on 401 (same pattern as rescope).
> 
> **Internal dev settings** expose **Create & Register account_info Key** with outcome text (`wraps_sent`, ours won vs adopted). No production user flow wires this yet.
> 
> Unit tests cover the manager, the HTTP call mapper, and remote 401 → `clearAll`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4983d34f7907f6039a9b64cc6d5869f311b70531. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->