### PR TITLE
[Drift Audit] Document DaxProgressSpinner and its build-breaking lint rule

### DIFF
--- a/.cursor/rules/android-design-system.mdc
+++ b/.cursor/rules/android-design-system.mdc
@@ -317,6 +317,17 @@ Wrap `SkeletonView` elements in `ShimmerFrameLayout`:
 
 Never set `android:background="@drawable/background_skeleton"` on SkeletonView — lint prevents it.
 
+### Progress spinner (Compose)
+
+For an indeterminate spinner in Compose, use `DaxProgressSpinner` from `com.duckduckgo.common.ui.compose.progress`. Material3's `CircularProgressIndicator` is build-breaking outside the design-system modules.
+
+```kotlin
+DaxProgressSpinner()                                                     // Material3 default size (40dp)
+DaxProgressSpinner(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)  // reduce the stroke when smaller
+```
+
+`strokeWidth` defaults to `4.dp`. Colours come from the theme (`DuckDuckGoTheme.colors.system.progressSpinner*`) — there is no colour parameter.
+
 ---
 
 ## NotifyMeView
@@ -408,6 +419,7 @@ These are enforced at compile time:
 | `DaxButtonStylingDetector` | Forbidden attributes on `DaxButton*` |
 | `DaxTextViewStylingDetector` | Forbidden attributes on `DaxTextView` |
 | `MissingDividerDetector` | Plain `View` used as divider |
+| `NoMaterial3CircularProgressIndicatorUsageDetector` | Compose: Material3 `CircularProgressIndicator` (use `DaxProgressSpinner`) |
 | `NoAlertDialogDetector` | `AlertDialog` / `MaterialAlertDialog` |
 | `NoBottomSheetDialogDetector` | Raw `BottomSheetDialog` without ADS style |
 | `SkeletonViewBackgroundDetector` | `background_skeleton` drawable on `SkeletonView` |


### PR DESCRIPTION
Task/Issue URL: (app.asana.com/redacted)

### Description
`.cursor/rules/android-design-system.mdc` — the "Lint Rules (build-breaking)" table and the loading-state guidance.

**What the doc described:** the table is introduced with *"These are enforced at compile time:"* and listed 10 detectors. The doc's only loading-state guidance was `SkeletonView` / `ShimmerFrameLayout`; it named no spinner component anywhere.

**The code change that invalidated it:** [`#9296` — Add DaxProgressSpinner composable to ADS](https://github.com/duckduckgo/Android/pull/9296) added `NoMaterial3CircularProgressIndicatorUsageDetector` and registered `NO_MATERIAL3_CIRCULAR_PROGRESS_INDICATOR_USAGE` in `DuckDuckGoIssueRegistry.issues` at `Severity.ERROR`. Reaching for Material3's `CircularProgressIndicator` in a Compose screen now fails the build, and the doc listed neither the rule nor the `DaxProgressSpinner` replacement it points at.

**How the doc now reads:**
1. The lint table gained a row for `NoMaterial3CircularProgressIndicatorUsageDetector`.
2. A short *Progress spinner (Compose)* subsection under *Skeleton / Loading State* names `com.duckduckgo.common.ui.compose.progress.DaxProgressSpinner`, its two parameters (`modifier`, `strokeWidth` defaulting to `4.dp`), and the fact that colours come from the theme rather than a parameter — all read from `DaxProgressSpinner.kt`.

**Overlap a reviewer should know (redacted) the still-open [`#9300`](https://github.com/duckduckgo/Android/pull/9300) edits the same lint-rules section, adding a separate table for the Compose detectors. It predates `#9296`, so it does not cover this rule or `DaxProgressSpinner`. I deliberately did not re-do its broader work here; if `#9300` merges first, this row belongs in its Compose table rather than the XML one.

I also checked, and did **not** treat as drift:
- **`.cursor/rules/pixels.mdc` / `pixel-definitions.mdc`** vs [`#9261`](https://github.com/duckduckgo/Android/pull/9261) — a routine pixel addition (definition entry + `removeAtb` registration) that follows the documented shape; no documented claim became false.
- **`.cursor/rules/architecture.mdc`** vs [`#9275`](https://github.com/duckduckgo/Android/pull/9275) (PIR webview count moved behind a remote-feature setting) and [`#9287`](https://github.com/duckduckgo/Android/pull/9287) (Moshi adapter reuse in content-scope-scripts) — both are inside `-impl` code the rule docs don't describe.
- The remaining merged PRs in this window (sync exchange UI, camera permissions, conscrypt cleanup, ELF-alignment script, PIR broker bundle) touch no area the rule docs cover.

Only prose changed — no code, and only the canonical `.cursor/rules/*.mdc` file (the `.claude/rules` symlink is untouched).

🤖 AI-docs Drift Auditor

### Steps to test this PR
- [ ] Confirm `NO_MATERIAL3_CIRCULAR_PROGRESS_INDICATOR_USAGE` is in `DuckDuckGoIssueRegistry.issues` and that `NoMaterial3CircularProgressIndicatorUsageDetector` is `Severity.ERROR`, so the new table row is accurate.
- [ ] Read the new *Progress spinner (Compose)* subsection against `android-design-system/design-system/src/main/java/com/duckduckgo/common/ui/compose/progress/DaxProgressSpinner.kt` and confirm the package, parameters, `4.dp` default, and theme-sourced colours match.

### UI changes
| Before  | After |
| ------ | ----- |
| No UI changes | No UI changes |




> [!NOTE]
> <details>
> <summary><b>🔒 Integrity filter blocked 3 items</b></summary>
>
> The following items were blocked because they don't meet the GitHub integrity level.
>
> - [#8809](https://github.com/duckduckgo/Android/pull/8809) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#8811](https://github.com/duckduckgo/Android/pull/8811) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
> - [#8891](https://github.com/duckduckgo/Android/pull/8891) `search_pull_requests`: has lower integrity than agent requires. The agent cannot read data with integrity below "approved".
>
> To allow these resources, lower `min-integrity` in your GitHub frontmatter:
>
> ```yaml
> tools:
>   github:
>     min-integrity: approved  # merged | approved | unapproved | none
> ```
>
> </details>


> Generated by [AI-docs Semantic Drift Audit](https://github.com/duckduckgo/Android/actions/runs/30333263871/agentic_workflow) · [◷](https://github.com/search?q=repo%3Aduckduckgo%2FAndroid+%22gh-aw-workflow-id%3A+drift-audit%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: AI-docs Semantic Drift Audit, engine: claude, model: auto, id: 30333263871, workflow_id: drift-audit, run: https://github.com/duckduckgo/Android/actions/runs/30333263871 -->

<!-- gh-aw-workflow-id: drift-audit -->