### PR TITLE
PIR: Add graceful handling of WebView renderer crash

### DIFF
--- a/PixelDefinitions/pixels/definitions/personal_information_removal.json5
+++ b/PixelDefinitions/pixels/definitions/personal_information_removal.json5
@@ -1657,6 +1657,49 @@
             }
         ]
     },
+    "m_dbp_scan_renderer-gone": {
+        "description": "Fired when the shared WebView renderer process is terminated (crash or system memory reclaim) during a PIR scan.",
+        "owners": ["landomen"],
+        "triggers": ["other"],
+        "suffixes": ["daily_count_short", "form_factor"],
+        "parameters": [
+            "appVersion",
+            {
+                "key": "manufacturer",
+                "description": "Manufacturer of the device",
+                "type": "string",
+                "enum": [
+                    "samsung",
+                    "google",
+                    "xiaomi",
+                    "huawei",
+                    "honor",
+                    "oneplus",
+                    "oppo",
+                    "vivo",
+                    "motorola",
+                    "realme",
+                    "sony",
+                    "lg",
+                    "nokia",
+                    "lenovo",
+                    "asus",
+                    "other"
+                ]
+            },
+            {
+                "key": "did_crash",
+                "description": "True if the renderer actually crashed (RenderProcessGoneDetail.didCrash()); false if the system reclaimed it (e.g. low memory)",
+                "type": "boolean"
+            },
+            {
+                "key": "scan_trigger",
+                "description": "What triggered the scan run",
+                "type": "string",
+                "enum": ["onboarding", "onboarding_resume", "profile_edit", "scheduled"]
+            }
+        ]
+    },
     "m_dbp_scheduled-run_scheduled": {
         "description": "Fired when the pir scheduled runs are scheduled",
         "owners": ["karlenDimla", "landomen"],
@@ -2327,8 +2370,14 @@
                     "io_exception",
                     "sqlite_exception",
                     "timeout_cancellation_exception",
+                    "renderer_gone",
                     "unknown_error"
                 ]
+            },
+            {
+                "key": "feature.data.ext.did_crash",
+                "description": "Only present on renderer_gone failures. true = the WebView renderer actually crashed; false = the system reclaimed it (e.g. low memory).",
+                "type": "boolean"
             },
             "pirCancellationReason",
             {
@@ -2643,8 +2692,14 @@
                     "io_exception",
                     "sqlite_exception",
                     "timeout_cancellation_exception",
+                    "renderer_gone",
                     "unknown_error"
                 ]
