### PR TITLE
Add nav buttons to native input in search-only mode

### DIFF
--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputAnimator.kt
@@ -103,7 +103,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
     private var widgetCompatPaddingHeight = 0
     private var isBottomCard = false
 
-    // In bottom mode the card is a weighted LinearLayout child (width=0dp), which ignores an
+    // The card is a weighted LinearLayout child (width=0dp), which ignores an
     // explicit width. We zero the weight for the duration of the morph so the width lerps take
     // effect, saving the original here to restore the resting layout afterwards.
     private var savedCardWeight = 0f
@@ -180,6 +180,8 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
     ) {
         // Morph only — hideNativeInput may already be sliding the nav bar out in parallel.
         cancelMorphAnimation()
+        // Search-only sessions skip the enter morph, so init() never captured these — capture now so the exit doesn't morph from 0f.
+        captureCardProperties(widgetCard, omnibarCard)
         clearLayoutTransitions(widgetView)
         (widgetView as? ViewGroup)?.clipChildren = false
         (widgetView.parent as? ViewGroup)?.clipChildren = false
@@ -390,8 +392,8 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         params.height = omnibarHeight + widgetCompatPaddingHeight
         params.topMargin = 0
         params.bottomMargin = 0
-        // Gravity only applies to FrameLayout children. For the LinearLayout (bottom) case the card's
-        // horizontal placement is driven by translationX toward the omnibar, so no gravity is needed.
+        // Gravity only applies to FrameLayout children. For the LinearLayout case the
+        // card's horizontal placement is driven by translationX toward the omnibar, so no gravity is needed.
         if (params is FrameLayout.LayoutParams) {
             params.gravity = Gravity.CENTER_HORIZONTAL or if (isBottom) Gravity.BOTTOM else Gravity.TOP
         }
@@ -528,7 +530,7 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         params.topMargin = margins.top
         params.bottomMargin = margins.bottom
         when (params) {
-            // Bottom mode: restore the card's XML resting state (width=0dp + weight) and hand width
+            // Both positions: restore the card's XML resting state (width=0dp + weight) and hand width
             // distribution back to the LinearLayout, undoing detachWeightForMorph.
             is LinearLayout.LayoutParams -> {
                 params.width = 0
@@ -545,8 +547,9 @@ class RealNativeInputAnimator @Inject constructor() : NativeInputAnimator {
         card.translationY = 0f
     }
 
-    // Bottom mode: a weighted (width=0dp) child ignores explicit widths, so zero the weight for the
-    // morph and remember it. restoreLayout puts it back (enter); exit ends in widget removal.
+    // A weighted (width=0dp) LinearLayout child, which ignores explicit
+    // widths, so zero the weight for the morph and remember it. restoreLayout puts it back (enter); exit
+    // ends in widget removal.
     private fun detachWeightForMorph(params: ViewGroup.MarginLayoutParams) {
         if (params is LinearLayout.LayoutParams) {
             savedCardWeight = params.weight

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -20,6 +20,10 @@ import android.app.Activity
 import android.content.res.Configuration
 import android.graphics.Outline
 import android.net.Uri
+import android.transition.ChangeBounds
+import android.transition.Fade
+import android.transition.TransitionManager
+import android.transition.TransitionSet
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
@@ -203,6 +207,9 @@ class RealNativeInputManager @Inject constructor(
     // The nav bar is shown once when the browser input opens empty, then latched off the first time the
     // user types. Latched stays off for the session — clearing text or toggling the keyboard won't bring it back.
     private var navBarInteractionLatched: Boolean = false
+
+    // True when this input session opened with the inline buttons shown (search-only, empty).
+    private var inlineNavButtonsShown: Boolean = false
     private var navBarHeightPx: Int = 0
     private var navBarIsBottom: Boolean = false
     private var navBarTabCountLiveData: LiveData<Int>? = null
@@ -392,7 +399,8 @@ class RealNativeInputManager @Inject constructor(
             slideNavBarOutWithClose(animate = animate)
         }
 
-        if (!animate) {
+        // When the inline buttons are showing, closing should not "slide".
+        if (!animate || inlineNavButtonsCurrentlyShown()) {
             animator.cancelAnimation()
             isExiting = false
             // Match animated exit: suspend LayoutTransition before resetting offsets so CHANGING
@@ -592,7 +600,16 @@ class RealNativeInputManager @Inject constructor(
         val createNavBar = shouldCreateNavBar(isNavBarFeatureEnabled, omnibarController.isDuckAiMode(), inputModeCapability) &&
             prefillText.isEmpty()
         val navBarView = if (createNavBar) createNavBarView(layoutInflater) else null
-        bindWidget(widgetView, lifecycleOwner, tabs, currentTabUrl, callbacks, isBottom)
+        // Inline Fire/Tabs/Menu buttons are the search-only counterpart to the nav-bar strip: shown when
+        // the browser input opens empty in search-only mode.
+        val showInlineNavButtons = shouldShowInlineNavButtons(
+            isDuckAiMode = omnibarController.isDuckAiMode(),
+            inputMode = inputModeCapability,
+            openedEmpty = prefillText.isEmpty(),
+            interactionLatched = false,
+        )
+        inlineNavButtonsShown = showInlineNavButtons
+        bindWidget(widgetView, lifecycleOwner, tabs, currentTabUrl, callbacks, isBottom, showInlineNavButtons)
         if (navBarView != null) bindNavBar(navBarView, widgetView, lifecycleOwner, tabs, callbacks)
         if (!omnibarController.isDuckAiMode() && prefillText.isNotEmpty()) {
             // Restore the cache before setting text — triggerAutocomplete preserves the
@@ -660,7 +677,7 @@ class RealNativeInputManager @Inject constructor(
             // Fires on every keystroke regardless of the selected tab (search text routes to
             // onSearchTextChanged, chat text to onChatTextChanged), so this is the tab-agnostic signal
             // that latches the nav bar off on the user's first input.
-            onInputTextEmptyChanged = { isEmpty -> if (!isEmpty) onNavBarInputInteraction() },
+            onInputTextEmptyChanged = ::onInputTextEmptyChanged,
             onSearchSubmitted = { query ->
                 nativeInputEventListener.onSearchSubmitted(query)
                 hideNativeInput(isNavigation = true)
@@ -810,20 +827,22 @@ class RealNativeInputManager @Inject constructor(
             onTabs = callbacks.onTabSwitcherPressed,
             onBrowserMenu = callbacks.onBrowserMenuPressed,
         )
-        bindNavBarTabCount(navBarView, lifecycleOwner, tabs)
+        navBarView.findViewById<TabSwitcherButton?>(R.id.inputModeWidgetNavTabs)?.let { tabsButton ->
+            bindNavBarTabCount(tabsButton, lifecycleOwner, tabs)
+        }
     }
 
     /**
      * Mirrors [NativeInputWidget.bindTabCount]: the fragment's viewLifecycleOwner is reused across
      * show/hide cycles, so the previous observer is removed before re-observing — otherwise each cycle
-     * stacks an observer that keeps updating a detached nav bar button.
+     * stacks an observer that keeps updating a detached button. Shared by the nav-bar strip and the
+     * search-only inline buttons.
      */
     private fun bindNavBarTabCount(
-        navBarView: View,
+        tabsButton: TabSwitcherButton,
         lifecycleOwner: LifecycleOwner,
         tabs: LiveData<List<TabEntity>>,
     ) {
-        val tabsButton = navBarView.findViewById<TabSwitcherButton?>(R.id.inputModeWidgetNavTabs) ?: return
         navBarTabCountObserver?.let { existing -> navBarTabCountLiveData?.removeObserver(existing) }
         val tabCount = tabs.map { it.size }
         val observer = Observer<Int> { count -> tabsButton.count = count }
@@ -840,6 +859,7 @@ class RealNativeInputManager @Inject constructor(
         currentTabUrl: Flow<String?>,
         callbacks: NativeInputCallbacks,
         isBottom: Boolean,
+        showInlineNavButtons: Boolean,
     ) {
         widgetFrom(widgetView)?.apply {
             onStopTapped = callbacks.onStopTapped
@@ -880,6 +900,7 @@ class RealNativeInputManager @Inject constructor(
         bindChatSuggestions(widgetView, lifecycleOwner, callbacks)
         bindSearchTabAutocompleteClearing(widgetView, callbacks.onClearAutocomplete)
         bindVoiceButtons(widgetView, callbacks)
+        bindInlineNavButtons(widgetView, lifecycleOwner, tabs, callbacks, showInlineNavButtons)
     }
 
     private fun bindVoiceButtons(
@@ -982,12 +1003,58 @@ class RealNativeInputManager @Inject constructor(
         widgetFrom(rootView)?.setNavBarVisible(navBarShown == true)
     }
 
-    /** The user typed: latch the nav bar off for the rest of this input session and slide it out. */
-    private fun onNavBarInputInteraction() {
-        if (navBarInteractionLatched || navBarRoot == null) return
+    /** On the user's first keystroke (empty to non-empty), latches the nav bar off for the rest of this input session and slide it out. */
+    private fun onInputTextEmptyChanged(isEmpty: Boolean) {
+        if (isEmpty || navBarInteractionLatched) return
         navBarInteractionLatched = true
-        refreshNavBarVisibility()
+        if (navBarRoot != null) {
+            refreshNavBarVisibility()
+        } else if (inlineNavButtonsShown) {
+            retractInlineButtons()
+        }
     }
+
+    /** Slides the search-only inline Fire/Tabs/Menu buttons out, widening the field into the freed space. */
+    private fun retractInlineButtons() {
+        val container = rootView.findViewById<View?>(R.id.inlineNavButtonsContainer) ?: return
+        // Matches the open/close morph duration so it feels consistent with the field closing.
+        (container.parent as? ViewGroup)?.let { parent ->
+            TransitionManager.beginDelayedTransition(
+                parent,
+                TransitionSet().apply {
+                    ordering = TransitionSet.ORDERING_TOGETHER
+                    addTransition(ChangeBounds())
+                    addTransition(Fade())
+                    duration = RealNativeInputAnimator.ANIMATION_DURATION_MS
+                },
+            )
+        }
+        container.gone()
+    }
+
+    /**
+     * Wires the inline Fire/Tabs/Menu buttons that live OUTSIDE the input card (search-only only).
+     * The buttons sit on the plain background beside the card like the legacy omnibar rather than on the card.
+     */
+    private fun bindInlineNavButtons(
+        widgetView: View,
+        lifecycleOwner: LifecycleOwner,
+        tabs: LiveData<List<TabEntity>>,
+        callbacks: NativeInputCallbacks,
+        show: Boolean,
+    ) {
+        val container = widgetView.findViewById<View?>(R.id.inlineNavButtonsContainer) ?: return
+        container.visibility = if (show) View.VISIBLE else View.GONE
+        widgetView.findViewById<View?>(R.id.inputModeWidgetNavFire)?.setOnClickListener { callbacks.onFireButtonPressed() }
+        widgetView.findViewById<View?>(R.id.inputModeWidgetNavMenu)?.setOnClickListener { callbacks.onBrowserMenuPressed() }
+        widgetView.findViewById<TabSwitcherButton?>(R.id.inputModeWidgetNavTabs)?.let { tabsButton ->
+            tabsButton.setOnClickListener { callbacks.onTabSwitcherPressed() }
+            bindNavBarTabCount(tabsButton, lifecycleOwner, tabs)
+        }
+    }
+
+    /** True when the inline search-only buttons are currently on screen (opened with them, not yet latched off). */
+    private fun inlineNavButtonsCurrentlyShown(): Boolean = inlineNavButtonsShown && !navBarInteractionLatched
 
     /**
      * Shows/hides the persistent nav bar. No-op when there is no bar (non-browser context) or the bar
@@ -1176,6 +1243,7 @@ class RealNativeInputManager @Inject constructor(
 
     private fun startEnterAnimation(widgetView: View, isBottom: Boolean): Boolean {
         if (omnibarController.isDuckAiMode()) return false
+        if (inlineNavButtonsShown) return false
         val widgetCard = widgetView.findViewById<View?>(R.id.inputModeWidgetCard) ?: return false
         val omnibarCard = omnibarController.getCardView() ?: return false
         // Apply focused-state layout so the widget is measured at its final size; otherwise
@@ -1426,6 +1494,19 @@ internal fun computeVoiceButtonAvailability(
  */
 internal fun shouldCreateNavBar(featureEnabled: Boolean, isDuckAiMode: Boolean, inputMode: NativeInputState.InputMode): Boolean =
     featureEnabled && !isDuckAiMode && inputMode == NativeInputState.InputMode.SEARCH_AND_DUCK_AI
+
+/**
+ * Whether the inline Fire/Tabs/Menu buttons should show for the current search-only browser input
+ * session. Only search-only browser input shows them: Duck.ai keeps its own controls and Search &
+ * Duck.ai uses the nav-bar strip. The widget is only shown in search-only when the feature flag is on
+ */
+internal fun shouldShowInlineNavButtons(
+    isDuckAiMode: Boolean,
+    inputMode: NativeInputState.InputMode,
+    openedEmpty: Boolean,
+    interactionLatched: Boolean,
+): Boolean =
+    !isDuckAiMode && inputMode == NativeInputState.InputMode.SEARCH_ONLY && openedEmpty && !interactionLatched
 
 /**
  * Whether the input-mode nav bar should currently be on screen. It's shown for a browser-input session that

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -268,11 +268,13 @@ class RealNativeInputManager @Inject constructor(
         duckChatInputModeState.inputModeCapability
             .onEach {
                 inputModeCapability = it
-                // A live switch to Search-only means the browser no longer uses native input. Tear down an
-                // open widget so the legacy omnibar returns instead of lingering as a toggle-less widget
-                // until the user closes and refocuses (hideNativeInput no-ops when nothing is shown).
-                // Otherwise re-evaluate the nav bar for the new mode.
-                if (!isNativeInputActive()) {
+                // Rebuild on the next focus (rather than half-update in place) when the new search mode no
+                // longer fits the open widget: native input is now inactive, or,with search-only on, it's
+                // the browser omnibar, whose two search layouts differ. An active Duck.ai input is unaffected,
+                // so just refresh its nav bar.
+                val rebuildOnRefocus = !isNativeInputActive() ||
+                    (nativeInputSearchOnlyFeature.self().isEnabled() && !omnibarController.isDuckAiMode())
+                if (rebuildOnRefocus) {
                     hideNativeInput(animate = false)
                 } else {
                     refreshNavBarVisibility()
@@ -291,12 +293,12 @@ class RealNativeInputManager @Inject constructor(
 
     override fun isNativeInputActive(): Boolean {
         if (!isNativeInputFieldEnabled) return false
-        // Duck.ai always uses the native input; the browser omnibar only does so outside search-only,
-        // unless the search-only feature flag is on.
+        // Native input is used in Duck.ai mode, in Search & Duck.ai mode, and in search-only mode
+        // only when the search-only feature flag is on.
         val inDuckAi = ::omnibarController.isInitialized && omnibarController.isDuckAiMode()
         return inDuckAi ||
-            inputModeCapability != NativeInputState.InputMode.SEARCH_ONLY ||
-            nativeInputSearchOnlyFeature.self().isEnabled()
+            inputModeCapability == NativeInputState.InputMode.SEARCH_AND_DUCK_AI ||
+            (nativeInputSearchOnlyFeature.self().isEnabled() && inputModeCapability == NativeInputState.InputMode.SEARCH_ONLY)
     }
 
     override fun isNativeInputShown(): Boolean {
@@ -400,7 +402,8 @@ class RealNativeInputManager @Inject constructor(
         }
 
         // When the inline buttons are showing, closing should not "slide".
-        if (!animate || inlineNavButtonsCurrentlyShown()) {
+        // If the card is full-width, it morphs back to the omnibar.
+        if (!animate || (inlineNavButtonsShown && !navBarInteractionLatched)) {
             animator.cancelAnimation()
             isExiting = false
             // Match animated exit: suspend LayoutTransition before resetting offsets so CHANGING
@@ -1074,9 +1077,6 @@ class RealNativeInputManager @Inject constructor(
             bindNavBarTabCount(tabsButton, lifecycleOwner, tabs)
         }
     }
-
-    /** True when the inline search-only buttons are currently on screen (opened with them, not yet latched off). */
-    private fun inlineNavButtonsCurrentlyShown(): Boolean = inlineNavButtonsShown && !navBarInteractionLatched
 
     /**
      * Shows/hides the persistent nav bar. No-op when there is no bar (non-browser context) or the bar

--- a/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
+++ b/app/src/main/java/com/duckduckgo/app/browser/nativeinput/NativeInputManager.kt
@@ -1017,7 +1017,23 @@ class RealNativeInputManager @Inject constructor(
     /** Slides the search-only inline Fire/Tabs/Menu buttons out, widening the field into the freed space. */
     private fun retractInlineButtons() {
         val container = rootView.findViewById<View?>(R.id.inlineNavButtonsContainer) ?: return
-        // Matches the open/close morph duration so it feels consistent with the field closing.
+        beginInlineButtonsMorph(container)
+        container.gone()
+    }
+
+    /**
+     * Split-mode first focus: the reverse of [retractInlineButtons]. The card opens at the omnibar's
+     * full width (buttons GONE) and then contracts as the buttons fade in, so the native input looks
+     * like it took over the omnibar before retracting to reveal them.
+     */
+    private fun revealInlineButtons(container: View) {
+        beginInlineButtonsMorph(container)
+        container.show()
+    }
+
+    /** ChangeBounds + Fade on the card/buttons row. Matches the open/close morph duration so the
+     *  reveal/retract feels consistent with the field opening and closing. */
+    private fun beginInlineButtonsMorph(container: View) {
         (container.parent as? ViewGroup)?.let { parent ->
             TransitionManager.beginDelayedTransition(
                 parent,
@@ -1029,7 +1045,6 @@ class RealNativeInputManager @Inject constructor(
                 },
             )
         }
-        container.gone()
     }
 
     /**
@@ -1044,7 +1059,14 @@ class RealNativeInputManager @Inject constructor(
         show: Boolean,
     ) {
         val container = widgetView.findViewById<View?>(R.id.inlineNavButtonsContainer) ?: return
-        container.visibility = if (show) View.VISIBLE else View.GONE
+        if (show && omnibarController.isSplitMode()) {
+            // Split mode: the omnibar was full-width, so start hidden (the card fills the row) and reveal
+            // the buttons with a contraction once the widget is laid out.
+            container.gone()
+            widgetView.post { revealInlineButtons(container) }
+        } else {
+            container.visibility = if (show) View.VISIBLE else View.GONE
+        }
         widgetView.findViewById<View?>(R.id.inputModeWidgetNavFire)?.setOnClickListener { callbacks.onFireButtonPressed() }
         widgetView.findViewById<View?>(R.id.inputModeWidgetNavMenu)?.setOnClickListener { callbacks.onBrowserMenuPressed() }
         widgetView.findViewById<TabSwitcherButton?>(R.id.inputModeWidgetNavTabs)?.let { tabsButton ->

--- a/app/src/main/res/layout/input_mode_nav_buttons.xml
+++ b/app/src/main/res/layout/input_mode_nav_buttons.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2026 DuckDuckGo
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<!-- The Fire/Tabs/Menu trio shared by the native input's two host layouts:
+     - the Search & Duck.ai nav-bar strip (input_mode_widget_nav_bar), where it sits after the Back button, and
+     - the search-only inline row (included in the input_mode_widget_card_view wrappers, beside the card),
+     which mirrors the legacy omnibar toolbar.
+     Ids match the nav-bar's original buttons so bindInputModeNavBar stays untouched; bindInlineNavButtons
+     reuses the same ids scoped to the widget. The two hosts are never in the same findViewById scope.
+     Visibility is driven by the manager (bindInlineNavButtons) for the inline row; the nav-bar strip keeps
+     it visible and toggles the whole strip instead. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/inputModeNavButtons"
+    android:layout_width="wrap_content"
+    android:layout_height="@dimen/toolbarIcon"
+    android:gravity="center_vertical"
+    android:orientation="horizontal">
+
+    <FrameLayout
+        android:id="@+id/inputModeWidgetNavFire"
+        android:layout_width="@dimen/toolbarIcon"
+        android:layout_height="@dimen/toolbarIcon"
+        android:background="@drawable/selectable_item_rounded_corner_background"
+        android:contentDescription="@string/duckChatFireButtonContentDescription">
+
+        <ImageView
+            android:id="@+id/inputModeWidgetNavFireIcon"
+            android:layout_width="@dimen/bottomNavIcon"
+            android:layout_height="@dimen/bottomNavIcon"
+            android:layout_gravity="center"
+            android:importantForAccessibility="no"
+            android:scaleType="center"
+            android:src="@drawable/ic_fire_24" />
+    </FrameLayout>
+
+    <com.duckduckgo.browser.ui.tabs.NewTabSwitcherButton
+        android:id="@+id/inputModeWidgetNavTabs"
+        android:layout_width="@dimen/toolbarIcon"
+        android:layout_height="@dimen/toolbarIcon" />
+
+    <FrameLayout
+        android:id="@+id/inputModeWidgetNavMenu"
+        android:layout_width="@dimen/toolbarIcon"
+        android:layout_height="@dimen/toolbarIcon"
+        android:background="@drawable/selectable_item_rounded_corner_background"
+        android:contentDescription="@string/duckChatBrowserMenuContentDescription">
+
+        <ImageView
+            android:id="@+id/inputModeWidgetNavMenuIcon"
+            android:layout_width="@dimen/bottomNavIcon"
+            android:layout_height="@dimen/bottomNavIcon"
+            android:layout_gravity="center"
+            android:importantForAccessibility="no"
+            android:scaleType="center"
+            android:src="@drawable/ic_menu_hamburger_24" />
+
+        <View
+            android:id="@+id/inputModeWidgetNavMenuHighlight"
+            android:layout_width="7dp"
+            android:layout_height="7dp"
+            android:layout_gravity="end"
+            android:layout_margin="@dimen/keyline_2"
+            android:background="@drawable/ic_dot_indicator_7"
+            android:visibility="gone" />
+    </FrameLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/input_mode_widget_card_view.xml
+++ b/app/src/main/res/layout/input_mode_widget_card_view.xml
@@ -19,25 +19,50 @@
     android:id="@+id/inputModeTopRoot"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_gravity="top">
+    android:layout_gravity="top"
+    android:clipChildren="false"
+    android:clipToPadding="false">
 
-    <!-- Negative top margin pulls the card up to account for the shadow -->
-    <com.google.android.material.card.MaterialCardView
-        android:id="@+id/inputModeWidgetCard"
-        android:theme="?attr/daxInputModeCardThemeOverlay"
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="-9dp"
-        app:cardBackgroundColor="?attr/daxColorSurface"
-        app:cardCornerRadius="24dp"
-        app:cardElevation="6dp"
-        app:cardUseCompatPadding="true">
+        android:clipChildren="false"
+        android:clipToPadding="false"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
 
-        <com.duckduckgo.duckchat.impl.ui.nativeinput.views.NativeInputModeWidget
-            android:id="@+id/inputModeWidget"
-            android:paddingHorizontal="8dp"
-            android:paddingVertical="4dp"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
-    </com.google.android.material.card.MaterialCardView>
+        <!-- Negative top margin pulls the card up to account for the shadow -->
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/inputModeWidgetCard"
+            android:theme="?attr/daxInputModeCardThemeOverlay"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="-9dp"
+            android:layout_weight="1"
+            app:cardBackgroundColor="?attr/daxColorSurface"
+            app:cardCornerRadius="24dp"
+            app:cardElevation="6dp"
+            app:cardUseCompatPadding="true">
+
+            <com.duckduckgo.duckchat.impl.ui.nativeinput.views.NativeInputModeWidget
+                android:id="@+id/inputModeWidget"
+                android:paddingHorizontal="8dp"
+                android:paddingVertical="4dp"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+        </com.google.android.material.card.MaterialCardView>
+
+        <!-- Shared Fire/Tabs/Menu trio (see input_mode_nav_buttons). Hidden by default; the manager
+        (bindInlineNavButtons) drives its visibility. The native input is 4dp larger than the omnibar
+        vertically so we shift the buttons by -2dp so they remain centered with the omnibar -->
+        <include
+            android:id="@+id/inlineNavButtonsContainer"
+            layout="@layout/input_mode_nav_buttons"
+            android:layout_width="wrap_content"
+            android:layout_height="?attr/actionBarSize"
+            android:layout_gravity="top"
+            android:layout_marginEnd="@dimen/keyline_1"
+            android:layout_marginTop="-2dp"
+            android:visibility="gone" />
+    </LinearLayout>
 </com.duckduckgo.duckchat.impl.ui.nativeinput.views.NonCollapsingFrameLayout>

--- a/app/src/main/res/layout/input_mode_widget_card_view_bottom.xml
+++ b/app/src/main/res/layout/input_mode_widget_card_view_bottom.xml
@@ -30,7 +30,7 @@
         android:gravity="center_vertical"
         android:orientation="horizontal"
         android:paddingStart="@dimen/keyline_2"
-        android:paddingEnd="@dimen/keyline_2">
+        android:paddingEnd="@dimen/keyline_1">
 
         <FrameLayout
             android:id="@+id/inputFieldFireIconMenu"
@@ -73,6 +73,15 @@
                 android:paddingBottom="@dimen/keyline_2" />
 
         </com.google.android.material.card.MaterialCardView>
+
+        <include
+            android:id="@+id/inlineNavButtonsContainer"
+            layout="@layout/input_mode_nav_buttons"
+            android:layout_width="wrap_content"
+            android:layout_height="?attr/actionBarSize"
+            android:layout_gravity="bottom"
+            android:layout_marginBottom="-2dp"
+            android:visibility="gone" />
 
     </LinearLayout>
 </com.duckduckgo.duckchat.impl.ui.nativeinput.views.NonCollapsingFrameLayout>

--- a/app/src/main/res/layout/input_mode_widget_card_view_bottom.xml
+++ b/app/src/main/res/layout/input_mode_widget_card_view_bottom.xml
@@ -57,9 +57,10 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/keyline_2"
             android:layout_marginBottom="@dimen/keyline_2"
+            android:layout_marginEnd="@dimen/keyline_1"
             android:layout_weight="1"
             app:cardBackgroundColor="?attr/daxColorWindow"
-            app:cardCornerRadius="26dp"
+            app:cardCornerRadius="@dimen/largeShapeCornerRadius"
             app:cardElevation="3dp"
             app:cardUseCompatPadding="false">
 

--- a/app/src/main/res/layout/input_mode_widget_nav_bar.xml
+++ b/app/src/main/res/layout/input_mode_widget_nav_bar.xml
@@ -41,62 +41,13 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:tint="?attr/daxColorPrimaryIcon" />
 
-    <FrameLayout
-        android:id="@+id/inputModeWidgetNavFire"
-        android:layout_width="@dimen/toolbarIcon"
+    <!-- Fire/Tabs/Menu trio shared with the search-only inline row; see input_mode_nav_buttons. -->
+    <include
+        layout="@layout/input_mode_nav_buttons"
+        android:layout_width="wrap_content"
         android:layout_height="@dimen/toolbarIcon"
-        android:background="@drawable/selectable_item_rounded_corner_background"
-        android:contentDescription="@string/duckChatFireButtonContentDescription"
-        app:layout_constraintEnd_toStartOf="@id/inputModeWidgetNavTabs"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <ImageView
-            android:id="@+id/inputModeWidgetNavFireIcon"
-            android:layout_width="@dimen/bottomNavIcon"
-            android:layout_height="@dimen/bottomNavIcon"
-            android:layout_gravity="center"
-            android:importantForAccessibility="no"
-            android:scaleType="center"
-            android:src="@drawable/ic_fire_24" />
-    </FrameLayout>
-
-    <com.duckduckgo.browser.ui.tabs.NewTabSwitcherButton
-        android:id="@+id/inputModeWidgetNavTabs"
-        android:layout_width="@dimen/toolbarIcon"
-        android:layout_height="@dimen/toolbarIcon"
-        app:layout_constraintEnd_toStartOf="@id/inputModeWidgetNavMenu"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <FrameLayout
-        android:id="@+id/inputModeWidgetNavMenu"
-        android:layout_width="@dimen/toolbarIcon"
-        android:layout_height="@dimen/toolbarIcon"
-        android:background="@drawable/selectable_item_rounded_corner_background"
-        android:contentDescription="@string/duckChatBrowserMenuContentDescription"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <ImageView
-            android:id="@+id/inputModeWidgetNavMenuIcon"
-            android:layout_width="@dimen/bottomNavIcon"
-            android:layout_height="@dimen/bottomNavIcon"
-            android:layout_gravity="center"
-            android:importantForAccessibility="no"
-            android:scaleType="center"
-            android:src="@drawable/ic_menu_hamburger_24" />
-
-        <View
-            android:id="@+id/inputModeWidgetNavMenuHighlight"
-            android:layout_width="7dp"
-            android:layout_height="7dp"
-            android:layout_gravity="end"
-            android:layout_margin="@dimen/keyline_2"
-            android:background="@drawable/ic_dot_indicator_7"
-            android:visibility="gone" />
-
-    </FrameLayout>
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/test/java/com/duckduckgo/app/browser/nativeinput/InlineNavButtonsDecisionTest.kt
+++ b/app/src/test/java/com/duckduckgo/app/browser/nativeinput/InlineNavButtonsDecisionTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 DuckDuckGo
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.duckduckgo.app.browser.nativeinput
+
+import com.duckduckgo.duckchat.api.nativeinput.NativeInputState.InputMode
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class InlineNavButtonsDecisionTest {
+
+    private fun decide(
+        isDuckAiMode: Boolean = false,
+        inputMode: InputMode = InputMode.SEARCH_ONLY,
+        openedEmpty: Boolean = true,
+        interactionLatched: Boolean = false,
+    ) = shouldShowInlineNavButtons(isDuckAiMode, inputMode, openedEmpty, interactionLatched)
+
+    @Test
+    fun `shown for empty first-focus search-only`() = assertTrue(decide())
+
+    @Test
+    fun `hidden in Duck ai mode`() = assertFalse(decide(isDuckAiMode = true))
+
+    @Test
+    fun `hidden in Search and Duck ai mode`() = assertFalse(decide(inputMode = InputMode.SEARCH_AND_DUCK_AI))
+
+    @Test
+    fun `hidden when opened with prefilled text`() = assertFalse(decide(openedEmpty = false))
+
+    @Test
+    fun `hidden once the interaction latch is set`() = assertFalse(decide(interactionLatched = true))
+}

--- a/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
+++ b/duckchat/duckchat-impl/src/main/java/com/duckduckgo/duckchat/impl/ui/nativeinput/views/NativeInputModeWidget.kt
@@ -1304,11 +1304,12 @@ class NativeInputModeWidget @JvmOverloads constructor(
         val card = parent as? MaterialCardView ?: return
         card.radius = card.resources.getDimension(com.duckduckgo.mobile.android.R.dimen.largeShapeCornerRadius)
         val targetTopMargin = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.omnibarCardMarginTop)
-        val targetHorizontalMargin = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.omnibarCardMarginHorizontal)
+        val targetStartMargin = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.omnibarCardMarginHorizontal)
+        val targetEndMargin = card.resources.getDimensionPixelSize(com.duckduckgo.mobile.android.R.dimen.keyline_1)
         (card.layoutParams as? MarginLayoutParams)?.let { lp ->
             lp.topMargin = targetTopMargin - card.paddingTop
-            lp.marginStart = targetHorizontalMargin - card.paddingLeft
-            lp.marginEnd = targetHorizontalMargin - card.paddingRight
+            lp.marginStart = targetStartMargin - card.paddingLeft
+            lp.marginEnd = targetEndMargin - card.paddingRight
             card.layoutParams = lp
         }
     }

--- a/duckchat/duckchat-impl/src/main/res/layout/view_native_input_mode_switch_widget.xml
+++ b/duckchat/duckchat-impl/src/main/res/layout/view_native_input_mode_switch_widget.xml
@@ -121,6 +121,7 @@
                         android:layout_marginStart="10dp"
                         android:layout_weight="1"
                         android:background="@null"
+                        android:ellipsize="end"
                         android:fontFamily="sans-serif"
                         android:gravity="start|center_vertical"
                         android:hint="@string/input_screen_search_hint"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1212810093780571/task/1216641958042104?focus=true 
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

## Description
This PR adds the native input overlay for **search-only** mode with the toolbar buttons and all the transitions. Everything here is gated by the same `nativeInputSearchOnly` flag introduced in previous PR.
No changes when the flag is off, and no behaviour change to the unfocused omnibar, Search & Duck.ai mode (the nav-bar strip), or Duck.ai input.I moved the buttons into a shared `input_mode_nav_buttons.xml` file to be reused in different layouts.

Full interactions can be found here: https://app.asana.com/1/137249556945/project/1212810093780571/task/1216764209336869?focus=true

## Steps to test this PR
Enable `nativeInputSearchOnly` feature-flag, and set the address bar to **Search only** (Settings → Duck.ai → address bar).

_Flag ON: search-only (test on both top and bottom address-bar positions)_
- [x] Tap the omnibar on an empty field → native input opens with Fire / Tabs / Menu beside the field, aligned with where the omnibar's buttons were.
- [x] Tabs button shows the current tab count. Fire / Tabs / Menu perform the correct actions.
- [x] Type one character → the buttons animate out and the field widens; clear the text → the buttons stay gone.
- [x] Close and reopen the input → the buttons appear again (fresh session).
- [x] Open any website or search. Focus a loaded page/URL (field opens prefilled) → no buttons.

_Flag ON: split omnibar mode:_
- [x] Tap the full-width omnibar → the card opens full width and contracts as the buttons fade in (took-over-then-retracted).

_Flag OFF (default):_
- [x] Search-only tap → legacy omnibar text input, no native overlay (unchanged from production).

**Regression Search & Duck.ai (nav-bar strip, unaffected by design):**
- [x] Same behaviour as Top bar (per requirements). Tap the omnibar → the nav-bar strip still shows Back + Fire / Tabs / Menu, the tab count updates, and the strip slides away on the first keystroke.

## UI changes
| Before | After |
| ------ | ----- |
| <img width="540" height="1200" alt="Screenshot_20260728_100404" src="https://github.com/user-attachments/assets/f40e5866-6427-442d-a77b-23b288eefcbb" /> | <img width="540" height="1200" alt="Screenshot_20260728_100325" src="https://github.com/user-attachments/assets/caa44bd7-5fe5-4c62-93a5-cb8d3f0bc5e4" /> |
| <img width="540" height="1200" alt="Screenshot_20260728_100353" src="https://github.com/user-attachments/assets/dc010335-1adc-4908-a83b-6976c0abd75f" /> | <img width="540" height="1200" alt="Screenshot_20260728_100312" src="https://github.com/user-attachments/assets/091cfe17-2fa5-4671-b797-737d84fa6b38" /> |



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches omnibar/native-input lifecycle, animations, and layout across top/bottom and split modes; gated by feature flag but regressions could affect Search & Duck.ai nav-bar behavior via shared button layout and morph logic.
> 
> **Overview**
> With **`nativeInputSearchOnly`** enabled, empty first-focus in **search-only** opens the native input overlay with **Fire / Tabs / Menu** beside the field (legacy omnibar placement), not the Search & Duck.ai nav-bar strip. Buttons latch off on the first keystroke and widen the field via **ChangeBounds + Fade**; split omnibar starts full-width then contracts as buttons reveal. Closing while buttons are still visible runs the **card→omnibar morph** instead of a slide-only dismiss.
> 
> **`isNativeInputActive()`** now treats Search & Duck.ai as always native and search-only as native only when the flag is on. Input-mode changes that alter browser search layout tear down the open widget for rebuild on next focus.
> 
> Shared **`input_mode_nav_buttons`** replaces duplicated toolbar controls in the nav-bar strip and top/bottom widget wrappers; top card uses a weighted horizontal row. **`NativeInputAnimator`** captures card properties on exit when enter morph was skipped, and restores LinearLayout **weight** for both omnibar positions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac6ae956bb959e09525a9c2ea466bacd49638d60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->