### PR TITLE
Sync: Adopt existing account_info key when set-if-absent conflicts

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountInfoKeyManager.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountInfoKeyManager.kt
@@ -87,7 +87,7 @@ class RealAccountInfoKeyManager @Inject constructor(
 
         logcat { "Sync-UnifiedDevices: registering $SYNC_PURPOSE_ACCOUNT_INFO key (kid=${minted.entry.kid}, wraps=${entries.size})" }
         when (val result = syncApi.setKeysIfAbsent(token, SYNC_PURPOSE_ACCOUNT_INFO, entries)) {
-            is Success -> onSetIfAbsentSuccess(minted, entries.size, result.data)
+            is Success -> onSetIfAbsentSuccess(token, minted, entries.size, result.data)
             is Error -> {
                 logcat(ERROR) { "Sync-UnifiedDevices: setKeysIfAbsent failed: ${result.reason}" }
                 result
@@ -119,6 +119,7 @@ class RealAccountInfoKeyManager @Inject constructor(
     }
 
     private fun onSetIfAbsentSuccess(
+        token: String,
         minted: MintedProtectedKey,
         wrapsSent: Int,
         outcome: SetKeysIfAbsentResult,
@@ -131,10 +132,30 @@ class RealAccountInfoKeyManager @Inject constructor(
                 )
             }
             is SetKeysIfAbsentResult.Existing -> {
-                logcat { "Sync-UnifiedDevices: another device's key won (kid=${outcome.kid}); discarding local mint" }
+                logcat { "Sync-UnifiedDevices: another device's key won (kid=${outcome.kid}); adopting from response" }
                 Success(
                     AccountInfoKeyResult(kid = outcome.kid, publicKey = outcome.publicKey, created = false, wrapsSent = wrapsSent),
                 )
+            }
+            SetKeysIfAbsentResult.ExistsFetchRequired -> adoptExistingFromServer(token, wrapsSent)
+        }
+    }
+
+    /** The server has a key for this purpose but didn't return it (409, or a 200 shim); fetch and adopt it. */
+    private fun adoptExistingFromServer(token: String, wrapsSent: Int): Result<AccountInfoKeyResult> {
+        logcat { "Sync-UnifiedDevices: key already exists on server; fetching to adopt" }
+        return when (val result = syncApi.getProtectedKeys(token)) {
+            is Success -> {
+                val existing = result.data.firstOrNull { it.purpose == SYNC_PURPOSE_ACCOUNT_INFO }
+                    ?: return Error(reason = "CreateAccountInfoKey: server reported an existing key but none was found on fetch")
+                logcat { "Sync-UnifiedDevices: adopted existing key (kid=${existing.kid})" }
+                Success(
+                    AccountInfoKeyResult(kid = existing.kid, publicKey = existing.publicKey, created = false, wrapsSent = wrapsSent),
+                )
+            }
+            is Error -> {
+                logcat(ERROR) { "Sync-UnifiedDevices: failed to fetch keys to adopt existing: ${result.reason}" }
+                result
             }
         }
     }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SetKeysIfAbsentCall.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SetKeysIfAbsentCall.kt
@@ -50,12 +50,23 @@ class RealSetKeysIfAbsentCall @Inject constructor(
 
             if (response.isSuccessful) {
                 if (response.code() == 201) {
+                    logcat { "Sync-UnifiedDevices: set-if-absent 201 — our keypair won" }
                     Result.Success(SetKeysIfAbsentResult.Created)
                 } else {
-                    val existing = response.body()?.keys?.firstOrNull() ?: return Result.Error(reason = "SetKeysIfAbsent: 200 response missing keys")
-
-                    Result.Success(SetKeysIfAbsentResult.Existing(existing.kid, existing.publicKey))
+                    // 200 is a backwards-compat shim for "a key already exists"; adopt it if the body carries it,
+                    // otherwise fall back to fetching (same path as a 409).
+                    val existing = response.body()?.keys?.firstOrNull()
+                    if (existing != null) {
+                        logcat { "Sync-UnifiedDevices: set-if-absent 200 — adopting key from response (kid=${existing.kid})" }
+                        Result.Success(SetKeysIfAbsentResult.Existing(existing.kid, existing.publicKey))
+                    } else {
+                        logcat { "Sync-UnifiedDevices: set-if-absent 200 — key exists but not returned; will fetch" }
+                        Result.Success(SetKeysIfAbsentResult.ExistsFetchRequired)
+                    }
                 }
+            } else if (response.code() == HTTP_CONFLICT) {
+                logcat { "Sync-UnifiedDevices: set-if-absent 409 — a different key already exists; will fetch" }
+                Result.Success(SetKeysIfAbsentResult.ExistsFetchRequired)
             } else {
                 mapError(response)
             }
@@ -79,5 +90,9 @@ class RealSetKeysIfAbsentCall @Inject constructor(
         } else {
             Result.Error(code = response.code(), reason = "empty response")
         }
+    }
+
+    companion object {
+        private const val HTTP_CONFLICT = 409
     }
 }

