### PR TITLE
Make remove device dialog destructive

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/EditDeviceActivity.kt
@@ -30,6 +30,8 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.view.button.ButtonType.DESTRUCTIVE
+import com.duckduckgo.common.ui.view.button.ButtonType.GHOST_ALT
 import com.duckduckgo.common.ui.view.dialog.CustomAlertDialogBuilder
 import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.view.getColorFromAttr
@@ -217,8 +219,8 @@ class EditDeviceActivity : DuckDuckGoActivity() {
         TextAlertDialogBuilder(this)
             .setTitle(R.string.sync_device_v2_remove_device_dialog_title)
             .setMessage(getString(R.string.sync_device_v2_remove_device_dialog_body, currentDevice.deviceName))
-            .setPositiveButton(R.string.sync_device_v2_remove_device_dialog_primary_button)
-            .setNegativeButton(R.string.sync_device_v2_remove_device_dialog_secondary_button)
+            .setPositiveButton(R.string.sync_device_v2_remove_device_dialog_primary_button, DESTRUCTIVE)
+            .setNegativeButton(R.string.sync_device_v2_remove_device_dialog_secondary_button, GHOST_ALT)
             .addEventListener(
                 object : TextAlertDialogBuilder.EventListener() {
                     override fun onPositiveButtonClicked() {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1215321458176118/task/1216916149729673?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1216103556496795/task/1216509582049467?focus=true
API Proposals URL(s) (if applicable): N/A

### Description

Updates the button styles of the "Remove Device?" confirmation dialog on the Edit Device screen in the simplified sync flow, so the dialog signals that removing a device is a destructive action.

### Steps to test this PR

_Remove device dialog styling_
- [ ] Sync with a second device using the legacy flow.
- [ ] Open Sync Dev Settings.
- [ ] Tap "Launch Sync Settings V2".
- [ ] Tap the second device in the "Synced Devices" list.
- [ ] Complete the device authentication prompt.
- [ ] Tap "Remove Device".
- [ ] Verify the dialog shows "Remove" as a red destructive button and "Cancel" as a neutral text button.

### UI changes
| Before  | After |
| ------ | ----- |
| <img width="540" alt="before" src="https://github.com/user-attachments/assets/851f369f-a4a2-48fa-9f83-4c6108104d79" /> | <img width="540" alt="after" src="https://github.com/user-attachments/assets/8793e9b2-3232-45e8-ba74-c36c0b238a05" /> |




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only dialog button styling with no changes to sync or device-removal logic.
> 
> **Overview**
> The **Remove Device** confirmation in `EditDeviceActivity` (sync v2) now passes **`DESTRUCTIVE`** to the primary **Remove** action and **`GHOST_ALT`** to **Cancel**, matching other destructive sync dialogs (e.g. delete account).
> 
> Dialog text and behavior are unchanged; only button presentation is updated so removal reads as a destructive action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb007f644566d39b3ec75198222317ea10312c5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->