### PR TITLE
Mitigate sync settings UI race condtions

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
@@ -107,5 +107,5 @@ interface SyncFeature {
     fun useSimplifiedSync(): Toggle
 
     @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
-    fun avoidSyncActivityViewModelRaceConditions(): Toggle
+    fun updateSyncActivityViewStateAtomically(): Toggle
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncFeature.kt
@@ -105,4 +105,7 @@ interface SyncFeature {
 
     @Toggle.DefaultValue(DefaultFeatureValue.FALSE)
     fun useSimplifiedSync(): Toggle
+
+    @Toggle.DefaultValue(DefaultFeatureValue.INTERNAL)
+    fun avoidSyncActivityViewModelRaceConditions(): Toggle
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModel.kt
@@ -39,6 +39,7 @@ import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAuthCode
+import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.SyncFeatureToggle
 import com.duckduckgo.sync.impl.auth.DeviceAuthenticator
 import com.duckduckgo.sync.impl.autorestore.SyncAutoRestoreManager
@@ -80,6 +81,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -104,6 +106,7 @@ class SyncActivityViewModel @Inject constructor(
     private val syncAutoRestore: SyncAutoRestore,
     @AppCoroutineScope private val appCoroutineScope: CoroutineScope,
     private val syncSetupWideEvent: SyncSetupWideEvent,
+    private val syncFeature: SyncFeature,
 ) : ViewModel() {
 
     private val syncStateObserverJob = ConflatedJob()
@@ -117,8 +120,16 @@ class SyncActivityViewModel @Inject constructor(
     // null until the first load from preference; used by onScreenExit() to detect changes.
     @Volatile private var initialAutoRestoreEnabled: Boolean? = null
 
+    @Volatile private var isAtomicViewStateUpdateEnabled = false
+
     private val command = Channel<Command>(1, DROP_OLDEST)
     private val viewState = MutableStateFlow(ViewState())
+
+    init {
+        viewModelScope.launch {
+            syncFeature.updateSyncActivityViewStateAtomically().enabled().collect { isAtomicViewStateUpdateEnabled = it }
+        }
+    }
     fun commands(): Flow<Command> = command.receiveAsFlow().onStart {
         checkIfDeviceSupported()
     }
@@ -129,19 +140,18 @@ class SyncActivityViewModel @Inject constructor(
         }.flowOn(dispatchers.io())
 
     private fun observeState() {
-        // Reset so the next signedInState() call re-reads from DataStore. This is necessary because
+        // Reset so the next updateSignedInState() call re-reads from DataStore. This is necessary because
         // the setup flow writes the auto-restore preference AFTER account creation, but the
         // syncStateMonitor can fire the signed-in event (and cache initialAutoRestoreEnabled=false)
         // while SetupAccountActivity is still on top and the user hasn't confirmed their preference yet.
         initialAutoRestoreEnabled = null
         syncStateObserverJob += syncStateMonitor.syncState()
             .onEach { syncState ->
-                val state = if (syncState == OFF) {
-                    signedOutState()
+                if (syncState == OFF) {
+                    updateViewState { signedOutState() }
                 } else {
-                    signedInState()
+                    updateSignedInState()
                 }
-                viewState.value = state
             }.onStart {
                 initViewStateThisDeviceState()
                 fetchRemoteDevices()
@@ -171,40 +181,34 @@ class SyncActivityViewModel @Inject constructor(
         }
     }
 
-    private suspend fun signedInState(): ViewState {
-        val currentState = viewState.value
-        val autoRestoreState = if (initialAutoRestoreEnabled == null) {
-            loadAutoRestoreState()
-        } else {
-            AutoRestoreState(showToggle = autoRestoreAvailable, enabled = currentState.autoRestoreEnabled)
-        }
-        val syncedDevices = currentState.syncedDevices.ifEmpty {
-            val thisDevice = syncAccountRepository.getThisConnectedDevice() ?: return signedOutState()
-            listOf(SyncedDevice(thisDevice))
-        }
+    private suspend fun updateSignedInState() {
+        val autoRestoreState = if (initialAutoRestoreEnabled == null) loadAutoRestoreState() else null
+        val showAccount = syncAccountRepository.isSignedIn()
+        val thisDevice = syncAccountRepository.getThisConnectedDevice()
+        val signedOutState = signedOutState()
 
-        return ViewState(
-            showAccount = syncAccountRepository.isSignedIn(),
-            syncedDevices = syncedDevices,
-            disabledSetupFlows = disabledSetupFlows(),
-            aiChatSyncEnabled = syncFeatureToggle.allowAiChatSync(),
-            newDesktopBrowserSettingEnabled = settingsPageFeature.newDesktopBrowserSettingEnabled().isEnabled(),
-            showAutoRestoreToggle = autoRestoreState.showToggle,
-            autoRestoreEnabled = autoRestoreState.enabled,
-            isThisDeviceSyncing = currentState.isThisDeviceSyncing,
-        )
+        updateViewState { current ->
+            val syncedDevices = current.syncedDevices.ifEmpty {
+                thisDevice?.let { listOf(SyncedDevice(it)) } ?: return@updateViewState signedOutState
+            }
+            signedOutState.copy(
+                showAccount = showAccount,
+                syncedDevices = syncedDevices,
+                showAutoRestoreToggle = autoRestoreState?.showToggle ?: autoRestoreAvailable,
+                autoRestoreEnabled = autoRestoreState?.enabled ?: current.autoRestoreEnabled,
+                isThisDeviceSyncing = current.isThisDeviceSyncing,
+            )
+        }
     }
 
     private suspend fun initViewStateThisDeviceState() {
-        val state = withContext(dispatchers.io()) {
+        withContext(dispatchers.io()) {
             if (!syncAccountRepository.isSignedIn()) {
-                signedOutState()
+                updateViewState { signedOutState() }
             } else {
-                signedInState()
+                updateSignedInState()
             }
         }
-
-        viewState.value = state
     }
 
     private suspend fun loadAutoRestoreState(): AutoRestoreState {
@@ -296,7 +300,7 @@ class SyncActivityViewModel @Inject constructor(
     }
 
     fun onSyncThisDevice(source: String? = null) {
-        viewState.value = viewState.value.setThisDeviceSyncInProgress()
+        updateViewState { it.setThisDeviceSyncInProgress() }
         viewModelScope.launch(dispatchers.io()) {
             syncSetupWideEvent.onFlowStarted(source)
             requiresSetupAuthentication(
@@ -367,15 +371,17 @@ class SyncActivityViewModel @Inject constructor(
     private fun fetchRemoteDevices(showLoadingState: Boolean = true) {
         fetchDevicesJob += viewModelScope.launch(dispatchers.io()) {
             if (showLoadingState) {
-                viewState.value = viewState.value.showDeviceListItemLoading()
+                updateViewState { it.showDeviceListItemLoading() }
             }
 
             val result = syncAccountRepository.getConnectedDevices()
             ensureActive() // don't apply a result that was superseded while in flight
-            viewState.value = if (result is Success) {
-                viewState.value.hideDeviceListItemLoading().setDevices(result.data.map { SyncedDevice(it) })
-            } else {
-                viewState.value.hideDeviceListItemLoading()
+            updateViewState { current ->
+                if (result is Success) {
+                    current.hideDeviceListItemLoading().setDevices(result.data.map { SyncedDevice(it) })
+                } else {
+                    current.hideDeviceListItemLoading()
+                }
             }
         }
     }
@@ -384,15 +390,15 @@ class SyncActivityViewModel @Inject constructor(
         viewModelScope.launch(dispatchers.io()) {
             syncPixels.fireUserConfirmedToTurnOffSync()
 
-            viewState.value = viewState.value.hideAccount().setThisDeviceSyncIdle()
+            updateViewState { it.hideAccount().setThisDeviceSyncIdle() }
             when (val result = syncAccountRepository.logout(connectedDevice.deviceId)) {
                 is Error -> {
-                    viewState.value = viewState.value.showAccount()
+                    updateViewState { it.showAccount() }
                     command.send(ShowError(R.string.sync_turn_off_error, result.reason))
                 }
 
                 is Success -> {
-                    viewState.value = signedOutState()
+                    updateViewState { signedOutState() }
                 }
             }
         }
@@ -423,15 +429,15 @@ class SyncActivityViewModel @Inject constructor(
 
     fun onDeleteAccountConfirmed() {
         viewModelScope.launch(dispatchers.io()) {
-            viewState.value = viewState.value.hideAccount()
+            updateViewState { it.hideAccount() }
             when (val result = syncAccountRepository.deleteAccount()) {
                 is Error -> {
-                    viewState.value = viewState.value.showAccount()
+                    updateViewState { it.showAccount() }
                     command.send(ShowError(R.string.sync_turn_off_error, result.reason))
                 }
 
                 is Success -> {
-                    viewState.value = signedOutState()
+                    updateViewState { signedOutState() }
                 }
             }
         }
@@ -476,7 +482,7 @@ class SyncActivityViewModel @Inject constructor(
 
     fun onAutoRestoreToggleChanged(enabled: Boolean) {
         logcat { "Sync-Recovery: restore on reinstall toggle changed to $enabled (pending until screen stopped)" }
-        viewState.value = viewState.value.copy(autoRestoreEnabled = enabled)
+        updateViewState { it.copy(autoRestoreEnabled = enabled) }
     }
 
     fun onScreenExit() {
@@ -552,10 +558,10 @@ class SyncActivityViewModel @Inject constructor(
 
     fun onRemoveDeviceConfirmed(device: ConnectedDevice) {
         viewModelScope.launch(dispatchers.io()) {
-            viewState.value = viewState.value.showDeviceListItemLoading(device)
+            updateViewState { it.showDeviceListItemLoading(device) }
             when (val result = syncAccountRepository.logout(device.deviceId)) {
                 is Error -> {
-                    viewState.value = viewState.value.hideDeviceListItemLoading(device)
+                    updateViewState { it.hideDeviceListItemLoading(device) }
                     command.send(ShowError(R.string.sync_remove_device_error, result.reason))
                 }
 
@@ -564,9 +570,11 @@ class SyncActivityViewModel @Inject constructor(
                     // server before the logout could otherwise land afterwards and re-insert the
                     // device until the next periodic refresh corrects it.
                     fetchDevicesJob.cancel()
-                    viewState.value = viewState.value.setDevices(
-                        viewState.value.syncedDevices.filterNot { it is SyncedDevice && it.device.deviceId == device.deviceId },
-                    )
+                    updateViewState { current ->
+                        current.setDevices(
+                            current.syncedDevices.filterNot { it is SyncedDevice && it.device.deviceId == device.deviceId },
+                        )
+                    }
                 }
             }
         }
@@ -574,10 +582,10 @@ class SyncActivityViewModel @Inject constructor(
 
     fun onDeviceEdited(editedConnectedDevice: ConnectedDevice) {
         viewModelScope.launch(dispatchers.io()) {
-            viewState.value = viewState.value.showDeviceListItemLoading(editedConnectedDevice)
+            updateViewState { it.showDeviceListItemLoading(editedConnectedDevice) }
             when (val result = syncAccountRepository.renameDevice(editedConnectedDevice)) {
                 is Error -> {
-                    viewState.value = viewState.value.hideDeviceListItemLoading(editedConnectedDevice)
+                    updateViewState { it.hideDeviceListItemLoading(editedConnectedDevice) }
                     command.send(ShowError(R.string.sync_edit_device_error, result.reason))
                 }
 
@@ -587,7 +595,7 @@ class SyncActivityViewModel @Inject constructor(
     }
 
     fun onDeviceConnected() {
-        viewState.value = viewState.value.setThisDeviceSyncIdle()
+        updateViewState { it.setThisDeviceSyncIdle() }
         fetchRemoteDevices()
     }
 
@@ -614,15 +622,15 @@ class SyncActivityViewModel @Inject constructor(
     }
 
     fun onSyncThisDeviceCanceled() {
-        viewState.value = viewState.value.setThisDeviceSyncIdle()
+        updateViewState { it.setThisDeviceSyncIdle() }
     }
 
     private fun showAccountDetailsIfNeeded() {
         viewModelScope.launch(dispatchers.io()) {
             if (syncAccountRepository.isSignedIn()) {
-                viewState.value = viewState.value.showAccount()
+                updateViewState { it.showAccount() }
             } else {
-                viewState.value = signedOutState()
+                updateViewState { signedOutState() }
             }
         }
     }
@@ -650,6 +658,14 @@ class SyncActivityViewModel @Inject constructor(
             command.send(RequestSetupAuthentication(forSyncThisDevice))
         } else {
             action()
+        }
+    }
+
+    private fun updateViewState(update: (ViewState) -> ViewState) {
+        if (isAtomicViewStateUpdateEnabled) {
+            viewState.update(update)
+        } else {
+            viewState.value = update(viewState.value)
         }
     }
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/SyncActivityViewModelTest.kt
@@ -43,6 +43,7 @@ import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.SyncAccountRepository
 import com.duckduckgo.sync.impl.SyncAccountRepository.AuthCode
 import com.duckduckgo.sync.impl.SyncAuthCode
+import com.duckduckgo.sync.impl.SyncFeature
 import com.duckduckgo.sync.impl.SyncFeatureToggle
 import com.duckduckgo.sync.impl.auth.DeviceAuthenticator
 import com.duckduckgo.sync.impl.autorestore.SyncAutoRestoreManager
@@ -111,6 +112,11 @@ class SyncActivityViewModelTest {
 
     private val fakeSettingsPageFeature = FakeFeatureToggleFactory.create(SettingsPageFeature::class.java)
 
+    private val syncFeature = FakeFeatureToggleFactory.create(
+        SyncFeature::class.java,
+        ioDispatcher = coroutineTestRule.testDispatcher,
+    )
+
     private val stateFlow = MutableStateFlow(SyncState.READY)
 
     private lateinit var testee: SyncActivityViewModel
@@ -132,6 +138,7 @@ class SyncActivityViewModelTest {
             syncAutoRestoreManager = syncAutoRestoreManager,
             syncAutoRestore = syncAutoRestore,
             appCoroutineScope = coroutineTestRule.testScope,
+            syncFeature = syncFeature,
         )
         whenever(deviceAuthenticator.isAuthenticationRequired()).thenReturn(true)
         whenever(syncStateMonitor.syncState()).thenReturn(emptyFlow())
@@ -139,6 +146,7 @@ class SyncActivityViewModelTest {
         whenever(syncAutoRestoreManager.isAutoRestoreAvailable()).thenReturn(false)
         whenever(syncAutoRestoreManager.isRestoreOnReinstallEnabled()).thenReturn(true)
         whenever(syncAutoRestore.canRestore()).thenReturn(false)
+        syncFeature.updateSyncActivityViewStateAtomically().setRawStoredState(State(true))
     }
 
     @Test


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216103556496795/task/1216942050413056?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1216103556496795/task/1216509582049467?focus=true
API Proposals URL(s) (if applicable): N/A

### Description

I've been running into inconsistencies in the new simplified sync flow (V2). Editing a device, removing a device, or turning sync off happens on a separate screen, and coming back to the main sync settings screen also kicks off a device list refresh. That refresh raced with the updates made by the action itself, so the screen would show stale or wrong data until the next refresh sorted it out.

The root cause is that the screen's view state gets written from several coroutines at once (the sync state monitor, device fetches, and user actions), and the old read-then-write pattern let one update silently overwrite another. This PR makes those updates atomic instead, behind a feature flag.

- Every view state write in `SyncActivityViewModel` now goes through one `updateViewState` helper that takes a function transforming the current state.
- With the new `updateSyncActivityViewStateAtomically` flag on, the helper uses `MutableStateFlow.update` so nothing gets lost. With the flag off, it keeps the old read-then-write behavior.
- The signed-in state is no longer built from one snapshot of the current state. The suspending reads (signed-in status, this connected device, the auto-restore preference) happen first, and only then is the change applied on top of whatever the latest state is. As before, the state falls back to signed out when the connected device can't be retrieved.

### Steps to test this PR

_Sync Settings regression_
- [ ] Open Settings.
- [ ] Tap "Sync & Backup".
- [ ] Enable sync on this device.
- [ ] Verify the "Synced Devices" section shows this device.

_Device management_
- [ ] Connect a second device to the same sync account.
- [ ] Verify the second device appears in the "Synced Devices" list.
- [ ] Rename the second device.
- [ ] Verify the updated name shows in the list.
- [ ] Remove the second device.
- [ ] Verify it disappears from the list.

_Turn off sync_
- [ ] Tap "Turn Off Sync & Backup…".
- [ ] Confirm with "Turn Off".
- [ ] Verify the screen returns to the signed-out state.

_Flag disabled_
- [ ] Disable the `updateSyncActivityViewStateAtomically` flag in the FF inventory.
- [ ] Repeat the scenarios above.
- [ ] Verify the screen behaves the same way.

### UI changes
N/A



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrency semantics for sync settings UI state across many code paths; rollout is gated by an internal feature flag with legacy behavior when off.
> 
> **Overview**
> Addresses **stale or wrong sync settings UI** when device list refreshes race with edits, removals, or turn-off actions from other screens. Concurrent coroutines (sync state monitor, device fetches, user actions) could overwrite each other via read-then-write on `viewState`.
> 
> **Changes:** All `SyncActivityViewModel` view-state writes go through a single `updateViewState` helper. With **`updateSyncActivityViewStateAtomically`** enabled (new `SyncFeature` toggle, default INTERNAL), updates use `MutableStateFlow.update`; when disabled, behavior stays the old assign-after-read path.
> 
> Signed-in state is rebuilt via **`updateSignedInState`**: repository reads (signed-in, this device, auto-restore) run first, then the lambda applies on the **latest** state—still falling back to signed-out if the connected device is missing. Tests wire the fake feature toggle with atomic updates on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6d6b4153af0d904b4ab0124c862dfb73f6e67bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->