--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/SyncServiceRemote.kt
@@ -119,8 +119,10 @@ interface SyncApi {
     /** List this account's protected keys across all purposes. */
     fun getProtectedKeys(token: String): Result<List<ProtectedKeyEntry>>
 
-    /** First-writer-wins registration of a purpose-scoped protected key. On [SetKeysIfAbsentResult.Existing]
-     *  the caller must discard its own minted keypair and adopt the returned one instead. */
+    /** First-writer-wins registration of a purpose-scoped protected key.
+     * If a key already exists the caller must discard its own mint and adopt the server's. If coming from the server, it could be either:
+     *   - the one in [SetKeysIfAbsentResult.Existing],
+     *   - or, for [SetKeysIfAbsentResult.ExistsFetchRequired], fetched via [getProtectedKeys]. */
     fun setKeysIfAbsent(
         token: String,
         purpose: String,
@@ -152,8 +154,11 @@ sealed class SetKeysIfAbsentResult {
     /** Our posted keys won (server returned 201). */
     data object Created : SetKeysIfAbsentResult()
 
-    /** Another device's key already existed (server returned 200); this is the one that won. */
+    /** A key already existed and the server returned it */
     data class Existing(val kid: String, val publicKey: RsaJwk?) : SetKeysIfAbsentResult()
+
+    /** A key already existed but wasn't returned (409, or a 200 with no body); the caller must fetch and adopt it. */
+    data object ExistsFetchRequired : SetKeysIfAbsentResult()
 }
 
 @ContributesBinding(AppScope::class)

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AccountInfoKeyManagerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AccountInfoKeyManagerTest.kt
@@ -186,6 +186,43 @@ class AccountInfoKeyManagerTest {
     }
 
     @Test
+    fun whenSetIfAbsentRequiresFetchThenFetchesKeysAndAdopts() = runTest {
+        whenever(syncStore.scopedPassword).thenReturn(null)
+        whenever(syncApi.setKeysIfAbsent(eq(token), eq("account_info"), any())).thenReturn(Success(SetKeysIfAbsentResult.ExistsFetchRequired))
+        whenever(syncApi.getProtectedKeys(token)).thenReturn(
+            Success(
+                listOf(
+                    ProtectedKeyEntry(
+                        kid = "server-kid",
+                        purpose = "account_info",
+                        encryptedWith = "ddg",
+                        encryptedPrivateKey = "AAAA",
+                        publicKey = RsaJwk(n = "server-mod", e = "AQAB"),
+                    ),
+                ),
+            ),
+        )
+
+        val result = manager.ensureKeyRegistered() as Success
+
+        assertEquals("server-kid", result.data.kid)
+        assertEquals(RsaJwk(n = "server-mod", e = "AQAB"), result.data.publicKey)
+        assertTrue(!result.data.created)
+    }
+
+    @Test
+    fun whenSetIfAbsentRequiresFetchButNoAccountInfoKeyFoundThenReturnsError() = runTest {
+        whenever(syncStore.scopedPassword).thenReturn(null)
+        whenever(syncApi.setKeysIfAbsent(eq(token), eq("account_info"), any()))
+            .thenReturn(Success(SetKeysIfAbsentResult.ExistsFetchRequired))
+        whenever(syncApi.getProtectedKeys(token)).thenReturn(Success(emptyList()))
+
+        val result = manager.ensureKeyRegistered()
+
+        assertTrue(result is Error)
+    }
+
+    @Test
     fun whenSetIfAbsentFailsThenReturnsError() = runTest {
         configureForSetIfAbsentFailure()
 

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/SetKeysIfAbsentCallTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/SetKeysIfAbsentCallTest.kt
@@ -66,12 +66,21 @@ class SetKeysIfAbsentCallTest {
     }
 
     @Test
-    fun whenResponseIs200WithNoKeyThenReturnError() {
+    fun whenResponseIs200WithNoKeyThenReturnExistsFetchRequired() {
         stubResponse(Response.success(200, SetKeyIfAbsentResponse(keys = emptyList())))
 
         val result = call.execute(token, "account_info", listOf(accountInfoKey))
 
-        assertEquals(Result.Error(reason = "SetKeysIfAbsent: 200 response missing keys"), result)
+        assertEquals(Result.Success(SetKeysIfAbsentResult.ExistsFetchRequired), result)
+    }
+
+    @Test
+    fun whenResponseIs409ThenReturnExistsFetchRequired() {
+        stubResponse(Response.error(409, """{"error":"conflict"}""".toResponseBody("application/json".toMediaTypeOrNull())))
+
+        val result = call.execute(token, "account_info", listOf(accountInfoKey))
+
+        assertEquals(Result.Success(SetKeysIfAbsentResult.ExistsFetchRequired), result)
     }
 
     @Test

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
@@ -627,7 +627,7 @@ constructor(
             logcat { "Sync-UnifiedDevices: creating & registering account_info key from dev screen" }
             when (val result = accountInfoKeyManager.ensureKeyRegistered()) {
                 is Success -> {
-                    val outcome = if (result.data.created) "201 created (ours won)" else "200 existing (adopted)"
+                    val outcome = if (result.data.created) "created (ours won)" else "adopted existing"
                     val text = "kid=${result.data.kid}, wraps_sent=${result.data.wrapsSent}, outcome=$outcome"
                     logcat { "Sync-UnifiedDevices: $text" }
                     viewState.update { it.copy(accountInfoKeyResult = text) }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1216957889523682?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Adopt existing `account_info` key when `set-if-absent` conflicts. The `set-if-absent` API can return 200, 201 or 409 indicating different things:
- 200: There is an existing key and the server should return it
- 201: There was no existing key; the one you registered will now be used
- 409 🆕: There was an existing key but the server hasn't returned it. The client must fetch it manually. This PR adds support for handling 409.

### Steps to test this PR

#### 
- [ ] Fresh install `internal` variant
- [ ] Set up device to sync
- [ ] From `Sync Dev Settings`, tap `Create & Register account_info key`
- [ ] Tap `Create 3party credential
- [ ] Tap `Fetch Keys`
- [ ] Tap `Create & Register account_info key` again
- [ ] Verify `outcome = adopted existing`, and that `kid` matches (2 out of the 4) keys listed under `Fetch Keys` button

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes first-writer-wins protected key registration and adoption for account_info; wrong handling could leave devices on mismatched keys, but behavior is narrowly scoped and covered by new unit tests.
> 
> **Overview**
> **`set-if-absent`** registration for the unified-devices **`account_info`** key now treats “key already exists but not in the response” as a normal outcome instead of failing.
> 
> **`SetKeysIfAbsentCall`** maps **409** and **200** responses with no key body to **`ExistsFetchRequired`**. **200** with a key in the body still yields **`Existing`**; **201** still means the local key won.
> 
> **`AccountInfoKeyManager`** handles **`ExistsFetchRequired`** by calling **`getProtectedKeys`**, picking the **`account_info`** entry, and returning an adopted result (`created = false`). Fetch failures or a missing **`account_info`** key surface as errors.
> 
> Dev settings messaging drops HTTP status wording and shows **created (ours won)** vs **adopted existing**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eecbaaee1363d7d2b009255853fd9501f0870f87. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->