### PR TITLE
Cache the account_info public key

### DIFF
--- a/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountInfoKeyManager.kt
+++ b/sync/sync-impl/src/main/java/com/duckduckgo/sync/impl/AccountInfoKeyManager.kt
@@ -22,6 +22,7 @@ import com.duckduckgo.sync.crypto.SyncLib
 import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.duckduckgo.sync.store.AccountInfoPublicKey
 import com.duckduckgo.sync.store.SyncStore
 import com.squareup.anvil.annotations.ContributesBinding
 import dagger.SingleInstanceIn
@@ -46,7 +47,7 @@ interface AccountInfoKeyManager {
      * (ddg always, 3party if a scoped password exists), and registers it with the server via set-if-absent.
      *
      * If another device already registered a key for this purpose first, the local mint is discarded and the server's key is adopted instead.
-     * The winning public key is returned in [AccountInfoKeyResult].
+     * The winning public key is returned in [AccountInfoKeyResult] and cached in [SyncStore.accountInfoPublicKey].
      */
     suspend fun ensureKeyRegistered(): Result<AccountInfoKeyResult>
 }
@@ -86,13 +87,18 @@ class RealAccountInfoKeyManager @Inject constructor(
         }
 
         logcat { "Sync-UnifiedDevices: registering $SYNC_PURPOSE_ACCOUNT_INFO key (kid=${minted.entry.kid}, wraps=${entries.size})" }
-        when (val result = syncApi.setKeysIfAbsent(token, SYNC_PURPOSE_ACCOUNT_INFO, entries)) {
+        val registration = when (val result = syncApi.setKeysIfAbsent(token, SYNC_PURPOSE_ACCOUNT_INFO, entries)) {
             is Success -> onSetIfAbsentSuccess(token, minted, entries.size, result.data)
             is Error -> {
                 logcat(ERROR) { "Sync-UnifiedDevices: setKeysIfAbsent failed: ${result.reason}" }
                 result
             }
         }
+        // Cache the winning public key once, covering all adopt paths (ours won, adopted from the response, or fetched after a conflict).
+        if (registration is Success) {
+            registration.data.publicKey?.let { syncStore.accountInfoPublicKey = it.toStoredKey(registration.data.kid) }
+        }
+        registration
     }
 
     private fun mintKeypair(accountSecretKey: String): Result<MintedProtectedKey> =
@@ -159,4 +165,6 @@ class RealAccountInfoKeyManager @Inject constructor(
             }
         }
     }
+
+    private fun RsaJwk.toStoredKey(kid: String) = AccountInfoPublicKey(keyId = kid, modulus = n, exponent = e)
 }

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/AppSyncDeviceIdsTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/AppSyncDeviceIdsTest.kt
@@ -20,6 +20,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.duckduckgo.common.utils.device.DeviceInfo
 import com.duckduckgo.sync.api.DeviceSyncState.Type
 import com.duckduckgo.sync.impl.AppSyncDeviceIds
+import com.duckduckgo.sync.store.AccountInfoPublicKey
 import com.duckduckgo.sync.store.ScopedPassword
 import com.duckduckgo.sync.store.SyncStore
 import kotlinx.coroutines.flow.emptyFlow
