### PR TITLE
Apply the toolbar color from the intent when calling enableEdgeToEdge and remove deprecated status bar and navigation bar color assignments

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1732,6 +1732,10 @@ class BrowserTabFragment :
                 customTabToolbarColor,
             )
 
+            if (!edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BROWSER)) {
+                requireActivity().window.navigationBarColor = customTabToolbarColor
+                requireActivity().window.statusBarColor = customTabToolbarColor
+            }
             // Update status bar icon colors based on toolbar color luminance
             updateStatusBarIconColors(customTabToolbarColor)
 

--- a/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/BrowserTabFragment.kt
@@ -1731,8 +1731,6 @@ class BrowserTabFragment :
             omnibar.configureCustomTab(
                 customTabToolbarColor,
             )
-            requireActivity().window.navigationBarColor = customTabToolbarColor
-            requireActivity().window.statusBarColor = customTabToolbarColor
 
             // Update status bar icon colors based on toolbar color luminance
             updateStatusBarIconColors(customTabToolbarColor)

--- a/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabActivity.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/customtabs/CustomTabActivity.kt
@@ -63,8 +63,10 @@ class CustomTabActivity : DuckDuckGoActivity() {
         super.onCreate(savedInstanceState)
         viewModel.onShowCustomTab()
 
+        val toolbarColor =
+            intent.getIntExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR, getColorFromAttr(com.duckduckgo.mobile.android.R.attr.preferredStatusBarColor))
+
         if (edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.BROWSER)) {
-            val toolbarColor = getColorFromAttr(com.duckduckgo.mobile.android.R.attr.daxColorToolbar)
             val barStyle = if (isDarkThemeEnabled()) {
                 SystemBarStyle.dark(toolbarColor)
             } else {
@@ -78,8 +80,6 @@ class CustomTabActivity : DuckDuckGoActivity() {
         setContentView(binding.root)
 
         val url = intent.intentText
-        val toolbarColor =
-            intent.getIntExtra(CustomTabsIntent.EXTRA_TOOLBAR_COLOR, getColorFromAttr(com.duckduckgo.mobile.android.R.attr.preferredStatusBarColor))
 
         logcat { "onCreate called with url=$url and toolbar color=$toolbarColor" }
 


### PR DESCRIPTION
Task/Issue URL:https://app.asana.com/1/137249556945/task/1216921385335614?focus=true
Tech Design URL (if applicable):

### Description

Moves the `toolbarColor` extraction from the intent earlier in `CustomTabActivity.onCreate()` so it can be used for both the edge-to-edge system bar styling and general toolbar configuration. Previously, the toolbar color was hardcoded to `daxColorToolbar` when edge-to-edge was enabled, ignoring the color passed by the launching app via `EXTRA_TOOLBAR_COLOR`.

Additionally, removes the redundant manual setting of `navigationBarColor` and `statusBarColor` from `BrowserTabFragment` when edge-to-edge is disabled, as these are now handled correctly through the edge-to-edge system bar styling in `CustomTabActivity`.

### Steps to test this PR

_Custom Tab toolbar color_

- [x] Go to Settings -> Dev Settings
- [x] Launch a Custom Tab with a specific toolbar color and verify the status bar and navigation bar reflect that color correctly
- [x] Launch a Custom Tab without specifying a toolbar color and verify the default color is applied
- [x] Verify behavior in both light and dark themes

### UI changes

| Before | After |
| --- | --- |
| !(Upload before screenshot) | (Upload after screenshot) |


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized custom-tab system bar and edge-to-edge styling; no auth, data, or core navigation logic changes.
> 
> **Overview**
> Custom tabs with **edge-to-edge** now style the status and navigation bars using the toolbar color from `CustomTabsIntent.EXTRA_TOOLBAR_COLOR` (with the existing default), instead of always using `daxColorToolbar` in `CustomTabActivity`.
> 
> `BrowserTabFragment.configureCustomTab()` only applies the legacy `window.statusBarColor` / `navigationBarColor` when edge-to-edge for the browser bucket is **off**, so system bar colors are not set twice when `enableEdgeToEdge` already handles them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cab7b9b832a2d4748939677fb18de2b2bfd561a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->