### PR TITLE
Display sync QR code in simplified sync

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/QrCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/QrCodeActivity.kt
@@ -89,13 +89,13 @@ class QrCodeActivity : DuckDuckGoActivity() {
     }
 
     private fun render(viewState: ViewState) {
-        val hasQrCode = viewState.bitmap != null
-        if (hasQrCode) {
-            binding.qrCodeImage.setImageBitmap(viewState.bitmap.bitmap)
-            binding.qrCodeText.text = viewState.bitmap.displayCode
+        val bitmapWrapper = viewState.bitmap
+        if (bitmapWrapper != null) {
+            binding.qrCodeImage.setImageBitmap(bitmapWrapper.bitmap)
+            binding.qrCodeText.text = bitmapWrapper.displayCode
         }
-        binding.loadingIndicator.isGone = hasQrCode
-        binding.qrCodeContent.isVisible = hasQrCode
+        binding.loadingIndicator.isGone = bitmapWrapper != null
+        binding.qrCodeContent.isVisible = bitmapWrapper != null
     }
 
     private fun processCommand(command: Command) {

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/QrCodeActivity.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/QrCodeActivity.kt
@@ -17,27 +17,126 @@
 package com.duckduckgo.sync.impl.ui.v2
 
 import android.os.Bundle
+import androidx.core.view.isGone
+import androidx.core.view.isVisible
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
 import com.duckduckgo.anvil.annotations.InjectWith
 import com.duckduckgo.common.ui.DuckDuckGoActivity
+import com.duckduckgo.common.ui.view.dialog.TextAlertDialogBuilder
 import com.duckduckgo.common.ui.viewbinding.viewBinding
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeBucket
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeHandler
+import com.duckduckgo.common.utils.edgetoedge.EdgeToEdgeProvider
 import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.sync.impl.R
 import com.duckduckgo.sync.impl.databinding.ActivitySyncV2QrCodeBinding
+import com.duckduckgo.sync.impl.ui.showV2PairingError
+import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Command
+import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Command.Close
+import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Command.SetFailureResult
+import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Command.ShowError
+import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Command.ShowV2Error
+import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.ViewState
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import logcat.logcat
+import javax.inject.Inject
 import com.duckduckgo.mobile.android.R as CommonR
 
 @InjectWith(ActivityScope::class)
 class QrCodeActivity : DuckDuckGoActivity() {
     private val binding by viewBinding<ActivitySyncV2QrCodeBinding>()
 
+    private val viewModel by bindViewModel<SyncExchangeViewModel>()
+
+    @Inject
+    lateinit var edgeToEdgeProvider: EdgeToEdgeProvider
+
+    @Inject
+    lateinit var edgeToEdgeHandler: EdgeToEdgeHandler
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        val edgeToEdgeEnabled = edgeToEdgeProvider.isEnabled(EdgeToEdgeBucket.SYNC)
+        if (edgeToEdgeEnabled) {
+            enableTransparentEdgeToEdge()
+        }
         setContentView(binding.root)
+        if (edgeToEdgeEnabled) {
+            configureEdgeToEdgeInsets()
+        }
 
         configureToolbar()
+
+        observeViewModel()
+    }
+
+    private fun observeViewModel() {
+        viewModel
+            .viewState
+            .flowWithLifecycle(lifecycle)
+            .onEach { render(it) }
+            .launchIn(lifecycleScope)
+
+        viewModel
+            .commands
+            .flowWithLifecycle(lifecycle, Lifecycle.State.CREATED)
+            .onEach { processCommand(it) }
+            .launchIn(lifecycleScope)
+    }
+
+    private fun render(viewState: ViewState) {
+        val hasQrCode = viewState.bitmap != null
+        if (hasQrCode) {
+            binding.qrCodeImage.setImageBitmap(viewState.bitmap.bitmap)
+            binding.qrCodeText.text = viewState.bitmap.displayCode
+        }
+        binding.loadingIndicator.isGone = hasQrCode
+        binding.qrCodeContent.isVisible = hasQrCode
+    }
+
+    private fun processCommand(command: Command) {
+        when (command) {
+            is ShowError -> showError(command)
+            is ShowV2Error -> showV2Error(command)
+            is SetFailureResult -> logcat { "TODO" }
+            is Close -> finish()
+        }
+    }
+
+    private fun showError(error: ShowError) {
+        TextAlertDialogBuilder(this)
+            .setTitle(R.string.sync_dialog_error_title)
+            .setMessage(getString(error.message) + "\n" + error.reason)
+            .setPositiveButton(R.string.sync_dialog_error_ok)
+            .addEventListener(
+                object : TextAlertDialogBuilder.EventListener() {
+                    override fun onPositiveButtonClicked() {
+                        viewModel.onErrorDialogDismissed()
+                    }
+                },
+            )
+            .show()
+    }
+
+    private fun showV2Error(error: ShowV2Error) {
+        showV2PairingError(error.content) {
+            viewModel.onErrorDialogDismissed()
+        }
     }
 
     private fun configureToolbar() {
         setSupportActionBar(binding.includeToolbar.toolbar)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         binding.includeToolbar.toolbar.setNavigationIcon(CommonR.drawable.ic_close_24)
+    }
+
+    private fun configureEdgeToEdgeInsets() {
+        edgeToEdgeHandler.applyHorizontalSystemBarInsets(binding.root)
+        edgeToEdgeHandler.applyStatusBarInsets(binding.includeToolbar.appBarLayout)
+        edgeToEdgeHandler.applyNavigationBarInsets(binding.contentScrollView, drawBehindGestureNav = true)
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncExchangeViewModel.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/ui/v2/SyncExchangeViewModel.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui.v2
+
+import android.graphics.Bitmap
+import androidx.annotation.StringRes
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.duckduckgo.anvil.annotations.ContributesViewModel
+import com.duckduckgo.common.utils.DispatcherProvider
+import com.duckduckgo.di.scopes.ActivityScope
+import com.duckduckgo.sync.impl.DispatchOutcome
+import com.duckduckgo.sync.impl.QREncoder
+import com.duckduckgo.sync.impl.R
+import com.duckduckgo.sync.impl.SyncAccountRepository
+import com.duckduckgo.sync.impl.SyncCodeDispatcher
+import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.onFailure
+import com.duckduckgo.sync.impl.onSuccess
+import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_CONNECT
+import com.duckduckgo.sync.impl.pixels.fireSetupCancelledIfDenied
+import com.duckduckgo.sync.impl.pixels.fireSetupFailed
+import com.duckduckgo.sync.impl.ui.V2PairingErrorContent
+import com.duckduckgo.sync.impl.ui.qrcode.SyncBarcodeUrl
+import com.duckduckgo.sync.impl.ui.qrcode.SyncBarcodeUrl.ProtocolVersion
+import com.duckduckgo.sync.impl.ui.toV2PairingError
+import com.duckduckgo.sync.impl.ui.v2AlreadyPairedError
+import com.duckduckgo.sync.impl.ui.v2UpgradeRequiredError
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import logcat.logcat
+import javax.inject.Inject
+
+@ContributesViewModel(ActivityScope::class)
+class SyncExchangeViewModel @Inject constructor(
+    private val accountRepository: SyncAccountRepository,
+    private val codeDispatcher: SyncCodeDispatcher,
+    private val pixels: SyncPixels,
+    private val syncFeature: SyncFeature,
+    private val qrEncoder: QREncoder,
+    private val dispatchers: DispatcherProvider,
+) : ViewModel() {
+    private val _commands = Channel<Command>(Channel.BUFFERED)
+    internal val commands = _commands.receiveAsFlow()
+
+    private val _viewState = MutableStateFlow(ViewState())
+    val viewState = _viewState.asStateFlow()
+
+    init {
+        viewModelScope.launch(dispatchers.io()) {
+            when (protocolVersion()) {
+                ProtocolVersion.V1 -> startV1Presentation()
+                ProtocolVersion.V2 -> startV2Presentation()
+            }
+        }
+    }
+
+    fun onErrorDialogDismissed() {
+        viewModelScope.launch {
+            _commands.send(Command.SetFailureResult)
+            _commands.send(Command.Close)
+        }
+    }
+
+    private suspend fun startV1Presentation() {
+        accountRepository.getConnectQR()
+            .onSuccess { showQrCode(it.qrCode) }
+            .onFailure { _commands.send(Command.ShowError(R.string.sync_connect_generic_error, it.reason)) }
+    }
+
+    private suspend fun startV2Presentation() {
+        codeDispatcher.presentV2().collect { outcome ->
+            pixels.fireSetupFailed(SYNC_CONNECT, outcome)
+            pixels.fireSetupCancelledIfDenied(SYNC_CONNECT, outcome)
+
+            when (outcome) {
+                is DispatchOutcome.LinkingCodeReady -> {
+                    showQrCode(outcome.linkingCode)
+                }
+
+                is DispatchOutcome.HostConfirmationRequested -> {
+                    logcat { "TODO" }
+                }
+
+                is DispatchOutcome.JoinerConfirmationRequested -> {
+                    logcat { "TODO" }
+                }
+
+                is DispatchOutcome.LoggedIn -> {
+                    logcat { "TODO" }
+                }
+
+                is DispatchOutcome.AlreadyConnected -> {
+                    _commands.send(Command.ShowV2Error(v2AlreadyPairedError))
+                }
+
+                is DispatchOutcome.UpgradeRequired -> {
+                    _commands.send(Command.ShowV2Error(v2UpgradeRequiredError))
+                }
+
+                is DispatchOutcome.Failed -> {
+                    _commands.send(Command.ShowV2Error(outcome.code.toV2PairingError()))
+                }
+            }
+        }
+    }
+
+    private suspend fun showQrCode(url: String) {
+        val bitmap = withContext(dispatchers.io()) {
+            qrEncoder.encodeAsBitmap(url, R.dimen.simplifiedSyncQrSize, R.dimen.simplifiedSyncQrSize)
+        }
+        val displayCode = SyncBarcodeUrl.parseUrl(url)?.webSafeB64EncodedCode ?: url
+        val bitmapWithCode = BitmapWithCode(bitmap, url, displayCode)
+        _viewState.update { it.copy(bitmap = bitmapWithCode) }
+    }
+
+    private suspend fun protocolVersion(): ProtocolVersion = withContext(dispatchers.io()) {
+        if (syncFeature.canUseV2ConnectFlow().isEnabled() && syncFeature.canShowV2ConnectCode().isEnabled()) {
+            ProtocolVersion.V2
+        } else {
+            ProtocolVersion.V1
+        }
+    }
+
+    data class ViewState(
+        val bitmap: BitmapWithCode? = null,
+    )
+
+    data class BitmapWithCode(
+        val bitmap: Bitmap,
+        val url: String,
+        val displayCode: String,
+    )
+
+    internal sealed interface Command {
+        data class ShowError(
+            @StringRes val message: Int,
+            val reason: String = "",
+        ) : Command
+
+        data class ShowV2Error(
+            val content: V2PairingErrorContent,
+        ) : Command
+
+        data object SetFailureResult : Command
+
+        data object Close : Command
+    }
+}

--- a/sync/sync-impl/src/main/res/drawable/background_qr_code_panel.xml
+++ b/sync/sync-impl/src/main/res/drawable/background_qr_code_panel.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright (c) 2023 DuckDuckGo
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) 2026 DuckDuckGo
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -15,12 +14,8 @@
   ~ limitations under the License.
   -->
 
-<resources>
-    <dimen name="qrSizeXLarge">220dp</dimen>
-    <dimen name="qrSizeLarge">192dp</dimen>
-    <dimen name="qrSizeMedium">160dp</dimen>
-    <dimen name="qrSizeSmall">96dp</dimen>
-    <dimen name="qrBarcodeSize">360dp</dimen>
-    <dimen name="simplifiedSyncQrSize">270dp</dimen>
-    <dimen name="syncOtherDevicesMaxItemWidth">600dp</dimen>
-</resources>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="?attr/daxColorBackground" />
+    <corners android:radius="28dp" />
+</shape>

--- a/sync/sync-impl/src/main/res/layout/activity_sync_v2_qr_code.xml
+++ b/sync/sync-impl/src/main/res/layout/activity_sync_v2_qr_code.xml
@@ -15,6 +15,8 @@
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -23,4 +25,115 @@
         android:id="@+id/includeToolbar"
         layout="@layout/include_default_toolbar" />
 
+    <ScrollView
+        android:id="@+id/contentScrollView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fillViewport="true">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <com.duckduckgo.sync.impl.ui.v2.CodeExchangeHeaderView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/keyline_4"
+                android:layout_marginTop="@dimen/keyline_5"
+                app:bodyText="@string/sync_scanner_v2_qr_code_screen_body"
+                app:headlineText="@string/sync_scanner_v2_qr_code_screen_headline" />
+
+            <FrameLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_marginHorizontal="@dimen/keyline_4"
+                android:layout_marginVertical="@dimen/keyline_5"
+                android:layout_weight="1"
+                android:background="@drawable/background_qr_code_panel"
+                android:padding="20dp"
+                android:theme="@style/Theme.DuckDuckGo.Light">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent">
+
+                    <com.google.android.material.progressindicator.CircularProgressIndicator
+                        android:id="@+id/loadingIndicator"
+                        style="@style/Widget.App.CircularProgressIndicator"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:indeterminate="true"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        tools:visibility="gone" />
+
+                    <ImageView
+                        android:id="@+id/qrCodeImage"
+                        android:layout_width="0dp"
+                        android:layout_height="0dp"
+                        android:layout_marginTop="@dimen/keyline_5"
+                        android:importantForAccessibility="no"
+                        app:layout_constraintDimensionRatio="1:1"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintWidth_max="@dimen/simplifiedSyncQrSize"
+                        tools:src="@drawable/ic_qr_24" />
+
+                    <com.duckduckgo.common.ui.view.text.DaxTextView
+                        android:id="@+id/qrCodeText"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/keyline_5"
+                        android:ellipsize="end"
+                        android:gravity="center_horizontal"
+                        android:maxLines="2"
+                        app:layout_constraintBottom_toTopOf="@+id/copyCodeButton"
+                        app:layout_constraintEnd_toEndOf="@+id/qrCodeImage"
+                        app:layout_constraintStart_toStartOf="@+id/qrCodeImage"
+                        app:layout_constraintTop_toBottomOf="@+id/qrCodeImage"
+                        app:layout_constraintVertical_bias="0"
+                        app:textType="secondary"
+                        app:typography="body1_mono" />
+
+                    <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
+                        android:id="@+id/copyCodeButton"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/keyline_5"
+                        android:text="@string/sync_scanner_v2_qr_code_copy_button"
+                        app:daxButtonSize="large"
+                        app:icon="@drawable/ic_copy_24"
+                        app:iconGravity="textStart"
+                        app:layout_constraintBottom_toTopOf="@+id/shareButton"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent" />
+
+                    <com.duckduckgo.common.ui.view.button.DaxButtonSecondary
+                        android:id="@+id/shareButton"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/keyline_3"
+                        android:text="@string/sync_scanner_v2_qr_code_share_button"
+                        app:daxButtonSize="large"
+                        app:icon="@drawable/ic_share_android_24"
+                        app:iconGravity="textStart"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent" />
+
+                    <androidx.constraintlayout.widget.Group
+                        android:id="@+id/qrCodeContent"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:visibility="gone"
+                        app:constraint_referenced_ids="qrCodeImage,qrCodeText,copyCodeButton,shareButton"
+                        tools:visibility="visible" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </FrameLayout>
+        </LinearLayout>
+    </ScrollView>
 </LinearLayout>

--- a/sync/sync-impl/src/main/res/values/donottranslate.xml
+++ b/sync/sync-impl/src/main/res/values/donottranslate.xml
@@ -62,4 +62,8 @@
     <string name="sync_scanner_v2_scan_button_cta">I’m Ready to Scan</string>
     <string name="sync_scanner_v2_enter_code_manually_tab_item_label">Enter Code</string>
     <string name="sync_scanner_v2_qr_code_screen_title">QR Code</string>
+    <string name="sync_scanner_v2_qr_code_screen_headline">Scan from another device</string>
+    <string name="sync_scanner_v2_qr_code_screen_body">On another device, open <annotation type="icon">&#65532;</annotation> <b><annotation type="highlight">DuckDuckGo</annotation></b>\n<annotation type="gap">\n</annotation>and go to <annotation type="highlight">Sync &amp; Backup</annotation> › <annotation type="highlight">Sync With Another Device</annotation>\n<annotation type="gap">\n</annotation>and scan this code:</string>
+    <string name="sync_scanner_v2_qr_code_copy_button">Copy Text Code</string>
+    <string name="sync_scanner_v2_qr_code_share_button">Share</string>
 </resources>

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/SyncExchangeViewModelTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/ui/v2/SyncExchangeViewModelTest.kt
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.sync.impl.ui.v2
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
+import com.duckduckgo.common.test.CoroutineTestRule
+import com.duckduckgo.feature.toggles.api.FakeFeatureToggleFactory
+import com.duckduckgo.feature.toggles.api.Toggle.State
+import com.duckduckgo.sync.TestSyncFixtures
+import com.duckduckgo.sync.impl.AccountErrorCodes.PAIRING_CANCELLED
+import com.duckduckgo.sync.impl.DispatchOutcome
+import com.duckduckgo.sync.impl.QREncoder
+import com.duckduckgo.sync.impl.R
+import com.duckduckgo.sync.impl.Result
+import com.duckduckgo.sync.impl.SyncAccountRepository
+import com.duckduckgo.sync.impl.SyncAccountRepository.AuthCode
+import com.duckduckgo.sync.impl.SyncCodeDispatcher
+import com.duckduckgo.sync.impl.SyncFeature
+import com.duckduckgo.sync.impl.pixels.SyncPixels
+import com.duckduckgo.sync.impl.pixels.SyncPixels.CancellationReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.ScreenType.SYNC_CONNECT
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupFailureReason
+import com.duckduckgo.sync.impl.pixels.SyncPixels.SetupPath
+import com.duckduckgo.sync.impl.ui.qrcode.SyncBarcodeUrl
+import com.duckduckgo.sync.impl.ui.qrcode.SyncBarcodeUrl.ProtocolVersion.V2
+import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.BitmapWithCode
+import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Command.Close
+import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Command.SetFailureResult
+import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Command.ShowError
+import com.duckduckgo.sync.impl.ui.v2.SyncExchangeViewModel.Command.ShowV2Error
+import com.duckduckgo.sync.impl.ui.v2AlreadyPairedError
+import com.duckduckgo.sync.impl.ui.v2UpgradeRequiredError
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
+@RunWith(AndroidJUnit4::class)
+class SyncExchangeViewModelTest {
+    @get:Rule
+    val coroutineTestRule: CoroutineTestRule = CoroutineTestRule()
+
+    private val bitmap = TestSyncFixtures.qrBitmap()
+    private val linkingUrl = SyncBarcodeUrl(
+        webSafeB64EncodedCode = "encoded-code",
+        deviceName = "Device Name",
+        protocolVersion = V2,
+    ).asUrl()
+
+    private val accountRepository = mock<SyncAccountRepository>()
+    private val codeDispatcher = mock<SyncCodeDispatcher>()
+    private val pixels = mock<SyncPixels>()
+    private val syncFeature = FakeFeatureToggleFactory.create(SyncFeature::class.java)
+    private val qrEncoder = mock<QREncoder>()
+
+    @Before
+    fun setup() {
+        whenever(codeDispatcher.presentV2()).thenReturn(emptyFlow())
+        whenever(qrEncoder.encodeAsBitmap(any(), any(), any())).thenReturn(bitmap)
+    }
+
+    private fun createTestee() = SyncExchangeViewModel(
+        accountRepository = accountRepository,
+        codeDispatcher = codeDispatcher,
+        pixels = pixels,
+        syncFeature = syncFeature,
+        qrEncoder = qrEncoder,
+        dispatchers = coroutineTestRule.testDispatcherProvider,
+    )
+
+    @Test
+    fun `when v2 is disabled then the v1 connect code is shown as a QR code`() = runTest {
+        givenV2Disabled()
+        whenever(accountRepository.getConnectQR()).thenReturn(Result.Success(AuthCode(qrCode = "raw-code", rawCode = "b64-code")))
+
+        val testee = createTestee()
+
+        testee.viewState.test {
+            assertEquals(BitmapWithCode(bitmap, "raw-code", "raw-code"), awaitItem().bitmap)
+            verify(qrEncoder).encodeAsBitmap(eq("raw-code"), any(), any())
+            verify(codeDispatcher, never()).presentV2()
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when v2 is disabled and the connect code cannot be generated then an error is shown`() = runTest {
+        givenV2Disabled()
+        whenever(accountRepository.getConnectQR()).thenReturn(Result.Error(reason = "boom"))
+
+        val testee = createTestee()
+
+        testee.commands.test {
+            val command = awaitItem()
+            assertIs<ShowError>(command)
+            assertEquals(R.string.sync_connect_generic_error, command.message)
+            assertEquals("boom", command.reason)
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when only the v2 connect flow flag is enabled then the v1 connect code is shown`() = runTest {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        syncFeature.canShowV2ConnectCode().setRawStoredState(State(false))
+        whenever(accountRepository.getConnectQR()).thenReturn(Result.Success(AuthCode(qrCode = "raw-code", rawCode = "b64-code")))
+
+        createTestee()
+
+        verify(accountRepository).getConnectQR()
+        verify(codeDispatcher, never()).presentV2()
+    }
+
+    @Test
+    fun `when v2 is enabled then the v2 linking code is shown as a QR code`() = runTest {
+        givenV2Enabled()
+        whenever(codeDispatcher.presentV2()).thenReturn(flowOf(DispatchOutcome.LinkingCodeReady(linkingUrl)))
+
+        val testee = createTestee()
+
+        testee.viewState.test {
+            assertEquals(BitmapWithCode(bitmap, linkingUrl, "encoded-code"), awaitItem().bitmap)
+            verify(qrEncoder).encodeAsBitmap(eq(linkingUrl), any(), any())
+            verify(accountRepository, never()).getConnectQR()
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when the devices are already paired then the already paired error is shown`() = runTest {
+        givenV2Enabled()
+        whenever(codeDispatcher.presentV2()).thenReturn(flowOf(DispatchOutcome.AlreadyConnected))
+
+        val testee = createTestee()
+
+        testee.commands.test {
+            val command = awaitItem()
+            assertIs<ShowV2Error>(command)
+            assertEquals(v2AlreadyPairedError, command.content)
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when the peer requires an app upgrade then the upgrade required error is shown`() = runTest {
+        givenV2Enabled()
+        whenever(codeDispatcher.presentV2()).thenReturn(flowOf(DispatchOutcome.UpgradeRequired(codeMajor = 2)))
+
+        val testee = createTestee()
+
+        testee.commands.test {
+            val command = awaitItem()
+            assertIs<ShowV2Error>(command)
+            assertEquals(v2UpgradeRequiredError, command.content)
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when pairing fails then the pairing failed error is shown`() = runTest {
+        givenV2Enabled()
+        whenever(codeDispatcher.presentV2()).thenReturn(flowOf(DispatchOutcome.Failed(reason = "boom")))
+
+        val testee = createTestee()
+
+        testee.commands.test {
+            val command = awaitItem()
+            assertIs<ShowV2Error>(command)
+            assertEquals(R.string.sync_v2_error_pairing_failed, command.content.title)
+            assertEquals(R.string.sync_v2_error_try_again, command.content.message)
+
+            cancel()
+        }
+    }
+
+    @Test
+    fun `when pairing fails then the setup failed pixel is fired`() = runTest {
+        givenV2Enabled()
+        whenever(codeDispatcher.presentV2()).thenReturn(flowOf(DispatchOutcome.Failed(reason = "boom", path = SetupPath.PAIRING)))
+
+        createTestee()
+
+        verify(pixels).fireSyncSetupFailed(SYNC_CONNECT, SetupFailureReason.UNEXPECTED_FAILURE, SetupPath.PAIRING, null, null, null)
+    }
+
+    @Test
+    fun `when pairing is denied then the setup abandoned pixel is fired`() = runTest {
+        givenV2Enabled()
+        whenever(codeDispatcher.presentV2()).thenReturn(flowOf(DispatchOutcome.Failed(reason = "denied", code = PAIRING_CANCELLED.code)))
+
+        createTestee()
+
+        verify(pixels).fireSyncSetupAbandoned(SYNC_CONNECT, CancellationReason.CONFIRMATION_DENIED)
+    }
+
+    @Test
+    fun `when pairing is denied then the setup failed pixel is not fired`() = runTest {
+        givenV2Enabled()
+        whenever(codeDispatcher.presentV2()).thenReturn(flowOf(DispatchOutcome.Failed(reason = "denied", code = PAIRING_CANCELLED.code)))
+
+        createTestee()
+
+        verify(pixels, never()).fireSyncSetupFailed(any(), any(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull())
+    }
+
+    @Test
+    fun `when the linking code is ready then no setup pixels are fired`() = runTest {
+        givenV2Enabled()
+        whenever(codeDispatcher.presentV2()).thenReturn(flowOf(DispatchOutcome.LinkingCodeReady(linkingUrl)))
+
+        createTestee()
+
+        verifyNoInteractions(pixels)
+    }
+
+    @Test
+    fun `when the error dialog is dismissed then the failure result is set and the screen closes`() = runTest {
+        givenV2Enabled()
+
+        val testee = createTestee()
+
+        testee.commands.test {
+            testee.onErrorDialogDismissed()
+            assertIs<SetFailureResult>(awaitItem())
+            assertIs<Close>(awaitItem())
+
+            cancel()
+        }
+    }
+
+    private fun givenV2Enabled() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(true))
+        syncFeature.canShowV2ConnectCode().setRawStoredState(State(true))
+    }
+
+    private fun givenV2Disabled() {
+        syncFeature.canUseV2ConnectFlow().setRawStoredState(State(false))
+        syncFeature.canShowV2ConnectCode().setRawStoredState(State(false))
+    }
+}
+
+@OptIn(ExperimentalContracts::class)
+private inline fun <reified T> assertIs(value: Any?) {
+    contract {
+        returns() implies (value is T)
+    }
+    assertTrue("Expected ${T::class.simpleName} but was ${value?.let { it::class.simpleName }}", value is T)
+}


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1216103556496795/task/1216942050561822?focus=true
Tech Design URL (if applicable): https://app.asana.com/1/137249556945/project/1216103556496795/task/1216509582049467?focus=true
API Proposals URL(s) (if applicable): N/A

### Description

Fills in the QR Code screen of the simplified Sync With Another Device flow. The screen now generates and displays the code that another device can scan or type to connect, instead of being an empty placeholder.

- While the code is being prepared, a loading spinner is shown inside the code panel.
- Once ready, the panel shows the QR code with its text code below it, so the user can type it on the other device instead of scanning.
- The "Copy Text Code" and "Share" buttons are displayed but not functional yet.
- Which code is offered depends on the feature flags. With both `canUseV2ConnectFlow` and `canShowV2ConnectCode` enabled, the screen starts a v2 exchange session and shows its linking code. Otherwise it shows the v1 connect code.

The screen is backed by a new `SyncExchangeViewModel` rather than the existing `SyncConnectViewModel`. The old view model starts its session as a side effect of collecting `viewState(source)`, which builds a new flow on each call and guards against restarts with internal flags. Since `SyncConnectViewModel` backs the sync setup flow that is currently live, adapting it for this screen felt riskier than starting clean with a plain state flow plus commands structure. Currently, in `SyncExchangeViewModel` source parameter isn't used but in the future it will be passed via the constructor.

The v2 session's confirmation prompts and successful login are not handled on this screen yet, and closing after a failure does not report a result back to the caller yet. Both are coming in follow-up PRs.

### Steps to test this PR

_View the QR code_
- [ ] Open Sync Dev Settings.
- [ ] Tap "Launch Sync Settings V2".
- [ ] Tap "Sync With Another Device".
- [ ] Complete the device authentication prompt.
- [ ] Tap the "Show QR Code" icon in the toolbar.
- [ ] Verify a loading spinner shows briefly inside the code panel.
- [ ] Verify a QR code appears with its text code below it.
- [ ] Verify the "Copy Text Code" and "Share" buttons are shown.

_Code generation failure_
- [ ] Enable airplane mode.
- [ ] Open the QR Code screen again.
- [ ] Verify an error dialog is shown.
- [ ] Dismiss the dialog.
- [ ] Verify the screen closes.

_Show the v2 linking code_
- [ ] Disable airplane mode.
- [ ] Enable the `canShowV2ConnectCode` flag in "Feature Flag Inventory".
- [ ] Open the QR Code screen again.
- [ ] Verify a QR code appears with its text code below it.

### UI changes
> [!note]
> This attachment is intentionally blurred.

<img width="540" height="1200" alt="screnshot" src="https://github.com/user-attachments/assets/db6aa5cd-e0eb-4025-acba-21434b72356e" />




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sync connect/pairing and account linking behind feature flags, but uses a new view model instead of the live setup flow; several v2 outcomes and activity result handling are incomplete.
> 
> **Overview**
> Replaces the empty **QR Code** placeholder in simplified Sync With Another Device with a real code-exchange screen: loading spinner, QR image, monospace text code, and **Copy Text Code** / **Share** buttons (UI only, not wired yet).
> 
> **`SyncExchangeViewModel`** drives the screen with a separate state/commands model from **`SyncConnectViewModel`**. On open it picks **v1** (`getConnectQR`) or **v2** (`SyncCodeDispatcher.presentV2()`) when both `canUseV2ConnectFlow` and `canShowV2ConnectCode` are enabled. Success updates view state with an encoded bitmap; failures show v1 or v2 pairing error dialogs and dismiss closes the activity. v2 confirmation prompts, successful login, and reporting failure back to the caller are still TODO.
> 
> **`QrCodeActivity`** observes the view model, applies SYNC edge-to-edge insets, and maps commands to dialogs/`finish()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62f0624506e17df1a5be56095598dc9278565292. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->