+            },
+            {
+                "key": "feature.data.ext.did_crash",
+                "description": "Only present on renderer_gone failures. true = the WebView renderer actually crashed; false = the system reclaimed it (e.g. low memory).",
+                "type": "boolean"
             },
             "pirCancellationReason",
             {

--- a/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/PirEndToEndTest.kt
+++ b/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/PirEndToEndTest.kt
@@ -1026,7 +1026,7 @@ class PirEndToEndTest {
         override suspend fun onOptOutStarted(executionType: PirExecutionType) = Unit
         override suspend fun onOptOutCompleted(executionType: PirExecutionType, totalOptOutJobs: Int) = Unit
         override suspend fun onOptOutSkipped(executionType: PirExecutionType) = Unit
-        override suspend fun onRunFailed(executionType: PirExecutionType, reason: PirScanWideEvent.FailureReason) = Unit
+        override suspend fun onRunFailed(executionType: PirExecutionType, reason: PirScanWideEvent.FailureReason, didCrash: Boolean?) = Unit
         override suspend fun onRunCancelled(executionType: PirExecutionType, reason: PirScanWideEvent.CancellationReason) = Unit
         override suspend fun onWorkCancelled(reason: PirScanWideEvent.CancellationReason) = Unit
         override suspend fun onRunCancelledBeforeStart(executionType: PirExecutionType, reason: PirScanWideEvent.CancellationReason) = Unit

--- a/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/fakes/FakePirDetachedWebViewProvider.kt
+++ b/pir/pir-impl/src/androidTest/java/com/duckduckgo/pir/impl/integration/fakes/FakePirDetachedWebViewProvider.kt
@@ -41,6 +41,7 @@ class FakePirDetachedWebViewProvider : PirDetachedWebViewProvider {
         scriptToLoad: String,
         onPageLoaded: (String?) -> Unit,
         onPageLoadFailed: (String?) -> Unit,
+        onRendererGone: (didCrash: Boolean) -> Unit,
     ): WebView {
         val webViewRef = AtomicReference<WebView>()
         val latch = CountDownLatch(1)
@@ -68,6 +69,7 @@ class FakePirDetachedWebViewProvider : PirDetachedWebViewProvider {
         scriptToLoad: String,
         onPageLoaded: (String?) -> Unit,
         onPageLoadFailed: (String?) -> Unit,
+        onRendererGone: (didCrash: Boolean) -> Unit,
     ): WebView {
         val latch = CountDownLatch(1)
 

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirActionsRunner.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirActionsRunner.kt
@@ -75,13 +75,16 @@ import com.duckduckgo.pir.impl.scripts.models.PirSuccessResponse
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
+import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import logcat.logcat
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 interface PirActionsRunner {
     /**
@@ -152,6 +155,8 @@ class RealPirActionsRunner @AssistedInject constructor(
             return Result.success(Unit)
         }
 
+        val runContinuationHolder = RunContinuationHolder()
+
         withContext(dispatcherProvider.main()) {
             logcat {
                 "PIR-RUNNER (${this@RealPirActionsRunner}): ${Thread.currentThread().name} " +
@@ -169,6 +174,9 @@ class RealPirActionsRunner @AssistedInject constructor(
                     onPageLoadFailed = {
                         onLoadingFailed(it)
                     },
+                    onRendererGone = {
+                        onRendererGone(runContinuationHolder, it)
+                    },
                 )
 
             brokerActionProcessor.register(detachedWebView!!, this@RealPirActionsRunner)
@@ -177,7 +185,7 @@ class RealPirActionsRunner @AssistedInject constructor(
         engine = engineFactory.create(runType, brokerSteps, profileQuery)
         engine!!.dispatch(Started)
 
-        return awaitResult()
+        return awaitResult(runContinuationHolder)
     }
 
     override suspend fun startOn(
@@ -189,6 +197,8 @@ class RealPirActionsRunner @AssistedInject constructor(
             logcat { "PIR-RUNNER ($this): No broker steps to execute ${Thread.currentThread().name}" }
             return Result.success(Unit)
         }
+
+        val runContinuationHolder = RunContinuationHolder()
 
         withContext(dispatcherProvider.main()) {
             logcat { "PIR-RUNNER (${this@RealPirActionsRunner}): ${Thread.currentThread().name} Brokers to execute $brokerSteps" }
@@ -203,6 +213,9 @@ class RealPirActionsRunner @AssistedInject constructor(
                     onPageLoadFailed = {
                         onLoadingFailed(it)
                     },
+                    onRendererGone = {
+                        onRendererGone(runContinuationHolder, it)
+                    },
                 )
 
             brokerActionProcessor.register(detachedWebView!!, this@RealPirActionsRunner)
@@ -211,7 +224,7 @@ class RealPirActionsRunner @AssistedInject constructor(
         engine = engineFactory.create(runType, brokerSteps, profileQuery)
         engine!!.dispatch(Started)
 
-        return awaitResult()
+        return awaitResult(runContinuationHolder)
     }
 
     private fun onLoadingComplete(url: String?) {
@@ -239,13 +252,36 @@ class RealPirActionsRunner @AssistedInject constructor(
         )
     }
 
-    private suspend fun awaitResult(): Result<Unit> =
+    private fun onRendererGone(
+        runContinuationHolder: RunContinuationHolder,
+        didCrash: Boolean,
+    ) {
+        val continuation = runContinuationHolder.continuation.getAndSet(null)
+        if (continuation == null || !continuation.isActive) {
+            logcat {
+                "PIR-RUNNER (${this@RealPirActionsRunner}): renderer process gone, didCrash=$didCrash - stale/no-op, ignoring"
+            }
+            return
+        }
+
+        if (timerJob.isActive) {
+            timerJob.cancel()
+        }
+        if (engineJob.isActive) {
+            engineJob.cancel()
+        }
+        logcat { "PIR-RUNNER (${this@RealPirActionsRunner}): renderer process gone, didCrash=$didCrash - failing current run" }
+        continuation.resumeWithException(PirRendererGoneException(didCrash))
+    }
+
+    private suspend fun awaitResult(runContinuationHolder: RunContinuationHolder): Result<Unit> =
         suspendCancellableCoroutine { continuation ->
+            runContinuationHolder.continuation.set(continuation)
             engineJob +=
                 coroutineScope.launch {
                     engine!!.sideEffect.collect { effect ->
                         if (effect is CompleteExecution) {
-                            continuation.resume(Result.success(Unit))
+                            runContinuationHolder.continuation.getAndSet(null)?.resume(Result.success(Unit))
                         } else {
                             handleEffect(effect)
                         }
@@ -253,6 +289,7 @@ class RealPirActionsRunner @AssistedInject constructor(
                 }
 
             continuation.invokeOnCancellation {
+                runContinuationHolder.continuation.getAndSet(null)
                 engineJob.cancel()
             }
         }
@@ -557,5 +594,9 @@ class RealPirActionsRunner @AssistedInject constructor(
         }?.also {
             engine?.dispatch(it)
         }
+    }
+
+    private class RunContinuationHolder {
+        val continuation: AtomicReference<CancellableContinuation<Result<Unit>>?> = AtomicReference(null)
     }
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirDetachedWebViewProvider.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirDetachedWebViewProvider.kt
@@ -20,6 +20,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Bitmap
 import android.os.Message
+import android.webkit.RenderProcessGoneDetail
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
@@ -46,12 +47,15 @@ interface PirDetachedWebViewProvider {
      * @param context in which the webview should run - could be service/activity
      * @param scriptToLoad the JS script that is needed for PIR to run.
      * @param onPageLoaded callback to receive whenever a url has finished loading.
+     * @param onPageLoadFailed callback to receive whenever a url has failed to load.
+     * @param onRendererGone callback to receive whenever the WebView's renderer process has died.
      */
     fun createInstance(
         context: Context,
         scriptToLoad: String,
         onPageLoaded: (String?) -> Unit,
         onPageLoadFailed: (String?) -> Unit,
+        onRendererGone: (didCrash: Boolean) -> Unit,
     ): WebView
 
     /**
@@ -60,12 +64,15 @@ interface PirDetachedWebViewProvider {
      * @param webView in which PIR should run
      * @param scriptToLoad the JS script that is needed for PIR to run.
      * @param onPageLoaded callback to receive whenever a url has finished loading.
+     * @param onPageLoadFailed callback to receive whenever a url has failed to load.
+     * @param onRendererGone callback to receive whenever the WebView's renderer process has died.
      */
     fun setupWebView(
         webView: WebView,
         scriptToLoad: String,
         onPageLoaded: (String?) -> Unit,
         onPageLoadFailed: (String?) -> Unit,
+        onRendererGone: (didCrash: Boolean) -> Unit,
     ): WebView
 }
 
@@ -82,8 +89,9 @@ class RealPirDetachedWebViewProvider @Inject constructor(
         scriptToLoad: String,
         onPageLoaded: (String?) -> Unit,
         onPageLoadFailed: (String?) -> Unit,
+        onRendererGone: (didCrash: Boolean) -> Unit,
     ): WebView {
-        return setupWebView(WebView(context), scriptToLoad, onPageLoaded, onPageLoadFailed)
+        return setupWebView(WebView(context), scriptToLoad, onPageLoaded, onPageLoadFailed, onRendererGone)
     }
 
     @SuppressLint("SetJavaScriptEnabled")
@@ -92,6 +100,7 @@ class RealPirDetachedWebViewProvider @Inject constructor(
         scriptToLoad: String,
         onPageLoaded: (String?) -> Unit,
         onPageLoadFailed: (String?) -> Unit,
+        onRendererGone: (didCrash: Boolean) -> Unit,
     ): WebView {
         return webView.apply {
             webChromeClient = object : WebChromeClient() {
@@ -172,6 +181,17 @@ class RealPirDetachedWebViewProvider @Inject constructor(
                         onPageLoadFailed(requestedUrl)
                     }
                     super.onReceivedError(view, request, error)
+                }
+
+                override fun onRenderProcessGone(
+                    view: WebView?,
+                    detail: RenderProcessGoneDetail?,
+                ): Boolean {
+                    val didCrash = detail?.didCrash() == true
+                    logcat { "PIR-SCAN: onRenderProcessGone didCrash=$didCrash - keeping :pir process alive" }
+                    onRendererGone(didCrash)
+                    // keep host process alive
+                    return true
                 }
             }
             settings.apply {

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirRendererGoneException.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/common/PirRendererGoneException.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.common
+
+/**
+ * Thrown out of a [PirActionsRunner] when its detached WebView's renderer process is terminated
+ * (see [android.webkit.WebViewClient.onRenderProcessGone]).
+ *
+ * @param didCrash true if the renderer actually crashed; false if the system reclaimed it (e.g. low memory).
+ */
+class PirRendererGoneException(val didCrash: Boolean) : Exception("PIR WebView renderer gone (didCrash=$didCrash)")

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixel.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixel.kt
@@ -346,6 +346,10 @@ enum class PirPixel(
         baseName = "m_dbp_user-eligible",
         type = Daily(),
     ),
+    PIR_SCAN_RENDERER_GONE(
+        baseName = "m_dbp_scan_renderer-gone",
+        types = setOf(Count, Daily()),
+    ),
     ;
 
     constructor(

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelInterceptor.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelInterceptor.kt
@@ -84,6 +84,7 @@ class PirPixelInterceptor @Inject constructor(
             "m_dbp_email-confirmation_completed",
             "m_dbp_initial-scan_incomplete",
             "m_dbp_initial_scan_duration",
+            "m_dbp_scan_renderer-gone",
             "wide_pir-initial-scan",
             "wide_pir-scheduled-scan",
             "wide_pir-time-to-first-scan-complete",

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/pixels/PirPixelSender.kt
@@ -81,6 +81,7 @@ import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_OPTOUT_STAGE_VALIDATE
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_OPTOUT_SUBMIT_FAILURE
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_OPTOUT_SUBMIT_SUCCESS
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_SCAN_INVALID_EVENT
+import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_SCAN_RENDERER_GONE
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_SCAN_STAGE
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_SCAN_STAGE_EMAIL_GET_DATA
 import com.duckduckgo.pir.impl.pixels.PirPixel.PIR_SCAN_STAGE_RESULT_ERROR
@@ -697,6 +698,11 @@ interface PirPixelSender {
     )
 
     fun reportUserReset()
+
+    fun reportRendererGone(
+        executionType: PirExecutionType,
+        didCrash: Boolean,
+    )
 }
 
 @ContributesBinding(AppScope::class)
@@ -1640,6 +1646,17 @@ class RealPirPixelSender @Inject constructor(
         fire(PIR_MANUAL_RESET)
     }
 
+    override fun reportRendererGone(
+        executionType: PirExecutionType,
+        didCrash: Boolean,
+    ) {
+        val params = mapOf(
+            PARAM_KEY_DID_CRASH to didCrash.toString(),
+            PARAM_KEY_SCAN_TRIGGER to executionType.toScanTriggerParam(),
+        )
+        enqueueFire(PIR_SCAN_RENDERER_GONE, params)
+    }
+
     private fun usageParams(): Map<String, String> = mapOf(
         // hardcoded values for now until we support freemium
         PARAM_KEY_IS_AUTHENTICATED to "true",
@@ -1739,5 +1756,6 @@ class RealPirPixelSender @Inject constructor(
         private const val PARAM_KEY_TRACKER_BLOCKING = "tracker_blocking_state"
         private const val PARAM_KEY_SCAN_TRIGGER = "scan_trigger"
         private const val PARAM_KEY_NOTIFICATIONS_PERMISSION = "notifications_permission_granted"
+        private const val PARAM_KEY_DID_CRASH = "did_crash"
     }
 }

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/scheduling/PirJobsRunner.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.networkprotection.api.NetworkProtectionState
 import com.duckduckgo.pir.impl.PirRemoteFeatures
 import com.duckduckgo.pir.impl.brokers.BrokerJsonUpdater
 import com.duckduckgo.pir.impl.common.PirJob.RunType
+import com.duckduckgo.pir.impl.common.PirRendererGoneException
 import com.duckduckgo.pir.impl.common.PirWebViewCountProvider
 import com.duckduckgo.pir.impl.models.ProfileQuery
 import com.duckduckgo.pir.impl.models.scheduling.JobRecord.OptOutJobRecord
@@ -275,6 +276,14 @@ class RealPirJobsRunner @Inject constructor(
         } catch (e: CancellationException) {
             pirScanWideEvent.onRunCancelled(executionType, PirScanWideEvent.CancellationReason.WORK_STOPPED)
             throw e
+        } catch (e: PirRendererGoneException) {
+            pixelSender.reportRendererGone(executionType = executionType, didCrash = e.didCrash)
+            pirScanWideEvent.onRunFailed(
+                executionType = executionType,
+                reason = FailureReason.RENDERER_GONE,
+                didCrash = e.didCrash,
+            )
+            return@withContext Result.failure(e)
         } catch (e: Exception) {
             pirScanWideEvent.onRunFailed(executionType = executionType, reason = FailureReason.fromException(e))
             throw e

--- a/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEvent.kt
+++ b/pir/pir-impl/src/main/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEvent.kt
@@ -72,7 +72,7 @@ interface PirScanWideEvent {
 
     suspend fun onOptOutSkipped(executionType: PirExecutionType)
 
-    suspend fun onRunFailed(executionType: PirExecutionType, reason: FailureReason)
+    suspend fun onRunFailed(executionType: PirExecutionType, reason: FailureReason, didCrash: Boolean? = null)
 
     suspend fun onRunCancelled(executionType: PirExecutionType, reason: CancellationReason)
 
@@ -116,14 +116,16 @@ interface PirScanWideEvent {
         IO_EXCEPTION("io_exception"),
         SQLITE_EXCEPTION("sqlite_exception"),
         TIMEOUT_CANCELLATION_EXCEPTION("timeout_cancellation_exception"),
+        RENDERER_GONE("renderer_gone"),
         UNKNOWN_ERROR("unknown_error"),
         ;
 
         companion object {
             // Order is intentional: more specific subclasses must come before their supertypes.
-            // TIMEOUT_CANCELLATION_EXCEPTION is intentionally not handled here — TimeoutCancellationException
-            // extends CancellationException, which the runner catches separately and routes via an
-            // explicit catch block ahead of the generic Exception catch that calls this helper.
+            // TIMEOUT_CANCELLATION_EXCEPTION and RENDERER_GONE are intentionally not handled here —
+            // TimeoutCancellationException extends CancellationException, and PirRendererGoneException
+            // is caught by an explicit catch block ahead of the generic Exception catch that calls
+            // this helper, so both are routed without going through fromException.
             fun fromException(e: Exception): FailureReason = when (e) {
                 is SQLiteException -> SQLITE_EXCEPTION
                 is IOException -> IO_EXCEPTION
@@ -215,9 +217,13 @@ class PirScanWideEventImpl @Inject constructor(
         stateFor(executionType).onOptOutSkipped()
     }
 
-    override suspend fun onRunFailed(executionType: PirExecutionType, reason: PirScanWideEvent.FailureReason) {
+    override suspend fun onRunFailed(
+        executionType: PirExecutionType,
+        reason: PirScanWideEvent.FailureReason,
+        didCrash: Boolean?,
+    ) {
         if (!isFeatureEnabled()) return
-        stateFor(executionType).onRunFailed(reason)
+        stateFor(executionType).onRunFailed(reason, didCrash)
     }
 
     override suspend fun onRunCancelled(executionType: PirExecutionType, reason: PirScanWideEvent.CancellationReason) {
@@ -526,7 +532,7 @@ class PirScanWideEventImpl @Inject constructor(
             }
         }
 
-        suspend fun onRunFailed(reason: PirScanWideEvent.FailureReason) {
+        suspend fun onRunFailed(reason: PirScanWideEvent.FailureReason, didCrash: Boolean?) {
             mutex.withLock {
                 val flowId = cachedFlowId ?: return@withLock
                 closeOpenIntervalsLocked(flowId)
@@ -535,6 +541,7 @@ class PirScanWideEventImpl @Inject constructor(
                 wideEventClient.flowFinish(
                     wideEventId = flowId,
                     status = FlowStatus.Failure(reason = reason.value),
+                    metadata = didCrash?.let { mapOf(KEY_DID_CRASH to it.toString()) } ?: emptyMap(),
                 )
                 clearStateLocked()
             }
@@ -671,6 +678,7 @@ class PirScanWideEventImpl @Inject constructor(
         const val KEY_LAST_STEP = "last_step"
         const val KEY_LAST_STEP_ELAPSED = "last_step_elapsed_ms_bucketed"
         const val KEY_CANCELLATION_REASON = "cancellation_reason"
+        const val KEY_DID_CRASH = "did_crash"
 
         const val STEP_STARTED = "started"
         const val STEP_PROGRESS_PREFIX = "progress_"

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEventTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEventTest.kt
@@ -1255,7 +1255,7 @@ class PirScanWideEventTest {
     @Test
     fun whenRunFailedWithRendererGoneAndSystemKillThenFlowFinishedAsFailureWithDidCrashFalse() = runTest {
         // Given
-        whenever(wideEventClient.flowStart(any(), any(), any(), any())).thenReturn(Result.success(50L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(50L))
         runStarted(PirExecutionType.MANUAL_INITIAL, profileQueriesCount = 1, brokerCount = 1, totalScanJobs = 1)
 
         // When
@@ -1276,7 +1276,7 @@ class PirScanWideEventTest {
     @Test
     fun whenRunFailedWithoutDidCrashThenFlowFinishedWithEmptyMetadata() = runTest {
         // Given
-        whenever(wideEventClient.flowStart(any(), any(), any(), any())).thenReturn(Result.success(51L))
+        whenever(wideEventClient.flowStart(any(), any(), any(), any(), any())).thenReturn(Result.success(51L))
         runStarted(PirExecutionType.MANUAL_INITIAL, profileQueriesCount = 1, brokerCount = 1, totalScanJobs = 1)
 
         // When (existing callers pass no didCrash)

--- a/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEventTest.kt
+++ b/pir/pir-impl/src/test/java/com/duckduckgo/pir/impl/wideevents/PirScanWideEventTest.kt
@@ -1252,6 +1252,47 @@ class PirScanWideEventTest {
         )
     }
 
+    @Test
+    fun whenRunFailedWithRendererGoneAndSystemKillThenFlowFinishedAsFailureWithDidCrashFalse() = runTest {
+        // Given
+        whenever(wideEventClient.flowStart(any(), any(), any(), any())).thenReturn(Result.success(50L))
+        runStarted(PirExecutionType.MANUAL_INITIAL, profileQueriesCount = 1, brokerCount = 1, totalScanJobs = 1)
+
+        // When
+        testee.onRunFailed(
+            executionType = PirExecutionType.MANUAL_INITIAL,
+            reason = PirScanWideEvent.FailureReason.RENDERER_GONE,
+            didCrash = false,
+        )
+
+        // Then
+        verify(wideEventClient).flowFinish(
+            wideEventId = 50L,
+            status = FlowStatus.Failure(reason = "renderer_gone"),
+            metadata = mapOf("did_crash" to "false"),
+        )
+    }
+
+    @Test
+    fun whenRunFailedWithoutDidCrashThenFlowFinishedWithEmptyMetadata() = runTest {
+        // Given
+        whenever(wideEventClient.flowStart(any(), any(), any(), any())).thenReturn(Result.success(51L))
+        runStarted(PirExecutionType.MANUAL_INITIAL, profileQueriesCount = 1, brokerCount = 1, totalScanJobs = 1)
+
+        // When (existing callers pass no didCrash)
+        testee.onRunFailed(
+            executionType = PirExecutionType.MANUAL_INITIAL,
+            reason = PirScanWideEvent.FailureReason.IO_EXCEPTION,
+        )
+
+        // Then
+        verify(wideEventClient).flowFinish(
+            wideEventId = 51L,
+            status = FlowStatus.Failure(reason = "io_exception"),
+            metadata = emptyMap(),
+        )
+    }
+
     private class FakeTimeProvider : CurrentTimeProvider {
         var elapsed: Long = 0L
         override fun elapsedRealtime(): Long = elapsed

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/PirRendererGoneExceptionTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/PirRendererGoneExceptionTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.pir.impl.common
+
+import com.duckduckgo.pir.impl.wideevents.PirScanWideEvent.FailureReason
+import kotlinx.coroutines.CancellationException
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PirRendererGoneExceptionTest {
+
+    @Test
+    fun whenCreatedThenCarriesDidCrashAndIsNotCancellation() {
+        val crashed = PirRendererGoneException(didCrash = true)
+        val killed = PirRendererGoneException(didCrash = false)
+
+        assertTrue(crashed.didCrash)
+        assertFalse(killed.didCrash)
+        // Must NOT be a CancellationException, or PirJobsRunner's cancellation catch would mis-route it.
+        assertFalse(CancellationException::class.java.isInstance(crashed))
+    }
+
+    @Test
+    fun whenRendererGoneFailureReasonThenWireValueIsStable() {
+        assertEquals("renderer_gone", FailureReason.RENDERER_GONE.value)
+    }
+}

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/RealPirActionsRunnerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/common/RealPirActionsRunnerTest.kt
@@ -145,7 +145,7 @@ class RealPirActionsRunnerTest {
 
     @Test
     fun whenStartWithBrokerStepsThenCreatesDetachedWebView() = runTest {
-        whenever(mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any()))
+        whenever(mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any(), any()))
             .thenReturn(mockWebView)
 
         // Start the runner asynchronously
@@ -167,12 +167,13 @@ class RealPirActionsRunnerTest {
             eq(testPirScript),
             any(),
             any(),
+            any(),
         )
     }
 
     @Test
     fun whenStartWithBrokerStepsThenRegistersBrokerActionProcessor() = runTest {
-        whenever(mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any()))
+        whenever(mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any(), any()))
             .thenReturn(mockWebView)
 
         val deferred = async {
@@ -190,7 +191,7 @@ class RealPirActionsRunnerTest {
 
     @Test
     fun whenStartWithBrokerStepsThenCreatesEngineAndDispatchesStarted() = runTest {
-        whenever(mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any()))
+        whenever(mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any(), any()))
             .thenReturn(mockWebView)
 
         val deferred = async {
@@ -209,7 +210,7 @@ class RealPirActionsRunnerTest {
 
     @Test
     fun whenStartAndCompleteExecutionReceivedThenReturnsSuccess() = runTest {
-        whenever(mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any()))
+        whenever(mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any(), any()))
             .thenReturn(mockWebView)
 
         val deferred = async {
@@ -237,7 +238,7 @@ class RealPirActionsRunnerTest {
 
     @Test
     fun whenStartOnWithBrokerStepsThenSetupsWebView() = runTest {
-        whenever(mockPirDetachedWebViewProvider.setupWebView(any(), any(), any(), any()))
+        whenever(mockPirDetachedWebViewProvider.setupWebView(any(), any(), any(), any(), any()))
             .thenReturn(mockWebView)
 
         val deferred = async {
@@ -255,12 +256,13 @@ class RealPirActionsRunnerTest {
             eq(testPirScript),
             any(),
             any(),
+            any(),
         )
     }
 
     @Test
     fun whenOnSuccessThenDispatchesJsActionSuccessEvent() = runTest {
-        whenever(mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any()))
+        whenever(mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any(), any()))
             .thenReturn(mockWebView)
 
         val deferred = async {
@@ -285,7 +287,7 @@ class RealPirActionsRunnerTest {
     @Test
     fun whenOnErrorWithActionFailedThenDispatchesBrokerActionFailedWithRetry() = runTest {
         val testError = PirError.ActionError.JsActionFailed("action-123", "Action execution failed")
-        whenever(mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any()))
+        whenever(mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any(), any()))
             .thenReturn(mockWebView)
 
         val deferred = async {
@@ -312,7 +314,7 @@ class RealPirActionsRunnerTest {
     @Test
     fun whenOnErrorWithJsErrorThenDispatchesErrorReceived() = runTest {
         val testError = PirError.JsError.ActionError("Javascript error")
-        whenever(mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any()))
+        whenever(mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any(), any()))
             .thenReturn(mockWebView)
 
         val deferred = async {
@@ -337,7 +339,7 @@ class RealPirActionsRunnerTest {
     @Test
     fun whenOnErrorWithCaptchaSolutionFailedThenDispatchesBrokerActionFailedWithoutRetry() = runTest {
         val testError = PirError.ActionError.CaptchaSolutionFailed("action-123", "Captcha solution failed")
-        whenever(mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any()))
+        whenever(mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any(), any()))
             .thenReturn(mockWebView)
 
         val deferred = async {
@@ -364,7 +366,7 @@ class RealPirActionsRunnerTest {
     @Test
     fun whenOnErrorWithUnknownErrorThenDoesNotDispatchEvent() = runTest {
         val testError = PirError.Unknown("Unknown error")
-        whenever(mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any()))
+        whenever(mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any(), any()))
             .thenReturn(mockWebView)
 
         val deferred = async {
@@ -387,7 +389,7 @@ class RealPirActionsRunnerTest {
 
     @Test
     fun whenStopThenCleansUpWebView() = runTest {
-        whenever(mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any()))
+        whenever(mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any(), any()))
             .thenReturn(mockWebView)
 
         val job = async {
@@ -409,7 +411,7 @@ class RealPirActionsRunnerTest {
     @Test
     fun whenOnLoadingCompleteWithUrlThenDispatchesLoadUrlComplete() = runTest {
         val loadedUrl = "https://example.com"
-        whenever(mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any()))
+        whenever(mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any(), any()))
             .thenReturn(mockWebView)
 
         val deferred = async {
@@ -419,7 +421,7 @@ class RealPirActionsRunnerTest {
         yield()
 
         val callbackCaptor = argumentCaptor<(String?) -> Unit>()
-        verify(mockPirDetachedWebViewProvider).createInstance(any(), any(), callbackCaptor.capture(), any())
+        verify(mockPirDetachedWebViewProvider).createInstance(any(), any(), callbackCaptor.capture(), any(), any())
         callbackCaptor.firstValue.invoke(loadedUrl)
 
         sideEffectFlow.tryEmit(SideEffect.CompleteExecution)
@@ -435,7 +437,7 @@ class RealPirActionsRunnerTest {
 
     @Test
     fun whenOnLoadingCompleteWithNullUrlThenDoesNotDispatchEvent() = runTest {
-        whenever(mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any()))
+        whenever(mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any(), any()))
             .thenReturn(mockWebView)
 
         val deferred = async {
@@ -445,7 +447,7 @@ class RealPirActionsRunnerTest {
         yield()
 
         val callbackCaptor = argumentCaptor<(String?) -> Unit>()
-        verify(mockPirDetachedWebViewProvider).createInstance(any(), any(), callbackCaptor.capture(), any())
+        verify(mockPirDetachedWebViewProvider).createInstance(any(), any(), callbackCaptor.capture(), any(), any())
         callbackCaptor.firstValue.invoke(null)
 
         sideEffectFlow.tryEmit(SideEffect.CompleteExecution)
@@ -461,7 +463,7 @@ class RealPirActionsRunnerTest {
     @Test
     fun whenOnLoadingFailedWithUrlThenDispatchesLoadUrlFailed() = runTest {
         val failedUrl = "https://example.com"
-        whenever(mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any()))
+        whenever(mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any(), any()))
             .thenReturn(mockWebView)
 
         val deferred = async {
@@ -471,7 +473,7 @@ class RealPirActionsRunnerTest {
         yield()
 
         val callbackCaptor = argumentCaptor<(String?) -> Unit>()
-        verify(mockPirDetachedWebViewProvider).createInstance(any(), any(), any(), callbackCaptor.capture())
+        verify(mockPirDetachedWebViewProvider).createInstance(any(), any(), any(), callbackCaptor.capture(), any())
         callbackCaptor.firstValue.invoke(failedUrl)
 
         sideEffectFlow.tryEmit(SideEffect.CompleteExecution)
@@ -483,5 +485,102 @@ class RealPirActionsRunnerTest {
 
         assertTrue(eventCaptor.allValues[1] is Event.LoadUrlFailed)
         assertEquals(failedUrl, (eventCaptor.allValues[1] as Event.LoadUrlFailed).url)
+    }
+
+    @Test
+    fun whenRenderProcessGoneThenStartThrowsPirRendererGoneExceptionWithDidCrash() = runTest {
+        val rendererGoneCaptor = argumentCaptor<(Boolean) -> Unit>()
+        whenever(
+            mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any(), rendererGoneCaptor.capture()),
+        ).thenReturn(mockWebView)
+
+        var thrown: Throwable? = null
+        val deferred = async {
+            try {
+                testee.start(testProfileQuery, testBrokerSteps)
+            } catch (e: Throwable) {
+                thrown = e
+            }
+        }
+
+        // Allow start() to reach awaitResult and register the continuation.
+        yield()
+
+        // Simulate the shared renderer being reclaimed by the system (not a crash).
+        rendererGoneCaptor.firstValue.invoke(false)
+
+        deferred.await()
+
+        assertTrue(thrown is PirRendererGoneException)
+        assertTrue(!(thrown as PirRendererGoneException).didCrash)
+    }
+
+    @Test
+    fun whenRendererGoneAfterCompleteExecutionThenIsSafeNoOp() = runTest {
+        val rendererGoneCaptor = argumentCaptor<(Boolean) -> Unit>()
+        whenever(
+            mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any(), rendererGoneCaptor.capture()),
+        ).thenReturn(mockWebView)
+
+        val deferred = async {
+            testee.start(testProfileQuery, testBrokerSteps)
+        }
+
+        yield()
+
+        // The run completes successfully first.
+        sideEffectFlow.tryEmit(SideEffect.CompleteExecution)
+
+        val result = deferred.await()
+        assertTrue(result.isSuccess)
+
+        // A renderer-gone signal arriving for this (now-completed) run's WebView must be a no-op:
+        // it must not throw, and must not retroactively affect the already-resolved result.
+        rendererGoneCaptor.firstValue.invoke(true)
+
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun whenStaleRendererGoneFromPreviousRunThenDoesNotFailCurrentRun() = runTest {
+        // RealPirActionsRunner instances are reused sequentially by production callers
+        // (PirScan/PirOptOut loop start()/stop() on the same instance per broker step). The
+        // previous run's WebView is destroyed asynchronously (see cleanUpRunner), so its
+        // onRendererGone callback can still fire after a new run has become active on the same
+        // instance. This verifies that stale callback cannot resume/fail the new run.
+        val rendererGoneCaptor = argumentCaptor<(Boolean) -> Unit>()
+        whenever(
+            mockPirDetachedWebViewProvider.createInstance(any(), any(), any(), any(), rendererGoneCaptor.capture()),
+        ).thenReturn(mockWebView)
+
+        // Step A: starts and completes successfully.
+        val deferredA = async {
+            testee.start(testProfileQuery, testBrokerSteps)
+        }
+
+        yield()
+
+        sideEffectFlow.tryEmit(SideEffect.CompleteExecution)
+
+        val resultA = deferredA.await()
+        assertTrue(resultA.isSuccess)
+
+        val staleOnRendererGoneFromStepA = rendererGoneCaptor.firstValue
+
+        // Step B: a new run starts on the SAME runner instance.
+        val deferredB = async {
+            testee.start(testProfileQuery, testBrokerSteps)
+        }
+
+        yield()
+
+        // Step A's stale (not-yet-destroyed) WebView reports its renderer gone while step B is
+        // the active run. This must not fail step B.
+        staleOnRendererGoneFromStepA.invoke(false)
+
+        sideEffectFlow.tryEmit(SideEffect.CompleteExecution)
+
+        val resultB = deferredB.await()
+        assertTrue(resultB.isSuccess)
     }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/PirPixelInterceptorTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/PirPixelInterceptorTest.kt
@@ -200,6 +200,42 @@ class PirPixelInterceptorTest {
     }
 
     @Test
+    fun whenInterceptRendererGoneCountPixelThenAddsManufacturerParameter() = runTest {
+        val request = Request.Builder()
+            .url("https://example.com/m_dbp_scan_renderer-gone_c")
+            .build()
+
+        whenever(mockChain.request()).thenReturn(request)
+
+        testee.intercept(mockChain)
+
+        val requestCaptor = org.mockito.kotlin.argumentCaptor<Request>()
+        verify(mockChain).proceed(requestCaptor.capture())
+
+        val capturedRequest = requestCaptor.firstValue
+        val man = capturedRequest.url.queryParameter("manufacturer")
+        assertEquals("samsung", man)
+    }
+
+    @Test
+    fun whenInterceptRendererGoneDailyPixelThenAddsManufacturerParameter() = runTest {
+        val request = Request.Builder()
+            .url("https://example.com/m_dbp_scan_renderer-gone_d")
+            .build()
+
+        whenever(mockChain.request()).thenReturn(request)
+
+        testee.intercept(mockChain)
+
+        val requestCaptor = org.mockito.kotlin.argumentCaptor<Request>()
+        verify(mockChain).proceed(requestCaptor.capture())
+
+        val capturedRequest = requestCaptor.firstValue
+        val man = capturedRequest.url.queryParameter("manufacturer")
+        assertEquals("samsung", man)
+    }
+
+    @Test
     fun whenInterceptInitialScanIncompletePixelThenAddsManufacturerParameter() = runTest {
         val request = Request.Builder()
             .url("https://example.com/m_dbp_initial-scan_incomplete")

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/pixels/RealPirPixelSenderTest.kt
@@ -22,6 +22,8 @@ import com.duckduckgo.networkprotection.api.NetworkProtectionState
 import com.duckduckgo.pir.impl.PirRemoteFeatures
 import com.duckduckgo.pir.impl.scheduling.PirExecutionType
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -1251,5 +1253,27 @@ class RealPirPixelSenderTest {
         assert(typeCaptor.firstValue is Pixel.PixelType.Unique)
         assert(paramsCaptor.firstValue["is_authenticated"] == "true")
         assert(paramsCaptor.firstValue["free_scan"] == "false")
+    }
+
+    @Test
+    fun whenReportRendererGoneThenEnqueuesCountAndDailyWithDidCrashAndScanTrigger() = runTest {
+        testee.reportRendererGone(
+            executionType = PirExecutionType.SCHEDULED,
+            didCrash = false,
+        )
+
+        val nameCaptor = argumentCaptor<String>()
+        val paramsCaptor = argumentCaptor<Map<String, String>>()
+        verify(mockPixelSender, times(2)).enqueueFire(
+            pixelName = nameCaptor.capture(),
+            parameters = paramsCaptor.capture(),
+            encodedParameters = any(),
+            type = any(),
+        )
+
+        assertTrue(nameCaptor.allValues.contains("m_dbp_scan_renderer-gone_c"))
+        assertTrue(nameCaptor.allValues.contains("m_dbp_scan_renderer-gone_d"))
+        assertEquals("false", paramsCaptor.firstValue["did_crash"])
+        assertEquals("scheduled", paramsCaptor.firstValue["scan_trigger"])
     }
 }

--- a/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealPirJobsRunnerTest.kt
+++ b/pir/pir-impl/src/test/kotlin/com/duckduckgo/pir/impl/scheduling/RealPirJobsRunnerTest.kt
@@ -25,6 +25,7 @@ import com.duckduckgo.networkprotection.api.NetworkProtectionState
 import com.duckduckgo.pir.impl.PirRemoteFeatures
 import com.duckduckgo.pir.impl.brokers.BrokerJsonUpdater
 import com.duckduckgo.pir.impl.common.PirJob.RunType
+import com.duckduckgo.pir.impl.common.PirRendererGoneException
 import com.duckduckgo.pir.impl.common.PirWebViewCountProvider
 import com.duckduckgo.pir.impl.models.ExtractedProfile
 import com.duckduckgo.pir.impl.models.ProfileQuery
@@ -1387,7 +1388,7 @@ class RealPirJobsRunnerTest {
         verify(mockPirScanWideEvent).onOptOutStarted(any())
         verify(mockPirScanWideEvent).onOptOutCompleted(any(), any())
         verify(mockPirScanWideEvent, never()).onOptOutSkipped(any())
-        verify(mockPirScanWideEvent, never()).onRunFailed(any(), any())
+        verify(mockPirScanWideEvent, never()).onRunFailed(any(), any(), anyOrNull())
         verify(mockPirScanWideEvent, never()).onRunCancelled(any(), any())
     }
 
@@ -1501,7 +1502,7 @@ class RealPirJobsRunnerTest {
             notificationsPermissionGranted = false,
             isTrackerBlockingEnabled = false,
         )
-        verify(mockPirScanWideEvent).onRunFailed(any(), eq(FailureReason.NO_ACTIVE_BROKERS))
+        verify(mockPirScanWideEvent).onRunFailed(any(), eq(FailureReason.NO_ACTIVE_BROKERS), anyOrNull())
         verify(mockPirScanWideEvent, never()).onScanCompleted(any())
         verify(mockPirScanWideEvent, never()).onOptOutStarted(any())
         verify(mockPirScanWideEvent, never()).onOptOutSkipped(any())
@@ -1552,7 +1553,7 @@ class RealPirJobsRunnerTest {
         )
         verify(mockPirScanWideEvent).onRunCancelled(any(), any())
         verify(mockPirScanWideEvent, never()).onScanCompleted(any())
-        verify(mockPirScanWideEvent, never()).onRunFailed(any(), any())
+        verify(mockPirScanWideEvent, never()).onRunFailed(any(), any(), anyOrNull())
     }
 
     @Test
@@ -1598,9 +1599,42 @@ class RealPirJobsRunnerTest {
             notificationsPermissionGranted = false,
             isTrackerBlockingEnabled = false,
         )
-        verify(mockPirScanWideEvent).onRunFailed(any(), eq(FailureReason.ILLEGAL_STATE_EXCEPTION))
+        verify(mockPirScanWideEvent).onRunFailed(any(), eq(FailureReason.ILLEGAL_STATE_EXCEPTION), anyOrNull())
         verify(mockPirScanWideEvent, never()).onScanCompleted(any())
         verify(mockPirScanWideEvent, never()).onRunCancelled(any(), any())
+    }
+
+    @Test
+    fun whenScanThrowsRendererGoneThenFiresPixelAndReturnsFailureWithoutRethrowing() = runTest {
+        // Given
+        whenever(mockPirRepository.getAllActiveBrokers()).thenReturn(listOf(testBrokerName))
+        whenever(mockPirRepository.getAllUserProfileQueries()).thenReturn(testUserProfileQueries)
+        whenever(mockPirRepository.getBrokersForOptOut(true)).thenReturn(emptyList())
+        whenever(
+            mockPirSchedulingRepository.getValidScanJobRecord(testBrokerName, testProfileQuery.id),
+        ).thenReturn(testScanJobRecord)
+        whenever(mockEligibleScanJobProvider.getAllEligibleScanJobs(testCurrentTime)).thenReturn(
+            listOf(testScanJobRecord),
+        )
+        whenever(mockCurrentTimeProvider.currentTimeMillis()).thenReturn(testCurrentTime)
+        whenever(mockPirRepository.latestBackgroundScanRunInMs()).thenReturn(testCurrentTime)
+        whenever(
+            mockPirScan.executeScanForJobs(any(), eq(mockContext), eq(RunType.MANUAL), anyOrNull(), anyOrNull()),
+        ).thenAnswer { throw PirRendererGoneException(didCrash = true) }
+
+        // When - runEligibleJobs must NOT rethrow; it must convert renderer-gone into a failure Result
+        // so the foreground service's launch{} coroutine does not crash the :pir process.
+        val result = testee.runEligibleJobs(mockContext, MANUAL_INITIAL)
+
+        // Then
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is PirRendererGoneException)
+        verify(mockPixelSender).reportRendererGone(executionType = MANUAL_INITIAL, didCrash = true)
+        verify(mockPirScanWideEvent).onRunFailed(
+            executionType = MANUAL_INITIAL,
+            reason = PirScanWideEvent.FailureReason.RENDERER_GONE,
+            didCrash = true,
+        )
     }
 
     @Test
@@ -1643,7 +1677,7 @@ class RealPirJobsRunnerTest {
         }
 
         // Then
-        verify(mockPirScanWideEvent).onRunFailed(any(), eq(FailureReason.TIMEOUT_CANCELLATION_EXCEPTION))
+        verify(mockPirScanWideEvent).onRunFailed(any(), eq(FailureReason.TIMEOUT_CANCELLATION_EXCEPTION), anyOrNull())
         verify(mockPirScanWideEvent, never()).onRunCancelled(any(), any())
     }
 
@@ -1680,7 +1714,7 @@ class RealPirJobsRunnerTest {
         // Then
         verify(mockPirScanWideEvent).onScanCompleted(any())
         verify(mockPirScanWideEvent).onOptOutStarted(any())
-        verify(mockPirScanWideEvent).onRunFailed(any(), eq(FailureReason.ILLEGAL_STATE_EXCEPTION))
+        verify(mockPirScanWideEvent).onRunFailed(any(), eq(FailureReason.ILLEGAL_STATE_EXCEPTION), anyOrNull())
         verify(mockPirScanWideEvent, never()).onOptOutCompleted(any(), any())
         verify(mockPirScanWideEvent, never()).onRunCancelled(any(), any())
     }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203581873609357/task/1216859979548186?focus=true
Tech Design URL (if applicable): N/A
API Proposals URL(s) (if applicable): N/A

### Description
See https://app.asana.com/1/137249556945/project/1203581873609357/task/1216859979548186?focus=true

### Steps to test this PR
Follow https://app.asana.com/1/137249556945/project/1203581873609357/task/1216925923141896?focus=true

### UI changes
No UI changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core PIR scan execution and job-runner error paths when WebViews lose their renderer; behavior is well-tested but affects long-running background/foreground scan reliability.
> 
> **Overview**
> PIR scan WebViews now listen for **renderer process death** via `onRenderProcessGone`, keep the `:pir` host process alive (`return true`), and surface the event through a new `onRendererGone(didCrash)` callback on detached WebView setup.
> 
> **`PirActionsRunner`** ties that callback to the active run’s suspend continuation: it cancels timer/engine work and fails the run with **`PirRendererGoneException`**, with guards so late or stale callbacks from a previous WebView cannot affect a completed or newer run.
> 
> **`PirJobsRunner`** catches that exception explicitly (not as cancellation), returns **`Result.failure`** instead of crashing the foreground coroutine, fires **`m_dbp_scan_renderer-gone`** (`did_crash`, `scan_trigger`), and records wide-event failure **`renderer_gone`** with optional **`did_crash`** metadata. Pixel definitions and interceptors are updated accordingly; tests cover runner, jobs, pixels, and wide events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85a057d236d9a064974e9221fe13892e29d16d22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->