### PR TITLE
Fix edge-to-edge issue on new tabs scroll on Android 16

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -39,7 +39,7 @@ version.androidx.constraintlayout=2.1.4
 
 version.androidx.biometric=1.1.0
 
-version.androidx.core-splashscreen=1.0.1
+version.androidx.core-splashscreen=1.2.0
 
 version.androidx.datastore=1.1.6
 
@@ -47,7 +47,7 @@ version.androidx.localbroadcastmanager=1.1.0
 
 version.androidx.recyclerview=1.3.2
 
-version.androidx.core=1.16.0
+version.androidx.core=1.17.0
 
 version.androidx.fragment=1.8.9
 

--- a/versions.properties
+++ b/versions.properties
@@ -21,7 +21,7 @@ plugin.com.diffplug.spotless=8.0.0
 
 version.android.billingclient=8.3.0
 
-version.androidx.activity=1.10.1
+version.androidx.activity=1.13.0
 
 version.androidx.autofill=1.1.0
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1202552961248957/task/1216821769596749?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Some of the Android libraries need to be updated after targeting Android 16 in order to include changes for edge-to-edge which are available only in newer versions and are needed for proper functionality of the feature.

### Steps to test this PR

- [ ] Install the app
- [ ] Create a couple of tabs 
- [ ] When scrolling up the omnibar collapses correctly
- [ ] Close and relaunch the app
- [ ] For both the existing tabs and newly created tabs the omnibar collapses correclty

### UI changes
Omnibar should collapse as expected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only Gradle property updates with no logic changes; risk is limited to transitive behavior changes from the newer AndroidX artifacts.
> 
> **Overview**
> Updates **dependency versions only** in `versions.properties`—no application code changes. The bumps align with targeting Android 16 and edge-to-edge behavior (including omnibar collapse when scrolling on new and existing tabs).
> 
> **androidx.activity** `1.10.1` → `1.13.0`, **androidx.core** `1.16.0` → `1.17.0`, and **androidx.core-splashscreen** `1.0.1` → `1.2.0`. These libraries carry edge-to-edge fixes that are not in the older versions the app was using.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac0601e5f0d8d5311fb3b64e2d4ea1384b4a2a03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->