@@ -112,6 +113,7 @@ class AppSyncDeviceIdsTest {
             override var secretKey: String? = "secretKey"
             override var credentialId: String? = null
             override var scopedPassword: ScopedPassword? = null
+            override var accountInfoPublicKey: AccountInfoPublicKey? = null
             override fun isEncryptionSupported() = true
 
             override fun isSignedInFlow() = emptyFlow<Boolean>()
@@ -146,6 +148,7 @@ class AppSyncDeviceIdsTest {
             override var secretKey: String? = null
             override var credentialId: String? = null
             override var scopedPassword: ScopedPassword? = null
+            override var accountInfoPublicKey: AccountInfoPublicKey? = null
             override fun isEncryptionSupported() = true
 
             override fun isSignedInFlow() = emptyFlow<Boolean>()

--- a/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AccountInfoKeyManagerTest.kt
+++ b/sync/sync-impl/src/test/java/com/duckduckgo/sync/impl/AccountInfoKeyManagerTest.kt
@@ -27,6 +27,7 @@ import com.duckduckgo.sync.impl.Result.Error
 import com.duckduckgo.sync.impl.Result.Success
 import com.duckduckgo.sync.impl.crypto.RsaKeyPair
 import com.duckduckgo.sync.impl.crypto.SyncJweCrypto
+import com.duckduckgo.sync.store.AccountInfoPublicKey
 import com.duckduckgo.sync.store.ScopedPassword
 import com.duckduckgo.sync.store.SyncStore
 import kotlinx.coroutines.test.runTest
@@ -170,6 +171,7 @@ class AccountInfoKeyManagerTest {
         assertTrue(result.data.created)
         assertEquals(1, result.data.wrapsSent)
         assertEquals(RsaJwk(n = "modulus", e = "AQAB"), result.data.publicKey)
+        verify(syncStore).accountInfoPublicKey = AccountInfoPublicKey(keyId = result.data.kid, modulus = "modulus", exponent = "AQAB")
     }
 
     @Test
@@ -183,6 +185,7 @@ class AccountInfoKeyManagerTest {
         assertEquals("other-kid", result.data.kid)
         assertEquals(RsaJwk(n = "other-mod", e = "AQAB"), result.data.publicKey)
         assertTrue(!result.data.created)
+        verify(syncStore).accountInfoPublicKey = AccountInfoPublicKey(keyId = "other-kid", modulus = "other-mod", exponent = "AQAB")
     }
 
     @Test
@@ -208,6 +211,7 @@ class AccountInfoKeyManagerTest {
         assertEquals("server-kid", result.data.kid)
         assertEquals(RsaJwk(n = "server-mod", e = "AQAB"), result.data.publicKey)
         assertTrue(!result.data.created)
+        verify(syncStore).accountInfoPublicKey = AccountInfoPublicKey(keyId = "server-kid", modulus = "server-mod", exponent = "AQAB")
     }
 
     @Test
@@ -229,6 +233,7 @@ class AccountInfoKeyManagerTest {
         val result = manager.ensureKeyRegistered()
 
         assertTrue(result is Error)
+        verify(syncStore, org.mockito.kotlin.times(0)).accountInfoPublicKey = anyOrNull()
     }
 
     @Test

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsActivity.kt
@@ -185,6 +185,8 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         binding.requestScopedTokenButton.setOnClickListener { viewModel.onRequestScopedTokenClicked() }
         binding.fetchKeysButton.setOnClickListener { viewModel.onFetchKeysClicked() }
         binding.createAccountInfoKeyButton.setOnClickListener { viewModel.onCreateAccountInfoKeyClicked() }
+        binding.showCachedAccountInfoKeyButton.setOnClickListener { viewModel.onShowCachedAccountInfoKeyClicked() }
+        binding.deleteCachedAccountInfoKeyButton.setOnClickListener { viewModel.onDeleteCachedAccountInfoKeyClicked() }
         binding.createThirdPartyCredentialButton.setOnClickListener { viewModel.onCreateThirdPartyCredentialClicked() }
         binding.refreshThirdPartyCredentialButton.setOnClickListener { viewModel.onRefreshThirdPartyCredentialClicked() }
         binding.showThirdPartyRecoveryQrButton.setOnClickListener { viewModel.onShowThirdPartyRecoveryQrClicked() }
@@ -341,6 +343,7 @@ class SyncInternalSettingsActivity : DuckDuckGoActivity() {
         binding.v2StoreFieldsTextView.text = viewState.v2StoreFieldsText
         binding.keysTextView.text = viewState.keysText
         binding.accountInfoKeyResultTextView.text = viewState.accountInfoKeyResult
+        binding.cachedAccountInfoKeyTextView.text = viewState.cachedAccountInfoKeyResult
         if (viewState.isSignedIn) {
             viewState.connectedDevices.forEach { device ->
                 val connectedBinding = ItemConnectedDeviceBinding.inflate(layoutInflater, binding.connectedDevicesList, true)

--- a/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
+++ b/sync/sync-internal/src/main/java/com/duckduckgo/sync/internal/ui/SyncInternalSettingsViewModel.kt
@@ -126,6 +126,7 @@ constructor(
         val keysText: String = "",
         val isTestSyncWarningEnabled: Boolean = false,
         val accountInfoKeyResult: String = "",
+        val cachedAccountInfoKeyResult: String = "",
     )
 
     sealed class BlockStoreValue {
@@ -312,6 +313,7 @@ constructor(
                 // Clear per-session dev-tool results once signed out so stale keys aren't shown.
                 keysText = if (accountInfo.isSignedIn) viewState.value.keysText else "",
                 accountInfoKeyResult = if (accountInfo.isSignedIn) viewState.value.accountInfoKeyResult else "",
+                cachedAccountInfoKeyResult = if (accountInfo.isSignedIn) viewState.value.cachedAccountInfoKeyResult else "",
             ),
         )
     }
@@ -640,6 +642,28 @@ constructor(
                     command.send(ShowMessage(text))
                 }
             }
+        }
+    }
+
+    fun onShowCachedAccountInfoKeyClicked() {
+        viewModelScope.launch(dispatchers.io()) {
+            val cached = syncStore.accountInfoPublicKey
+            val text = if (cached == null) {
+                "No cached account_info key"
+            } else {
+                "keyId=${cached.keyId}, modulus=${cached.modulus.take(24)}…, exponent=${cached.exponent}"
+            }
+            logcat { "Sync-UnifiedDevices: cached account_info key: $text" }
+            viewState.update { it.copy(cachedAccountInfoKeyResult = text) }
+        }
+    }
+
+    fun onDeleteCachedAccountInfoKeyClicked() {
+        viewModelScope.launch(dispatchers.io()) {
+            syncStore.accountInfoPublicKey = null
+            logcat { "Sync-UnifiedDevices: cleared cached account_info key" }
+            viewState.update { it.copy(cachedAccountInfoKeyResult = "Cached account_info key cleared") }
+            command.send(ShowMessage("Cached account_info key cleared"))
         }
     }
 

--- a/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
+++ b/sync/sync-internal/src/main/res/layout/activity_internal_sync_settings.xml
@@ -188,6 +188,29 @@
             android:layout_marginBottom="@dimen/keyline_4"
             app:typography="body2" />
 
+        <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+            android:id="@+id/showCachedAccountInfoKeyButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:text="Show Cached account_info Key" />
+
+        <com.duckduckgo.common.ui.view.button.DaxButtonPrimary
+            android:id="@+id/deleteCachedAccountInfoKeyButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="10dp"
+            android:text="Delete Cached account_info Key" />
+
+        <com.duckduckgo.common.ui.view.text.DaxTextView
+            android:id="@+id/cachedAccountInfoKeyTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/keyline_4"
+            android:layout_marginEnd="@dimen/keyline_4"
+            android:layout_marginBottom="@dimen/keyline_4"
+            app:typography="body2" />
+
         <com.duckduckgo.common.ui.view.listitem.SectionHeaderListItem
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/sync/sync-store/src/main/java/com/duckduckgo/sync/store/SyncStore.kt
+++ b/sync/sync-store/src/main/java/com/duckduckgo/sync/store/SyncStore.kt
@@ -15,6 +15,11 @@ import kotlinx.coroutines.launch
 @JvmInline
 value class ScopedPassword(val raw: String)
 
+/**
+ * Cached public half of the account-wide `account_info` protected key (RSA-OAEP-256 JWK components).
+ */
+data class AccountInfoPublicKey(val keyId: String, val modulus: String, val exponent: String)
+
 interface SyncStore {
     var syncingDataEnabled: Boolean
     var userId: String?
@@ -29,6 +34,9 @@ interface SyncStore {
 
     /** Scoped password (SP primary key) for the 3party credential. Only present when a 3party credential exists. */
     var scopedPassword: ScopedPassword?
+
+    /** Cached public key for the account's `account_info` protected key, once registered. */
+    var accountInfoPublicKey: AccountInfoPublicKey?
 
     fun isEncryptionSupported(): Boolean
     fun isSignedInFlow(): Flow<Boolean>
@@ -163,6 +171,27 @@ constructor(
             }
         }
 
+    override var accountInfoPublicKey: AccountInfoPublicKey?
+        get() {
+            val keyId = encryptedPreferences?.getString(KEY_ACCOUNT_INFO_KID, null) ?: return null
+            val modulus = encryptedPreferences?.getString(KEY_ACCOUNT_INFO_MODULUS, null) ?: return null
+            val exponent = encryptedPreferences?.getString(KEY_ACCOUNT_INFO_EXPONENT, null) ?: return null
+            return AccountInfoPublicKey(keyId, modulus, exponent)
+        }
+        set(value) {
+            encryptedPreferences?.edit(commit = true) {
+                if (value == null) {
+                    remove(KEY_ACCOUNT_INFO_KID)
+                    remove(KEY_ACCOUNT_INFO_MODULUS)
+                    remove(KEY_ACCOUNT_INFO_EXPONENT)
+                } else {
+                    putString(KEY_ACCOUNT_INFO_KID, value.keyId)
+                    putString(KEY_ACCOUNT_INFO_MODULUS, value.modulus)
+                    putString(KEY_ACCOUNT_INFO_EXPONENT, value.exponent)
+                }
+            }
+        }
+
     override fun isEncryptionSupported(): Boolean = encryptedPreferences != null
 
     override fun isSignedInFlow(): Flow<Boolean> = isSignedInStateFlow
@@ -207,5 +236,8 @@ constructor(
         private const val KEY_SK = "KEY_SK"
         private const val KEY_CREDENTIAL_ID = "KEY_CREDENTIAL_ID"
         private const val KEY_SCOPED_PASSWORD = "KEY_SCOPED_PASSWORD"
+        private const val KEY_ACCOUNT_INFO_KID = "KEY_ACCOUNT_INFO_KID"
+        private const val KEY_ACCOUNT_INFO_MODULUS = "KEY_ACCOUNT_INFO_MODULUS"
+        private const val KEY_ACCOUNT_INFO_EXPONENT = "KEY_ACCOUNT_INFO_EXPONENT"
     }
 }


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/608920331025315/task/1216856074810004?focus=true
Tech Design URL (if applicable): 
API Proposals URL(s) (if applicable):

### Description
Completes the "cache the winning public key" step of the `account_info` keypair work. Once a device knows the winning `account_info` public key (regardless of whether it was the one it submitted or a server-given one), it's persisted so that it can be later used to encrypt `device_info` (encrypting that will be done in future PRs). 

### Steps to test this PR

#### No cached key found by default
- [ ] Fresh install `internal` build
- [ ] Start sync on the device
- [ ] Visit `Sync Dev Settings` 
- [ ] Tap `Show Cached account_info Key`, and verify it says none cached

#### Caching key when our key wins
- [ ] Tap on `Create & Register account_info key` button
- [ ] Tap `Show Cached account_info Key`, and verify the cached `keyId` matches the one that you registered (i.e., the `keyId` matches in both labels)

#### Caching key when adopting from server
- [ ] Continuing from previous test, tap `Delete Cached account_info key` button
- [ ] Tap on `Create & Register account_info key` button (output will say `adopted existing`)
- [ ] Tap `Show Cached account_info Key`, and verify the cached `keyId` matches the one you adopted in previous step (i.e., the `keyId` matches in both labels)




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sync credential storage and key-registration flow; only public JWK material is cached, but incorrect persistence could affect future `device_info` encryption.
> 
> **Overview**
> Persists the winning **`account_info`** RSA public key (key id, modulus, exponent) in encrypted **`SyncStore`** after **`ensureKeyRegistered()`** succeeds, whether the device created the key or adopted one from the server.
> 
> **`AccountInfoKeyManager`** writes that key on every successful registration path and skips caching when registration fails. **`AccountInfoPublicKey`** is a new store type backed by three encrypted preference keys; **`clearAll()`** clears it with the rest of sync credentials.
> 
> Internal sync dev settings add show/delete controls and a readout for the cached key. Tests assert store updates for create, adopt, and fetch-adopt outcomes, and that failures do not cache.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b792ad81589a8d83df5ea8a7bb7bd0ae5322a49. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->